### PR TITLE
Worflow Templates do not have job_plays and raw_stdout_via_worker

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -67,6 +67,7 @@ module ServiceHelper::TextualSummary
 
   def textual_group_tower_job_plays
     return nil unless fetch_job
+    return nil unless @job.respond_to?(:job_plays)
     fetch_job_plays
   end
 

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -41,7 +41,7 @@
       - if @record.type == "ServiceAnsibleTower"
         = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
-          - if job
+          - if job && job.respond_to?(:raw_stdout_via_worker)
             %ansible-raw-stdout#service_detail_ansible_tower_job{'task-id' => @record.job.raw_stdout_via_worker(nil, 'html')}
             :javascript
               miq_bootstrap('#service_detail_ansible_tower_job');


### PR DESCRIPTION
Added a check in code to not try to show "Plays" section and load standard output for workflow template type services.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/4444

Ansible Playbook Service details
![ansible_playbook_service](https://user-images.githubusercontent.com/3450808/44224024-48c69280-a157-11e8-80fa-fa64a923f9ab.png)

Workflow Template Service details
![workflow_template_service](https://user-images.githubusercontent.com/3450808/44224032-4d8b4680-a157-11e8-9ca5-3ec94e489cb9.png)

@lfu please review/test