### PR TITLE
Display the correct quadicon for NTFS datastore entities

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -51,6 +51,8 @@ class StorageDecorator < MiqDecorator
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
     when 'iscsi'
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
+    when 'ntfs'
+      {:fileicon => 'svg/vendor-microsoft.svg'}
     when 'glusterfs'
       {:fileicon => 'svg/vendor-gluster.svg'}
     else


### PR DESCRIPTION
Location: `Compute` -> `Infrastructure` -> `Datastores`

**Before:**
![screenshot from 2018-07-26 14-12-30](https://user-images.githubusercontent.com/649130/43261716-03e502c0-90de-11e8-9999-72f4ab21a804.png)

**After:**
![screenshot from 2018-07-26 14-10-31](https://user-images.githubusercontent.com/649130/43261723-082b7cd8-90de-11e8-9c28-357c14c6cec2.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608461

@miq-bot add_label bug, gaprindashvili/no, graphics
@miq-bot add_reviewer @epwinchell 