### PR TITLE
Use the browser's native printing for asynchronously generated saved reports

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -39,6 +39,8 @@ module ApplicationController::ReportDownloads
       :title       => @result.name
     }
 
+    @data = @result.html_rows.join
+
     render :template => '/layouts/print/report', :layout => '/layouts/print'
   end
 

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -71,10 +71,14 @@ module ApplicationController::ReportDownloads
       javascript_flash(:spinner_off => true)
     else
       @sb[:render_rr_id] = miq_task.miq_report_result.id
-      render :update do |page|
-        page << javascript_prologue
-        page << "miqSparkle(false);"
-        page << "DoNav('#{url_for_only_path(:action => "send_report_data")}');"
+      if @sb[:render_type] == :pdf
+        javascript_open_window(url_for_only_path(:action => "send_report_data"))
+      else
+        render :update do |page|
+          page << javascript_prologue
+          page << "miqSparkle(false);"
+          page << "DoNav('#{url_for_only_path(:action => "send_report_data")}');"
+        end
       end
     end
   end
@@ -85,14 +89,28 @@ module ApplicationController::ReportDownloads
   # Send rendered report data
   def send_report_data
     if @sb[:render_rr_id]
-      rr = MiqReportResult.find(@sb[:render_rr_id])
-      filename = filename_timestamp(rr.report.title, 'export_filename')
       disable_client_cache
-      generated_result = rr.get_generated_result(@sb[:render_type])
-      rr.destroy
-      send_data(generated_result,
-                :filename => "#{filename}.#{@sb[:render_type]}",
-                :type     => "application/#{@sb[:render_type]}")
+      @result = MiqReportResult.find(@sb[:render_rr_id])
+      @report = @result.report
+      @data = @result.get_generated_result(@sb[:render_type])
+      # We need the last_run_on time from the original result
+      last_run_on = MiqReportResult.select(:last_run_on).find(session[:report_result_id]).last_run_on
+      @result.destroy
+
+      if @sb[:render_type] == :pdf
+        @options = {
+          :page_layout => 'landscape',
+          :page_size   => @report.page_size || 'a4',
+          :run_date    => format_timezone(last_run_on, @result.user_timezone, "gtl"),
+          :title       => @result.name
+        }
+        render :template => '/layouts/print/report', :layout => '/layouts/print'
+      else
+        filename = filename_timestamp(@result.report.title, 'export_filename')
+        send_data(@data,
+                  :filename => "#{filename}.#{@sb[:render_type]}",
+                  :type     => "application/#{@sb[:render_type]}")
+      end
     end
   end
 

--- a/app/helpers/application_helper/button/pdf.rb
+++ b/app/helpers/application_helper/button/pdf.rb
@@ -1,5 +1,0 @@
-class ApplicationHelper::Button::Pdf < ApplicationHelper::Button::Basic
-  def visible?
-    PdfGenerator.available?
-  end
-end

--- a/app/helpers/application_helper/button/render_report_pdf.rb
+++ b/app/helpers/application_helper/button/render_report_pdf.rb
@@ -1,3 +1,0 @@
-class ApplicationHelper::Button::RenderReportPdf < ApplicationHelper::Button::Pdf
-  include ApplicationHelper::Button::Mixins::RenderReportMixin
-end

--- a/app/helpers/application_helper/toolbar/report_view.rb
+++ b/app/helpers/application_helper/toolbar/report_view.rb
@@ -49,10 +49,10 @@ class ApplicationHelper::Toolbar::ReportView < ApplicationHelper::Toolbar::Basic
           :klass     => ApplicationHelper::Button::RenderReport),
         button(
           :render_report_pdf,
-          'fa fa-file-pdf-o fa-lg',
-          N_('Download this report in PDF format'),
-          N_('Download as PDF'),
-          :klass     => ApplicationHelper::Button::RenderReportPdf,
+          'pficon pficon-print fa-lg',
+          N_('Print or export this report in PDF format'),
+          N_('Print or export as PDF'),
+          :klass     => ApplicationHelper::Button::RenderReport,
           :url_parms => "?render_type=pdf"),
       ]
     ),

--- a/app/views/layouts/print/report.html.haml
+++ b/app/views/layouts/print/report.html.haml
@@ -6,4 +6,4 @@
           %th
             = h(header)
   %tbody
-    = @result.html_rows.join.html_safe
+    = @data.html_safe

--- a/spec/helpers/application_helper/buttons/render_report_pdf_spec.rb
+++ b/spec/helpers/application_helper/buttons/render_report_pdf_spec.rb
@@ -1,4 +1,0 @@
-describe ApplicationHelper::Button::RenderReportPdf do
-  it_behaves_like 'a render_report button'
-  it_behaves_like 'a Pdf button'
-end


### PR DESCRIPTION
Saved report PDFs are being generated asynchronously due to their size, the most time-consuming operation (except of the PDF generation itself) was the joining the sub-reports together. As we're moving the PDF generation to the client, I modified the asynchronous task to return with the `html_rows` only. This is later being used in the rendering the print view using the `@data` instance variable.

To have a new window for printing, the `:popup => true` was not effective due to the `wait_for_task` so I also had to add an exception for opening PDF reports in a new window. I know that the code is ugly, but it is now consistent with the other printing views in the UI. I will refactor this in the future in a separate PR.

![4codogqpid6paqugqoglrzlsmm-y0bg7gfo0kqpp9h8](https://user-images.githubusercontent.com/649130/41852657-0d03518c-788c-11e8-866d-8c6d205273b7.png)

@miq-bot add_label pending core, gaprindashvili/no, reporting, enhancement
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @epwinchell 

Depends on: https://github.com/ManageIQ/manageiq/pull/17632
Closes: #4113

https://bugzilla.redhat.com/show_bug.cgi?id=1588072