### PR TITLE
Fix date/time display on request screen

### DIFF
--- a/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_date_and_date_time_control.html.haml
@@ -5,20 +5,21 @@
     = field.value
 
 - if field.type == "DialogFieldDateTimeControl"
-  - date_val = field.refresh_json_value
+  - date_val, time_val = field.value.split(" ")
+  - hour_val, minute_val = time_val.split(":")
   - if edit
-    = datepicker_input_tag("miq_date__#{field.name}", date_val[:date], date_tag_options(field, url, auto_refresh_options))
+    = datepicker_input_tag("miq_date__#{field.name}", date_val, date_tag_options(field, url, auto_refresh_options))
   - else
-    = date_val[:date]
+    = date_val
 
   &nbsp;at&nbsp;
   - if edit
-    = select_tag("start_hour", hour_select_options(date_val[:hour]), time_tag_options(field, url, "hour", auto_refresh_options))
+    = select_tag("start_hour", hour_select_options(hour_val), time_tag_options(field, url, "hour", auto_refresh_options))
     = ':'
-    = select_tag("start_min", minute_select_options(date_val[:min]), time_tag_options(field, url, "min", auto_refresh_options))
+    = select_tag("start_min", minute_select_options(minute_val), time_tag_options(field, url, "min", auto_refresh_options))
 
   - else
-    = "#{date_val[:hour].rjust(2, '0')}:#{date_val[:min].rjust(2, '0')}"
+    = "#{hour_val.rjust(2, '0')}:#{minute_val.rjust(2, '0')}"
   &nbsp;
   = session[:user_tz]
 


### PR DESCRIPTION
Found this while I was testing for https://github.com/ManageIQ/ui-components/pull/317, but basically when the user submits a date/time, the request screen was simply showing the current date/time instead of the selected date/time.

This is not necessary to fix the linked BZ, but it is related and thus linked for posterity.

Related to https://github.com/ManageIQ/ui-components/pull/317
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1583177

@miq-bot add_label gaprindashvili/yes, bug
@d-m-u Can you review, please? I changed the view to use `.value` instead of `.refresh_json_value` since now that the other backend pieces have changed, `.value` should make more sense. (Also, `.refresh_json_value` doesn't really make sense if the field isn't dynamic)
