### PR TITLE
Add a tooltip to health state of the cards in the physical infra dashboard

### DIFF
--- a/app/services/ems_physical_infra_dashboard_service.rb
+++ b/app/services/ems_physical_infra_dashboard_service.rb
@@ -66,7 +66,7 @@ class EmsPhysicalInfraDashboardService < DashboardService
         :title        => attr_hsh[attr],
         :count        => ems_attr.length,
         :href         => get_url(@ems_id, attr_url[attr]),
-        :notification => notification_data(ems_attr)
+        :notification => notification_data(ems_attr, attr_hsh[attr])
       )
     end
     attr_data
@@ -101,39 +101,46 @@ class EmsPhysicalInfraDashboardService < DashboardService
     }
   end
 
-  def notification_data(attrs)
-    valid = 0
-    warning = 0
-    critical = 0
-    attrs.each do |attr|
-      next unless attr.respond_to?(:health_state)
-      case attr.health_state&.downcase
-      when 'critical'
-        critical += 1
-      when 'warning'
-        warning += 1
-      when 'valid'
-        valid += 1
-      end
-    end
-    if critical.positive?
-      icon_class = 'pficon pficon-error-circle-o'
-      count = critical
-    elsif warning.positive?
-      icon_class = 'pficon pficon-warning-triangle-o'
-      count = warning
-    elsif valid.positive?
-      icon_class = 'pficon pficon-ok'
-      count = valid
-    else
-      icon_class = 'pficon pficon-error-circle-o'
+  def notification_data(components, component_type)
+    if components&.first.respond_to?(:health_state)
       count = 0
-    end
+      health_states = components.group('lower(health_state)').count
+      health_states.default = 0
+      critical_count = health_states["critical"]
+      warning_count = health_states["warning"]
 
-    {
-      :iconClass => icon_class,
-      :count     => count,
+      if critical_count.positive?
+        icon_class = 'pficon pficon-error-circle-o'
+        count = critical_count
+        health_state = 'critical'
+      elsif warning_count.positive?
+        icon_class = 'pficon pficon-warning-triangle-o'
+        count = warning_count
+        health_state = 'warning'
+      else
+        health_state = 'valid'
+        icon_class = 'pficon pficon-ok'
+      end
+      tooltip_count = count.positive? ? count : components.count
+      {
+        :count     => count,
+        :iconClass => icon_class,
+        :tooltip   => format_tooltip(health_state, component_type.downcase, tooltip_count),
+      }
+    end
+  end
+
+  def format_tooltip(health_state, component_type, count)
+    tooltip_data = {
+      :count          => count,
+      :component_type => count > 1 ? component_type : component_type.singularize,
+      :health_state   => health_state,
     }
+    n_(
+      "%{count} %{component_type} is in %{health_state} state.",
+      "%{count} %{component_type} are in %{health_state} state.",
+      count
+    ) % tooltip_data
   end
 
   def servers_group

--- a/app/views/static/pf_charts/aggregate-status-card.html.haml
+++ b/app/views/static/pf_charts/aggregate-status-card.html.haml
@@ -46,7 +46,7 @@
 
   %div{:class => "card-pf-body"}
     %p{"ng-if" => "$ctrl.status.notification.iconImage || $ctrl.status.notification.iconClass || $ctrl.status.notification.count", :class => "card-pf-aggregate-status-notifications"}
-      %span{:class => "card-pf-aggregate-status-notification"}
+      %span{:class => "card-pf-aggregate-status-notification", :title => "{{$ctrl.status.notification.tooltip}}" }
         %a{"ng-if" => "$ctrl.status.notification.href", :href => "{{$ctrl$ctrl.status.notification.href}}"}
           %image{"ng-if" => "$ctrl.status.notification.iconImage", "ng-src" => "{{$ctrl.status.notification.iconImage}}", :alt => "", :class => "card-pf-icon-image"}
           %span{"ng-if" => "$ctrl.status.notification.iconClass", :class => "{{$ctrl.status.notification.iconClass}}"}
@@ -58,3 +58,7 @@
           %span{"ng-if" => "$ctrl.status.notification.iconClass", :class => "{{$ctrl.status.notification.iconClass}}"}
           %span{"ng-if" => "$ctrl.status.notification.count"}
             {{$ctrl.status.notification.count}}
+
+        %span{"ng-if" => "!$ctrl.status.notification.href && !$ctrl.status.notification.count"}
+          %image{"ng-if" =>"$ctrl.status.notification.iconImage", "ng-src" => "{{$ctrl.status.notification.iconImage}}", :alt => "", :class => "card-pf-icon-image"}
+          %span{"ng-if" => "$ctrl.status.notification.iconClass", :class => "{{$ctrl.status.notification.iconClass}}"}


### PR DESCRIPTION
This pr is able to:
* Remove the redundant number if all components are healthy.
**Before**
![tooltip-img-3](https://user-images.githubusercontent.com/12627705/43971914-22e1fb2a-9ca9-11e8-8962-8b27c13b0a4a.jpg)
**After**
![screenshot-localhost-3000-2018 08 10-14-34-28](https://user-images.githubusercontent.com/12627705/43972319-546f5920-9caa-11e8-9da7-7bff337da7fc.png)

* Add a tooltip in the health state icon in the provider dasborad
![tooltip-img2](https://user-images.githubusercontent.com/12627705/43971835-ef4b0e5a-9ca8-11e8-9a6e-c1ab162e5fab.gif)


 