### PR TITLE
Fix open_url with dialog

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -248,6 +248,11 @@ module ApplicationController::Buttons
     end
   end
 
+  def open_url_after_dialog
+    url = SystemConsole.find_by(:vm_id => params[:targetId]).url
+    render :json => {:open_url => url}
+  end
+
   private
 
   BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
@@ -338,10 +343,11 @@ module ApplicationController::Buttons
       }
 
       options[:dialog_locals] = DialogLocalService.new.determine_dialog_locals_for_custom_button(obj, button.name, button.resource_action, display_options)
+      options[:dialog_locals][:open_url] = button.options.present? && button.options.fetch_path(:open_url)
       options.merge!(display_options) unless display_options.empty?
       dialog_initialize(button.resource_action, options)
 
-    elsif button.options && button.options.key?(:open_url) && button.options[:open_url]
+    elsif button.options.present? && button.options.fetch_path(:open_url)
       # not supported for objs: cannot do wait for task for multiple tasks
       task_id = button.invoke_async(obj)
       initiate_wait_for_task(:task_id => task_id, :action => :custom_button_done)

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -50,4 +50,5 @@
                 :finish_submit_endpoint => finish_submit_endpoint,
                 :api_submit_endpoint    => api_submit_endpoint,
                 :api_action             => api_action,
-                :cancel_endpoint        => cancel_endpoint}
+                :cancel_endpoint        => cancel_endpoint,
+                :open_url               => open_url}

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -27,4 +27,5 @@
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
   ManageIQ.angular.app.value('apiAction', '#{api_action}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
+  ManageIQ.angular.app.value('openUrl', '#{open_url}');
   miq_bootstrap('.wrapper');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
     dynamic_date_refresh
     dynamic_radio_button_refresh
     dynamic_text_box_refresh
+    open_url_after_dialog
   )
 
   discover_get_post = %w(

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -40,6 +40,7 @@ describe('dialogUserController', function() {
       resourceActionId: '789',
       targetId: '987',
       targetType: 'targettype',
+      openUrl: false,
     });
   }));
 
@@ -119,6 +120,7 @@ describe('dialogUserController', function() {
           targetId: '987',
           targetType: 'targettype',
           saveable: true,
+          openUrl: false,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});
@@ -152,6 +154,7 @@ describe('dialogUserController', function() {
           targetId: '987',
           targetType: 'targettype',
           saveable: true,
+          openUrl: false,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1602023

Create custom button with Automate method:

1) Automation -> Automate -> Explorer:
a) create a new domain with a name
b) select ManageIQ/System/Request
c) Configuration -> Copy this Class (copy it to your new domain from step 1a)
d) select Request Class in your new domain -> Configuration -> Add a new Instance
   * name `TestOpenUrl`
   * to `meth1` write `test_open_url`
e) Select Request class in your new domain, click Methods -> Configuration -> Add a new Method
   * type: inline
   * name: test_open_url
   *data should be (or anything that sets `vm.remote_console_url` to something):
```
      vm = $evm.root['vm']
      $evm.log(:info, "VM to launch SSH for is #{vm.hostnames[0]}")
      vm.remote_console_url = "ssh://10.13.153.96"
```

Automation -> Automate -> Customization -> Buttons

Create a new button for VMs with Open Url checked and with a Dialog(doesn't matter which one) and  Request has to be `TestOpenUrl`

Go to VM summary page and click the new button

After submitting the dialog a new page should be open

@miq-bot add_label wip

**Related PRs:** https://github.com/ManageIQ/manageiq/pull/17802  and https://github.com/ManageIQ/manageiq-automation_engine/pull/205 and https://github.com/ManageIQ/manageiq-api/pull/444
