### PR TITLE
Add single_quad definition for embedded ansible credentials

### DIFF
--- a/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/authentication_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers
     def self.fonticon
       'pficon pficon-locked'
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end


### PR DESCRIPTION
When going to `Automation -> Ansible -> Credentials` the quadicons were missing, fixing it.

**Before:**
![screenshot from 2018-06-28 11-10-21](https://user-images.githubusercontent.com/649130/42025072-04d8557c-7ac4-11e8-85dc-fe76518ad48e.png)

**After:**
![screenshot from 2018-06-28 11-10-35](https://user-images.githubusercontent.com/649130/42025080-07f9b48a-7ac4-11e8-9a87-2ff273f72f3f.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no, bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594824