### PR TITLE
Fix path to jQuery when loading it separately for remote consoles

### DIFF
--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -7,7 +7,7 @@
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     -# Load the required JS based on the console type
-    = javascript_include_tag 'jquery', "remote_consoles/#{@console[:type]}", 'remote_console'
+    = javascript_include_tag 'jquery/dist/jquery.js', "remote_consoles/#{@console[:type]}", 'remote_console'
   %body
     #remote-console{'data-url' => @console[:url], 'data-secret' => @console[:secret]}
     = render :partial => 'shared/remote_console_footer', :layout   => false, :locals   => { :console_type => @console[:type].upcase }

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -2,7 +2,7 @@
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     = favicon_link_tag
-    = javascript_include_tag 'jquery'
+    = javascript_include_tag 'jquery/dist/jquery.js'
     :javascript
       // INITIALIZE
       $(document).ready(function(){

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -5,7 +5,7 @@
       = _('%{product_name} WebMKS Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
-    = javascript_include_tag 'jquery', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
+    = javascript_include_tag 'jquery/dist/jquery.js', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
     :javascript
       $(function () {
         var mksOpts = {};

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,7 @@ end
 Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/modes/*.js
   bower_components/codemirror/themes/*.css
-  jquery.js
+  jquery/dist/jquery.js
   bower_components/jquery-ui/jquery-ui.js
 
   jquery_overrides.js


### PR DESCRIPTION
After examining the `public/assets/.sprockets-manifest.json` file on an appliance, I deduced that this might fix the missing jquery issue for remote consoles.

@miq-bot assign @himdel 
@miq-bot add_label bug, gaprindashvili/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600139
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597352