### PR TITLE
Set the href for notifications emitted through WS the same as in API

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -129,7 +129,7 @@ function eventNotifications($timeout, API) {
       type: levelToType(type),
       message: message,
       data: notificationData,
-      href: id ? '/api/notifications/' + id : undefined,
+      href: id ? window.location.origin + '/api/notifications/' + id : undefined,
       timeStamp: (new Date()).getTime(),
     };
 


### PR DESCRIPTION
The notification mark/delete would might work without this, but it's better to have the same full `href` for the items as it would come from the API. I am not sure about the `window.location.origin`, maybe there's a better way, so pinging some JS-people for review.

Depends on: https://github.com/ManageIQ/manageiq/pull/17875

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @karelhala 
@miq-bot add_label pending core, bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618705