### PR TITLE
Service AnsibleTower and EmbeddedAnsible UI parity

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -215,7 +215,7 @@ class ServiceController < ApplicationController
   def textual_group_list
     if @item && @item.kind_of?(GenericObject)
       [%i(go_properties attribute_details_list methods)]
-    elsif @record.type == "ServiceAnsiblePlaybook"
+    elsif %w(ServiceAnsiblePlaybook ServiceAnsibleTower).include?(@record.type)
       [%i(properties miq_custom_attributes), %i(lifecycle tags generic_objects)]
     else
       [%i(properties lifecycle relationships generic_objects miq_custom_attributes), %i(vm_totals tags)]
@@ -232,6 +232,11 @@ class ServiceController < ApplicationController
     [%i(retirement_results retirement_plays), %i(retirement_details retirement_credentials)]
   end
   helper_method :textual_retirement_group_list
+
+  def textual_tower_job_group_list
+    [%i(tower_job_results tower_job_plays), %i(tower_job_details tower_job_credentials)]
+  end
+  helper_method :textual_tower_job_group_list
 
   def features
     [ApplicationController::Feature.new_with_hash(:role     => "service",

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -50,6 +50,26 @@ module ServiceHelper::TextualSummary
     fetch_job_plays
   end
 
+  def textual_group_tower_job_results
+    return nil unless fetch_job
+    TextualGroup.new(_("Results"), %i(status start_time finish_time elapsed_time owner))
+  end
+
+  def textual_group_tower_job_details
+    return nil unless fetch_job
+    TextualGroup.new(_("Details"), %i(verbosity))
+  end
+
+  def textual_group_tower_job_credentials
+    return nil unless fetch_job
+    TextualGroup.new(_("Credentials"), %i(machine_credential vault_credential network_credential cloud_credential))
+  end
+
+  def textual_group_tower_job_plays
+    return nil unless fetch_job
+    fetch_job_plays
+  end
+
   def textual_group_vm_totals
     TextualGroup.new(
       _("Totals for Service VMs"),
@@ -272,9 +292,8 @@ module ServiceHelper::TextualSummary
     fetch_job("Retirement")
   end
 
-  def fetch_job(type)
+  def fetch_job(type = nil)
     @job = @record.try(:job, type)
-    @job
   end
 
   def fetch_job_plays

--- a/app/views/layouts/_textual_groups_tabs.html.haml
+++ b/app/views/layouts/_textual_groups_tabs.html.haml
@@ -1,3 +1,4 @@
-#textual_summary
+- tab_id = "textual_summary#{tab_id ? "_" + tab_id : ""}"
+%div{:id => tab_id}
 :javascript
-  ManageIQ.component.componentFactory('TextualSummaryWrapper', '#textual_summary', {summary: #{process_textual_info(textual_group_list, @record).to_json}});
+  ManageIQ.component.componentFactory('TextualSummaryWrapper', "##{tab_id}", {summary: #{process_textual_info(textual_group_list, @record).to_json}});

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -11,6 +11,10 @@
         - if retirement_job
           = miq_tab_header("retirement") do
             = _("Retirement")
+      -if @record.type == "ServiceAnsibleTower"
+        - job = @record.try(:job)
+        = miq_tab_header("tower_job") do
+          = _("Job")
     .tab-content
       = miq_tab_content("details", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_generic"
@@ -34,6 +38,13 @@
               = _('VMs')
             - if @view
               = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
+      - if @record.type == "ServiceAnsibleTower"
+        = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
+          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
+          - if job
+            %ansible-raw-stdout#service_detail_ansible_tower_job{'task-id' => @record.job.raw_stdout_via_worker(nil, 'html')}
+            :javascript
+              miq_bootstrap('#service_detail_ansible_tower_job');
 
       - if @record.type == "ServiceAnsiblePlaybook"
         = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -37,7 +37,7 @@
 
       - if @record.type == "ServiceAnsiblePlaybook"
         = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
-          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list}
+          = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list, :tab_id => "provisioning"}
           - if provision_job
             %ansible-raw-stdout#service_detail_ansible_playbook{'task-id' => provision_job.raw_stdout_via_worker(nil, 'html')}
             :javascript
@@ -45,7 +45,7 @@
 
         - if retirement_job
           = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
-            = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list}
+            = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list, :tab_id => "retirement"}
             %ansible-raw-stdout#service_detail_job{'task-id' => retirement_job.raw_stdout_via_worker(nil, 'html')}
             :javascript
               miq_bootstrap('#service_detail_job');


### PR DESCRIPTION
Make the service layout same for AnsibleTower as it is for EmbeddedAnsible - UI

- **FIX**: There happen to be duplicate IDs when `layout/textual_groups_tabs` is used for multiple times (or along with `layouts/textual_groups_generic`).
- Make the _Details_ tab the same for both service types
- Add a new tab called _Job_ which displays as much of the same info as the EmbeddedAnsible shows on _Provisioning_ or _Retirement_ tabs

Depends on (merge in this order):  https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/108 https://github.com/ManageIQ/manageiq/pull/17712
Fixes: [BUG 1590840](https://bugzilla.redhat.com/show_bug.cgi?id=1590840) [BUG 1590844](https://bugzilla.redhat.com/show_bug.cgi?id=1590844)

Before:
![image](https://user-images.githubusercontent.com/7453394/42764618-5bc12b92-8916-11e8-875c-5921a58c2a74.png)

After:
![image](https://user-images.githubusercontent.com/7453394/42764577-4a7a1682-8916-11e8-86af-47b549d2f494.png)
![image](https://user-images.githubusercontent.com/7453394/42764599-53315574-8916-11e8-9cc5-c55e6c987735.png)

