### PR TITLE
Fix visibility of toolbar buttons

### DIFF
--- a/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
+++ b/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
@@ -10,4 +10,8 @@ class ApplicationHelper::Button::GenericFeatureButtonWithDisable < ApplicationHe
                     end
     @error_message.present?
   end
+
+  def visible?
+    true
+  end
 end

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -5,5 +5,16 @@ describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 
-  it_behaves_like 'a generic feature button with disabled'
+  context 'the feature is unavailable' do
+    let(:supports_feature) { false }
+
+    it 'the button is visible' do
+      expect(button.visible?).to be_truthy
+    end
+
+    it 'the button has error message in the title' do
+      button.calculate_properties
+      expect(button[:title]).not_to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
**Make some disabled toolbar buttons visible** which weren't visible but
they should be. The core of the problem was class inheritance.

For many toolbar buttons found under _app/helpers/application_helper/toolbar_, there is
`:klass   => ApplicationHelper::Button::GenericFeatureButtonWithDisable,`.
We would expect that if a feature was not supported, the button would be just disabled - but this is not true. The button was not visible at all. This PR fixes this problem the simle way.

**Before:**
![invisible](https://user-images.githubusercontent.com/13417815/43268792-cae1fee2-90f1-11e8-817e-103e72acfa9f.png)

**After:**
![visible](https://user-images.githubusercontent.com/13417815/43269057-5c40d9da-90f2-11e8-86a8-39cfbde20318.png)
![power](https://user-images.githubusercontent.com/13417815/43269603-7b26c1c4-90f3-11e8-9ab3-4d4bac85ffc7.png)
