### PR TITLE
use request_admin_user

### DIFF
--- a/app/helpers/application_helper/button/miq_request_delete.rb
+++ b/app/helpers/application_helper/button/miq_request_delete.rb
@@ -4,7 +4,7 @@ class ApplicationHelper::Button::MiqRequestDelete < ApplicationHelper::Button::M
 
   def disabled?
     requester = current_user
-    return false if requester.role_allows?(:feature => "miq_request_superadmin")
+    return false if requester.miq_user_role.request_admin_user?
     @error_message = _("Users are only allowed to delete their own requests") if requester.name != @record.requester_name
     if %w(approved denied).include?(@record.approval_state)
       @error_message = _("%{approval_states} requests cannot be deleted") %


### PR DESCRIPTION
correcting 1 line from #3993

related: https://github.com/ManageIQ/manageiq/pull/17849

This uses a helper method instead of calling out the the `miq_request_approval` role.
(yes, if you notice, this change will effectively change the feature from `miq_request_superadmin` to
`miq_request_approval` - since that feature was erroneously introduced.

https://bugzilla.redhat.com/show_bug.cgi?id=1608554

