### PR TITLE
Enable 'Paste' button if the coppied data are in the session

### DIFF
--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,6 +1,6 @@
 #ab_form
   #policy_bar
-    - if @resolve[:uri] && Hash[*@resolve[:target_classes].flatten].invert[@resolve[:new][:target_class]] == @edit[:new][:target_class]
+    - if session[:resolve_object].present?
       = link_to({:action => "resolve", :button => "paste"},
         "data-miq_sparkle_on"  => true,
         "data-miq_sparkle_off" => true,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1426390

I didn't much understood the original condition used to decide button's state, but I didn't yet found another button, which functionality I could break by the change.

The `@resolve[:uri]` is only possibly getting filled, if the `params[:button]` is `"throw"` or `"retry"`:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/automate.rb#L155

The condition now tests for the data presence in the session (data are assigned to the session in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/automate.rb#L40-L44)

Links
----------------
* https://github.com/ManageIQ/manageiq-ui-classic/pull/175#discussion_r102018852
* https://github.com/ManageIQ/manageiq-ui-classic/issues/4189
* https://bugzilla.redhat.com/show_bug.cgi?id=1426390

Steps for Testing/QA
-------------------------------

1) Automate - Simulation
2) fill the form and submit - the Copy button will get enabled 
2) Automate - Customization - Buttons accordion - Add a new Button
3) paste button should be enabled and work
