### PR TITLE
Travis - output yarn.lock

### DIFF
--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -8,5 +8,5 @@ bundle show
 echo "travis_fold:end:GEMFILE_LOCK"
 
 echo "travis_fold:start:YARN_LOCK"
-cat yarn.lock
+yarn list
 echo "travis_fold:end:YARN_LOCK"

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -2,11 +2,15 @@ if [ "$TEST_SUITE" = "spec" ]; then
   bundle exec codeclimate-test-reporter;
 fi
 
-# Collapse Travis output https://github.com/travis-ci/travis-ci/issues/2158
-echo "travis_fold:start:GEMFILE_LOCK"
-bundle show
-echo "travis_fold:end:GEMFILE_LOCK"
+if [ "$TEST_SUITE" = "spec:compile" ]; then
+  # Collapse Travis output https://github.com/travis-ci/travis-ci/issues/2158
+  echo "travis_fold:start:GEMFILE_LOCK"
+  bundle show
+  echo "travis_fold:end:GEMFILE_LOCK"
+fi
 
-echo "travis_fold:start:YARN_LOCK"
-yarn list
-echo "travis_fold:end:YARN_LOCK"
+if [ "$TEST_SUITE" = "spec:javascript" ]; then
+  echo "travis_fold:start:YARN_LOCK"
+  yarn list
+  echo "travis_fold:end:YARN_LOCK"
+fi

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -6,3 +6,7 @@ fi
 echo "travis_fold:start:GEMFILE_LOCK"
 bundle show
 echo "travis_fold:end:GEMFILE_LOCK"
+
+echo "travis_fold:start:YARN_LOCK"
+cat yarn.lock
+echo "travis_fold:end:YARN_LOCK"


### PR DESCRIPTION
whenever there's a breakage caused by JS dependencies, it's useful to be able to get the last working configuration

we're already doing the same with Gemfile.lock (https://github.com/ManageIQ/manageiq-ui-classic/pull/263)