### PR TITLE
Topology screens - fix parseUrl to deal with hash router

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -267,12 +267,12 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     };
 
     controller.parseUrl = function(screenUrl) {
-      if (screenUrl.match('show/?$')) {
+      if (screenUrl.match('show/?($|#)')) {
         return controller.dataUrl;
       }
 
-      var match = screenUrl.match(/(ems_container|show)\/([0-9]+)\?display=topology$/) ||
-        screenUrl.match(/(_topology)\/show\/([0-9]+)\/?$/);
+      var match = screenUrl.match(/(ems_container|show)\/([0-9]+)\?display=topology($|#)/) ||
+        screenUrl.match(/(_topology)\/show\/([0-9]+)\/?($|#)/);
 
       if (match) {
         var id = match[2];

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -137,6 +137,11 @@ describe('topologyService', function() {
         var url = controller.parseUrl('/network_topology/show/10000000000005');
         expect(url).toEqual('/network_topology/data/10000000000005');
       });
+
+      it('works with a hash url', function() {
+        var url = controller.parseUrl('/network_topology/show/4#/');
+        expect(url).toEqual('/network_topology/data/4');
+      });
     })
 
     context('physical infra', function() {


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq-ui-classic/pull/4284, our urls can end with a hash + a route.

But the topology "where am I" url parsing code failed to take that into account, resulting in gets for undefined urls:

    angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:14962 Error: [$http:badreq] Http request configuration url must be a string or a $sce trusted object.  Received: undefined
    https://errors.angularjs.org/1.6.10/$http/badreq?p0=undefined
        at angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:126
        at $http (angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:12345)
        at Function.$http.(anonymous function) [as get] (http://localhost:3000/assets/angular/angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js?body=1:12626:18)
        at NetworkTopologyCtrl.controller.refresh (topology_service.self-c603c946f63ec7a10e96c995629c8421ebdce0c741ab4f07065db80c7cdb9c8e.js:287)
        at Object.mixinTopology (topology_service.self-c603c946f63ec7a10e96c995629c8421ebdce0c741ab4f07065db80c7cdb9c8e.js:326)
        at NetworkTopologyCtrl (network_topology_controller.self-066c5e882e6e89f073cc47542bc7827285fb13d00dc65516ac1bfac5a07f4cc9.js:10)
        at Object.invoke (angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:5118)
        at $controllerInit (angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:11140)
        at nodeLinkFn (angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:10003)
        at compositeLinkFn (angular.self-f52e96200e93eab5e5989b1cfc1563dcd14957ec50245b37ea763e6abd127a54.js:9312)

Cc @Hyperkid123 