### PR TITLE
Fix unresponsive Save button while editing VM

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -717,7 +717,7 @@ module VmCommon
     render :update do |page|
       page << javascript_prologue
       page.replace_html("main_div", :partial => "vm_common/form") if %w(allright left right).include?(params[:button])
-      page << javascript_for_miq_button_visibility(changed) if changed
+      page << javascript_for_miq_button_visibility(changed)
       page << "miqSparkle(false);"
     end
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1610466

---

**What:**
_Save_ button in editing screen of VM is not responsive: it remains enabled even if no change was made (of if there is nothing to save).

**Why:**
The problem was that if `changed` variable was set to `false`, no update for _Save_ button visibility was made. That's ok BUT what if _Save_ button was enabled before and needs to be disabled now? This situation was not implemented in the code and it is simply fixed by removing condition `if changed` which is unnecessary and caused the bug.

**Steps to Reproduce:**
1. Go to _Compute > Infra > VMs_ (or to any page with VMs list screen)
2. Click on some VM or check the checkbox
3. _Configuration > Edit Selected item/Edit this VM_
4. Make some change(s) in _Basic Information_ or _Parent VM Selection_ section,
   for example enter something in _Description_ form
   => _Save_ button enables
5. Remove all of your changes
   => _Save_ button remains enabled!

Right after starting editing of a chosen VM:
![before_editing](https://user-images.githubusercontent.com/13417815/43475850-4ee94ade-94f7-11e8-89a4-6482159297db.png)

Making some change of a VM:
![editing](https://user-images.githubusercontent.com/13417815/43475890-65b12994-94f7-11e8-92c7-8f6b92b6e979.png)

**Before:** (after removing changes for VM)
![after_removing_changes](https://user-images.githubusercontent.com/13417815/43475918-7606873a-94f7-11e8-8f97-63db94aa1afa.png)

**After:**
![after_removing_changes-after](https://user-images.githubusercontent.com/13417815/43476071-ed5427d4-94f7-11e8-8761-102c54b6e483.png)