### PR TITLE
Fixed to use bootstrap select event instead of UJS observer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1650,7 +1650,7 @@ class CatalogController < ApplicationController
           @group_changed = false
           @edit[:new][:rsc_groups].each_with_index do |groups, i|
             groups.each do |g|
-              if g[:id] == rid
+              if g[:id].to_i == rid.to_i
                 @edit[:new][:rsc_groups][val.to_i - 1].push(g)
                 @edit[:new][:rsc_groups][i].delete(g)
                 @group_changed = true

--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -63,36 +63,42 @@
                   - else
                     = select_tag("gidx_#{sr[:id]}",
                       options_for_select((1..@edit[:new][:rsc_groups].length).to_a, (i + 1).to_s),
-                      "data-miq_sparkle_on" => true,
-                      "data-miq_observe" => {:url => url}.to_json)
+                      "data-miq_sparkle_on" => true)
+                    :javascript
+                      miqSelectPickerEvent('gidx_#{sr[:id]}', '#{url}')
                 %td
                   - if @edit[:new][:selected_resources].length <= 1
                     = h(@edit[:new][:selected_resources].length)
                   - else
                     = select_tag("provision_index_#{i}_#{k}",
                       options_for_select((1..@edit[:new][:provision_order].length).to_a, (sr[:provision_index] + 1).to_s),
-                      "data-miq_sparkle_on" => true,
-                      "data-miq_observe" => {:url => url}.to_json)
+                      "data-miq_sparkle_on" => true)
+                    :javascript
+                      miqSelectPickerEvent('provision_index_#{i}_#{k}', '#{url}')
                 - start_action_values = [_('Do Nothing'), _('Power On')]
                 - stop_action_values = [_('Do Nothing'), _('Suspend'), _('Shutdown'), _('Power Off')]
                 - delay_values = [[_("None"), 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [10, 10], [20, 20], [30, 30], [40, 40], [50, 50], [60, 60]]
                 %td
                   = select_tag("start_action_#{i}_#{k}",
                     options_for_select(start_action_values, sr[:start_action]),
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_observe" => {:url => url}.to_json)
+                    "data-miq_sparkle_on" => true)
+                  :javascript
+                    miqSelectPickerEvent('start_action_#{i}_#{k}', '#{url}')
                 %td
                   = select_tag("stop_action_#{i}_#{k}",
                     options_for_select(stop_action_values, sr[:stop_action]),
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_observe" => {:url => url}.to_json)
+                    "data-miq_sparkle_on" => true)
+                  :javascript
+                    miqSelectPickerEvent('stop_action_#{i}_#{k}', '#{url}')
                 %td
                   = select_tag("start_delay_#{i}_#{k}",
                     options_for_select(delay_values, (sr[:start_delay] / 60).to_s),
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_observe" => {:url => url}.to_json)
+                    "data-miq_sparkle_on" => true)
+                  :javascript
+                    miqSelectPickerEvent('start_delay_#{i}_#{k}', '#{url}')
                 %td
                   = select_tag("stop_delay_#{i}_#{k}",
                     options_for_select(delay_values, (sr[:stop_delay] / 60).to_s),
-                    "data-miq_sparkle_on" => true,
-                    "data-miq_observe" => {:url => url}.to_json)
+                    "data-miq_sparkle_on" => true)
+                  :javascript
+                    miqSelectPickerEvent('stop_delay_#{i}_#{k}', '#{url}')


### PR DESCRIPTION
Using old leftover UJS observers on the drop downs was causing form to send up multipe transaction when a selection was made in drop downs, causing other issues in the form.
convert id to_i to make sure the comparison of is between same types

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615853

@dclarizio Attached a video in the BZ that verifies the fix.

@lgalis can you please review/verify fix.