### PR TITLE
[WIP] Redux controlled amazon dialog

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,4 +27,5 @@
  *= require ./remote_console
  *= require graphiql/graphiql.css
  *= require piecharts
+ *= require @manageiq/react-ui-components/dist/amazon-security-form-group.css
 */

--- a/app/javascript/components/create-amazon-security-group.jsx
+++ b/app/javascript/components/create-amazon-security-group.jsx
@@ -16,20 +16,56 @@ const createGroups = (values, providerId) =>
     resource: { ...values },
   });
 
-const CreateAmazonSecurityGroupForm = ({ providerId }) => (
-  <AmazonSecurityGroupForm
-    onSave={values => createGroups(values, providerId)}
-    onCancel={() => console.log('Cancel clicked')}
-    loadData={getData}
-  />
-);
+class CreateAmazonSecurityGroupForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      values: {},
+    };
+    this.handleFormStateUpdate = this.handleFormStateUpdate.bind(this);
+  }
+
+  componentDidMount() {
+    this.props.dispatch({
+      type: 'FormButtons.init',
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => {
+          createGroups(this.state.values, this.props.recordId);
+        },
+      },
+    });
+  }
+
+  handleFormStateUpdate(formState) {
+    this.props.dispatch({
+      type: 'FormButtons.saveable',
+      payload: formState.valid,
+    });
+    this.props.dispatch({
+      type: 'FormButtons.pristine',
+      payload: formState.pristine,
+    });
+    this.setState({ values: formState.values });
+  }
+
+  render() {
+    return (
+      <AmazonSecurityGroupForm
+        onSave={values => createGroups(values, this.props.recordId)}
+        onCancel={() => console.log('Cancel clicked')}
+        loadData={getData}
+        updateFormState={this.handleFormStateUpdate}
+        hideControls
+      />
+    );
+  }
+}
 
 CreateAmazonSecurityGroupForm.propTypes = {
-  providerId: PropTypes.number.isRequired,
+  recordId: PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };
 
-const mapDispatchToProps = dispatch => ({
-  test: dispatch,
-});
-
-export default connect(() => {}, mapDispatchToProps)(CreateAmazonSecurityGroupForm);
+export default connect()(CreateAmazonSecurityGroupForm);

--- a/app/javascript/components/create-amazon-security-group.jsx
+++ b/app/javascript/components/create-amazon-security-group.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { AmazonSecurityGroupForm } from '@manageiq/react-ui-components/dist/amazon-security-form-group';
+import { API } from '../http_api';
+
+const getData = () => API.get("/api/cloud_networks/?attributes=ems_ref,name,type&expand=resources&filter[]=type='ManageIQ::Providers::Amazon*'")
+  .then(data => data.resources.map(resource => ({
+    value: resource.ems_ref,
+    label: resource.name,
+  })));
+
+const createGroups = (values, providerId) =>
+  API.post(`/api/providers/${providerId}/security_groups`, {
+    action: 'create',
+    resource: { ...values },
+  });
+
+const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+  <AmazonSecurityGroupForm
+    onSave={values => createGroups(values, providerId)}
+    onCancel={() => console.log('Cancel clicked')}
+    loadData={getData}
+  />
+);
+
+CreateAmazonSecurityGroupForm.propTypes = {
+  providerId: PropTypes.number.isRequired,
+};
+
+const mapDispatchToProps = dispatch => ({
+  test: dispatch,
+});
+
+export default connect(() => {}, mapDispatchToProps)(CreateAmazonSecurityGroupForm);

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { combineReducers } from 'redux';
+
+import FormButtons from './form-buttons';
+
+function FormButtonsRedux(props) {
+  initReducer();
+
+  return <FormButtons {...props} />;
+}
+
+FormButtonsRedux.propTypes = {
+};
+
+FormButtonsRedux.defaultProps = {
+};
+
+
+function mapStateToProps(state) {
+  return {...state.FormButtons};
+}
+
+export default connect(mapStateToProps)(FormButtonsRedux);
+
+function initReducer() {
+  if (! ManageIQ.redux || ! ManageIQ.redux.addReducer) {
+    // login screen
+    return;
+  }
+  if (initReducer.done) {
+    // don't init twice
+    return;
+  }
+  initReducer.done = true;
+
+
+  const initialState = {
+    customLabel: '',
+    newRecord: false,
+    pristine: false,
+    saveable: true,
+  };
+
+  const actions = {
+    'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),
+    'FormButtons.customLabel': (state, payload) => ({ ...state, customLabel: payload || ''}),
+    'FormButtons.newRecord': (state, payload) => ({ ...state, newRecord: !! payload }),
+    'FormButtons.pristine': (state, payload) => ({ ...state, pristine: !! payload }),
+    'FormButtons.saveable': (state, payload) => ({ ...state, saveable: !! payload }),
+
+    'FormButtons.callbacks': (state, payload) => ({ ...state, ...payload }),
+  };
+
+
+  ManageIQ.redux.addReducer(combineReducers({
+    FormButtons: function FormButtonsReducer(state = initialState, action) {
+
+      if (actions[action.type]) {
+        return actions[action.type](state, action.payload);
+      } else if (action.type.match(/^FormButtons\./)) {
+        console.warn(`FormButtonsReducer - unknown action type: ${action.type}`, action);
+      }
+
+      return state;
+    },
+  }));
+}

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -12,14 +12,29 @@ function FormButtonsRedux(props) {
 }
 
 FormButtonsRedux.propTypes = {
+  callbackOverrides: PropTypes.object,
 };
 
 FormButtonsRedux.defaultProps = {
+  callbackOverrides: {},
 };
 
 
-function mapStateToProps(state) {
-  return {...state.FormButtons};
+function mapStateToProps(state, ownProps) {
+  let props = {...state.FormButtons};
+
+  if (state.FormButtons && ownProps.callbackOverrides) {
+    // allow overriding click handlers
+    // the original handler is passed as the only argument to the new one
+    Object.keys(ownProps.callbackOverrides).forEach((name) => {
+      props[name] = () => {
+        let origHandler = state.FormButtons[name];
+        ownProps.callbackOverrides[name](origHandler);
+      };
+    });
+  }
+
+  return props;
 }
 
 export default connect(mapStateToProps)(FormButtonsRedux);
@@ -36,12 +51,7 @@ function initReducer() {
   initReducer.done = true;
 
 
-  const initialState = {
-    customLabel: '',
-    newRecord: false,
-    pristine: false,
-    saveable: true,
-  };
+  const initialState = {...FormButtons.defaultProps};
 
   const actions = {
     'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MiqButton from './miq-button';
+
+function FormButtons(props) {
+  let primaryTitle = props.customLabel || (props.newRecord ? __('Add') : __('Save'));
+  let primaryHandler = (props.newRecord ? props.addClicked : props.saveClicked) || props.addClicked || props.saveClicked;
+
+  let resetTitle = __("Reset");
+  let cancelTitle = __("Cancel");
+
+  return (
+    <React.Fragment>
+      <div className="clearfix"></div>
+      <div className="pull-right button-group edit_buttons">
+        <MiqButton name={primaryTitle} title={primaryTitle} enabled={props.saveable} onClick={primaryHandler} primary={true} />
+        {props.newRecord || <MiqButton name={resetTitle} title={resetTitle} enabled={! props.pristine} onClick={props.resetClicked} />}
+        <MiqButton name={cancelTitle} title={cancelTitle} enabled={true} onClick={props.cancelClicked} />
+
+      </div>
+    </React.Fragment>
+  );
+}
+
+FormButtons.propTypes = {
+  newRecord: PropTypes.bool,
+  customLabel: PropTypes.string,
+  saveable: PropTypes.bool,
+  pristine: PropTypes.bool,
+  addClicked: PropTypes.func,
+  saveClicked: PropTypes.func,
+  resetClicked: PropTypes.func,
+  cancelClicked: PropTypes.func,
+};
+
+const noop = () => null;
+
+FormButtons.defaultProps =  {
+  newRecord: false,
+  customLabel: '',
+  saveable: false,
+  pristine: true,
+  addClicked: noop,
+  saveClicked: noop,
+  resetClicked: noop,
+  cancelClicked: noop,
+}
+
+export default FormButtons;

--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ClassNames from 'classnames';
+
+function MiqButton(props) {
+  let title = props.title;
+  if (props.enabled && props.enabledTitle) {
+    title = props.enabledTitle;
+  }
+  if (! props.enabled && props.disabledTitle) {
+    title = props.disabledTitle;
+  }
+
+  let klass = ClassNames({
+    'btn': true,
+    'btn-xs': props.xs,
+    'btn-primary': props.primary,
+    'btn-default': !props.primary,
+    'disabled': !props.enabled,
+  });
+
+  let buttonClicked = (event) => {
+    if (props.enabled) {
+      props.onClick();
+    }
+
+    event.preventDefault();
+    event.target.blur();
+  };
+
+  return (
+    <button className={klass}
+      onClick={buttonClicked}
+      title={title}
+      alt={title}>
+      {props.name}
+    </button>
+  );
+}
+
+MiqButton.propTypes = {
+  name: PropTypes.string.isRequired,
+  enabled: PropTypes.bool.isRequired,
+  title: PropTypes.string,
+  enabledTitle: PropTypes.string,
+  disabledTitle: PropTypes.string,
+  primary: PropTypes.bool,
+  xs: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+};
+
+MiqButton.defaultProps = {
+  title: '',
+  enabledTitle: '',
+  disabledTitle: '',
+  primary: false,
+  xs: false,
+};
+
+export default MiqButton;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -6,6 +6,7 @@ import GenericGroupWrapper from '../react/generic_group_wrapper';
 import { addReact } from '../miq-component/helpers';
 import VmSnapshotFormComponent from '../components/vm-snapshot-form-component';
 import FormButtonsRedux from '../forms/form-buttons-redux';
+import CreateAmazonSecurityGroupForm from '../components/create-amazon-security-group';
 
 /**
 * Add component definitions to this file.
@@ -21,3 +22,4 @@ addReact('GenericGroupWrapper', GenericGroupWrapper);
 addReact('TextualSummaryWrapper', TextualSummaryWrapper);
 addReact('VmSnapshotFormComponent', VmSnapshotFormComponent);
 addReact('FormButtonsRedux', FormButtonsRedux);
+addReact('CreateAmazonSecurityGroupForm', CreateAmazonSecurityGroupForm);

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -5,6 +5,7 @@ import TableListViewWrapper from '../react/table_list_view_wrapper';
 import GenericGroupWrapper from '../react/generic_group_wrapper';
 import { addReact } from '../miq-component/helpers';
 import VmSnapshotFormComponent from '../components/vm-snapshot-form-component';
+import FormButtonsRedux from '../forms/form-buttons-redux';
 
 /**
 * Add component definitions to this file.
@@ -19,3 +20,4 @@ addReact('GenericGroup', GenericGroup);
 addReact('GenericGroupWrapper', GenericGroupWrapper);
 addReact('TextualSummaryWrapper', TextualSummaryWrapper);
 addReact('VmSnapshotFormComponent', VmSnapshotFormComponent);
+addReact('FormButtonsRedux', FormButtonsRedux);

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Icon, Modal } from 'patternfly-react';
+import FormButtonsRedux from '../forms/form-buttons-redux';
 
 function closeModal(id) {
   // this should have been div.remove();
@@ -25,6 +26,19 @@ export default function renderModal(title = __("Modal"), Inner = () => <div>Empt
 }
 
 function modal(title, Inner, closed, removeId) {
+  const overrides = {
+    addClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    saveClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    cancelClicked: function(orig) {
+      Promise.when(orig()).then(closed);
+    },
+    // don't close on reset
+  };
+
   return (
     <Modal
       show={true}
@@ -47,13 +61,7 @@ function modal(title, Inner, closed, removeId) {
         <div id={/* see closeModal */ removeId}></div>
       </Modal.Body>
       <Modal.Footer>
-        <Button
-          bsStyle="primary"
-          onClick={closed}
-          autoFocus
-        >
-          {__('Close')}
-        </Button>
+        <FormButtonsRedux callbackOverrides={overrides} />
       </Modal.Footer>
     </Modal>
   );

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Icon, Modal } from 'patternfly-react';
+import { Provider } from 'react-redux';
 import FormButtonsRedux from '../forms/form-buttons-redux';
 
 function closeModal(id) {
@@ -28,41 +29,43 @@ export default function renderModal(title = __("Modal"), Inner = () => <div>Empt
 function modal(title, Inner, closed, removeId) {
   const overrides = {
     addClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     saveClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     cancelClicked: function(orig) {
-      Promise.when(orig()).then(closed);
+      Promise.resolve(orig()).then(closed);
     },
     // don't close on reset
   };
 
   return (
-    <Modal
-      show={true}
-      onHide={closed}
-      onExited={closed}
-    >
-      <Modal.Header>
-        <button
-          className="close"
-          onClick={closed}
-          aria-hidden="true"
-          aria-label="Close"
-        >
-          <Icon type="pf" name="close" />
-        </button>
-        <Modal.Title>{title}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Inner />
-        <div id={/* see closeModal */ removeId}></div>
-      </Modal.Body>
-      <Modal.Footer>
-        <FormButtonsRedux callbackOverrides={overrides} />
-      </Modal.Footer>
-    </Modal>
+    <Provider store={ManageIQ.redux.store}>
+      <Modal
+        show={true}
+        onHide={closed}
+        onExited={closed}
+      >
+        <Modal.Header>
+          <button
+            className="close"
+            onClick={closed}
+            aria-hidden="true"
+            aria-label="Close"
+          >
+            <Icon type="pf" name="close" />
+          </button>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Inner />
+          <div id={/* see closeModal */ removeId}></div>
+        </Modal.Body>
+        <Modal.Footer>
+          <FormButtonsRedux callbackOverrides={overrides} />
+        </Modal.Footer>
+      </Modal>
+    </Provider>
   );
 }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,21 +1,2 @@
 = render :partial => "layouts/flash_msg"
-- if  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
-  .row#modules
-    .col-md-6.col-lg-4#col1{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col1].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-    .col-md-6.col-lg-4#col2{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col2].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-    .col-md-6.col-lg-4#col3{:style => "position: relative; min-height: 50px;"}
-      - @sb[:dashboards][@sb[:active_db]][:col3].each do |w|
-        - widget = MiqWidget.find_by_id(w)
-        - if widget && widget.enabled && @available_widgets.include?(widget.id)
-          = WidgetPresenter.new(self, controller, widget).render_partial
-- if WidgetPresenter.chart_data.present?
-  :javascript
-    ManageIQ.charts.chartData = #{{"widgetchart" => WidgetPresenter.chart_data}.to_json.html_safe};
+

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,2 +1,21 @@
 = render :partial => "layouts/flash_msg"
-
+- if  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
+  .row#modules
+    .col-md-6.col-lg-4#col1{:style => "position: relative; min-height: 50px;"}
+      - @sb[:dashboards][@sb[:active_db]][:col1].each do |w|
+        - widget = MiqWidget.find_by_id(w)
+        - if widget && widget.enabled && @available_widgets.include?(widget.id)
+          = WidgetPresenter.new(self, controller, widget).render_partial
+    .col-md-6.col-lg-4#col2{:style => "position: relative; min-height: 50px;"}
+      - @sb[:dashboards][@sb[:active_db]][:col2].each do |w|
+        - widget = MiqWidget.find_by_id(w)
+        - if widget && widget.enabled && @available_widgets.include?(widget.id)
+          = WidgetPresenter.new(self, controller, widget).render_partial
+    .col-md-6.col-lg-4#col3{:style => "position: relative; min-height: 50px;"}
+      - @sb[:dashboards][@sb[:active_db]][:col3].each do |w|
+        - widget = MiqWidget.find_by_id(w)
+        - if widget && widget.enabled && @available_widgets.include?(widget.id)
+          = WidgetPresenter.new(self, controller, widget).render_partial
+- if WidgetPresenter.chart_data.present?
+  :javascript
+    ManageIQ.charts.chartData = #{{"widgetchart" => WidgetPresenter.chart_data}.to_json.html_safe};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular.validators": "~4.4.2",
     "base64-js": "~1.2.3",
     "bootstrap-switch": "~3.3.4",
+    "classnames": "^2.2.5",
     "graphiql": "^0.11.11",
     "graphql": "^0.13.2",
     "jquery": "~2.2.4",


### PR DESCRIPTION
Adds a option to create amazon provider from modal.

## Controls
In order to avoid any bugs in current version, component cannot be show from UI. You have to run a few commands from browser console.
```
ManageIQ.record.recordId = 'someId'
sendDataWithRx({controller: 'provider_dialogs', component_name: 'CreateAmazonSecurityGroupForm', modal_title: 'Create amazon provider.', props: {recordId: 'neco'}})
```

## Dependencies
This pr is dependent on #3509 and https://github.com/ManageIQ/react-ui-components/pull/61. Also a new version of react-ui-components is required for this to work properly .


## Some issues
Currently props cannot be passed to component inside modal. That can be fixed ni `modal.js`. @himdel knows about this. Therefore the providerId must be set in console first, before showing the modal.

Also the API endpoint for creating is not available until https://github.com/ManageIQ/manageiq-providers-amazon/issues/453 will be merged