### PR TITLE
[RFE] Allow to upload and display a custom brand image on login/header

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -6,6 +6,7 @@ module OpsController::Settings::Common
   Dir.mkdir logo_dir unless File.exist?(logo_dir)
   @@logo_file = File.join(logo_dir, "custom_logo.png")
   @@login_logo_file = File.join(logo_dir, "custom_login_logo.png")
+  @@login_brand_file = File.join(logo_dir, "custom_brand.png")
 
   # AJAX driven routine to check for changes in ANY field on the form
   def settings_form_field_changed
@@ -877,6 +878,7 @@ module OpsController::Settings::Common
     when "settings_custom_logos"                                            # Custom Logo tab
       new[:server][:custom_logo] = (params[:server_uselogo] == "true") if params[:server_uselogo]
       new[:server][:custom_login_logo] = (params[:server_useloginlogo] == "true") if params[:server_useloginlogo]
+      new[:server][:custom_brand] = (params[:server_usebrand] == "true") if params[:server_usebrand]
       new[:server][:use_custom_login_text] = (params[:server_uselogintext] == "true") if params[:server_uselogintext]
       if params[:login_text]
         new[:server][:custom_login_text] = params[:login_text]
@@ -1105,11 +1107,16 @@ module OpsController::Settings::Common
     if @edit[:current].config[:server][:custom_login_logo].nil?
       @edit[:current].config[:server][:custom_login_logo] = false # Set default custom_logo flag
     end
+    if @edit[:current].config[:server][:custom_brand].nil?
+      @edit[:current].config[:server][:custom_brand] = false # Set default custom_brand flag
+    end
+
     if @edit[:current].config[:server][:use_custom_login_text].nil?
-      @edit[:current].config[:server][:use_custom_login_text] = false # Set default custom_logo flag
+      @edit[:current].config[:server][:use_custom_login_text] = false # Set default custom_login_text flag
     end
     @logo_file = @@logo_file
     @login_logo_file = @@login_logo_file
+    @login_brand_file = @@login_brand_file
     @in_a_form = true
   end
 

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -11,6 +11,11 @@ module OpsController::Settings::Upload
     upload_logos(login_logo_file, params[:login], _('Custom login image'))
   end
 
+  def upload_login_brand
+    login_logo_file = File.join(logo_dir, "custom_brand.png")
+    upload_logos(login_logo_file, params[:brand], _('Custom brand'))
+  end
+
   def upload_logos(file, field, text)
     if field && field[:logo] && field[:logo].respond_to?(:read)
       if field[:logo].original_filename.split(".").last.downcase != "png"
@@ -87,8 +92,8 @@ module OpsController::Settings::Upload
   private
 
   def logo_dir
-    dir = File.expand_path(Rails.root.join('public', 'upload'))
-    Dir.mkdir(dir) unless File.exist?(dir)
-    dir
+    dir = Rails.root.join('public', 'upload').expand_path
+    Dir.mkdir(dir) unless dir.exist?
+    dir.to_s
   end
 end

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -7,7 +7,7 @@
   .row
     .col-md-12
       #brand
-        %img{:src => image_path("layout/brand.svg"), :alt => "ManageIQ"}
+        %img{:src => ::Settings.server.custom_brand ? '/upload/custom_brand.png' : image_path("layout/brand.svg"), :alt => "ManageIQ"}
 
     .col-md-6.col-lg-5.login
       .form-horizontal#login_div

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,7 +8,7 @@
       %span.icon-bar
       %span.icon-bar
     %a.navbar-brand{:href => '/dashboard/start_url', :title => _("Go to my start page")}
-      %img.navbar-brand-name{:src => image_path("layout/brand.svg"), :alt => "ManageIQ"}
+      %img.navbar-brand-name{:src => ::Settings.server.custom_brand ? '/upload/custom_brand.png' : image_path("layout/brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
       %li{:class => "dropdown brand-white-label #{::Settings.server.custom_logo ? "whitelabeled" : ""}"}

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -24,7 +24,7 @@
         %label.col-md-2.control-label
           = _("Use Custom Logo Image")
         .col-md-8
-          = check_box_tag("server_uselogo", true, @edit[:new][:server][:custom_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
+          = check_box_tag("server_uselogo", true, @edit[:new][:server][:custom_logo], :data => {:on_text => _('Yes'), :off_text => _('No')})
   %hr
   %h3= _("Custom Login & 'About' Screen Background Image")
   - if File.exist?(@login_logo_file)
@@ -58,7 +58,37 @@
         %label.col-md-2.control-label
           = _("Use Custom Login & 'About' Screen Background Image")
         .col-md-8
-          = check_box_tag("server_useloginlogo", true, @edit[:new][:server][:custom_login_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
+          = check_box_tag("server_useloginlogo", true, @edit[:new][:server][:custom_login_logo], :data => {:on_text => _('Yes'), :off_text => _('No')})
+  %hr
+  %h3=_("Custom Brand Image (Shown on top right of all screens and above login panel)")
+  - if File.exist?(@login_brand_file)
+    = image_tag("/upload/custom_brand.png?#{rand(99_999_999)}")
+    %br/
+    %br/
+  - else
+    = render :partial => 'layouts/info_msg', :locals => {:message => _("No custom login brand image has been uploaded yet.")}
+  = form_tag({:action    => "upload_login_brand"},
+             :class     => "form-horizontal",
+             :multipart => true,
+             :method    => :post) do
+    .form-group
+      .col-md-4
+        = render :partial => "shared/file_chooser", :locals => {:object_name => "brand", :method => "logo"}
+      .col-md-6
+        = submit_tag(_("Upload"), :class => "btn btn-default")
+        = _("* Requirements: File-type - PNG;")
+      .col-md-8
+        .spacer
+        = _("(Note: Login brand can be resized using /public/custom.css)")
+
+  - if File.exist?(@login_brand_file)
+    %br/
+    %form.form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _("Use Custom Brand Image")
+        .col-md-8
+          = check_box_tag("server_usebrand", true, @edit[:new][:server][:custom_brand], :data => {:on_text => _('Yes'), :off_text => _('No')})
   %hr
   %h3
     = _("Custom Login Panel Text (")
@@ -83,3 +113,4 @@
         miqInitBootstrapSwitch('server_uselogintext', "#{url}");
         miqInitBootstrapSwitch('server_uselogo', "#{url}");
         miqInitBootstrapSwitch('server_useloginlogo', "#{url}");
+        miqInitBootstrapSwitch('server_usebrand', "#{url}");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2597,6 +2597,7 @@ Rails.application.routes.draw do
         update
         upload_csv
         upload_form_field_changed
+        upload_login_brand
         upload_login_logo
         upload_logo
         validate_replcation_worker


### PR DESCRIPTION
This PR creates a brand image upload feature under the custom logo tab, eliminating the need to manually change the html, css, and drop images into the public folder. The image appears on the login screen and the main header. The code in the area was awful, so I also did a little refactoring. 

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label pending core

![screenshot from 2018-08-01 17-34-10](https://user-images.githubusercontent.com/649130/43531955-3fe10abc-95b1-11e8-8266-311b12228033.png)
![screenshot from 2018-08-01 17-34-16](https://user-images.githubusercontent.com/649130/43531956-40005458-95b1-11e8-8f05-f63b54970c19.png)
![screenshot from 2018-08-01 17-34-36](https://user-images.githubusercontent.com/649130/43531957-401b38e0-95b1-11e8-811c-49f5903c4efd.png)


Depends on: https://github.com/ManageIQ/manageiq/pull/17773
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1471301