### PR TITLE
Add single_quad definition for ansible tower jobs

### DIFF
--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/job_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers::AnsibleTower
     def self.fonticon
       'ff ff-stack'
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end


### PR DESCRIPTION
Navigate to: Automation -> Ansible Tower -> Jobs -> select any job

**Before:**
![screenshot from 2018-07-09 15-05-32](https://user-images.githubusercontent.com/649130/42452177-9e124acc-8389-11e8-950d-7c399979ca7f.png)

**Afer:**
![screenshot from 2018-07-09 15-04-14](https://user-images.githubusercontent.com/649130/42452183-a0f56422-8389-11e8-8300-411fcdd907d9.png)

@miq-bot add_label graphics, gaprindashvili/no, bug
@miq-bot add_reviewer @epwinchell 