### PR TITLE
Change reconfigure setup to include values configured with originally

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -58,15 +58,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', finishSubmitEndpoint);
     }).catch(function(err) {
-      miqService.sparkleOff();
-      var fullErrorMessage = err.data.error.message;
-      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
-      clearFlash();
-      _.forEach(allErrorMessages, (function(errorMessage) {
-        add_flash(errorMessage, 'error');
-      }));
-      console.error(err);
-      return Promise.reject(err);
+      return Promise.reject(dialogUserSubmitErrorHandlerService.handleError(err));
     });
   }
 

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, resourceActionId, targetId) {
+ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, resourceActionId, targetId) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -32,7 +32,7 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
       dialogId: vm.dialogId,
       resourceActionId: resourceActionId,
       targetId: targetId,
-      targetType: "service"
+      targetType: "service",
     };
 
     return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, idList);
@@ -52,15 +52,7 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', '/service/explorer');
     }).catch(function(err) {
-      miqService.sparkleOff();
-      var fullErrorMessage = err.data.error.message;
-      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
-      clearFlash();
-      _.forEach(allErrorMessages, (function(errorMessage) {
-        add_flash(errorMessage, 'error');
-      }));
-      console.error(err);
-      return Promise.reject(err);
+      return Promise.reject(dialogUserSubmitErrorHandlerService.handleError(err));
     });
   }
 

--- a/app/assets/javascripts/services/dialog_user_submit_error_handler_service.js
+++ b/app/assets/javascripts/services/dialog_user_submit_error_handler_service.js
@@ -1,0 +1,13 @@
+ManageIQ.angular.app.service('dialogUserSubmitErrorHandlerService', ['miqService', function(miqService) {
+  this.handleError = function(err) {
+    miqService.sparkleOff();
+    var fullErrorMessage = err.data.error.message;
+    var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
+    clearFlash();
+    _.forEach(allErrorMessages, function(errorMessage) {
+      add_flash(errorMessage, 'error');
+    });
+    console.error(err);
+    return err;
+  };
+}]);

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -145,9 +145,12 @@ module ApplicationController::DialogRunner
   def dialog_initialize(ra, options)
     @edit = {}
     @edit[:new] = options[:dialog] || {}
+
     opts = {
       :target => options[:target_kls].constantize.find_by_id(options[:target_id])
     }
+    opts[:reconfigure] = true if options[:dialog_mode] == :reconfigure
+
     @edit[:wf] = ResourceActionWorkflow.new(@edit[:new], current_user, ra, opts)
     @record = Dialog.find_by_id(ra.dialog_id.to_i)
     @edit[:rec_id]   = @record.id

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -155,21 +155,13 @@ class ServiceController < ApplicationController
 
   def service_reconfigure
     @explorer = true
-    s = Service.find_by_id(params[:id])
-    st = s.service_template
-    ra = st.resource_actions.find_by_action('Reconfigure') if st
-    if ra && ra.dialog_id
-      @right_cell_text = _("Reconfigure Service \"%{name}\"") % {:name => st.name}
-      options = {
-        :header        => @right_cell_text,
-        :target_id     => s.id,
-        :target_kls    => s.class.name,
-        :dialog        => s.options[:dialog],
-        :dialog_mode   => :reconfigure,
-        :dialog_locals => DialogLocalService.new.determine_dialog_locals_for_service_reconfiguration(ra, s)
-      }
-      dialog_initialize(ra, options)
-    end
+    service = Service.find_by(:id => params[:id])
+    service_template = service.service_template
+    resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
+
+    @right_cell_text = _("Reconfigure Service \"%{name}\"") % {:name => service_template.name}
+    dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
+    replace_right_cell(:action => "reconfigure_dialog", :dialog_locals => dialog_locals)
   end
 
   def service_form_fields
@@ -377,6 +369,10 @@ class ServiceController < ApplicationController
       partial = "shared/views/retire"
       header = _("Set/Remove retirement date for Service")
       action = "retire"
+    when "reconfigure_dialog"
+      partial = "shared/dialogs/reconfigure_dialog"
+      header = @right_cell_text
+      action = nil
     when "service_edit"
       partial = "service_form"
       header = _("Editing Service \"%{name}\"") % {:name => @service.name}
@@ -425,7 +421,7 @@ class ServiceController < ApplicationController
     # Replace right cell divs
     presenter.update(
       :main_div,
-      if %w(dialog_provision ownership retire service_edit tag service_tag).include?(action)
+      if %w(dialog_provision ownership retire service_edit tag service_tag reconfigure_dialog).include?(action)
         r[:partial => partial, :locals => options[:dialog_locals]]
       elsif params[:display]
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -20,20 +20,6 @@ class DialogLocalService
     Vm
   ).freeze
 
-  def determine_dialog_locals_for_service_reconfiguration(resource_action, target)
-    {
-      :resource_action_id     => resource_action.id,
-      :target_id              => target.id,
-      :target_type            => "service",
-      :dialog_id              => resource_action.dialog_id,
-      :force_old_dialog_use   => false,
-      :api_submit_endpoint    => "/api/services/#{target.id}",
-      :api_action             => "reconfigure",
-      :finish_submit_endpoint => "/service/explorer",
-      :cancel_endpoint        => "/service/explorer"
-    }
-  end
-
   def determine_dialog_locals_for_svc_catalog_provision(resource_action, target, finish_submit_endpoint)
     api_submit_endpoint = "/api/service_catalogs/#{target.service_template_catalog_id}/service_templates/#{target.id}"
 

--- a/app/views/shared/dialogs/_reconfigure_dialog.html.haml
+++ b/app/views/shared/dialogs/_reconfigure_dialog.html.haml
@@ -1,0 +1,25 @@
+#main_div
+  .row.wrapper{"ng-controller" => "dialogUserReconfigureController as vm"}
+    .spinner{'ng-show' => "!vm.dialogLoaded"}
+
+    .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
+      %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
+
+      .clearfix
+      .pull-right.button-group{'ng-show' => "vm.dialogLoaded"}
+        %miq-button{:name      => t = _("Submit"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'vm.saveable()',
+                    'on-click' => "vm.submitButtonClicked()",
+                    :primary   => 'true'}
+        %miq-button{:name      => t = _("Cancel"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'true',
+                    'on-click' => "vm.cancelClicked($event)"}
+
+  :javascript
+    ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
+    ManageIQ.angular.app.value('targetId', '#{target_id}');
+    miq_bootstrap('.wrapper');

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -21,6 +21,35 @@ describe ServiceController do
     service
   end
 
+  describe "#service_reconfigure" do
+    let(:service) { instance_double("Service", :id => 321, :service_template => service_template) }
+    let(:service_template) { instance_double("ServiceTemplate", :name => "the name") }
+    let(:ar_association_dummy) { double }
+    let(:resource_action) { instance_double("ResourceAction", :id => 123) }
+
+    before do
+      allow(Service).to receive(:find_by).with(:id => 321).and_return(service)
+      allow(service_template).to receive(:resource_actions).and_return(ar_association_dummy)
+      allow(ar_association_dummy).to receive(:find_by).with(:action => 'Reconfigure').and_return(resource_action)
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@_params, :id => 321)
+    end
+
+    it "sets the right cell text" do
+      controller.send(:service_reconfigure)
+      expect(controller.instance_variable_get(:@right_cell_text)).to eq("Reconfigure Service \"the name\"")
+    end
+
+    it "replaces the right cell with the reconfigure dialog partial" do
+      expect(controller).to receive(:replace_right_cell).with(
+        :action        => "reconfigure_dialog",
+        :dialog_locals => {:resource_action_id => 123, :target_id => 321}
+      )
+
+      controller.send(:service_reconfigure)
+    end
+  end
+
   describe "#service_delete" do
     it "display flash message with description of deleted Service" do
       st  = FactoryGirl.create(:service_template)

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -1,11 +1,16 @@
 describe('dialogUserController', function() {
-  var $controller, API, dialogFieldRefreshService, miqService;
+  var $controller, API, dialogFieldRefreshService, dialogUserSubmitErrorHandlerService, miqService;
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(_$controller_, _API_, _dialogFieldRefreshService_, _miqService_) {
+  beforeEach(inject(function(_$controller_,
+                             _API_,
+                             _dialogFieldRefreshService_,
+                             _dialogUserSubmitErrorHandlerService_,
+                             _miqService_) {
     API = _API_;
     dialogFieldRefreshService = _dialogFieldRefreshService_;
+    dialogUserSubmitErrorHandlerService = _dialogUserSubmitErrorHandlerService_;
     miqService = _miqService_;
 
     var responseResult = {content: ['the dialog']};
@@ -15,6 +20,7 @@ describe('dialogUserController', function() {
     });
 
     spyOn(dialogFieldRefreshService, 'refreshField');
+    spyOn(dialogUserSubmitErrorHandlerService, 'handleError');
     spyOn(miqService, 'miqAjaxButton');
     spyOn(miqService, 'redirectBack');
     spyOn(miqService, 'sparkleOn');
@@ -24,6 +30,7 @@ describe('dialogUserController', function() {
     $controller = _$controller_('dialogUserController', {
       API: API,
       dialogFieldRefreshService: dialogFieldRefreshService,
+      dialogUserSubmitErrorHandlerService: dialogUserSubmitErrorHandlerService,
       miqService: miqService,
       dialogId: '1234',
       apiSubmitEndpoint: 'submit endpoint',
@@ -201,34 +208,17 @@ describe('dialogUserController', function() {
     });
 
     context('when the API call fails', function() {
+      var rejectionData;
+
       beforeEach(function() {
-        var rejectionData = {data: {error: {message: "Failed! -One,Two"}}};
+        rejectionData = {data: {error: {message: "Failed! -One,Two"}}};
         spyOn(API, 'post').and.returnValue(Promise.reject(rejectionData));
-        spyOn(window, 'clearFlash');
-        spyOn(window, 'add_flash');
       });
 
-      it('turns off the sparkle', function(done) {
+      it('delegates to the dialogUserSubmitErrorHandlerService', function(done) {
         $controller.submitButtonClicked()
           .catch(function() {
-            expect(miqService.sparkleOff).toHaveBeenCalled();
-            done();
-          });
-      });
-
-      it('clears flash messages', function(done) {
-        $controller.submitButtonClicked()
-          .catch(function() {
-            expect(window.clearFlash).toHaveBeenCalled();
-            done();
-          });
-      });
-
-      it('adds flash messages for each message after the -', function(done) {
-        $controller.submitButtonClicked()
-          .catch(function() {
-            expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
-            expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
+            expect(dialogUserSubmitErrorHandlerService.handleError).toHaveBeenCalledWith(rejectionData);
             done();
           });
       });

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -1,25 +1,6 @@
 describe DialogLocalService do
   let(:service) { described_class.new }
 
-  describe "#determine_dialog_locals_for_service_reconfiguration" do
-    let(:target) { instance_double("Service", :id => 123) }
-    let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
-
-    it "returns a hash" do
-      expect(service.determine_dialog_locals_for_service_reconfiguration(resource_action, target)).to eq(
-        :resource_action_id     => 456,
-        :target_id              => 123,
-        :target_type            => "service",
-        :dialog_id              => 654,
-        :force_old_dialog_use   => false,
-        :api_submit_endpoint    => "/api/services/123",
-        :api_action             => "reconfigure",
-        :finish_submit_endpoint => "/service/explorer",
-        :cancel_endpoint        => "/service/explorer"
-      )
-    end
-  end
-
   describe "#determine_dialog_locals_for_svc_catalog_provision" do
     let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
     let(:target) { instance_double("ServiceTemplate", :class => ServiceTemplate, :id => 321, :service_template_catalog_id => 123) }


### PR DESCRIPTION
This PR is the UI counterpart to the [backend PR found here](https://github.com/ManageIQ/manageiq/pull/17647). I decided to write a new javascript controller and haml file corresponding to the reconfigure action instead of reusing `dialogUserController` because there were enough differences that I felt it would be much cleaner and easier to understand this way.

Essentially, when clicking on the reconfigure button, it now will make an API call to get the reconfigure dialog, which will return the dialog with the correct "default" values (they are not actually the default values, they are the values which the service was originally configured with).

https://bugzilla.redhat.com/show_bug.cgi?id=1591484

@miq-bot add_label gaprindashvili/yes, bug, blocker
/cc @gmcculloug @tinaafitz 

@d-m-u Can you test this in conjunction with the main repo PR please?
@syncrou Can you review this as well please?