### PR TITLE
Use onchange as well as onfocus for radio buttons

### DIFF
--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -137,6 +137,22 @@ $(document).ready(function () {
     }
   });
 
+  // Firefox on MacOs isn't firing onfocus events for radio buttons so onchange is used instead
+  $(document).on('change', '[data-miq_observe]', function () {
+    var el = $(this);
+    var parms = $.parseJSON(el.attr('data-miq_observe'));
+    var id = el.attr('id');
+    var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
+
+    miqObserveRequest(parms.url, {
+      no_encoding: true,
+      data: id + '=' + value,
+      beforeSend: !! el.attr('data-miq_sparkle_on'),
+      complete: !! el.attr('data-miq_sparkle_off'),
+      done: attemptAutoRefreshTrigger(parms),
+    });
+  });
+
   $(document).on('change', '[data-miq_observe_checkbox]', function (event) {
     var el = $(this);
     var parms = $.parseJSON(el.attr('data-miq_observe_checkbox'));


### PR DESCRIPTION
Firefox on **MacOS** doesn't fire `onfocus` when radio button is clicked. And it's by design as seen [here](https://bugzilla.mozilla.org/show_bug.cgi?id=577316) [here](https://bugzilla.mozilla.org/show_bug.cgi?id=643968) [here](https://bugzilla.mozilla.org/show_bug.cgi?id=756028) so adding `onchange` to do the same as `onfocus`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594714

How to reproduce:
1. Using Firefox, create a new custom button of type "Ansible Playbook". Select "Target Machine" as the inventory type. Complete the remaining button details and save.
2. Observe that the Target has been set to "localhost"
3. Try to edit the button. Observe that changing the "Inventory" radio button value does not enable the 'Save' button. 
4. Change the button name (which does re-enable the 'Save' button), and change the "Inventory" radio button value to "Target Machine". Save the change

Before:
Save/Reset buttons disabled.
Change to Inventory not saved.
After:
Save/Reset buttons enabled
Change to Inventory saved.

@miq-bot add_label bug, blocker, gaprindashvili/yes
