### PR TITLE
Use decorator to determine the root node icon in a provider tree

### DIFF
--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -15,7 +15,7 @@ class TreeBuilderVat < TreeBuilderDatacenter
     {
       :text    => @root.name,
       :tooltip => @root.name,
-      :image   => "svg/vendor-#{@root.image_name}.svg"
+      :image   => @root.decorate.fileicon
     }
   end
 

--- a/spec/presenters/tree_builder_vat_spec.rb
+++ b/spec/presenters/tree_builder_vat_spec.rb
@@ -21,11 +21,10 @@ describe TreeBuilderVat do
 
     it 'returns EmsCluster as root' do
       root = @vat_tree.send(:root_options)
-      image = "svg/vendor-#{@vat_tree.instance_variable_get(:@root).image_name}.svg"
       expect(root).to eq(
         :text    => @vat_tree.instance_variable_get(:@root).name,
         :tooltip => @vat_tree.instance_variable_get(:@root).name,
-        :image   => image
+        :image   => nil
       )
     end
 


### PR DESCRIPTION
When rendering the VMs and Templates tree for a specific provider, the root icon (provider type) is statically set as an SVG file. This can be replaced with a call to the related decorator.

![screenshot from 2018-07-13 11-39-29](https://user-images.githubusercontent.com/649130/42684933-de5fc0a4-8691-11e8-84da-d68d10a907b3.png)

@miq-bot add_label gaprindashvili/no, cleanup