### PR TITLE
[WIP] Added demo to add amazon-security-group

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,4 +27,5 @@
  *= require ./remote_console
  *= require graphiql/graphiql.css
  *= require piecharts
+ *= require @manageiq/react-ui-components/dist/amazon-security-form-group.css
 */

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AmazonSecurityGroupForm } from '@manageiq/react-ui-components/dist/amazon-security-form-group';
+import { API } from '../http_api';
+
+const getData = () => API.get("/api/cloud_networks/?attributes=ems_ref,name,type&expand=resources&filter[]=type='ManageIQ::Providers::Amazon*'")
+  .then(data => data.resources.map(resource => ({
+    value: resource.ems_ref,
+    label: resource.name,
+  })));
+
+const createGroups = (values, providerId) =>
+  API.post(`/api/providers/${providerId}/security_groups`, {
+    action: 'create',
+    resource: { ...values },
+  });
+
+const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+  <AmazonSecurityGroupForm
+    onSave={values => createGroups(values, providerId)}
+    onCancel={() => console.log('Cancel clicked')}
+    loadData={getData}
+  />
+);
+
+CreateAmazonSecurityGroupForm.propTypes = {
+  providerId: PropTypes.number.isRequired,
+};
+
+export default CreateAmazonSecurityGroupForm;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -5,6 +5,7 @@ import TableListViewWrapper from '../react/table_list_view_wrapper';
 import GenericGroupWrapper from '../react/generic_group_wrapper';
 import { addReact } from '../miq-component/helpers';
 import VmSnapshotFormComponent from '../components/vm-snapshot-form-component';
+import CreateAmazonSecurityGroupForm from '../components/create-amazon-security-group-form';
 
 /**
 * Add component definitions to this file.
@@ -19,3 +20,4 @@ addReact('GenericGroup', GenericGroup);
 addReact('GenericGroupWrapper', GenericGroupWrapper);
 addReact('TextualSummaryWrapper', TextualSummaryWrapper);
 addReact('VmSnapshotFormComponent', VmSnapshotFormComponent);
+addReact('CreateAmazonSecurityGroupForm', CreateAmazonSecurityGroupForm);

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,21 +1,3 @@
 = render :partial => "layouts/flash_msg"
-- if  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
-  .row#modules
-    .col-md-6.col-lg-4#col1{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col1].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-    .col-md-6.col-lg-4#col2{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col2].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-    .col-md-6.col-lg-4#col3{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col3].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-- if WidgetPresenter.chart_data.present?
-  :javascript
-    ManageIQ.charts.chartData = #{{"widgetchart" => WidgetPresenter.chart_data}.to_json.html_safe};
+
+= react 'CreateAmazonSecurityGroupForm', {:providerId => 4}


### PR DESCRIPTION
Demo component for creating new amazon security groups. Eventually should be used with [this](https://github.com/ManageIQ/manageiq-providers-amazon/pull/453). UI is not complete, just functionality.

![screenshot from 2018-06-21 16-36-32](https://user-images.githubusercontent.com/22619452/41725929-4e33b85e-7571-11e8-9b42-fd0e2b1d8753.png)

Preview of form component is available at https://5b2bb82f0733d57f9bb3d44a--confident-banach-ee0a7a.netlify.com/?selectedKind=Amazon%20Security%20forms&selectedStory=Amazon%20Security%20form%20group&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel

