### PR TITLE
Fix enabled Save button while viewing Chargeback Rate Assignments

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -227,7 +227,8 @@ class ChargebackController < ApplicationController
     cb_assign_get_form_vars
     render :update do |page|
       page << javascript_prologue
-      changed = (@edit[:new] != @edit[:current])
+      except = %i(cbshow_typ cbtag_cat cblabel_key)
+      changed = (@edit[:new].except(*except) != @edit[:current].except(*except))
       page.replace("cb_assignment_div", :partial => "cb_assignments") if params[:cbshow_typ] || params[:cbtag_cat] || params[:cblabel_key]
       page << javascript_for_miq_button_visibility(changed)
     end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -6,7 +6,7 @@ describe ChargebackController do
     let(:tag)      { FactoryGirl.create(:classification, :parent_id => category.id) }
     let(:entry)    { FactoryGirl.create(:classification, :parent_id => tag.id) }
 
-    context "#get_tags_all" do
+    describe "#get_tags_all" do
       before { entry }
 
       it "returns the classification entry record" do
@@ -19,7 +19,7 @@ describe ChargebackController do
       end
     end
 
-    context "#cb_assign_set_form_vars" do
+    describe "#cb_assign_set_form_vars" do
       before do
         cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
         ChargebackRate.set_assignments(:Storage, [{:cb_rate => cbr, :tag => [tag, "vm"]}])
@@ -110,7 +110,7 @@ describe ChargebackController do
     end
   end
 
-  context "#explorer" do
+  describe "#explorer" do
     render_views
 
     it "can be rendered" do
@@ -121,7 +121,7 @@ describe ChargebackController do
     end
   end
 
-  context "#process_cb_rates" do
+  describe "#process_cb_rates" do
     it "delete unassigned" do
       cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage", :description => "Storage Rate")
 
@@ -149,7 +149,7 @@ describe ChargebackController do
     end
   end
 
-  context "#get_cis_all" do
+  describe "#get_cis_all" do
     let!(:storage) { FactoryGirl.create(:storage) }
     let!(:miq_enterprise) { FactoryGirl.create(:miq_enterprise) }
 
@@ -616,7 +616,7 @@ describe ChargebackController do
     end
   end
 
-  context "#replace_right_cell" do
+  describe "#replace_right_cell" do
     it "Can build the :cb_rates tree" do
       seed_session_trees('chargeback', :cb_rates, 'root')
       session_to_sb
@@ -732,6 +732,63 @@ describe ChargebackController do
         expect(controller.session[:chargeback_lastaction]).to eq(lastaction)
         expect(controller.session[:chargeback_display]).to eq(display)
         expect(controller.session[:chargeback_current_page]).to eq(current_page)
+      end
+    end
+  end
+
+  describe '#cb_assign_field_changed' do
+    let(:edit) do
+      {
+        :cb_assign => {
+          :cats => {
+            '1' => 'Category1',
+            '2' => 'Category2'
+          },
+          :tags => {
+            1 => {
+              '2' => 'Tag1',
+              '3' => 'Tag2',
+              '4' => 'Tag3'
+            },
+            2 => {}
+          }
+        },
+        :current   => {
+          :cbshow_typ       => 'storage-tags',
+          :cbtag_cat        => '1',
+          'storage-tags__2' => '3'
+        },
+        :new       => {
+          :cbshow_typ       => 'storage-tags',
+          :cbtag_cat        => '1',
+          'storage-tags__2' => '3'
+        }
+      }
+    end
+
+    before do
+      allow(controller).to receive(:load_edit).and_return(true)
+      controller.instance_variable_set(:@edit, edit)
+    end
+
+    context 'changing Tag Category for assignments' do
+      it 'hides buttons as no change has been made' do
+        post :cb_assign_field_changed, :params => {:cbtag_cat => '2'}
+        expect(response.body).to include("miqButtons('hide');")
+      end
+    end
+
+    context 'changing Assigned To, for assignments' do
+      it 'hides buttons as no change has been made' do
+        post :cb_assign_field_changed, :params => {:cbshow_typ => 'storage'}
+        expect(response.body).to include("miqButtons('hide');")
+      end
+    end
+
+    context 'changing item under Selections, for assignments' do
+      it 'shows buttons as a change in Selections has been made' do
+        post :cb_assign_field_changed, :params => {'storage-tags__3' => '4'}
+        expect(response.body).to include("miqButtons('show');")
       end
     end
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1614982

Fix enabled _Save_ button while viewing Chargeback Rates assigned to **multiple Tag Categories**,
under _Cloud Intel > Chargeback > Assignments_ accordion.

---

**Steps to reproduce:**
1. Go to _Cloud Intel > Chargeback > Assignments_ accordion and choose _Compute_ or _Storage_ Assignments
2. Assign Rates to (at least) two different _Tag Categories_ (if thery are not assigned yet; for _Assign To_ choose  _Tagged Datastores/Tagged VMs and Instances/Tagged Container Images_ ) and save the assignments (then you should see them under _Saved Items_ in the same page)
3. View the saved assignments: change the _Tag Category_ to the second one which was saved before
=> _Save_ button enables immediately, even when no change was made (only different _Tag Category_ was selected from the drop down), and this should not happen

**How it should work and why:**
If you choose some _Tag Category_, _Save_ button should be disabled. No change was already made. This should happen also while changing _Assign To_ under _Basic Info_. _Save_ button should be enabled/disabled only while changing any _Selections_.

**Note:**
For proper enabling/disabling _Save_ button, checking `@edit[:new] != @edit[:current]` is just not ok! Why? Because.. just look what in `@edit[:new]` and `@edit[:current]` is while changing _Tag Category_ (example):
```
>     @edit[:new] => {"cbshow_typ"=>"storage-tags", "cbtag_cat"=>"106", "storage-tags__86"=>"2", "storage-tags__107"=>"11"}
> @edit[:current] => {"cbshow_typ"=>"storage-tags", "cbtag_cat"=>"85", "storage-tags__86"=>"2", "storage-tags__107"=>"11"}
```
Similar situation happens while changing _Assign To_ under _Basic Info_. This is why we have to look at (and only at) _Selections_ changes, not the others.

---

Step 2 from Steps to reproduce:
![assign_two_categories](https://user-images.githubusercontent.com/13417815/44400629-2dd79200-a54c-11e8-9456-3c8b6937d06f.png)

**Before:** (we changed _Tag Category_ from _Auto Approve - Max CPU_ to _Auto Approve - Max Memory_ )
![tag_cat_before](https://user-images.githubusercontent.com/13417815/44401076-ab4fd200-a54d-11e8-89bb-efaa8cf1038c.png)

**After:**
![tag_cat_after](https://user-images.githubusercontent.com/13417815/44400897-2c5a9980-a54d-11e8-9f50-7916e33ea05a.png)
