### PR TITLE
Enforce version 2.13.2 of redux-devtools-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-redux": "^5.0.7",
     "react-select": "~1.2.1",
     "redux": "~3.7.2",
-    "redux-devtools-extension": "^2.13.2",
+    "redux-devtools-extension": "2.13.2",
     "rxjs": "~5.6.0-forward-compat.2",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8"


### PR DESCRIPTION
 `redux-devtools-extension` v2.13.3 is broken and `bin/webpack` isn't working

@himdel opened issue https://github.com/zalmoxisus/redux-devtools-extension/issues/519

Run `bin/webpack`

Before:
```
ERROR in [at-loader] ./node_modules/redux-devtools-extension/index.d.ts:159:60 
    TS2314: Generic type 'StoreEnhancer' requires 1 type argument(s).

ERROR in [at-loader] ./node_modules/redux-devtools-extension/index.d.ts:161:61 
    TS2314: Generic type 'StoreEnhancer' requires 1 type argument(s).
```
After:
It works again.

@miq-bot add_label bug, dependencies

@himdel please have a look, thanks :)