### PR TITLE
Adding PhysicalStorages list and summary pages

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -125,6 +125,7 @@ module EmsCommon
         physical_chassis
         physical_servers_with_host
         physical_switches
+        physical_storages
         security_groups
         storage_managers
         storages

--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -27,6 +27,6 @@ class PhysicalChassisController < ApplicationController
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_servers)
+    %w(physical_storages physical_servers)
   end
 end

--- a/app/controllers/physical_rack_controller.rb
+++ b/app/controllers/physical_rack_controller.rb
@@ -42,6 +42,6 @@ class PhysicalRackController < ApplicationController
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_chassis physical_servers)
+    %w(physical_chassis physical_storages physical_servers)
   end
 end

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -1,0 +1,37 @@
+class PhysicalStorageController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
+
+  before_action :check_privileges
+  before_action :session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.table_name
+    @table_name ||= "physical_storages"
+  end
+
+  def session_data
+    @title  = _("Physical Storages")
+    @layout = "physical_storage"
+    @lastaction = session[:physical_storage_lastaction]
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+    session[:physical_storage_lastaction] = @lastaction
+  end
+
+  def show_list
+    process_show_list
+  end
+
+  def textual_group_list
+    [
+      %i(properties relationships asset_details),
+    ]
+  end
+  helper_method(:textual_group_list)
+end

--- a/app/decorators/physical_storage_decorator.rb
+++ b/app/decorators/physical_storage_decorator.rb
@@ -1,0 +1,12 @@
+class PhysicalStorageDecorator < MiqDecorator
+  def self.fonticon
+    'pficon pficon-container-node'
+  end
+
+  def single_quad
+    {
+      :fonticon => fonticon,
+      :tooltip  => ui_lookup(:model => type),
+    }
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1158,6 +1158,7 @@ module ApplicationHelper
                         physical_rack
                         physical_chassis
                         physical_switch
+                        physical_storage
                         physical_server
                         persistent_volume
                         policy

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -52,6 +52,7 @@ module ApplicationHelper
         physical_rack
         physical_chassis
         physical_server
+        physical_storage
         physical_switch
         resource_pool
         security_group

--- a/app/helpers/application_helper/toolbar/physical_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storage_center.rb
@@ -1,0 +1,26 @@
+class ApplicationHelper::Toolbar::PhysicalStorageCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_storage_vmdb',
+    [
+      select(
+        :physical_storage_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :physical_storage_refresh,
+            'fa fa-refresh fa-lg',
+            N_('Refresh relationships and power states for all items related to this Physical Storage'),
+            N_('Refresh Relationships and Power States'),
+            :image   => "refresh",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "refresh", "controller": "physicalStorageToolbarController"}'},
+            :confirm => N_("Refresh relationships and power states for all items related to this Physical Storage?"),
+            :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
+end

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -1,0 +1,26 @@
+class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_storage_vmdb',
+    [
+      select(
+        :physical_storage_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :physical_storage_refresh,
+            'fa fa-refresh fa-lg',
+            N_('Refresh relationships and power states for all items related to these Physical Storages'),
+            N_('Refresh Relationships and Power States'),
+            :image   => "refresh",
+            :data    => {'function'      => 'sendDataWithRx',
+                         'function-data' => '{"type": "refresh", "controller": "physicalStorageToolbarController"}'},
+            :confirm => N_("Refresh relationships and power states for all items related to these Physical Storages?"),
+            :options => {:feature => :refresh}
+          ),
+        ]
+      ),
+    ]
+  )
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -515,6 +515,7 @@ class ApplicationHelper::ToolbarChooser
             physical_rack
             physical_server
             physical_switch
+            physical_storage
             resource_pool
             container_template
             ems_block_storage

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_racks physical_chassis physical_switches physical_servers datastores vms physical_servers_with_host)
+      %i(physical_racks physical_chassis physical_switches physical_storages physical_servers datastores vms physical_servers_with_host)
     )
   end
 
@@ -59,6 +59,10 @@ module EmsPhysicalInfraHelper::TextualSummary
 
   def textual_physical_switches
     textual_link(@record.physical_switches, :as => PhysicalSwitch)
+  end
+
+  def textual_physical_storages
+    textual_link(@record.physical_storages)
   end
 
   def textual_physical_servers

--- a/app/helpers/physical_rack_helper/textual_summary.rb
+++ b/app/helpers/physical_rack_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module PhysicalRackHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ext_management_system physical_chassis physical_servers)
+      %i(ext_management_system physical_chassis physical_servers physical_storages)
     )
   end
 
@@ -31,5 +31,9 @@ module PhysicalRackHelper::TextualSummary
 
   def textual_physical_servers
     textual_link(@record.physical_servers)
+  end
+
+  def textual_physical_storages
+    textual_link(@record.physical_storages)
   end
 end

--- a/app/helpers/physical_storage_helper.rb
+++ b/app/helpers/physical_storage_helper.rb
@@ -1,0 +1,3 @@
+module PhysicalStorageHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/physical_storage_helper/textual_summary.rb
+++ b/app/helpers/physical_storage_helper/textual_summary.rb
@@ -1,0 +1,100 @@
+module PhysicalStorageHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i(name product_name serial_number health_state enclosures drive_bays uid_ems description)
+    )
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(
+      _("Relationships"),
+      %i(ext_management_system physical_rack physical_chassis)
+    )
+  end
+
+  def textual_group_asset_details
+    TextualGroup.new(
+      _("Asset Details"),
+      %i(machine_type model contact location room_id rack_name lowest_rack_unit)
+    )
+  end
+
+  def textual_physical_rack
+    rack_id = @record.physical_rack_id
+    return nil if rack_id.nil?
+
+    textual_link(PhysicalRack.find(rack_id))
+  end
+
+  def textual_physical_chassis
+    chassis_id = @record.physical_chassis_id
+    return nil if chassis_id.nil?
+
+    textual_link(PhysicalChassis.find(chassis_id))
+  end
+
+  def textual_ext_management_system
+    textual_link(ExtManagementSystem.find(@record.ems_id))
+  end
+
+  def textual_name
+    {:label => _("Name"), :value => @record.name }
+  end
+
+  def textual_product_name
+    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+  end
+
+  def textual_serial_number
+    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+  end
+
+  def textual_health_state
+    {:label => _("Health State"), :value => @record.health_state}
+  end
+
+  def textual_enclosures
+    {:label => _("Enclosure Count"), :value => @record.enclosures}
+  end
+
+  def textual_drive_bays
+    {:label => _("Drive Bays"), :value => @record.drive_bays}
+  end
+
+  def textual_uid_ems
+    {:label => _("UUID"), :value => @record.uid_ems }
+  end
+
+  def textual_description
+    {:label => _("Description"), :value => @record.asset_detail["description"]}
+  end
+
+  def textual_machine_type
+    {:label => _("Machine Type"), :value => @record.asset_detail["machine_type"]}
+  end
+
+  def textual_model
+    {:label => _("Model"), :value => @record.asset_detail["model"]}
+  end
+
+  def textual_contact
+    {:label => _("Contact"), :value => @record.asset_detail["contact"]}
+  end
+
+  def textual_location
+    {:label => _("Location"), :value => @record.asset_detail["location"]}
+  end
+
+  def textual_room_id
+    {:label => _("Room ID"), :value => @record.asset_detail["room_id"]}
+  end
+
+  def textual_rack_name
+    {:label => _("Rack Name"), :value => @record.asset_detail["rack_name"]}
+  end
+
+  def textual_lowest_rack_unit
+    {:label => _("Lowest Rack Unit"), :value => @record.asset_detail["lowest_rack_unit"]}
+  end
+end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -91,6 +91,7 @@ module Menu
           Menu::Item.new('physical_chassis', N_('Chassis'), 'physical_chassis', {:feature => 'physical_chassis_show_list'}, '/physical_chassis'),
           Menu::Item.new('physical_rack', N_('Racks'), 'physical_rack', {:feature => 'physical_rack_show_list'}, '/physical_rack'),
           Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
+          Menu::Item.new('physical_storage', N_('Storages'), 'physical_storage', {:feature => 'physical_storage_show_list'}, '/physical_storage'),
           Menu::Item.new('physical_switch', N_('Switches'),  'physical_switch', {:feature => 'physical_switch_show_list'}, '/physical_switch'),
           Menu::Item.new('physical_infra_topology', N_('Topology'), 'physical_infra_topology', {:feature => 'physical_infra_topology', :any => true}, '/physical_infra_topology'),
         ])

--- a/app/services/ems_physical_infra_dashboard_service.rb
+++ b/app/services/ems_physical_infra_dashboard_service.rb
@@ -34,24 +34,27 @@ class EmsPhysicalInfraDashboardService < DashboardService
   end
 
   def attributes_data
-    attributes = %i(physical_servers physical_switches physical_racks)
+    attributes = %i(physical_servers physical_switches physical_racks physical_storages)
 
     attr_icon = {
       :physical_servers  => 'pficon pficon-cluster',
       :physical_switches => 'pficon ff ff-network-switch',
       :physical_racks    => 'pficon pficon-enterprise',
+      :physical_storages => 'pficon pficon-container-node',
     }
 
     attr_url = {
       :physical_servers  => 'physical_servers',
       :physical_switches => 'physical_switches',
       :physical_racks    => 'physical_racks',
+      :physical_storages => 'physical_storages',
     }
 
     attr_hsh = {
       :physical_servers  => _('Servers'),
       :physical_switches => _('Switches'),
       :physical_racks    => _('Racks'),
+      :physical_storages => _('Storages'),
     }
 
     attr_data = []
@@ -117,7 +120,7 @@ class EmsPhysicalInfraDashboardService < DashboardService
       icon_class = 'pficon pficon-error-circle-o'
       count = critical
     elsif warning.positive?
-      icon_class = 'pficon pficon-warning-circle-o'
+      icon_class = 'pficon pficon-warning-triangle-o'
       count = warning
     elsif valid.positive?
       icon_class = 'pficon pficon-ok'

--- a/app/services/ui_service_mixin.rb
+++ b/app/services/ui_service_mixin.rb
@@ -25,6 +25,7 @@ module UiServiceMixin
       :PhysicalRack            => {:type => "glyph", :class => 'pficon pficon-enterprise'},
       :PhysicalServer          => {:type => "glyph", :class => 'pficon pficon-server-group'},
       :PhysicalSwitch          => {:type => "glyph", :class => 'ff ff-network-switch'},
+      :PhysicalStorage         => {:type => "glyph", :class => 'pficon-container-node'},
       :SecurityGroup           => {:type => "glyph", :class => 'pficon pficon-cloud-security'},
       :Tag                     => {:type => "glyph", :class => 'fa fa-tag'},
       :Vm                      => {:type => "glyph", :class => 'pficon pficon-virtual-machine'},

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -15,17 +15,20 @@
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
         %li
-          = li_link(:count => @record.number_of(:physical_switches),
-            :text          => _('Physical Switches'),
-            :record        => @record,
-            :display       => 'physical_switches')
           = li_link(:count => @record.number_of(:physical_servers),
             :tables        => 'physical_servers',
             :record        => @record,
             :display       => 'physical_servers')
-
           - hosts = (@record.physical_servers.select { |server| !server.host.nil? }).length
           = li_link(:count => hosts,
             :text          => _('Physical Servers with Host'),
             :record        => @record,
             :display       => 'physical_servers_with_host')
+          = li_link(:count => @record.number_of(:physical_storages),
+            :text          => _('Physical Storages'),
+            :record        => @record,
+            :display       => 'physical_storages')
+          = li_link(:count => @record.number_of(:physical_switches),
+            :text          => _('Physical Switches'),
+            :record        => @record,
+            :display       => 'physical_switches')

--- a/app/views/layouts/listnav/_physical_storage.html.haml
+++ b/app/views/layouts/listnav/_physical_storage.html.haml
@@ -1,0 +1,17 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "ems_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Summary'), {:action => 'show', :id => @record, :display => 'main'}, {:title => _("Show Summary")})
+
+    = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - if  @record.ext_management_system
+          %li
+            = link_to(_("Provider: %{name}") % {:name => @record.ext_management_system.name},
+              ems_physical_infra_path(@record.ext_management_system.id),
+              :title => _("Show this parent Provider"))

--- a/app/views/physical_rack/show.html.haml
+++ b/app/views/physical_rack/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(physical_chassis physical_servers).include?(@display)
+  - if %w(physical_chassis physical_racks physical_servers physical_storages).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/app/views/physical_storage/show.html.haml
+++ b/app/views/physical_storage/show.html.haml
@@ -1,0 +1,14 @@
+#main_div
+  - if %w(physical_rack physical_chassis).include?(@display)
+    = render :partial => 'layouts/gtl', :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    - case @showtype
+    - when "main"
+      = render :partial => 'layouts/textual_groups_generic'
+    - when "timeline"
+      = render :partial => 'layouts/tl_show_async'
+
+  %physical-storage-toolbar#physical_storage_show_form{'physical-storage-id' => @record.id}
+
+:javascript
+  miq_bootstrap('#physical_storage_show_form');

--- a/app/views/physical_storage/show_list.html.haml
+++ b/app/views/physical_storage/show_list.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  = render :partial => 'layouts/gtl'
+
+  %physical-switch-toolbar#physical_storage_show_list_form
+
+:javascript
+  miq_bootstrap('#physical_storage_show_list_form');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1379,21 +1379,37 @@ Rails.application.routes.draw do
       )
     },
 
-    :physical_network_port    =>  {
-      :get  =>  %w(
+    :physical_network_port    => {
+      :get  => %w(
         download_data
         show_list
         show
       ),
 
-      :post   =>  %w(
+      :post  => %w(
         button
         show_list
       )
     },
 
-    :physical_chassis    =>  {
-      :get  =>  %w(
+    :physical_storage    => {
+      :get  => %w(
+        download_data
+        show_list
+        show
+      ),
+
+      :post  => %w(
+        button
+        show_list
+        create
+        update
+        quick_search
+      ) + adv_search_post + save_post,
+    },
+
+    :physical_chassis    => {
+      :get  => %w(
         download_data
         perf_top_chart
         protect
@@ -1401,7 +1417,7 @@ Rails.application.routes.draw do
         show
       ),
 
-      :post   =>  %w(
+      :post  => %w(
         button
         show_list
         quick_search

--- a/product/views/PhysicalStorage.yaml
+++ b/product/views/PhysicalStorage.yaml
@@ -1,0 +1,63 @@
+#Report title
+title: Physical Storages
+
+#Menu name
+name: Physical Storage
+
+
+db: PhysicalStorage
+
+
+# Columns to fetch from main table
+cols:
+- name
+- type
+- health_state
+- power_state
+- asset_detail
+
+
+include:
+
+
+include_for_find:
+  :ext_management_system: {}
+
+
+col_order:
+- name
+- type
+- health_state
+- power_state
+- asset_detail.product_name
+- asset_detail.manufacturer
+
+col_formats:
+-
+- :model_name
+
+headers:
+- Name
+- Type
+- Health State
+- Power State
+- Product Name
+- Manufacturer
+
+
+conditions:
+
+
+order: Ascending
+
+
+sortby:
+- name
+
+group: n
+
+
+graph:
+
+
+dims:

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -1,0 +1,69 @@
+describe PhysicalStorageController do
+  render_views
+
+  let(:physical_storage) do
+    ems = FactoryGirl.create(:ems_physical_infra)
+    asset_detail = FactoryGirl.create(:asset_detail)
+    FactoryGirl.create(:physical_storage, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+  end
+
+  before do
+    stub_user(:features => :all)
+    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user)
+  end
+
+  describe "#show_list" do
+    subject { get(:show_list) }
+
+    context '#GTL' do
+      it "renders a GTL page" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_gtl")
+      end
+
+      it 'renders GTL with PhysicalStorage model' do
+        physical_storage
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name      => physical_storage.class.to_s,
+                                                                                         :gtl_type_string => "list",)
+        post :show_list
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context '#report_data' do
+      it 'calls "page_display_options" and returns the MiqRequest data' do
+        physical_storage
+        report_data_request(
+          :model => physical_storage.class.to_s,
+        )
+        results = assert_report_data_response
+        expect(results['data']['rows'].length).to eq(1)
+      end
+    end
+  end
+
+  describe "#show" do
+    context "with valid id" do
+      subject { get(:show, :params => {:id => physical_storage.id}) }
+
+      it "should respond to show" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      end
+    end
+
+    context "with invalid id" do
+      subject { get(:show, :params => {:id => 2}) }
+
+      it "should redirect to #show_list" do
+        is_expected.to have_http_status 302
+        is_expected.to redirect_to(:action => :show_list)
+
+        flash_messages = assigns(:flash_array)
+        expect(flash_messages.first[:message]).to include("Can't access selected records")
+      end
+    end
+  end
+end

--- a/spec/helpers/physical_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_storage_helper/textual_summary_spec.rb
@@ -1,0 +1,291 @@
+describe PhysicalStorageHelper::TextualSummary do
+  include ApplicationHelper
+
+  let(:ems) do
+    FactoryGirl.create(:physical_infra,
+                       :name      => 'LXCA',
+                       :hostname  => 'my.physicalinfra.com',
+                       :port      => '443',
+                       :ipaddress => '1.2.3.4')
+  end
+
+  let(:asset_detail) do
+    FactoryGirl.create(:asset_detail,
+                       :machine_type     => '6411',
+                       :model            => 'S2200',
+                       :contact          => 'Jonas Arioli',
+                       :location         => 'teste',
+                       :room             => 'Room',
+                       :rack_name        => 'teste',
+                       :lowest_rack_unit => '46',
+                       :product_name     => 'S2200',
+                       :manufacturer     => 'IBM',
+                       :serial_number    => '2647DA',
+                       :description      => 'S2200 used to test dh-storage-irm')
+  end
+
+  let(:network) do
+    FactoryGirl.build(:network, :ipaddress => '10.243.5.64')
+  end
+
+  let(:guest_device) do
+    FactoryGirl.build(:guest_device,
+                      :device_type => 'management',
+                      :network     => network)
+  end
+
+  let(:hardware) do
+    FactoryGirl.build(:hardware, :guest_devices => [guest_device])
+  end
+
+  let(:computer_system) do
+    FactoryGirl.build(:computer_system, :hardware => hardware)
+  end
+
+  let(:physical_rack) do
+    FactoryGirl.create(:physical_rack, :name => 'Rack XYZ')
+  end
+
+  let(:physical_storage) do
+    FactoryGirl.create(:physical_storage,
+                       :ems_id               => ems.id,
+                       :uid_ems              => '208000C0FF2647DA',
+                       :name                 => 'S2200-Test',
+                       :health_state         => 'Warning',
+                       :access_state         => 'Online',
+                       :overall_health_state => 'Warning',
+                       :drive_bays           => 24,
+                       :enclosures           => 1,
+                       :canister_slots       => 2,
+                       :asset_detail         => asset_detail,
+                       :computer_system      => computer_system,
+                       :physical_rack        => physical_rack)
+  end
+
+  before do
+    @record = physical_storage
+  end
+
+  #
+  # Textual Groups
+  # Properties, Relationships, Management Network, Slots
+  #
+  describe '.textual_group_properties' do
+    subject { textual_group_properties }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Properties')
+    end
+
+    it 'shows 8 fields' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(8)
+    end
+
+    it 'shows main properties' do
+      expect(subject.items).to include(
+        :name,
+        :product_name,
+        :serial_number,
+        :health_state,
+        :enclosures,
+        :drive_bays,
+        :uid_ems,
+        :description
+      )
+    end
+  end
+
+  describe '.textual_group_relationships' do
+    subject { textual_group_relationships }
+
+    it 'has the right title' do
+      expect(subject.title).to eq('Relationships')
+    end
+
+    it 'shows 2 relationships' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(3)
+    end
+
+    it 'shows main relationships' do
+      expect(subject.items).to include(:ext_management_system, :physical_rack, :physical_chassis)
+    end
+  end
+
+  describe '.textual_group_asset_details' do
+    subject { textual_group_asset_details }
+
+    it 'shows 7 asset_details info' do
+      expect(subject.items).to be_kind_of(Array)
+      expect(subject.items.size).to eq(7)
+    end
+
+    it 'shows main storage asset details' do
+      expect(subject.items).to include(
+        :machine_type,
+        :model,
+        :contact,
+        :location,
+        :room_id,
+        :rack_name,
+        :lowest_rack_unit
+      )
+    end
+  end
+
+  #
+  # Properties
+  #
+  describe '.textual_name' do
+    subject { textual_name }
+
+    it 'show the storage name' do
+      expect(subject).to eq(:label => 'Name', :value => 'S2200-Test')
+    end
+  end
+
+  describe '.textual_product_name' do
+    subject { textual_product_name }
+
+    it 'show the storage product name' do
+      expect(subject).to eq(:label => 'Product Name', :value => 'S2200')
+    end
+  end
+
+  describe '.textual_serial_number' do
+    subject { textual_serial_number }
+
+    it 'show the storage Serial Number' do
+      expect(subject).to eq(:label => 'Serial Number', :value => '2647DA')
+    end
+  end
+
+  describe '.textual_health_state' do
+    subject { textual_health_state }
+
+    it 'show the storage Health State' do
+      expect(subject).to eq(:label => 'Health State', :value => 'Warning')
+    end
+  end
+
+  describe '.textual_enclosures' do
+    subject { textual_enclosures }
+
+    it 'show the storage Enclosure Count' do
+      expect(subject).to eq(:label => 'Enclosure Count', :value => 1)
+    end
+  end
+
+  describe '.textual_drive_bays' do
+    subject { textual_drive_bays }
+
+    it 'show the storage Drive Bays' do
+      expect(subject).to eq(:label => 'Drive Bays', :value => 24)
+    end
+  end
+
+  describe '.textual_uid_ems' do
+    subject { textual_uid_ems }
+
+    it 'show the storage UUID' do
+      expect(subject).to eq(:label => 'UUID', :value => '208000C0FF2647DA')
+    end
+  end
+
+  describe '.textual_description' do
+    subject { textual_description }
+
+    it 'show the storage description' do
+      expect(subject).to eq(:label => 'Description', :value => 'S2200 used to test dh-storage-irm')
+    end
+  end
+
+  #
+  # Relashionships
+  #
+  describe '.textual_ext_management_system' do
+    subject { textual_ext_management_system }
+
+    it 'show the storage provider' do
+      expect(subject).to eq(
+        :label => 'Physical Infrastructure Provider',
+        :icon  => nil,
+        :value => 'LXCA',
+        :image => 'svg/vendor-lenovo_ph_infra.svg'
+      )
+    end
+  end
+
+  describe '.textual_physical_rack' do
+    subject { textual_physical_rack }
+
+    it 'show the storage physical rack' do
+      expect(subject).to eq(
+        :label => "Physical Rack",
+        :value => "Rack XYZ",
+        :icon  => "pficon pficon-enterprise",
+        :image => nil
+      )
+    end
+  end
+
+  #
+  # Asset Details
+  #
+  describe '.textual_machine_type' do
+    subject { textual_machine_type }
+
+    it 'show the storage Machine Type' do
+      expect(subject).to eq(:label => 'Machine Type', :value => '6411')
+    end
+  end
+
+  describe '.textual_model' do
+    subject { textual_model }
+
+    it 'show the storage Model' do
+      expect(subject).to eq(:label => 'Model', :value => 'S2200')
+    end
+  end
+
+  describe '.textual_contact' do
+    subject { textual_contact }
+
+    it 'show the storage Contact' do
+      expect(subject).to eq(:label => 'Contact', :value => 'Jonas Arioli')
+    end
+  end
+
+  describe '.textual_location' do
+    subject { textual_location }
+
+    it 'show the storage Location' do
+      expect(subject).to eq(:label => 'Location', :value => 'teste')
+    end
+  end
+
+  describe '.textual_room_id' do
+    subject { textual_room_id }
+
+    it 'show the storage Room ID' do
+      expect(subject).to eq(:label => 'Room ID', :value => nil)
+    end
+  end
+
+  describe '.textual_rack_name' do
+    subject { textual_rack_name }
+
+    it 'show the storage Rack Name' do
+      expect(subject).to eq(:label => 'Rack Name', :value => 'teste')
+    end
+  end
+
+  describe '.textual_lowest_rack_unit' do
+    subject { textual_lowest_rack_unit }
+
+    it 'show the storage Lowest Rack Unit' do
+      expect(subject).to eq(:label => 'Lowest Rack Unit', :value => '46')
+    end
+  end
+end


### PR DESCRIPTION
This PR is able to:
- Add PhysicalStorages to dashboard view
- Add PhysicalStorages list page
- Add PhysicalStorages summary page

Depends on:
- ~[ManageIQ/manageiq-schema#224](https://github.com/ManageIQ/manageiq-schema/pull/224)~ [Merged]
- ~[ManageIQ/manageiq#17616](https://github.com/ManageIQ/manageiq/pull/17616)~ [Merged]
- ~[ManageIQ/manageiq-providers-lenovo#201](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/201)~ [Merged]
- ~[ManageIQ/manageiq#17586](https://github.com/ManageIQ/manageiq/pull/17586)~ [Merged]
- ~[ManageIQ/manageiq-api#397](https://github.com/ManageIQ/manageiq-api/pull/397)~ [Merged]
- ~[ManageIQ/manageiq-ui-classic#4065](https://github.com/ManageIQ/manageiq-ui-classic/pull/4065)~ [Merged]

**Storage Menu:**
![image](https://user-images.githubusercontent.com/7563089/41742388-2adf07b6-7574-11e8-8bea-d667fe890411.png)

**Storage On Physical Infra Provider Dashboard:**
![image](https://user-images.githubusercontent.com/7563089/41797800-c5939222-7641-11e8-9223-965271b66882.png)

**Storage On Physical Infra Provider Summary Page:**
![image](https://user-images.githubusercontent.com/7563089/41797920-31aa5676-7642-11e8-98a8-4f960a0d54a5.png)

**Storage List Page:**
![image](https://user-images.githubusercontent.com/7563089/41797975-68a2d27a-7642-11e8-9b99-67b7feec98b6.png)

**Storage Summary Page:**
![image](https://user-images.githubusercontent.com/7563089/42292106-77574d4c-7fa6-11e8-8f15-af1727477c59.png)

**Storage Inside Rack Reference**
![image](https://user-images.githubusercontent.com/7563089/42292125-968f7e96-7fa6-11e8-8f63-d463b0a5798d.png)
