### PR TITLE
bower to npm - spice-html5-bower

### DIFF
--- a/app/assets/javascripts/remote_consoles/spice.js
+++ b/app/assets/javascripts/remote_consoles/spice.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require bower_components/spice-html5-bower/spice-html5-rails
+//= require spice-html5-bower/spice-html5-rails
 //= require_tree ../locale
 //= require gettext/all
 

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,6 @@
     "patternfly-timeline": "~1.0.5",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",
-    "spice-html5-bower": "himdel/spice-html5-bower#~1.7.2",
     "spin.js": "~2.3.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
     "rxjs": "~5.6.0-forward-compat.2",
+    "spice-html5-bower": "~1.7.2",
     "sprintf-js": "~1.1.1",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8",


### PR DESCRIPTION
this is our spice-html5-rails fork for bower + npm - https://github.com/himdel/spice-html5-bower

Still using the asset pipeline for this one, only changing the download tool.

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/3734