### PR TITLE
fix find_checked_items

### DIFF
--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -16,7 +16,7 @@ module Mixins
         prefix = "check" if prefix.nil?
         params.each_with_object([]) do |(var, val), items|
           vars = var.to_s.split("_")
-          if vars[0] == prefix && val == "1"
+          if vars[0] == prefix
             ids = vars[1..-1]
             items << ids.join("_")
           end


### PR DESCRIPTION
if ``:miq_grid_checks`` is not present in ``params``, this method only returns 1 or no ids.
this PR fixes it.