### PR TITLE
Add a source definition when invoking CustomButton

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -287,9 +287,9 @@ module ApplicationController::Buttons
   def custom_buttons_invoke(button, objs)
     if objs.length > 1 &&
        (button.options && button.options.key?(:submit_how) && button.options[:submit_how].to_s == 'all')
-      button.invoke(objs)
+      button.invoke(objs, 'UI')
     else
-      objs.each { |obj| button.invoke(obj) }
+      objs.each { |obj| button.invoke(obj, 'UI') }
     end
   end
 
@@ -343,7 +343,7 @@ module ApplicationController::Buttons
 
     elsif button.options && button.options.key?(:open_url) && button.options[:open_url]
       # not supported for objs: cannot do wait for task for multiple tasks
-      task_id = button.invoke_async(obj)
+      task_id = button.invoke_async(obj, 'UI')
       initiate_wait_for_task(:task_id => task_id, :action => :custom_button_done)
 
     else

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -52,7 +52,7 @@ describe ApplicationController do
 
       it "Vm button" do
         controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
-        expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm)
+        expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm, 'UI')
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(vm.name)
@@ -68,7 +68,7 @@ describe ApplicationController do
 
       it "Vm button" do
         controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
-        expect_any_instance_of(CustomButton).to receive(:invoke).with(vm)
+        expect_any_instance_of(CustomButton).to receive(:invoke).with(vm, 'UI')
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(vm.name)
@@ -79,7 +79,7 @@ describe ApplicationController do
         button.applies_to = host
         button.save
         controller.instance_variable_set(:@_params, :id => host.id, :button_id => button.id)
-        expect_any_instance_of(CustomButton).to receive(:invoke).with(host)
+        expect_any_instance_of(CustomButton).to receive(:invoke).with(host, 'UI')
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(host.name)
@@ -90,7 +90,7 @@ describe ApplicationController do
         button.applies_to = ServiceTemplate
         button.save
         controller.instance_variable_set(:@_params, :id => service.id, :button_id => button.id)
-        expect_any_instance_of(CustomButton).to receive(:invoke).with(service)
+        expect_any_instance_of(CustomButton).to receive(:invoke).with(service, 'UI')
 
         controller.send(:custom_buttons)
         expect(assigns(:right_cell_text)).to include(service.name)


### PR DESCRIPTION
When `CustomButton` is invoked - and corresponding `CustomEvent` is being emited, let's propagate the source.

Design: [GDoc](https://docs.google.com/document/d/1wtgC3fQLLoR-g2jVMzINgYAeoojB0FkzQQR3pyv5Cns/edit)
RFE: [BUGZILLA 1511126](https://bugzilla.redhat.com/show_bug.cgi?id=1511126)
Depends on: https://github.com/ManageIQ/manageiq/pull/17764