### PR TITLE
Do not rely on decorators when displaying top-level policy folders

### DIFF
--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -26,12 +26,14 @@
         - if %w(Compliance Control).include?(f)
           - model_name = f.split.first
           - click = f.downcase
+          - klass = f == 'Compliance' ? 'pficon pficon-history fa-fw' : 'fa fa-shield fa-fw'
         - else
           - model_name = f.split[0..-2].join.camelize(:lower)
           - type = f.split[-1].downcase
           - click = "#{type}_xx-#{type}-#{model_name}"
+          - klass = model_name.camelize.safe_constantize.try(:decorate).try(:fonticon)
         %tr{:onclick => "miqTreeActivateNode('policy_tree', 'xx-#{click}');", :title => _("Open Folder")}
           %td.table-view-pf-select
-            %i{:class => model_name.camelize.safe_constantize.try(:decorate).try(:fonticon)}
+            %i{:class => klass}
           %td
             = folders_i18n[f]


### PR DESCRIPTION
There are no models behind the control/compliance policies, so there are no decorators and for now there's no better way to solve this. I added the `fa-fw` class on both icons as the shield was looking bad without it.

**Before:**
![screenshot from 2018-08-14 15-35-26](https://user-images.githubusercontent.com/649130/44095064-2111cb0e-9fd8-11e8-956a-deaa4cc07eee.png)

**After:**
![screenshot from 2018-08-14 15-35-08](https://user-images.githubusercontent.com/649130/44095072-2480869a-9fd8-11e8-86a9-3900033e809e.png)

@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, gaprindashvili/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615814