### PR TITLE
Revert "travis - create manageiq/log manually"

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,8 +8,5 @@ unless gem_root.join("spec/manageiq").exist?
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
 end
 
-# ensure a log dir always exists
-system "mkdir -p spec/manageiq/log"
-
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_setup


### PR DESCRIPTION
This reverts commit 2840e7ccd483a23b5a2987c278a2962b4b28631c (#4502)

Because the change is no longer needed, as it was fixed in https://github.com/ManageIQ/manageiq/pull/17886

