### PR TITLE
Add tenant filtering for templates in provisioning and summary pages

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -163,7 +163,7 @@ module Mixins
     end
 
     def display_images
-      nested_list(ManageIQ::Providers::CloudManager::Template, :named_scope => :without_volume_templates)
+      nested_list(ManageIQ::Providers::CloudManager::Template, :named_scope => :filtered_without_volume_templates)
     end
 
     # options:

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1056,7 +1056,7 @@ module VmCommon
     else      # Get list of child VMs of this node
       options = {:model => model}
       if model == "ManageIQ::Providers::CloudManager::Template"
-        options[:named_scope] = [:without_volume_templates]
+        options[:named_scope] = [:filtered_without_volume_templates]
       end
       if x_node == "root"
         if x_active_tree == :vandt_tree

--- a/app/services/ems_cloud_dashboard_service.rb
+++ b/app/services/ems_cloud_dashboard_service.rb
@@ -37,7 +37,7 @@ class EmsCloudDashboardService < EmsDashboardService
     attr_url = {
       :flavors            => "flavors",
       :cloud_tenants      => "cloud_tenants",
-      :miq_templates      => "miq_templates",
+      :miq_templates      => "images",
       :vms                => "vms",
       :availability_zones => "availability_zones",
       :security_groups    => "security_groups",


### PR DESCRIPTION
This PR adds tenant filtering for templates in provisioning and summary pages. I added new named scopes and made dashboard route to `images` summary instead of `miq_templates`.
https://bugzilla.redhat.com/show_bug.cgi?id=1524368
https://bugzilla.redhat.com/show_bug.cgi?id=1598520
https://bugzilla.redhat.com/show_bug.cgi?id=1546539


@aufi 