### PR TITLE
Add angular gettext and make translation directive working

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require patternfly
 //= require bower_components/jquery-ujs/src/rails
 //= require angular
+//= require angular-gettext/dist/angular-gettext.min.js
 //= require bower_components/angular-drag-and-drop-lists/angular-drag-and-drop-lists
 //= require bower_components/angular-patternfly/dist/angular-patternfly
 //= require bower_components/angular-bootstrap/ui-bootstrap

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require bower_components/sprintf/dist/sprintf.min
 //= require bower_components/numeral/numeral
 //= require ./cable
+//= require ./gettextCatalog
 //= require ./miq_api
 //= require ./miq_angular_application
 //= require_tree ./angular_modules/

--- a/app/assets/javascripts/gettextCatalog.js
+++ b/app/assets/javascripts/gettextCatalog.js
@@ -1,0 +1,12 @@
+// gettextCatalog
+//
+// This is to override angular-gettext's standard gettextCatalog so that
+// the angular-gettext directive use our __ and n__ (and our i18n catalogs)
+// instead of the native mechanism of gettextCatalog.
+
+angular.module('gettext').factory('gettextCatalog', function() {
+  return {
+    getString: __,
+    getPlural: n__,
+  };
+});

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -3,6 +3,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'angular.validators',
   'ngRedux',
   'frapontillo.bootstrap-switch',
+  'gettext',
   'kubernetesUI',
   'miq.api',
   'miq.card',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",
+    "angular-gettext": "^2.4.1",
     "angular-sanitize": "~1.6.6",
     "angular.validators": "~4.4.2",
     "base64-js": "~1.2.3",


### PR DESCRIPTION
This PR:
* adds `angular-gettext` into ManageIQ
* adds overrides for `gettextCatalog`: an internal mechanism of angular-gettext to retrieve i18n strings from catalogs. For our purposes (read: `ui-components`) we want to use `__()` and `n__()` instead of angular-gettext's native catalog / strings mechanism.

This needs to go into gaprindashvili as well, as it supports other i18n work in ui-components.

@himdel review please?

https://bugzilla.redhat.com/show_bug.cgi?id=1592571