### PR TITLE
Make name and description visible on CloudTenant details page

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -225,7 +225,7 @@ class CloudTenantController < ApplicationController
   private
 
   def textual_group_list
-    [%i(relationships quotas), %i(tags)]
+    [%i(properties relationships quotas), %i(tags)]
   end
   helper_method :textual_group_list
 

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -4,6 +4,11 @@ module CloudTenantHelper::TextualSummary
   #
   # Groups
   #
+
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i(name description))
+  end
+
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
@@ -13,6 +18,14 @@ module CloudTenantHelper::TextualSummary
         network_routers security_groups floating_ips network_ports
       )
     )
+  end
+
+  def textual_name
+    @record.name
+  end
+
+  def textual_description
+    @record.description
   end
 
   def textual_group_quotas


### PR DESCRIPTION
With this commit we add **Properties** group where Name and Description are visible to user:

![image](https://user-images.githubusercontent.com/8102426/43083003-bcf5b854-8e95-11e8-86bd-06287873a355.png)

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574903

@miq-bot add_label enhancement
@miq-bot assign @himdel 