### PR TITLE
Fix nonexistent pficon-error-octagon

### DIFF
--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -107,7 +107,7 @@ var setUpImportClickHandlers = function(url, grid, importCallback) {
 var clearMessages = function() {
   $('.import-flash-message .alert').removeClass('alert-success alert-danger alert-warning');
   $('.icon-placeholder').removeClass('pficon pficon-ok pficon-layered');
-  $('.pficon-error-octagon').removeClass('pficon-error-octagon');
+  $('.pficon-error-circle-o').removeClass('pficon-error-circle-o');
   $('.pficon-error-exclamation').removeClass('pficon-error-exclamation');
   $('.pficon-warning-triangle-o').removeClass('pficon-warning-triangle-o');
   $('.pficon-warning-exclamation').removeClass('pficon-warning-exclamation');
@@ -130,7 +130,7 @@ var showSuccessMessage = function(message) {
 var showErrorMessage = function(message) {
   $('.import-flash-message .alert').addClass('alert-danger');
   $('.icon-placeholder').addClass('pficon-layered');
-  $('.icon-placeholder .pficon').first().addClass('pficon-error-octagon');
+  $('.icon-placeholder .pficon').first().addClass('pficon-error-circle-o');
   $('.icon-placeholder .pficon').last().addClass('pficon-error-exclamation');
   $('.import-flash-message .alert .message').html(message);
   $('.import-flash-message').show();

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -1,10 +1,8 @@
 - if @sb[:active_tab] == "settings_advanced"
   - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   #form_div
-    .alert.alert-danger
-      %span.pficon-layered
-        %span.pficon.pficon-error-octagon
-        %span.pficon.pficon-error-exclamation
+    .alert.alert-warning
+      %span.pficon.pficon-warning-triangle-o
       %strong
         = advanced_tab_warning
 

--- a/spec/javascripts/import_spec.js
+++ b/spec/javascripts/import_spec.js
@@ -219,7 +219,7 @@ describe('import.js', function() {
       html += '  <div class="alert alert-success alert-danger alert-warning"></div>';
       html += '</div>';
       html += '<div class="icon-placeholder pficon pficon-ok pficon-layered"></div>';
-      html += '<div id="error-octagon" class="pficon-error-octagon"></div>';
+      html += '<div id="error-circle-o" class="pficon-error-circle-o"></div>';
       html += '<div id="error-exclamation" class="pficon-error-exclamation"></div>';
       html += '<div id="warning-triangle" class="pficon-warning-triangle-o"></div>';
       html += '<div id="warning-exclamation" class="pficon-warning-exclamation"></div>';
@@ -240,8 +240,8 @@ describe('import.js', function() {
       expect($('.icon-placeholder')).not.toHaveClass('pficon-layered');
     });
 
-    it('removes pficon-error-octagon class', function() {
-      expect($('#error-octagon')).not.toHaveClass('pficon-error-octagon');
+    it('removes pficon-error-circle-o class', function() {
+      expect($('#error-circle-o')).not.toHaveClass('pficon-error-circle-o');
     });
 
     it('removes pficon-error-exclamation class', function() {


### PR DESCRIPTION
From discussion in https://github.com/ManageIQ/manageiq-ui-classic/pull/4224...

We have a bunch of places using `pficon-error-octagon`. This does not exist in current patternfly, and doesn't seem to exist in 3.3 (ancient version) either.

According to https://www.patternfly.org/styles/icons/, the right icon to use is `pficon-error-circle-o`.

---

So, using that error icon for the import error message.

But for Advanced settings in ops, the message is a warning, is called a warning in code, so it should not be using error styling.

Updated to use the proper warning style instead:

![now](https://user-images.githubusercontent.com/289743/42023974-a94d9374-7ab0-11e8-83c9-bbc67056f733.png)
