### PR TITLE
Use ui lookup for model name in listnav

### DIFF
--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -105,7 +105,7 @@ module ApplicationHelper
         link_to("#{name}: #{ent.name}",
                 link_params,
                 :title => _("Show this %{entity_name}'s parent %{linked_entity_name}") %
-                          {:entity_name        => record.class.name.demodulize.titleize,
+                          {:entity_name        => ui_lookup(:model => record.class.name.demodulize),
                            :linked_entity_name => name})
       end
     end

--- a/spec/views/layouts/listnav/_floating_ip.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_floating_ip.html.haml_spec.rb
@@ -32,7 +32,7 @@ describe "layouts/listnav/_floating_ip.html.haml" do
         @record = @floating_ip
         render
         expect(response).to include("href=\"/floating_ip/show/#{@record.id}?display=main\">Summary")
-        expect(response).to include("Show this Floating Ip&#39;s parent Network Provider\" href=\"/ems_network/#{@record.ext_management_system.id}\">")
+        expect(response).to include("Show this Floating IP&#39;s parent Network Provider\" href=\"/ems_network/#{@record.ext_management_system.id}\">")
       end
     end
   end


### PR DESCRIPTION
Instead of `record.class.name.demodulize.titleize` we need to use `ui_lookup()`, which would return proper model's display name (plus we get i18n with it).