### PR TITLE
Changing Topology icons colors to black

### DIFF
--- a/app/assets/stylesheets/physical_infra_topology.scss
+++ b/app/assets/stylesheets/physical_infra_topology.scss
@@ -1,7 +1,8 @@
 $topology-colors: (
-  PhysicalServer: #00659c,
-  PhysicalRack:   #2d7623,
-  PhysicalSwitch: #b35c00,
+  PhysicalServer:  #030303,
+  PhysicalRack:    #030303,
+  PhysicalSwitch:  #030303,
+  PhysicalChassis: #030303,
 );
 
 @each $component, $color in $topology-colors {


### PR DESCRIPTION
This PR changes the colors of all physical infrastructure components icons to black. This decision was made on [ManageIQ/manageiq-ui-classic#4396](https://github.com/ManageIQ/manageiq-ui-classic/pull/4396) discussion.

![image](https://user-images.githubusercontent.com/7563089/43839697-2185cc80-9af5-11e8-9ae6-b3f4f9de37e6.png)
