### PR TITLE
Remove Snapshot field from EC2 Instance summary screen

### DIFF
--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -23,8 +23,10 @@ module VmCloudHelper::TextualSummary
       _("Properties"),
       %i(
         name region server description ipaddress mac_address custom_1 container preemptible tools_status
-        load_balancer_health_check_state osinfo architecture snapshots advanced_settings resources guid
-        virtualization_type root_device_type ems_ref
+        load_balancer_health_check_state osinfo architecture
+      ) + (@record.type == 'ManageIQ::Providers::Amazon::CloudManager::Vm' ? %i() : %i(snapshots)) +
+      %i(
+        advanced_settings resources guid virtualization_type root_device_type ems_ref
       )
     )
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1583754

---

**Before:**
![ec2_before](https://user-images.githubusercontent.com/13417815/42633957-3b6537c6-85e2-11e8-934f-d698689a55c7.png)

**After:**
![ec2_after](https://user-images.githubusercontent.com/13417815/42633962-3d1f5f74-85e2-11e8-9180-ec3bd57e188c.png)
