### PR TITLE
Add spec for dialogUserSubmitErrorHandlingService

### DIFF
--- a/spec/javascripts/services/dialog_user_submit_error_handling_service.spec.js
+++ b/spec/javascripts/services/dialog_user_submit_error_handling_service.spec.js
@@ -1,0 +1,41 @@
+describe('dialogUserSubmitErrorHandlerService', function() {
+  var testService, miqService;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function(dialogUserSubmitErrorHandlerService, _miqService_) {
+    testService = dialogUserSubmitErrorHandlerService;
+    miqService = _miqService_;
+  }));
+
+  describe('#handleError', function() {
+    var errorData;
+
+    beforeEach(function() {
+      errorData = {data: {error: {message: "Failed! -One,Two"}}};
+      spyOn(miqService, 'sparkleOff');
+      spyOn(window, 'clearFlash');
+      spyOn(window, 'add_flash');
+    });
+
+    it('turns off the sparkle', function() {
+      testService.handleError(errorData);
+      expect(miqService.sparkleOff).toHaveBeenCalled();
+    });
+
+    it('clears flash messages', function() {
+      testService.handleError(errorData);
+      expect(window.clearFlash).toHaveBeenCalled();
+    });
+
+    it('adds flash messages for each message after the -', function() {
+      testService.handleError(errorData);
+      expect(window.add_flash).toHaveBeenCalledWith('One', 'error');
+      expect(window.add_flash).toHaveBeenCalledWith('Two', 'error');
+    });
+
+    it('returns the error data to bubble up to the parent', function() {
+      expect(testService.handleError(errorData)).toEqual(errorData);
+    });
+  });
+});


### PR DESCRIPTION
I forgot to add this to #4226. It's a spec for the logic I refactored out, but the specs were mostly transferred over from the old spec logic (just without the need to be called async).

Figured out I forgot to add it when I made the Gaprindashvili manual backport after #4226 was already merged. Oops 😢 

@miq-bot add_label gaprindashvili/no
@miq-bot assign @mzazrivec 

