### PR TITLE
Fixed visible memory switch while adding snapshot for turned off vm.

### DIFF
--- a/app/views/vm_common/_snap.html.haml
+++ b/app/views/vm_common/_snap.html.haml
@@ -5,4 +5,5 @@
   = _('Snapshot information')
 = react 'VmSnapshotFormComponent', {:createUrl => url_for_only_path(:action => "snap_vm", :id => @record.id, :button => @edit ? "create" : nil),
                            :cancelUrl => url_for_only_path(:action => "snap_vm", :id => @record.id, :button => @edit ? "cancel" : nil),
-                           :nameOptional => @record.try(:snapshot_name_optional?)}
+                           :nameOptional => @record.try(:snapshot_name_optional?),
+                           :showMemorySwitch => @show_snapshot_memory_checkbox}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@manageiq/react-ui-components": "~0.9.1",
+    "@manageiq/react-ui-components": "~0.9.3",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",


### PR DESCRIPTION
Big fix for https://bugzilla.redhat.com/show_bug.cgi?id=1599661. Memory snapshot switch is now visible only when `@show_snapshot_memory_checkbox` is true.

Actual component fix is here: https://github.com/ManageIQ/react-ui-components/issues/56

@h-kataria 