### PR TITLE
Add sysprep support for ovirt

### DIFF
--- a/app/services/customize_fields_visibility_service.rb
+++ b/app/services/customize_fields_visibility_service.rb
@@ -14,7 +14,19 @@ class CustomizeFieldsVisibilityService
         :hostname,
         :ip_addr,
         :root_password,
-        :subnet_mask
+        :subnet_mask,
+        :sysprep_admin_password,
+        :sysprep_computer_name,
+        :sysprep_domain_name,
+        :sysprep_domain_password,
+        :sysprep_locale_input,
+        :sysprep_locale_system,
+        :sysprep_locale_ui,
+        :sysprep_locale_user,
+        :sysprep_machine_object_ou,
+        :sysprep_product_key,
+        :sysprep_timezone,
+        :sysprep_domain_admin
       ]
     else
       exclude_list = [
@@ -24,7 +36,6 @@ class CustomizeFieldsVisibilityService
         :sysprep_upload_file,
         :sysprep_upload_text,
         :linux_host_name,
-        :sysprep_computer_name,
         :ip_addr,
         :subnet_mask,
         :gateway,

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -87,11 +87,14 @@
             :sysprep_full_name, :sysprep_organization,
             :sysprep_product_id, :sysprep_computer_name,
             :sysprep_per_server_max_connections, :vm_description,
-            :vm_name, :wins_servers].include?(field)
+            :vm_name, :wins_servers, :sysprep_domain,
+            :sysprep_admin_password, :sysprep_product_key, :sysprep_locale_ui,
+            :sysprep_locale_input, :sysprep_locale_system, :sysprep_locale_user,
+            :sysprep_machine_object_ou].include?(field)
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
             -# Allow editing of the text field
-            - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
+            - if [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].include?(field)
               = password_field_tag(field_id, options[field],
                                    :maxlength         => ViewHelper::MAX_NAME_LEN,
                                    :class             => "form-control",
@@ -113,7 +116,7 @@
                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           - else
             -# Just show the field value
-            - if [:root_password, :sysprep_password, :sysprep_domain_password].include?(field)
+            - if [:root_password, :sysprep_password, :sysprep_domain_password, :sysprep_admin_password].include?(field)
               - unless options[field].nil?
                 - options[field].length.times do
                   *

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -191,42 +191,80 @@
           :keys                       => keys})
       - if (@edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] == "fields") || (@options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] == "fields")
         - if wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow)
-          - keys = [:root_username, :root_password]
-          = render(:partial => "/miq_request/prov_dialog_fieldset",
-            :locals         => {:workflow => wf,
-              :dialog                     => dialog,
-              :label                      => _("Credentials"),
-              :prefix                     => "/miq_request/",
-              :keys                       => keys})
-          - keys = [:addr_mode, :hostname, :ip_addr, :subnet_mask, :gateway]
-          = render(:partial => "/miq_request/prov_dialog_fieldset",
-            :locals         => {:workflow => wf,
-              :dialog                     => dialog,
-              :label                      => _("IP Address Information"),
-              :prefix                     => "/miq_request/",
-              :keys                       => keys})
-          - keys = [:dns_servers, :dns_suffixes]
-          = render(:partial => "/miq_request/prov_dialog_fieldset",
-            :locals         => {:workflow => wf,
-              :dialog                     => dialog,
-              :label                      => _("DNS"),
-              :prefix                     => "/miq_request/",
-              :keys                       => keys})
-          - keys = [:customization_template_id]
-          = render(:partial => "/miq_request/prov_dialog_fieldset",
-            :locals         => {:workflow => wf,
-              :dialog                     => dialog,
-              :label                      => _("Customize Template"),
-              :prefix                     => "/miq_request/",
-              :keys                       => keys})
-          - show_customization_template_script = (@edit && @edit[:new] && @edit[:new][:customization_template_script]) || (@options && @options[:customization_template_script])
-          - keys = [show_customization_template_script ? :customization_template_script : nil].compact
-          = render(:partial => "/miq_request/prov_dialog_fieldset",
-            :locals         => {:workflow => wf,
-              :dialog                     => dialog,
-              :label                      => _("Selected Template Contents"),
-              :prefix                     => "/miq_request/",
-              :keys                       => keys})
+          - if @edit[:new][:sysprep_enabled][1] == "Sysprep Specification"
+            - keys = [:sysprep_computer_name, :sysprep_organization, :sysprep_admin_password, :sysprep_product_key]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Computer Details"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - keys = [:sysprep_domain, :sysprep_domain_admin, :sysprep_domain_password, :sysprep_machine_object_ou]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+                :locals         => {:workflow => wf,
+                  :dialog                     => dialog,
+                  :label                      => _("Domain Information"),
+                  :prefix                     => "/miq_request/",
+                  :keys                       => keys})
+            - keys = [:sysprep_timezone, :sysprep_locale_ui, :sysprep_locale_system, :sysprep_locale_input, :sysprep_locale_user]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+                :locals         => {:workflow => wf,
+                  :dialog                     => dialog,
+                  :label                      => _("Localization"),
+                  :prefix                     => "/miq_request/",
+                  :keys                       => keys})
+            - keys = [:customization_template_id]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Customize Template"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - show_customization_template_script = (@edit && @edit[:new] && @edit[:new][:customization_template_script]) || (@options && @options[:customization_template_script])
+            - keys = [show_customization_template_script ? :customization_template_script : nil].compact
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Selected Template Contents"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+          - else
+            - keys = [:root_username, :root_password]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Credentials"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - keys = [:addr_mode, :hostname, :ip_addr, :subnet_mask, :gateway]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("IP Address Information"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - keys = [:dns_servers, :dns_suffixes]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("DNS"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - keys = [:customization_template_id]
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Customize Template"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
+            - show_customization_template_script = (@edit && @edit[:new] && @edit[:new][:customization_template_script]) || (@options && @options[:customization_template_script])
+            - keys = [show_customization_template_script ? :customization_template_script : nil].compact
+            = render(:partial => "/miq_request/prov_dialog_fieldset",
+              :locals         => {:workflow => wf,
+                :dialog                     => dialog,
+                :label                      => _("Selected Template Contents"),
+                :prefix                     => "/miq_request/",
+                :keys                       => keys})
         - else
           - keys = [:sysprep_custom_spec, :sysprep_spec_override]
           = render(:partial => "/miq_request/prov_dialog_fieldset",

--- a/spec/services/customize_fields_visibility_service_spec.rb
+++ b/spec/services/customize_fields_visibility_service_spec.rb
@@ -21,6 +21,18 @@ describe CustomizeFieldsVisibilityService do
             ip_addr
             root_password
             subnet_mask
+            sysprep_admin_password
+            sysprep_computer_name
+            sysprep_domain_name
+            sysprep_domain_password
+            sysprep_locale_input
+            sysprep_locale_system
+            sysprep_locale_ui
+            sysprep_locale_user
+            sysprep_machine_object_ou
+            sysprep_product_key
+            sysprep_timezone
+            sysprep_domain_admin
           )
         )
       end
@@ -38,7 +50,6 @@ describe CustomizeFieldsVisibilityService do
             sysprep_upload_file
             sysprep_upload_text
             linux_host_name
-            sysprep_computer_name
             ip_addr
             subnet_mask
             gateway


### PR DESCRIPTION
Add sysprep specification support for vm provisioning from template
for the oVirt provider.

Depends on: https://github.com/ManageIQ/manageiq/pull/17636
Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/275
Implements: https://bugzilla.redhat.com/show_bug.cgi?id=1553833

![image](https://user-images.githubusercontent.com/3274731/44465504-71063380-a626-11e8-94bc-7586a5ffba10.png)

