### PR TITLE
[WIP] Fix infra request reconfig

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -46,6 +46,7 @@ module Mixins
 
         # Reconfigure selected VMs
         def reconfigurevms
+          binding.pry
           assert_privileges(params[:pressed])
           # check to see if coming from show_list or drilled into vms from another CI
           rec_cls = "vm"


### PR DESCRIPTION
Fix editing request for reconfigure for infra

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/2598

TODO:
- [ ]  Make `vm.id = params[:id]`
- [ ] Make that ☝️ work for `reconfigurevms`
- [ ]  Make that ☝️ work for `resizevms`

@miq-bot add_label gaprindashvili/yes, wip, bug
