### PR TITLE
Do not store cockpit_redirect when remembering tabs on dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1824,7 +1824,7 @@ class ApplicationController < ActionController::Base
     return if request.xml_http_request? || !request.get? || request.format != Mime[:html] ||
               request.headers['X-Angular-Request'].present?
 
-    return if controller_name == 'dashboard' && %(iframe maintab).include?(action_name)
+    return if controller_name == 'dashboard' && %(iframe maintab cockpit_redirect).include?(action_name)
 
     remember_tab
   end


### PR DESCRIPTION
If a cockpit worker is running, the redirection to the proxy URL is being handled by the dashboard controller. The reason behind this is unknown, but I found out that the `handle_remember_tab` is being called with the `cockpit_redirect` action. This causes the session to store this action for the next time the user clicks on the cloud intel in the menu.

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @mzazrivec 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1585569