### PR TITLE
bower to npm: sprintf

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,6 @@
 //= require bower_components/moment-strftime/lib/moment-strftime
 //= require bower_components/moment-timezone/moment-timezone
 //= require bower_components/moment-duration-format/lib/moment-duration-format
-//= require bower_components/sprintf/dist/sprintf.min
 //= require bower_components/numeral/numeral
 //= require ./cable
 //= require ./gettextCatalog

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -42,6 +42,8 @@ ManageIQ.angular.rxSubject = rxSubject;
 window.sendDataWithRx = sendDataWithRx;
 window.listenToRx = listenToRx;
 
+window.sprintf = require('sprintf-js').sprintf;
+
 // compatibility: vanillaJsAPI should be considered deprecated
 // the new convention is: API is for vanilla/react, $API is for angular
 window.API = API;

--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,6 @@
     "qs": "~0.3.10",
     "spice-html5-bower": "himdel/spice-html5-bower#~1.7.2",
     "spin.js": "~2.3.2",
-    "sprintf": "~1.0.3",
     "xml_display": "~0.1.1"
   },
   "resolutions": {

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -4,14 +4,12 @@ window.$ = require('jquery');
 window._ = require('lodash');
 window.__ = (x) => x;
 window.n__ = (x) => x;
+window.sprintf = require('sprintf-js').sprintf;
 
 require('../app/assets/javascripts/miq_global');
 require('../app/assets/javascripts/miq_application');
 require('../app/assets/javascripts/miq_api');
 require('../app/assets/javascripts/miq_angular_application');
-
-let sprintf = require('../vendor/assets/bower/bower_components/sprintf/src/sprintf.js');
-window.sprintf = sprintf.sprintf;
 
 import { API } from '../app/javascript/http_api';
 window.vanillaJsAPI = API;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
     "rxjs": "~5.6.0-forward-compat.2",
+    "sprintf-js": "~1.1.1",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8"
   },


### PR DESCRIPTION
we're using https://github.com/alexei/sprintf.js
upgrading from 1.0.3 to 1.1.1 and moving to npm

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/3734