### PR TITLE
Fixing link for physical switches ports

### DIFF
--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module PhysicalSwitchHelper::TextualSummary
     ports_count = @record.physical_network_ports.count
     ports = {:label => _("Ports"), :value => ports_count, :icon => "ff ff-network-port"}
     if ports_count.positive?
-      ports[:link] = "/physical_switch/show/#{@record.id}?display=ports"
+      ports[:link] = "/physical_switch/show/#{@record.id}?display=physical_network_ports"
     end
     ports
   end


### PR DESCRIPTION
__This PR is able to__
Fix the link for Physical Network Ports of Physical Switch summary page.

@miq-bot add_label bug
@miq-bot add_label compute/physical infrastructure

@miq-bot assign @himdel 