### PR TITLE
Display "FloatingIp belongs to NetworkRouter" relation

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -11,7 +11,7 @@ class NetworkRouterController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets)
+    %w(instances cloud_subnets floating_ips)
   end
 
   def button

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module FloatingIpHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instance network_port))
+    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instance network_port network_router))
   end
 
   #
@@ -56,5 +56,9 @@ module FloatingIpHelper::TextualSummary
 
   def textual_network_port
     @record.network_port
+  end
+
+  def textual_network_router
+    textual_link(@record.network_router, :label => _('Network Router'))
   end
 end

--- a/app/helpers/network_router_helper/textual_summary.rb
+++ b/app/helpers/network_router_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module NetworkRouterHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets external_gateway)
+      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets external_gateway floating_ips)
     )
   end
 
@@ -85,5 +85,9 @@ module NetworkRouterHelper::TextualSummary
 
   def textual_external_gateway
     textual_link(@record.cloud_network, :label => _('Cloud Network'))
+  end
+
+  def textual_floating_ips
+    textual_link(@record.floating_ips, :label => _('Floating Ips'))
   end
 end

--- a/app/views/network_router/show.html.haml
+++ b/app/views/network_router/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(instances cloud_subnets).include?(@display) && @showtype != "compare"
+  - if %w(instances cloud_subnets floating_ips).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
With this commit we enhance UI with relation between NetworkRouter and FloatingIp (and vice versa):

![image](https://user-images.githubusercontent.com/8102426/43079850-861dd8ae-8e8e-11e8-8a34-6d420d71e1fb.png)

![image](https://user-images.githubusercontent.com/8102426/43082793-2d02e6ae-8e95-11e8-8b07-e4c2c8e9242a.png)

![image](https://user-images.githubusercontent.com/8102426/43079914-b22226da-8e8e-11e8-8cb1-6275fc364a24.png)

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574922

@miq-bot add_label enhancement
@miq-bot assign @himdel 