### PR TITLE
Fix travis by adding beta version of @babel/runtime because react-bootstrap is special

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "xml_display": "~0.1.1"
   },
   "devDependencies": {
+    "@babel/runtime": "7.0.0-beta.42",
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
     "angular-mocks": "~1.6.9",


### PR DESCRIPTION
react-bootstrap 0.32.2+ depends on @babel/runtime
..specifically on @babel/runtime 7.0.0-beta.42

7.0.0-rc.1 doesn't work because of different paths

So, this is a very temporary fix to get travis green, just adding the missing dependency.
