### PR TITLE
Make policy assignment, simulation and tagging quads non-clickable

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -473,7 +473,7 @@ miq-quadicon > .single-wrapper {
 
 .no-action .miq-data-table,
 .no-action .miq-tile-section {
-  td {
+  td, a {
     cursor: default !important;
   }
 }

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -171,7 +171,7 @@ module ApplicationController::PolicySupport
     )
     # session[:pol_db] = session[:pol_db] == Vm ? VmOrTemplate : session[:pol_db]
     @politems = session[:pol_db].find(session[:pol_items]).sort_by(&:name)  # Get the db records
-    @view = get_db_view(session[:pol_db])             # Instantiate the MIQ Report view object
+    @view = get_db_view(session[:pol_db], :clickable => false) # Instantiate the MIQ Report view object
     @view.table = ReportFormatter::Converter.records2table(@politems, @view.cols + ['id'])
 
     @edit = {}
@@ -235,7 +235,7 @@ module ApplicationController::PolicySupport
     @edit[:pol_items] = session[:tag_items]
     @catinfo = {}
     @lastaction = "policy_sim"
-    @pol_view = get_db_view(session[:tag_db])       # Instantiate the MIQ Report view object
+    @pol_view = get_db_view(session[:tag_db], :clickable => false) # Instantiate the MIQ Report view object
     @pol_view.table = ReportFormatter::Converter.records2table(@tagitems, @pol_view.cols + ['id'])
 
     # Build the profiles selection list

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -221,7 +221,7 @@ module ApplicationController::Tags
       @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }
     end
 
-    @view = get_db_view(@tagging)               # Instantiate the MIQ Report view object
+    @view = get_db_view(@tagging, :clickable => false) # Instantiate the MIQ Report view object
     @view.table = ReportFormatter::Converter.records2table(@tagitems, @view.cols + ['id'])
 
     # Start with the first items assignments

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -15,7 +15,7 @@ module GtlHelper
     content_tag(
       'miq-tile-view', '',
       "ng-if"            => "dataCtrl.gtlType === 'grid' || dataCtrl.gtlType === 'tile'",
-      "ng-class"         => "{'no-action': dataCtrl.initObject.showUrl === ''}",
+      "ng-class"         => "{'no-action': dataCtrl.initObject.showUrl === false}",
       "settings"         => "dataCtrl.settings",
       "per-page"         => "dataCtrl.perPage",
       "rows"             => "dataCtrl.gtlData.rows",

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -156,7 +156,33 @@ describe StorageController do
         expect(main_content).to include("<h3>\n1 Datastore Being Tagged\n<\/h3>")
         expect(main_content).to include("modelName: 'Storage'")
         expect(main_content).to include("isExplorer: 'true' === 'true' ? true : false")
-        expect(main_content).to include("showUrl: '/storage/x_show/'")
+      end
+
+      it "tagging has no clickable quadicons" do
+        ems = FactoryGirl.create(:ems_vmware)
+        datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+        datastore.parent = ems
+        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryGirl.create(:classification_tag,
+                                   :name   => "tag1",
+                                   :parent => classification)
+        @tag2 = FactoryGirl.create(:classification_tag,
+                                   :name   => "tag2",
+                                   :parent => classification)
+        allow(Classification).to receive(:find_assigned_entries).and_return([@tag1, @tag2])
+
+        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+          :model_name                     => 'Storage',
+          :report_data_additional_options => {
+            :model     => "Storage",
+            :clickable => false
+          }
+        )
+
+        post :x_button, :params => {:miq_grid_checks => datastore.id, :pressed => "storage_tag", :format => :js}
+
+        expect(response.status).to eq(200)
+        expect(response.body).to_not be_empty
       end
 
       it 'can Perform a datastore Smart State Analysis from the datastore summary page' do

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -207,6 +207,36 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  it 'policy management has no clickable quadicons' do
+    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      :model_name                     => 'VmOrTemplate',
+      :report_data_additional_options => {
+        :model     => "VmOrTemplate",
+        :clickable => false
+      }
+    )
+
+    post :x_button, :params => {:pressed => 'vm_protect', :id => vm_vmware.id}
+
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
+  end
+
+  it 'policy simulation has no clickable quadicons' do
+    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      :model_name                     => 'VmOrTemplate',
+      :report_data_additional_options => {
+        :model     => "VmOrTemplate",
+        :clickable => false
+      }
+    )
+
+    post :x_button, :params => {:pressed => 'vm_policy_sim', :id => vm_vmware.id}
+
+    expect(response.status).to eq(200)
+    expect(response.body).to_not be_empty
+  end
+
   it 'can cancel Manage Policies' do
     post :explorer
     expect(response.status).to eq(200)


### PR DESCRIPTION
On the policy simulation, policy assignment and tagging screens the quadicons should not be clickable. The solution is to pass the `:clickable => false` argument to the related `get_db_view` methods.

I also made the `miq_tile_view` method a little bit more consistent with the `miq_data_table` by setting the `no-action` class on it if `showUrl` is set to `false` in the controller. This parameter is being set by the 
`clickable` from above. @karelhala please validate this approach.

Then I edited the CSS overrides by disabling the hand cursor on links under `.no-action`, @epwinchell please take a look.

@miq-bot add_label bug, gtls, gaprindashvili/yes
@miq-bot assign @martinpovolny 

Fixes: #4175
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1593394