### PR TITLE
Fix parent_id being a number, not string in JS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -973,7 +973,7 @@ class ApplicationController < ActionController::Base
       if row.data["job.target_class"] && row.data["job.target_id"]
         controller = view_to_hash_controller_from_job_target_class(row.data["job.target_class"])
         new_row[:parent_path] = (url_for_only_path(:controller => controller, :action => "show") rescue nil)
-        new_row[:parent_id] = row.data["job.target_id"] if row.data["job.target_id"]
+        new_row[:parent_id] = row.data["job.target_id"].to_s if row.data["job.target_id"]
       end
       root[:rows] << new_row
 

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -31,7 +31,7 @@ class ApplicationController
       additional_options.gtl_dbname = options[:gtl_dbname]
       additional_options.with_model(options[:model]) if options[:model]
       additional_options.match_via_descendants = options[:match_via_descendants]
-      additional_options.parent_id = options[:parent].id if options[:parent]
+      additional_options.parent_id = options[:parent].id.to_s if options[:parent]
       additional_options.parent_class_name = options[:parent].class.name if options[:parent]
       additional_options.association = options[:association]
       additional_options.view_suffix = options[:view_suffix]

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -371,7 +371,7 @@ class InfraNetworkingController < ApplicationController
       partial_locals = {:controller =>'infra_networking'}
       if partial == 'layouts/x_gtl'
         partial_locals[:action_url] = @lastaction
-        presenter[:parent_id] = @record.id # Set parent rec id for JS function miqGridSort to build URL
+        presenter[:parent_id] = @record.id.to_s # Set parent rec id for JS function miqGridSort to build URL
         presenter[:parent_class] = params[:controller] # Set parent class for URL also
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1253,8 +1253,10 @@ module VmCommon
       partial_locals = { :controller => 'vm' }
       if partial == 'layouts/x_gtl'
         partial_locals[:action_url]  = @lastaction
-        presenter[:parent_id]    = @record.id.to_s           # Set parent rec id for JS function miqGridSort to build URL
-        presenter[:parent_class] = params[:controller] # Set parent class for URL also
+
+        # Set parent record id & class for JS function miqGridSort to build URL
+        presenter[:parent_id]    = @record.id.to_s
+        presenter[:parent_class] = params[:controller]
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1253,7 +1253,7 @@ module VmCommon
       partial_locals = { :controller => 'vm' }
       if partial == 'layouts/x_gtl'
         partial_locals[:action_url]  = @lastaction
-        presenter[:parent_id]    = @record.id           # Set parent rec id for JS function miqGridSort to build URL
+        presenter[:parent_id]    = @record.id.to_s           # Set parent rec id for JS function miqGridSort to build URL
         presenter[:parent_class] = params[:controller] # Set parent class for URL also
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -228,7 +228,7 @@ describe HostController do
     it "renders a grid of associated Users" do
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name      => 'Account',
-        :parent_id       => @host.id,
+        :parent_id       => @host.id.to_s,
         :parent          => @host,
         :gtl_type_string => 'list'
       )
@@ -241,7 +241,7 @@ describe HostController do
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name      => 'GuestApplication',
-        :parent_id       => @host.id,
+        :parent_id       => @host.id.to_s,
         :parent          => @host,
         :gtl_type_string => 'list'
       )
@@ -254,7 +254,7 @@ describe HostController do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'Filesystem',
-        :parent_id                      => @host.id,
+        :parent_id                      => @host.id.to_s,
         :parent                         => @host,
         :gtl_type_string                => 'list',
         :report_data_additional_options => {
@@ -270,7 +270,7 @@ describe HostController do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
-        :parent_id                      => @host.id,
+        :parent_id                      => @host.id.to_s,
         :parent                         => @host,
         :gtl_type_string                => 'list',
         :report_data_additional_options => {
@@ -286,7 +286,7 @@ describe HostController do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
-        :parent_id                      => @host.id,
+        :parent_id                      => @host.id.to_s,
         :parent                         => @host,
         :gtl_type_string                => 'list',
         :report_data_additional_options => {
@@ -302,7 +302,7 @@ describe HostController do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
-        :parent_id                      => @host.id,
+        :parent_id                      => @host.id.to_s,
         :parent                         => @host,
         :gtl_type_string                => 'list',
         :report_data_additional_options => {

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -260,7 +260,7 @@ describe ServiceController do
         report_data_request(
           :model         => 'Vm',
           :parent_model  => 'Service',
-          :parent_id     => service.id,
+          :parent_id     => service.id.to_s,
           :active_tree   => 'svcs_tree',
           :parent_method => 'all_vms'
         )
@@ -277,7 +277,7 @@ describe ServiceController do
       it 'renders GTL of VMs associated to the selected Service' do
         expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
           :model_name                     => 'Vm',
-          :parent_id                      => service.id,
+          :parent_id                      => service.id.to_s,
           :report_data_additional_options => {
             :parent_class_name => 'Service',
             :parent_method     => :all_vms,

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -253,7 +253,7 @@ describe StorageController do
       it " returns VM Templates associated with selected Datastore" do
         req = {
           :model_name                     => 'MiqTemplate',
-          :parent_id                      => storage_with_miq_templates.id,
+          :parent_id                      => storage_with_miq_templates.id.to_s,
           :display                        => 'all_miq_templates',
           :parent                         => storage_with_miq_templates,
           :report_data_additional_options => {
@@ -308,7 +308,7 @@ describe StorageController do
         seed_session_trees('storage', :storage_pod_tree, 'root')
         expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
           :model_name                     => 'Storage',
-          :parent_id                      => storage_cluster.id,
+          :parent_id                      => storage_cluster.id.to_s,
           :report_data_additional_options => {
             :association       => 'storages',
             :parent_class_name => 'StorageCluster',


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/3243 and https://github.com/ManageIQ/manageiq-ui-classic/pull/4397 and https://github.com/ManageIQ/manageiq-ui-classic/pull/2902.

Trying to make sure `parent_id` always ends up as a string in JS, not a number.

https://bugzilla.redhat.com/show_bug.cgi?id=1610353

Cc @skateman 