### PR TITLE
Fix displaying multiple Catalogs with the same name in the dropdown while creating a Catalog Item

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalogItemFormId', 'currentRegion', 'miqService', 'postService', 'catalogItemDataFactory', 'playbookReusableCodeMixin', function($scope, catalogItemFormId, currentRegion, miqService, postService, catalogItemDataFactory, playbookReusableCodeMixin) {
+ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalogItemFormId', 'currentRegion', 'miqService', 'postService', 'catalogItemDataFactory', 'playbookReusableCodeMixin', 'allCatalogsNames', function($scope, catalogItemFormId, currentRegion, miqService, postService, catalogItemDataFactory, playbookReusableCodeMixin, allCatalogsNames) {
   var vm = this;
   var init = function() {
     vm.catalogItemModel = {
@@ -54,6 +54,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.formId = catalogItemFormId;
     vm.afterGet = false;
     vm.inventory_mode = 'localhost';
+    vm.all_catalogs = allCatalogsNames;
 
     ManageIQ.angular.scope = $scope;
 

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -112,6 +112,17 @@ function playbookReusableCodeMixin(API, $q, miqService) {
     );
   };
 
+  var formOptsCatalogTenants = function(catalogs) {
+    var allCatalogs = [];
+    for (var i = 0; i < catalogs.length; i++) {
+      var cat = {};
+      cat.name = catalogs[i][0];
+      cat.id = catalogs[i][1].toString();
+      allCatalogs.push(cat);
+    }
+    return allCatalogs;
+  };
+
   // list of service catalogs
   var formOptions = function(vm) {
     miqService.sparkleOn();
@@ -119,6 +130,10 @@ function playbookReusableCodeMixin(API, $q, miqService) {
       allApiPromises.push(API.get('/api/service_catalogs/?expand=resources&attributes=id,name' + sortOptions)
         .then(function(data) {
           vm.catalogs = data.resources;
+          // edit the name of each catalog to get all tenant ancestors in the name if they exist
+          for (var i = 0; i < vm.catalogs.length; i++) {
+            vm.catalogs[i].name = _.find(formOptsCatalogTenants(vm.allCatalogs), {id: vm.catalogs[i].id}).name;
+          }
           vm.catalogs.unshift({"href": "", "id": "", "name": "<Unassigned>"});
           vm._catalog = _.find(vm.catalogs, {id: vm[vm.model].catalog_id});
         })

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -30,10 +30,9 @@
       %label.col-md-2.control-label
         = _('Catalog')
       .col-md-4
-        - available_catalogs = @edit[:new][:available_catalogs]
         - catalog_id = @edit[:new][:catalog_id]
         = select_tag('catalog_id',
-                     options_for_select(([["<#{_('Unassigned')}>", nil]]) + available_catalogs, catalog_id),
+                     options_for_select(([["<#{_('Unassigned')}>", nil]]) + @available_catalogs, catalog_id),
                      "data-miq_sparkle_on" => true,
                      :class                => "selectpicker")
         :javascript
@@ -44,7 +43,7 @@
         = _('Dialog')
       .col-md-4
         %p.form-control-static
-          - available_dialogs =  @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
+          - available_dialogs = @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
           - options = [["<#{_('No Dialog')}>", nil]] + available_dialogs
           = select_tag('dialog_id',
                         options_for_select(options, @edit[:new][:dialog_id]),

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -73,5 +73,6 @@
 :javascript
   ManageIQ.angular.app.value('catalogItemFormId', '#{@record.id || "new"}');
   ManageIQ.angular.app.value('currentRegion', '#{@current_region}');
+  ManageIQ.angular.app.value('allCatalogsNames', #{@available_catalogs});
   miq_bootstrap('#form_div');
 

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -1,5 +1,5 @@
 describe('catalogItemFormController', function() {
-  var $scope, $controller, currentRegion, postService;
+  var $scope, $controller, currentRegion, postService, allCatalogsNames;
 
   beforeEach(module('ManageIQ'));
 
@@ -54,6 +54,7 @@ describe('catalogItemFormController', function() {
     $controller = _$controller_('catalogItemFormController', {
       $scope: $scope,
       currentRegion: currentRegion,
+      allCatalogsNames: allCatalogsNames,
       catalogItemFormId: 1000000000001
     });
   }));

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -11,6 +11,7 @@ describe "catalog/_form.html.haml" do
     create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
     create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
     @automate_tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
+    @available_catalogs = [%w(test 1)]
   end
 
   it "Renders form when adding catalog bundle and st_prov_type is not set" do


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1451300

---

**Steps to reproduce:**
1. Enable Ansible Embedded role (not sure if this is required)
2. Add multiple (child) Tenants (_Configuration > Access Control > Tenants_), each Tenant has one super admin user which then creates Catalog with name 'catalog' (under _Services > Catalogs > Catalogs_)
3. Add Ansible Credentials and Repo (not sure if this is required)
4. Try to add new catalog item of _Ansible Playbook_ type  ( _Services > Catalogs > Catalog Items_ )
   (or also any other type, but the BZ is mainly about Ansible Playbook type)

**Before:** (multiple Catalogs with the same name in the dropdown)
Adding a new Service Catalog Item:
![catalog_before](https://user-images.githubusercontent.com/13417815/42569914-6feeb7f4-8512-11e8-9ab0-35d918b6fe22.png)
Editing an existing Catalog Item - similar problem as the picture above

**After:**
Adding a new Service Catalog Item:
![catalog_after](https://user-images.githubusercontent.com/13417815/42569820-20a752a0-8512-11e8-8c6e-1962cd2c194d.png)
Editing an existing Catalog Item:
![edit_item](https://user-images.githubusercontent.com/13417815/44103297-1c90f276-9fec-11e8-905d-cc1094a9b0d3.png)


**This PR:**
- adds a new method `available_catalogs` for getting all the available catalogs with the names containing tenant names and their ancestors (if they exist) to prevent displaying multiple catalogs with the same name in the dropdown menu while creating/editing a _Catalog Item_ or also _Catalog Bundle_ because the same problems occurs also there
- passes the variable with the new available catalogs to angular form, for editing catalogs' names to display  also tenants and their ancestors names in the drop down menu
- finally edits the original name of each catalog to get tenants and their ancestors names in the name of the Catalog
