### PR TITLE
Fixes page header when displaying Cloud Networks list

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -350,7 +350,7 @@ module VmCommon
   end
 
   def cloud_networks
-    show_association('cloud_subnets', _('Networks'), :cloud_subnets, CloudNetwork)
+    show_association('cloud_networks', _('Networks'), :cloud_networks, CloudNetwork)
   end
 
   def cloud_volumes


### PR DESCRIPTION
Fixes incorrect action value passed when building page header text for Cloud Networks list view.

https://bugzilla.redhat.com/show_bug.cgi?id=1588326

Screen shot prior to code fix:
![cloud networks incorrect page header prior to code fix](https://user-images.githubusercontent.com/552686/42352071-2b6f9674-806d-11e8-830e-bb7e96b63d95.png)

Screen shot post code fix:
![cloud networks correct page header post code fix](https://user-images.githubusercontent.com/552686/42352088-4490c2f4-806d-11e8-9d02-e2e22c597cc5.png)


