### PR TITLE
Display "CloudSubnet has many NetworkPorts" relation

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -11,7 +11,7 @@ class CloudSubnetController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets)
+    %w(instances cloud_subnets network_ports)
   end
 
   def button

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module CloudSubnetHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network
-        network_router parent_subnet managed_subnets
+        network_router parent_subnet managed_subnets network_ports
       )
     )
   end
@@ -105,5 +105,9 @@ module CloudSubnetHelper::TextualSummary
 
   def textual_availability_zone
     textual_link(@record.availability_zone, :label => _('Availability Zone'))
+  end
+
+  def textual_network_ports
+    textual_link(@record.network_ports, :label => _('Network Ports'))
   end
 end

--- a/app/views/cloud_subnet/show.html.haml
+++ b/app/views/cloud_subnet/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "cloud_subnets"].include?(@display) && @showtype != "compare"
+  - if ["instances", "cloud_subnets", "network_ports"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
With this commit we provide the missing link on CloudSubnet details page:

![image](https://user-images.githubusercontent.com/8102426/43139719-cb2c2f76-8f52-11e8-9c87-ffa7d2936662.png)

![image](https://user-images.githubusercontent.com/8102426/43139749-e5de8832-8f52-11e8-86ae-d04e84d1757b.png)


RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1574927

@miq-bot add_label enhancement
@miq-bot assign @mzazrivec 