### PR TITLE
Removed `data-miq_observe` from drop down

### DIFF
--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -16,7 +16,6 @@
               - @categories.delete(cat_key)
           = select_tag("tag_cat",
             options_for_select(@categories, @edit[:cat].name),
-            "data-miq_observe"     => {:url => url}.to_json,
             "data-live-search"     => "true",
             "data-container"       => "body",
             "class"                => "selectpicker")


### PR DESCRIPTION
miqSelectPickerEvent is being called to observe botstrap dropdowns, having both observers causes double transactions to be sent upto server and causes an issue in UI randomly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601915
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614437

@himdel do you know why all of a sudden we are seeing these type of issues in UI with double transactions beings sent on drop downs, i recently fixed another one https://github.com/ManageIQ/manageiq-ui-classic/pull/4488
This issue does not happen always, but something to do with timings of transactions