### PR TITLE
Fix selection of container images label in Chargeback assignments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -817,7 +817,7 @@ class ChargebackController < ApplicationController
       get_tags_all(params[:cbtag_cat]) if params[:cbtag_cat]
     elsif @edit[:new][:cbshow_typ].ends_with?("-labels")
       get_docker_labels_all_keys
-      get_docker_labels_all_values(params[:cblabel_key]) unless params[:cblabel_key].blank?
+      get_docker_labels_all_values(params[:cblabel_key]) if params[:cblabel_key] && params[:cblabel_key] != 'null'
     else
       get_cis_all
     end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -41,6 +41,17 @@ describe ChargebackController do
         expect(assigns(:edit)[:current_assignment]).to eq([])
       end
     end
+
+    describe '#cb_assign_get_form_vars' do
+      before do
+        controller.instance_variable_set(:@_params, :cblabel_key => 'null')
+        controller.instance_variable_set(:@edit, :new => {:cbshow_typ => '-labels'}, :cb_assign => {})
+      end
+
+      it "returns tag for current assignments" do
+        expect { controller.send(:cb_assign_get_form_vars) }.not_to raise_error
+      end
+    end
   end
 
   context "Saved chargeback rendering" do


### PR DESCRIPTION
if you don't have any labels the scenario here will produce error message:

```
(byebug) D, [2018-07-18T11:07:20.135484 #58529] DEBUG -- :   CustomAttribute Load (0.3ms)  SELECT  "custom_attributes".* FROM "custom_attributes" WHERE "custom_attributes"."id" = $1 LIMIT $2  [["id", 0], ["LIMIT", 1]]
D, [2018-07-18T11:07:20.136942 #58529] DEBUG -- :   CustomAttribute Inst Including Associations (0.0ms - 0rows)
F, [2018-07-18T11:07:20.137892 #58529] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find CustomAttribute with 'id'=null
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activerecord-5.0.7/lib/active_record/core.rb:173:in `find'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/chargeback_controller.rb:758:in `get_docker_labels_all_values'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/chargeback_controller.rb:821:in `cb_assign_get_form_vars'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/chargeback_controller.rb:226:in `cb_assign_field_changed'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/abstract_controller/base.rb:188:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/rendering.rb:30:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:126:in `call'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:455:in `call'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/callbacks.rb:90:in `run_callbacks'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/abstract_controller/callbacks.rb:19:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/rescue.rb:20:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:164:in `block in instrument'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:164:in `instrument'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activerecord-5.0.7/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/abstract_controller/base.rb:126:in `process'
/Users/liborpich
```

scenario:

![bahuouu0nq](https://user-images.githubusercontent.com/14937244/42874962-c03fd790-8a82-11e8-8aa6-ad9ceaf172ab.gif)


@miq-bot assign @mzazrivec 