### PR TITLE
Adding connected physical servers to physical switches page

### DIFF
--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -31,13 +31,13 @@ class PhysicalSwitchController < ApplicationController
   def textual_group_list
     [
       %i(properties management_networks relationships),
-      %i(power_management firmware_details),
+      %i(power_management firmware_details connected_components),
     ]
   end
   helper_method(:textual_group_list)
 
   def self.display_methods
-    %w(physical_switches physical_network_ports)
+    %w(physical_switches physical_network_ports physical_servers)
   end
 
   def display_physical_network_ports

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -30,17 +30,33 @@ module PhysicalSwitchHelper::TextualSummary
     TextualTable.new(_("Firmwares"), firmware_details, [_("Name"), _("Version")])
   end
 
+  def textual_group_connected_components
+    TextualGroup.new(
+      _("Connected Components"),
+      %i(connected_physical_servers)
+    )
+  end
+
   def textual_ports
     ports_count = @record.physical_network_ports.count
-    ports = {:label => _("Ports"), :value => ports_count, :icon => "ff ff-network-port"}
+    ports = {:label => _("Ports"), :value => ports_count, :icon => PhysicalNetworkPortDecorator.fonticon}
     if ports_count.positive?
-      ports[:link] = "/physical_switch/show/#{@record.id}?display=physical_network_ports"
+      ports[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'physical_network_ports')
     end
     ports
   end
 
   def textual_ext_management_system
     textual_link(ExtManagementSystem.find(@record.ems_id))
+  end
+
+  def textual_connected_physical_servers
+    physical_servers_count = @record.physical_servers.count
+    physical_servers = {:label => _("Physical Servers"), :value => physical_servers_count, :icon => PhysicalServerDecorator.fonticon}
+    if physical_servers_count.positive?
+      physical_servers[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'physical_servers')
+    end
+    physical_servers
   end
 
   def textual_name

--- a/app/views/physical_switch/show.html.haml
+++ b/app/views/physical_switch/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(physical_switches physical_network_ports).include?(@display)
+  - if %w(physical_switches physical_network_ports physical_servers).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/spec/helpers/physical_switch_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_switch_helper/textual_summary_spec.rb
@@ -14,4 +14,6 @@ describe PhysicalSwitchHelper::TextualSummary do
   include_examples "textual_group", "Relationships", %i(ext_management_system)
 
   include_examples "textual_group", "Power Management", %i(power_state), "power_management"
+
+  include_examples "textual_group", "Connected Components", %i(connected_physical_servers), "connected_components"
 end


### PR DESCRIPTION
__This PR is able to__
- Add a new table to physical switch page to list the connected components;
- Add the list of connected physical servers (that are the unique component that we track the connections, for now);

![screenshot-localhost 3000-2018-07-25-15-42-56](https://user-images.githubusercontent.com/8550928/43221348-04d2fa0e-9023-11e8-99b3-e1c95c1b0dd5.png)

![screenshot-localhost 3000-2018-07-25-15-51-43](https://user-images.githubusercontent.com/8550928/43221367-0e73f59a-9023-11e8-8659-460473718973.png)

__Depends on__
~https://github.com/ManageIQ/manageiq/pull/17735~ - Merged