### PR TITLE
Use a single method for tree node key generation across the codebase

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -969,7 +969,7 @@ class ApplicationController < ActionController::Base
         new_row[:parent_id] = "xx-#{row.data['miq_report_id']}" if row.data['miq_report_id']
       end
       new_row[:parent_id] = "xx-#{CONTENT_TYPE_ID[target[:content_type]]}" if target && target[:content_type]
-      new_row[:tree_id] = TreeNode.new(target).key if target
+      new_row[:tree_id] = TreeNode.new(target).key if target && TreeNode.exists?(target)
       if row.data["job.target_class"] && row.data["job.target_id"]
         controller = view_to_hash_controller_from_job_target_class(row.data["job.target_class"])
         new_row[:parent_path] = (url_for_only_path(:controller => controller, :action => "show") rescue nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -969,7 +969,7 @@ class ApplicationController < ActionController::Base
         new_row[:parent_id] = "xx-#{row.data['miq_report_id']}" if row.data['miq_report_id']
       end
       new_row[:parent_id] = "xx-#{CONTENT_TYPE_ID[target[:content_type]]}" if target && target[:content_type]
-      new_row[:tree_id] = TreeBuilder.build_node_cid(target) if target
+      new_row[:tree_id] = TreeNode.new(target).key if target
       if row.data["job.target_class"] && row.data["job.target_id"]
         controller = view_to_hash_controller_from_job_target_class(row.data["job.target_class"])
         new_row[:parent_path] = (url_for_only_path(:controller => controller, :action => "show") rescue nil)

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -214,7 +214,7 @@ module ApplicationController::Explorer
         tree_select
       end
       format.html do # HTML, redirect to explorer
-        tree_node_id = TreeBuilder.build_node_id(@record)
+        tree_node_id = TreeNode.new(@record).key
         session[:exp_parms] = {:id => tree_node_id}
         redirect_to :action => "explorer"
       end

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -504,8 +504,7 @@ module ApplicationController::Performance
     session[:sandboxes][cont][:perf_options][:hourly_date] = [ts.month, ts.day, ts.year].join("/") if chart_click_data.type == "Hourly"
 
     if data_row["resource_type"] == "VmOrTemplate"
-      prefix = TreeBuilder.get_prefix_for_model(@record.class.base_model)
-      tree_node_id = "#{prefix}-#{@record.id}" # Build the tree node id
+      tree_node_id = TreeNode.new(@record).key
       session[:exp_parms] = {:display => "performance", :refresh => "n", :id => tree_node_id}
       javascript_redirect :controller => data_row["resource_type"].underscore.downcase.singularize,
                           :action     => "explorer"

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -396,7 +396,7 @@ module ApplicationController::Performance
         @_params[:refresh] = "n"
         show_timeline
       elsif data_row["resource_type"] == "VmOrTemplate"
-        tree_node_id = TreeBuilder.build_node_id(@record.class.base_model, @record.id)
+        tree_node_id = TreeNode.new(@record).key
         session[:exp_parms] = {:display => "timeline", :refresh => "n", :id => tree_node_id}
         javascript_redirect(:controller => data_row["resource_type"].underscore.downcase.singularize,
                             :action     => "explorer")

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -190,7 +190,7 @@ class CatalogController < ApplicationController
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     record = ServiceTemplate.find_by_id(params[:id])
     if !@explorer
-      tree_node_id = TreeBuilder.build_node_id(record)
+      tree_node_id = TreeNode.new(record).key
       redirect_to :controller => "catalog",
                   :action     => "explorer",
                   :id         => tree_node_id

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1852,7 +1852,7 @@ class MiqAeClassController < ApplicationController
     model = @edit[:selected_items].count > 1 ? :models : :model
     add_flash(_("Copy selected %{record} was saved") % {:record => ui_lookup(model => @edit[:typ].to_s)})
     @record = res.kind_of?(Array) ? @edit[:typ].find(res.first) : res
-    self.x_node = "#{TreeBuilder.get_prefix_for_model(@edit[:typ])}-#{@record.id}"
+    self.x_node = TreeNode.new(@record).key
     @in_a_form = @changed = session[:changed] = false
     @sb[:action] = @edit = session[:edit] = nil
     replace_right_cell

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -163,7 +163,7 @@ class MiqAeCustomizationController < ApplicationController
     record = Dialog.find_by(:id =>nodes.last)
     self.x_active_accord = "dialogs"
     self.x_active_tree   = "#{x_active_accord}_tree"
-    self.x_node = TreeBuilder.build_node_cid(record)
+    self.x_node = TreeNode.new(record).key
     get_node_info
     redirect_to :controller => "miq_ae_customization",
                 :action     => "explorer",

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -57,7 +57,7 @@ class ServiceController < ApplicationController
     end
 
     unless @explorer
-      tree_node_id = TreeBuilder.build_node_id(@record)
+      tree_node_id = TreeNode.new(@record).key
       redirect_to :controller => "service",
                   :action     => "explorer",
                   :id         => tree_node_id

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -40,7 +40,7 @@ class StorageController < ApplicationController
   def init_show
     return unless super
     if !@explorer && @display == "main"
-      tree_node_id = TreeBuilder.build_node_id(@record)
+      tree_node_id = TreeNode.new(@record).key
       session[:exp_parms] = {:display => @display, :refresh => params[:refresh], :id => tree_node_id}
 
       # redirect user back to where they came from if they dont have access to any of vm explorers

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -875,18 +875,18 @@ module VmCommon
     elsif vm.archived
       "xx-arch"
     elsif vm.cloud && vm.template
-      TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      TreeNode.new(vm.ext_management_system).key
     elsif vm.cloud && vm.availability_zone_id.nil?
-      TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      TreeNode.new(vm.ext_management_system).key
     elsif vm.cloud
-      TreeBuilder.build_node_cid(vm.availability_zone_id, 'AvailabilityZone')
+      TreeNode.new(vm.availability_zone).key
     elsif (blue_folder = vm.parent_blue_folder) && !blue_folder.hidden
-      TreeBuilder.build_node_cid(blue_folder.id, 'EmsFolder')
+      TreeNode.new(blue_folder).key
     elsif vm.ems_id # has no folder parent but is in the tree
       if vm.parent_datacenter
-        TreeBuilder.build_node_cid(vm.parent_datacenter.id, 'Datacenter')
+        TreeNode.new(vm.parent_datacenter).key
       else
-        TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+        TreeNode.new(vm.ext_management_system).key
       end
 
     else
@@ -1154,7 +1154,7 @@ module VmCommon
     end
 
     if !@in_a_form && !@sb[:action]
-      id = @record.present? && hide_vms ? TreeBuilder.build_node_cid(@record) : x_node
+      id = @record.present? && hide_vms ? TreeNode.new(@record).key : x_node
       id = @sb[@sb[:active_accord]] if @sb[@sb[:active_accord]].present? && params[:action] != 'tree_select'
       get_node_info(id)
       type, _id = parse_nodetype_and_id(id)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -150,7 +150,7 @@ module VmCommon
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     unless @explorer
-      tree_node_id = TreeBuilder.build_node_id(@record)
+      tree_node_id = TreeNode.new(@record).key
       session[:exp_parms] = {:display => @display, :refresh => params[:refresh], :id => tree_node_id}
       controller_name = controller_for_vm(model_for_vm(@record))
       # redirect user back to where they came from if they dont have access to any of vm explorers
@@ -205,7 +205,7 @@ module VmCommon
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
       session[:snap_selected] = nil if Snapshot.find_by(:id => session[:snap_selected]).nil?
-      @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
+      @sb[@sb[:active_accord]] = TreeNode.new(@record).key
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @active = if @snapshot_tree.selected_node
                   snap_selected = Snapshot.find(@snapshot_tree.selected_node.split('-').last)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -360,7 +360,7 @@ module ApplicationHelper
                  IsoDatastore
                  CustomizationTemplate).include?(view.db) &&
               %w(miq_policy ops pxe report).include?(params[:controller])
-          return "/#{params[:controller]}/tree_select/?id=#{TreeBuilder.get_prefix_for_model(view.db)}"
+          return "/#{params[:controller]}/tree_select/?id=#{TreeNode.new(view.db).key}"
         elsif %w(MiqPolicy).include?(view.db) && %w(miq_policy).include?(params[:controller])
           return "/#{params[:controller]}/tree_select/?id=#{x_node}"
         else

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -69,22 +69,6 @@ class TreeBuilder
     X_TREE_NODE_PREFIXES_INVERTED[model]
   end
 
-  def self.build_node_id(record)
-    prefix = get_prefix_for_model(record.class.base_model)
-    "#{prefix}-#{record.id}"
-  end
-
-  def self.build_node_cid(record_or_id, type = nil)
-    if record_or_id.kind_of?(Integer)
-      prefix = get_prefix_for_model(type)
-      id = record_or_id
-    else
-      prefix = get_prefix_for_model(record_or_id.class.base_model)
-      id = record_or_id.id
-    end
-    "#{prefix}-#{id}"
-  end
-
   def self.hide_vms
     !User.current_user.settings.fetch_path(:display, :display_vms) # default value is false
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -65,8 +65,7 @@ class TreeBuilder
   end
 
   def self.get_prefix_for_model(model)
-    model = model.to_s unless model.kind_of?(String)
-    X_TREE_NODE_PREFIXES_INVERTED[model]
+    X_TREE_NODE_PREFIXES_INVERTED[model.to_s] || X_TREE_NODE_PREFIXES_INVERTED[model.base_model.name]
   end
 
   def self.hide_vms

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -7,7 +7,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
   end
 
   def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:ch_root] = TreeBuilder.build_node_id(root) if root
+    sandbox[:ch_root] = TreeNode.new(root).key if root
     @root = root
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:ch_root])

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -23,7 +23,7 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:datacenter_root] = TreeBuilder.build_node_id(root) if root
+    sandbox[:datacenter_root] = TreeNode.new(root).key if root
     @root = root
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:datacenter_root])

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -7,7 +7,7 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:network_root] = TreeBuilder.build_node_id(root) if root
+    sandbox[:network_root] = TreeNode.new(root).key if root
     @root = root
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:network_root])

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -56,11 +56,7 @@ module TreeNode
         # to handle "Unassigned groups" node in automate buttons tree
         "-#{@object.name.split('|').last}"
       else
-        base_class = @object.class.base_model.name # i.e. Vm or MiqTemplate
-        base_class = "Datacenter" if base_class == "EmsFolder" && @object.kind_of?(Datacenter)
-        base_class = "ManageIQ::Providers::Foreman::ConfigurationManager" if @object.kind_of?(ManageIQ::Providers::Foreman::ConfigurationManager)
-        base_class = "ManageIQ::Providers::AnsibleTower::AutomationManager" if @object.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager)
-        prefix = TreeBuilder.get_prefix_for_model(base_class)
+        prefix = TreeBuilder.get_prefix_for_model(@object.class)
         cid = @object.id
         "#{@options[:full_ids] && @parent_id.present? ? "#{@parent_id}_" : ''}#{prefix}-#{cid}"
       end

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -214,7 +214,7 @@
       - if tree_node == "root"
         = miq_tab_header("db_summary", @sb[:active_tab]) do
           = _("Summary")
-      - if tree_node == "root" || tree_node.split("-").first == TreeBuilder.get_prefix_for_model("VmdbTable")
+      - if tree_node == "root" || TreeBuilder.get_model_for_prefix(tree_node.split("-").first) == "VmdbTable"
         = miq_tab_header("db_details", @sb[:active_tab]) do
           = @tab_text
       - if tree_node == "root"
@@ -224,7 +224,7 @@
           = _("Settings")
         = miq_tab_header("db_connections", @sb[:active_tab]) do
           = _("Client Connections")
-      - if tree_node == "root" || tree_node.split("-").first == TreeBuilder.get_prefix_for_model("VmdbTable")
+      - if tree_node == "root" || TreeBuilder.get_model_for_prefix(tree_node.split("-").first) == "VmdbTable"
         = miq_tab_header("db_utilization", @sb[:active_tab]) do
           = _("Utilization")
     .tab-content
@@ -245,7 +245,7 @@
         = miq_tab_content("db_connections", @sb[:active_tab]) do
           - if @sb[:active_tab] == "db_connections"
             = render :partial => "db_details_tab"
-      - if tree_node == "root" || tree_node.split("-").first == TreeBuilder.get_prefix_for_model("VmdbTable")
+      - if tree_node == "root" || TreeBuilder.get_model_for_prefix(tree_node.split("-").first) == "VmdbTable"
         = miq_tab_content("db_utilization", @sb[:active_tab]) do
           - if @sb[:active_tab] == "db_utilization" && @record
             = render(:partial => "layouts/performance")

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -551,7 +551,7 @@ describe ProviderForemanController do
     # then get to explorer renders the data for the active node
     # we test the textual_summary for a configured system
 
-    seed_session_trees('provider_foreman', 'cs_tree', "cs-#{tree_node_id}")
+    seed_session_trees('provider_foreman', 'cs_tree', "csf-#{tree_node_id}")
     get :explorer
 
     expect(response.status).to eq(200)

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -230,7 +230,7 @@ describe StorageController do
       end
 
       it 'can render datastore details' do
-        tree_node_id = TreeBuilder.build_node_id(storage)
+        tree_node_id = TreeNode.new(storage).key
         session[:sandboxes] = {} # no prior data in @sb
         session[:exp_parms] = {:controller => 'storage',
                                :action     => 'show',

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -231,7 +231,7 @@ describe VmOrTemplateController do
                                             :ext_management_system => FactoryGirl.create(:ems_google),
                                             :storage               => FactoryGirl.create(:storage),
                                             :availability_zone     => FactoryGirl.create(:availability_zone_google))
-      expect(controller.parent_folder_id(vm_cloud_with_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_with_az.availability_zone))
+      expect(controller.parent_folder_id(vm_cloud_with_az)).to eq(TreeNode.new(vm_cloud_with_az.availability_zone).key)
     end
 
     it 'returns id of Provider folder for Cloud VM without Availability Zone' do
@@ -239,21 +239,21 @@ describe VmOrTemplateController do
                                                :ext_management_system => FactoryGirl.create(:ems_google),
                                                :storage               => FactoryGirl.create(:storage),
                                                :availability_zone     => nil)
-      expect(controller.parent_folder_id(vm_cloud_without_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_without_az.ext_management_system))
+      expect(controller.parent_folder_id(vm_cloud_without_az)).to eq(TreeNode.new(vm_cloud_without_az.ext_management_system).key)
     end
 
     it 'returns id of Provider folder for Cloud Template' do
       template_cloud = FactoryGirl.create(:template_cloud,
                                           :ext_management_system => FactoryGirl.create(:ems_google),
                                           :storage               => FactoryGirl.create(:storage))
-      expect(controller.parent_folder_id(template_cloud)).to eq(TreeBuilder.build_node_cid(template_cloud.ext_management_system))
+      expect(controller.parent_folder_id(template_cloud)).to eq(TreeNode.new(template_cloud.ext_management_system).key)
     end
 
     it 'returns id of Provider folder for infra VM/Template without blue folder' do
       vm_infra = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
       template_infra = FactoryGirl.create(:template_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
-      expect(controller.parent_folder_id(vm_infra)).to eq(TreeBuilder.build_node_cid(vm_infra.ext_management_system))
-      expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_cid(template_infra.ext_management_system))
+      expect(controller.parent_folder_id(vm_infra)).to eq(TreeNode.new(vm_infra.ext_management_system).key)
+      expect(controller.parent_folder_id(template_infra)).to eq(TreeNode.new(template_infra.ext_management_system).key)
     end
 
     it 'returns id of Datacenter folder for infra VM/Template without blue folder but with Datacenter parent' do
@@ -264,8 +264,8 @@ describe VmOrTemplateController do
       allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
       template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
       allow(template_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
-      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
-      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
+      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeNode.new(datacenter).key)
+      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeNode.new(datacenter).key)
     end
 
     it 'returns id of blue folder for VM/Template with one' do
@@ -275,8 +275,8 @@ describe VmOrTemplateController do
       template_infra_folder = FactoryGirl.create(:template_infra,
                                                  :ext_management_system => FactoryGirl.create(:ems_infra))
       template_infra_folder.with_relationship_type("ems_metadata") { template_infra_folder.parent = folder } # add folder
-      expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
-      expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
+      expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeNode.new(folder).key)
+      expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeNode.new(folder).key)
     end
   end
 
@@ -295,15 +295,15 @@ describe VmOrTemplateController do
       User.current_user.settings[:display] = {:display_vms => false}
 
       allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(controller.parent_folder_id(@vm_arch)) }
-      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
+      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeNode.new(@vm_arch).key) }
       vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
     end
 
     it 'when VM shown select it in tree and show its info' do
       User.current_user.settings[:display] = {:display_vms => true}
 
-      allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
-      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
+      allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(TreeNode.new(@vm_arch).key) }
+      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeNode.new(@vm_arch).key) }
       vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
     end
   end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -187,13 +187,6 @@ describe TreeBuilder do
     end
   end
 
-  context "#build_node_cid" do
-    it "returns correct cid for VM" do
-      vm = FactoryGirl.create(:vm)
-      expect(TreeBuilder.build_node_cid(vm)).to eq("v-#{vm.id}")
-    end
-  end
-
   context "#hide_vms" do
     before(:each) do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")

--- a/spec/presenters/tree_node/configured_system_spec.rb
+++ b/spec/presenters/tree_node/configured_system_spec.rb
@@ -1,16 +1,16 @@
 describe TreeNode::ConfiguredSystem do
   subject { described_class.new(object, nil, {}) }
 
-  %i(
-    configured_system
-    configured_system_foreman
-    configured_system_ansible_tower
-  ).each do |factory|
+  {
+    :configured_system               => 'cs-',
+    :configured_system_foreman       => 'csf-',
+    :configured_system_ansible_tower => 'csa-'
+  }.each do |factory, prefix|
     klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
       let(:object) { FactoryGirl.create(factory) }
 
-      include_examples 'TreeNode::Node#key prefix', 'cs-'
+      include_examples 'TreeNode::Node#key prefix', prefix
       include_examples 'TreeNode::Node#icon', 'ff ff-configured-system'
       include_examples 'TreeNode::Node#tooltip prefix', 'Configured System'
     end

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -2,17 +2,17 @@ describe TreeNode::EmsFolder do
   subject { described_class.new(object, nil, options) }
   let(:options) { {} }
 
-  %i(
-    ems_folder
-    storage_cluster
-    inventory_group
-    inventory_root_group
-  ).each do |factory|
+  {
+    :ems_folder           => 'f-',
+    :storage_cluster      => 'dsc-',
+    :inventory_group      => 'f-',
+    :inventory_root_group => 'f-'
+  }.each do |factory, prefix|
     klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
       let(:object) { FactoryGirl.create(factory) }
 
-      include_examples 'TreeNode::Node#key prefix', 'f-'
+      include_examples 'TreeNode::Node#key prefix', prefix
       include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
       include_examples 'TreeNode::Node#tooltip prefix', 'Folder'
 

--- a/spec/presenters/tree_node/orchestration_template_spec.rb
+++ b/spec/presenters/tree_node/orchestration_template_spec.rb
@@ -2,16 +2,16 @@ describe TreeNode::OrchestrationTemplate do
   subject { described_class.new(object, nil, {}) }
 
   {
-    :orchestration_template_amazon              => %w(ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate cfn),
-    :orchestration_template_openstack_in_yaml   => %w(ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate hot),
-    :orchestration_template_azure_in_json       => %w(ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate azure),
-    :vnfd_template_openstack_in_yaml            => %w(ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate vnfd),
-    :orchestration_template_vmware_cloud_in_xml => %w(ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate vapp)
+    :orchestration_template_amazon              => %w(ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate cfn-),
+    :orchestration_template_openstack_in_yaml   => %w(ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate hot-),
+    :orchestration_template_azure_in_json       => %w(ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate azu-),
+    :vnfd_template_openstack_in_yaml            => %w(ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate vnf-),
+    :orchestration_template_vmware_cloud_in_xml => %w(ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate vap-)
   }.each do |factory, config|
     context(config.first) do
       let(:object) { FactoryGirl.create(factory) }
 
-      include_examples 'TreeNode::Node#key prefix', 'ot-'
+      include_examples 'TreeNode::Node#key prefix', config.last
       include_examples 'TreeNode::Node#icon', "pficon pficon-template"
     end
   end


### PR DESCRIPTION
There were multiple different ways to generate the key of a tree node:
* `TreeBuilder.get_prefix_for_model` and appending `-#{id}`
* `TreeBuilder.build_node_id` with a record
* `TreeBuilder.build_node_cid` with a record or an ID + type combo
* `TreeNode#key`

All these methods do the same thing, but the `TreeNode#key` had some extra exceptions that probably came from bugfixes in Foreman/Ansible. To eliminate these exceptions, it was enough to first look for the model's `class.to_s` in the `X_TREE_NODE_PREFIXES_INVERTED` and if it has no result, look for the `base_model.name`.

@miq-bot add_label refactoring, gaprindashvili/no
@miq-bot add_reviewer @martinpovolny 