### PR TITLE
Remove main_div and flash_msg_div from label_tag_mapping_form

### DIFF
--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -1,47 +1,45 @@
 - url = url_for_only_path(:action => 'label_tag_mapping_field_changed', :id => @lt_map && @lt_map.id ? @lt_map.id.to_s : "new")
-#main_div
-  = render :partial => "layouts/flash_msg"
-  = form_tag({:action => 'label_tag_mapping_update'},
-             {:id     => "label_tag_mapping_form",
-              :class  => "form-horizontal",
-              :method => :post}) do
-    - disabled = !@lt_map.nil?
-    - if disabled
-      %h3= _("Resource entity and label")
-    - else
-      %h3= _("Choose a resource entity and label")
-    .form-group
-      %label.col-md-2.control-label
-        = _("Entity")
-      .col-md-8
-        = select_tag('entity',
-                     options_for_select(@edit[:new][:options],
-                                        @edit[:new][:entity]),
-                                        :class    => "selectpicker",
-                                        :disabled => disabled)
-      :javascript
-        miqInitSelectPicker();
-        miqSelectPickerEvent('entity', "#{url}")
-    .form-group
-      %label.col-md-2.control-label
-        = _("Label")
-      .col-md-8
-        = text_field_tag("label_name", @edit[:new][:label_name],
-                         :maxlength         => 25,
-                         :class             => "form-control",
-                         :disabled          => disabled,
-                         "data-miq_observe" => {:interval => '.5',
-                                                :url      => url}.to_json)
-    %h3= _("Choose a tag category to map to")
-    .form-group
-      %label.col-md-2.control-label
-        = _("Category")
-      .col-md-8
-        = text_field_tag("category", @edit[:new][:category],
-                         :maxlength         => 50,
-                         :class             => "form-control",
-                         "data-miq_observe" => {:interval => '.5',
-                                                :url      => url}.to_json)
-    .form-group
-      %label.col-md-2.control-label
-      .col-md-8
+= form_tag({:action => 'label_tag_mapping_update'},
+           {:id     => "label_tag_mapping_form",
+            :class  => "form-horizontal",
+            :method => :post}) do
+  - disabled = !@lt_map.nil?
+  - if disabled
+    %h3= _("Resource entity and label")
+  - else
+    %h3= _("Choose a resource entity and label")
+  .form-group
+    %label.col-md-2.control-label
+      = _("Entity")
+    .col-md-8
+      = select_tag('entity',
+                   options_for_select(@edit[:new][:options],
+                                      @edit[:new][:entity]),
+                                      :class    => "selectpicker",
+                                      :disabled => disabled)
+    :javascript
+      miqInitSelectPicker();
+      miqSelectPickerEvent('entity', "#{url}")
+  .form-group
+    %label.col-md-2.control-label
+      = _("Label")
+    .col-md-8
+      = text_field_tag("label_name", @edit[:new][:label_name],
+                       :maxlength         => 25,
+                       :class             => "form-control",
+                       :disabled          => disabled,
+                       "data-miq_observe" => {:interval => '.5',
+                                              :url      => url}.to_json)
+  %h3= _("Choose a tag category to map to")
+  .form-group
+    %label.col-md-2.control-label
+      = _("Category")
+    .col-md-8
+      = text_field_tag("category", @edit[:new][:category],
+                       :maxlength         => 50,
+                       :class             => "form-control",
+                       "data-miq_observe" => {:interval => '.5',
+                                              :url      => url}.to_json)
+  .form-group
+    %label.col-md-2.control-label
+    .col-md-8


### PR DESCRIPTION
This is to address the duplicate div warning shown on Settings -> [Region] -> Tags -> Map Tags -> Add

Both `main_div` and `flash_msg_div` are already present in the tree. The partial is only rendered from presenter in ops controller (i.e. it doesn't seem to be included from anywhere).