### PR TITLE
Added autoprefixer plugin to postcss-loader.

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -36,6 +36,7 @@ module.exports = [
         loader: 'postcss-loader',
         options: {
           sourceMap: true,
+          plugins: () => [require('autoprefixer')],
         },
       },
       'resolve-url-loader',


### PR DESCRIPTION
This allows to directly import css files to JS bundles. You might need this sometimes, if you are adding some React component outside of the manageiq-ui-classic (from another plugin) and using ui-classic webpack to build the components.

fixes:
```
ERROR in ./node_modules/css-loader?{"minimize":false}!./node_modules/postcss-loader?{"sourceMap":true}!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js?{"sourceMap":true}!../react-ui-components/dist/amazon-security-form-group.css
Module build failed: Error: No PostCSS Config found in: /home/mmarosi/react-ui-components/dist
    at /home/mmarosi/manageiq-ui-classic/node_modules/postcss-load-config/index.js:51:26
    at <anonymous>
 @ ../react-ui-components/dist/amazon-security-form-group.css 4:14-343
 @ ../manageiq-providers-amazon/app/javascript/packs/component-definitions-common.js
```