### PR TITLE
Show and allow the server name to be saved in the settings/server screen

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -953,6 +953,7 @@ module OpsController::Settings::Common
     @edit[:current].config[:smtp][:openssl_verify_mode] ||= "none"
     @edit[:current].config[:ntp] ||= {}
     @edit[:current].config[:server][:zone] = MiqServer.find(@sb[:selected_server_id]).zone.name
+    @edit[:current].config[:server][:name] = MiqServer.find(@sb[:selected_server_id]).name
 
     @in_a_form = true
   end

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -750,6 +750,7 @@ module OpsController::Settings::Common
 
       new[:server][:custom_support_url] = params[:custom_support_url].strip if params[:custom_support_url]
       new[:server][:custom_support_url_description] = params[:custom_support_url_description] if params[:custom_support_url_description]
+      new[:server][:name] = params[:server_name] if params[:server_name]
     when "settings_authentication"                                        # Authentication tab
       auth = new[:authentication]
       @sb[:form_vars][:session_timeout_mins] = params[:session_timeout_mins] if params[:session_timeout_mins]

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -360,6 +360,15 @@ describe OpsController do
           edit_current = assigns(:edit)
           expect(edit_current[:current].config[:server][:zone]).to eq("default")
         end
+
+        it 'sets the server name' do
+          zone = FactoryGirl.create(:zone, :name => 'Foo Zone')
+          server = FactoryGirl.create(:miq_server, :zone => zone, :name => 'ServerName')
+          controller.instance_variable_set(:@sb, :selected_server_id => server.id)
+          controller.send(:settings_set_form_vars_server)
+          edit_current = assigns(:edit)
+          expect(edit_current[:current].config[:server][:name]).to eq(server.name)
+        end
       end
     end
   end


### PR DESCRIPTION
Show and allow the server name to be saved in the settings/server screen

Links 
----------------

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1595377

Steps for Testing/QA 
-------------------------------

Before  -the server name entered in the Appliance Name field was not saved. The value in the config file was saved instead on the first save ( when other fields were also changed). The save button was only enabled when fields other than Appliance name were modified.

After:

The Save button is enbabled when only the server name is changed, and the name is changed to the new value. 

![screenshot from 2018-06-29 14-12-38](https://user-images.githubusercontent.com/12769982/42107942-16f3edb4-7ba7-11e8-9be7-18f3e726ff71.png)

