### PR TITLE
Remove extract-text-plugin

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -1,4 +1,3 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const merge = require('webpack-merge')
 
 const { env, publicPath } = require('./configuration.js')
@@ -25,30 +24,28 @@ module.exports = [
 
   {
     test: /\.(scss|sass|css)$/i,
-    use: ExtractTextPlugin.extract({
-      fallback: 'style-loader',
-      use: [
-        {
-          loader: 'css-loader',
-          options: {
-            minimize: env.NODE_ENV === 'production',
-          },
+    use: [
+      'style-loader',
+      {
+        loader: 'css-loader',
+        options: {
+          minimize: env.NODE_ENV === 'production',
         },
-        {
-          loader: 'postcss-loader',
-          options: {
-            sourceMap: true,
-          },
+      },
+      {
+        loader: 'postcss-loader',
+        options: {
+          sourceMap: true,
         },
-        'resolve-url-loader',
-        {
-          loader: 'sass-loader',
-          options: {
-            sourceMap: true,
-          },
+      },
+      'resolve-url-loader',
+      {
+        loader: 'sass-loader',
+        options: {
+          sourceMap: true,
         },
-      ],
-    }),
+      },
+    ],
   },
 
   {

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -7,7 +7,6 @@ const webpack = require('webpack')
 const merge = require('webpack-merge')
 const { basename, dirname, join, relative, resolve } = require('path')
 const { sync } = require('glob')
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, settings, output, engines } = require('./configuration.js')
@@ -46,7 +45,6 @@ module.exports = {
 
   plugins: [
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
-    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
 
     // Workaround for graphql/graphql-language-service#128
     new webpack.ContextReplacementPlugin(

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "eslint-plugin-promise": "~3.3.0",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "~2.0.1",
-    "extract-text-webpack-plugin": "~2.1.0",
     "file-loader": "~0.11.1",
     "glob": "~7.1.1",
     "jest": "^22.0.6",


### PR DESCRIPTION
Without it, css will get compiled into js packs, but actually works.

Pretty much taken from https://github.com/ManageIQ/manageiq-ui-classic/pull/3776/commits/c73158dde55c53fcbf5894dd23f6e698b634353d (#3776 Webpack 4)

Cc @martinpovolny 

Because we can do this now, and then css in ui plugins is as simple as importing the css in the component definition.

(Needed by https://github.com/ManageIQ/manageiq-providers-amazon/pull/462)