### PR TITLE
Hide tasks from the notification drawer

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -63,6 +63,7 @@ function eventNotifications($timeout, API) {
       notifications: [],
     };
     state.groups.push(events);
+    /*
     state.groups.push(
       {
         notificationType: this.TASK_NOTIFICATION,
@@ -71,6 +72,7 @@ function eventNotifications($timeout, API) {
         notifications: [],
       }
     );
+    */
     state.unreadNotifications = false;
     state.toastNotifications = [];
 

--- a/spec/javascripts/services/event_notifications_service_spec.js
+++ b/spec/javascripts/services/event_notifications_service_spec.js
@@ -18,7 +18,7 @@ describe('eventNotifications', function() {
   });
 
   it('should add to the notifications list and toast notifications when an event is added', function() {
-    expect(testService.state().groups.length).toBe(2);
+    expect(testService.state().groups.length).toBe(1);
 
     testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test message", {}, 1);
     expect(testService.state().groups[0].notifications.length).toBe(1);


### PR DESCRIPTION
This has never been used and there is no suitable backend to display anything here, so hiding it.

@miq-bot add_label gaprindashvili/yes, fine/yes
@miq-bot add_reviewer @epwinchell 

**Before:**
![screenshot from 2018-08-07 12-20-52](https://user-images.githubusercontent.com/649130/43771103-6ea3586e-9a3e-11e8-98f8-add7414e265b.png)

**After:**
![screenshot from 2018-08-07 12-31-13](https://user-images.githubusercontent.com/649130/43771107-723643d8-9a3e-11e8-977d-d8ce765a0f17.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1612002