### PR TITLE
Fix Object Attribute Type dropdown

### DIFF
--- a/app/views/static/ae_resolve_options/ae-resolve-options-component.html.haml
+++ b/app/views/static/ae_resolve_options/ae-resolve-options-component.html.haml
@@ -43,11 +43,12 @@
       %label.col-md-2.control-label{'for' => 'target_class'}
         = _('Type')
       .col-md-8
-        %select#target_class{'ng-model'     => '$ctrl.targetClass',
-                             'name'         => 'target_class',
-                             'ng-options'   => 'target_class[1] as target_class[0]  for target_class in $ctrl.targetClassOptions',
-                             'ng-change'    => '$ctrl.targetClassChange({targetClass: $ctrl.targetClass})',
-                             'pf-select'    => true}
+        %select#target_class{'ng-model'       => '$ctrl.targetClass',
+                             'name'           => 'target_class',
+                             'ng-options'     => 'target_class[1] as target_class[0]  for target_class in $ctrl.targetClassOptions',
+                             'ng-change'      => '$ctrl.targetClassChange({targetClass: $ctrl.targetClass})',
+                             'data-container' => 'body',
+                             'pf-select'      => true}
           %option{'value' => ''}
             = "<#{_('Choose')}>"
     .form-group{'ng-class' => "{'has-error': aeResolveOptionsForm.target_id.$invalid}",


### PR DESCRIPTION
This PR fixes a problem where the bootstrap-select dropdown was being hidden under the toolbar by setting the data-container to "body."

https://bugzilla.redhat.com/show_bug.cgi?id=1613934

Old
<img width="1170" alt="screen shot 2018-08-09 at 1 19 52 pm" src="https://user-images.githubusercontent.com/1287144/43916804-9d7a9a36-9bdc-11e8-99a5-a06f168b7881.png">

New
<img width="1180" alt="screen shot 2018-08-09 at 1 55 37 pm" src="https://user-images.githubusercontent.com/1287144/43916803-9d676fb0-9bdc-11e8-92a6-5f759a524e4c.png">
