### PR TITLE
Add long_description field into Ansible Playbook catalog item form

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -4,6 +4,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     vm.catalogItemModel = {
       name: '',
       description: '',
+      long_description: '',
       display: false,
       prov_type: 'generic_ansible_playbook',
       catalog_id: '',
@@ -67,6 +68,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
         $scope.newRecord = false;
         vm.catalogItemModel.name = catalogItemData.name;
         vm.catalogItemModel.description = catalogItemData.description;
+        vm.catalogItemModel.long_description = catalogItemData.long_description;
         vm.catalogItemModel.display = catalogItemData.display;
         vm.catalogItemModel.catalog_id = catalogItemData.service_template_catalog_id === undefined ? '' : catalogItemData.service_template_catalog_id;
         vm.catalogItemModel.provisioning_dialog_id = catalogItemData.config_info.provision.dialog_id;
@@ -209,6 +211,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', 'catalog
     var catalog_item = {
       name: configData.name,
       description: configData.description,
+      long_description: configData.long_description,
       display: configData.display,
       service_template_catalog_id: configData.catalog_id,
       prov_type: 'generic_ansible_playbook',

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -182,7 +182,9 @@ function playbookReusableCodeMixin(API, $q, miqService) {
 
   var checkFormDataRetrieval = function(vm) {
     $q.all(allApiPromises)
-      .then(retrievedFormData(vm));
+      .then(function() {
+        retrievedFormData(vm);
+      });
   };
 
   // get playbooks for selected repository

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -1,63 +1,74 @@
 - @angular_form = true
 
 %form.form-horizontal#form_div{"name"          => "angularForm",
-               "ng-controller" => "catalogItemFormController as vm",
-               "miq-form"      => 'true',
-               "ng-show"       => "vm.afterGet",
-               "model"         => "vm.catalogItemModel",
-               "model-copy"    => 'vm.modelCopy'}
+                               "ng-controller" => "catalogItemFormController as vm",
+                               "miq-form"      => 'true',
+                               "model"         => "vm.catalogItemModel",
+                               "model-copy"    => 'vm.modelCopy',
+                               "ng-cloak"      => ''}
   = render :partial => "layouts/flash_msg"
-  %div
+  %div{"ng-if" => "vm.afterGet"}
     %div
-      .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-        %label.col-md-2.control-label{"for" => "name"}
-          = _("Name")
-        .col-md-8
-          %input.form-control{"type"           => "text",
-                              "id"             => "name",
-                              "name"           => "name",
-                              "ng-model"       => "vm.catalogItemModel.name",
-                              "maxlength"      => 40,
-                              "miqrequired"    => "",
-                              "checkchange"    => "",
-                              "auto-focus"     => ""}
-          %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
-            = _("Required")
-      .form-group
-        %label.col-md-2.control-label{"for" => "description"}
-          = _("Description")
-        .col-md-8
-          %input.form-control{"type"        => "text",
-                              "id"          => "description",
-                              "name"        => "description",
-                              "ng-model"    => "vm.catalogItemModel.description",
-                              "maxlength"   => 60,
+      %div
+        .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+          %label.col-md-2.control-label{"for" => "name"}
+            = _("Name")
+          .col-md-8
+            %input.form-control{"type"           => "text",
+                                "id"             => "name",
+                                "name"           => "name",
+                                "ng-model"       => "vm.catalogItemModel.name",
+                                "maxlength"      => 40,
+                                "miqrequired"    => "",
+                                "checkchange"    => "",
+                                "auto-focus"     => ""}
+            %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
+              = _("Required")
+        .form-group
+          %label.col-md-2.control-label{"for" => "description"}
+            = _("Description")
+          .col-md-8
+            %input.form-control{"type"        => "text",
+                                "id"          => "description",
+                                "name"        => "description",
+                                "ng-model"    => "vm.catalogItemModel.description",
+                                "maxlength"   => 60,
+                                "checkchange" => ""}
+        .form-group
+          %label.col-md-2.control-label
+            = _("Display in Catalog")
+          .col-md-8
+            %input#use_config{"bs-switch"       => "",
+                              "type"            => "checkbox",
+                              "name"            => "display",
+                              "ng-model"        => "vm.catalogItemModel.display",
+                              "switch-on-text"  => _("Yes"),
+                              "switch-off-text" => _("No"),
                               "checkchange" => ""}
+        .form-group{"ng-if" => "vm.catalogItemModel.display == true"}
+          %label.col-md-2.control-label{"for" => "long_description"}
+            = _("Long Description")
+          .col-md-8
+            %textarea{"ui-codemirror" => "{mode: 'htmlmixed',
+                                          lineNumbers: true,
+                                          angular: true,
+                                          lineWrapping: true}",
+                      "name"          => "long_description",
+                      "ng-model"      => "vm.catalogItemModel.long_description",
+                      "checkchange"   => ""}
       .form-group
-        %label.col-md-2.control-label
-          = _("Display in Catalog")
+        %label.col-md-2.control-label{"for" => "catalog_id"}
+          = _('Catalog')
         .col-md-8
-          %input#use_config{"bs-switch"       => "",
-                            "type"            => "checkbox",
-                            "name"            => "display",
-                            "ng-model"        => "vm.catalogItemModel.display",
-                            "switch-on-text"  => _("Yes"),
-                            "switch-off-text" => _("No"),
-                            "checkchange" => ""}
+          %select{"ng-model"         => "vm._catalog",
+                  "name"             => "catalog_id",
+                  'ng-options'       => 'catalog as catalog.name for catalog in vm.catalogs',
+                  "data-live-search" => "true",
+                  'pf-select'        => true}
 
-    .form-group
-      %label.col-md-2.control-label{"for" => "catalog_id"}
-        = _('Catalog')
-      .col-md-8
-        %select{"ng-model"         => "vm._catalog",
-                "name"             => "catalog_id",
-                'ng-options'       => 'catalog as catalog.name for catalog in vm.catalogs',
-                "data-live-search" => "true",
-                'pf-select'        => true}
-
-  = render :partial => "layouts/angular/multi_tab_ansible_form_options",
-           :locals  => {:record => @record, :ng_model => "vm.catalogItemModel"}
-  = render :partial => "layouts/angular/x_edit_buttons_angular"
+    = render :partial => "layouts/angular/multi_tab_ansible_form_options",
+            :locals  => {:record => @record, :ng_model => "vm.catalogItemModel"}
+    = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('catalogItemFormId', '#{@record.id || "new"}');

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -18,6 +18,7 @@ describe('catalogItemFormController', function() {
     $scope.vm.catalogItemModel = {
       name:                         'catalogItemName',
       description:                  'catalogItemDescription',
+      long_description:             'catalogItemLongDescription',
       display:                      true,
       service_template_catalog_id:  10000000000012,
       prov_type: 'generic_ansible_playbook',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1482905

Description of problem:
Unable to add Long Description for Playbook based Catalog Items 

Steps to Reproduce:
1. look at the service catalog, there's a line that says "long description"
2. go to the catalog item and try to edit it
3. there is a now way how to edit it

Before/After
![screenshot from 2018-08-02 13-09-54](https://user-images.githubusercontent.com/32869456/43580870-2ab9cb00-9657-11e8-8e8b-cd6a79de4995.png)

Before
![screenshot from 2018-08-02 13-09-51](https://user-images.githubusercontent.com/32869456/43580871-2e97ba34-9657-11e8-9b1c-543875176857.png)

After
![screenshot from 2018-08-02 13-08-38](https://user-images.githubusercontent.com/32869456/43580888-3f4be968-9657-11e8-9933-7588ee6a47c7.png)

@miq-bot add_label gaprindashvili/yes, bug
