### PR TITLE
Disabling delete for AuthKeys imported from Provider

### DIFF
--- a/app/helpers/application_helper/button/auth_key_pair_cloud_delete.rb
+++ b/app/helpers/application_helper/button/auth_key_pair_cloud_delete.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::AuthKeyPairCloudDelete < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    return true if @record.validate_delete_key_pair[:available]
+    @error_message = _('Deletion is unavailable for this keypair.')
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
@@ -12,6 +12,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudCenter < ApplicationHelper::To
           t = N_('Remove this Key Pair from Inventory'),
           t,
           :url_parms => "&refresh=y",
+          :klass     => ApplicationHelper::Button::AuthKeyPairCloudDelete,
           :confirm   => N_("Warning: The selected Key Pair and ALL of its components will be permanently removed!")),
         button(
           :auth_key_pair_cloud_download,

--- a/spec/helpers/application_helper/buttons/auth_key_pair_cloud_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/auth_key_pair_cloud_delete_spec.rb
@@ -1,0 +1,19 @@
+describe ApplicationHelper::Button::AuthKeyPairCloudDelete do
+  describe '#disabled?' do
+    it "when a private key is deletable, then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.new, :auth_key => "present")}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when a private key is not deletable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.new, :auth_key => "")}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1418481

When a local user auth key is created that can be deleted, but not
ones imported from the provider.

This is an improved PR over https://github.com/ManageIQ/manageiq-ui-classic/pull/4061

The logic for the PR is now in the individual provider. See PRs  https://github.com/ManageIQ/manageiq-providers-amazon/pull/457 & https://github.com/ManageIQ/manageiq-providers-openstack/pull/311