### PR TITLE
Remove Redux environment warning in production

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require bower_components/angular-bootstrap/ui-bootstrap-tpls
 //= require angular-sanitize
 //= require angular.validators/angular.validators
-//= require ng-redux/dist/ng-redux
 //= require bower_components/moment/moment
 //= require bower_components/moment-strftime/lib/moment-strftime
 //= require bower_components/moment-timezone/moment-timezone

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -7,6 +7,7 @@
 // layout file, like app/views/layouts/application.html.erb
 
 import 'proxy-polyfill';
+import 'ng-redux';
 
 import { mount } from '../react/mounter';
 import componentRegistry from '../react/componentRegistry';

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -44,7 +44,9 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || 'development'),
+    }),
 
     // Workaround for graphql/graphql-language-service#128
     new webpack.ContextReplacementPlugin(


### PR DESCRIPTION
When running in production, there is a warning in the console:

```
You are currently using minified code outside of NODE_ENV === 'production'.
This means that you are running a slower development build of Redux.
You can use loose-envify (https://github.com/zertosh/loose-envify) for browserify
or DefinePlugin for webpack (http://stackoverflow.com/questions/30030031) 
to ensure you have the correct code for your production build.
```

That warning is present in both redux and ng-redux, but appears only because we're using the pre-built version of ng-redux, which was built with the development environment.

So... moving ng-redux to webpack so that we compile our own environment-dependnent version.

---

Also changed how we expose the environment - previously, for some reason we would take all the environment and pass it as a list of defaults to EnvironmentPlugin.

Now, we're only explicittly sharing `NODE_ENV`.

---

Testing: 

```
RAILS_ENV=production NODE_ENV=production bin/rake assets:precompile
UNSAFE_PG_VERSION=true RAILS_SERVE_STATIC_FILES=true RAILS_ENV=production be bin/rails s
```

Check the browser console on the login screen.

---

(As far as I know, this is just a warning, no point in backporting unless somebody complains.)
