### PR TITLE
Move setting toolbar filename to Ansible Playbook/Repository/Credential controllers

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -55,6 +55,11 @@ class AnsibleCredentialController < ApplicationController
     @id = auth.id
   end
 
+  def toolbar
+    return 'ansible_repositories_center' if %w(repositories).include?(@display) # for nested list screen
+    %w(show_list).include?(@lastaction) ? 'ansible_credentials_center' : 'ansible_credential_center'
+  end
+
   private
 
   def textual_group_list

--- a/app/controllers/ansible_playbook_controller.rb
+++ b/app/controllers/ansible_playbook_controller.rb
@@ -21,6 +21,10 @@ class AnsiblePlaybookController < ApplicationController
     end
   end
 
+  def toolbar
+    %w(show_list).include?(@lastaction) ? 'ansible_playbooks_center' : 'ansible_playbook_center'
+  end
+
   private
 
   def textual_group_list

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -110,6 +110,11 @@ class AnsibleRepositoryController < ApplicationController
     javascript_flash
   end
 
+  def toolbar
+    return 'ansible_playbooks_center' if %w(playbooks).include?(@display) # for nested list screen
+    %w(show_list).include?(@lastaction) ? 'ansible_repositories_center' : 'ansible_repository_center'
+  end
+
   private
 
   def textual_group_list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -778,6 +778,8 @@ module ApplicationHelper
                               "#{controller.class.toolbar_plural}_center_tb"
                             elsif controller.class.toolbar_singular.present?
                               "#{controller.class.toolbar_singular}_center_tb"
+                            elsif controller.try(:toolbar)
+                              controller.toolbar.to_s
                             else
                               center_toolbar_filename
                             end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -431,7 +431,6 @@ class ApplicationHelper::ToolbarChooser
                     security_groups storages middleware_deployments
                     middleware_servers)
     to_display_center = %w(stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers guest_devices)
-    to_display_ansible = %w(playbooks repositories credentials)
     performance_layouts = %w(vm host ems_container)
 
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
@@ -449,8 +448,6 @@ class ApplicationHelper::ToolbarChooser
         return "#{@layout}_center_tb"
       elsif to_display.include?(@display)
         return "#{@display}_center_tb"
-      elsif to_display_ansible.include?(@display) # toolbars for nested list screens of Ansible Playbooks/Repositories/Credentials
-        return "ansible_#{@display}_center"
       elsif to_display_center.include?(@display)
         return "#{@display}_center"
       elsif @layout == 'ems_container'
@@ -540,25 +537,9 @@ class ApplicationHelper::ToolbarChooser
         return @lastaction == 'show_list' ? 'miq_requests_center_tb' : 'miq_request_center_tb'
       elsif %w(my_tasks all_tasks).include?(@layout)
         return "tasks_center_tb"
-      elsif @layout.to_s.starts_with?("manageiq") # toolbars for list/summary screens of Ansible Playbooks/Repositories/Credentials
-        return "#{center_toolbar_filename_embedded_ansible}_center"
       end
     end
     nil
-  end
-
-  def center_toolbar_filename_embedded_ansible
-    case @layout
-    when "manageiq/providers/embedded_ansible/automation_manager/playbook"
-      toolbar_filename = "ansible_playbook"
-    when "manageiq/providers/embedded_automation_manager/configuration_script_source"
-      toolbar_filename = "ansible_repository"
-    when "manageiq/providers/embedded_automation_manager/authentication"
-      toolbar_filename = "ansible_credential"
-    else
-      return
-    end
-    %w(show_list).include?(@lastaction) ? toolbar_filename.pluralize : toolbar_filename
   end
 
   def x_node_split

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -89,4 +89,37 @@ describe AnsibleCredentialController do
       end
     end
   end
+
+  describe '#toolbar' do
+    let(:action) { 'show' }
+    subject { controller.send(:toolbar) }
+
+    before do
+      controller.instance_variable_set(:@lastaction, action)
+    end
+
+    context 'displaying list of credentials' do
+      let(:action) { 'show_list' }
+
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_credentials_center')
+      end
+    end
+
+    context 'displaying summary screen of a credential' do
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_credential_center')
+      end
+    end
+
+    context 'displaying nested list of repositories' do
+      before do
+        controller.instance_variable_set(:@display, 'repositories')
+      end
+
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_repositories_center')
+      end
+    end
+  end
 end

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -55,4 +55,27 @@ describe AnsiblePlaybookController do
       end
     end
   end
+
+  describe '#toolbar' do
+    let(:action) { 'show' }
+    subject { controller.send(:toolbar) }
+
+    before do
+      controller.instance_variable_set(:@lastaction, action)
+    end
+
+    context 'displaying list of playbooks' do
+      let(:action) { 'show_list' }
+
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_playbooks_center')
+      end
+    end
+
+    context 'displaying summary screen of a playbook' do
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_playbook_center')
+      end
+    end
+  end
 end

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -126,4 +126,37 @@ describe AnsibleRepositoryController do
       end
     end
   end
+
+  describe '#toolbar' do
+    let(:action) { 'show' }
+    subject { controller.send(:toolbar) }
+
+    before do
+      controller.instance_variable_set(:@lastaction, action)
+    end
+
+    context 'displaying list of repositories' do
+      let(:action) { 'show_list' }
+
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_repositories_center')
+      end
+    end
+
+    context 'displaying summary screen of repository' do
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_repository_center')
+      end
+    end
+
+    context 'displaying nested list of playbooks' do
+      before do
+        controller.instance_variable_set(:@display, 'playbooks')
+      end
+
+      it 'returns proper toolbar filename' do
+        expect(subject).to eq('ansible_playbooks_center')
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -173,38 +173,4 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
     end
   end
-
-  describe '#center_toolbar_filename_classic' do
-    subject { chooser.send(:center_toolbar_filename_classic) }
-
-    {
-      "manageiq/providers/embedded_ansible/automation_manager/playbook"            => "playbook",
-      "manageiq/providers/embedded_automation_manager/configuration_script_source" => "repository",
-      "manageiq/providers/embedded_automation_manager/authentication"              => "credential"
-    }.each do |layout, screen|
-      context "toolbar for summary screen of Ansible #{screen}" do
-        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :display => "main", :lastaction => "show", :layout => layout) }
-
-        it 'returns proper toolbar filename for the screen' do
-          expect(subject).to eq("ansible_#{screen}_center")
-        end
-      end
-
-      context "toolbars for list screens of Ansible #{screen.pluralize}" do
-        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :lastaction => "show_list", :layout => layout) }
-
-        it 'returns proper toolbar filename for the screen' do
-          expect(subject).to eq("ansible_#{screen.pluralize}_center")
-        end
-      end
-
-      context "toolbars for nested list screens of Ansible #{screen.pluralize}" do
-        let(:chooser) { ApplicationHelper::ToolbarChooser.new(nil, nil, :display => screen.pluralize, :lastaction => "show", :layout => layout) }
-
-        it 'returns proper toolbar filename for the screen' do
-          expect(subject).to eq("ansible_#{screen.pluralize}_center")
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
**Related (older) PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3721

**What:**
Move setting toolbar filename to Ansible Playbook/Repository/Credential controllers, by using new controller's method `toolbar_filename` to set toolbar filename properly.

**Why:**
Avoid defining various ugly methods in toolbar chooser for setting toolbar filename.
