### PR TITLE
Hide quadicon setting for decorators that inherit the quadicon method

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -15,7 +15,7 @@ module ConfigurationHelper
   # Returns with a hash of allowed quadicons for the current user
   def allowed_quadicons
     MiqDecorator.descendants # Get all the decorator classes
-                .select { |klass| klass.method_defined?(:quadicon) } # Select only the decorators that define a quadicon
+                .select { |klass| klass.instance_methods(false).include?(:quadicon) } # Select only the decorators that define a quadicon
                 .sort(&method(:compare_decorator_class))
                 .map do |decorator|
       # Get the model name by removing Decorator from the class name


### PR DESCRIPTION
The quadicon setting sliders in `My Settings` are generated from the decorators based on if they define the `quadicon` method or not. For now we did not allow inheritance among decorators, but our friends at OpenStack [need it](https://github.com/ManageIQ/manageiq-providers-openstack/pull/309). This would mess up our UI a little, something like this:
![screenshot from 2018-06-26 10-43-39](https://user-images.githubusercontent.com/649130/41900409-f82338f6-792e-11e8-9a3a-6ce911ca1d69.png)

To avoid this behavior, only those decorators should be selected from the available ones that explicitly define the `quadicon` method. This way the UI will not break and also the OpenStack guys will be happy :cake: :sparkles: 

/cc @alexander-demichev 

@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label enhancement, gaprindashvili/no