### PR TITLE
Ensure Look up groups checkbox is not shown when OIDC is enabled.

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -2,9 +2,10 @@
   - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
   - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
 - mode = ::Settings.authentication.mode
+- oidc_enabled = ::Settings.authentication.oidc_enabled
 - saml_enabled = ::Settings.authentication.saml_enabled
 - can_lookup_groups = mode.downcase.start_with?('ldap')
-- can_lookup_groups = mode.downcase == "httpd" && ! saml_enabled unless can_lookup_groups
+- can_lookup_groups = mode.downcase == "httpd" && ! (saml_enabled || oidc_enabled) unless can_lookup_groups
 = render :partial => "layouts/flash_msg"
 #group_info
   %h3

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -65,14 +65,21 @@ describe 'ops/_rbac_group_details.html.haml' do
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode httpd' do
-      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => false}, :server => {})
+      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => false, :oidc_enabled => false}, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up External Authentication Groups')
     end
 
     it 'should not show "Look up groups" checkbox and label for auth mode httpd with SAML enabled' do
-      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => true}, :server => {})
+      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => true, :oidc_enabled => false}, :server => {})
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).not_to have_selector('input#lookup')
+      expect(rendered).not_to include('Look up External Authentication Groups')
+    end
+
+    it 'should not show "Look up groups" checkbox and label for auth mode httpd with OIDC enabled' do
+      stub_settings(:authentication => { :mode => 'httpd', :saml_enabled => false, :oidc_enabled => true}, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).not_to have_selector('input#lookup')
       expect(rendered).not_to include('Look up External Authentication Groups')


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609321

This PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/2855 added support
for OpenID-Connect to the manageiq-ui-classic.

The "Lookup Groups" is not supported with OIDC. This PR ensures the Lookup
Groups checkbox is not displayed when OIDC is enabled.




Links [Optional]
----------------

* This PR is similar to this one: https://github.com/ManageIQ/manageiq-ui-classic/pull/3881 and is needed now that OIDC support has been added to the UI 

Steps for Testing/QA [Optional]
-------------------------------
Configuration -> Settings -> select Current Server -> Authentication -> Mode -> set to Amazon/Database/External with OIDC enabled

Navigate to
Configuration -> Access Control -> Create a new Group

Ensure the "(Look up External Authentication Groups)" checkbox is not displayed
