### PR TITLE
Use fonticons for relative/specific date selection in exp editor

### DIFF
--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -111,23 +111,23 @@
             - else
               = h(@edit[@expkey][:exp_value][1])
         - if @edit[@expkey][:val1][:date_format] == 's'
-          - t = _('Click to change to a relative Date/Time format')
-          = link_to(image_tag(image_path('toolbars/specific_date.png'), :class => "rollover tiny", :alt => t),
-            {:action => 'exp_changed', :date_format_1 => 'r'},
+          = link_to({:action => 'exp_changed', :date_format_1 => 'r'},
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             :remote                => true,
+            :class                 => 'btn btn-default',
             "data-method"          => :post,
-            :title                 => t)
+            :title                 => _('Click to change to a relative Date/Time format')) do
+            %i.fa.fa-moon-o
         - else
-          - t = _('Click to change to a specific Date/Time format')
-          = link_to(image_tag(image_path('toolbars/relative_date.png'), :class => "rollover tiny", :alt => t),
-            {:action => 'exp_changed', :date_format_1 => 's'},
+          = link_to({:action => 'exp_changed', :date_format_1 => 's'},
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             :remote                => true,
+            :class                 => 'btn btn-default',
             "data-method"          => :post,
-            :title                 => t)
+            :title                 => _('Click to change to a specific Date/Time format')) do
+            %i.fa.fa-calendar
 
       - else
         -# String field

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -94,23 +94,23 @@
               = h(@edit[@expkey][:exp_value][1])
 
         - if @edit[@expkey][:val1][:date_format] == 's'
-          - t = _('Click to change to a relative Date/Time format')
-          = link_to(image_tag(image_path('toolbars/specific_date.png'), :class => "rollover tiny", :alt => t),
-            {:action => 'exp_changed', :date_format_1 => 'r'},
+          = link_to({:action => 'exp_changed', :date_format_1 => 'r'},
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             :remote                => true,
+            :class                 => 'btn btn-default',
             "data-method"          => :post,
-            :title                 => t)
+            :title                 => _('Click to change to a relative Date/Time format'))
+            %i.fa.fa-moon-o
         - else
-          - t = _('Click to change to a specific Date/Time format')
-          = link_to(image_tag(image_path('toolbars/relative_date.png'), :class => "rollover tiny", :alt => t),
-            {:action => 'exp_changed', :date_format_1 => 's'},
+          = link_to({:action => 'exp_changed', :date_format_1 => 's'},
             "data-miq_sparkle_on"  => true,
             "data-miq_sparkle_off" => true,
             :remote                => true,
+            :class                 => 'btn btn-default',
             "data-method"          => :post,
-            :title                 => t)
+            :title                 => _('Click to change to a specific Date/Time format'))
+            %i.fa.fa-calendar
 
       - else
         = text_field_tag("chosen_value", @edit[@expkey][:exp_value],
@@ -210,23 +210,23 @@
                   = h(@edit[@expkey][:exp_cvalue][1])
 
             - if @edit[@expkey][:val2][:date_format] == 's'
-              - t = _('Click to change to a relative Date/Time format')
-              = link_to(image_tag(image_path('toolbars/specific_date.png'), :class => "rollover tiny", :alt => t),
-                {:action => 'exp_changed', :date_format_2 => 'r'},
+              = link_to({:action => 'exp_changed', :date_format_2 => 'r'},
                 "data-miq_sparkle_on"  => true,
                 "data-miq_sparkle_off" => true,
                 :remote                => true,
+                :class                 => 'btn btn-default',
                 "data-method"          => :post,
-                :title                 => t)
+                :title                 => _('Click to change to a relative Date/Time format')) do
+                %i.fa.fa-moon-o
             - else
-              - t = _('Click to change to a specific Date/Time format')
-              = link_to(image_tag(image_path('toolbars/relative_date.png'), :class => "rollover tiny", :alt => t),
-                {:action => 'exp_changed', :date_format_2 => 's'},
+              = link_to({:action => 'exp_changed', :date_format_2 => 's'},
                 "data-miq_sparkle_on"  => true,
                 "data-miq_sparkle_off" => true,
                 :remote                => true,
+                :class                 => 'btn btn-default',
                 "data-method"          => :post,
-                :title                 => t)
+                :title                 => _('Click to change to a specific Date/Time format')) do
+                %i.fa.fa-calendar
 
           - else
             = text_field_tag("chosen_cvalue", @edit[@expkey][:exp_cvalue],


### PR DESCRIPTION
Since I [removed](https://github.com/ManageIQ/manageiq-ui-classic/pull/4151) the toolbar PNG files, the expression editor produces 404 errors for the date buttons. This PR fixes these issues by replacing the images with fonticons.

![screenshot from 2018-06-20 13-57-13](https://user-images.githubusercontent.com/649130/41656991-0fbe0a32-7492-11e8-9543-e2be80d0bd9a.png)
![screenshot from 2018-06-20 13-57-20](https://user-images.githubusercontent.com/649130/41656993-0fe9f3e0-7492-11e8-82fc-ccb8cd063800.png)

@miq-bot add_label bug, gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4051