### PR TITLE
Add missing single_quad definition for ansible tower provider

### DIFF
--- a/app/decorators/manageiq/providers/automation_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager_decorator.rb
@@ -7,5 +7,11 @@ module ManageIQ::Providers
     def fileicon
       "svg/vendor-#{image_name.downcase}.svg"
     end
+
+    def single_quad
+      {
+        :fileicon => fileicon
+      }
+    end
   end
 end


### PR DESCRIPTION
**Before:**
![screenshot from 2018-07-17 15-44-22](https://user-images.githubusercontent.com/649130/42821239-683f959e-89d8-11e8-88d0-c5c400ef53b7.png)

**After:**
![screenshot from 2018-07-17 15-43-51](https://user-images.githubusercontent.com/649130/42821244-6ad52422-89d8-11e8-8461-45058acbb94a.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601540

@miq-bot add_label bug, gaprindashvili/no