### PR TITLE
Fix the health_state quadicon

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -64,9 +64,9 @@ module QuadiconHelper
     when "Critical"
       {:fonticon => "fa fa-exclamation", :color => '#cc0000', :tooltip => _('Critical health state')}
     when "Warning"
-      {:fileicon => "pficon pficon-warning-triangle-o", :tooltip => _('Health state warning')}
+      {:fonticon => "pficon pficon-warning-triangle-o", :tooltip => _('Health state warning')}
     else
-      {:fonticon => "pficon-unknown", :tooltip => _('Could not determine health state')}
+      {:fonticon => "pficon pficon-unknown", :tooltip => _('Could not determine health state')}
     end
   end
 


### PR DESCRIPTION
This PR is able to:
*  Fix the health state quadicon not shown the warning icon and unknown icon when a resource have one these states

![switch_page](https://user-images.githubusercontent.com/12627705/43160323-3624dffa-8f5b-11e8-9eb5-51fa5fe7d479.png)
