### PR TITLE
Support all service types for dialog buttons

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -23,7 +23,10 @@ class DialogLocalService
     SecurityGroup
     Service
     ServiceAnsiblePlaybook
+    ServiceAnsibleTower
     ServiceContainerTemplate
+    ServiceGeneric
+    ServiceOrchestration
     Storage
     Switch
     Template
@@ -132,7 +135,7 @@ class DialogLocalService
       "miq_template"
     when /InfraManager/
       "ext_management_system"
-    when /ServiceAnsiblePlaybook/, /ServiceContainerTemplate/
+    when /^Service/
       "service"
     else
       obj.class.name.demodulize.underscore

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -214,8 +214,29 @@ describe DialogLocalService do
                        "service", "services", "/service/explorer"
     end
 
+    context "when the object is a ServiceAnsibleTower" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceAnsibleTower, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "service", "services", "/service/explorer"
+    end
+
     context "when the object is a ServiceContainerTemplate" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceContainerTemplate, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "service", "services", "/service/explorer"
+    end
+
+    context "when the object is a ServiceGeneric" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceGeneric, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "service", "services", "/service/explorer"
+    end
+
+    context "when the object is a ServiceOrchestration" do
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceOrchestration, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"


### PR DESCRIPTION
An extension of https://github.com/ManageIQ/manageiq-ui-classic/pull/4404, this adds all the `Service` class's descendants to the list of object types that are supported by custom buttons.

https://bugzilla.redhat.com/show_bug.cgi?id=1611527

@miq-bot add_label gaprindashvili/yes, bug, blocker, services, angular dialogs
@miq-bot assign @h-kataria 

/cc @tinaafitz 