### PR TITLE
Add support for links to a details page in the notification drawer

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -116,6 +116,10 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.markRead(notification, group);
   };
 
+  vm.customScope.viewSubjectDetails = function(notification) {
+    eventNotifications.viewDetails(notification);
+  }
+
   vm.customScope.clearNotification = function(notification, group) {
     eventNotifications.clear(notification, group);
   };

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -1,9 +1,9 @@
 angular.module('miq.notifications')
   .service('eventNotifications', eventNotifications);
 
-eventNotifications.$inject = ['$timeout', 'API'];
+eventNotifications.$inject = ['$timeout', '$window', '$httpParamSerializerJQLike', 'API'];
 
-function eventNotifications($timeout, API) {
+function eventNotifications($timeout, $window, $httpParamSerializerJQLike, API) {
   if (! ManageIQ.angular.eventNotificationsData) {
     ManageIQ.angular.eventNotificationsData = {
       state: {
@@ -129,6 +129,8 @@ function eventNotifications($timeout, API) {
       type: levelToType(type),
       message: message,
       data: notificationData,
+      actionTitle: notificationData.link ? __('View details') : undefined,
+      actionCallback: notificationData.link ? this.viewDetails : undefined,
       href: id ? window.location.origin + '/api/notifications/' + id : undefined,
       timeStamp: (new Date()).getTime(),
     };
@@ -200,6 +202,10 @@ function eventNotifications($timeout, API) {
       });
     }
     notifyObservers();
+  };
+
+  this.viewDetails = function(notification) {
+    $window.location.href = '/restful_redirect?' + $httpParamSerializerJQLike(notification.data.link);
   };
 
   this.markUnread = function(notification, group) {

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -88,7 +88,7 @@ function eventNotifications($timeout, API) {
             type: resource.details.level,
             message: msg,
             data: {
-              message: msg,
+              link: _.get(resource.details, 'bindings.link'),
             },
             href: resource.href,
             timeStamp: resource.details.created_at,
@@ -327,7 +327,7 @@ function eventNotifications($timeout, API) {
   listenToRx(function(data) {
     if (data.notification) {
       var msg = miqFormatNotification(data.notification.text, data.notification.bindings);
-      _this.add('event', data.notification.level, msg, {message: msg}, data.notification.id);
+      _this.add('event', data.notification.level, msg, {link: _.get(data.notification, 'bindings.link')}, data.notification.id);
     }
   });
 }

--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -1,4 +1,6 @@
 class RestfulRedirectController < ApplicationController
+  before_action :check_privileges
+
   def index
     case params[:model]
     when 'MiqRequest'
@@ -12,8 +14,8 @@ class RestfulRedirectController < ApplicationController
                    end
       redirect_to :controller => controller, :action => 'show', :id => params[:id]
     else
-      flash_to_session(_("Could not find %{model}[id=%{id}]") % {:model => params[:model], :id => params[:id]})
-      redirect_to(:controller => 'dashboard')
+      flash_to_session(_("Could not find the given \"%{model}\" record.") % {:model => ui_lookup(:model => params[:model])}, :error)
+      redirect_to(:controller => 'dashboard', :action => 'show')
     end
   end
 end

--- a/app/views/static/notification_drawer/notification-body.html.haml
+++ b/app/views/static/notification_drawer/notification-body.html.haml
@@ -1,63 +1,28 @@
-%div{"ng-if"    => "!drawerExpanded",
-     "ng-click" => "customScope.markNotificationRead(notification, notificationGroup)"}
-  %div.dropdown.pull-right.dropdown-kebab-pf
-    %button.btn.btn-link.dropdown-toggle{:type      => "button",
-                                         "ng-click" => "customScope.clearNotification(notification, notificationGroup)"}
-      %span.pficon.pficon-close
-  %span.pull-left{"ng-class" => "customScope.getNotficationStatusIconClass(notification)"}
-  %span.drawer-pf-notification-message.notification-message{"tooltip-popup-delay" => "500",
-                                                            "tooltip-placement"   => "bottom",
-                                                            "uib-tooltip"         => "{{notification.data.message}}"}
-    {{notification.data.message}}
-  .drawer-pf-notification-info{"ng-if" => "!notification.data.inProgress"}
-    %span.date
-      {{notification.timeStamp | date:'MM/dd/yyyy'}}
-    %span.time
-      {{notification.timeStamp | date:'h:mm:ss a'}}
-  .mini-progress.clearfix{"ng-if" => "notification.data.inProgress"}
-    %span.time
-      {{notification.timeStamp | date:'h:mm:ss a'}}
-    .mini-progress-area
-      .progress
-        %span.progress-bar.progress-bar-info{"ng-style"    => "{ width: notification.data.percentComplete + '%' }",
-                                             "uib-tooltip" => "{{notification.data.percentComplete}} #{_("% Complete")}"}
-
-.container-fluid.expanded-notification{"ng-if"    => "drawerExpanded",
-                                       "ng-click" => "customScope.markNotificationRead(notification, notificationGroup)"}
-  .row
-    .col-sm-6{"ng-class" => "{ 'col-md-4': notificationGroup.notificationType == 'task' }"}
-      %span.pull-left{"ng-class" => "customScope.getNotficationStatusIconClass(notification)"}
-      %span.drawer-pf-notification-message.notification-message{"tooltip-append-to-body" => "true",
-                                                                "tooltip-popup-delay"    => "500",
-                                                                "tooltip-placement"      => "bottom",
-                                                                "uib-tooltip"            => "{{notification.data.message}}"}
-        {{notification.data.message}}
-    .col-md-4.col-sm-3{"ng-if" => "notificationGroup.notificationType == 'task'"}
-      .drawer-pf-notification-info.expanded-info
-        %span.info-title
-          = _("Started:")
-        %span.date
-          {{notification.data.startTime | date:'MM/dd/yyyy'}}
-        %span.time
-          {{notification.data.startTime | date:'h:mm:ss a'}}
-      .progress{"ng-if" => "notification.data.inProgress"}
-        .progress-bar.progress-bar-info{"ng-style"    => "{ width: notification.data.percentComplete + '%' }",
-                                        "uib-tooltip" => "{{notification.data.percentComplete}} #{_("% Complete")}"}
-    .col-md-4.col-sm-3{"ng-if" => "notificationGroup.notificationType == 'task'"}
-      .drawer-pf-notification-info
-        %span.info-title
-          = _("Completed:")
-        %span.date
-          {{notification.data.endTime | date:'MM/dd/yyyy'}}
-        %span.time
-          {{notification.data.endTime | date:'h:mm:ss a'}}
-    .col-sm-6{"ng-if" => "notificationGroup.notificationType == 'event'"}
-      .drawer-pf-notification-info
-        %span.date
-          {{notification.data.timeStamp | date:'MM/dd/yyyy'}}
-        %span.time
-          {{notification.data.timeStamp | date:'h:mm:ss a'}}
-      .pull-right.dropdown-kebab-pf
-        %button.btn.btn-link.dropdown-toggle{:type      => "button",
-                                             "ng-click" => "customScope.clearNotification(notification, notificationGroup)"}
-          %span.pficon.pficon-close
+%div{"ng-if" => "!drawerExpanded"}
+  .dropdown.pull-right.dropdown-kebab-pf{'uib-dropdown' => ''}
+    %button.btn.btn-link.dropdown-toggle{'uib-dropdown-toggle' => '',
+                                         :type                 => 'button',
+                                         :id                   => 'dropdownKebabRight-{{ notification.id }}',
+                                         'aria-haspopup'       => 'true',
+                                         'aria-expanded'       => 'false'}
+      %span.fa.fa-ellipsis-v
+    %ul.dropdown-menu.dropdown-menu-right{'aria-labelledby' => 'dropdownKebabRight-{{ notification.id }}'}
+      %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.unread}"}
+        %a.secondary-action{:title => _('Mark as read'), 'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
+          = _('Mark as read')
+      %li{:role => 'menuitem'}
+        %a.secondary-action{:title => _('Remove'), 'ng-click' => 'customScope.clearNotification(notification, notificationGroup)'}
+          = _('Remove')
+  %span.pull-left{'ng-class' => 'customScope.getNotficationStatusIconClass(notification)',
+                  'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
+  .drawer-pf-notification-content{'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
+    %span.drawer-pf-notification-message{'uib-tooltip-append'      => true,
+                                         'uib-tooltip-popup-delay' => 500,
+                                         'uib-tooltip-placement'   => 'bottom',
+                                         'uib-tooltip'             => '{{ notification.message }}'}
+      {{ notification.message }}
+    .drawer-pf-notification-info{'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
+      %span.date
+        {{ notification.timeStamp | date:'MM/dd/yyyy' }}
+      %span.time
+        {{ notification.timeStamp | date:'h:mm:ss a' }}

--- a/app/views/static/notification_drawer/notification-body.html.haml
+++ b/app/views/static/notification_drawer/notification-body.html.haml
@@ -7,6 +7,10 @@
                                          'aria-expanded'       => 'false'}
       %span.fa.fa-ellipsis-v
     %ul.dropdown-menu.dropdown-menu-right{'aria-labelledby' => 'dropdownKebabRight-{{ notification.id }}'}
+      %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.data.link}"}
+        %a.secondary-action{:title => _('View details'), 'ng-click' => 'customScope.viewSubjectDetails(notification)'}
+          = _('View details')
+      %li.divider{:role => 'separator'}
       %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.unread}"}
         %a.secondary-action{:title => _('Mark as read'), 'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
           = _('Mark as read')


### PR DESCRIPTION
The angular-patternfly has a new notification-body template example for the [notification drawer](https://www.patternfly.org/angular-patternfly/#/api/patternfly.notification.component:pfNotificationDrawer) that displays a kebab on the right side of a notification with all the available actions inside.

![screenshot from 2018-08-17 11-15-05](https://user-images.githubusercontent.com/649130/44258308-d2856700-a20e-11e8-8c7f-92d6323df3dc.png)

For now we supported just two actions: marking a notification as read (by clicking on it) and removing the notification (by clicking on the `x`). However, the plan is to support at least one extra action to redirect the user to a page where the user can see more details.

![screenshot from 2018-08-17 11-18-46](https://user-images.githubusercontent.com/649130/44258488-563f5380-a20f-11e8-8491-22a107332d36.png)

After the changes it will have the three actions inside the kebab, where the new View Details should redirect to the subject's screen:
![screenshot from 2018-08-17 12-57-45](https://user-images.githubusercontent.com/649130/44262934-2a2acf00-a21d-11e8-8d14-848344852109.png)

For the toasts, it will have an extra `View details` link that does the same:
![screenshot from 2018-08-21 10-26-57](https://user-images.githubusercontent.com/649130/44390089-c5c58380-a52c-11e8-8ebd-c77970bd488d.png)

Unfortunately, it is not possible to hide the link if the subject has an actual page to redirect to, so if the user clicks on the `View Details` for a such record, it will redirect to the dashboard with an error message:
![screenshot from 2018-08-20 11-05-31](https://user-images.githubusercontent.com/649130/44331117-f9d77080-a468-11e8-8662-7eb6de8e6457.png)

Hopefully this could be resolved in the future by omitting the link if it is not available, probably by using decorators or something similar.

@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @AparnaKarve 

@miq-bot add_label enhancement

Related issue: https://github.com/ManageIQ/manageiq-v2v/issues/578
Schema PR: https://github.com/ManageIQ/manageiq-schema/pull/263
Backend PR: https://github.com/ManageIQ/manageiq/pull/17913
