### PR TITLE
Implement toolbar extension mechanism for providers

### DIFF
--- a/app/helpers/application_helper/toolbar/base.rb
+++ b/app/helpers/application_helper/toolbar/base.rb
@@ -1,0 +1,67 @@
+class ApplicationHelper::Toolbar::Base
+  include Singleton
+  extend SingleForwardable
+  delegate %i(api_button button select twostate separator definition button_group custom_content) => :instance
+
+  def custom_content(name, args)
+    @definition[name] = ApplicationHelper::Toolbar::Custom.new(name, args)
+  end
+
+  def button_group(name, buttons)
+    @definition[name] = ApplicationHelper::Toolbar::Group.new(name, buttons)
+  end
+
+  def api_button(id, icon, title, text, keys = {})
+    keys[:data] = {
+      'function'      => 'sendDataWithRx',
+      'function-data' => {
+        'type'       => "generic",
+        'controller' => "toolbarActions",
+        'payload'    => {
+          'entity' => keys[:api][:entity].pluralize,
+          'action' => keys[:api][:action]
+        }
+      }.to_json
+    }
+    generic_button(:button, id, icon, title, text, keys)
+  end
+
+  def button(id, icon, title, text, keys = {})
+    generic_button(:button, id, icon, title, text, keys)
+  end
+
+  def select(id, icon, title, text, keys = {})
+    generic_button(:buttonSelect, id, icon, title, text, keys)
+  end
+
+  def twostate(id, icon, title, text, keys = {})
+    generic_button(:buttonTwoState, id, icon, title, text, keys)
+  end
+
+  def separator
+    {:separator => true}
+  end
+
+  attr_reader :definition
+
+  private
+
+  def initialize
+    @loaded = false
+    @definition = {}
+  end
+
+  def generic_button(type, id, icon, title, text, keys)
+    if text.kind_of?(Hash)
+      keys = text
+      text = title
+    end
+    {
+      :type  => type,
+      :id    => id.to_s,
+      :icon  => icon,
+      :title => title,
+      :text  => text
+    }.merge(keys)
+  end
+end

--- a/app/helpers/application_helper/toolbar/basic.rb
+++ b/app/helpers/application_helper/toolbar/basic.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::Basic < ApplicationHelper::Toolbar::Base
     # "ManageIQ::Providers::Amazon::ToolbarOverrides::EmsCloudCenter" is a match for
     #   "ManageIQ::Providers::Amazon::CloudManager
     extension_classes.find_all do |ext|
-      ext.name.split('::')[0..-3] == record.class.name.split('::')[0..-2]
+      ext.name.split('::')[0..2] == record.class.name.split('::')[0..2]
     end
   end
 

--- a/app/helpers/application_helper/toolbar/override.rb
+++ b/app/helpers/application_helper/toolbar/override.rb
@@ -1,0 +1,3 @@
+class ApplicationHelper::Toolbar::Override < ApplicationHelper::Toolbar::Base
+  # For now this class is empty. However we want the provider toolbar extentions to inherit from here.
+end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -16,12 +16,12 @@ class ApplicationHelper::ToolbarBuilder
 
     build_toolbar_setup
     toolbar_class = toolbar_class(toolbar_name)
-    build_toolbar_from_class(toolbar_class)
+    build_toolbar_from_class(toolbar_class, @record)
   end
 
   def build_toolbar_by_class(toolbar_class)
     build_toolbar_setup
-    build_toolbar_from_class(toolbar_class)
+    build_toolbar_from_class(toolbar_class, @record)
   end
 
   private
@@ -450,8 +450,8 @@ class ApplicationHelper::ToolbarBuilder
     @sep_added = false
   end
 
-  def build_toolbar_from_class(toolbar_class)
-    toolbar_class.definition.each_with_index do |(name, group), group_index|
+  def build_toolbar_from_class(toolbar_class, record)
+    toolbar_class.definition(record).each_with_index do |(_name, group), group_index|
       @sep_added = false
       @groups_added.push(group_index)
       case group


### PR DESCRIPTION
### Context

We want to allow the provider authors to extend ManageIQ UI with Ansible playbooks and roles. ManageIQ core provides the capability to execute an Asible playbook from the provider repository. The ManageIQ UI provides a way to call that playbook from a toolbar. Before calling the playbook additional parameters can be collected using a custom dialog.

Related UI PRs:
 * https://github.com/ManageIQ/manageiq-ui-classic/pull/4267
 * https://github.com/ManageIQ/manageiq-ui-classic/pull/4231

### Goal of this PR

This allows providers to extend existing toolbars by creating classes such as:

`app/helpers/manageiq/providers/amazon/toolbar_overrides/ems_cloud_center.rb` in the `manageiq-providers-amazon` repo.

```ruby
module ManageIQ
  module Providers
    module Amazon
      module ToolbarOverrides
        class EmsCloudCenter < ::ApplicationHelper::Toolbar::Override
          button_group('magic', [
            button(
              :magic,
              'fa fa-magic fa-lg',
              t = N_('Magic'),
              t,
              :data  => {'function'      => 'sendDataWithRx',
                         'function-data' => {:controller     => 'provider_dialogs', # this one is required
                                             :button         => :magic,
                                             :modal_title    => N_('Create a Security Group'),
                                             :component_name => 'CreateAmazonSecurityGroupForm',
                                              }.to_json},
              :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
            button(
              :magic_dialog,
              'fa fa-magic fa-lg',
              t = N_('Magic'),
              t,
              :data  => {'function'      => 'sendDataWithRx',
                         'function-data' => {:controller => 'provider_dialogs', # this one is required
                                             :button     => :magic_dialog}.to_json},
              :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
          ])
        end
      end
    end
  end
end

```

Any toolbar can be overridden but we focus on providers on the entity detail screen in this PR. Examples: 
 * Instance detail screen, 
 * Cloud provider detail screen (the example above).

For these (detail) screens. The toolbar is not only extended, but the proper extension is selected by matching `@record` with the toolbar's class.

For screens where there is no `@record` all available extensions are loaded.

### How it is done?

Toolbar base class is reorganized as follows:

 * `Toolbar::Basic` is moved to a base class `Toolbar::Base`
 * `Toolbar::Override` (practically `Toolbar::Base`) is where the provider
	extentions should inherit from.
 * `Toolbar::Basic` newly includes the extention mechanism.

`ToolbarBuilder` now passed the `@record` to the toolbar `definition` method (now a method). And it filters the available extensions by matching the record's class with the extension class (the provider base module).


Example provider PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4231
