### PR TITLE
create rails log manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ matrix:
   - rvm: 2.4.4
     env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
-before_install: source tools/ci/before_install.sh
+before_install:
+- source tools/ci/before_install.sh
+- mkdir  $TRAVIS_BUILD_DIR/spec/manageiq/log
 before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE
 before_cache:


### PR DESCRIPTION
log is no longer present
per https://github.com/ManageIQ/manageiq/pull/17663
This is causing the build to fail

travis.yml will Manually create it
