### PR TITLE
Jest - fix "SecurityError: localStorage is not available for opaque origins"

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   roots: ['app/javascript'],
   setupFiles: ['./config/jest.setup.js'],
   testRegex: '(/__tests__/.*|(\\.|_|/)(test|spec))\\.(jsx?|tsx?)$',
+  testURL: 'http://localhost',
   transform: {
     '^.+\\.jsx?$': 'babel-jest',
     '.(ts|tsx)': 'ts-jest'


### PR DESCRIPTION
with jsDom 11.12, jest starts failing with

    Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Looks like jsdom is just trying to follow the browser behaviour more closely, and without `testURL` jest defaults to assuming "about:blank".

Providing a sane url fixes it.

https://github.com/facebook/jest/issues/6766
https://github.com/jsdom/jsdom/issues/2304#issuecomment-408320484
