### PR TITLE
Remove remaining references to toolbar images

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -108,18 +108,15 @@
               = image_tag("#{@record.picture.url_path}?#{rand(99_999_999)}",
                           :style => "width:100px; height:100px;")
             .col-md-9{:valign => "bottom"}
-              = link_to(image_tag(image_path('toolbars/remove.png'),
-                                  :class => "rollover small",
-                                  :alt   => t = _("Remove this Custom Image")),
-                        {:action  => "st_upload_image",
-                         :id      => @record.id,
-                         :pressed => "remove"},
+              = link_to({:action => "st_upload_image", :id => @record.id, :pressed => "remove"},
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true,
                         :remote                => true,
+                        :class                 => 'btn btn-default',
                         "data-method"          => :post,
                         :confirm               => _("Are you sure you want to remove this Custom Image?"),
-                        :title                 => t)
+                        :title                 => _("Remove this Custom Image")) do
+                %i.pficon.pficon-delete
         - else
           = _('No custom image has been uploaded')
           %br

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -31,11 +31,12 @@
         - else
           - session[:policies].invert.sort.each do |desc, id|
             %tr{:id => "#{desc}_tr"}
-              %td{:onclick => "#{remote_function(:loading  => "miqSparkle(true);",
-                                                 :complete => "miqSparkle(false);",
-                                                 :url      => {:action  => 'policy_sim_remove', :del_pol => id})}",
-                  :title => t = _("Click to remove this policy")}
-                = image_tag(image_path('toolbars/delete.png'), :alt => t)
+              %td
+                %button.btn.btn-default{:onclick  => "#{remote_function(:loading  => "miqSparkle(true);",
+                                        :complete => "miqSparkle(false);",
+                                        :url      => {:action  => 'policy_sim_remove', :del_pol => id})}",
+                                        :title    => _("Click to remove this policy")}
+                  %i.pficon.pficon-delete
               %td
                 = h(desc)
   %hr

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -64,22 +64,21 @@
     = _('Export')
   = form_tag({:action => "export_datastore"},
              :method => :get) do
-    = image_submit_tag(image_path('toolbars/export.png'),
-                       :alt   => t = _("Export all classes and instances"),
-                       :title => t)
+    %button.btn.btn-default{:type => :submit, :title => _("Export all classes and instances")}
+      %i.pficon.pficon-export
     = _('Export all classes and instances to a file')
 
   %hr
   %h3
     = (t = _("Reset all components in the following domains: %{domains}") % {:domains => MiqAeDatastore.default_domain_names.join(', ')})
-  = link_to(image_tag(image_path('toolbars/reset.png'),
-                      :alt => t),
-            {:action              => 'reset_datastore'},
+  = link_to({:action => 'reset_datastore'},
             "data-miq_sparkle_on" => true,
             :confirm              => _("All Datastore customizations will be lost. Are you sure you want to reset all classes and instances to default?"),
             :remote               => true,
+            :class                => 'btn btn-default',
             "data-method"         => :post,
-            :title                => t)
+            :title                => t) do
+    %i.pficon.pficon-refresh
 
 .git-import-data{:style => "display: none;"}
   %h3

--- a/app/views/ops/_diagnostics_savedreports.html.haml
+++ b/app/views/ops/_diagnostics_savedreports.html.haml
@@ -16,7 +16,8 @@
           - question = _("Are you sure you want to delete orphaned records for user '%{user}'?") % {:user => rec[:userid]}
           - onclick = remote_function(:url => {:action => 'orphaned_records_delete', :userid => rec[:userid]}, :confirm => question)
 
-          %td.table-view-pf-select{:onclick => onclick, :title => _("Click to delete Orphaned Records for this user")}
-            = image_tag(image_path('toolbars/delete.png'), :class => "rollover small")
+          %td.table-view-pf-select
+            %button.btn.btn-default{:onclick => onclick, :title => _("Click to delete Orphaned Records for this user")}
+              %i.pficon.pficon-delete
           %td= h(rec[:userid])
           %td= h(rec[:count])

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -73,10 +73,11 @@
           - else
             - unless forest.blank?
               %tr
-                %td{:onclick => remote_function(:url => {:action => 'forest_delete',
-                :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %{ldaphost} ?") % {:ldaphost => forest[:ldaphost]}),
-                :title => _("Click to delete this forest")}
-                  = image_tag(image_path('toolbars/delete.png'))
+                %td
+                  %button.btn.btn-default{:onclick => remote_function(:url => {:action => 'forest_delete',
+                  :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %{ldaphost} ?") % {:ldaphost => forest[:ldaphost]}),
+                  :title => _("Click to delete this forest")}
+                    %i.pficon.pficon-delete
                 %td{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => forest[:ldaphost].to_s}), :title => _("Click to edit this forest")}
                   = h(forest[:ldaphost])
                 %td{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => forest[:ldaphost].to_s}), :title => _("Click to edit this forest")}

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -17,9 +17,10 @@
           %th= _("Bind Password")
       %tbody
         - if entry != "new"
-          %tr{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => "new"}), :title => _("Click to add a new forest")}
+          %tr
             %td
-              = image_tag(image_path('toolbars/new.png'))
+              %button.btn.btn-default{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => "new"}), :title => _("Click to add a new forest")}
+                %i.fa.fa-plus
             %td
               = _("<Click on this row to create a new forest>")
             %td
@@ -30,10 +31,8 @@
         - else
           %tr
             %td
-              = image_submit_tag(image_path('toolbars/import.png'),
-                :class => "listbutton",
-                :id => "accept", :name => "accept",
-                :alt => _("Add this entry"), :title => _("Add this entry"))
+              %button.btn.btn-default#accept{:type => 'submit', :name => 'accept', :title => _("Add this entry")}
+                %i.pficon.pficon-import
             %td
               = text_field("user_proxies", "ldaphost", "maxlength" => 50)
             %td
@@ -52,10 +51,8 @@
           - if entry != nil && entry != "new" && entry[:ldaphost] == forest[:ldaphost]
             %tr
               %td
-                = image_submit_tag(image_path('toolbars/import.png'),
-                  :class => "listbutton",
-                  :id => "accept", :name => "accept",
-                  :alt => _("Update this entry"), :title => _("Update this entry"))
+                %button.btn.btn-default#accept{:type => :submit, :name => 'accept', :title => _("Update this entry")}
+                  %i.pficon.pficon-import
               %td
                 = text_field("user_proxies", "ldaphost", "maxlength" => 50, "value" => entry[:ldaphost])
               %td


### PR DESCRIPTION
There were some remaining references to PNG images from the `toolbars` folder.

When removing orphaned data from diagnostics:
![screenshot from 2018-06-22 15-02-18](https://user-images.githubusercontent.com/649130/41778599-76ff0d88-762f-11e8-85a0-00ea0ccdbc22.png)

Importing/exporting stuff from Automate:
![screenshot from 2018-06-22 15-02-49](https://user-images.githubusercontent.com/649130/41778600-771d0b8a-762f-11e8-8446-ec468a70a320.png)

When displaying a service template:
![screenshot from 2018-06-22 15-03-31](https://user-images.githubusercontent.com/649130/41778601-77430d30-762f-11e8-8e1f-20aece0a0fa3.png)

I was not able to display the LDAP forest entries page in the UI. I could render it with a hack, but that's not really doable without changing some conditions in the code.

@miq-bot add_label cleanup, graphics, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 

Parent issue: #4051 