### PR TITLE
Hide Driving Event field for Containers.

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -1,6 +1,10 @@
 module MiqPolicyController::Alerts
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :display_driving_event?
+  end
+
   def alert_edit_cancel
     @edit = nil
     @alert = session[:edit][:alert_id] ? MiqAlert.find(session[:edit][:alert_id]) : MiqAlert.new
@@ -105,6 +109,7 @@ module MiqPolicyController::Alerts
         @edit[:expression_options] = MiqAlert.expression_options(@edit[:new][:expression][:eval_method])
         alert_build_exp_options_info
       end
+      @edit[:new][:exp_event] = %w(ContainerNode ContainerProject).include?(@edit[:new][:db]) ? nil : @edit[:current][:exp_event]
     end
 
     if params.key?(:exp_name)
@@ -232,6 +237,11 @@ module MiqPolicyController::Alerts
   end
 
   private
+
+  def display_driving_event?
+    (@edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] != "nothing") ||
+      %w(ContainerNode ContainerProject).include?(@edit[:new][:db])
+  end
 
   def process_alerts(alerts, task)
     process_elements(alerts, MiqAlert, task)
@@ -568,7 +578,7 @@ module MiqPolicyController::Alerts
     if alert.expression.nil?
       add_flash(_("A valid expression must be present"), :error)
     end
-    unless @edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] != "nothing"
+    unless display_driving_event?
       add_flash(_("A Driving Event must be selected"), :error) if alert.responds_to_events.blank?
     end
     if alert.options[:notifications][:automate]

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -80,7 +80,7 @@
 
         -# Expression driving event
         - if @edit
-          - unless @edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] != "nothing"
+          - unless display_driving_event?
             .form-group
               %label.control-label.col-md-2
                 = _("Driving Event")
@@ -93,7 +93,7 @@
                   miqInitSelectPicker();
                   miqSelectPickerEvent('exp_event', '#{url}', {beforeSend: true, complete: true})
         - else
-          - if @alert.expression.kind_of?(MiqExpression) || @alert.expression[:eval_method] == "nothing"
+          - if (@alert.expression.kind_of?(MiqExpression) || @alert.expression[:eval_method] == "nothing") && !%w(ContainerNode ContainerProject).include?(@alert.db)
             .form-group
               %label.control-label.col-md-2
                 = _("Driving Event")

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -134,5 +134,47 @@ describe MiqPolicyController do
         expect(response).to render_template(:partial => 'miq_policy/_alert_details')
       end
     end
+
+    context "alert_valid_record?" do
+      before do
+        login_as FactoryGirl.create(:user, :features => "alert_admin")
+      end
+
+      before :each do
+        expression = MiqExpression.new("=" => {:tag => "name", :value => "Test"}, :token => 1)
+        @miq_alert = FactoryGirl.create(
+          :miq_alert,
+          :db         => "Host",
+          :options    => {:notifications => {:email => {:to => "fred@test.com"}}},
+          :expression => expression
+        )
+        edit = {
+          :new => {
+            :name       => "New Name",
+            :expression => {:eval_method => nil},
+            :db         => "Host"
+          }
+        }
+        controller.instance_variable_set(:@edit, edit)
+      end
+
+      it "forces Driving Event to be present for non-container alerts" do
+        controller.send(:alert_valid_record?, @miq_alert)
+        expect(assigns(:flash_array).first[:message]).to match("A Driving Event must be selected")
+      end
+
+      it "does not force Driving Event to be present for container alerts" do
+        edit = {
+          :new => {
+            :name       => "New Name",
+            :expression => {:eval_method => nil},
+            :db         => "ContainerNode",
+          }
+        }
+        controller.instance_variable_set(:@edit, edit)
+        controller.send(:alert_valid_record?, @miq_alert)
+        expect(assigns(:flash_array)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=1578115#c26 in BZ removed an option to be able to set/display 'Driving Event' field when adding/editing an Alert that's based on 'Container Node' or 'Container Project' models.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1578115

before:
![before](https://user-images.githubusercontent.com/3450808/42959760-e32e70a6-8b57-11e8-93ae-5c2fbb18987c.png)


after:
![container_alert_after](https://user-images.githubusercontent.com/3450808/42959714-b60943a8-8b57-11e8-976c-029c26e08848.png)

![non_container_aert](https://user-images.githubusercontent.com/3450808/42959706-b2ff59b8-8b57-11e8-8de9-72d0a8d085be.png)
