### PR TITLE
Add groupdate dependency

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.2"
+  s.add_dependency "groupdate", "~> 4.0.1"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "more_core_extensions", "~>3.2"


### PR DESCRIPTION
This PR adds the groupdate gem to the list of dependencies. With this we can do nice things like:

`Vm.group_by_day(:created_on, :range => 3.days.ago.utc..Time.now.utc, :format => '%Y-%m-%d').count`

For more information on the groupdate gem, please visit https://github.com/ankane/groupdate.

Part one of a solution for ManageIQ/manageiq-ui-classic#4447