### PR TITLE
Expose redux routing actions

### DIFF
--- a/app/javascript/miq-redux/redux-router-actions.js
+++ b/app/javascript/miq-redux/redux-router-actions.js
@@ -1,0 +1,11 @@
+import { push, replace, go, goBack, goForward } from 'connected-react-router';
+
+const createReduxRoutingActions = ({ dispatch }) => ({
+  push: where => dispatch(push(where)),
+  replace: where => dispatch(replace(where)),
+  go: howMany => dispatch(go(howMany)),
+  goBack: () => dispatch(goBack()),
+  goForward: () => dispatch(goForward()),
+});
+
+export default createReduxRoutingActions;

--- a/app/javascript/miq-redux/redux-router-actions.test.js
+++ b/app/javascript/miq-redux/redux-router-actions.test.js
@@ -1,0 +1,65 @@
+import configureStore from 'redux-mock-store';
+import { connectRouter } from 'connected-react-router';
+import createReduxRoutingActions from './redux-router-actions';
+import { createMiddlewares } from './middleware.ts';
+import { history } from '../miq-component/react-history.ts';
+
+describe('Redux routing actions', () => {
+  const mockStore = configureStore(createMiddlewares(history));
+  let store;
+  let dispatchSpy;
+  let expectedPayload;
+
+  beforeAll(() => {
+    expectedPayload = {
+      payload: {
+      },
+      type: '@@router/CALL_HISTORY_METHOD',
+    };
+  });
+
+  beforeEach(() => {
+    store = mockStore(connectRouter(history)(() => {}));
+    dispatchSpy = jest.spyOn(store, 'dispatch');
+  });
+
+  it('Should dispatch push action', () => {
+    const { push } = createReduxRoutingActions(store);
+    expectedPayload.payload.args = ['/foo'];
+    expectedPayload.payload.method = 'push';
+    push('/foo');
+    expect(dispatchSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('Should dispatch replace action', () => {
+    const { replace } = createReduxRoutingActions(store);
+    expectedPayload.payload.args = ['/foo'];
+    expectedPayload.payload.method = 'replace';
+    replace('/foo');
+    expect(dispatchSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('Should dispatch go action', () => {
+    const { go } = createReduxRoutingActions(store);
+    expectedPayload.payload.args = [2];
+    expectedPayload.payload.method = 'go';
+    go(2);
+    expect(dispatchSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('Should dispatch goBack action', () => {
+    const { goBack } = createReduxRoutingActions(store);
+    expectedPayload.payload.args = [];
+    expectedPayload.payload.method = 'goBack';
+    goBack();
+    expect(dispatchSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('Should dispatch goForward action', () => {
+    const { goForward } = createReduxRoutingActions(store);
+    expectedPayload.payload.args = [];
+    expectedPayload.payload.method = 'goForward';
+    goForward();
+    expect(dispatchSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+});

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -20,6 +20,7 @@ import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
 
 import { store, addReducer } from '../miq-redux';
 import { history } from '../miq-component/react-history.ts';
+import createReduxRoutingActions from '../miq-redux/redux-router-actions';
 
 ManageIQ.react = {
   mount,
@@ -36,6 +37,7 @@ ManageIQ.redux = {
   store,
   addReducer,
   history,
+  ...createReduxRoutingActions(store),
 };
 
 ManageIQ.angular.rxSubject = rxSubject;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
+    "redux-mock-store": "^1.5.3",
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
     "rxjs": "~5.6.0-forward-compat.2",


### PR DESCRIPTION
Added routing actions to ManageIQ.redux interface. These should be called only outside of react components if you need to do some react routing (miqTreeController for example).