### PR TITLE
Adding Physical Chassis Location LED actions

### DIFF
--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -25,6 +25,7 @@ class PhysicalChassisController < ApplicationController
     ]
   end
   helper_method(:textual_group_list)
+  toolbar('physical_chassis_summary', 'physical_chassis_list')
 
   def self.display_methods
     %w(physical_storages physical_servers)

--- a/app/helpers/application_helper/toolbar/physical_chassis_list_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_chassis_list_center.rb
@@ -1,0 +1,54 @@
+class ApplicationHelper::Toolbar::PhysicalChassisListCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_chassis_operations',
+    [
+      select(
+        :physical_chassis_identify_choice,
+        nil,
+        N_('Identify LED Operations'),
+        N_('Identify'),
+        :items => [
+          api_button(
+            :physical_chassis_blink_loc_led,
+            nil,
+            N_('Blink the Identify LED'),
+            N_('Blink LED'),
+            :icon    => "pficon pficon-connected fa-lg",
+            :api     => {
+              :action => 'blink_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Blink the Identify LED?"),
+            :options => {:feature => :blink_loc_led}
+          ),
+          api_button(
+            :physical_chassis_turn_on_loc_led,
+            nil,
+            N_('Turn on the Idenfity LED'),
+            N_('Turn On LED'),
+            :icon    => "pficon pficon-on fa-lg",
+            :api     => {
+              :action => 'turn_on_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Turn on the Identify LED?"),
+            :options => {:feature => :turn_on_loc_led}
+          ),
+          api_button(
+            :physical_chassis_turn_off_loc_led,
+            nil,
+            N_('Turn off the Identify LED'),
+            N_('Turn Off LED'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'turn_off_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Turn off the Identify LED?"),
+            :options => {:feature => :turn_off_loc_led}
+          ),
+        ]
+      )
+    ]
+  )
+end

--- a/app/helpers/application_helper/toolbar/physical_chassis_summary_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_chassis_summary_center.rb
@@ -1,0 +1,54 @@
+class ApplicationHelper::Toolbar::PhysicalChassisSummaryCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'physical_chassis_operations',
+    [
+      select(
+        :physical_chassis_identify_choice,
+        nil,
+        N_('Identify LED Operations'),
+        N_('Identify'),
+        :items => [
+          api_button(
+            :physical_chassis_blink_loc_led,
+            nil,
+            N_('Blink the Identify LED'),
+            N_('Blink LED'),
+            :icon    => "pficon pficon-connected fa-lg",
+            :api     => {
+              :action => 'blink_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Blink the Identify LED?"),
+            :options => {:feature => :blink_loc_led}
+          ),
+          api_button(
+            :physical_chassis_turn_on_loc_led,
+            nil,
+            N_('Turn on the Idenfity LED'),
+            N_('Turn On LED'),
+            :icon    => "pficon pficon-on fa-lg",
+            :api     => {
+              :action => 'turn_on_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Turn on the Identify LED?"),
+            :options => {:feature => :turn_on_loc_led}
+          ),
+          api_button(
+            :physical_chassis_turn_off_loc_led,
+            nil,
+            N_('Turn off the Identify LED'),
+            N_('Turn Off LED'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'turn_off_loc_led',
+              :entity => 'physical_chassis'
+            },
+            :confirm => N_("Turn off the Identify LED?"),
+            :options => {:feature => :turn_off_loc_led}
+          ),
+        ]
+      )
+    ]
+  )
+end


### PR DESCRIPTION
__This PR is able to__
- Add Location LED actions for Physical Chassis:
  - blink_loc_led;
  - turn_on_loc_led;
  - turn_off_loc_led.

__Depends on__
~https://github.com/ManageIQ/manageiq/pull/17668~ - Merged
~https://github.com/ManageIQ/manageiq-ui-classic/pull/4065~ - Merged
~https://github.com/ManageIQ/manageiq-api/pull/410~ - Merged