### PR TITLE
Ensure lodash 3 is available via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "kubernetes-topology-graph": "~0.0.23",
+    "lodash": "~3.10.0",
     "manageiq-ui-components": "bower-dev",
     "moment-duration-format": "~1.3.0",
     "moment-strftime": "~0.2.0",

--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -22,7 +22,6 @@ else
 end
 
 require 'high_voltage'
-require 'lodash-rails'
 require 'jquery-hotkeys-rails'
 require "novnc-rails"
 require 'webpacker'

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency "font-fabulous", "~> 1.0.2"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "jquery-hotkeys-rails"
-  s.add_dependency "lodash-rails", "~>3.10.0"
   s.add_dependency "more_core_extensions", "~>3.2"
   s.add_dependency "novnc-rails", "~>0.2"
   s.add_dependency "patternfly-sass", "~> 3.48.4"


### PR DESCRIPTION
we're still on lodash3, required via bower (in application.js).

but looks like at some point we've lost the explicit bower dependency

and now, something started depending on lodash4, breaking the UI:

```
angular.self-4d4ad11…a00bb8370c.js:14801 TypeError: _.contains is not a function
    at ToolbarController (toolbar_controller.s…fd6b619fb5f82.js:66)
    at Object.invoke (angular.self-4d4ad11…2a00bb8370c.js:5107)
    at $controllerInit (angular.self-4d4ad11…a00bb8370c.js:11077)
    at nodeLinkFn (angular.self-4d4ad11…2a00bb8370c.js:9940)
    at compositeLinkFn (angular.self-4d4ad11…2a00bb8370c.js:9249)
    at publicLinkFn (angular.self-4d4ad11…2a00bb8370c.js:9114)
    at angular.self-4d4ad11…2a00bb8370c.js:1961
    at Scope.$eval (angular.self-4d4ad11…a00bb8370c.js:18543)
    at Scope.$apply (angular.self-4d4ad11…a00bb8370c.js:18642)
    at bootstrapApply (angular.self-4d4ad11…2a00bb8370c.js:1959)
(anonymous)	@	angular.self-4d4ad11…a00bb8370c.js:14801
miq_application.self…7bff860d22b.js:1223 Uncaught TypeError: _.contains is not a function
    at miqSelectPickerEvent (miq_application.self…7bff860d22b.js:1223)
    at show_list:1841
```

So.. removing the old and unused gem dependency on lodash, and adding a bower require.