### PR TITLE
Include main.scss through the asset pipeline path resolver

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,7 +1,7 @@
 /*
  *= require bower_components/c3/c3
  *= require bower_components/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min
- *= require ./main
+ *= require main
  *= require ./automate_import_export
  *= require ./dialog_fields
  *= require angular


### PR DESCRIPTION
When sprockets loads a file using the `require` directive, it usually goes through the `config.assets.paths` and searches for the given file. However, if you prepend the filename with a `./` as we did in https://github.com/ManageIQ/manageiq-ui-classic/pull/3343/commits/f18e5d6784075b1b15f132e5a173f1a6724d9517 it will search only in the directory of the file with the directive.

This is all good until you don't want to override a file from a location with higher priority...

@miq-bot add_label bug
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @himdel 