### PR TITLE
Adding Physical Storages to Physical Chassis summary page

### DIFF
--- a/app/helpers/physical_chassis_helper/textual_summary.rb
+++ b/app/helpers/physical_chassis_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module PhysicalChassisHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ext_management_system physical_rack physical_servers)
+      %i(ext_management_system physical_rack physical_servers physical_storages)
     )
   end
 
@@ -79,6 +79,10 @@ module PhysicalChassisHelper::TextualSummary
 
   def textual_physical_servers
     textual_link(@record.physical_servers)
+  end
+
+  def textual_physical_storages
+    textual_link(@record.physical_storages)
   end
 
   #

--- a/app/views/physical_chassis/show.html.haml
+++ b/app/views/physical_chassis/show.html.haml
@@ -1,8 +1,12 @@
 #main_div
-  - if %w(physical_rack physical_servers).include?(@display)
+  - if %w(physical_rack physical_servers physical_storages).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
     - if %w(physical_servers).include?(@display)
       %physical-server-toolbar#ems_physical_infra_show_list_form
+      :javascript
+        miq_bootstrap('#ems_physical_infra_show_list_form')
+    - if %w(physical_storages).include?(@display)
+      %physical-storage-toolbar#ems_physical_infra_show_list_form
       :javascript
         miq_bootstrap('#ems_physical_infra_show_list_form')
   - else

--- a/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
@@ -48,6 +48,12 @@ describe PhysicalChassisHelper::TextualSummary do
     ]
   end
 
+  let(:physical_storages) do
+    [
+      FactoryGirl.create(:physical_storage, :name => 'Physical Storage A')
+    ]
+  end
+
   let(:physical_chassis) do
     FactoryGirl.create(:physical_chassis,
                        :ems_id                       => ems.id,
@@ -62,7 +68,8 @@ describe PhysicalChassisHelper::TextualSummary do
                        :blade_slot_count             => 16,
                        :powersupply_slot_count       => 1,
                        :physical_rack                => physical_rack,
-                       :physical_servers             => physical_servers)
+                       :physical_servers             => physical_servers,
+                       :physical_storages            => physical_storages)
   end
 
   before do
@@ -106,13 +113,13 @@ describe PhysicalChassisHelper::TextualSummary do
       expect(subject.title).to eq('Relationships')
     end
 
-    it 'shows 3 relationships' do
+    it 'shows 4 relationships' do
       expect(subject.items).to be_kind_of(Array)
-      expect(subject.items.size).to eq(3)
+      expect(subject.items.size).to eq(4)
     end
 
     it 'shows main relationships' do
-      expect(subject.items).to include(:ext_management_system, :physical_rack, :physical_servers)
+      expect(subject.items).to include(:ext_management_system, :physical_rack, :physical_servers, :physical_storages)
     end
   end
 
@@ -257,6 +264,19 @@ describe PhysicalChassisHelper::TextualSummary do
         :label => "Physical Servers",
         :value => "3",
         :icon  => "pficon pficon-server",
+        :image => nil
+      )
+    end
+  end
+
+  describe '.textual_physical_storages' do
+    subject { textual_physical_storages }
+
+    it 'show the chassis physical storages' do
+      expect(subject).to eq(
+        :label => "Physical Storages",
+        :value => "1",
+        :icon  => "pficon pficon-container-node",
         :image => nil
       )
     end


### PR DESCRIPTION
This PR is able to:
- Add Physical Storages reference to Physical Chassis summary page

![image](https://user-images.githubusercontent.com/7563089/43201831-fd26bea4-8fef-11e8-98b9-4cc68de453ef.png)