### PR TITLE
Stop N+1 with EmsDashboardService#recent_records

### DIFF
--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -54,12 +54,10 @@ class EmsDashboardService < DashboardService
     to_char_args = [db_table[:created_on], Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
     group_by_sql = Arel::Nodes::NamedFunction.new("to_char", to_char_args)
 
-    sql = model.where(:ems_id => @ems.id)
-               .where(db_table[:created_on].gt(30.days.ago.utc))
-               .group(group_by_sql.to_sql)
-    sql = sql.includes(:resource => [:ext_management_system]) if @ems.blank?
-
-    sql.count
+    model.where(:ems_id => @ems.id)
+         .where(db_table[:created_on].gt(30.days.ago.utc))
+         .group(group_by_sql.to_sql)
+         .count
   end
 
   def format_data(ems_type, attributes, attr_icon, attr_url, attr_hsh)


### PR DESCRIPTION
The addition of `EmsDashboardService#recent_records` in https://github.com/ManageIQ/manageiq-ui-classic/pull/3427 causes an N+1, and seems to choke on the amazon provider because of the vast number of public images (`MiqTemplate` records) that are pulled in from a refresh.

This change provides a single query method for accomplishing the same task.  It is somewhat slow on a larger table (was testing with something around the size of 180k `MiqTemplate` records), but avoids any memory bloat entirely as we are only getting the counts.


Benchmarks
----------

Prior to this change, the `/ems_cloud_dashboard/recent_images_data/:id` route would not even complete a request on my machine.  This was running against a small Amazon provider that had ~77k images (most of which were probably just public images from the Amazon EC2 marketplace), and just hit that N+1 endless (I stopped after the request ran for an hour and puma process was using 5+ gigs of RAM).

After the change these are the results of a few refreshes against the Dashboard page:

```
GET    '/ems_cloud_dashboard/recent_images_data/4' 549ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 785ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 358ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 450ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 279ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 315ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 329ms
GET    '/ems_cloud_dashboard/recent_images_data/4' 364ms
```


Background
----------

The code previously would create an initial query of the following:

```SQL
SELECT "vms".*
FROM "vms"
WHERE "vms"."type" IN ('MiqTemplate', ...)
  AND "vms"."template"= 't'
  AND (created_on > '2018-01-01 00:00:00.000000' and ems_id = 1)
```

This means it fetches all of the `vms` table, which is 88 columns, for a given EMS and date range.  There is an addition of `.includes` in the original code as well, but I don't see how that was ever able to fire without an error as `@ems.id` would have most likely not worked, so the `@ems.blank?` check shouldn't have ever been triggered.

From this is triggered by the `records.sort_by(&:created_on)` in the previous code, since `sort_by` is just inherited from `Enumerable` in Ruby's stdlib.  It then calls a `.uniq` on the records, and then iterates over each record (I am pretty sure this `uniq` does not do anything, but can't be sure).

In the code, we then see `strftime` applied on to the only column that was actually needed for every row returned (besides the id), and then a subsequent query is executed on each record to get count of every record that matches that date (forgetting to do the original sort by `ems.id` as well).

All to return a hash that looks like this:

```ruby
{
  "2018-01-01" => 123,
  "2018-01-02" => 234,
  "2018-01-03" => 345,
}
```

* * *

The code change does all of this, but in SQL, only returning from the DB an array of 2 element arrays of the same hash as above, and then converts that array into a hash.

This is done in a single query then, and only instantiates enough data to then generate the hash, but 0 `ActiveRecord` objects are necessary.  String formatting is also done in the postgres format, which is equivalent to Ruby's (and C's) `"%Y-%m-%d"` format.


Links
-----

* Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3427
* Noticed when debugging https://bugzilla.redhat.com/show_bug.cgi?id=1610924


Steps for Testing/QA
--------------------

I believe at a minimum, the steps done for https://github.com/ManageIQ/manageiq-ui-classic/pull/3427 should be reviewed and confirm that the counts provided on the dashboard are now (or still) accurate.  I have some questions about the previous code that has made me skeptical of the results shown had skewed numbers.