### PR TITLE
Redux - fix store.dispatch not being a function

### DIFF
--- a/app/javascript/miq-redux/middleware.ts
+++ b/app/javascript/miq-redux/middleware.ts
@@ -1,14 +1,7 @@
 import thunk from 'redux-thunk';
 import { routerMiddleware } from 'connected-react-router';
-import { compose } from 'redux';
 
-const composeEnhancers = window['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'] || compose;
-
-/**
- * @param history history for redux routing for react components * 
- * @description
- *  routerMiddleware adds middleware which is listening for location changes and updates router state
- *  thunk is a middleware for async redux functions
- */
-
-export const createMiddlewares = ({ history, middlewares = [] }) => composeEnhancers(routerMiddleware(history), thunk, ...middlewares);
+export const createMiddlewares = (history) => [
+  routerMiddleware(history),
+  thunk,
+];

--- a/app/javascript/miq-redux/store.js
+++ b/app/javascript/miq-redux/store.js
@@ -1,14 +1,15 @@
 import { connectRouter } from 'connected-react-router';
-import { createStore, applyMiddleware } from 'redux';
+import { applyMiddleware, compose, createStore } from 'redux';
 import { rootReducer } from './reducer';
 import { createMiddlewares } from './middleware';
 import { history } from '../miq-component/react-history';
 
 const initialState = {};
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
 export const store = createStore(
   connectRouter(history)(rootReducer),
   initialState,
-  applyMiddleware( createMiddlewares({ history }) ),
+  composeEnhancers(applyMiddleware(...createMiddlewares(history))),
 );
-


### PR DESCRIPTION
the actual problem was that composeEnhancers is only supposed to work with enhancers, not middleware (even though the vanilla redux composer function seems to work)

and applyMiddleware is the function to convert one or more middlewares into an enhancer

---

Testing:

* have the redux-devtools-extension (http://extension.remotedev.io/) installed in the browser
* load manageiq
* look at `ManageIQ.redux.store.dispatch`

Before:

Since https://github.com/ManageIQ/manageiq-ui-classic/pull/4380, `store.dispatch` was **not** a function but an object containing a dispatch function.

After:

`ManageIQ.redux.store.dispatch` is a function

---

Cc @karelhala 
Cc @martinpovolny - this should fix the problems you've seen in https://github.com/ManageIQ/manageiq-ui-classic/pull/4315
