### PR TITLE
[DO NOT MERGE] Quick fix for /alerts_list/class_icons

### DIFF
--- a/app/assets/images/svg/container_node.svg
+++ b/app/assets/images/svg/container_node.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="116 0 100 100" enable-background="new 116 0 100 100" xml:space="preserve">
+  <text x="0" y="0" class="pficon pficon-container-node">\ue621</text>
+</svg>

--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -23,7 +23,7 @@ class AlertsListController < ApplicationController
       'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
       'ManageIQ::Providers::Openshift::ContainerManager',
     ].each do |klass|
-      fileicon = klass.constantize.decorate.fileicon
+      fileicon = klass.constantize.new.decorate.fileicon
       res[klass] = ActionController::Base.helpers.image_path(fileicon)
     end
     render :json => res

--- a/app/decorators/container_node_decorator.rb
+++ b/app/decorators/container_node_decorator.rb
@@ -3,6 +3,10 @@ class ContainerNodeDecorator < MiqDecorator
     'pficon pficon-container-node'
   end
 
+  def fileicon
+    "svg/container_node.svg"
+  end
+
   def single_quad
     {
       :fonticon => fonticon

--- a/spec/controllers/alerts_list_controller_spec.rb
+++ b/spec/controllers/alerts_list_controller_spec.rb
@@ -1,0 +1,26 @@
+describe AlertsListController do
+  let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
+
+  before(:each) do
+    EvmSpecHelper.create_guid_miq_server_zone
+    MiqRegion.seed
+    login_as user
+  end
+
+  describe "#class_icons" do
+    it "returns a json response of the class icons" do
+      get :class_icons, :format => :json
+      response_body = JSON.parse(response.body)
+      
+      expect(response.status).to eq(200)
+
+      {
+        "ManageIQ::Providers::Kubernetes::ContainerManager"                => /^\/assets\/svg\/vendor-kubernetes.*\.svg/,
+        "ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode" => /^\/assets\/svg\/container_node.*\.svg/, 
+        "ManageIQ::Providers::Openshift::ContainerManager"                 => /^\/assets\/svg\/vendor-openshift.*\.svg/,
+      }.each do |klass_key, image_match|
+        expect(response_body[klass_key]).to match(image_match)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note:  This is simply meant as a stop gap to allow `alerts_list/show` (which calls
`/alerts_list/class_icons` ) to function without throwing an error.  A better solution can be found in https://github.com/ManageIQ/manageiq-ui-classic/pull/4247 that matches the current standards and practices, and frankly this has no purpose being merged.  Simply putting this up for posterity and for those that and to pull it down to allow these routes to function.

In the following two pull requests:

  - https://github.com/ManageIQ/manageiq-ui-classic/pull/3794
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/4029

The functionality that was defined on the decorators to allow `klass.fileicon` to function was removed.  From the first pull request, both the image and `.fileicon` method were removed from the `ContainerNodeDecorator`, and in the second, the subclasses that the `Openshift::ContainerManager` and the `Kubernetes::ContainerManager` classes used as decorators were also removed (each having their own `.fileicon` class methods.

The new class that that `ContainerManager` classes used could be instantiated as an instance and have access to the `#fileicon` instance method.  The `ContainerNodeDecorator` was the only class that needed some form of the `fileicon` method added back, so adding it to the instance seemed to be the simplest, and then updating the controller to use some dummy instances to get the `#fileicon` method calls to work was all that was necessary to get the controller to work.

I have also included an SVG (that probably doesn't work) as a place holder image and attempts to use the fonticon for the image content.  I don't know how this stuff works, but it at least returns something this way.

¯\\(°\_o)/¯


Links
-----

- https://github.com/ManageIQ/manageiq-ui-classic/pull/3794
- https://github.com/ManageIQ/manageiq-ui-classic/pull/4029


Steps for Testing/QA
--------------------

Once you are logged in, you should be able to go to the `/alerts_list/class_icons` round and get a blob of JSON with this patch in place.  Without it, it will cause a 500 error.