### PR TITLE
adding support to filter events by new group levels

### DIFF
--- a/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
+++ b/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
@@ -21,6 +21,12 @@ ManageIQ.angular.app.controller('timelineOptionsController', ['$http', 'miqServi
     vm.availableCategories = categories;
   };
 
+  vm.clearLevelsIfNotSelected = function() {
+    if (vm.reportModel.tl_categories.length === 0) {
+      vm.reportModel.tl_levels = undefined;
+    }
+  };
+
   vm.eventTypeUpdated = function() {
     vm.reportModel.tl_categories = [];
   };
@@ -72,13 +78,6 @@ ManageIQ.angular.app.controller('timelineOptionsController', ['$http', 'miqServi
     }
     ManageIQ.calendar.calDateFrom = startDay.toDate();
     ManageIQ.calendar.calDateTo = endDay.toDate();
-    if (vm.reportModel.tl_show === 'timeline') {
-      if (vm.reportModel.showDetailedEvents) {
-        vm.reportModel.tl_fl_typ = 'detail';
-      } else {
-        vm.reportModel.tl_fl_typ = 'critical';
-      }
-    }
     miqService.sparkleOn();
     miqService.miqAsyncAjaxButton(url, miqService.serializeModel(vm.reportModel));
   };

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -61,7 +61,6 @@ module ApplicationController::Timelines
 
     if @tl_options.policy_events?
       @tl_options.policy.result ||= "both"
-
       @tl_options.policy.categories ||= []
       if @tl_options.policy.categories.blank?
         @tl_options.policy.categories.push("VM Operation")
@@ -72,8 +71,6 @@ module ApplicationController::Timelines
           end
         end
       end
-    elsif @tl_options.management.level.nil?
-      @tl_options.management.level = "critical"
     end
   end
 

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -29,6 +29,21 @@
                   = select_tag("tl_category_management",
                     options_for_select(@tl_options.management.events.keys.sort, nil),
                     'ng-model'                    => 'vm.reportModel.tl_categories',
+                    'ng-change'                   => 'vm.clearLevelsIfNotSelected()',
+                    'title'                       => _('No category selected'),
+                    "selectpicker-for-select-tag" => '',
+                    'data-live-search'            => 'true',
+                    'data-actions-box'            => 'true',
+                    'data-select-all-text'        => _('Select All'),
+                    'data-deselect-all-text'      => _('Deselect All'),
+                    'multiple'                    => '',
+                    :class                        => 'selectpicker category-selector')
+                %span{'ng-if' => 'vm.reportModel.tl_show === "timeline"'}
+                  = select_tag("tl_levels_management",
+                    options_for_select(@tl_options.management.levels_text_and_value.sort, nil),
+                    'ng-model'                    => 'vm.reportModel.tl_levels',
+                    'title'                       => _('No severity selected'),
+                    'ng-disabled'                 => 'vm.reportModel.tl_categories.length === 0',
                     "selectpicker-for-select-tag" => '',
                     'data-live-search'            => 'true',
                     'data-actions-box'            => 'true',
@@ -47,12 +62,6 @@
                     'data-deselect-all-text'      => _('Deselect All'),
                     'multiple'                    => '',
                     :class                        => 'selectpicker category-selector')
-                %span{'ng-if' => 'vm.reportModel.tl_show === "timeline"', 'class' => 'timeline-option'}
-                  %label
-                    %input{:type         => 'checkbox',
-                           :name         => 'showDetailedEvents',
-                           'ng-model'    => 'vm.reportModel.showDetailedEvents'}
-                    = _("Show Detailed Events")
                 %span{'ng-if' => 'vm.reportModel.tl_show !== "timeline"', 'class' => 'timeline-option'}
                   %label.radio
                     %input{"ng-model" => "vm.reportModel.tl_result", :type => "radio", :value => "success"}

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -155,17 +155,20 @@ module ReportFormatter
                :ems_container => ems_container,
                :time_zone     => tz}
       tl_message = TimelineMessage.new(row, rec, flags, mri.db)
-      e_text = ''
+      event_data = {}
       col_order.each_with_index do |co, co_idx|
-        val = tl_message.message_html(co)
-        e_text += "<b>#{headers[co_idx]}:</b>&nbsp;#{val}<br/>" unless val.to_s.empty? || co == "id"
+        value = tl_message.message_html(co)
+        next if value.to_s.empty? || co == "id"
+        event_data[co] = {
+          :value => value,
+          :text  => headers[co_idx]
+        }
       end
-      e_text = e_text.chomp('<br/>')
 
       # Add the event to the timeline
-      @events_data.push("start"       => format_timezone(row[col], tz, 'view'),
-                        "title"       => e_title.length < 20 ? e_title : e_title[0...17] + "...",
-                        "description" => e_text)
+      @events_data.push("start" => format_timezone(row[col], tz, 'view'),
+                        "title" => e_title.length < 20 ? e_title : e_title[0...17] + "...",
+                        "event" => event_data)
     end
   end
 end

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -38,11 +38,11 @@ describe ApplicationController, "#Timelines" do
         expect(options.policy[:categories]).to include('VM Operation')
       end
 
-      it "unchecking Detailed events checkbox of Timelines options should remove them from list of events" do
+      it "selecting critical option of the selectpicker in the timeline should append them to events filter list" do
         controller.instance_variable_set(:@_params,
                                          :id            => @ems.id,
                                          :tl_show       => "timeline",
-                                         :tl_fl_typ     => "critical",
+                                         :tl_levels     => ["critical"],
                                          :tl_categories => ["Power Activity"])
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
@@ -51,17 +51,30 @@ describe ApplicationController, "#Timelines" do
         expect(options.management[:categories][:power][:event_groups]).to_not include('PowerOffVM_Task')
       end
 
-      it "checking Detailed events checkbox of Timelines options should append them to list of events" do
+      it "selecting details option of the selectpicker in the timeline should append them to events filter list" do
         controller.instance_variable_set(:@_params,
                                          :id            => @ems.id,
                                          :tl_show       => "timeline",
-                                         :tl_fl_typ     => "detail",
+                                         :tl_levels     => ["detail"],
                                          :tl_categories => ["Power Activity"])
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
         expect(options.management[:categories][:power][:event_groups]).to include('PowerOffVM_Task')
+        expect(options.management[:categories][:power][:event_groups]).to_not include('AUTO_FAILED_SUSPEND_VM')
+      end
+
+      it "selecting two options of the selectpicker in the timeline should append both to events filter list" do
+        controller.instance_variable_set(:@_params,
+                                         :id            => @ems.id,
+                                         :tl_show       => "timeline",
+                                         :tl_levels     => %w(critical detail),
+                                         :tl_categories => ["Power Activity"])
+        expect(controller).to receive(:render)
+        controller.send(:tl_chooser)
+        options = assigns(:tl_options)
         expect(options.management[:categories][:power][:event_groups]).to include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:event_groups]).to include('PowerOffVM_Task')
       end
     end
   end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -208,9 +208,8 @@ describe '#set data for headers that exist in col headers' do
     @report.rpt_options = nil
     allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
     events = ReportFormatter::ReportTimeline.new.build_document_body
-    expect(JSON.parse(events)[0]["data"][0][0]["description"]).to include("Source Instance Location:")
-    expect(JSON.parse(events)[0]["data"][0][0]["description"]).to_not include("Source Instance:")
-    expect(JSON.parse(events)[0]["data"][0][0]["description"]).to_not include("Destination Instance:")
-    expect(JSON.parse(events)[0]["data"][0][0]["description"]).to_not include("Destination Instance Location:")
+    json = JSON.parse(events)[0]["data"][0][0]["event"]
+    expect(json["vm_location"]["text"]).to eq("Source Instance Location")
+    expect(json["vm_location"]["value"]).to eq("foo")
   end
 end


### PR DESCRIPTION
This PR is able to:
* Refactor the timeline page to support filter events using the group_levels
* Color the event accordingly the severity
![timeline2](https://user-images.githubusercontent.com/12627705/42572111-53b579f6-84ef-11e8-9164-3849748968c1.gif)
* Color the `Group Level` information accordingly the severity
![image](https://user-images.githubusercontent.com/12627705/43022258-fe548308-8c3c-11e8-9a9f-d3e559bd77f9.png)


Depends_on:  [~PR 17611~](https://github.com/ManageIQ/manageiq/pull/17611) - MERGED
Depends_on: [~PR 17702~](https://github.com/ManageIQ/manageiq/pull/17702) - MERGED