### PR TITLE
Fixed format of Disk size for a VM

### DIFF
--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -46,7 +46,7 @@ module TextualMixins::TextualDevices
 
       hd_name = disk.device_name.upcase
       location = disk.location.presence || _("N/A")
-      size = disk.size.presence || _("N/A")
+      size = disk.size.present? ? number_to_human_size(disk.size, :precision => 2) : _("N/A")
       pct_prov = disk.size_on_disk.nil? ? _("N/A") : disk.used_percent_of_provisioned
       filename = disk.filename.presence || _("N/A")
       mode = disk.mode.presence || _("N/A")

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -47,7 +47,7 @@ describe TextualMixins::TextualDevices do
                                                          :controller_type => "AZURE")])
       end
       it { expect(subject[0][:name]).to include("Hard Disk") }
-      it { expect(subject[0][:description]).to include("Name: HD01, Location: N/A, Size: 1072693248, Percent Used Provisioned Space: N/A, Filename: N/A, Mode: N/A") }
+      it { expect(subject[0][:description]).to include("Name: HD01, Location: N/A, Size: 1023 MB, Percent Used Provisioned Space: N/A, Filename: N/A, Mode: N/A") }
     end
 
     context "with hdd with size_on_disk and percent provisioned collected (AZURE)" do
@@ -66,7 +66,7 @@ describe TextualMixins::TextualDevices do
       it "expect hard disk description with percent provisioned " do
         expected_description = "Name: CLIA566D60F38FB9ECC, " \
                                "Location: https://jdg.blob.core.windows.net/vhds/clia566d60f38fb9ecc.vhd, " \
-                               "Size: 1072693248, " \
+                               "Size: 1023 MB, " \
                                "Percent Used Provisioned Space: 33.3, " \
                                "Filename: N/A, " \
                                "Mode: N/A"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536711

Disk size formatting was lost in https://github.com/ManageIQ/manageiq-ui-classic/pull/752. Code was changed from 
https://github.com/ManageIQ/manageiq-ui-classic/pull/752/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eL1243
to https://github.com/ManageIQ/manageiq-ui-classic/pull/752/files#diff-0477435a7227f32a30f48f81a7b52afcR43

before:
![before](https://user-images.githubusercontent.com/3450808/43802278-515f2588-9a63-11e8-865c-acff25a7e8b0.png)

after:
![after](https://user-images.githubusercontent.com/3450808/43802289-546795e4-9a63-11e8-9473-3b95888cdd37.png)
