### PR TITLE
Allow skipping empty event group levels

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -477,10 +477,10 @@ module MiqPolicyController::Alerts
       @sb[:alert][:events] ||= {}
       EmsEvent.event_groups.each do |_k, v|
         name = v[:name]
-        v[:detail].each do |d|
+        v[:detail]&.each do |d|
           @sb[:alert][:events][d] = name + ": " + d if vm_events.include?(d)
         end
-        v[:critical].each do |c|
+        v[:critical]&.each do |c|
           @sb[:alert][:events][c] = name + ": " + c if vm_events.include?(c)
         end
       end


### PR DESCRIPTION
This minimalistic patch makes sure that any empty event group levels can be left out of the configuration file instead of requiring an empty array in that place.