### PR TITLE
Replaced fileicons with fonticons in alerts.

### DIFF
--- a/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_list_controller.js
@@ -10,7 +10,6 @@ angular.module('alertsCenter').controller('alertsListController',
 
     function processData(response) {
       var updatedAlerts = alertsCenterService.convertToAlertsList(response);
-
       // update display data for the alerts from the current alert settings
       angular.forEach(updatedAlerts, function(nextUpdate) {
         var matchingAlert = _.find(vm.alerts, function(existingAlert) {

--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -490,7 +490,6 @@ function alertsCenterService(API, $q, $timeout, $document, $uibModal, $http) {
 
   function convertAlert(alertData, objectName, objectClassifiedType, objectType, retrievalTime) {
     var hostType = alertData.resource.type;
-
     var newAlert = {
       id: alertData.id,
       description: alertData.description,

--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -23,8 +23,7 @@ class AlertsListController < ApplicationController
       'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
       'ManageIQ::Providers::Openshift::ContainerManager',
     ].each do |klass|
-      fileicon = klass.constantize.decorate.fileicon
-      res[klass] = ActionController::Base.helpers.image_path(fileicon)
+      res[klass] = klass.constantize.decorate.fonticon
     end
     render :json => res
   end

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -20,14 +20,16 @@
                               "tooltip-placement" => "bottom",
                               "tooltip-popup-delay" => "1000",
                               "ng-class" => "{'transparent': item.hostImg == item.objectTypeImg}"}
-                  %img.list-view-type-img{"ng-src" => "{{item.hostImg}}"}
+                  %i{:style => "color: #000",
+                     :class => "{{item.hostImg}}"}
                   {{item.hostName}}
             %div
               %a{"href" => "#", "ng-click" => "customScope.showObjectPage(item, $event)"}
                 %span.no-wrap{"uib-tooltip" => "{{item.objectName}}",
                               "tooltip-placement" => "bottom",
                               "tooltip-popup-delay" => "1000"}
-                  %img.list-view-type-img{"ng-src" => "{{item.objectTypeImg}}"}
+                  %i{:style => "color: #000",
+                     :class => "{{item.objectTypeImg}}"}
                   {{item.objectName}}
           .col-lg-3.col-lg-push-4.col-md-4.col-md-push-3.col-sm-3.col-sm-push-3.col-xs-6.container-fluid
             %div


### PR DESCRIPTION
Fixed missing images in alerts. Now using fonticons instead of fileicons.

http://localhost:3000/alerts_list/show

![screenshot from 2018-07-03 17-05-56](https://user-images.githubusercontent.com/22619452/42228117-6e4dc104-7ee3-11e8-9179-ed9ce904deba.png)

should replace #4243 