### PR TITLE
Towards provider plugins: dialog definition action

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -19,6 +19,26 @@ class DashboardController < ApplicationController
     redirect_to :action => 'show'
   end
 
+  def dialog_definition
+    name = params[:name].gsub(/[^a-z_]/, '')
+    definition = load_dialog_definition(name, params[:class])
+    if definition.present?
+      render :json => { :dialog => definition }
+    else
+      head :not_found
+    end
+  end
+
+  def load_dialog_definition(name, klass)
+    plugin = Vmdb::Plugins.find { |plug| plug.name.chomp('::Engine') == klass }
+    if plugin.present?
+      name = plugin.root.join('dialogs', "#{name}.json")
+      return File.read(name) if File.exist?(name)
+    end
+    nil
+  end
+  private :load_dialog_definition
+
   def current_hostname
     return URI.parse(request.env['HTTP_X_FORWARDED_FOR']).hostname if request.env['HTTP_X_FORWARDED_FOR']
     URI.parse(request.original_url).hostname

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1109,6 +1109,7 @@ Rails.application.routes.draw do
         widget_rss_data
       ),
       :post => %w(
+        dialog_definition
         external_authenticate
         kerberos_authenticate
         initiate_saml_login

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@manageiq/react-ui-components": "~0.9.3",
+    "@manageiq/react-ui-components": "~0.10.7",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -421,6 +421,77 @@ describe DashboardController do
     end
   end
 
+  describe '#dialog_definition' do
+    before do
+      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
+      allow(controller).to receive(:check_privileges).and_return(true)
+    end
+
+    let(:klass) { 'someboringclass' }
+    let(:name) { 'a_random_name' }
+
+    context 'existing dialog' do
+      it 'returns json with data' do
+        data = 'bububububuraky'
+        expect(controller).to receive(:load_dialog_definition).and_return(data)
+        post :dialog_definition, :params => {:name => name, :class => klass}
+        expect(response.status).to eq(200)
+        expect(response.body).to include(data)
+      end
+    end
+
+    context 'not existing dialog' do
+      it 'does not find' do
+        expect(controller).to receive(:load_dialog_definition).and_return(nil)
+        post :dialog_definition, :params => {:name => name, :class => klass}
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'directory traversal' do
+      it 'ignores anything but [a-z_]' do
+        expect(controller).to receive(:load_dialog_definition).with('abc_de', klass).and_return('data')
+        post :dialog_definition, :params => {:name => '../../abc-!_de', :class => klass}
+      end
+    end
+  end
+
+  describe 'private #load_dialog_definition' do
+    let (:klass) { 'Foobar' }
+    let (:name) { 'existing_dialog' }
+    let (:dialog_path) { Pathname.new("/dialogs/#{name}.json") }
+
+    before do
+      plug = double('Plugin')
+      allow(plug).to receive(:name).and_return("#{klass}::Engine")
+      allow(plug).to receive(:root).and_return(Pathname.new('/'))
+
+      allow(Vmdb::Plugins).to receive(:find).and_return(plug)
+    end
+
+    context 'existing dialog' do
+      it 'returns data read from the filesystem' do
+        data = 'some data'
+        expect(File).to receive(:'exist?').with(dialog_path).and_return(true)
+        expect(File).to receive(:read).with(dialog_path).and_return(data)
+        expect(controller.send(:load_dialog_definition, name, klass)).to eq(data)
+      end
+    end
+
+    context 'not existing dialog' do
+      it 'returns nil' do
+        expect(File).to receive(:'exist?').with(dialog_path).and_return(false)
+        expect(controller.send(:load_dialog_definition, name, klass)).to be_nil
+      end
+    end
+
+    context 'unknown class' do
+      it 'returns nil' do
+        expect(controller.send(:load_dialog_definition, name, klass)).to be_nil
+      end
+    end
+  end
+
   def skip_data_checks(url = '/')
     allow_any_instance_of(UserValidationService).to receive(:server_ready?).and_return(true)
     allow(controller).to receive(:start_url_for_user).and_return(url)


### PR DESCRIPTION
Increase version of react-ui-components (needed for demo).

Implement `/dashboars/dialog_definition` with tests.

Extracted from https://github.com/ManageIQ/manageiq-ui-classic/pull/4315 with added specs. 