### PR TITLE
VM: associate only unused floating IPs

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/associate_floating_ip.rb
+++ b/app/controllers/mixins/actions/vm_actions/associate_floating_ip.rb
@@ -44,7 +44,7 @@ module Mixins
         def associate_floating_ip_form_fields
           assert_privileges("instance_associate_floating_ip")
           @record = find_record_with_rbac(VmCloud, params[:id])
-          floating_ips = @record.cloud_tenant.nil? ? [] : @record.cloud_tenant.floating_ips
+          floating_ips = @record.cloud_tenant.nil? ? [] : @record.cloud_tenant.floating_ips.find_by(:vm_id => nil)
 
           render :json => {
             :floating_ips => floating_ips


### PR DESCRIPTION
Offers only floating IPs which are not used by a VM 

https://bugzilla.redhat.com/show_bug.cgi?id=1595767