### PR TITLE
Use .count, not .length, for better performance

### DIFF
--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -51,7 +51,7 @@ class EmsDashboardService < DashboardService
         :id           => attr_hsh[attr] + '_' + @ems_id,
         :iconClass    => attr_icon[attr],
         :title        => attr_hsh[attr],
-        :count        => @ems.send(attr).length,
+        :count        => @ems.send(attr).count,
         :href         => get_url(ems_type, @ems_id, attr_url[attr]),
         :notification => {
           :iconClass => 'pficon pficon-error-circle-o',

--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -48,7 +48,7 @@ class EmsDashboardService < DashboardService
     attr_data = []
     attributes.each do |attr|
       attr_data.push(
-        :id           => attr_hsh[attr] + '_' + @ems_id,
+        :id           => "#{attr_hsh[attr]}_#{@ems_id}",
         :iconClass    => attr_icon[attr],
         :title        => attr_hsh[attr],
         :count        => @ems.send(attr).count,


### PR DESCRIPTION
Vastly improves the `/ems_cloud_dashboard/aggregate_status_data/:id` route.

Benchmarks
----------

**Before**

```
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 12581ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 11285ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 11794ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 11783ms
```

**After**

```
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 921ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 481ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 273ms
GET    '/ems_cloud_dashboard/aggregate_status_data/:id' 390ms
```

Data run with a DB on my local machine using a small Amazon provider with ~77k images (most of them probably public images).


Background
----------

`.length` on an `ActiveRecord::Relation` object will trigger `ActiveRecord::Base#load`, which will execute the current query, and then do a count on that array-like object.

`.count` will make use of the database adapter's SQL `COUNT` call, and wrap the current `SELECT` statement in a `COUNT(...)`, which will only return the integer value for the number records that would have been returned if that query was otherwise run without the `COUNT`.

Since in this case, we are simply using this as an aggregation for a summary view, the `.count` method is vastly prefered over the `.length` as doing `.length` will instantiate all the `ActiveRecord` objects in memory for all of the records before counting the records in ruby.  Doing the same with `.count` not only is faster in ruby, but it is less strain on the DB as well, since it won't have to transmit almost any data over the wire as well.


Links
-----

* Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3427
* Related fix:  https://github.com/ManageIQ/manageiq-ui-classic/pull/4447
* Noticed when debugging https://bugzilla.redhat.com/show_bug.cgi?id=1610924


Steps for Testing/QA
--------------------

I believe at a minimum, the steps done for #3427 should be reviewed and confirm that the counts provided on the dashboard are now (or still) accurate.  I have some questions about the previous code that has made me skeptical of the results when original reviewed might have had skewed numbers.