### PR TITLE
Webpack4 - emit webpack runtime chunk only in the vendor bundle, not in every one

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -81,6 +81,9 @@ module.exports = {
   ],
 
   optimization: {
+    runtimeChunk: {
+      name: 'vendor',
+    },
     splitChunks: {
       minChunks: 1,
       minSize: 0,


### PR DESCRIPTION
without this, when the same file is included from multiple packs (webpack entrypoints), it will get run separately for each

this is because each bundle has its own copy of the webpack runtime, which deals with this "has it run yet" logic

this change causes the webpack runtime to only be emitted once, and shared by the other packs

thus, multiple imports of the same package should run it only once again, regardless of whether this happens within one pack or accross multiple packs

Caused by & more info in: https://github.com/ManageIQ/manageiq-ui-classic/pull/3776 (from https://github.com/ManageIQ/manageiq-ui-classic/pull/3776#issuecomment-411060992 on, https://github.com/ManageIQ/manageiq-ui-classic/pull/3776#issuecomment-411368111 specifically)

Cc @Hyperkid123 