### PR TITLE
Fix saving of multiple container images label in Chargeback assignments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -762,6 +762,8 @@ class ChargebackController < ApplicationController
 
   def get_docker_labels_all_values(label_id)
     @edit[:cb_assign][:docker_label_values] = {}
+    return if label_id && label_id == 'null' || label_id.nil?
+
     label_name = CustomAttribute.find(label_id).name
 
     CustomAttribute.where(:section => "docker_labels", :name => label_name).pluck(:id, :value).uniq(&:second).each do |label|
@@ -824,7 +826,7 @@ class ChargebackController < ApplicationController
       get_tags_all(params[:cbtag_cat].to_i) if params[:cbtag_cat]
     elsif @edit[:new][:cbshow_typ].ends_with?("-labels")
       get_docker_labels_all_keys
-      get_docker_labels_all_values(params[:cblabel_key]) if params[:cblabel_key] && params[:cblabel_key] != 'null'
+      get_docker_labels_all_values(params[:cblabel_key])
     else
       get_cis_all
     end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -51,6 +51,19 @@ describe ChargebackController do
       it "returns tag for current assignments" do
         expect { controller.send(:cb_assign_get_form_vars) }.not_to raise_error
       end
+
+      it "initializes hash when data are no available(params[:cblabel_key] == null)" do
+        controller.send(:cb_assign_get_form_vars)
+        docker_label_values = controller.instance_variable_get(:@edit)[:cb_assign][:docker_label_values]
+        expect(docker_label_values).to eq({})
+      end
+
+      it "initializes hash when data are no available (params[:cblabel_key] == nil)" do
+        controller.instance_variable_set(:@_params, :cblabel_key => nil)
+        controller.send(:cb_assign_get_form_vars)
+        docker_label_values = controller.instance_variable_get(:@edit)[:cb_assign][:docker_label_values]
+        expect(docker_label_values).to eq({})
+      end
     end
   end
 


### PR DESCRIPTION
Move condition inside method in ChargebackController
follow up of https://github.com/ManageIQ/manageiq-ui-classic/pull/4311

to make sure that @edit[:cb_assign][:docker_label_values] is initialized.
It was causing other error log

and

**Fix saving labels in Chargeback assigments for multiple categories**
Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/4310 but this is for containers labels.

Fix saving labels for mutliple label categories
add new array @edit[:cb_assign][:docker_label_values_saved]
to keep selected categories.

**After:**

![g0sqk4swdh](https://user-images.githubusercontent.com/14937244/43761524-9fbde838-9a25-11e8-9609-aef71b1b8de4.gif)


Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/4311
* https://bugzilla.redhat.com/show_bug.cgi?id=1612889

@miq-bot assign @mzazrivec 

@miq-bot add_label bug