### PR TITLE
Fixing display of subcollections of physical components

### DIFF
--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -27,6 +27,6 @@ class PhysicalChassisController < ApplicationController
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_chassis)
+    %w(physical_servers)
   end
 end

--- a/app/controllers/physical_rack_controller.rb
+++ b/app/controllers/physical_rack_controller.rb
@@ -42,6 +42,6 @@ class PhysicalRackController < ApplicationController
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_servers)
+    %w(physical_chassis physical_servers)
   end
 end


### PR DESCRIPTION
Wrong list of components is shown when click on link in summary table.

If we take this physical chassis as example, we can see only one physical server inside this component:

![screenshot-localhost 3000-2018-07-23-14-50-05](https://user-images.githubusercontent.com/8550928/43094065-51b7fac8-8e88-11e8-8274-8ad16a09229a.png)

__Current result__
10 physical servers are shown

![screenshot-localhost 3000-2018-07-23-14-49-33](https://user-images.githubusercontent.com/8550928/43094115-7783c7f0-8e88-11e8-9b4e-8b665659446e.png)


__After this PR__
Only the right physical server is shown

![screenshot-localhost 3000-2018-07-23-14-47-41](https://user-images.githubusercontent.com/8550928/43094192-9b4f385e-8e88-11e8-94f4-d85ec5f2b3c7.png)

This error also occurs in physical rack page.