### PR TITLE
Reprioritize icons and images for GTLs, prefer images first

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -981,15 +981,13 @@ class ApplicationController < ActionController::Base
 
       # Generate html for the list icon
       item = listicon_item(view, row['id'])
-      icon, icon2, image, picture = listicon_glyphicon(item)
+      icon, icon2, image = fonticon_or_fileicon(item)
       # FIXME: adding exceptions here is a wrong approach
       icon = nil if params[:controller] == 'pxe'
       new_row[:cells] << {:title => _('View this item'),
                           :image   => ActionController::Base.helpers.image_path(image.to_s),
-                          :picture => ActionController::Base.helpers.image_path(picture.to_s),
                           :icon    => icon,
                           :icon2   => icon2}
-
 
       view.col_order.each_with_index do |col, col_idx|
         next if view.column_is_hidden?(col)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1255,17 +1255,16 @@ module ApplicationHelper
       ).include?(x_tree[:type])
   end
 
-  def listicon_glyphicon(item)
+  def fonticon_or_fileicon(item)
     return nil unless item
     decorated = item.decorate
     [
       decorated.try(:fonticon),
       decorated.try(:secondary_icon),
-      decorated.try(:fileicon),
-      item.try(:picture) ? decorated.try(:fileicon) : nil
+      decorated.try(:fileicon)
     ]
   end
-  private :listicon_glyphicon
+  private :fonticon_or_fileicon
 
   CONTENT_TYPE_ID = {
     "report" => "r",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1280,15 +1280,6 @@ module ApplicationHelper
     MiqWidget
   ).freeze
 
-  def fileicon_tag(item)
-    icon, _icon2, image = listicon_glyphicon(item)
-    if icon
-      content_tag(:i, nil, :class => icon)
-    else
-      image_tag(ActionController::Base.helpers.image_path(image), :alt => nil)
-    end
-  end
-
   def process_show_list_options(options, curr_model = nil)
     @report_data_additional_options = ApplicationController::ReportDataAdditionalOptions.from_options(options)
     @report_data_additional_options.with_quadicon_options(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1133,15 +1133,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#fileicon_tag" do
-    it "returns correct image for miq task record based upon it's status" do
-      task = FactoryGirl.create(:miq_task)
-      task.state = "Running"
-      image = helper.fileicon_tag(task)
-      expect(image).to eq("<i class=\"pficon pficon-running\"></i>")
-    end
-  end
-
   it 'output of remote_function should not be html_safe' do
     expect(helper.remote_function(:url => {:controller => 'vm_infra', :action => 'explorer'}).html_safe?).to be_falsey
   end


### PR DESCRIPTION
When both a `fonticon` and a `fileicon` is defined for an item, the preferred one was the `fonticon`, except of some special cases when there's a `picture` attribute available. This was unnecessarily complicated and as all the unnecessary PNG files and their references [have been removed](https://github.com/ManageIQ/manageiq-ui-classic/issues/4051), we can simplify this a little.

So I'm proposing the same preference as we have for treeviews: `fileicon` over `fonticon` and also dropping the `picture` attribute. 

UI components PR: https://github.com/ManageIQ/ui-components/pull/308

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_labels gaprindashvili/no, GTLs, graphics