### PR TITLE
Change the paste image with a fonticon in custom button forms

### DIFF
--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,20 +1,17 @@
 #ab_form
   #policy_bar
     - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]
-
-      %li
-        - t = _("Paste object details for use in a Button.")
-        = link_to(image_tag(image_path('toolbars/paste.png'), :border => "0", :class  => "", :alt => t),
-          {:action => "resolve", :button => "paste"},
-          "data-miq_sparkle_on"  => true,
-          "data-miq_sparkle_off" => true,
-          :remote                => true,
-          "data-method"          => :post,
-          :title                 => t)
+      = link_to({:action => "resolve", :button => "paste"},
+        "data-miq_sparkle_on"  => true,
+        "data-miq_sparkle_off" => true,
+        :remote                => true,
+        "data-method"          => :post,
+        :class                 => 'btn btn-default',
+        :title                 => _("Paste object details for use in a Button.")) do
+        %i.fa.fa-clipboard
     - else
-      = image_tag(image_path('toolbars/paste.png'),
-        :class => "dimmed",
-        :title => _("Paste is not available, no object information has been copied from the Simulation screen"))
+      %button.btn.btn-default.disabled{:title => _("Paste is not available, no object information has been copied from the Simulation screen")}
+        %i.fa.fa-clipboard
   = render :partial => "layouts/flash_msg"
 
   #custom_button_tabs


### PR DESCRIPTION
Removed the PNGs but forgot to replace all the references, this fixes a 404 error when creating/editing a custom button.

![screenshot from 2018-06-20 14-09-52](https://user-images.githubusercontent.com/649130/41657418-9f3ffb38-7493-11e8-9572-da0c3e5878ed.png)

![screenshot from 2018-06-20 14-09-34](https://user-images.githubusercontent.com/649130/41657402-9516c088-7493-11e8-9b26-44b525e061c4.png)

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4051

@miq-bot add_label bug, gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 