### PR TITLE
Fixed variable name

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -364,7 +364,7 @@ class MiqRequestController < ApplicationController
 
   def requester_label(request)
     if request.requester.nil?
-      (_("%{name} (no longer exists)") % {:name => r.requester_name})
+      (_("%{name} (no longer exists)") % {:name => request.requester_name})
     else
       request.requester_name
     end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -368,6 +368,31 @@ describe MiqRequestController do
     end
   end
 
+  context "requester_label" do
+    before(:each) do
+      EvmSpecHelper.local_miq_server
+      stub_server_configuration(:server => {}, :session => {})
+
+      # Create user
+      @approver = FactoryGirl.create(:user, :role => "approver")
+      allow(@approver).to receive(:role_allows?).with(:identifier => 'miq_request_approval').and_return(true)
+
+      # Create request
+      @request = FactoryGirl.create(:vm_migrate_request, :requester => @approver)
+    end
+
+    it "returns label with requester_name" do
+      label = controller.send(:requester_label, @request)
+      expect(label).to eq(@approver.name)
+    end
+
+    it "returns label when requester no longer exists" do
+      @request.update_attributes(:requester => nil)
+      label = controller.send(:requester_label, @request)
+      expect(label).to eq("#{@approver.name} (no longer exists)")
+    end
+  end
+
   private
 
   def create_user_in_other_region(userid)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597193

To recreate: Add a request with a non-admin user role, then login as Admin, and delete the User that you used to create a Provisioning Request, not try going to list of Requests screen.

@lgalis please test.
@dclarizio please review.