### PR TITLE
Fix toolbar switching for Buttons accord and Add a new Button action 

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -1005,7 +1005,7 @@ module ApplicationController::Buttons
                                                                 x_node.split('-')[1].split('_')[1]]
     end
     @record = @edit[:custom_button] = @custom_button
-    @edit[:instance_names] = @resolve[:instance_names]
+    @edit[:instance_names] = Array(@resolve[:instance_names])
     @edit[:new] = {}
     @edit[:current] = {}
     @edit[:new][:attrs] ||= []

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -21,7 +21,7 @@ module MiqAeCustomizationController::CustomButtons
       else
         build_resolve_screen
       end
-      @resolve[:target_classes].each do |node|
+      Array(@resolve[:target_classes]).each do |node|
         @sb[:obj_list][node[0]] = "ab_#{node[0]}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2   # one of the CI's node selected


### PR DESCRIPTION
**Automation** :arrow_right: **Automate** :arrow_right: **Customization**

Toolbar for **Buttons** accord is not displayed, console shows a pretty traceback.
```ruby
FATAL -- : Error caught: [NoMethodError] undefined method `each' for nil:NilClass
.../manageiq-ui-classic/app/controllers/miq_ae_customization_controller/custom_buttons.rb:24:in `ab_get_node_info'
.../manageiq-ui-classic/app/controllers/miq_ae_customization_controller.rb:252:in `get_specific_node_info'
...
```
Probably caused by empty database and session on my setup or something like that.

Same happens for the **Add a new Button** action in the **Buttons** toolbar, fixing that as well.

Before:
![image](https://user-images.githubusercontent.com/7453394/41980971-21e30e06-7a28-11e8-96bb-1bf4ec722d6d.png)
_Showing previously used toolbar_

After:
![image](https://user-images.githubusercontent.com/7453394/41980700-6934149a-7a27-11e8-8c03-60d1d40d657e.png)
_Correct toobar_

cc @martinpovolny