### PR TITLE
Fix rendering of child orchestration stacks

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -24,6 +24,10 @@ class OrchestrationStackController < ApplicationController
                     :url  => show_link(@record, :display => @display))
   end
 
+  def display_children
+    show_association('children', _('Children'), :children, OrchestrationStack)
+  end
+
   def show_list
     process_show_list(
       :named_scope => [[:without_type, 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job']]


### PR DESCRIPTION
Compute ➛ Cloud ➛ Stacks ➛ Find a stack with child stacks ➛ In summary, click on child stacks

Before, the action would give the following error:

```
Error caught: [NameError] uninitialized constant Child
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/inflector/methods.rb:268:in `const_get'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/inflector/methods.rb:268:in `block in constantize'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/inflector/methods.rb:266:in `each'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/inflector/methods.rb:266:in `inject'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/inflector/methods.rb:266:in `constantize'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
manageiq-ui-classic/app/controllers/mixins/generic_show_mixin.rb:138:in `display_nested_generic'
manageiq-ui-classic/app/controllers/mixins/generic_show_mixin.rb:134:in `display_nested_list'
manageiq-ui-classic/app/controllers/mixins/generic_show_mixin.rb:29:in `show'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1610252