### PR TITLE
Add restful redirect rule for notifications arriving from V2V

### DIFF
--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -3,6 +3,9 @@ class RestfulRedirectController < ApplicationController
 
   def index
     case params[:model]
+    when 'ServiceTemplateTransformationPlanRequest'
+      req = ServiceTemplateTransformationPlanRequest.select(:source_id).find(params[:id])
+      redirect_to :controller => 'migration', :action => 'index', :anchor => "plan/#{req.source_id}"
     when 'MiqRequest'
       redirect_to :controller => 'miq_request', :action => 'show', :id => params[:id]
     when 'VmOrTemplate'


### PR DESCRIPTION
This is an addition to a really bad antipattern that allows us to redirect the user to an URL based on a record type and an ID. However, for now there's no other way to do this, but I will actively think on a [better solution](http://media.ifunny.com/results/2018/03/29/482i5kkucz.jpg) in the future.

@AparnaKarve stated that it's 100% sure that the `ServiceTemplateTransformationPlanRequest` is not used for anything else than V2V and I believed her, so any request coming with this model will be redirected to the `migration` controller defined in V2V. As they're using hash routes, I had to use the `:anchor` parameter of the `redirect_to` method.

Related drawer modifications: https://github.com/ManageIQ/manageiq-ui-classic/pull/4492
Related issue: https://github.com/ManageIQ/manageiq-v2v/issues/578

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @AparnaKarve 