### PR TITLE
Use "true" instead of true in Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ build:
   tests:
     override:
       -
-        command: true
+        command: "true"
   nodes:
     analysis:
       tests:


### PR DESCRIPTION
Yaml uses `true` as a boolean not as a string

Go see results of Scrutinizer for node `tests`
<img width="1234" alt="screen shot 2018-07-26 at 11 39 58 am" src="https://user-images.githubusercontent.com/9210860/43254899-ac9ba0b0-90c8-11e8-814c-52338521dd63.png">
See that Scrutinizer runs command `1` and it fails
<img width="904" alt="screen shot 2018-07-26 at 11 39 48 am" src="https://user-images.githubusercontent.com/9210860/43254900-acb65b30-90c8-11e8-9d08-5f0a3aa3391f.png">

@miq-bot add_label gaprindashvili/no, developer

cc @martinpovolny @himdel 

