### PR TITLE
Fix physical server provision page

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -25,7 +25,11 @@ module ApplicationController::MiqRequestMethods
       refresh_divs = prov_get_form_vars  # Get changed option, returns true if divs need refreshing
       build_grid if refresh_divs
       changed = (@edit[:new] != @edit[:current])
-      @record = MiqTemplate.find(@edit[:new][:src_vm_id].first)
+      @record = if @edit[:new][:src_configured_system_ids].present?
+                  PhysicalServer.find(@edit[:new][:src_configured_system_ids].first)
+                else
+                  MiqTemplate.find(@edit[:new][:src_vm_id].first)
+                end
       render :update do |page|
         page << javascript_prologue
         # Going thru all dialogs to see if model has set any of the dialog display to hide/ignore


### PR DESCRIPTION
Physical server provisioning was being impossible due to an error blowing when accessing it.
Thanks to @h-kataria it's fully working now.

## Before
![provision_error](https://user-images.githubusercontent.com/19214410/44405504-c6abe480-a52f-11e8-9d64-1f6e0b0bd8ee.gif)
## After
![provision_fixed](https://user-images.githubusercontent.com/19214410/44405511-cdd2f280-a52f-11e8-8905-dc396f867e24.gif)
