### PR TITLE
Add security protocol to physical infra form data

### DIFF
--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -33,17 +33,18 @@ class EmsPhysicalInfraController < ApplicationController
     @ems = find_record_with_rbac(model, params[:id]) if params[:id] != 'new'
 
     render :json => {
-      :name                => @ems.name,
-      :emstype             => @ems.emstype,
-      :zone                => zone,
-      :provider_id         => @ems.provider_id ? @ems.provider_id : "",
-      :hostname            => @ems.hostname,
-      :default_hostname    => @ems.connection_configurations.default.endpoint.hostname,
-      :default_api_port    => @ems.connection_configurations.default.endpoint.port,
-      :provider_region     => @ems.provider_region,
-      :default_userid      => @ems.authentication_userid ? @ems.authentication_userid : "",
-      :ems_controller      => controller_name,
-      :default_auth_status => default_auth_status,
+      :name                      => @ems.name,
+      :emstype                   => @ems.emstype,
+      :zone                      => zone,
+      :provider_id               => @ems.provider_id ? @ems.provider_id : "",
+      :hostname                  => @ems.hostname,
+      :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
+      :default_api_port          => @ems.connection_configurations.default.endpoint.port,
+      :provider_region           => @ems.provider_region,
+      :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
+      :ems_controller            => controller_name,
+      :default_auth_status       => default_auth_status,
+      :default_security_protocol => @ems.security_protocol || "",
     }
   end
 


### PR DESCRIPTION
Redfish physical infra provider uses security protocol as an input to
determine how connection to the Redfish endpoint should be
established. This information is entered into the form at provider
instance creation time.

But because this information is not returned when we edit existing
provider, security protocol dropdown is initialized to an empty value.

This commit adds default_security_protocol field to the for data that
is used to populate the edit form.

This resolves the issue #4271 

/cc @matejart