### PR TITLE
Teporarily removing the topology icon from physical infra view

### DIFF
--- a/app/helpers/application_helper/button/topology_feature_button.rb
+++ b/app/helpers/application_helper/button/topology_feature_button.rb
@@ -2,7 +2,8 @@ class ApplicationHelper::Button::TopologyFeatureButton < ApplicationHelper::Butt
   needs :@record
 
   def visible?
-    return false if @record.kind_of?(ManageIQ::Providers::InfraManager)
+    return false if [ManageIQ::Providers::InfraManager,
+                     ManageIQ::Providers::PhysicalInfraManager,].any? { |klass| @record.kind_of?(klass) }
     super
   end
 end


### PR DESCRIPTION
Removing the topology icon from Physical Infra dashboard page as decided here https://github.com/ManageIQ/manageiq-ui-classic/pull/4158