### PR TITLE
Move webmks console button to instance operations button mixin

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -115,6 +115,15 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :url   => "html5_console",
             :klass => ApplicationHelper::Button::VmVncConsole),
           included_class.button(
+            :vm_webmks_console,
+            'pficon pficon-screen fa-lg',
+            N_('Open a web-based WebMKS console for this VM'),
+            N_('VM Console'),
+            :url     => "console",
+            :confirm => N_("Open a WebMKS console for this VM"),
+            :klass   => ApplicationHelper::Button::VmWebmksConsole
+          ),
+          included_class.button(
             :cockpit_console,
             'pficon pficon-screen fa-lg',
             N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -208,35 +208,4 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
     ),
   ])
   include ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
-  button_group(
-    'vm_access',
-    [
-      select(
-        :vm_remote_access_choice,
-        'fa pficon-screen fa-lg',
-        N_('VM Remote Access'),
-        N_('Access'),
-        :items => [
-          button(
-            :vm_webmks_console,
-            'pficon pficon-screen fa-lg',
-            N_('Open a web-based WebMKS console for this VM'),
-            N_('VM Console'),
-            :url     => "console",
-            :confirm => N_("Open a WebMKS console for this VM"),
-            :klass   => ApplicationHelper::Button::VmWebmksConsole
-          ),
-          # TODO: remove cockpit button because backend isn't implemented yet.
-          button(
-            :cockpit_console,
-            'pficon pficon-screen fa-lg',
-            N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-            N_('Web Console'),
-            :url   => "launch_cockpit",
-            :klass => ApplicationHelper::Button::CockpitConsole
-          )
-        ]
-      )
-    ]
-  )
 end


### PR DESCRIPTION
The `button_group('vm_access')` defined in `x_vm_cloud_center.rb` overrides the same group created in the `InstanceOperationsButtonGroupMixin` that is being included just before. Therefore, the remote console button for OpenStack instances is missing. By moving the webmks console to the `InstanceOperationsButtonGroupMixin` and dropping the `button_group` the issue is fixed.

**Before:**
![screenshot from 2018-08-16 12-03-52](https://user-images.githubusercontent.com/649130/44202508-778b3b80-a14c-11e8-9c9c-b3504ce9b53f.png)

**After:**
![screenshot from 2018-08-16 12-01-06](https://user-images.githubusercontent.com/649130/44202459-50cd0500-a14c-11e8-8c08-d231213f40fb.png)

@miq-bot add_label bug, toolbars
@miq-bot add_reviewer @mzazrivec 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615796