### PR TITLE
Fix duplicate DOM id in Settings Zone and Server

### DIFF
--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -1,6 +1,5 @@
 - if @sb[:active_tab] == "settings_evm_servers"
   - if @servers
-    = render(:partial => "layouts/flash_msg")
     %h3= _("Basic Information")
     .form-horizontal.static
       .form-group

--- a/app/views/ops/_settings_smartproxy_affinity_tab.html.haml
+++ b/app/views/ops/_settings_smartproxy_affinity_tab.html.haml
@@ -1,3 +1,2 @@
 - if @sb[:active_tab] == "settings_smartproxy_affinity"
-  = render :partial => "layouts/flash_msg"
   = render :partial => "smartproxy_affinity"

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -1,5 +1,4 @@
 - url = url_for_only_path(:action => 'zone_field_changed', :id => (@zone.id || "new"))
-= render :partial => "layouts/flash_msg"
 - disabled_name = !@zone.name.nil? && !@edit[:current][:name].nil?
 %h3
   = _("Zone Information")


### PR DESCRIPTION
`settings_smartproxy_affinity_tab` and `settings_evm_servers_tab` are included only from `app/views/ops/_all_tabs.html.haml` and that already has the `flash_msg` div in that context.

`zone_form` is only called from `app/controllers/ops_controller.rb` `settings_replace_right_cell` and in that context the `replace_right_cell` replaces `flash_msg_div` separately.