### PR TITLE
Passing capacity hash to values broke PV screen

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -32,7 +32,8 @@ module PersistentVolumeHelper::TextualSummary
 
   def textual_group_capacity
     labels = [_("Resource"), _("Quantity")]
-    TextualMultilabel.new(_("Capacity"), :labels => labels, :values => @record.capacity)
+    values = (@record.capacity || {}).collect { |type, capacity| [type.to_s, capacity.to_s] }
+    TextualMultilabel.new(_("Capacity"), :labels => labels, :values => values)
   end
 
   #


### PR DESCRIPTION
Passing capacity hash to values broke the PV summary screen - table rows are expected to be an array.

cc: @cben @himdel @martinpovolny @oourfali 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1594567

Before:
![screenshot from 2018-07-02 18-04-40](https://user-images.githubusercontent.com/8366181/42214282-c663a95a-7ec3-11e8-845d-fb3fe3a53912.png)

After:
![screenshot from 2018-07-03 13-16-43](https://user-images.githubusercontent.com/8366181/42214295-cc69e206-7ec3-11e8-83cd-e31a73553000.png)
