### PR TITLE
[WIP] Fix displaying extra flash messages after canceling provisioning

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -76,7 +76,7 @@ module ApplicationController::MiqRequestMethods
   # Pre provisioning, select a template
   def pre_prov
     if params[:button] == "cancel"
-      flash_to_session(_("Add of new %{type} Request was cancelled by the user") % {:type => session[:edit][:prov_type]})
+      add_flash(_("Add of new %{type} Request was cancelled by the user") % {:type => session[:edit][:prov_type]})
       @explorer = session[:edit][:explorer] ? session[:edit][:explorer] : false
       @edit = session[:edit] =  nil                                               # Clear out session[:edit]
       prov_request_cancel_submit_response


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1611612

---

**What:**
There is a problem after canceling VM/Instance provisioning: Empty extra flash message is displayed in the screen. This PR simply fixes the problem, by calling `add_flash` method instead of `flash_to_session`.

**Steps to reproduce:**
1. Go to _Compute > Infra > VMs_ or _Compute > Clouds > Instances_
2. _Lifecycle > Provision VMs/Provision Instances_
3. Click on _Cancel_ button to cancel provisioning

---

**Before:**
![prov_before](https://user-images.githubusercontent.com/13417815/44024962-0b6645ee-9eef-11e8-909e-25b9ed600b09.png)

**After:**
![prov_after](https://user-images.githubusercontent.com/13417815/44024963-0b856b4a-9eef-11e8-9244-2a252203bda0.png)