### PR TITLE
Escape special chars in tooltip & text of TreeBuilder's root

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -173,7 +173,7 @@ class TreeBuilder
   end
 
   def add_root_node(nodes)
-    root = nodes.first.merge!(root_options)
+    root = nodes.first.merge!(%i(text tooltip).each_with_object(root_options) { |key, hsh| hsh[key] = ERB::Util.html_escape(hsh[key]) })
     if root[:image]
       root[:image] = ActionController::Base.helpers.image_path(root[:image])
     else


### PR DESCRIPTION
Those two items may contain characters which would make javascript fail later down the road (apostrophes for example).

How to reproduce:
1. Simulate a situation where the root of some tree builder would contain `:text` or `:tooltip` with an apostrophe.
2. Navigate to the screen containing the tree

Before:
![go-before](https://user-images.githubusercontent.com/6648365/41995139-fddb4612-7a50-11e8-8bf7-e1ee76dfa9a8.png)

After:
![go-after](https://user-images.githubusercontent.com/6648365/41995143-029f5a30-7a51-11e8-8a5a-d49b96fec4c4.png)

This problem would show for example on Generic Objects list screen in French locale. The following error would be shown in JS console:
```
angular.self-7e0b2baf4553bcd25cbb45cbe35556b3c2fbcb170db636503b5bee55a75e7b9b.js:14701 Error: [$parse:lexerr] Lexer Error: Unexpected next character  at columns 342-342 [é] in expression [vm.initData('generic_object_definitions_tree', '[{"key":"root","nodes":[{"key":"god-10r1","text":"123","icon":"fa fa-file-text-o","selectable":true,"image":"/assets/100/generic_object_definition-d8f9afdc4cc7384728577418b8cf79d72e0e29f6abd72195a74757feb20ffa9e.png","state":{"expanded":false},"class":""}],"text":"Toutes les classes d'objets génériques","tooltip":"Toutes les classes d'objets génériques","icon":"pficon pficon-folder-close","state":{"expanded":true},"class":""}]', 'root')].
```

https://bugzilla.redhat.com/show_bug.cgi?id=1594480