### PR TITLE
Remove all references to the unnecessary listicon instance variable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -470,7 +470,6 @@ class ApplicationController < ActionController::Base
       show_item
     else
       drop_breadcrumb(:name => @record.name + " (#{bc_text})", :url => "/#{obj}/event_logs/#{@record.id}")
-      @listicon = "event_logs"
       show_details(EventLog, :association => "event_logs")
     end
   end

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -14,7 +14,6 @@ class ApplicationController
     :menu_click,
     :sb_controller,
 
-    :listicon,
     :embedded,
     :showlinks,
     :policy_sim,
@@ -43,7 +42,6 @@ class ApplicationController
     end
 
     def with_quadicon_options(options)
-      self.listicon   = options[:listicon]
       self.embedded   = options[:embedded]
       self.showlinks  = options[:showlinks]
       self.policy_sim = options[:policy_sim]

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -308,7 +308,6 @@ class AutomationManagerController < ApplicationController
   def configuration_scripts_list(id, model)
     return configuration_script_node(id) if id
     @show_adv_search = true
-    @listicon = "configuration_script"
     if x_active_tree == :configuration_scripts_tree
       options = {:model      => model.to_s,
                  :gtl_dbname => "configuration_scripts"}

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -72,7 +72,6 @@ class ChargebackController < ApplicationController
 
   # Show the main Schedules list view
   def cb_rates_list
-    @listicon = "chargeback_rates"
     @gtl_type = "list"
     @explorer = true
     if params[:ppsetting]                                              # User selected new per page value

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -17,7 +17,7 @@ class ConfigurationJobController < ApplicationController
   end
 
   def parameters
-    show_association('parameters', _('Parameters'), 'parameter', :parameters, OrchestrationStackParameter)
+    show_association('parameters', _('Parameters'), :parameters, OrchestrationStackParameter)
   end
 
   # handle buttons pressed on the button bar

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -20,11 +20,11 @@ class ContainerImageController < ApplicationController
   end
 
   def guest_applications
-    show_association('guest_applications', _('Packages'), 'guest_application', :guest_applications, GuestApplication)
+    show_association('guest_applications', _('Packages'), :guest_applications, GuestApplication)
   end
 
   def openscap_rule_results
-    show_association('openscap_rule_results', 'Openscap', 'openscap_rule_result', :openscap_rule_results,
+    show_association('openscap_rule_results', 'Openscap', :openscap_rule_results,
                      OpenscapRuleResult)
   end
 

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -60,7 +60,7 @@ class HostController < ApplicationController
 
   def filesystems
     label, scope = filesystems_subsets
-    show_association('filesystems', label, 'filesystems', :filesystems, Filesystem, nil, scope)
+    show_association('filesystems', label, :filesystems, Filesystem, nil, scope)
   end
 
   def host_services_subsets
@@ -87,27 +87,27 @@ class HostController < ApplicationController
 
   def host_services
     label, scope = host_services_subsets
-    show_association('host_services', label, 'service', :host_services, SystemService, nil, scope)
+    show_association('host_services', label, :host_services, SystemService, nil, scope)
     session[:host_display] = "host_services"
   end
 
   def host_cloud_services
     @center_toolbar = 'host_cloud_services'
     @no_checkboxes = false
-    show_association('host_cloud_services', _('Cloud Services'), 'service', :cloud_services, CloudService, nil, nil)
+    show_association('host_cloud_services', _('Cloud Services'), :cloud_services, CloudService, nil, nil)
   end
 
   def advanced_settings
-    show_association('advanced_settings', _('Advanced Settings'), 'advancedsetting', :advanced_settings, AdvancedSetting)
+    show_association('advanced_settings', _('Advanced Settings'), :advanced_settings, AdvancedSetting)
   end
 
   def firewall_rules
     @display = "main"
-    show_association('firewall_rules', _('Firewall Rules'), 'firewallrule', :firewall_rules, FirewallRule)
+    show_association('firewall_rules', _('Firewall Rules'), :firewall_rules, FirewallRule)
   end
 
   def guest_applications
-    show_association('guest_applications', _('Packages'), 'guest_application', :guest_applications, GuestApplication)
+    show_association('guest_applications', _('Packages'), :guest_applications, GuestApplication)
   end
 
   # Show the main Host list view overriding method from Mixins::GenericListMixin

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -481,8 +481,6 @@ class InfraNetworkingController < ApplicationController
   def show_details(db, options = {}) # Pass in the db, parent vm is in @vm
     association = options[:association]
     conditions  = options[:conditions]
-    # generate the grid/tile/list url to come back here when gtl buttons are pressed
-    @gtl_url       = "/infra_networking/#{@listicon.pluralize}/#{@record.id}?"
     @showtype      = "details"
     @display       = "main"
     @no_checkboxes = @no_checkboxes.nil? || @no_checkboxes

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -75,7 +75,6 @@ class MiqRequestController < ApplicationController
     end
     @sortcol = session[:request_sortcol].nil? ? 0 : session[:request_sortcol].to_i
     @sortdir = session[:request_sortdir].nil? ? "ASC" : session[:request_sortdir]
-    @listicon = "miq_request"
     @no_checkboxes = true # Don't show checkboxes, read_only
     kls = @layout == "miq_request_ae" ? AutomationRequest : MiqRequest
     @view, @pages = get_view(kls, :named_scope => prov_scope(prov_set_default_options))
@@ -96,7 +95,6 @@ class MiqRequestController < ApplicationController
       prov_set_show_vars
     elsif @display == "miq_provisions"
       @showtype = "miq_provisions"
-      @listicon = "miq_request"
       @no_checkboxes = true
       @showlinks = true
       @view, @pages = get_view(MiqProvision, :named_scope => [[:with_miq_request_id, @miq_request.id]]) # Get all requests

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -8,7 +8,7 @@ module Mixins
       obj
     end
 
-    def show_association(action, display_name, listicon, method, klass, association = nil, scopes = nil)
+    def show_association(action, display_name, method, klass, association = nil, scopes = nil)
       params[:display] = klass.name
       # Ajax request means in explorer, or if current explorer is one of the explorer controllers
       @explorer = true if request.xml_http_request? && explorer_controller?
@@ -37,7 +37,6 @@ module Mixins
                          :url  => "/#{controller_name}/show/#{@record.id}"}, true)
         drop_breadcrumb(:name => "#{@record.name} (#{display_name})",
                         :url  => "/#{controller_name}/#{action}/#{@record.id}")
-        @listicon = listicon
 
         show_details(klass, :association => association, :scopes => scopes)
       end

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -184,8 +184,6 @@ module Mixins
     def show_details(db, options = {})  # Pass in the db, parent vm is in @vm
       association = options[:association]
       scopes = options[:scopes]
-      # generate the grid/tile/list url to come back here when gtl buttons are pressed
-      @gtl_url       = "/#{@db}/#{@listicon.pluralize}/#{@record.id}?"
       @showtype      = "details"
       @display       = "main"
       @no_checkboxes = @no_checkboxes.nil? || @no_checkboxes

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -77,7 +77,6 @@ module Mixins
         drop_breadcrumb({:name => @record.name, :url => "/#{@db}/show/#{@record.id}"}, true)
         drop_breadcrumb(:name => breadcrumb_name % {:name => @record.name},
                         :url  => "/#{@db}/guest_applications/#{@record.id}")
-        @listicon = "guest_application"
         show_details(GuestApplication)
       end
     end
@@ -101,7 +100,6 @@ module Mixins
       else
         drop_breadcrumb(:name => _("%{name} (Patches)") % {:name => @record.name},
                         :url  => "/#{@db}/patches/#{@record.id}")
-        @listicon = "patch"
         show_details(Patch)
       end
     end
@@ -120,7 +118,6 @@ module Mixins
       else
         drop_breadcrumb(:name => _("%{name} (Groups)") % {:name => @record.name},
                         :url  => "/#{@db}/groups/#{@record.id}")
-        @listicon = "group"
         show_details(Account, :association => "groups")
       end
     end
@@ -139,7 +136,6 @@ module Mixins
       else
         drop_breadcrumb(:name => _("%{name} (Users)") % {:name => @record.name},
                         :url  => "/#{@db}/users/#{@record.id}")
-        @listicon = "user"
         show_details(Account, :association => "users")
       end
     end
@@ -159,7 +155,6 @@ module Mixins
       else
         drop_breadcrumb(:name => _("%{name} (Hosts)") % {:name => @record.name},
                         :url  => "/#{controller_name}/hosts/#{@record.id}")
-        @listicon = "host"
         show_details(Host, :association => "hosts")
       end
     end

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -31,19 +31,19 @@ class OrchestrationStackController < ApplicationController
   end
 
   def cloud_networks
-    show_association('cloud_networks', _('Cloud Networks'), 'cloud_network', :cloud_networks, CloudNetwork)
+    show_association('cloud_networks', _('Cloud Networks'), :cloud_networks, CloudNetwork)
   end
 
   def outputs
-    show_association('outputs', _('Outputs'), 'output', :outputs, OrchestrationStackOutput)
+    show_association('outputs', _('Outputs'), :outputs, OrchestrationStackOutput)
   end
 
   def parameters
-    show_association('parameters', _('Parameters'), 'parameter', :parameters, OrchestrationStackParameter)
+    show_association('parameters', _('Parameters'), :parameters, OrchestrationStackParameter)
   end
 
   def resources
-    show_association('resources', _('Resources'), 'resource', :resources, OrchestrationStackResource)
+    show_association('resources', _('Resources'), :resources, OrchestrationStackResource)
   end
 
   # handle buttons pressed on the button bar

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -129,13 +129,12 @@ class StorageController < ApplicationController
   end
 
   def files
-    show_association('files', _('All Files'), 'storage_files', :storage_files, StorageFile, 'files')
+    show_association('files', _('All Files'), :storage_files, StorageFile, 'files')
   end
 
   def disk_files
     show_association('disk_files',
                      _('VM Provisioned Disk Files'),
-                     'storage_disk_files',
                      :storage_files,
                      StorageFile,
                      'disk_files')
@@ -144,7 +143,6 @@ class StorageController < ApplicationController
   def snapshot_files
     show_association('snapshot_files',
                      _('VM Snapshot Files'),
-                     'storage_snapshot_files',
                      :storage_files,
                      StorageFile,
                      'snapshot_files')
@@ -153,7 +151,6 @@ class StorageController < ApplicationController
   def vm_ram_files
     show_association('vm_ram_files',
                      _('VM Memory Files'),
-                     'storage_memory_files',
                      :storage_files, StorageFile,
                      'vm_ram_files')
   end
@@ -161,7 +158,6 @@ class StorageController < ApplicationController
   def vm_misc_files
     show_association('vm_misc_files',
                      _('Other VM Files'),
-                     'storage_other_vm_files',
                      :storage_files, StorageFile,
                      'vm_misc_files')
   end
@@ -169,7 +165,6 @@ class StorageController < ApplicationController
   def debris_files
     show_association('debris_files',
                      _('Non-VM Files'),
-                     'storage_non_vm_files',
                      :storage_files, StorageFile,
                      'debris_files')
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -834,7 +834,6 @@ module VmCommon
   def scan_history
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     @scan_history = ScanHistory.find_by(:vm_or_template_id => @record.id)
-    @listicon = "scan_history"
     @showtype = "scan_history"
     @lastaction = "scan_history"
     @gtl_url = "/scan_history"
@@ -880,7 +879,6 @@ module VmCommon
       show_item
     else
       drop_breadcrumb({:name => time_ago_in_words(@scan_history.started_on.in_time_zone(Time.zone)).titleize, :url => "/vm/show/#{@scan_history.vm_or_template_id}"}, true)
-      @listicon = "scan_history"
       show_details(ScanHistory)
     end
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -313,73 +313,73 @@ module VmCommon
   end
 
   def processes
-    show_association('processes', _('Running Processes'), 'processes', [:operating_system, :processes], OsProcess,
+    show_association('processes', _('Running Processes'), [:operating_system, :processes], OsProcess,
                      'processes')
   end
 
   def registry_items
-    show_association('registry_items', _('Registry Entries'), 'registry_items', :registry_items, RegistryItem)
+    show_association('registry_items', _('Registry Entries'), :registry_items, RegistryItem)
   end
 
   def advanced_settings
-    show_association('advanced_settings', _('Advanced Settings'), 'advancedsetting', :advanced_settings,
+    show_association('advanced_settings', _('Advanced Settings'), :advanced_settings,
                      AdvancedSetting)
   end
 
   def linux_initprocesses
-    show_association('linux_initprocesses', _('Init Processes'), 'linuxinitprocesses', :linux_initprocesses,
+    show_association('linux_initprocesses', _('Init Processes'), :linux_initprocesses,
                      SystemService, 'linux_initprocesses')
   end
 
   def win32_services
-    show_association('win32_services', _('Win32 Services'), 'win32service', :win32_services, SystemService,
+    show_association('win32_services', _('Win32 Services'), :win32_services, SystemService,
                      'win32_services')
   end
 
   def kernel_drivers
-    show_association('kernel_drivers', _('Kernel Drivers'), 'kerneldriver', :kernel_drivers, SystemService,
+    show_association('kernel_drivers', _('Kernel Drivers'), :kernel_drivers, SystemService,
                      'kernel_drivers')
   end
 
   def filesystem_drivers
-    show_association('filesystem_drivers', _('File System Drivers'), 'filesystemdriver', :filesystem_drivers,
+    show_association('filesystem_drivers', _('File System Drivers'), :filesystem_drivers,
                      SystemService, 'filesystem_drivers')
   end
 
   def filesystems
-    show_association('filesystems', _('Files'), 'filesystems', :filesystems, Filesystem)
+    show_association('filesystems', _('Files'), :filesystems, Filesystem)
   end
 
   def security_groups
-    show_association('security_groups', _('Security Groups'), 'security_group', :security_groups, SecurityGroup)
+    show_association('security_groups', _('Security Groups'), :security_groups, SecurityGroup)
   end
 
   def floating_ips
-    show_association('floating_ips', _('Floating IPs'), 'floating_ip', :floating_ips, FloatingIp)
+    show_association('floating_ips', _('Floating IPs'), :floating_ips, FloatingIp)
   end
 
   def cloud_subnets
-    show_association('cloud_subnets', _('Subnets'), 'cloud_subnet', :cloud_subnets, CloudSubnet)
+    show_association('cloud_subnets', _('Subnets'), :cloud_subnets, CloudSubnet)
   end
 
   def cloud_networks
-    show_association('cloud_subnets', _('Networks'), 'cloud_subnet', :cloud_subnets, CloudNetwork)
+    show_association('cloud_subnets', _('Networks'), :cloud_subnets, CloudNetwork)
   end
 
   def cloud_volumes
-    show_association('cloud_volumes', _('Cloud Volumes'), 'cloud_volume', :cloud_volumes, CloudVolume)
+    show_association('cloud_volumes', _('Cloud Volumes'), :cloud_volumes, CloudVolume)
   end
 
   def network_routers
-    show_association('network_routers', _('Routers'), 'network_router', :network_routers, NetworkRouter)
+    show_association('network_routers', _('Routers'), :network_routers, NetworkRouter)
   end
 
   def network_ports
-    show_association('network_ports', _('Ports'), 'network_port', :network_ports, NetworkPort)
+    show_association('network_ports', _('Ports'), :network_ports, NetworkPort)
   end
 
   def load_balancers
-    show_association('load_balancers', _('Load Balancers'), 'load_balancer', :load_balancers, LoadBalancer)
+    show_association('load_balancers', _('Load Balancers'), :load_balancers, LoadBalancer)
   end
 
   def snap

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1295,7 +1295,6 @@ module ApplicationHelper
   def process_show_list_options(options, curr_model = nil)
     @report_data_additional_options = ApplicationController::ReportDataAdditionalOptions.from_options(options)
     @report_data_additional_options.with_quadicon_options(
-      :listicon   => @listicon,
       :embedded   => @embedded,
       :showlinks  => @showlinks,
       :policy_sim => @policy_sim,
@@ -1333,7 +1332,6 @@ module ApplicationHelper
   # This is a temporary solution that is ot be replaced by proper
   # parametrization of an ancessor class of QuadiconHelper.
   def restore_quadicon_options(quadicon_options)
-    @listicon = quadicon_options[:listicon]
     @embedded = quadicon_options[:embedded]
     @showlinks = quadicon_options[:showlinks]
     @policy_sim = quadicon_options[:policy_sim]

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -109,7 +109,7 @@ module Spec
             'parent_class_name'     => options[:parent_model],
             'parent_method'         => options[:parent_method],
             'lastaction'            => options[:lastaction],
-            'association' => nil, 'view_suffix' => nil, 'listicon' => nil, 'embedded' => nil, 'showlinks' => nil, 'policy_sim' => nil
+            'association' => nil, 'view_suffix' => nil, 'embedded' => nil, 'showlinks' => nil, 'policy_sim' => nil
           }.compact
         }.compact
       end


### PR DESCRIPTION
There were two places where the `@listicon` was used to generate the `@gtl_url`. After looking into this I found out that the `@gtl_url` is being only used in GTL view type selection (the 3 icons on the right side) that is not available on any screens related to the remaining references. Therefore, I think it is safe to remove this evilness and simplify our codebase :scissors: :toilet: :fire: 

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @karelhala 
@miq-bot add_label GTLs, refactoring, gaprindashvili/no