### PR TITLE
Added promise middleware, to enable v2v redux-actions.

### DIFF
--- a/app/javascript/miq-redux/middleware.ts
+++ b/app/javascript/miq-redux/middleware.ts
@@ -1,7 +1,9 @@
 import thunk from 'redux-thunk';
 import { routerMiddleware } from 'connected-react-router';
+import promiseMiddleware from 'redux-promise-middleware';
 
 export const createMiddlewares = (history) => [
   routerMiddleware(history),
   thunk,
+  promiseMiddleware(),
 ];

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -19,6 +19,7 @@ import * as helpers from '../miq-component/helpers';
 import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
 
 import { store, addReducer } from '../miq-redux';
+import { history } from '../miq-component/react-history.ts';
 
 ManageIQ.react = {
   mount,
@@ -34,6 +35,7 @@ ManageIQ.component = {
 ManageIQ.redux = {
   store,
   addReducer,
+  history,
 };
 
 ManageIQ.angular.rxSubject = rxSubject;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-router-dom": "^4.3.1",
     "react-select": "~1.2.1",
     "redux": "^4.0.0",
+    "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
     "rxjs": "~5.6.0-forward-compat.2",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",


### PR DESCRIPTION
This is related to https://github.com/ManageIQ/manageiq-ui-classic/pull/4361#issuecomment-409544861. In order to merge our stores and routing, we need to add this middleware to enable v2v async redux actions. Fortunately it does not break our async actions :).