### PR TITLE
Fix path to jQuery in application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,7 @@
 //= require bower_components/es6-shim/es6-shim
 //= require bower_components/array-includes/array-includes
 //= require bower_components/fetch/fetch
-//= require jquery
+//= require jquery/dist/jquery.js
 //= require ./jquery_overrides
 //= require ./i18n
 //= require patternfly


### PR DESCRIPTION
Analogous with https://github.com/ManageIQ/manageiq-ui-classic/pull/4329, this is needed if we want to load it properly from npm.

@miq-bot add_label bug
@miq-bot assign @himdel 