### PR TITLE
VM Name in Remote Console Title

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -68,6 +68,7 @@ module VmRemote
         :secret => j(params[:secret]),
         :type   => proto
       }
+      @vm = identify_record(params[:id], VmOrTemplate)
       render(:template => 'layouts/remote_console', :layout => false)
     else
       raise 'Unsupported protocol'

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = _('%{product_name} HTML5 Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
+      = _('%{vm_hostname} - %{product_name} HTML5 Remote Console') % {:vm_hostname => @vm.hostnames[0] || @vm.name, :product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = _('%{product_name} WebMKS Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
+      = _('%{vm_hostname} - %{product_name} WebMKS Remote Console') % {:vm_hostname => @vm.hostnames[0] || @vm.name, :product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
     = javascript_include_tag 'jquery', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'


### PR DESCRIPTION
This PR modifies the information shown in the browser tab for the Remote Console. In stead of showing the same text in all Remote Console tabs, the browser tab now identifies the VM by its hostname or name. This is very usefull when multiple remote consoles of different VMs are open in the browser. The hostname is the preferred name to show because when it is different from the VM name this is a deliberate decision of the VM owner where he prefers to alter the hostname which defaults to the VM name. An OS-less VM has no hostname, so that's why the VM name is shown when there is no hostname.

