### PR TITLE
Add check if found item is defined for is_displayed action on GTL

### DIFF
--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -250,8 +250,8 @@ ManageIQ.qe.gtl = {
       },
       'is_displayed': function(identificator) {
         var foundItem = queryItem(identificator, 'name', this.gtlData.rows, false);
-        ManageIQ.qe.gtl.result = foundItem.id ? true : false;
-        return foundItem.id ? true : false;
+        ManageIQ.qe.gtl.result = Boolean(foundItem && foundItem.id);
+        return ManageIQ.qe.gtl.result;
       },
       'pagination_range': function() {
         ManageIQ.qe.gtl.result = {


### PR DESCRIPTION
### Fixes #4426
When running action to check if item is present in GTL, but such item is not found error is thrown which will break every other action for GTL.