### PR TITLE
Fix link in textual_region

### DIFF
--- a/app/helpers/textual_mixins/textual_region.rb
+++ b/app/helpers/textual_mixins/textual_region.rb
@@ -4,16 +4,15 @@ module TextualMixins::TextualRegion
     h = {:label => _("Region")}
     reg = @record.miq_region
     url = reg.remote_ui_url
-    h[:value] = if url
-                  # TODO: Why is this link different than the others?
-                  link_to(reg.description, url_for_only_path(:host   => url,
-                                                   :action => 'show',
-                                                   :id     => @record),
-                          :title   => _("Connect to this VM in its Region"),
-                          :onclick => "return miqClickAndPop(this);")
-                else
-                  reg.description
-                end
+    h[:value] = reg.description
+    if url
+      # this must be url_for to make sure :host is used
+      h[:link] = url_for(:host   => url,
+                         :action => 'show',
+                         :id     => @record)
+      h[:title] = _("Connect to this VM in its Region")
+      h[:external] = true
+    end
     h
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1602095

Steps to Reproduce:
1.) Configure an appliance in region 0 as a remote appliance and an appliance in region 99 as the global appliance.
2.) Add an infrastructure provider to the remote appliance.
3.) View one of the provider's VM's in the global appliance's web UI.

Or a little hack in code:

```diff
--- a/app/helpers/textual_mixins/textual_region.rb
+++ b/app/helpers/textual_mixins/textual_region.rb
 module TextualMixins::TextualRegion
   def textual_region
-    return nil if @record.region_number == MiqRegion.my_region_number
+    #return nil if @record.region_number == MiqRegion.my_region_number
     h = {:label => _("Region")}
     reg = @record.miq_region
-    url = reg.remote_ui_url
+    url = "reg.remote_ui_url"
```

Click at `Region` and new window should open.

Before:
<img width="1193" alt="screen shot 2018-07-19 at 11 28 34 am" src="https://user-images.githubusercontent.com/9210860/42934243-fa845d58-8b46-11e8-966b-c4880827d298.png">

After:
<img width="1186" alt="screen shot 2018-07-19 at 11 27 16 am" src="https://user-images.githubusercontent.com/9210860/42934174-d47f68be-8b46-11e8-90bb-1ea99aef21d6.png">

@miq-bot add_label gaprindashvili/no, bug, blocker, wip

`"return miqClickAndPop(this);"` replaced by `:external => true`
