### PR TITLE
Fix asset pipeline for remote consoles when loading jquery

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,4 @@
-@import 'bower_components/manageiq-ui-components/dist/css/ui-components';
+@import 'bower_components/manageiq-ui-components/dist/css/ui-components.css';
 
 @import 'patternfly-sprockets';
 @import 'patternfly/variables';


### PR DESCRIPTION
When precompiling assets, somehow sprockets goes crazy because of this line and skips everything after. This caused issues with remote consoles that are dependent on jQuery.

Closes #4251

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597352
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600139

@miq-bot add_label bug, gaprindashvili/no
@miq-bot assign @himdel 