### PR TITLE
Allow registering events to timelines using regexes

### DIFF
--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -68,15 +68,15 @@ module ApplicationController::Timelines
       @events = @event_groups = @lvl_text_value = nil
     end
 
-    def event_groups
-      @event_groups ||= EmsEvent.event_groups
-    end
-
     def levels_text_and_value
       @lvl_text_value ||= group_levels.map { |level| [level.to_s.titleize, level] }
     end
 
     private
+
+    def event_groups
+      @event_groups ||= EmsEvent.event_groups
+    end
 
     def group_levels
       EmsEvent::GROUP_LEVELS
@@ -141,6 +141,10 @@ module ApplicationController::Timelines
 
     def event_set
       (policy_events? ? policy : management).event_set
+    end
+
+    def categories
+      (policy_events? ? policy : management).categories
     end
 
     def drop_cache

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -47,8 +47,8 @@ describe ApplicationController, "#Timelines" do
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
-        expect(options.management[:categories][:power][:event_groups]).to include('AUTO_FAILED_SUSPEND_VM')
-        expect(options.management[:categories][:power][:event_groups]).to_not include('PowerOffVM_Task')
+        expect(options.management[:categories][:power][:include_set]).to include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:include_set]).to_not include('PowerOffVM_Task')
       end
 
       it "selecting details option of the selectpicker in the timeline should append them to events filter list" do
@@ -60,8 +60,8 @@ describe ApplicationController, "#Timelines" do
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
-        expect(options.management[:categories][:power][:event_groups]).to include('PowerOffVM_Task')
-        expect(options.management[:categories][:power][:event_groups]).to_not include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:include_set]).to_not include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:include_set]).to include('PowerOffVM_Task')
       end
 
       it "selecting two options of the selectpicker in the timeline should append both to events filter list" do
@@ -73,8 +73,8 @@ describe ApplicationController, "#Timelines" do
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
-        expect(options.management[:categories][:power][:event_groups]).to include('AUTO_FAILED_SUSPEND_VM')
-        expect(options.management[:categories][:power][:event_groups]).to include('PowerOffVM_Task')
+        expect(options.management[:categories][:power][:include_set]).to include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:include_set]).to include('PowerOffVM_Task')
       end
     end
   end


### PR DESCRIPTION
Up until now, in order to register event type to the timeline, we needed to list all of the event types in settings yaml.

This commit adds another option: specify event type to group/level mapping using regular expressions, which should make mapping definitions much shorter for providers with many different event types
that follow a certain pattern.

Changes were made in two areas: in database querying and in event to category assignment.

When creating database condition for events, we now use three sources:

 1. a set of event types that should be included in result,
 2. a set of event types that should not be present in result and
 3. a set of regular expressions that event types can match.

An event is part of the result if its type is in include set or matches any of the regular expressions and is not part of the exclude set. For example, take this fragment of settings file:

    :ems:
      :ems_dummy:
        :event_handling:
          :event_groups:
            :addition:
              :critical:
              - !ruby/regexp /^dummy_add_.+$/
            :update:
              :critical:
              - dummy_123_update
              - !ruby/regexp /^dummy_.+_update$/
              :detail:
              - dummy_abc_update
              - dummy_def_update
              - !ruby/regexp /^dummy_detail_.+_update$/

This translates into following three sources for `:update` category, assuming user does not want to display details:

  * include_set: `dummy_123_update`
  * exclude_set: `dummy_abc_update`, `dummy_def_update`
  * regexes: `^dummy_.+_updates$`

In this case, events of type `dummy_abc_update` will not be displayed, since they match details and are thus put in exclude set. On the other hand, if user does want to see the details, things are a bit
different:

  * include_set: `dummy_123_update`, `dummy_abc_update`, `dummy_def_update`
  * exclude_set:
  * regexes: `^dummy_.+_updates$`, `^dummy_detail_.+_update$`

All this is done in order to preserve the existing behavior.

Category assignment is done in two phases. First, we try to assign category only looking at the full name of event. If this yields no category, we try to assign one by matching against regular expressions. If we continue with categories from example above, we would get those mappings:

  * `dummy_123_update` is mapped to `:update`. It also matches `:addition` category, but since explicit names have higher priority, that regular expression is not checked at all.
  * `dummy_nil_update` is mapped to `:update` because it matches one of the `:critical` expressions.
  * `dummy_add_event` is mapped to `:addition`.


This pull depends on https://github.com/ManageIQ/manageiq/pull/17772.

@miq-bot add_label wip

/cc @miha-plesko @gberginc 