### PR TITLE
Makes get_task_args a bit more readable

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -92,8 +92,7 @@ module Mixins
       result, details = if %w(ems_cloud ems_infra).include?(params[:controller]) && session[:selected_roles].try(:include?, 'user_interface')
                           realtime_raw_connect(ems_type)
                         elsif %w(ems_cloud ems_infra).include?(params[:controller])
-                          method_name = params[:cred_type] == 'amqp' ? 'raw_event_connect?' : 'raw_connect?'
-                          ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone], method_name)
+                          ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
                         else
                           realtime_authentication_check(ems_type.new)
                         end

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -124,8 +124,12 @@ module Mixins
       user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
       case ems.to_s
       when 'ManageIQ::Providers::Openstack::CloudManager', 'ManageIQ::Providers::Openstack::InfraManager'
-        connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)] if params[:cred_type] == "default"
-        connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)] if params[:cred_type] == "amqp"
+        case params[:cred_type]
+        when 'amqp'
+          connect_opts = [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
+        when 'default'
+          connect_opts = [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
+        end
         connect_opts
       when 'ManageIQ::Providers::Amazon::CloudManager'
         uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))


### PR DESCRIPTION
This was initially created to address credential validation for OpenStack (BZ#1593663) which is now  directly handled in raw_connect.

Meanwhile the cosmetic change is still relevant as it makes `get_task_args`a bit more readable.