### PR TITLE
Fix issues in Reconfigure/Resize

### DIFF
--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
@@ -27,8 +27,9 @@ ManageIQ.angular.app.controller('vmCloudResizeFormController', ['$http', '$scope
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/resize_vm/' + vmCloudResizeFormId + '?button=submit';
-    miqService.miqAjaxButton(url, {objectId: vm.objectId,
-                                   flavor_id: vm.vmCloudModel.flavor_id});
+    miqService.miqAjaxButton(url, {
+      objectId: vm.objectId,
+      flavor_id: vm.vmCloudModel.flavor_id});
   };
 
   function getResizeFormData(response) {

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
@@ -13,6 +13,7 @@ ManageIQ.angular.app.controller('vmCloudResizeFormController', ['$http', '$scope
 
     vm.newRecord = vm.formId == 'new';
 
+    miqService.sparkleOn();
     $http.get('/vm_cloud/resize_form_fields/' + vm.formId + '?objectId=' + vm.objectId)
       .then(getResizeFormData)
       .catch(miqService.handleFailure);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
@@ -6,27 +6,27 @@ ManageIQ.angular.app.controller('vmCloudResizeFormController', ['$http', '$scope
       flavor_id: null,
     };
     vm.flavors = [];
-    vm.vmCloudResizeformId = vmCloudResizeFormId;
+    vm.formId = vmCloudResizeFormId;
     vm.objectId = objectId;
 
     ManageIQ.angular.scope = vm;
 
-    vm.newRecord = vmCloudResizeFormId == 'new';
+    vm.newRecord = vm.formId == 'new';
 
-    $http.get('/vm_cloud/resize_form_fields/' + vmCloudResizeFormId + '?objectId=' + vm.objectId)
+    $http.get('/vm_cloud/resize_form_fields/' + vm.formId + '?objectId=' + vm.objectId)
       .then(getResizeFormData)
       .catch(miqService.handleFailure);
   };
 
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/resize_vm/' + vmCloudResizeFormId + '?button=cancel';
+    var url = '/vm_cloud/resize_vm/' + vm.formId + '?button=cancel';
     miqService.miqAjaxButton(url, {objectId: vm.objectId});
   };
 
   $scope.submitClicked = function() {
     miqService.sparkleOn();
-    var url = '/vm_cloud/resize_vm/' + vmCloudResizeFormId + '?button=submit';
+    var url = '/vm_cloud/resize_vm/' + vm.formId + '?button=submit';
     miqService.miqAjaxButton(url, {
       objectId: vm.objectId,
       flavor_id: vm.vmCloudModel.flavor_id});

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_resize_form_controller.js
@@ -21,7 +21,9 @@ ManageIQ.angular.app.controller('vmCloudResizeFormController', ['$http', '$scope
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/resize_vm/' + vm.formId + '?button=cancel';
-    miqService.miqAjaxButton(url, {objectId: vm.objectId});
+    miqService.miqAjaxButton(url, {
+      objectId: vm.objectId,
+    });
   };
 
   $scope.submitClicked = function() {
@@ -29,7 +31,8 @@ ManageIQ.angular.app.controller('vmCloudResizeFormController', ['$http', '$scope
     var url = '/vm_cloud/resize_vm/' + vm.formId + '?button=submit';
     miqService.miqAjaxButton(url, {
       objectId: vm.objectId,
-      flavor_id: vm.vmCloudModel.flavor_id});
+      flavor_id: vm.vmCloudModel.flavor_id,
+    });
   };
 
   function getResizeFormData(response) {

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -48,7 +48,7 @@ module Mixins
             )
           end
           @sb[:explorer] = @explorer
-          @request_id = params[:req_id] ? params[:req_id] : nil
+          @request_id = params[:req_id]
           @in_a_form = true
           @resize = true
           render :action => "show" unless @explorer

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -3,7 +3,12 @@ module Mixins
     module VmActions
       module Resize
         def resizevms
-          assert_privileges(params[:pressed])
+          case params[:pressed]
+          when "instance_resize"
+            assert_privileges("instance_resize")
+          when "miq_request_edit"
+            assert_privileges("miq_request_edit")
+          end
           # if coming in to edit from miq_request list view
           recs = checked_or_params
           @record = nil

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -17,7 +17,6 @@ module Mixins
             @record = VmCloudReconfigureRequest.find(request_id).vms.first
           end
 
-          recs = [params[:id].to_i] if recs.blank?
           @record ||= find_record_with_rbac(VmOrTemplate, recs.first) # Set the VM object
           if @record.supports_resize?
             if @explorer

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -6,6 +6,7 @@ module Mixins
           assert_privileges(params[:pressed])
           # if coming in to edit from miq_request list view
           recs = checked_or_params
+          @record = nil
           if !session[:checked_items].nil? && (@lastaction == "set_checked_items" || params[:pressed] == "miq_request_edit")
             request_id = params[:id]
             @record = VmCloudReconfigureRequest.find(request_id).vms.first

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -8,6 +8,8 @@ module Mixins
             assert_privileges("instance_resize")
           when "miq_request_edit"
             assert_privileges("miq_request_edit")
+          else
+            raise MiqException::RbacPrivilegeException, _("The user is not authorized for this task or item.")
           end
           # if coming in to edit from miq_request list view
           recs = checked_or_params

--- a/app/views/vm_common/_resize.html.haml
+++ b/app/views/vm_common/_resize.html.haml
@@ -20,8 +20,7 @@
         %select{:name        => 'flavor_id',
                 'ng-model'   => 'vm.vmCloudModel.flavor_id',
                 'ng-options' => 'flavor.id as flavor.name for flavor in vm.flavors',
-                :miqrequired => true,
-                :checkchange => true}
+                :miqrequired => true}
 
   %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",


### PR DESCRIPTION
TODO:
- [x] keep vm.formId in the angular controller, no vmCloudResizeformId, especially not with the small f ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r195044205 )
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/d5e4ad7cbc1626be1dcaac2b0702ab999943adf0
- [x] fix the formatting on line 30 in the controller ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#diff-40f8be8bd21ba536e9696e881ec5b792R30 )
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/c4595a1fbe61a9e7d5de7fd1ff881e94a08f76aa
- [x] replace that assert_privileges(params[:pressed]) with an explicit check for the rbac features we're expecting ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194668783 )
Commits: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/8b1dc95b9d63b71c4a25edce1705058cd619556a https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/6128f848f8c9c90d691a69582f35fbb17b7818ec
- [x] make sure checked_or_params giving you params[:id] won't break anything, in either version ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194740761 )
```diff
-recs = find_checked_items
+ recs = checked_or_params
```
It's ok :)
Before:
```
recs = find_checked_items
[some code]
recs = [params[:id].to_i] if recs.blank?
```
After:
```diff
-recs = find_checked_items
+ recs = checked_or_params
[some code]
- recs = [params[:id].to_i] if recs.blank?
```
So just removing extra `recs = [params[:id].to_i] if recs.blank?` :)
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/b466d11cf0ed24dcddf6975c943b1d5f03a37547
- [x] fix the problem when @record would already be set ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194669262 )
https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194740662
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/99bc9d3e86c9e2428a7107225df469532c1be594
- [x] remove checkchange ( https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194673529 )
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/f9e748e9555517d7987e6309efc7158bed38eb60
- [x] this is just `@request_id = params[:req_id]` https://github.com/ManageIQ/manageiq-ui-classic/pull/2598/files#r194669547
Commit: https://github.com/ManageIQ/manageiq-ui-classic/pull/4182/commits/d69fc47e3f52be5f4435120e8704b02a6efb0d05

@miq-bot add_label gaprindashvili/yes, bug, wip

Fix for https://github.com/ManageIQ/manageiq-ui-classic/pull/2598