### PR TITLE
Fix multi saving tag categories in chargeback assigments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -694,7 +694,7 @@ class ChargebackController < ApplicationController
       tag = @edit[:current_assignment][0][:tag][0]
       if tag
         @edit[:new][:cbtag_cat] = tag["parent_id"].to_s
-        get_tags_all(tag["parent_id"])
+        get_tags_all
       else
         @edit[:current_assignment] = []
       end
@@ -739,11 +739,15 @@ class ChargebackController < ApplicationController
     end
   end
 
-  def get_tags_all(category)
+  def get_tags_all
     @edit[:cb_assign][:tags] ||= {}
-    @edit[:cb_assign][:tags][category] ||= {}
-    classification = Classification.find_by_id(category.to_s)
-    classification&.entries&.each { |e| @edit[:cb_assign][:tags][category][e.id.to_s] = e.description }
+
+    Classification.all.each do |category|
+      @edit[:cb_assign][:tags][category.id] ||= {}
+      category.entries.each do |entry|
+        @edit[:cb_assign][:tags][category.id][entry.id.to_s] = entry.description
+      end
+    end
   end
 
   DEFAULT_CHARGEBACK_LABELS = ["com.redhat.component"].freeze
@@ -821,7 +825,7 @@ class ChargebackController < ApplicationController
 
     if @edit[:new][:cbshow_typ].ends_with?("-tags")
       get_categories_all
-      get_tags_all(params[:cbtag_cat].to_i) if params[:cbtag_cat]
+      get_tags_all
     elsif @edit[:new][:cbshow_typ].ends_with?("-labels")
       get_docker_labels_all_keys
       get_docker_labels_all_values(params[:cblabel_key]) if params[:cblabel_key] && params[:cblabel_key] != 'null'

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -11,14 +11,11 @@ describe ChargebackController do
 
       it "returns the classification entry record" do
         controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
-        controller.send(:get_tags_all, tag.id)
-        expect(assigns(:edit)[:cb_assign][:tags][tag.id]).to eq(entry.id.to_s => entry.description)
-      end
+        controller.send(:get_tags_all)
 
-      it "returns empty hash when classification entry is not found" do
-        controller.instance_variable_set(:@edit, :cb_assign => {:tags => {}})
-        controller.send(:get_tags_all, 1)
-        expect(assigns(:edit)[:cb_assign][:tags][1]).to eq({})
+        result = {category.id => {tag.id.to_s => tag.description}, tag.id => { entry.id.to_s => entry.description}, entry.id => {}}
+
+        expect(assigns(:edit)[:cb_assign][:tags]).to eq(result)
       end
     end
 


### PR DESCRIPTION
Consider all tags not only for current category in Chargeback Assignments

`@edit[:cb_assign][:tags]` has to keep all tags because it is used as
reference array when assignments are saved.

Before there were stored only tags from current selected categories
and it was causing issues when we came back to this pages.
(@edit[:cb_assign][:tags] have not been properly loaded)


### Links
FIX of https://github.com/ManageIQ/manageiq-ui-classic/pull/4310
https://bugzilla.redhat.com/show_bug.cgi?id=1612889
@miq-bot assign @mzazrivec

@miq-bot add_label bug
@miq-bot add_label gapridashvili/yes, blocker