### PR TITLE
Fix custom button without dialog

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -105,7 +105,8 @@ module ApplicationController::Buttons
       end
       @edit[:new][:display] = params[:display] == "1" if params[:display]
       @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
-      copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color dialog_id disabled_text button_type inventory_type))
+      copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color disabled_text button_type inventory_type))
+      @edit[:new][:dialog_id] = params[:dialog_id] == "" ? nil : params[:dialog_id] if params.keys.include?("dialog_id")
       visibility_box_edit
 
       if params[:button_type] == 'default'
@@ -1074,7 +1075,7 @@ module ApplicationController::Buttons
     MiqUserRole.all.sort_by { |ur| ur.name.downcase }.each do |r|
       @edit[:sorted_user_roles].push(r.name => r.id)
     end
-    @edit[:new][:dialog_id] = @custom_button.resource_action.dialog_id.to_i
+    @edit[:new][:dialog_id] = @custom_button.resource_action.dialog_id
     load_available_dialogs
 
     button_set_playbook_form_vars


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1603080

Make sure that for no Dialog `@edit[:new][:dialog_id]` is set to `nil` and `0` or `""`

Steps to Reproduce:
1.Navigate to Automation -> Automate -> Customization
2. Click on Buttons and select any Object Types.
3. Click on configuration and select 'Add a new button'.
4. Fill in details, BUT don't select any `Dialog`.
5. Click on `Add`.

Try to Edit any button to not to have Dialog as well.

Before:
```
Error caught: [ActiveRecord::RecordNotFound] Couldn't find Dialog with 'id'=0
/usr/local/lib/ruby/gems/2.3.0/gems/activerecord-5.0.7/lib/active_record/core.rb:173:in `find'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:932:in `button_set_resource_action'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:896:in `button_set_record_vars'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:542:in `ab_button_add'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:493:in `button_create_update'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:187:in `button_create'
```
After:
<img width="885" alt="screen shot 2018-07-19 at 5 03 58 pm" src="https://user-images.githubusercontent.com/9210860/42951119-c1302bca-8b75-11e8-8979-a73046a1c78b.png">

@miq-bot add_label bug, blocker, gaprindashvili/no

@h-kataria please review, thanks :)