### PR TITLE
Set the Status of some topology nodes

### DIFF
--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -67,8 +67,12 @@ class PhysicalInfraTopologyService < TopologyService
     case entity
     when ManageIQ::Providers::PhysicalInfraManager
       entity.authentications.blank? ? _('Unknown') : entity.authentications.first.status.try(:capitalize)
-    when PhysicalServer, PhysicalSwitch
+    when PhysicalServer, PhysicalSwitch, PhysicalStorage, PhysicalChassis
       entity.health_state ? entity.health_state : _('Unknown')
+    when Host
+      entity.state ? entity.state.downcase.capitalize : _('Unknown')
+    when Vm
+      entity.power_state ? entity.power_state.downcase.capitalize : _('Unknown')
     else
       _('Unknown')
     end


### PR DESCRIPTION
**What this PR does:**
- Set the status of the PhysicalChassis and PhysicalStorage nodes in the topology view to be relative to the entity's `health_state`;
- Set the status of the Hosts nodes in the topology view to be relative to the entity's `state`;
- Set the status of the Vms nodes in the topology view to be relative to the entity's `power_state`.

Note: Physical Chassis and Physical Storage were added because as soon as they are added to the topology, the status border will work for them.

![topology](https://user-images.githubusercontent.com/14334253/43155556-18e7115e-8f4e-11e8-811e-799ca1f0fff1.png)

As the picture shows, the nodes get borders in one of this colors:
- Gray => `Unknown` Health State status (Chassis/Storage) or Power State status (Host/VM);
- Green => `Valid` or `On`;
- Yellow => `Warning`;
- Red => `Critical`;