### PR TITLE
travis - create manageiq/log manually

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,5 +8,8 @@ unless gem_root.join("spec/manageiq").exist?
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
 end
 
+# ensure a log dir always exists
+system "mkdir -p spec/manageiq/log"
+
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_setup


### PR DESCRIPTION
Since ManageIQ/manageiq#17663, there is no manageiq/log directory by default.

That breaks travis with 

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /home/travis/build/ManageIQ/manageiq-ui-classic/spec/manageiq/log/audit.log
/home/travis/build/ManageIQ/manageiq-ui-classic/vendor/bundle/bundler/gems/manageiq-gems-pending-f74f387d9e36/lib/gems/pending/util/vmdb-logger.rb:11:in `initialize'
```

Creating the log file.

Closes #4501 

@kbrock I took the liberty of replicating your PR with the log creation happening before `setup_js_env.sh` which seems to need it :)