### PR TITLE
Increase upper limit of the range for daily chargeback report to 5 weeks

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -208,7 +208,7 @@
       = _("going back")
       - case @edit[:new][:cb_interval]
       - when "daily"
-        - opts = (1..6).map { |i| [n_('%{number} Day', '%{number} Days', i) % {:number => i}, i] } + (1..4).map { |i| [n_('%{number} Week', '%{number} Weeks', i) % {:number => i}, i * 7] }
+        - opts = (1..6).map { |i| [n_('%{number} Day', '%{number} Days', i) % {:number => i}, i] } + (1..5).map { |i| [n_('%{number} Week', '%{number} Weeks', i) % {:number => i}, i * 7] }
       - when "weekly"
         - opts = [1, 2, 3, 4, 8, 12].map! { |i| [n_('%{number} Week', '%{number} Weeks', i) % {:number => i}, i] }
       - when "monthly"


### PR DESCRIPTION
This enables running daily report for a calendar month as opposed to 28 days (4 weeks)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1591217
