### PR TITLE
Add single_quad definition into the SwitchDecorator

### DIFF
--- a/app/decorators/switch_decorator.rb
+++ b/app/decorators/switch_decorator.rb
@@ -2,4 +2,10 @@ class SwitchDecorator < MiqDecorator
   def self.fonticon
     'ff ff-network-switch'
   end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
+  end
 end


### PR DESCRIPTION
Should fix the missing quadicons on the tagging screen for vm infra networking switches. I don't really have any of them in my DB so I was not able to test this :disappointed: 

https://bugzilla.redhat.com/show_bug.cgi?id=1546729