### PR TITLE
Replace vendor SVG references in textual summaries with decorators

### DIFF
--- a/app/helpers/automation_manager_helper.rb
+++ b/app/helpers/automation_manager_helper.rb
@@ -28,7 +28,7 @@ module AutomationManagerHelper
 
   def textual_provider_name
     {:label    => _("Provider"),
-     :image    => "svg/vendor-#{@record.configuration_manager.image_name}.svg",
+     :image    => @record.configuration_manager.decorate.fileicon,
      :value    => @record.configuration_manager.try(:name),
      :explorer => true}
   end

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module ConfigurationJobHelper::TextualSummary
   end
 
   def textual_provider
-    h = {:label => _("Provider"), :image => "svg/vendor-ansible.svg"}
+    h = {:label => _("Provider"), :image => @record.ext_management_system.try(:decorate).try(:fileicon)}
     provider = @record.ext_management_system
     if provider.nil?
       h[:value] = _("None")

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -109,7 +109,7 @@ module ContainerGroupHelper::TextualSummary
     lives_on_entity_name = lives_on_ems.kind_of?(EmsCloud) ? _("Instance") : _("Virtual Machine")
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
-      :image => "svg/vendor-#{lives_on_ems.image_name}.svg",
+      :image => lives_on_ems.decorate.fileicon,
       :value => @record.container_node.lives_on.name.to_s,
       :link  => url_for_only_path(
         :action     => 'show',

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -89,7 +89,7 @@ module ContainerNodeHelper::TextualSummary
     lives_on_entity_name = lives_on_ems.kind_of?(EmsCloud) ? _("Instance") : _("Virtual Machine")
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
-      :image => "svg/vendor-#{lives_on_ems.image_name}.svg",
+      :image => lives_on_ems.decorate.fileicon,
       :value => @record.lives_on.name.to_s,
       :link  => url_for_only_path(
         :action     => 'show',

--- a/app/helpers/provider_configuration_manager_helper.rb
+++ b/app/helpers/provider_configuration_manager_helper.rb
@@ -31,7 +31,7 @@ module ProviderConfigurationManagerHelper
 
   def textual_provider_name
     {:label    => _("Provider"),
-     :image    => "svg/vendor-#{@record.configuration_manager.image_name}.svg",
+     :image    => @record.configuration_manager.decorate.fileicon,
      :value    => @record.configuration_manager.try(:name),
      :explorer => true
     }

--- a/app/helpers/provider_foreman_helper.rb
+++ b/app/helpers/provider_foreman_helper.rb
@@ -41,7 +41,7 @@ module ProviderForemanHelper
   def textual_provider_name
     {
       :label    => _("Provider"),
-      :image    => "svg/vendor-#{@record.configuration_manager.image_name}.svg",
+      :image    => @record.configuration_manager.decorate.fileicon,
       :value    => @record.configuration_manager.try(:name),
       :explorer => true
     }

--- a/app/helpers/textual_mixins/textual_vmm_info.rb
+++ b/app/helpers/textual_mixins/textual_vmm_info.rb
@@ -8,7 +8,7 @@ module TextualMixins::TextualVmmInfo
       h[:value] = _("None")
       h[:icon] = "fa fa-question-circle"
     else
-      h[:image] = "svg/vendor-#{vmm_info[0][:description].downcase}.svg"
+      h[:image] = @record.decorate.fileicon
       h[:value] = vmm_info[0][:description]
       h[:title] = _("Show VMM information")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'hv_info')

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -136,7 +136,7 @@ module VmHelper::TextualSummary
     if vendor.blank?
       h[:value] = _("None")
     else
-      h[:image] = "svg/vendor-#{vendor}.svg"
+      h[:image] = @record.decorate.fileicon
       h[:title] = _("Show VMM container information")
       h[:explorer] = true
       h[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'hv_info')


### PR DESCRIPTION
Decorators should be the single source of truth everywhere across the UI, so let's use them in textual summaries a little bit more.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label gaprindashvili/no, refactoring, textual summaries