### PR TITLE
Added alias to react package.

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -107,6 +107,7 @@ module.exports = {
   },
 
   resolve: {
+    alias: { 'react': resolve(dirname(__filename), '../../node_modules', 'react') },
     extensions: settings.extensions,
     modules: [],
     plugins: [


### PR DESCRIPTION
I have found another issue with multiple copies of react. This time it was affecting the `react-select` component (specifically the multi select variant). Issues are described in #4430.

Adding alias to react package in webpack resolved the issue. Webpack will now always use react package installed in ui-classic node_modules.