### PR TITLE
Don't create create schedule if already created

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -241,7 +241,7 @@ module ReportController::Schedules
       add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
       if x_active_tree != :reports_tree
         # dont set these if new schedule is being added from a report show screen
-        @schedule = if params[:id] == "new"
+        @schedule ||= if params[:id] == "new"
                       MiqSchedule.new(:userid => session[:userid])
                     else
                       find_record_with_rbac(MiqSchedule, checked_or_params)


### PR DESCRIPTION
Schedule was already created in `schedule_new` but code is trying to create/load it again in `schedule_edit`

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1595132

Steps for Testing/QA [Optional]
-------------------------------
1. Navigate to Cloud Intel/Reports.
2. Expand Schedules accordion.
3. Click Configuration "Add a new Schedule".
