### PR TITLE
Use new registry even for older bower versions

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "vendor/assets/bower/bower_components"
+  "directory": "vendor/assets/bower/bower_components",
+  "registry":  "https://registry.bower.io"
 }


### PR DESCRIPTION
Use new registry even for older bower versions.

[source](https://bower.herokuapp.com/)

@himdel @Hyperkid123 