### PR TITLE
Prevent double submit in Dialog Editor

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -1,6 +1,7 @@
 ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqService', 'DialogEditor', 'DialogEditorHttp', 'DialogValidation', 'dialogIdAction', function($window, miqService, DialogEditor, DialogEditorHttp, DialogValidation, dialogIdAction) {
   var vm = this;
 
+  vm.saveButtonDisabled = false;
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
 
@@ -97,6 +98,8 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
     var action;
     var dialogData;
     var dialogId;
+
+    vm.saveButtonDisabled = true;
 
     // load dialog data
     if (requestDialogAction() === 'edit') {

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -20,7 +20,8 @@
     %dialog-editor{'tree-selector-data' => 'vm.treeSelectorData', 'tree-selector-lazy-load' => 'vm.lazyLoad'}
     .pull-right
       %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
-                              "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content)",
+                              "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) || vm.saveButtonDisabled",
+                              "ng-dblclick" => "return false;",
                               "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
                               :type => "button"}= _("Save")
       %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1602848

First I've tried using a directive ngDblclick (https://docs.angularjs.org/api/ng/directive/ngDblclick#ngDblclick-info), which didn't help.
Disabling the button after click did the magic.

I've kept both solutions.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1602848

Steps for Testing/QA
-------------------------------
1.  Edit service dialog OR Copy service dialog
2.  Double click save (double click sometimes reproduces the issue, sometimes I had to click three times)
