### PR TITLE
[GAPRINDASHVILI] Change reconfigure setup to include values configured with originally

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', function(API, dialogFieldRefreshService, miqService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -58,15 +58,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', finishSubmitEndpoint);
     }).catch(function(err) {
-      miqService.sparkleOff();
-      var fullErrorMessage = err.data.error.message;
-      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
-      clearFlash();
-      _.forEach(allErrorMessages, (function(errorMessage) {
-        add_flash(errorMessage, 'error');
-      }));
-      console.error(err);
-      return Promise.reject(err);
+      return Promise.reject(dialogUserSubmitErrorHandlerService.handleError(err));
     });
   }
 

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -65,7 +65,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
       _.forEach(allErrorMessages, (function(errorMessage) {
         add_flash(errorMessage, 'error');
       }));
-      console.log(err);
+      console.error(err);
       return Promise.reject(err);
     });
   }

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, resourceActionId, targetId) {
+ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, resourceActionId, targetId) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -32,7 +32,7 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
       dialogId: vm.dialogId,
       resourceActionId: resourceActionId,
       targetId: targetId,
-      targetType: "service"
+      targetType: "service",
     };
 
     return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, idList);
@@ -52,15 +52,7 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
       miqService.redirectBack(__('Order Request was Submitted'), 'info', '/service/explorer');
     }).catch(function(err) {
-      miqService.sparkleOff();
-      var fullErrorMessage = err.data.error.message;
-      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
-      clearFlash();
-      _.forEach(allErrorMessages, (function(errorMessage) {
-        add_flash(errorMessage, 'error');
-      }));
-      console.error(err);
-      return Promise.reject(err);
+      return Promise.reject(dialogUserSubmitErrorHandlerService.handleError(err));
     });
   }
 

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -1,0 +1,74 @@
+ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, resourceActionId, targetId) {
+  var vm = this;
+
+  vm.$onInit = function() {
+    var apiCall = new Promise(function(resolve) {
+      var url = '/api/services/' + targetId +
+        '?attributes=reconfigure_dialog';
+
+      resolve(API.get(url).then(init));
+    });
+
+    Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
+  };
+
+  function init(data) {
+    vm.dialogId = data.reconfigure_dialog[0].id;
+    vm.dialog = data.reconfigure_dialog[0];
+    vm.dialogLoaded = true;
+  }
+
+  vm.refreshField = refreshField;
+  vm.setDialogData = setDialogData;
+  vm.refreshUrl = '/api/service_dialogs/';
+
+  vm.submitButtonClicked = submitButtonClicked;
+  vm.cancelClicked = cancelClicked;
+  vm.saveable = saveable;
+  vm.isValid = false;
+
+  function refreshField(field) {
+    var idList = {
+      dialogId: vm.dialogId,
+      resourceActionId: resourceActionId,
+      targetId: targetId,
+      targetType: "service"
+    };
+
+    return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, idList);
+  }
+
+  function setDialogData(data) {
+    vm.isValid = data.validations.isValid;
+    vm.dialogData = data.data;
+  }
+
+  function submitButtonClicked() {
+    miqService.sparkleOn();
+
+    var apiData = {action: 'reconfigure', resource: _.omit(vm.dialogData, 'action')};
+    var apiSubmitEndpoint = '/api/services/' + targetId;
+
+    return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {
+      miqService.redirectBack(__('Order Request was Submitted'), 'info', '/service/explorer');
+    }).catch(function(err) {
+      miqService.sparkleOff();
+      var fullErrorMessage = err.data.error.message;
+      var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
+      clearFlash();
+      _.forEach(allErrorMessages, (function(errorMessage) {
+        add_flash(errorMessage, 'error');
+      }));
+      console.error(err);
+      return Promise.reject(err);
+    });
+  }
+
+  function cancelClicked(_event) {
+    miqService.redirectBack(__('Dialog Cancelled'), 'info', '/service/explorer');
+  }
+
+  function saveable() {
+    return vm.isValid && ! dialogFieldRefreshService.areFieldsBeingRefreshed;
+  }
+}]);

--- a/app/assets/javascripts/services/dialog_user_submit_error_handler_service.js
+++ b/app/assets/javascripts/services/dialog_user_submit_error_handler_service.js
@@ -1,0 +1,13 @@
+ManageIQ.angular.app.service('dialogUserSubmitErrorHandlerService', ['miqService', function(miqService) {
+  this.handleError = function(err) {
+    miqService.sparkleOff();
+    var fullErrorMessage = err.data.error.message;
+    var allErrorMessages = fullErrorMessage.split('-')[1].split(',');
+    clearFlash();
+    _.forEach(allErrorMessages, function(errorMessage) {
+      add_flash(errorMessage, 'error');
+    });
+    console.error(err);
+    return err;
+  };
+}]);

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -145,9 +145,12 @@ module ApplicationController::DialogRunner
   def dialog_initialize(ra, options)
     @edit = {}
     @edit[:new] = options[:dialog] || {}
+
     opts = {
       :target => options[:target_kls].constantize.find_by_id(options[:target_id])
     }
+    opts[:reconfigure] = true if options[:dialog_mode] == :reconfigure
+
     @edit[:wf] = ResourceActionWorkflow.new(@edit[:new], current_user, ra, opts)
     @record = Dialog.find_by_id(ra.dialog_id.to_i)
     @edit[:rec_id]   = @record.id

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -20,20 +20,6 @@ class DialogLocalService
     Vm
   ).freeze
 
-  def determine_dialog_locals_for_service_reconfiguration(resource_action, target)
-    {
-      :resource_action_id     => resource_action.id,
-      :target_id              => target.id,
-      :target_type            => "service",
-      :dialog_id              => resource_action.dialog_id,
-      :force_old_dialog_use   => false,
-      :api_submit_endpoint    => "/api/services/#{target.id}",
-      :api_action             => "reconfigure",
-      :finish_submit_endpoint => "/service/explorer",
-      :cancel_endpoint        => "/service/explorer"
-    }
-  end
-
   def determine_dialog_locals_for_svc_catalog_provision(resource_action, target, finish_submit_endpoint)
     api_submit_endpoint = "/api/service_catalogs/#{target.service_template_catalog_id}/service_templates/#{target.id}"
 

--- a/app/views/shared/dialogs/_reconfigure_dialog.html.haml
+++ b/app/views/shared/dialogs/_reconfigure_dialog.html.haml
@@ -1,0 +1,25 @@
+#main_div
+  .row.wrapper{"ng-controller" => "dialogUserReconfigureController as vm"}
+    .spinner{'ng-show' => "!vm.dialogLoaded"}
+
+    .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
+      %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
+
+      .clearfix
+      .pull-right.button-group{'ng-show' => "vm.dialogLoaded"}
+        %miq-button{:name      => t = _("Submit"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'vm.saveable()',
+                    'on-click' => "vm.submitButtonClicked()",
+                    :primary   => 'true'}
+        %miq-button{:name      => t = _("Cancel"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'true',
+                    'on-click' => "vm.cancelClicked($event)"}
+
+  :javascript
+    ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
+    ManageIQ.angular.app.value('targetId', '#{target_id}');
+    miq_bootstrap('.wrapper');

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -23,6 +23,35 @@ describe ServiceController do
     service
   end
 
+  describe "#service_reconfigure" do
+    let(:service) { instance_double("Service", :id => 3000000000001, :service_template => service_template) }
+    let(:service_template) { instance_double("ServiceTemplate", :name => "the name") }
+    let(:ar_association_dummy) { double }
+    let(:resource_action) { instance_double("ResourceAction", :id => 123) }
+
+    before do
+      allow(Service).to receive(:find_by_id).with(3000000000001).and_return(service)
+      allow(service_template).to receive(:resource_actions).and_return(ar_association_dummy)
+      allow(ar_association_dummy).to receive(:find_by).with(:action => 'Reconfigure').and_return(resource_action)
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@_params, :id => "3r1")
+    end
+
+    it "sets the right cell text" do
+      controller.send(:service_reconfigure)
+      expect(controller.instance_variable_get(:@right_cell_text)).to eq("Reconfigure Service \"the name\"")
+    end
+
+    it "replaces the right cell with the reconfigure dialog partial" do
+      expect(controller).to receive(:replace_right_cell).with(
+        :action        => "reconfigure_dialog",
+        :dialog_locals => {:resource_action_id => 123, :target_id => 3000000000001}
+      )
+
+      controller.send(:service_reconfigure)
+    end
+  end
+
   describe "#service_delete" do
     it "display flash message with description of deleted Service" do
       st  = FactoryGirl.create(:service_template)

--- a/spec/javascripts/services/dialog_user_submit_error_handling_service_spec.js
+++ b/spec/javascripts/services/dialog_user_submit_error_handling_service_spec.js
@@ -1,0 +1,41 @@
+describe('dialogUserSubmitErrorHandlerService', function() {
+  var testService, miqService;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function(dialogUserSubmitErrorHandlerService, _miqService_) {
+    testService = dialogUserSubmitErrorHandlerService;
+    miqService = _miqService_;
+  }));
+
+  describe('#handleError', function() {
+    var errorData;
+
+    beforeEach(function() {
+      errorData = {data: {error: {message: "Failed! -One,Two"}}};
+      spyOn(miqService, 'sparkleOff');
+      spyOn(window, 'clearFlash');
+      spyOn(window, 'add_flash');
+    });
+
+    it('turns off the sparkle', function() {
+      testService.handleError(errorData);
+      expect(miqService.sparkleOff).toHaveBeenCalled();
+    });
+
+    it('clears flash messages', function() {
+      testService.handleError(errorData);
+      expect(window.clearFlash).toHaveBeenCalled();
+    });
+
+    it('adds flash messages for each message after the -', function() {
+      testService.handleError(errorData);
+      expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
+      expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
+    });
+
+    it('returns the error data to bubble up to the parent', function() {
+      expect(testService.handleError(errorData)).toEqual(errorData);
+    });
+  });
+});

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -1,25 +1,6 @@
 describe DialogLocalService do
   let(:service) { described_class.new }
 
-  describe "#determine_dialog_locals_for_service_reconfiguration" do
-    let(:target) { instance_double("Service", :id => 123) }
-    let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
-
-    it "returns a hash" do
-      expect(service.determine_dialog_locals_for_service_reconfiguration(resource_action, target)).to eq(
-        :resource_action_id     => 456,
-        :target_id              => 123,
-        :target_type            => "service",
-        :dialog_id              => 654,
-        :force_old_dialog_use   => false,
-        :api_submit_endpoint    => "/api/services/123",
-        :api_action             => "reconfigure",
-        :finish_submit_endpoint => "/service/explorer",
-        :cancel_endpoint        => "/service/explorer"
-      )
-    end
-  end
-
   describe "#determine_dialog_locals_for_svc_catalog_provision" do
     let(:resource_action) { instance_double("ResourceAction", :id => 456, :dialog_id => 654) }
     let(:target) { instance_double("ServiceTemplate", :class => ServiceTemplate, :id => 321, :service_template_catalog_id => 123) }


### PR DESCRIPTION
This is a manual backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/4226 since as @simaishi pointed out, we need to take into account compressed ids and the spec surely would have broken.

There was also another small conflict in the javascript spec regarding calling `setTimeout` whereas the master PR does not do that, so I've fixed that as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1591484 is the Gaprindashvili BZ, the original BZ is https://bugzilla.redhat.com/show_bug.cgi?id=1580987.

@simaishi Please let me know if there is anything else I need to change about this PR/commits. Thanks!

@miq-bot assign @simaishi 