### PR TITLE
Don't enforce  v2.13.2 of redux-devtools-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-redux": "^5.0.7",
     "react-select": "~1.2.1",
     "redux": "~3.7.2",
-    "redux-devtools-extension": "2.13.2",
+    "redux-devtools-extension": "~2.13.5",
     "rxjs": "~5.6.0-forward-compat.2",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8"


### PR DESCRIPTION
Before release of `v2.13.5` there was following error:
```
ERROR in [at-loader] ./node_modules/redux-devtools-extension/index.d.ts:159:60
    TS2314: Generic type 'StoreEnhancer' requires 1 type argument(s).

ERROR in [at-loader] ./node_modules/redux-devtools-extension/index.d.ts:161:61
    TS2314: Generic type 'StoreEnhancer' requires 1 type argument(s).
```
That was [fixed](https://github.com/ManageIQ/manageiq-ui-classic/pull/4174) by enforcing `v2.13.2`. But we don't need that change anymore so getting back to original :)

How to reproduce:
Run `bin/webpack`

@miq-bot add_label gaprindashvili/yes, dependencies
