### PR TITLE
Make sure that react helper always closes the div tag

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -8,7 +8,7 @@ module ReactjsHelper
   def react(name, data = {})
     uid = unique_html_id('react')
     capture do
-      concat(tag('div', :id => uid))
+      concat(content_tag('div', nil, :id => uid))
       concat(javascript_tag("ManageIQ.component.componentFactory('#{j(name)}', '##{j(uid)}', #{data.to_json})"))
     end
   end


### PR DESCRIPTION
The `tag` method sometimes behaves weird (maybe a rails bug) and doesn't close the tags. This can break the whole DOM and e.g. hide the left side tree when creating a tenant.

@miq-bot add_reviewer @hstastna 
@miq-bot add_reviewer @Hyperkid123 

Closes #4273
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593152