### PR TITLE
Make toolbar buttons work when viewing Instances

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -296,7 +296,7 @@ module EmsCommon
                   @flash_array.nil?
 
         unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename'].include?(params[:pressed])
+                "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
           @refresh_div = "main_div"
           @refresh_partial = "layouts/gtl"
           show                                                        # Handle EMS buttons

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -235,6 +235,9 @@ module EmsCommon
       when "ems_cluster_protect"              then assign_policies(EmsCluster)
       when "ems_cluster_scan"                 then scanclusters
       when "ems_cluster_tag"                  then tag(EmsCluster)
+      # Flavor
+      when 'flavor_create'                    then javascript_redirect(:action => 'new')
+      when 'flavor_delete'                    then delete_flavors
       # Hosts
       when "host_analyze_check_compliance"    then analyze_check_compliance_hosts
       when "host_check_compliance"            then check_compliance_hosts

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -6,8 +6,8 @@ class FlavorController < ApplicationController
 
   include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
-  include Mixins::GenericButtonMixin
   include Mixins::GenericSessionMixin
+  include EmsCommon
 
   def self.display_methods
     %w(instances)
@@ -18,14 +18,6 @@ class FlavorController < ApplicationController
     drop_breadcrumb(:name => _("Add a new Flavor"), :url => "/flavor/new")
     @in_a_form = true
     @id = 'new'
-  end
-
-  def button
-    case params[:pressed]
-    when 'flavor_create' then javascript_redirect(:action => 'new')
-    when 'flavor_delete' then delete_flavors
-    when 'flavor_tag'    then tag(Flavor)
-    end
   end
 
   def ems_list

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -85,7 +85,7 @@ class HostAggregateController < ApplicationController
             page << "miqSetButtons(0, 'center_tb');"
             page.replace_html("main_div",
                               :partial => "layouts/gtl",
-                              :locals  => {:action_url => "show/#{@host_aggregate.id}"})
+                              :locals  => {:action_url => @breadcrumbs.last[:url]})
           else
             page.replace_html(@refresh_div, :partial => @refresh_partial)
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,8 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         ems_form_choices
         download_private_key
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         create
@@ -155,12 +156,17 @@ Rails.application.routes.draw do
         form_field_changed
         listnav_search_selected
         quick_search
+        sections_field_changed
         show
         show_list
         tagging_edit
         tag_edit_form_field_changed
         wait_for_task
-      ) + adv_search_post + exp_post + save_post
+      ) +
+        adv_search_post +
+        compare_post +
+        exp_post +
+        save_post
     },
 
     :automation_manager => {
@@ -217,7 +223,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         listnav_search_selected
@@ -230,7 +237,13 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         tl_chooser
         wait_for_task
-      ) + adv_search_post + exp_post + perf_post + save_post + dialog_runner_post
+      ) +
+        adv_search_post +
+        compare_post +
+        dialog_runner_post +
+        exp_post +
+        perf_post +
+        save_post
     },
 
     :host_aggregate           => {
@@ -247,7 +260,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         add_host
         add_host_select
@@ -265,7 +279,12 @@ Rails.application.routes.draw do
         tl_chooser
         update
         wait_for_task
-      ) + adv_search_post + exp_post + perf_post + save_post
+      ) +
+        adv_search_post +
+        compare_post +
+        exp_post +
+        perf_post +
+        save_post
     },
 
     :catalog                  => {
@@ -443,7 +462,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         listnav_search_selected
@@ -457,7 +477,12 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         update
         wait_for_task
-      ) + adv_search_post + exp_post + save_post + dialog_runner_post
+      ) +
+        adv_search_post +
+        compare_post +
+        dialog_runner_post +
+        exp_post +
+        save_post
     },
 
     :cloud_object_store_object => {
@@ -1148,7 +1173,8 @@ Rails.application.routes.draw do
         show_list
         sync_users
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         create
@@ -1173,6 +1199,7 @@ Rails.application.routes.draw do
         squash_toggle
       ) +
                adv_search_post +
+               compare_post +
                dialog_runner_post +
                discover_get_post +
                exp_post +
@@ -1777,7 +1804,8 @@ Rails.application.routes.draw do
         new
         tagging_edit
         ems_list
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         listnav_search_selected
@@ -1789,6 +1817,7 @@ Rails.application.routes.draw do
         tagging_edit
       ) +
                adv_search_post +
+               compare_post +
                exp_post +
                save_post
     },
@@ -2570,7 +2599,8 @@ Rails.application.routes.draw do
         stacks_ot_info
         tagging_edit
         protect
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         cloud_networks
@@ -2589,6 +2619,7 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
       ) +
                adv_search_post +
+               compare_post +
                exp_post +
                save_post +
                dialog_runner_post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
         download_summary_pdf
         index
         new
+        protect
         show
         show_list
         tagging_edit
@@ -155,6 +156,7 @@ Rails.application.routes.draw do
         dynamic_checkbox_refresh
         form_field_changed
         listnav_search_selected
+        protect
         quick_search
         sections_field_changed
         show
@@ -256,6 +258,7 @@ Rails.application.routes.draw do
         index
         new
         perf_top_chart
+        protect
         remove_host_select
         show
         show_list
@@ -268,6 +271,7 @@ Rails.application.routes.draw do
         button
         listnav_search_selected
         create
+        protect
         quick_search
         remove_host
         remove_host_select
@@ -1799,6 +1803,7 @@ Rails.application.routes.draw do
         download_data
         download_summary_pdf
         index
+        protect
         show
         show_list
         new
@@ -1809,6 +1814,7 @@ Rails.application.routes.draw do
       :post => %w(
         button
         listnav_search_selected
+        protect
         quick_search
         sections_field_changed
         show


### PR DESCRIPTION
**Fixes BZ:** https://bugzilla.redhat.com/show_bug.cgi?id=1600678

There is a bug, in many pages under _Compute > Clouds_: when viewing **Instances list** (nested list) from _Relationships_ table, many toolbar buttons don't work. For Instances of some _Flavor_ (BZ above), none of the buttons work!

**Steps to reproduce:** (one of possible scenarios)
1. Go to _Compute > Clouds > Flavors_
2. Choose any Flavor, display its details page
3. In _Relationships_ table, click on _Instances_
4. Select some Instances (check the checkboxes)
5. Click on some available toolbar buttons, for example _Policy > Edit Tags_
=> nothing happens; log:
```
I, [2018-07-16T18:48:13.977565 #21925]  INFO -- : No template found for FlavorController#button, rendering head :no_content
Session:	 Hash of Size 7981, Elements 28
```

---

**Done:**
- some of the toolbar buttons when viewing list of instances of a Flavor:
  tagging, editing, Policy Sim, provisioning (see the screenshots below)
- _Configuration > Compare Selected Items_  - already working everywhere
- _Policy > Manage Policies_ - did not work for Instances of: _Host Aggregates, Flavors, Key Pairs_
- _Configuration > Refresh Relationships and Power States_ - did not work anywhere for any Instances
   (undefined method `validate_refresh_ems`, )
- _Configuration > Remove selected items from Inventory_ - fixed by https://github.com/ManageIQ/manageiq/pull/17780
- _Remove selected items from Inventory_ button for Host Aggregates' Instances
- _Refresh Relationships and Power States_ for VMs, Instances, Images - fixed by https://github.com/ManageIQ/manageiq/pull/17863

**Note:**
The other buttons work as expected.

---

**Before:** (example: tagging Instances of some Flavor)
![tag_before](https://user-images.githubusercontent.com/13417815/42771982-3af56802-8929-11e8-92d0-3fc8764c2c72.png)

**After:**
![tag_after](https://user-images.githubusercontent.com/13417815/42771726-6a556bde-8928-11e8-8ee0-c1134d0e51ed.png)
