### PR TITLE
Allow to save multiple tag categories in chargeback controller

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -605,7 +605,8 @@ class ChargebackController < ApplicationController
   def cb_assign_set_record_vars
     if @edit[:new][:cbshow_typ].ends_with?("-tags")
       @edit[:set_assignments] = []
-      @edit[:cb_assign][:tags].each do |id, _tag|
+      assigned_rates_from_all_categories = @edit[:cb_assign][:tags].values.reduce({}, :merge)
+      assigned_rates_from_all_categories.each_key do |id|
         key = "#{@edit[:new][:cbshow_typ]}__#{id}"
         if !@edit[:new][key].nil? && @edit[:new][key] != "nil"
           temp = {
@@ -734,9 +735,10 @@ class ChargebackController < ApplicationController
   end
 
   def get_tags_all(category)
-    @edit[:cb_assign][:tags] = {}
+    @edit[:cb_assign][:tags] ||= {}
+    @edit[:cb_assign][:tags][category] ||= {}
     classification = Classification.find_by_id(category.to_s)
-    classification.entries.each { |e| @edit[:cb_assign][:tags][e.id.to_s] = e.description } if classification
+    classification&.entries&.each { |e| @edit[:cb_assign][:tags][category][e.id.to_s] = e.description }
   end
 
   DEFAULT_CHARGEBACK_LABELS = ["com.redhat.component"].freeze
@@ -794,15 +796,15 @@ class ChargebackController < ApplicationController
     end
   end
 
-  def cb_assign_params_to_edit(cb_assign_key)
-    return unless @edit[:cb_assign][cb_assign_key]
+  def cb_assign_params_to_edit(cb_assign_key, tag_category_id = nil)
+    current_assingments = cb_assign_key == :tags ? @edit[:cb_assign][cb_assign_key].try(:[], tag_category_id) : @edit[:cb_assign][cb_assign_key]
 
-    @edit[:cb_assign][cb_assign_key].each do |id, _ci|
+    return unless current_assingments
+    current_assingments.each_key do |id|
       key = "#{@edit[:new][:cbshow_typ]}__#{id}"
       @edit[:new][key] = params[key].to_s if params[key]
     end
   end
-
 
   # Get variables from edit form
   def cb_assign_get_form_vars
@@ -814,7 +816,7 @@ class ChargebackController < ApplicationController
 
     if @edit[:new][:cbshow_typ].ends_with?("-tags")
       get_categories_all
-      get_tags_all(params[:cbtag_cat]) if params[:cbtag_cat]
+      get_tags_all(params[:cbtag_cat].to_i) if params[:cbtag_cat]
     elsif @edit[:new][:cbshow_typ].ends_with?("-labels")
       get_docker_labels_all_keys
       get_docker_labels_all_values(params[:cblabel_key]) unless params[:cblabel_key].blank?
@@ -823,7 +825,7 @@ class ChargebackController < ApplicationController
     end
 
     cb_assign_params_to_edit(:cis)
-    cb_assign_params_to_edit(:tags)
+    cb_assign_params_to_edit(:tags, @edit[:new][:cbtag_cat].try(:to_i))
     cb_assign_params_to_edit(:docker_label_values)
   end
 

--- a/app/views/chargeback/_cb_assignments.html.haml
+++ b/app/views/chargeback/_cb_assignments.html.haml
@@ -90,7 +90,7 @@
               %th= _('Name')
               %th= _('Rate')
           %tbody
-            - @edit[:cb_assign][:tags].invert.sort_by { |a| a.first.downcase }.each do |tag, id|
+            - @edit[:cb_assign][:tags][@edit[:new][:cbtag_cat].to_i].invert.sort_by { |a| a.first.downcase }.each do |tag, id|
               %tr
                 %td
                   = h(tag)

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -12,13 +12,13 @@ describe ChargebackController do
       it "returns the classification entry record" do
         controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
         controller.send(:get_tags_all, tag.id)
-        expect(assigns(:edit)[:cb_assign][:tags]).to eq(entry.id.to_s => entry.description)
+        expect(assigns(:edit)[:cb_assign][:tags][tag.id]).to eq(entry.id.to_s => entry.description)
       end
 
       it "returns empty hash when classification entry is not found" do
         controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
         controller.send(:get_tags_all, 1)
-        expect(assigns(:edit)[:cb_assign][:tags]).to eq({})
+        expect(assigns(:edit)[:cb_assign][:tags][1]).to eq({})
       end
     end
 


### PR DESCRIPTION
Behaviour:

**Before:**
It was possible to save just assignment for **Tagged VMs and Instances** only for **ONE** Tag Category 

**After:**
It is possible to save it also for multiple categories:

<img width="959" alt="screen shot 2018-07-18 at 10 36 29" src="https://user-images.githubusercontent.com/14937244/42870178-660c551a-8a77-11e8-8e00-9fb3dcdc8803.png">

**Implementation details**

`@edit[:cb_assign][:tags]` as you can see in
code(`@edit[:cb_assign][cb_assign_key]`) is bringing
selected chargeback rates for tags in selected tag category which is
stored in `@edit[:new][:cbtag_cat]`

to keep selected chargeback rates for any count of tag categories
we need to extend `@edit[:cb_assign][:tags]`  to
`@edit[:cb_assign][:tags] [category_id]`  and this hash can
keep multiple chargeback rates across any count of
tag categories.

we need to update code when chargeback rate is
selected (  in method `cb_assign_params_to_edit` called by
controller action `cb_assign_field_changed`) and then
when we want to save this selection of chargeback rates
in `cb_assign_update`.

**Note**
This PR will need probably also some work to make it better from UX aspects but leave it on other PR.
This PR accomplish it from functional aspects.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1581349
https://bugzilla.redhat.com/show_bug.cgi?id=1601228