### PR TITLE
Fix typo in detach_volume error handling

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -149,8 +149,8 @@ class CloudVolumeController < ApplicationController
           javascript_flash(:spinner_off => true)
         end
       else
-        add_flash(_(volume.is_available_now_error_message(:detach_volume)), :error)
-        javascript_flash
+        add_flash(_(@volume.is_available_now_error_message(:detach_volume)), :error)
+        javascript_flash(:spinner_off => true)
       end
     end
   end


### PR DESCRIPTION
This fixes a typo in `detach_volume` which was leading to an exception being thrown when a volume was unavailable for detach. Fixes one of the symptoms present in https://bugzilla.redhat.com/show_bug.cgi?id=1544344