### PR TITLE
Fix search text on non gtl screens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1117,8 +1117,8 @@ class ApplicationController < ActionController::Base
       @title = new_bc [:name] # Set the title to be the new breadcrumb
     end
 
-    # Modify user feedback for quick searches when not found
-    unless @search_text.blank?
+    # add @search_text to title for gtl screens only
+    if @search_text.present? && @display.nil?
       @title += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text}
     end
   end

--- a/spec/controllers/flavor_controller_spec.rb
+++ b/spec/controllers/flavor_controller_spec.rb
@@ -15,6 +15,16 @@ describe FlavorController do
         is_expected.to render_template(:partial => "layouts/listnav/_flavor")
       end
     end
+
+    context "with @search_text set" do
+      render_views
+      it "doesn't render @search_text in summary screen" do
+        controller.instance_variable_set(:@search_text, 'search text')
+        get :show, :params => {:id => @flavor.id}
+        expect(response.body).not_to include('search text')
+        expect(controller.instance_variable_get(:@title)).not_to include('search text')
+      end
+    end
   end
 
   describe 'button' do


### PR DESCRIPTION
This fix is to make sure `@search_text` is not rendered on non-gtl screens.

1. Navitage to Cloud -> Flavors
2. Enter quick search text
3. Navigate to Cloud -> [a cloud provider] -> Flavors -> [a flavor]

Before:
![flavors-before](https://user-images.githubusercontent.com/6648365/42638004-ceb59e26-85ec-11e8-8262-2ca6a935fa6f.png)


After:
![flavors-after](https://user-images.githubusercontent.com/6648365/42637959-b36fa350-85ec-11e8-92ac-b05e0136f77c.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1579753