### PR TITLE
Correctly render orchestration template's name

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -20,7 +20,7 @@ class OrchestrationStackController < ApplicationController
   end
 
   def display_stack_orchestration_template
-    drop_breadcrumb(:name => "%{name} (Orchestration Template)" % {:name => @record.name},
+    drop_breadcrumb(:name => "%{name} (Orchestration Template)" % {:name => @record.orchestration_template.name},
                     :url  => show_link(@record, :display => @display))
   end
 

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -49,7 +49,8 @@ describe OrchestrationStackController do
     end
 
     context "orchestration templates" do
-      let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
+      let(:ems) { FactoryGirl.create(:ems_cloud) }
+      let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template, :ext_management_system => ems, :name => 'stack01') }
 
       before do
         session[:settings] = {
@@ -66,6 +67,12 @@ describe OrchestrationStackController do
       it "renders the orchestration template details" do
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "orchestration_stack/_stack_orchestration_template")
+      end
+
+      it "renders template name correctly" do
+        expect(response.status).to eq(200)
+        expect(response.body).to include("<h1>\ntemplate name")
+        expect(response.body).not_to include("<h1>\nstack01")
       end
     end
   end


### PR DESCRIPTION
Before, we'd be mistakenly rendering name of it's stack.

Before:
![ot-before](https://user-images.githubusercontent.com/6648365/43846525-d9d661c6-9b2e-11e8-8878-427dd24e8f27.png)

After:
![ot-after](https://user-images.githubusercontent.com/6648365/43846531-de0b9ae0-9b2e-11e8-8aca-e9821f7fed5d.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1601523