### PR TITLE
Remove the unnecessary view_to_hash call from Foreman controller

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -473,7 +473,6 @@ class ProviderForemanController < ApplicationController
   def add_unassigned_configuration_profile_record_to_view(unassigned_profile_row, unassigned_configuration_profile)
     @view.table.data.push(unassigned_profile_row)
     @targets_hash[unassigned_profile_row['id']] = unassigned_configuration_profile
-    @grid_hash = view_to_hash(@view)
   end
 
   def update_options(options = {})


### PR DESCRIPTION
I'm doing stuff in the GTL area ant this call seems unused and unnecessary. All these things go through the `report_data` call and it's always a separate request. @AparnaKarve could you please verify?

@miq-bot add_reviewer @AparnaKarve 
@miq-bot add_label celanup, gaprindashvili/no, GTLs, configuration management