### PR TITLE
Don't show refresh button on Request page

### DIFF
--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -23,7 +23,14 @@
                               :auto_refreshable_field_indicies => auto_refreshable_field_indicies,
                               :trigger                         => field.trigger_auto_refresh,
                               :current_index                   => current_index}
-    - locals = {:edit => edit, :field => field, :url => url, :wf => wf, :auto_refresh_options => auto_refresh_options}
+    -# Don't show refresh buttons on Requests page
+    - show_refresh_button = field.show_refresh_button? && !controller.kind_of?(MiqRequestController)
+    - locals = {:edit                 => edit,
+                :field                => field,
+                :url                  => url,
+                :wf                   => wf,
+                :auto_refresh_options => auto_refresh_options,
+                :show_refresh_button  => show_refresh_button}
     - case field.type
     - when 'DialogFieldTextBox'
       = render(:partial => "shared/dialogs/dialog_field_text_box", :locals => locals)

--- a/app/views/shared/dialogs/_dialog_field_check_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_check_box.html.haml
@@ -9,7 +9,7 @@
 
     = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-  - if field.show_refresh_button?
+  - if show_refresh_button
     = button_tag(_('Refresh'), :id => "refresh-dynamic-checkbox-#{field.id}", :class => "btn btn-default")
 
   :javascript

--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -31,7 +31,7 @@
 
     = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-  - if field.show_refresh_button?
+  - if show_refresh_button
     = button_tag(_('Refresh'), :id => "refresh-dynamic-date-#{field.id}", :class => "btn btn-default")
 
   :javascript

--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -22,7 +22,7 @@
 
       = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-    - if field.show_refresh_button?
+    - if show_refresh_button
       = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
 
     :javascript

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -30,7 +30,7 @@
 
     = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-  - if field.show_refresh_button?
+  - if show_refresh_button
     = button_tag(_('Refresh'), :id => "refresh-dynamic-field-#{field.id}", :class => "btn btn-default")
 
   :javascript

--- a/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_area_box.html.haml
@@ -12,7 +12,7 @@
 
     = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-  - if field.show_refresh_button?
+  - if show_refresh_button
     = button_tag(_('Refresh'), :id => "refresh-dynamic-text-field-#{field.id}", :class => "btn btn-default")
 
     :javascript

--- a/app/views/shared/dialogs/_dialog_field_text_box.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_text_box.html.haml
@@ -13,7 +13,7 @@
 
       = render(:partial => "shared/dialogs/auto_refresh_javascript", :locals => javascript_locals)
 
-    - if field.show_refresh_button?
+    - if show_refresh_button
       = button_tag(_('Refresh'), :id => "refresh-dynamic-text-field-#{field.id}", :class => "btn btn-default")
 
       :javascript


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1574638

How to reproduce:
Create a Service Dialog with all possible inputs and set those inputs to be dynamic and has show refresh button
Create Service Item with the created Service Dialog
Order created Service Item
Go check it to Services -> Requests -> Detail page of the ordered Service Item  

Before:
![image](https://user-images.githubusercontent.com/9210860/42561863-8d9744e6-84fa-11e8-88fa-2fd1f617f916.png)

After:
![image](https://user-images.githubusercontent.com/9210860/42561874-92f621aa-84fa-11e8-9d97-e8b0c598da34.png)


@miq-bot add_label bug, gaprindashvili/yes

@h-kataria please review, thanks :)