### PR TITLE
Fix 'Remove selected items from Inventory' button for Images, Instances

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -692,12 +692,18 @@ module ApplicationController::CiProcessing
       reboot_guest stop start check_compliance_queue destroy
       refresh_ems vm_miq_request_new suspend reset shutdown_guest
     )
-    ems_cluster_untestable_actions = %w(scan)
-    if controller == "vm_infra"
+    ems_cluster_untestable_actions = %w(scan destroy)
+    other_untestable_actions = %w(destroy) # Note: destroy is testable for host controller
+
+    case controller
+    when 'vm_infra'
       return vm_infra_untestable_actions.exclude?(action)
-    end
-    if controller == "ems_cluster"
+    when 'ems_cluster'
       return ems_cluster_untestable_actions.exclude?(action)
+    when 'host'
+      return true
+    else
+      return other_untestable_actions.exclude?(action)
     end
     true
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1601955

There is a problem with 'Remove selected items from Inventory' button in many (all?) pages under _Compute > Clouds_ while trying to remove Instance or Image. It's because `validate_destroy` method is called every time we try to delete some item but this method is available only for Host, at least for now.

---

**Steps to reproduce:** (one of possible scenarios)
1. Go to _Compute > Clouds > Providers_ and add some provider if there is no one
2. In provider's details screen, in Relationships table, click on Images
3. Choose some Images (check the checkboxes)
4. Click on  _Configuration > Remove selected items from Inventory_ 
=> the selected Images are not removed, error:
```
I, [2018-07-19T11:06:07.102659 #9372]  INFO -- : Started POST "/ems_cloud/button/38?pressed=image_delete" for ::1 at 2018-07-19 11:06:07 +0200
I, [2018-07-19T11:06:07.152445 #9372]  INFO -- : Processing by EmsCloudController#button as JS
I, [2018-07-19T11:06:07.153491 #9372]  INFO -- :   Parameters: {"miq_grid_checks"=>"2099", "check_2099"=>"2099", "pressed"=>"image_delete", "id"=>"38"}
F, [2018-07-19T11:06:07.382083 #9372] FATAL -- : Error caught: [NoMethodError] undefined method `validate_destroy' for #<ManageIQ::Providers::Amazon::CloudManager::Template:0x007f803d597d28>
Did you mean?  validate_stop
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activemodel-5.0.7/lib/active_model/attribute_methods.rb:433:in `method_missing'
/home/hstastna/manageiq/manageiq/app/models/mixins/availability_mixin.rb:24:in `is_available?'
```

**Before:**
![image_before](https://user-images.githubusercontent.com/13417815/42935397-d165a56e-8b49-11e8-80d0-f651c0376db2.png)

**After:**
![image_after](https://user-images.githubusercontent.com/13417815/42935412-d9f3fe92-8b49-11e8-974c-5d8733640497.png)
