### PR TITLE
Reload the automation manager trees on provider updates

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -340,6 +340,18 @@ class AutomationManagerController < ApplicationController
     end
   end
 
+  def build_automation_manager_providers_tree(_type)
+    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, @sb)
+  end
+
+  def build_automation_manager_cs_filter(_type)
+    TreeBuilderAutomationManagerConfiguredSystems.new(:automation_manager_cs_filter_tree, :automation_manager_cs_filter, @sb)
+  end
+
+  def build_configuration_scripts_tree(_type)
+    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, @sb)
+  end
+
   def rebuild_trees(replace_trees)
     build_replaced_trees(replace_trees, %i(automation_manager_providers automation_manager_cs_filter configuration_scripts))
   end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -265,7 +265,7 @@ module Mixins
                      "Delete initiated for %{count} Providers",
                      providers.length) % {:count => providers.length})
       end
-      replace_right_cell
+      replace_right_cell(:replace_trees => [x_active_accord])
     end
 
     def refresh

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -265,7 +265,7 @@ module Mixins
                      "Delete initiated for %{count} Providers",
                      providers.length) % {:count => providers.length})
       end
-      replace_right_cell(:replace_trees => [x_active_accord])
+      replace_right_cell
     end
 
     def refresh


### PR DESCRIPTION
Reload the automation manager trees on provider updates

Links
-------

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1560552

Steps for Testing/QA 
-------------------------------
Add a Tower provider - even after reload, the new provider will not be displayed in the tree.

For both Foreman and Tower  - when removing an existing provider, without this fix, it will not be removed from the tree until an accordion or controller switch.