### PR TITLE
Remove VM Transform buttons

### DIFF
--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -190,13 +190,6 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::BasicImage),
         button(
-          :vm_transform_mass,
-          'fa fa-random fa-lg',
-          t = N_('Transform tagged VMs to RHV'),
-          t,
-          :klass => ApplicationHelper::Button::MassTransformVmButton
-        ),
-        button(
           :vm_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for the selected items'),

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -129,13 +129,6 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :klass   => ApplicationHelper::Button::GenericFeatureButton,
           :options => {:feature => :migrate}),
         button(
-          :vm_transform,
-          'fa fa-random fa-lg',
-          t = N_('Transform this VM to RHV'),
-          t,
-          :klass => ApplicationHelper::Button::TransformVmButton
-        ),
-        button(
           :vm_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this VM'),


### PR DESCRIPTION
Remove 'Transform tagged VMs to RHV' and 'Transform this VM to RHV' from
the toolbar.

Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585452