### PR TITLE
Don't render table header for empty automate domain and namespace

### DIFF
--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -1,24 +1,28 @@
 #ns_details_div
   - unless @in_a_form
     = render :partial => 'layouts/info_msg', :locals => {:message => @version_message} if @version_message
-    %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
-      %thead
-        %th.table-view-pf-select
-          %input.checkall{:type => 'checkbox', :title => _('Check All')}
-        %th
-        %th
-      %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
-        - @records.each do |record|
-          - next if record.name == '$'
-          - cls_cid = "#{class_prefix(record.class)}-#{record.id}"
-          %tr{'data-click-id' => cls_cid}
-            %td.table-view-pf-select.noclick
-              %input{:type => 'checkbox', :value => cls_cid}
-            %td.table-view-pf-select
-              %i{:class => record.decorate.fonticon}
-            %td
-              = record_name(record)
-    :javascript
-      $(function () {
-        $('#ns_details_grid').miqGrid();
-      });
+    - if @records.length.zero?
+      - info_message = @record.class.to_s == 'MiqAeDomain' ? _("The selected domain is empty") : _("The selected Namespace is empty")
+      = render :partial => 'layouts/info_msg', :locals => {:message => info_message}
+    - else
+      %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
+        %thead
+          %th.table-view-pf-select
+            %input.checkall{:type => 'checkbox', :title => _('Check All')}
+          %th
+          %th
+        %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
+          - @records.each do |record|
+            - next if record.name == '$'
+            - cls_cid = "#{class_prefix(record.class)}-#{record.id}"
+            %tr{'data-click-id' => cls_cid}
+              %td.table-view-pf-select.noclick
+                %input{:type => 'checkbox', :value => cls_cid}
+              %td.table-view-pf-select
+                %i{:class => record.decorate.fonticon}
+              %td
+                = record_name(record)
+      :javascript
+        $(function () {
+          $('#ns_details_grid').miqGrid();
+        });


### PR DESCRIPTION
Before:
![domain-before](https://user-images.githubusercontent.com/6648365/43580567-2cf0ee04-9656-11e8-89d8-3cc39e98265d.png)
![namespace-before](https://user-images.githubusercontent.com/6648365/43580568-2d113196-9656-11e8-9db8-52ec99656478.png)

After:
![domain01-after](https://user-images.githubusercontent.com/6648365/43580586-3a9a2a52-9656-11e8-8fad-806a9fb52677.png)
![namespace-after](https://user-images.githubusercontent.com/6648365/43580588-3abb8800-9656-11e8-8265-fab1949079d7.png)
