### PR TITLE
Fixed to pass in correct class for Template summary screen pdf download

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -295,7 +295,7 @@ class ApplicationController < ActionController::Base
     redirect_to(:action => params[:tab], :id => params[:id])
   end
 
-  def download_summary_pdf
+  def download_summary_pdf(klass = self.class.model)
     # do not build quadicon links
     @embedded = true
     @showlinks = false
@@ -303,7 +303,7 @@ class ApplicationController < ActionController::Base
     # encode images and embed in HTML that is sent to Prince
     @base64_encode_images = true
 
-    @record = identify_record(params[:id])
+    @record = identify_record(params[:id], klass)
     yield if block_given?
     return if record_no_longer_exists?(@record)
     get_tagdata(@record) if @record.try(:taggings)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -123,7 +123,7 @@ module VmCommon
   end
 
   def download_summary_pdf
-    super do
+    super(VmOrTemplate) do
       @flash_array = []
       @record = identify_record(params[:id], VmOrTemplate)
     end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -331,3 +331,7 @@ describe VmOrTemplateController do
   include_examples '#download_summary_pdf', :vm_cloud
   include_examples '#download_summary_pdf', :vm_infra
 end
+
+describe VmInfraController do
+  include_examples '#download_summary_pdf', :template_infra
+end

--- a/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
+++ b/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
@@ -19,5 +19,9 @@ shared_examples '#download_summary_pdf' do |object|
     it 'title is set correctly' do
       expect(pdf_options[:title]).to eq("#{ui_lookup(:model => record.class.name)} \"#{record.name}\"")
     end
+
+    it "should not raise error" do
+      expect(assigns(:bang)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
When downloading Template summary to PDF code was passing in incorrct class to find_records_with_rbac mthod, class was being passed in as ManageIQ::Providers::InfraManager::Vm this was causing code to raise an error that was displaye don screen as well as in evm.log. Changed download_summary_pdf method to pass in class from vm_common.
Added spec test to verify that code does not raise any errors.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544317

@martinpovolny please review