### PR TITLE
Don't allow user to create a repository if he has no rights to EA provider

### DIFF
--- a/app/helpers/application_helper/button/embedded_ansible.rb
+++ b/app/helpers/application_helper/button/embedded_ansible.rb
@@ -3,6 +3,8 @@ class ApplicationHelper::Button::EmbeddedAnsible < ApplicationHelper::Button::Ba
     if !MiqRegion.my_region.role_active?('embedded_ansible') ||
        ManageIQ::Providers::EmbeddedAnsible::Provider.count <= 0
       @error_message = _("Embedded Ansible Role is not enabled.")
+    elsif Rbac.filtered(ManageIQ::Providers::EmbeddedAnsible::AutomationManager.all).empty?
+      @error_message = _("User isn't allowed to use the Embedded Ansible provider.")
     end
     @error_message.present?
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1560535

How to reproduce:

Enable Embedded Ansible
Create a Group that is restricted to some tags
Create a User that is in the Group
Add tag that isn't in the Group to Embedded Ansible Provider via console 
```
Classification.bulk_reassignment(:model => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager", :object_ids => [<id of Embedded Ansible Automation Manager>], :add_ids => [<id(s) of tag(s)>])
```
Go to Automation -> Ansible -> Repositories -> Configuration -> Add a new Repository

Before:
![image](https://user-images.githubusercontent.com/9210860/41916143-ab1c1af4-7957-11e8-9db2-1e29f739e56f.png)

![image](https://user-images.githubusercontent.com/9210860/41916129-a24a3c12-7957-11e8-87d1-a3995932bee5.png)

After:
<img width="1207" alt="screen shot 2018-06-26 at 3 39 55 pm" src="https://user-images.githubusercontent.com/9210860/41915956-3d06bd08-7957-11e8-92dd-6e688ec41168.png">

@miq-bot add_label bug, gaprindashvili/yes,  automation/ansible, toolbars

@romanblanco @PanSpagetka please review, thanks :)