### PR TITLE
Disable ruby-scrutinizer-run to prevent time out of Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,3 +7,11 @@ build:
     override:
       -
         command: true
+  nodes:
+    analysis:
+      tests:
+        override:
+          -
+            command: rubocop-run
+            use_website_config: false
+          - js-scrutinizer-run


### PR DESCRIPTION
`ruby-scrutinizer-run` runs too long for some reason and Scrutinizer times out after a while.

<img width="1077" alt="screen shot 2018-07-26 at 10 35 07 am" src="https://user-images.githubusercontent.com/9210860/43251200-9b8c9f12-90bf-11e8-8476-e22f0c12a69f.png">

So skipping `ruby-scrutinizer-run` for now.

@miq-bot add_label wip