### PR TITLE
Don't show Add Flavor in sublist view

### DIFF
--- a/app/helpers/application_helper/button/new_flavor.rb
+++ b/app/helpers/application_helper/button/new_flavor.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::NewFlavor < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::NewFlavor < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
     super || ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::Flavor.supports?(:create) }
   end

--- a/spec/helpers/application_helper/buttons/new_flavor_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_flavor_spec.rb
@@ -1,6 +1,10 @@
 describe ApplicationHelper::Button::NewFlavor do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:button) { described_class.new(view_context, {}, {}, {}) }
+  let(:lastaction) { '' }
+  let(:display) { '' }
+  let(:button) { described_class.new(view_context, {}, {'lastaction' => lastaction, 'display' => display}, {}) }
+
+  it_behaves_like 'a _new or _discover button'
 
   describe '#disabled?' do
     subject { button[:title] }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1584158

**Before:**
Compute -> Cloud -> Providers -> choose one with flavors -> click Flavors in chosen provider summary screen -> Configuration
<img width="905" alt="screen shot 2018-06-21 at 4 03 29 pm" src="https://user-images.githubusercontent.com/9210860/41723933-ab2ef104-756c-11e8-9eb0-2cfdf6f73aab.png">
Compute -> Cloud -> Flavors -> Configuration
<img width="971" alt="screen shot 2018-06-21 at 3 58 14 pm" src="https://user-images.githubusercontent.com/9210860/41723706-0fd8b7a8-756c-11e8-8656-a3b3c4deb526.png">
**After:**
Compute -> Cloud -> Providers -> choose one with flavors -> click Flavors in chosen provider summary screen -> Configuration
<img width="924" alt="screen shot 2018-06-21 at 3 58 43 pm" src="https://user-images.githubusercontent.com/9210860/41723698-09419658-756c-11e8-81c3-c516e6491270.png">
Compute -> Cloud -> Flavors -> Configuration 
*No change!*
<img width="971" alt="screen shot 2018-06-21 at 3 58 14 pm" src="https://user-images.githubusercontent.com/9210860/41723706-0fd8b7a8-756c-11e8-8656-a3b3c4deb526.png">

`ApplicationHelper::Button::ButtonNewDiscover` handles `visible?` for buttons that may appear on sublist view screen and on list view screen.

@romanblanco @PanSpagetka Please review, thanks :)

@miq-bot add_label bug, gaprindashvili/yes, fine/yes, toolbars
