### PR TITLE
[WIP] update:ui - support node_modules locations outside of gem engine dirs

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -29,7 +29,7 @@ namespace :update do
       puts "    namespace: #{engine.namespace}"
       puts "    path: #{engine.path}"
       puts "    node_modules: #{engine.node_modules}"
-      puts "    is_gem: #{engine.is_gem}"
+      puts "    development_gem?: #{engine.development_gem?}"
     end
     puts
   end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -9,7 +9,7 @@ namespace :update do
     asset_engines.each do |engine|
       Dir.chdir engine.path do
         next unless File.file? 'package.json'
-        system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
+        system("yarn --modules-folder='#{engine.node_modules}'") || abort("\n== yarn failed in #{engine.path} (output: #{engine.node_modules}) ==")
       end
     end
   end
@@ -28,6 +28,8 @@ namespace :update do
       puts "  #{engine.name}:"
       puts "    namespace: #{engine.namespace}"
       puts "    path: #{engine.path}"
+      puts "    node_modules: #{engine.node_modules}"
+      puts "    is_gem: #{engine.is_gem}"
     end
     puts
   end
@@ -78,7 +80,7 @@ namespace :webpack do
       :engines => asset_engines.map { |p|
                     key = p.namespace
                     value = {:root => p.path,
-                             :node_modules => File.join(p.path, 'node_modules')}
+                             :node_modules => p.node_modules}
 
                     [key, value]
                   }.to_h


### PR DESCRIPTION
this depends on a core PR (ManageIQ/manageiq#17818) to provide the right path to node_modules via AssetPath

On our side, we just use the directories provided.

(except for running webpack, using the dir even there, postcss config, and typescript)