### PR TITLE
Add guidance text for new <<reset>> magic word

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -26,14 +26,25 @@ module OpsHelper
   end
 
   def advanced_tab_warning
-    if selected?(x_node, "z")
-      _('Caution: Manual changes to configuration files can disable the Zone!') + ' ' +
-        _('Changes made to any individual settings will overwrite settings inherited from the Region.')
-    elsif selected?(x_node, "svr")
-      _('Caution: Manual changes to configuration files can disable the Server!') + ' ' +
-        _('Changes made to any individual settings will overwrite settings inherited from the Zone.')
+    if selected?(x_node, "svr")
+      _('Caution: Manual changes to configuration files can disable the Server!') << " " <<
+        _('Changes made to any individual settings will overwrite settings inherited from the Zone!')
+    elsif selected?(x_node, "z")
+      _('Caution: Manual changes to configuration files can disable the Zone!') << " " <<
+        _('Changes made to any individual settings will overwrite settings inherited from the Region!')
     else
-      _('Caution: Manual changes to configuration files can disable the Region!')
+      _('Caution: Manual changes to configuration files can disable the Region!') << " " <<
+        _('Changes made to any individual settings will overwrite settings inherited from the template!')
+    end
+  end
+
+  def advanced_tab_info
+    if selected?(x_node, "svr")
+      _('To reset back to the Zone\'s setting or to delete a setting, set the value to <<reset>>.')
+    elsif selected?(x_node, "z")
+      _('To reset back to the Regions\'s setting or to delete a setting, set the value to <<reset>>.')
+    else
+      _('To reset back to the template\'s setting or to delete a setting, set the value to <<reset>>.')
     end
   end
 

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -5,6 +5,10 @@
       %span.pficon.pficon-warning-triangle-o
       %strong
         = advanced_tab_warning
+    .alert.alert-info
+      %span.pficon.pficon-info
+      %strong
+        = advanced_tab_info
 
     = text_area_tag("file_data", @edit[:new][:file_data], :style => "display:none;")
     = render :partial => "/layouts/my_code_mirror",


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1576984, we've added "magic word" `<<reset>>` support to the AdvancedSettings to allow resetting values to inherit from the parent, or in the case of a key added by a user (say, through a typo), to delete that key.  We are added some info text, because without it, there is no way a user would know they can set this value.

~~https://user-images.githubusercontent.com/52120/41993112-5e99255c-7a18-11e8-8537-006358172069.png~~

~~WIP because I need help on
~~ - how to substitute the parent string and still maintain i18n rules.  `_()` doesn't seem to take a second parameter, so I'm not sure what to do.  @himdel or @mzazrivec ?~~
~~ - wording for the info box, and also placement (should it be above or below the error warning already there?)  @terezanovotna ~~

~~separately...question about the error that's already there  (@himdel)
a) why error as opposed to warning?
b) the code says pficon-error-octagon, but I get no icon at all...should I?~~
EDIT: Fixed via #4227