### PR TITLE
Display "FloatingIp belongs to CloudNetwork" relation

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -11,7 +11,7 @@ class CloudNetworkController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_networks network_routers cloud_subnets)
+    %w(instances cloud_networks network_routers cloud_subnets floating_ips)
   end
 
   def button

--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module CloudNetworkHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets network_routers)
+      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets network_routers floating_ips)
     )
   end
 
@@ -57,5 +57,9 @@ module CloudNetworkHelper::TextualSummary
 
   def textual_cloud_subnets
     @record.cloud_subnets
+  end
+
+  def textual_floating_ips
+    textual_link(@record.floating_ips, :label => _("Floating IPs"))
   end
 end

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module FloatingIpHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instance network_port network_router))
+    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems_network cloud_tenant instance network_port network_router cloud_network))
   end
 
   #
@@ -60,5 +60,9 @@ module FloatingIpHelper::TextualSummary
 
   def textual_network_router
     textual_link(@record.network_router, :label => _('Network Router'))
+  end
+
+  def textual_cloud_network
+    textual_link(@record.cloud_network, :label => _("Cloud Network"))
   end
 end

--- a/app/views/cloud_network/show.html.haml
+++ b/app/views/cloud_network/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "network_routers", "cloud_subnets"].include?(@display) && @showtype != "compare"
+  - if ["instances", "network_routers", "cloud_subnets", "floating_ips"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
With this commit we enhance CloudNetwork details page with "Floating Ips" relation as well as FloatingIp's details page with "Cloud Network" relation.

![image](https://user-images.githubusercontent.com/8102426/43121355-c3175ae8-8f1d-11e8-8122-d18d5a4e3603.png)

![image](https://user-images.githubusercontent.com/8102426/43121420-02057ca8-8f1e-11e8-9474-13fa062f4ae3.png)

![image](https://user-images.githubusercontent.com/8102426/43121544-6cbf1162-8f1e-11e8-88b8-4b522b72a465.png)

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574922

@miq-bot add_label enhancement
@miq-bot assign @himdel 