### PR TITLE
Use safer way when filter charts

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -1577,9 +1577,11 @@ module ApplicationController::Performance
   # rpt.where_clause[2] should be id
   def perf_filter_charts(chart_layout, rpt)
     return unless rpt&.where_clause
-    model = rpt.where_clause[1].constantize
-    id = rpt.where_clause[2]
-    if model.find(id).type == "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone"
+    model = rpt.where_clause.dig(1).constantize
+    id = rpt.where_clause.dig(2)
+    return unless model && id
+    if model == AvailabilityZone &&
+       model.find(id).type == "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone"
       chart_layout.reject! { |chart| chart[:title].include?("Memory") }
     end
   end


### PR DESCRIPTION
When filter which chart should be displayed, use more safer way, which doesn't raise an exception.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1597640

Steps for Testing/QA [Optional]
-------------------------------

(1. Add provider I added VirtualCenter-65
2. Enabled C&U on appliance also ordered data with gap collection)
Or just have a datastore with C&U data,
3. Navigate to Datastore and wait for Utilization Enable (Datastore > Monitoring > Utilization)
4. Click on Utilization you will get an error


@romanblanco could you please review
