### PR TITLE
Revert "jquery - move to npm"

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,7 @@
 //= require bower_components/es6-shim/es6-shim
 //= require bower_components/array-includes/array-includes
 //= require bower_components/fetch/fetch
-//= require jquery
+//= require bower_components/jquery/dist/jquery
 //= require ./jquery_overrides
 //= require ./i18n
 //= require patternfly

--- a/app/assets/javascripts/remote_consoles/spice.js
+++ b/app/assets/javascripts/remote_consoles/spice.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require bower_components/jquery/dist/jquery
 //= require bower_components/spice-html5-bower/spice-html5-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/assets/javascripts/remote_consoles/vnc.js
+++ b/app/assets/javascripts/remote_consoles/vnc.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require bower_components/jquery/dist/jquery
 //= require novnc-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -7,7 +7,7 @@
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     -# Load the required JS based on the console type
-    = javascript_include_tag 'jquery', "remote_consoles/#{@console[:type]}", 'remote_console'
+    = javascript_include_tag 'bower_components/jquery/dist/jquery.js', "remote_consoles/#{@console[:type]}", 'remote_console'
   %body
     #remote-console{'data-url' => @console[:url], 'data-secret' => @console[:secret]}
     = render :partial => 'shared/remote_console_footer', :layout   => false, :locals   => { :console_type => @console[:type].upcase }

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     = favicon_link_tag
-    = javascript_include_tag 'jquery'
+    = javascript_include_tag 'bower_components/jquery/dist/jquery.js'
     :javascript
       // INITIALIZE
       $(document).ready(function(){

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -5,7 +5,7 @@
       = _('%{product_name} WebMKS Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
-    = javascript_include_tag 'jquery', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
+    = javascript_include_tag 'bower_components/jquery/dist/jquery.js', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
     :javascript
       $(function () {
         var mksOpts = {};

--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "es6-shim": "~0.35.1",
     "fetch": "~1.0.0",
     "jasmine-jquery": "~2.1.1",
+    "jquery": "~2.2.4",
     "jquery-ui": "jqueryui#~1.12.1",
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,7 @@ end
 Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/modes/*.js
   bower_components/codemirror/themes/*.css
-  jquery.js
+  bower_components/jquery/dist/jquery.js
   bower_components/jquery-ui/jquery-ui.js
 
   jquery_overrides.js

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "bootstrap-switch": "~3.3.4",
     "graphiql": "^0.11.11",
     "graphql": "^0.13.2",
-    "jquery": "~2.2.4",
     "lodash": "^4.17.4",
     "ng-redux": "^3.5.2",
     "patternfly-react": "2.10.1",


### PR DESCRIPTION
NPM assets somehow don't work using `javascript_include_tag` in production, but they do in development. This is just my way of fixing any maybe there's something more JS-ish way to do this.

This reverts commit cd6c0f11cf2bad0b53c6fc6b7776b1a34a2efd41.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597352

@miq-bot add_label bug, gaprindashvili/no
@miq-bot assign @himdel 