### PR TITLE
Don't run set_global_session_data() for csp_report()

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,7 +82,7 @@ class ApplicationController < ActionController::Base
   before_action :set_user_time_zone
   before_action :set_gettext_locale
   before_action :allow_websocket
-  after_action :set_global_session_data, :except => [:resize_layout]
+  after_action :set_global_session_data, :except => %i(csp_report resize_layout)
 
   TIMELINES_FOLDER = Rails.root.join("product", "timelines")
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -492,6 +492,19 @@ describe DashboardController do
     end
   end
 
+  context 'skip_after_action :set_global_session_data' do
+    before do
+      _, _server, = EvmSpecHelper.create_guid_miq_server_zone
+      session[:edit] = "xyz"
+    end
+
+    it 'retains the existing value of session[:edit] after the POST request' do
+      post :csp_report, '{"csp-report":{"document-uri":"https://example.com/foo/bar"}}', :format => 'json'
+      expect(session[:edit]).to eq("xyz")
+      expect(response.status).to eq(200)
+    end
+  end
+
   def skip_data_checks(url = '/')
     allow_any_instance_of(UserValidationService).to receive(:server_ready?).and_return(true)
     allow(controller).to receive(:start_url_for_user).and_return(url)


### PR DESCRIPTION
`csp_report()` is meant to report policy violation, it should not be touching session data at all (othewise it would cause ugly side-effects, such as deleting the whole session).

@martinpovolny review please?