### PR TITLE
Provider dialogs - React

### DIFF
--- a/app/javascript/miq-component/component-typings.ts
+++ b/app/javascript/miq-component/component-typings.ts
@@ -128,6 +128,7 @@ export interface ComponentBlueprint {
     unmountFrom?: HTMLElement
   ): void;
 
+  component?: any;
 }
 
 /**

--- a/app/javascript/miq-component/helpers.js
+++ b/app/javascript/miq-component/helpers.js
@@ -14,3 +14,7 @@ export function componentFactory(blueprintName, selector, props) {
   const allProps = { ...element.dataset, ...props };
   ManageIQ.component.newInstance(blueprintName, allProps, element);
 }
+
+export function getReact(name) {
+  return registry.getDefinition(name).blueprint.component;
+}

--- a/app/javascript/miq-component/react-blueprint.tsx
+++ b/app/javascript/miq-component/react-blueprint.tsx
@@ -38,6 +38,8 @@ export default (
 
     destroy(instance, unmountFrom) {
       ReactDOM.unmountComponentAtNode(unmountFrom);
-    }
+    },
+
+    component: ReactElement,
   };
 }

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -35,6 +35,23 @@ function reactModal(buttonData, response) {
 }
 
 function dialogModal(buttonData, response) {
-  // TODO
   console.log('TODO dialogModal', arguments);
+
+  // %dialog-user{"dialog" =>"vm.dialog"}
+  const elem = $('<dialog-user></dialog-user>');
+  elem.attr('dialog', JSON.stringify(response.dialog));
+
+  const id = 'angular-provider-dialog';
+
+  let inner = () => {
+    // TODO react component lifecycle instead of setTimeout?
+    setTimeout(() => {
+      elem.appendTo(`#${id}`);
+      miq_bootstrap(`#${id}`);
+    });
+
+    return <div id={id}></div>;
+  };
+
+  renderModal(__("My dialog-user"), inner);
 }

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -1,3 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Button, Icon, Modal } from 'patternfly-react';
+
 function call_the_endpoint(buttonData) {
   return Promise.resolve({
     react: 'CreateAmazonSecurityGroupForm',
@@ -33,3 +37,60 @@ function dialogModal(buttonData, response) {
   // TODO
   console.log('TODO dialogModal', arguments);
 }
+
+function closeModal(id) {
+  // this should have been div.remove();
+  // except patternfly modal does not render itself in its parent element
+  // but creates a new one in body, without any id
+  // so we're abusing the modal body to provide the id so that we can remove the right div when closing
+  // yay
+
+  const divs = $('#' + id).parents('div');
+  divs[divs.length - 1].remove(); // the div closest to body
+}
+
+function renderModal(title = __("Modal"), Inner = () => <div>Empty?</div>) {
+  const div = $('<div></div>').appendTo('body');
+  const removeId = 'provider-dialogs';
+
+  const close = () => closeModal(removeId);
+
+  const output = modal(title, Inner, close, removeId);
+
+  ReactDOM.render(output, div[0]);
+}
+
+function modal(title, Inner, closed, removeId) {
+  return (
+    <Modal
+      show={true}
+      onHide={closed}
+      onExited={closed}
+    >
+      <Modal.Header>
+        <button
+          className="close"
+          onClick={closed}
+          aria-hidden="true"
+          aria-label="Close"
+        >
+          <Icon type="pf" name="close" />
+        </button>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Inner />
+        <div id={/* see closeModal */ removeId}></div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          bsStyle="primary"
+          onClick={closed}
+          autoFocus
+        >
+          {__('Close')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -1,56 +1,26 @@
 import React from 'react';
 import renderModal from '../provider-dialogs/modal'
 
-function call_the_endpoint(buttonData) {
-  return Promise.resolve({
-    react: 'CreateAmazonSecurityGroupForm',
-    props: {
-      providerId: buttonData.ems_id,
-    },
-  });
-}
-
 window.listenToRx(function(buttonData) {
   if (!buttonData || buttonData.controller !== 'provider_dialogs') {
     return;
   }
 
-  call_the_endpoint(buttonData)
-    .then(function(response) {
-      if (response.react) {
-        reactModal(buttonData, response);
-      } else if (response.dialog) {
-        dialogModal(buttonData, response);
-      } else {
-        console.error('provider-dialogs: surprising response', buttonData, response);
-      }
-    });
+  if (! buttonData.component_name) {
+    console.error('provider-dialogs: missing component_name', buttonData);
+    return;
+  }
+
+  reactModal(buttonData);
 });
 
-function reactModal(buttonData, response) {
-  let Component = ManageIQ.component.getReact(response.react);
-  let inner = () => <Component {...response.props} />;
-
-  renderModal(__("My React Modal"), inner);
-}
-
-function dialogModal(buttonData, response) {
-  // %dialog-user{"dialog" =>"vm.dialog"}
-  const elem = $('<dialog-user></dialog-user>');
-  elem.attr('dialog', JSON.stringify(response.dialog));
-
-  const id = 'angular-provider-dialog';
-
-  let inner = class extends React.Component {
-    componentDidMount() {
-      elem.appendTo(`#${id}`);
-      miq_bootstrap(`#${id}`);
-    }
-
-    render() {
-      return <div id={id}></div>;
-    }
+function reactModal(buttonData) {
+  const props = {
+    recordId: ManageIQ.record.recordId,
   };
 
-  renderModal(__("My dialog-user"), inner);
+  let Component = ManageIQ.component.getReact(buttonData.component_name);
+  let inner = () => <Component {...props} />;
+
+  renderModal(__(buttonData.modal_title), inner);
 }

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { Button, Icon, Modal } from 'patternfly-react';
+import renderModal from '../provider-dialogs/modal'
 
 function call_the_endpoint(buttonData) {
   return Promise.resolve({
@@ -39,60 +38,3 @@ function dialogModal(buttonData, response) {
   // TODO
   console.log('TODO dialogModal', arguments);
 }
-
-function closeModal(id) {
-  // this should have been div.remove();
-  // except patternfly modal does not render itself in its parent element
-  // but creates a new one in body, without any id
-  // so we're abusing the modal body to provide the id so that we can remove the right div when closing
-  // yay
-
-  const divs = $('#' + id).parents('div');
-  divs[divs.length - 1].remove(); // the div closest to body
-}
-
-function renderModal(title = __("Modal"), Inner = () => <div>Empty?</div>) {
-  const div = $('<div></div>').appendTo('body');
-  const removeId = 'provider-dialogs';
-
-  const close = () => closeModal(removeId);
-
-  const output = modal(title, Inner, close, removeId);
-
-  ReactDOM.render(output, div[0]);
-}
-
-function modal(title, Inner, closed, removeId) {
-  return (
-    <Modal
-      show={true}
-      onHide={closed}
-      onExited={closed}
-    >
-      <Modal.Header>
-        <button
-          className="close"
-          onClick={closed}
-          aria-hidden="true"
-          aria-label="Close"
-        >
-          <Icon type="pf" name="close" />
-        </button>
-        <Modal.Title>{title}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Inner />
-        <div id={/* see closeModal */ removeId}></div>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button
-          bsStyle="primary"
-          onClick={closed}
-          autoFocus
-        >
-          {__('Close')}
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
-};

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -29,8 +29,10 @@ window.listenToRx(function(buttonData) {
 });
 
 function reactModal(buttonData, response) {
-  // TODO
-  console.log('TODO reactModal', arguments);
+  let Component = ManageIQ.component.getReact(response.react);
+  let inner = () => <Component {...response.props} />;
+
+  renderModal(__("My React Modal"), inner);
 }
 
 function dialogModal(buttonData, response) {

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -35,22 +35,21 @@ function reactModal(buttonData, response) {
 }
 
 function dialogModal(buttonData, response) {
-  console.log('TODO dialogModal', arguments);
-
   // %dialog-user{"dialog" =>"vm.dialog"}
   const elem = $('<dialog-user></dialog-user>');
   elem.attr('dialog', JSON.stringify(response.dialog));
 
   const id = 'angular-provider-dialog';
 
-  let inner = () => {
-    // TODO react component lifecycle instead of setTimeout?
-    setTimeout(() => {
+  let inner = class extends React.Component {
+    componentDidMount() {
       elem.appendTo(`#${id}`);
       miq_bootstrap(`#${id}`);
-    });
+    }
 
-    return <div id={id}></div>;
+    render() {
+      return <div id={id}></div>;
+    }
   };
 
   renderModal(__("My dialog-user"), inner);

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -1,0 +1,35 @@
+function call_the_endpoint(buttonData) {
+  return Promise.resolve({
+    react: 'CreateAmazonSecurityGroupForm',
+    props: {
+      providerId: buttonData.ems_id,
+    },
+  });
+}
+
+window.listenToRx(function(buttonData) {
+  if (!buttonData || buttonData.controller !== 'provider_dialogs') {
+    return;
+  }
+
+  call_the_endpoint(buttonData)
+    .then(function(response) {
+      if (response.react) {
+        reactModal(buttonData, response);
+      } else if (response.dialog) {
+        dialogModal(buttonData, response);
+      } else {
+        console.error('provider-dialogs: surprising response', buttonData, response);
+      }
+    });
+});
+
+function reactModal(buttonData, response) {
+  // TODO
+  console.log('TODO reactModal', arguments);
+}
+
+function dialogModal(buttonData, response) {
+  // TODO
+  console.log('TODO dialogModal', arguments);
+}

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Button, Icon, Modal } from 'patternfly-react';
+
+function closeModal(id) {
+  // this should have been div.remove();
+  // except patternfly modal does not render itself in its parent element
+  // but creates a new one in body, without any id
+  // so we're abusing the modal body to provide the id so that we can remove the right div when closing
+  // yay
+
+  const divs = $('#' + id).parents('div');
+  divs[divs.length - 1].remove(); // the div closest to body
+}
+
+export default function renderModal(title = __("Modal"), Inner = () => <div>Empty?</div>) {
+  const div = $('<div></div>').appendTo('body');
+  const removeId = 'provider-dialogs';
+
+  const close = () => closeModal(removeId);
+
+  const output = modal(title, Inner, close, removeId);
+
+  ReactDOM.render(output, div[0]);
+}
+
+function modal(title, Inner, closed, removeId) {
+  return (
+    <Modal
+      show={true}
+      onHide={closed}
+      onExited={closed}
+    >
+      <Modal.Header>
+        <button
+          className="close"
+          onClick={closed}
+          aria-hidden="true"
+          aria-label="Close"
+        >
+          <Icon type="pf" name="close" />
+        </button>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Inner />
+        <div id={/* see closeModal */ removeId}></div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          bsStyle="primary"
+          onClick={closed}
+          autoFocus
+        >
+          {__('Close')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}


### PR DESCRIPTION
This is a simpler version of #4231 - provider dialogs for toolbar buttons.

Only react components are supported now,
the toolbar button needs to provide (in `javascript_data`):
  * `component_name` - the name of the react component, registered via `ManageIQ.component.addReact`
  * `modal_title` - a N_ string, used in the title of that dialog
  * (and `controller = "provider-dialogs"`)