### PR TITLE
ansible-raw-stdout: parse task id as string, not number

### DIFF
--- a/app/assets/javascripts/components/ansible-raw-stdout.js
+++ b/app/assets/javascripts/components/ansible-raw-stdout.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app.component('ansibleRawStdout', {
   bindings: {
-    taskId: '<',
+    taskId: '@',
   },
   controller: ['$sce', 'API', function($sce, API) {
     var vm = this;


### PR DESCRIPTION
The "JS ids can't be numbers in region >9006" is here again, this is the same fix as https://github.com/ManageIQ/manageiq-ui-classic/pull/3243, but for `ansible-raw-stdout`.

https://bugzilla.redhat.com/show_bug.cgi?id=1610353
