### PR TITLE
Added missing 'public_service_templates' scope

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1784,7 +1784,7 @@ class CatalogController < ApplicationController
   end
 
   def get_node_info_handle_unassigned_node
-    scope = [[:without_service_template_catalog_id]]
+    scope = [:public_service_templates, [:without_service_template_catalog_id]]
     service_template_list(scope, :no_order_button => true)
     @right_cell_text = _("Services in Catalog \"Unassigned\"")
   end


### PR DESCRIPTION
Added 'public_service_templates' scope when fetching right side list for unassigned folder node

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594408

before:
![before](https://user-images.githubusercontent.com/3450808/44098496-59fbf450-9fae-11e8-8722-16665d9d0a75.png)

after:
![after](https://user-images.githubusercontent.com/3450808/44098499-5efae268-9fae-11e8-9aec-617cb7f868fe.png)

@hsong-rh @bzwei please review