### PR TITLE
Increase maxlength for playbooks' host option field

### DIFF
--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -127,13 +127,12 @@
                  'name'       => "#{prefix}_inventory_radio"}
           = _('Specify host values')
         %br
-        %input.form-control{'type'        => "text",
-                            'ng-model'    => "#{ng_model}.#{prefix}_inventory",
-                            'ng-if'       => "vm.inventory_mode !== 'localhost'",
-                            'name'        => "#{prefix}_inventory",
-                            'maxlength'   => 50,
-                            'miqrequired' => "",
-                            'checkchange' => true}
+        %textarea.form-control{'ng-model'    => "#{ng_model}.#{prefix}_inventory",
+                               'ng-if'       => "vm.inventory_mode !== 'localhost'",
+                                'name'        => "#{prefix}_inventory",
+                                'maxlength'   => 512,
+                                'miqrequired' => "",
+                                'checkchange' => true}
           %span.help-block{"ng-show" => "angularForm.#{prefix}_inventory.$error.miqrequired"}
             = _("Required")
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_execution_ttl.$invalid}"}


### PR DESCRIPTION
Increase maxlength for playbooks' host option field nd change it to a textarea


Links
----------------
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594426

Steps for Testing/QA
-------------------------------

1. Enable the Embedded Ansible provider and add a repository with a playbook
2. Navigate to Automation -> Automate -> Explorer
3. Create a Method of type playbook
4. Click the "Specify host values" checkbox for the Host
5. Attempt to enter more than 50 characters.


Before:
![screenshot from 2018-06-23 01-32-47](https://user-images.githubusercontent.com/12769982/41806274-b2b50932-7688-11e8-84fd-cff3a0f1c23b.png)

![screenshot from 2018-06-23 02-10-31](https://user-images.githubusercontent.com/12769982/41806364-c06523da-768a-11e8-80e0-5b517def6d89.png)


