### PR TITLE
Set Status of Physical Servers and Physical Switches in Topology View

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -184,6 +184,7 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       case 'Error':
       case 'Unreachable':
       case 'Inactive':
+      case 'Critical':
         return 'error';
       case 'Warning':
       case 'Waiting':

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -67,6 +67,8 @@ class PhysicalInfraTopologyService < TopologyService
     case entity
     when ManageIQ::Providers::PhysicalInfraManager
       entity.authentications.blank? ? _('Unknown') : entity.authentications.first.status.try(:capitalize)
+    when PhysicalServer, PhysicalSwitch
+      entity.health_state ? entity.health_state : _('Unknown')
     else
       _('Unknown')
     end


### PR DESCRIPTION
**What this PR does:**
- Set the status of the PhysicalServers and PhysicalSwitches nodes in the topology view to be relative to the entity's `health_state`.

![physical_topology](https://user-images.githubusercontent.com/14334253/42654374-c492c372-85ee-11e8-8e71-44f336373dbd.png)
As the picture shows, the nodes get borders in one of this colors:
- Gray: `Unknown` Health State status;
- Green: `Valid` Health State status;
- Yellow: `Warning` Health State status;
- Red: `Critical` Health State status;