### PR TITLE
Display custom button events for the records that have them

### DIFF
--- a/app/controllers/availability_zone_controller.rb
+++ b/app/controllers/availability_zone_controller.rb
@@ -11,7 +11,7 @@ class AvailabilityZoneController < ApplicationController
   include EmsCommon
 
   def self.display_methods
-    %w(ems_cloud instances cloud_volumes)
+    %w(ems_cloud instances cloud_volumes custom_button_events)
   end
 
   private

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -11,7 +11,7 @@ class CloudNetworkController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_networks network_routers cloud_subnets floating_ips)
+    %w(instances cloud_networks network_routers cloud_subnets floating_ips custom_button_events)
   end
 
   def button

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -36,7 +36,7 @@ class CloudObjectStoreContainerController < ApplicationController
   end
 
   def self.display_methods
-    %w(cloud_object_store_objects)
+    %w(cloud_object_store_objects custom_button_events)
   end
 
   def new

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -11,7 +11,7 @@ class CloudSubnetController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets network_ports security_groups)
+    %w(instances cloud_subnets network_ports security_groups custom_button_events)
   end
 
   def button

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -46,7 +46,7 @@ class CloudTenantController < ApplicationController
 
   def self.display_methods
     %w(instances images security_groups cloud_volumes cloud_volume_snapshots cloud_object_store_containers floating_ips
-       network_ports cloud_networks cloud_subnets network_routers)
+       network_ports cloud_networks cloud_subnets network_routers custom_button_events)
   end
 
   def new

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -11,7 +11,7 @@ class CloudVolumeController < ApplicationController
   include Mixins::GenericButtonMixin
 
   def self.display_methods
-    %w(cloud_volume_snapshots cloud_volume_backups instances)
+    %w(cloud_volume_snapshots cloud_volume_backups instances custom_button_events)
   end
 
   def specific_buttons(pressed)

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -19,7 +19,7 @@ class EmsClusterController < ApplicationController
   end
 
   def self.display_methods
-    %w(descendant_vms all_vms miq_templates vms hosts resource_pools config_info storage)
+    %w(descendant_vms all_vms miq_templates vms hosts resource_pools config_info storage custom_button_events)
   end
 
   # handle buttons pressed on the button bar

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -103,6 +103,7 @@ module EmsCommon
         containers
         container_services
         container_templates
+        custom_button_events
         ems_clusters
         flavors
         floating_ips

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -18,7 +18,7 @@ class GenericObjectController < ApplicationController
   end
 
   def self.display_methods
-    []
+    %w(custom_button_events)
   end
 
   def display_methods(record)
@@ -33,7 +33,7 @@ class GenericObjectController < ApplicationController
   private
 
   def textual_group_list
-    [%i(go_properties attribute_details_list associations methods)]
+    [%i(go_properties attribute_details_list associations methods go_relationships)]
   end
 
   helper_method :textual_group_list

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -10,7 +10,7 @@ class HostController < ApplicationController
   include Mixins::MoreShowActions
 
   def self.display_methods
-    %w(hv_info os_info devices network storage_adapters performance timeline storages resource_pools vms miq_templates compliance_history)
+    %w(hv_info os_info devices network storage_adapters performance timeline storages resource_pools vms miq_templates compliance_history custom_button_events)
   end
 
   def display_config_info

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -147,6 +147,15 @@ class InfraNetworkingController < ApplicationController
     end
   end
 
+  def custom_button_events
+    return unless init_show_variables('switch')
+
+    @lastaction = "custom_button_events"
+    drop_breadcrumb(:name => _("%{name} (Custom Button Events)") % {:name => @record.name},
+                    :url  => "/infra_networking/custom_button_events/#{@record.id}")
+    show_details(CustomButtonEvent, :association => "custom_button_events", :clickable => false)
+  end
+
   private
 
   def textual_group_list
@@ -478,6 +487,7 @@ class InfraNetworkingController < ApplicationController
   def show_details(db, options = {}) # Pass in the db, parent vm is in @vm
     association = options[:association]
     conditions  = options[:conditions]
+    clickable   = options[:clickable].nil?
     @showtype      = "details"
     @display       = "main"
     @no_checkboxes = @no_checkboxes.nil? || @no_checkboxes
@@ -487,6 +497,7 @@ class InfraNetworkingController < ApplicationController
                              :parent      => @record,
                              :association => association,
                              :conditions  => conditions,
+                             :clickable   => clickable,
                              :dbname      => "#{@db}item") # Get the records into a view & paginator
 
     if @explorer # In explorer?

--- a/app/controllers/load_balancer_controller.rb
+++ b/app/controllers/load_balancer_controller.rb
@@ -10,7 +10,7 @@ class LoadBalancerController < ApplicationController
   include Mixins::GenericShowMixin
 
   def self.display_methods
-    %w(instances network_ports floating_ips security_groups)
+    %w(instances network_ports floating_ips security_groups custom_button_events)
   end
 
   private

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -190,7 +190,7 @@ module ContainersCommonMixin
       %w(
         container_groups containers container_services container_routes container_replicators
         container_projects container_images container_image_registries container_nodes
-        persistent_volumes container_builds container_templates
+        persistent_volumes container_builds container_templates custom_button_events
       )
     end
   end

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -180,7 +180,7 @@ module Mixins
                       :url  => show_link(@record, :display => @display))
 
       view_options = {:parent => @record}
-      view_options.update(options.slice(:association, :parent_method, :where_clause, :named_scope))
+      view_options.update(options.slice(:association, :parent_method, :where_clause, :named_scope, :clickable))
 
       @view, @pages = get_view(model, view_options)
       @showtype = @display

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -154,6 +154,11 @@ module Mixins
       nested_list(Vm, :breadcrumb_title => _("Direct VMs"))
     end
 
+    def display_custom_button_events
+      @no_checkboxes = true # FIXME: move this to a parameter below and handle with ReportDataAdditionalOptions
+      nested_list(CustomButtonEvent, :breadcrumb_title => _('Custom Button Events'), :clickable => false, :parent_method => 'custom_button_events')
+    end
+
     def display_resource_pools
       nested_list(ResourcePool)
     end

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -11,7 +11,7 @@ class NetworkRouterController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets floating_ips security_groups)
+    %w(instances cloud_subnets floating_ips security_groups custom_button_events)
   end
 
   def button

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -16,7 +16,7 @@ class OrchestrationStackController < ApplicationController
   end
 
   def self.display_methods
-    %w(instances children security_groups stack_orchestration_template)
+    %w(instances children security_groups stack_orchestration_template custom_button_events)
   end
 
   def display_stack_orchestration_template

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -10,7 +10,7 @@ class SecurityGroupController < ApplicationController
   include Mixins::GenericShowMixin
 
   def self.display_methods
-    %w(instances network_ports network_routers cloud_subnets)
+    %w(instances network_ports network_routers cloud_subnets custom_button_events)
   end
 
   menu_section :net

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -51,8 +51,12 @@ class ServiceController < ApplicationController
 
     set_display
 
-    if @display == 'generic_objects'
+    case @display
+    when 'generic_objects'
       show_generic_object
+      return
+    when 'custom_button_events'
+      display_nested_list(@display)
       return
     end
 
@@ -189,7 +193,7 @@ class ServiceController < ApplicationController
   end
 
   def self.display_methods
-    %w(generic_objects)
+    %w(generic_objects custom_button_events)
   end
 
   def display_generic_objects

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -218,7 +218,7 @@ class ServiceController < ApplicationController
 
   def textual_group_list
     if @item && @item.kind_of?(GenericObject)
-      [%i(go_properties attribute_details_list methods)]
+      [%i(go_properties attribute_details_list methods go_relationships)]
     elsif %w(ServiceAnsiblePlaybook ServiceAnsibleTower).include?(@record.type)
       [%i(properties miq_custom_attributes), %i(lifecycle tags generic_objects)]
     else

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -13,7 +13,7 @@ class StorageController < ApplicationController
   after_action :set_session_data
 
   def self.display_methods
-    %w(all_vms hosts all_miq_templates registered_vms unregistered_vms)
+    %w(all_vms hosts all_miq_templates registered_vms unregistered_vms custom_button_events)
   end
 
   def self.custom_display_method

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -217,6 +217,12 @@ module VmCommon
     elsif @display == "devices"
       drop_breadcrumb(:name => @record.name + _(" (Devices)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+    elsif @display == "custom_button_events"
+      drop_breadcrumb(:name => @record.name + _(" (Custom Button Events)"),
+                      :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+      @no_checkboxes = true # FIXME: move this to a parameter below and handle with ReportDataAdditionalOptions
+      @showtype = "details"
+      get_view(CustomButtonEvent, :parent => @record, :parent_method => 'custom_button_events', :clickable => false)
     elsif @display == "vmtree_info"
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)
       drop_breadcrumb(:name => @record.name + _(" (Genealogy)"),

--- a/app/decorators/custom_button_event_decorator.rb
+++ b/app/decorators/custom_button_event_decorator.rb
@@ -1,0 +1,5 @@
+class CustomButtonEventDecorator < MiqDecorator
+  def self.fonticon
+    'fa fa-star'
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1178,7 +1178,7 @@ module ApplicationHelper
   def render_gtl_view_tb?
     GTL_VIEW_LAYOUTS.include?(@layout) && @gtl_type && !@tagitems &&
       !@ownershipitems && !@retireitems && !@politems && !@in_a_form &&
-      %w(show show_list).include?(params[:action])
+      %w(show show_list).include?(params[:action]) && @display != "custom_button_events"
   end
 
   def update_paging_url_parms(action_url, parameter_to_update = {}, post = false)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -449,6 +449,7 @@ class ApplicationHelper::ToolbarChooser
       elsif to_display_center.include?(@display)
         return "#{@display}_center"
       elsif @layout == 'ems_container'
+        return nil if @display == 'custom_button_events'
         return "#{@display}_center"
       end
     elsif @display == 'generic_objects'

--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -1,12 +1,13 @@
 module AvailabilityZoneHelper::TextualSummary
   include TextualMixins::TextualEmsCloud
   include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(ems_cloud instances cloud_volumes))
+    TextualGroup.new(_("Relationships"), %i(ems_cloud instances cloud_volumes custom_button_events))
   end
 
   def textual_group_availability_zone_totals

--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module CloudNetworkHelper::TextualSummary
   include TextualMixins::TextualEmsNetwork
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -13,7 +14,7 @@ module CloudNetworkHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets network_routers floating_ips)
+      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets network_routers floating_ips custom_button_events)
     )
   end
 

--- a/app/helpers/cloud_object_store_container_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_container_helper/textual_summary.rb
@@ -1,13 +1,14 @@
 module CloudObjectStoreContainerHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i(key size))
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems cloud_tenant cloud_object_store_objects))
+    TextualGroup.new(_("Relationships"), %i(parent_ems_cloud ems cloud_tenant cloud_object_store_objects custom_button_events))
   end
 
   def textual_parent_ems_cloud

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module CloudSubnetHelper::TextualSummary
   include TextualMixins::TextualEmsNetwork
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -18,7 +19,7 @@ module CloudSubnetHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network
-        network_router parent_subnet managed_subnets network_ports security_groups
+        network_router parent_subnet managed_subnets network_ports security_groups custom_button_events
       )
     )
   end

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -1,6 +1,7 @@
 module CloudTenantHelper::TextualSummary
   include TextualMixins::TextualEmsCloud
   include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -16,6 +17,7 @@ module CloudTenantHelper::TextualSummary
         ems_cloud instances images cloud_object_store_containers
         cloud_volumes cloud_volume_snapshots cloud_networks cloud_subnets
         network_routers security_groups floating_ips network_ports
+        custom_button_events
       )
     )
   end

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module CloudVolumeHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i(name size bootable description))
@@ -12,7 +13,7 @@ module CloudVolumeHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems availability_zone cloud_tenant base_snapshot cloud_volume_backups
-        cloud_volume_snapshots attachments
+        cloud_volume_snapshots attachments custom_button_events
       )
     )
   end

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module ContainerGroupHelper::TextualSummary
   #
   # Groups
   #
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(
@@ -16,7 +17,7 @@ module ContainerGroupHelper::TextualSummary
       _("Relationships"),
       %i(
         ems container_project container_services container_replicator containers container_node
-        lives_on container_images persistent_volumes
+        lives_on container_images persistent_volumes custom_button_events
       )
     )
   end

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module ContainerImageHelper
   module TextualSummary
+    include TextualMixins::TextualCustomButtonEvents
     #
     # Groups
     #
@@ -17,7 +18,7 @@ module ContainerImageHelper
     def textual_group_relationships
       TextualGroup.new(
         _("Relationships"),
-        %i(ems container_image_registry container_projects container_groups containers container_nodes)
+        %i(ems container_image_registry container_projects container_groups containers container_nodes custom_button_events)
       )
     end
 

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module ContainerNodeHelper::TextualSummary
   #
   # Groups
   #
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(
@@ -19,7 +20,7 @@ module ContainerNodeHelper::TextualSummary
       _("Relationships"),
       %i(
         ems container_routes container_services container_replicators container_groups containers
-        lives_on container_images
+        lives_on container_images custom_button_events
       )
     )
   end

--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module ContainerProjectHelper::TextualSummary
   #
   # Groups
   #
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i(name display_name creation_timestamp resource_version))
@@ -12,7 +13,7 @@ module ContainerProjectHelper::TextualSummary
       _("Relationships"),
       %i(
         ems container_routes container_services container_replicators container_groups
-        container_nodes container_images container_templates
+        container_nodes container_images container_templates custom_button_events
       )
     )
   end

--- a/app/helpers/container_template_helper/textual_summary.rb
+++ b/app/helpers/container_template_helper/textual_summary.rb
@@ -2,13 +2,14 @@ module ContainerTemplateHelper::TextualSummary
   #
   # Groups
   #
+  include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i(name creation_timestamp resource_version))
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(ems container_project))
+    TextualGroup.new(_("Relationships"), %i(ems container_project custom_button_events))
   end
 
   def textual_group_smart_management

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module EmsCloudHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -16,7 +17,7 @@ module EmsCloudHelper::TextualSummary
       _("Relationships"),
       %i(
         ems_infra network_manager availability_zones host_aggregates cloud_tenants flavors
-        security_groups instances images orchestration_stacks storage_managers
+        security_groups instances images orchestration_stacks storage_managers custom_button_events
       )
     )
   end

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module EmsClusterHelper::TextualSummary
   include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -23,7 +24,7 @@ module EmsClusterHelper::TextualSummary
       _("Relationships"),
       %i(
         ems parent_datacenter total_hosts total_direct_vms allvms_size total_miq_templates
-        total_vms rps_size states_size
+        total_vms rps_size states_size custom_button_events
       )
     )
   end

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -3,6 +3,7 @@ module EmsContainerHelper::TextualSummary
   include TextualMixins::TextualAuthenticationsStatus
   include TextualMixins::TextualMetricsStatus
   include TextualMixins::TextualDataCollectionState
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -17,7 +18,8 @@ module EmsContainerHelper::TextualSummary
     items.concat(%i(container_projects))
     items.concat(%i(container_routes)) if @record.respond_to?(:container_routes)
     items.concat(%i(container_services container_replicators container_groups containers container_nodes
-                    container_image_registries container_images volumes container_builds container_templates))
+                    container_image_registries container_images volumes container_builds container_templates
+                    custom_button_events))
     TextualGroup.new(_("Relationships"), items)
   end
 

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(infrastructure_folders folders clusters hosts datastores vms templates orchestration_stacks ems_cloud network_manager)
+      %i(infrastructure_folders folders clusters hosts datastores vms templates orchestration_stacks ems_cloud network_manager custom_button_events)
     )
   end
 
@@ -184,5 +184,16 @@ module EmsInfraHelper::TextualSummary
      :icon  => "pficon pficon-topology",
      :link  => url_for_only_path(:controller => '/infra_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
+  end
+
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :title => _('Custom Button Events'),
+      :value => num = @record.number_of(:custom_button_events),
+      :link  => num.positive? ? ems_infra_path(:id => @record, :display => 'custom_button_events') : nil,
+      :icon  => CustomButtonEvent.decorate.fonticon,
+    }
   end
 end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module EmsNetworkHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -13,7 +14,7 @@ module EmsNetworkHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud cloud_tenants cloud_networks cloud_subnets network_routers security_groups floating_ips
-        network_ports load_balancers
+        network_ports load_balancers custom_button_events
       )
     )
   end

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module EmsPhysicalInfraHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -14,7 +15,10 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(datastores physical_chassis physical_racks physical_servers physical_servers_with_host physical_storages physical_switches vms)
+      %i(
+        datastores physical_chassis physical_racks physical_servers physical_servers_with_host
+        physical_storages physical_switches vms custom_button_events
+      )
     )
   end
 

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module EmsStorageHelper::TextualSummary
   include TextualMixins::TextualRefreshStatus
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -9,9 +10,11 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(
-      _("Relationships"),
-      %i(parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups cloud_object_store_containers cloud_volume_types)
+    TextualGroup.new(_("Relationships"),
+      %i(
+        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
+        cloud_object_store_containers cloud_volume_types custom_button_events
+      )
     )
   end
 

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -11,11 +11,10 @@ module EmsStorageHelper::TextualSummary
 
   def textual_group_relationships
     TextualGroup.new(_("Relationships"),
-      %i(
-        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
-        cloud_object_store_containers cloud_volume_types custom_button_events
-      )
-    )
+                     %i(
+                       parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
+                       cloud_object_store_containers cloud_volume_types custom_button_events
+                     ))
   end
 
   def textual_group_status

--- a/app/helpers/generic_object_helper/textual_summary.rb
+++ b/app/helpers/generic_object_helper/textual_summary.rb
@@ -66,4 +66,19 @@ module GenericObjectHelper::TextualSummary
       TextualGroup.new(_('Methods'), methods)
     end
   end
+
+  def textual_group_go_relationships
+    TextualGroup.new(_("Relationships"), %i(go_custom_button_events))
+  end
+
+  def textual_go_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :label => _('Custom Button Events'),
+      :value => num = @record.number_of(:custom_button_events),
+      :link  => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events', :controller => 'generic_object') : nil,
+      :icon  => CustomButtonEvent.decorate.fonticon
+    }
+  end
 end

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module HostHelper::TextualSummary
+  include TextualMixins::TextualCustomButtonEvents
   include TextualMixins::TextualDevices
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualVmmInfo
@@ -23,7 +24,10 @@ module HostHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history physical_server network_manager)
+      %i(
+        ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history
+        physical_server network_manager custom_button_events
+      )
     )
   end
 

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -8,7 +8,7 @@ module InfraNetworkingHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(hosts))
+    TextualGroup.new(_("Relationships"), %i(hosts custom_button_events))
   end
 
   def textual_group_smart_management
@@ -27,5 +27,17 @@ module InfraNetworkingHelper::TextualSummary
       h[:link] = url_for_only_path(:action => 'hosts', :id => @record, :db => 'switch')
     end
     h
+  end
+
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :label    => _('Custom Button Events'),
+      :value    => num = @record.number_of(:custom_button_events),
+      :link     => num.positive? ? url_for_only_path(:action => 'custom_button_events', :id => @record, :db => 'switch') : nil,
+      :icon     => CustomButtonEvent.decorate.fonticon,
+      :explorer => true
+    }
   end
 end

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module LoadBalancerHelper::TextualSummary
   include TextualMixins::TextualEmsNetwork
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -13,7 +14,7 @@ module LoadBalancerHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances network_ports floating_ips security_groups)
+      %i(parent_ems_cloud ems_network cloud_tenant instances network_ports floating_ips security_groups custom_button_events)
     )
   end
 

--- a/app/helpers/network_router_helper/textual_summary.rb
+++ b/app/helpers/network_router_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module NetworkRouterHelper::TextualSummary
   include TextualMixins::TextualEmsNetwork
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -15,7 +16,7 @@ module NetworkRouterHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems_network cloud_tenant instances cloud_subnets external_gateway floating_ips
-        security_groups
+        security_groups custom_button_events
       )
     )
   end

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -3,6 +3,7 @@ module OrchestrationStackHelper::TextualSummary
   include TextualMixins::TextualEmsCloud
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #

--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module PersistentVolumeHelper::TextualSummary
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -23,7 +24,7 @@ module PersistentVolumeHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(parent pods_using_persistent_volume))
+    TextualGroup.new(_("Relationships"), %i(parent pods_using_persistent_volume custom_button_events))
   end
 
   def textual_group_smart_management

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module SecurityGroupHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualEmsNetwork
   include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualCustomButtonEvents
   #
   # Groups
   #
@@ -15,7 +16,7 @@ module SecurityGroupHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems_network cloud_tenant instances orchestration_stack network_ports network_router
-        cloud_subnet
+        cloud_subnet custom_button_events
       )
     )
   end

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -2,6 +2,7 @@ module ServiceHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
   include GenericObjectHelper::TextualSummary
 
   # Groups
@@ -87,7 +88,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i(catalog_item parent_service orchestration_stack job))
+    TextualGroup.new(_("Relationships"), %i(catalog_item parent_service orchestration_stack job custom_button_events))
   end
 
   def textual_group_miq_custom_attributes
@@ -276,6 +277,17 @@ module ServiceHelper::TextualSummary
                :title => _('Show Generic Object Instances for this Service'))
     end
     h
+  end
+
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :label => _('Custom Button Events'),
+      :value => num = @record.number_of(:custom_button_events),
+      :link  => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events') : nil,
+      :icon  => CustomButtonEvent.decorate.fonticon,
+    }
   end
 
   def credential(credential, label)

--- a/app/helpers/storage_helper/textual_summary.rb
+++ b/app/helpers/storage_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module StorageHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(hosts managed_vms managed_miq_templates registered_vms unregistered_vms unmanaged_vms)
+      %i(hosts managed_vms managed_miq_templates registered_vms unregistered_vms unmanaged_vms custom_button_events)
     )
   end
 
@@ -226,5 +226,16 @@ module StorageHelper::TextualSummary
       h[:link]  = url_for_only_path(:action => 'debris_files', :id => @record)
     end
     h
+  end
+
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :label => _('Custom Button Events'),
+      :value => num = @record.number_of(:custom_button_events),
+      :link  => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events') : nil,
+      :icon  => CustomButtonEvent.decorate.fonticon
+    }
   end
 end

--- a/app/helpers/textual_mixins/textual_custom_button_events.rb
+++ b/app/helpers/textual_mixins/textual_custom_button_events.rb
@@ -2,10 +2,16 @@ module TextualMixins::TextualCustomButtonEvents
   def textual_custom_button_events
     return nil unless User.current_user.super_admin_user? || User.current_user.admin?
 
+    link = if controller.restful?
+             polymorphic_path(@record, :display => 'custom_button_events')
+           else
+             url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events')
+           end
+
     {
       :label    => _('Custom Button Events'),
       :value    => num = @record.number_of(:custom_button_events),
-      :link     => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events') : nil,
+      :link     => num.positive? ? link : nil,
       :icon     => CustomButtonEvent.decorate.fonticon,
       :explorer => @explorer
     }

--- a/app/helpers/textual_mixins/textual_custom_button_events.rb
+++ b/app/helpers/textual_mixins/textual_custom_button_events.rb
@@ -1,0 +1,13 @@
+module TextualMixins::TextualCustomButtonEvents
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+
+    {
+      :label    => _('Custom Button Events'),
+      :value    => num = @record.number_of(:custom_button_events),
+      :link     => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events') : nil,
+      :icon     => CustomButtonEvent.decorate.fonticon,
+      :explorer => false
+    }
+  end
+end

--- a/app/helpers/textual_mixins/textual_custom_button_events.rb
+++ b/app/helpers/textual_mixins/textual_custom_button_events.rb
@@ -7,7 +7,7 @@ module TextualMixins::TextualCustomButtonEvents
       :value    => num = @record.number_of(:custom_button_events),
       :link     => num.positive? ? url_for_only_path(:action => 'show', :id => @record, :display => 'custom_button_events') : nil,
       :icon     => CustomButtonEvent.decorate.fonticon,
-      :explorer => false
+      :explorer => @explorer
     }
   end
 end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -12,6 +12,7 @@ module VmHelper::TextualSummary
   include TextualMixins::TextualRegion
   include TextualMixins::TextualScanHistory
   include TextualMixins::TextualDevices
+  include TextualMixins::TextualCustomButtonEvents
   include TextualMixins::TextualVmmInfo
   include TextualMixins::VmCommon
   # TODO: Determine if DoNav + url_for + :title is the right way to do links, or should it be link_to with :title
@@ -43,7 +44,7 @@ module VmHelper::TextualSummary
       _("Relationships"),
       %i(
         ems cluster host resource_pool storage service parent_vm genealogy drift scan_history
-        cloud_network cloud_subnet
+        cloud_network cloud_subnet custom_button_events
       )
     )
   end
@@ -54,13 +55,13 @@ module VmHelper::TextualSummary
       %i(
         ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service genealogy
         cloud_network cloud_subnet orchestration_stack cloud_networks cloud_subnets network_routers security_groups
-        floating_ips network_ports load_balancers cloud_volumes
+        floating_ips network_ports load_balancers cloud_volumes custom_button_events
       )
     )
   end
 
   def textual_group_template_cloud_relationships
-    TextualGroup.new(_("Relationships"), %i(ems parent_vm genealogy drift scan_history cloud_tenant))
+    TextualGroup.new(_("Relationships"), %i(ems parent_vm genealogy drift scan_history cloud_tenant custom_button_events))
   end
 
   def textual_group_security

--- a/app/views/cloud_object_store_container/show.html.haml
+++ b/app/views/cloud_object_store_container/show.html.haml
@@ -1,4 +1,4 @@
-- if @display == 'cloud_object_store_objects'
+- if %w(cloud_object_store_objects custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"

--- a/app/views/cloud_subnet/show.html.haml
+++ b/app/views/cloud_subnet/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "cloud_subnets", "network_ports", "security_groups"].include?(@display) && @showtype != "compare"
+  - if ["instances", "cloud_subnets", "network_ports", "security_groups", "custom_button_events"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -3,7 +3,7 @@
     = render :partial => "layouts/performance_async"
   - else
     - arr = %w(floating_ips network_ports cloud_tenants cloud_networks cloud_subnets network_routers instances images)
-    - arr.concat(%w(security_groups cloud_object_store_containers cloud_volumes cloud_volume_snapshots))
+    - arr.concat(%w(security_groups cloud_object_store_containers cloud_volumes cloud_volume_snapshots custom_button_events))
     - if arr.include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
     - elsif @showtype == "compare"

--- a/app/views/cloud_volume/show.html.haml
+++ b/app/views/cloud_volume/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(cloud_volume_backups cloud_volume_snapshots instances).include?(@display)
+- if %w(cloud_volume_backups cloud_volume_snapshots instances custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
   - if @showtype == "item"

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(containers container_services container_images persistent_volumes).include?(@display)
+- if %w(containers container_services container_images persistent_volumes custom_button_events).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
     - case @showtype

--- a/app/views/container_image/show.html.haml
+++ b/app/views/container_image/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(container_projects container_groups containers container_nodes).include?(@display)
+- if %w(container_projects container_groups containers container_nodes custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
   - case @showtype

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(container_routes container_services container_replicators container_groups containers container_images).include?(@display) && @showtype != "compare"
+- if %w(container_routes container_services container_replicators container_groups containers container_images custom_button_events).include?(@display) && @showtype != "compare"
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
   = render(:partial => "layouts/tl_show_async")

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(container_routes container_services container_replicators container_groups container_nodes container_images container_templates containers).include?(@display)
+- if %w(container_routes container_services container_replicators container_groups container_nodes container_images container_templates containers custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
   = render :partial => "layouts/tl_show_async"

--- a/app/views/container_template/show.html.haml
+++ b/app/views/container_template/show.html.haml
@@ -1,4 +1,4 @@
-- if @display == 'containers'
+- if %w(containers custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"

--- a/app/views/ems_cluster/show.html.haml
+++ b/app/views/ems_cluster/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - list = %w(vms all_vms hosts miq_templates resource_pools storage storage_extents storage_systems)
+  - list = %w(vms all_vms hosts miq_templates resource_pools storage storage_extents storage_systems custom_button_events)
   - if list.include?(@display) && !%w(compare drift_history).include?(@showtype)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else

--- a/app/views/generic_object/show.html.haml
+++ b/app/views/generic_object/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if @record.property_associations.keys.include?(@display)
+  - if @record.property_associations.keys.include?(@display) || %w(custom_button_events).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(vms cloud_tenants storages miq_proxies miq_templates resource_pools).include?(@display) && @showtype != "compare"
+  - if %w(vms cloud_tenants storages miq_proxies miq_templates resource_pools custom_button_events).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/app/views/load_balancer/show.html.haml
+++ b/app/views/load_balancer/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(instances network_ports floating_ips security_groups).include?(@display) && @showtype != "compare"
+  - if %w(instances network_ports floating_ips security_groups custom_button_events).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/miq_template/show.html.haml
+++ b/app/views/miq_template/show.html.haml
@@ -11,7 +11,7 @@
     - case @showtype
     - when "details"
       = render :partial => "layouts/gtl", :locals => {:action_url => @lastaction}
-    - when "miq_proxies", "storage_extents", "storage_systems"
+    - when "miq_proxies", "storage_extents", "storage_systems", "custom_button_events"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@miq_template.id}"}
     - when "compare"
       = render :partial => "layouts/compare"

--- a/app/views/network_router/show.html.haml
+++ b/app/views/network_router/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(instances cloud_subnets floating_ips security_groups).include?(@display) && @showtype != "compare"
+  - if %w(instances cloud_subnets floating_ips security_groups custom_button_events).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/orchestration_stack/show.html.haml
+++ b/app/views/orchestration_stack/show.html.haml
@@ -5,7 +5,7 @@
   - when "item"
     = render(:partial => "layouts/item")
   - else
-    - if %w(instances security_groups children).include?(@display)
+    - if %w(instances security_groups children custom_button_events).include?(@display)
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
     - elsif @display == 'stack_orchestration_template'
       = render :partial => "stack_orchestration_template"

--- a/app/views/persistent_volume/show.html.haml
+++ b/app/views/persistent_volume/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(containers container_groups).include?(@display)
+- if %w(containers container_groups custom_button_events).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == 'main'
   = render :partial => "layouts/textual_groups_generic"

--- a/app/views/security_group/show.html.haml
+++ b/app/views/security_group/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "network_ports"].include?(@display) && @showtype != "compare"
+  - if %w(instances network_ports custom_button_events).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(generic_objects).include?(@display)
+  - if %w(generic_objects custom_button_events).include?(@display)
     - if @lastaction == 'generic_object' && @item
       = render :partial => 'layouts/textual_groups_generic'
     - else

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(all_vms hosts miq_proxies all_miq_templates storage_extents storage_systems registered_vms unregistered_vms).include?(@display) && @showtype != "compare"
+  - if %w(all_vms hosts miq_proxies all_miq_templates storage_extents storage_systems registered_vms unregistered_vms custom_button_events).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/x_gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1940,6 +1940,7 @@ Rails.application.routes.draw do
       ),
       :post => %w(
         button
+        custom_button_events
         explorer
         hosts
         listnav_search_selected

--- a/product/views/CustomButtonEvent.yaml
+++ b/product/views/CustomButtonEvent.yaml
@@ -1,0 +1,77 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Custom Button Events
+
+# Menu name
+name: Custom Button Events
+
+# Main DB table report is based on
+db: CustomButtonEvent
+
+# Columns to fetch from the main table
+cols:
+- button_name
+- automate_entry_point
+- username
+- timestamp
+- message
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Included tables and columns for query performance
+include_for_find:
+
+# Order of columns (from all tables)
+col_order:
+- button_name
+- automate_entry_point
+- username
+- timestamp
+- message
+
+# Column titles, in order
+headers:
+- Button Name
+- Automate Entry Point
+- User name
+- Created On
+- Message
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Descending
+
+# Columns to sort the report on, in order
+sortby: timestamp
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/helpers/availability_zone_helper/textual_summary_spec.rb
+++ b/spec/helpers/availability_zone_helper/textual_summary_spec.rb
@@ -1,5 +1,5 @@
 describe AvailabilityZoneHelper::TextualSummary do
-  include_examples "textual_group", "Relationships", %i(ems_cloud instances cloud_volumes)
+  include_examples "textual_group", "Relationships", %i(ems_cloud instances cloud_volumes custom_button_events)
   include_examples "textual_group", "Totals for Availability Zone", %i(
     block_storage_disk_capacity
     block_storage_disk_usage

--- a/spec/helpers/cloud_network_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_network_helper/textual_summary_spec.rb
@@ -7,6 +7,7 @@ describe CloudNetworkHelper::TextualSummary do
     cloud_subnets
     network_routers
     floating_ips
+    custom_button_events
   )
   include_examples "textual_group", "Properties", %i(name type status ems_ref)
 end

--- a/spec/helpers/cloud_object_store_container_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_object_store_container_helper/textual_summary_spec.rb
@@ -1,4 +1,4 @@
 describe CloudObjectStoreContainerHelper::TextualSummary do
   include_examples "textual_group", "Properties", %i(key size)
-  include_examples "textual_group", "Relationships", %i(parent_ems_cloud ems cloud_tenant cloud_object_store_objects)
+  include_examples "textual_group", "Relationships", %i(parent_ems_cloud ems cloud_tenant cloud_object_store_objects custom_button_events)
 end

--- a/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
@@ -22,5 +22,6 @@ describe CloudSubnetHelper::TextualSummary do
     managed_subnets
     network_ports
     security_groups
+    custom_button_events
   )
 end

--- a/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
@@ -19,6 +19,7 @@ describe CloudTenantHelper::TextualSummary do
     security_groups
     floating_ips
     network_ports
+    custom_button_events
   )
 
   include_examples "textual_group", "Quotas", []

--- a/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
@@ -8,6 +8,7 @@ describe CloudVolumeHelper::TextualSummary do
     cloud_volume_backups
     cloud_volume_snapshots
     attachments
+    custom_button_events
   )
   include_examples "textual_group", "Properties", %i(name size bootable description)
 end

--- a/spec/helpers/container_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/container_group_helper/textual_summary_spec.rb
@@ -9,6 +9,7 @@ describe ContainerGroupHelper::TextualSummary do
     lives_on
     container_images
     persistent_volumes
+    custom_button_events
   )
 
   include_examples "textual_group", "Properties", %i(

--- a/spec/helpers/container_image_helper/textual_summary_spec.rb
+++ b/spec/helpers/container_image_helper/textual_summary_spec.rb
@@ -6,6 +6,7 @@ describe ContainerImageHelper::TextualSummary do
     container_groups
     containers
     container_nodes
+    custom_button_events
   )
   include_examples "textual_group", "Properties", %i(
     name

--- a/spec/helpers/container_node_helper/textual_summary_spec.rb
+++ b/spec/helpers/container_node_helper/textual_summary_spec.rb
@@ -8,6 +8,7 @@ describe ContainerNodeHelper::TextualSummary do
     containers
     lives_on
     container_images
+    custom_button_events
   )
   include_examples "textual_group", "Properties", %i(
     name

--- a/spec/helpers/container_project_helper/textual_summary_spec.rb
+++ b/spec/helpers/container_project_helper/textual_summary_spec.rb
@@ -8,6 +8,7 @@ describe ContainerProjectHelper::TextualSummary do
     container_nodes
     container_images
     container_templates
+    custom_button_events
   )
   include_examples "textual_group", "Properties", %i(name display_name creation_timestamp resource_version)
   include_examples "textual_group_smart_management"

--- a/spec/helpers/container_template_helper/textual_summary_spec.rb
+++ b/spec/helpers/container_template_helper/textual_summary_spec.rb
@@ -1,5 +1,5 @@
 describe ContainerTemplateHelper::TextualSummary do
-  include_examples "textual_group", "Relationships", %i(ems container_project)
+  include_examples "textual_group", "Relationships", %i(ems container_project custom_button_events)
   include_examples "textual_group", "Properties", %i(name creation_timestamp resource_version)
   include_examples "textual_group_smart_management"
 end

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -44,6 +44,7 @@ describe EmsCloudHelper::TextualSummary do
       images
       orchestration_stacks
       storage_managers
+      custom_button_events
     )
     include_examples "textual_group", "Properties", %i(description hostname ipaddress type port guid region keystone_v3_domain_id)
 

--- a/spec/helpers/ems_cluster_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cluster_helper/textual_summary_spec.rb
@@ -19,6 +19,7 @@ describe EmsClusterHelper::TextualSummary do
     total_vms
     rps_size
     states_size
+    custom_button_events
   )
   include_examples "textual_group", "Totals for VMs", %i(aggregate_vm_memory aggregate_vm_cpus), 'vm_totals'
   include_examples "textual_group", "Totals for 101", %i(

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -37,6 +37,7 @@ describe EmsContainerHelper::TextualSummary do
       volumes
       container_builds
       container_templates
+      custom_button_events
     )
     include_examples "textual_group", "Status", %i(authentications_status metrics_status refresh_status refresh_date data_collection_state)
     include_examples "textual_group_smart_management", %i(zone)

--- a/spec/helpers/ems_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_infra_helper/textual_summary_spec.rb
@@ -15,6 +15,7 @@ describe EmsInfraHelper::TextualSummary do
     orchestration_stacks
     ems_cloud
     network_manager
+    custom_button_events
   )
 
   include_examples "textual_group", "Properties", %i(

--- a/spec/helpers/ems_network_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_network_helper/textual_summary_spec.rb
@@ -16,6 +16,7 @@ describe EmsNetworkHelper::TextualSummary do
     floating_ips
     network_ports
     load_balancers
+    custom_button_events
   )
 
   include_examples "textual_group", "Status", %i(refresh_status refresh_date)

--- a/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
@@ -18,6 +18,7 @@ describe EmsPhysicalInfraHelper::TextualSummary do
     physical_storages
     physical_switches
     vms
+    custom_button_events
   )
 
   include_examples "textual_group_smart_management", %i(zone)

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -13,6 +13,7 @@ describe EmsStorageHelper::TextualSummary do
     cloud_volume_backups
     cloud_object_store_containers
     cloud_volume_types
+    custom_button_events
   )
 
   include_examples "textual_group", "Status", %i(refresh_status refresh_date)

--- a/spec/helpers/host_helper/textual_summary_spec.rb
+++ b/spec/helpers/host_helper/textual_summary_spec.rb
@@ -44,6 +44,7 @@ describe HostHelper::TextualSummary do
     drift_history
     physical_server
     network_manager
+    custom_button_events
   )
 
   include_examples "textual_group", "Security", %i(users groups patches firewall_rules ssh_root)

--- a/spec/helpers/infra_networking_helper/textual_summary_spec.rb
+++ b/spec/helpers/infra_networking_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe InfraNetworkingHelper::TextualSummary do
   include_examples "textual_group", "UNUSED?", %i(switch_type), "properties"
 
-  include_examples "textual_group", "Relationships", %i(hosts)
+  include_examples "textual_group", "Relationships", %i(hosts custom_button_events)
 
   include_examples "textual_group_smart_management"
 end

--- a/spec/helpers/load_balancer_helper/textual_summary_spec.rb
+++ b/spec/helpers/load_balancer_helper/textual_summary_spec.rb
@@ -9,5 +9,6 @@ describe LoadBalancerHelper::TextualSummary do
     network_ports
     floating_ips
     security_groups
+    custom_button_events
   )
 end

--- a/spec/helpers/network_router_helper/textual_summary_spec.rb
+++ b/spec/helpers/network_router_helper/textual_summary_spec.rb
@@ -10,5 +10,6 @@ describe NetworkRouterHelper::TextualSummary do
     external_gateway
     floating_ips
     security_groups
+    custom_button_events
   )
 end

--- a/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
+++ b/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe OrchestrationStackHelper::TextualSummary do
   before { @record = FactoryGirl.build(:orchestration_stack) }
 
   it "#textual_group_lifecycle includes retirement_date" do
-    expect(textual_group_lifecycle.items).to eq([:retirement_date])
+    expect(textual_group_lifecycle.items).to eq(%i(retirement_date custom_button_events))
   end
 
   describe "#textual_retirement_date value" do

--- a/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
+++ b/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe OrchestrationStackHelper::TextualSummary do
   before { @record = FactoryGirl.build(:orchestration_stack) }
 
   it "#textual_group_lifecycle includes retirement_date" do
-    expect(textual_group_lifecycle.items).to eq(%i(retirement_date custom_button_events))
+    expect(textual_group_lifecycle.items).to eq(%i(retirement_date))
   end
 
   describe "#textual_retirement_date value" do

--- a/spec/helpers/persistent_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/persistent_volume_helper/textual_summary_spec.rb
@@ -33,7 +33,7 @@ describe PersistentVolumeHelper::TextualSummary do
       allow(@record).to receive(:persistent_volume_claim).and_return(true)
     end
 
-    include_examples "textual_group", "Relationships", %i(parent pods_using_persistent_volume)
+    include_examples "textual_group", "Relationships", %i(parent pods_using_persistent_volume custom_button_events)
 
     include_examples "textual_group_smart_management"
 

--- a/spec/helpers/security_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/security_group_helper/textual_summary_spec.rb
@@ -26,5 +26,6 @@ describe SecurityGroupHelper::TextualSummary do
     network_ports
     network_router
     cloud_subnet
+    custom_button_events
   )
 end

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -137,7 +137,7 @@ describe ServiceHelper::TextualSummary do
 
   include_examples "textual_group", "Lifecycle", %i(retirement_date retirement_state owner group created)
 
-  include_examples "textual_group", "Relationships", %i(catalog_item parent_service orchestration_stack job)
+  include_examples "textual_group", "Relationships", %i(catalog_item parent_service orchestration_stack job custom_button_events)
 
   include_examples "textual_group", "Custom Attributes", [], "miq_custom_attributes"
 

--- a/spec/helpers/storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/storage_helper/textual_summary_spec.rb
@@ -92,6 +92,7 @@ describe StorageHelper do
     registered_vms
     unregistered_vms
     unmanaged_vms
+    custom_button_events
   )
 
   include_examples "textual_group_smart_management"

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -56,6 +56,7 @@ describe VmHelper::TextualSummary do
     scan_history
     cloud_network
     cloud_subnet
+    custom_button_events
   )
 
   include_examples "textual_group", "Relationships", %i(
@@ -82,9 +83,10 @@ describe VmHelper::TextualSummary do
     network_ports
     load_balancers
     cloud_volumes
+    custom_button_events
   ), "vm_cloud_relationships"
 
-  include_examples "textual_group", "Relationships", %i(ems parent_vm genealogy drift scan_history cloud_tenant),
+  include_examples "textual_group", "Relationships", %i(ems parent_vm genealogy drift scan_history cloud_tenant custom_button_events),
                    "template_cloud_relationships"
 
   include_examples "textual_group", "Security", %i(users groups patches)


### PR DESCRIPTION
Adding a link to the related textual summaries with the number of custom button events. The link takes you to a GTL where you can see all these events in detail.

![screenshot from 2018-08-27 14-32-40](https://user-images.githubusercontent.com/649130/44659891-15f98580-aa06-11e8-88cc-9a471749da25.png)

![screenshot from 2018-08-27 14-33-04](https://user-images.githubusercontent.com/649130/44659903-1f82ed80-aa06-11e8-9745-75800c15b776.png)

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label pending core

Depends on: https://github.com/ManageIQ/manageiq/pull/17885