### PR TITLE
[GAPRINDASHVILI] Faster report result index pages

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -347,9 +347,8 @@ class ChargebackController < ApplicationController
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime]  = rr.last_run_on
       if rr.status.downcase == "complete"
-        @report = rr.report_results
         session[:rpt_task_id] = nil
-        if @report.blank?
+        unless rr.valid_report_column?
           @saved_reports = cb_rpts_get_all_reps(rr.miq_report_id.to_s)
           rep = MiqReport.find_by_id(rr.miq_report_id)
           if x_active_tree == :cb_reports_tree
@@ -357,7 +356,7 @@ class ChargebackController < ApplicationController
           end
           return
         else
-          if @report.contains_records?
+          if rr.contains_records?
             @html = report_first_page(rr) # Get the first page of the results
             unless @report.graph.blank?
               @render_chart = true

--- a/app/controllers/mixins/saved_report_paging.rb
+++ b/app/controllers/mixins/saved_report_paging.rb
@@ -14,7 +14,7 @@ module Mixins
       @sb[:pages][:perpage] = settings(:perpage, :reports)
 
       rr = MiqReportResult.find(@sb[:pages][:rr_id])
-      @html = report_build_html_table(rr.report_results,
+      @html = report_build_html_table(rr.report,
                                       rr.html_rows(:page     => @sb[:pages][:current],
                                                    :per_page => @sb[:pages][:perpage]).join)
 

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -35,10 +35,9 @@ module ReportController::SavedReports
 
     return unless rr.status.downcase == "complete"
 
-    @report = rr.report_results
     session[:rpt_task_id] = nil
 
-    if @report.blank?
+    unless rr.valid_report_column?
       add_flash(_("Saved Report \"%{time}\" not found, Schedule may have failed") %
                 {:time => format_timezone(rr.created_on, Time.zone, "gtl")},
                 :error)
@@ -56,7 +55,7 @@ module ReportController::SavedReports
       return
     end
 
-    unless @report.contains_records?
+    unless rr.contains_records?
       add_flash(_("No records found for this report"), :warning)
       return
     end

--- a/app/helpers/application_helper/button/report_download_choice.rb
+++ b/app/helpers/application_helper/button/report_download_choice.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::ReportDownloadChoice < ApplicationHelper::Button::Basic
   def disabled?
-    MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:length).to_i == 0
+    !MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:exists?)
   end
 end

--- a/app/helpers/application_helper/button/report_only.rb
+++ b/app/helpers/application_helper/button/report_only.rb
@@ -11,6 +11,6 @@ class ApplicationHelper::Button::ReportOnly < ApplicationHelper::Button::RenderR
 
   def report_records?
     @report.present? && @report_result_id.present? &&
-      MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:length).to_i > 0
+      MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:exists?)
   end
 end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -581,7 +581,8 @@ describe ChargebackController do
       miq_task.state_finished
       miq_report_result.report = chargeback_report.to_hash.merge(:extras=> {:total_html_rows => 100})
       miq_report_result.save
-      allow(controller).to receive(:report_first_page)
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@settings, :perpage => { :reports => 20 })
     end
 
     it "fetch existing report" do

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -23,17 +23,21 @@ describe ReportController do
       it 'renders show' do
         user = FactoryGirl.create(:user_with_group)
         login_as user
+        session[:settings] = {:perpage => {:reports => 20}}
         controller.instance_variable_set(:@html, "<h1>Test</h1>")
-        allow(controller).to receive(:report_first_page)
+
         report = FactoryGirl.create(:miq_report_with_results)
-        allow(report).to receive(:contains_records?).and_return(true)
         task = FactoryGirl.create(:miq_task)
         task.update_attributes(:state => "Finished")
         task.reload
-        report_result = FactoryGirl.create(:miq_report_result,
+
+        report_result = FactoryGirl.build(:miq_report_result,
                                            :miq_group_id => user.current_group.id,
-                                           :miq_task_id  => task.id)
-        allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
+                                           :miq_task_id  => task.id,
+                                           :miq_report   => report)
+        report_result.report = report.to_hash.merge(:extras=> {:total_html_rows => 100})
+        report_result.save
+
         binary_blob = FactoryGirl.create(:binary_blob,
                                          :resource_type => "MiqReportResult",
                                          :resource_id   => report_result.id)
@@ -41,7 +45,7 @@ describe ReportController do
                            :data           => "--- Quota \xE2\x80\x93 Max CPUs\n...\n",
                            :binary_blob_id => binary_blob.id)
 
-        post :tree_select, :params => { :id => "rr-#{report_result.id}", :format => :js, :accord => 'savedreports' }
+        post :tree_select, :params => { :id => "rr-#{report_result.id}", :ppsetting => 20, :format => :js, :accord => 'savedreports' }
         expect(response).to render_template('shared/_report_chart_and_html')
       end
     end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1306,6 +1306,8 @@ describe ReportController do
 
       context "User2 generates report under Group1" do
         before :each do
+          os = OperatingSystem.create(:name => "RHEL 7", :product_name => "RHEL7")
+          FactoryGirl.create(:vm_vmware, :operating_system => os)
           @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
         end
 
@@ -1330,12 +1332,16 @@ describe ReportController do
           controller.instance_variable_set(:@_params, :id => controller.to_cid(report_result_id),
                                                       :controller => "report", :action => "explorer")
           controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
+          controller.instance_variable_set(:@settings, :perpage => { :reports => 20 })
           allow(controller).to receive(:get_all_reps)
           controller.send(:show_saved_report)
+
           fetched_report_result_id = controller.instance_variable_get(:@report_result_id)
           expect(fetched_report_result_id).to eq(@rpt.miq_report_results.first.id)
-          fetched_report = controller.instance_variable_get(:@report)
-          expect(fetched_report.id).to eq(@rpt.id)
+
+          fetched_report    = controller.instance_variable_get(:@report)
+          fetched_report.id = @rpt.id # Reports serialized into the report column don't have ids
+          expect(fetched_report).to eq(@rpt)
         end
       end
     end


### PR DESCRIPTION
This is the Gaprindashvili port of #4143.  Original PR message below.


* * *


Merge after https://github.com/ManageIQ/manageiq/pull/17590  (**NOTE:** Not relavent, this is already backported)

This makes both the `ChargebackController` and `ReportController::SavedReports` actions for viewing reports signficantly faster by:

* avoiding loading the `binary_blob` data entirely (avoids massive YAML deserialization).  This uses methods provided by https://github.com/ManageIQ/manageiq/pull/17590 to accomplish this.
* Fix button helpers to use `.exists?` instead of `.length > 0`, which prevents needing to fetch all of the report result row records, which were then thrown away and never used.


Benchmarks
----------

This is displaying a `MiqReportResult` index page that has 23k+ rows associated with it.  Showing the first page, paginated by 20 records.

**Before**

|   ms | queries | query (ms) |  rows |
| ---: |    ---: |       ---: |  ---: |
| 5701 |      20 |      178.9 | 47523 |
| 4475 |      20 |      161.2 | 47523 |
| 5070 |      20 |      151.8 | 47523 |
| 4976 |      20 |      140.1 | 47523 |
| 5189 |      20 |      141.4 | 47523 |


**After**

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  462 |      19 |       55.8 |   30 |
|  234 |      19 |       53.5 |   30 |
|  272 |      19 |       51.0 |   30 |
|  234 |      19 |       46.2 |   30 |
|  283 |      19 |       55.8 |   30 |


Links
-----

* Main repo PR (~~Merge First!~~ Already done):  https://github.com/ManageIQ/manageiq/pull/17590
* https://bugzilla.redhat.com/show_bug.cgi?id=1594386


QA Steps
--------

I tested the did the following when running the `Before`/`After` benchmarks:

* Log in as an `admin` and go to `Cloud Intel` -> `Reports`
* Find a report that has a large number of report results, chargeback with some subtotals is prefered
* Select that report on the tree view, and select one of the report results table that is loaded in
* After the first paginated page has been returned, change the size of the page to 200 or something.  Make sure the switch between is also snappy.  (I toggled between page sizes with little to no wait time with all of the fixes in place).
* Make sure you can download using the `Download` toolbar button as well.