### PR TITLE
Display the correct quadicon for ReFS and StorageFileShare datastores

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -51,7 +51,7 @@ class StorageDecorator < MiqDecorator
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
     when 'iscsi'
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
-    when 'ntfs'
+    when 'cvsfs', 'ntfs', 'refs', 'storagefileshare'
       {:fileicon => 'svg/vendor-microsoft.svg'}
     when 'glusterfs'
       {:fileicon => 'svg/vendor-gluster.svg'}


### PR DESCRIPTION
These storage types are also SCVMM-related and they should display the microsoft icon. 

@miq-bot add_label bug, GTLs, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 
@miq-bot assign @mzazrivec 

**Before:**
![screenshot from 2018-08-14 16-21-50](https://user-images.githubusercontent.com/649130/44097485-2c6cfa18-9fde-11e8-9677-2501bf78bd06.png)

**After:**
![screenshot from 2018-08-14 16-07-53](https://user-images.githubusercontent.com/649130/44096756-538be89a-9fdc-11e8-864d-f80b87cf6b55.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615441