### PR TITLE
Depend on patternfly 3.52.3 - do not upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "history": "^4.7.2",
     "jquery": "~2.2.4",
     "lodash": "^4.17.4",
+    "patternfly": "3.52.3",
     "patternfly-react": "2.10.1",
     "prop-types": "^15.6.0",
     "proxy-polyfill": "^0.1.7",


### PR DESCRIPTION
3.53 started depending on newer version of node than we can build with

forcing the dependency to 3.52 so that we can build

this is a temporary fix pending the resolution of https://github.com/patternfly/patternfly/issues/1113

Cc @simaishi 