### PR TITLE
Reword Get Roles to Get Groups from Home Forest.

### DIFF
--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -166,7 +166,7 @@
       .form-horizontal
         .form-group#get_roles_now{:style => @edit[:new][:authentication][:user_proxies].blank? ? "display: none" : ""}
           %label.col-md-2.control-label
-            = _("Get Roles from Home Forest")
+            = _("Get Groups from Home Forest")
           .col-md-8
             = check_box_tag("get_direct_groups", "1",
                             @edit[:new][:authentication][:get_direct_groups],


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1475891

This is a very simple PR that will clarify what is being retrieved when a checkbox is activated.

The wording of the authorization checkbox titled: _Get Roles from Home Forest_ is confusing
for a couple of reasons.

1. It causes _Groups_ not _Roles_ to be retrieved.
2. The term _Forest_, although a bit misleading to AD purists, was likely chosen initially due to the similarity to the functionality for LDAP and AD. Since  the term _Forest_ has been used generically here it will stay.

The term _Roles_ is not correct and will be changed to _Groups_

Steps for Testing/QA
-------------------------------

Navigate to Configuration->Authentication and select mode **LDAP** or **LDAPS**
Check the box _Get User Groups from LDAP_
Note the wording of the next checkbox has been update to _Get **Groups** from Home Forest_