### PR TITLE
Fix the EMS fallback decorator's single_quad definition

### DIFF
--- a/app/decorators/ext_management_system_decorator.rb
+++ b/app/decorators/ext_management_system_decorator.rb
@@ -13,7 +13,7 @@ class ExtManagementSystemDecorator < MiqDecorator
 
   def single_quad
     {
-      :fonticon => fonticon
+      :fileicon => fileicon
     }
   end
 end


### PR DESCRIPTION
This decorator is only being used as a fallback to not have scary errors if someone creates a new EMS type. As the `fonticon` is set to `nil`, it would always return with an empty quad, so I'm setting the `single_quad` to return with `fileicon` instead.

@miq-bot add_label gaprindashvili/no, GTLs