### PR TITLE
Add spec to fail on indirect inheritance of MiqDecorator

### DIFF
--- a/spec/decorators/miq_decorator_spec.rb
+++ b/spec/decorators/miq_decorator_spec.rb
@@ -1,0 +1,15 @@
+describe MiqDecorator do
+  described_class.descendants.each do |klass|
+    next if klass == described_class # Skipping MiqDecorator
+
+    # This spec is intended to test the decorators defined in the ui-classic repo
+    # Any other decorator coming from e.g. the providers is allowed to inherit indirectly
+    next unless File.exist?(ManageIQ::UI::Classic.root.join('app', 'decorators', "#{klass.to_s.underscore}.rb"))
+
+    context "subclass #{klass}" do
+      it "is directly inherited from #{described_class}" do
+        expect(klass.superclass).to be(described_class)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Code sharing by inheritance in decorators is something we don't want. Every decorator has to be inherited from the `MiqDecorator`, otherwise this test fails. This test only checks decorators that are defined in the `ui-classic`, on other places such as providers we want to allow inheritance.

@miq-bot add_reviewer @himdel 

@miq-bot add_label tests, gaprindashvili/no, developer