### PR TITLE
Added helper that clears all unused react components from virtual DOM.

### DIFF
--- a/app/javascript/miq-component/helpers.js
+++ b/app/javascript/miq-component/helpers.js
@@ -1,5 +1,5 @@
-import * as registry from '../miq-component/registry';
-import reactBlueprint from '../miq-component/react-blueprint';
+import * as registry from './registry.ts';
+import reactBlueprint from './react-blueprint.tsx';
 
 export function addReact(name, component) {
   return registry.define(name, reactBlueprint(component));
@@ -17,4 +17,18 @@ export function componentFactory(blueprintName, selector, props) {
 
 export function getReact(name) {
   return registry.getDefinition(name).blueprint.component;
+}
+
+/**
+ * @description Removes lingering React components in the virtual DOM
+ * if mounting element with generated ID is no longer in actual DOM,
+ * instance is destroyed and removed from virtual DOM
+ */
+export function cleanVirtualDom() {
+  registry.getComponentNames().forEach(name =>
+    registry.getComponentInstances(name).forEach((instance) => {
+      if (!document.getElementById(instance.elementId)) {
+        instance.destroy();
+      }
+    }));
 }

--- a/app/javascript/miq-component/helpers.spec.jsx
+++ b/app/javascript/miq-component/helpers.spec.jsx
@@ -1,0 +1,33 @@
+import { define } from './registry.ts';
+import { cleanVirtualDom } from './helpers';
+
+describe('Helpers', () => {
+  it('Should call instance destroy method if component mounting element is missing', () => {
+    const elemId = 'foo-component';
+
+    const expectedElemet = document.createElement('div');
+    expectedElemet.setAttribute('id', 'first');
+    document.getElementsByTagName('body')[0].appendChild(expectedElemet);
+
+    const destroy1 = jest.fn();
+    const destroy2 = jest.fn();
+    const testInstances = [
+      {
+        id: 'first',
+        destroy: destroy1,
+        elementId: 'first',
+
+      }, {
+        id: 'second',
+        elementId: elemId,
+        destroy: destroy2,
+      },
+    ];
+
+    define('FooComponent', {}, testInstances);
+
+    cleanVirtualDom();
+    expect(destroy1).not.toHaveBeenCalled();
+    expect(destroy2).toHaveBeenCalled();
+  });
+});

--- a/app/javascript/miq-component/react-blueprint.tsx
+++ b/app/javascript/miq-component/react-blueprint.tsx
@@ -29,7 +29,7 @@ export default (
   return {
     create(props, mountTo) {
       render(props, mountTo);
-      return { interact: mapPropsToInteract(props) };
+      return { interact: mapPropsToInteract(props), elementId: mountTo.id };
     },
 
     update(newProps, mountedTo) {


### PR DESCRIPTION
When page is reloaded using ajax, and part of the DOM, in which was some react component is changed, the component will remain in virtual DOM and can sometimes break the UI (if you are using some RxJS or Redux features).

I have added a simple function, that will clear all component instances, which don't have their mounting element in DOM.

- [x] clear function
- [x] tests

(I have also changed the import statements in helpers, because linter was driving me mad)