### PR TITLE
Respect days parameter when listing timeline events

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -76,30 +76,21 @@ module ApplicationController::Timelines
 
   def tl_build_timeline_report_options
     if !@tl_options.date.start.nil? && !@tl_options.date.end.nil?
-      case @tl_options.date.typ
-      when "Hourly"
-        tl_rpt = @tl_options.management_events? ? "tl_events_hourly" : "tl_policy_events_hourly"
-        @report = tl_get_rpt(tl_rpt)
-        @report.headers.map! { |header| _(header) }
-        mm, dd, yy = @tl_options.date.hourly.split("/")
-        from_dt = create_time_in_utc("#{yy}-#{mm}-#{dd} 00:00:00", session[:user_tz]) # Get tz 12am in user's time zone
-        to_dt = create_time_in_utc("#{yy}-#{mm}-#{dd} 23:59:59", session[:user_tz])   # Get tz 11pm in user's time zone
-        st_time = Time.gm(yy, mm, dd, 00, 00, 00)
-        end_time = Time.gm(yy, mm, dd, 23, 59, 00)
-        #        START of TIMELINE TIMEZONE Code
-        #        @report.timeline[:bands][0][:center_position] = Time.gm(yy,mm,dd,21,00,00)    # calculating mid position to align timeline in center
-        #        @report.timeline[:bands][0][:st_time] = st_time.strftime("%b %d %Y 00:00:00 GMT")
-        #        @report.timeline[:bands][0][:end_time] = end_time.strftime("%b %d %Y 23:59:00 GMT")
-        tz = @report.tz ? @report.tz : Time.zone
-      when "Daily"
-        tl_rpt = @tl_options.management_events? ? "tl_events_daily" : "tl_policy_events_daily"
-        @report = tl_get_rpt(tl_rpt)
-        @report.headers.map! { |header| _(header) }
-        from = Date.parse(@tl_options.date.daily) - @tl_options.date.days.to_i
-        from_dt = create_time_in_utc("#{from.year}-#{from.month}-#{from.day} 00:00:00", session[:user_tz])  # Get tz 12am in user's time zone
-        mm, dd, yy = @tl_options.date.daily.split("/")
-        to_dt = create_time_in_utc("#{yy}-#{mm}-#{dd} 23:59:59", session[:user_tz]) # Get tz 11pm in user's time zone
-      end
+      tl_type = @tl_options.management_events? ? "events" : "policy_events"
+      tl_granularity = case @tl_options.date.typ
+                       when "Hourly" then "hourly"
+                       when "Daily" then "daily"
+                       end
+      @report = tl_get_rpt("tl_#{tl_type}_#{tl_granularity}")
+      @report.headers.map! { |header| _(header) }
+
+      to_date = Date.parse(@tl_options.date.end_date)
+      to_dt = create_time_in_utc("#{to_date.strftime} 23:59:59",
+                                 session[:user_tz])
+
+      from_date = to_date - @tl_options.date.days.to_i + 1
+      from_dt = create_time_in_utc("#{from_date.strftime} 00:00:00",
+                                   session[:user_tz])
 
       rec_cond, *rec_params = @tl_record.event_where_clause(@tl_options.evt_type)
       conditions = [rec_cond, "timestamp >= ?", "timestamp <= ?"]

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -2,26 +2,23 @@ module ApplicationController::Timelines
   SELECT_EVENT_TYPE = [[N_('Management Events'), 'timeline'], [N_('Policy Events'), 'policy_timeline']].freeze
 
   DateOptions = Struct.new(
-    :daily,
+    :end_date,
     :days,
     :end,
-    :hourly,
     :start,
     :typ
   ) do
     def update_from_params(params)
       self.typ = params[:tl_typ] if params[:tl_typ]
       self.days = params[:tl_days] if params[:tl_days]
-      self.hourly = params[:miq_date_1] || params[:miq_date] if (params[:miq_date_1] || params[:miq_date]) && typ == 'Hourly'
-      self.daily = params[:miq_date_1] || params[:miq_date] if (params[:miq_date_1] || params[:miq_date]) && typ == 'Daily'
+      self.end_date = params[:miq_date_1] || params[:miq_date]
     end
 
     def update_start_end(sdate, edate)
       if !sdate.nil? && !edate.nil?
         self.start = [sdate.year.to_s, (sdate.month - 1).to_s, sdate.day.to_s].join(", ")
         self.end = [edate.year.to_s, (edate.month - 1).to_s, edate.day.to_s].join(", ")
-        self.hourly ||= [edate.month, edate.day, edate.year].join("/")
-        self.daily ||= [edate.month, edate.day, edate.year].join("/")
+        self.end_date ||= [edate.month, edate.day, edate.year].join("/")
       else
         self.start = self.end = nil
       end


### PR DESCRIPTION
Up until now, when the user requested hourly report (by selecting days selector in the UI), the code always returned only the events from the last day of selected interval.

This commit fixes this by unifying the time interval construction for all types of reports, getting rid of the buggy date construction in the process.

Fixes #4503 