### PR TITLE
Avoid using string math in flash messages

### DIFF
--- a/app/assets/javascripts/components/miq_ae_class/namespace-form.js
+++ b/app/assets/javascripts/components/miq_ae_class/namespace-form.js
@@ -55,12 +55,11 @@ ManageIQ.angular.app.component('namespaceForm', {
         message = vm.aeNsDomain ? __('Edit of Domain "%s" was cancelled by user.') : __('Edit of Namespace "%s" was cancelled by user.');
         message = sprintf(message, vm.namespaceModel.name);
       }
-      var url = '/miq_ae_class/explorer';
       miqFlashLater({
         message: message,
         level: 'warning',
       });
-      $window.location.href = url;
+      $window.location.href = '/miq_ae_class/explorer';
     };
 
     vm.resetClicked = function(angularForm) {

--- a/app/assets/javascripts/components/miq_ae_class/namespace-form.js
+++ b/app/assets/javascripts/components/miq_ae_class/namespace-form.js
@@ -48,8 +48,13 @@ ManageIQ.angular.app.component('namespaceForm', {
 
     vm.cancelClicked = function() {
       miqService.sparkleOn();
-      var type = vm.aeNsDomain ? __("Domain") : __("Namespace");
-      var message = vm.newRecord ? sprintf(__('Add of %s \"%s\" cancelled by user.'), type, vm.namespaceModel.name) : sprintf(__('Edit of %s \"%s\" cancelled by user.'), type, vm.namespaceModel.name);
+      var message = '';
+      if (vm.newRecord) {
+        message = vm.aeNsDomain ? __('Add of Domain was cancelled by user.') : __('Add of Namespace was cancelled by user.');
+      } else {
+        message = vm.aeNsDomain ? __('Edit of Domain "%s" was cancelled by user.') : __('Edit of Namespace "%s" was cancelled by user.');
+        message = sprintf(message, vm.namespaceModel.name);
+      }
       var url = '/miq_ae_class/explorer';
       miqFlashLater({
         message: message,


### PR DESCRIPTION
Also, there's no need to escape double quotes in single quote js strings, such as: `'abc \"def\" ghi'`

Also, removed `url` variable (used only once).