### PR TITLE
There is no need to check for tab title uniqueness for default dashboard

### DIFF
--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -318,7 +318,7 @@ module ReportController::Dashboards
       return
     end
     # no need to check this for default dashboard, it doesn't belong to any group
-    if @sb[:nodes][2] != "d"
+    if @sb[:nodes][1] == "g_g"
       ws = MiqWidgetSet.where(:owner_id => @sb[:nodes][2])
       # make sure description is unique within group
       ws.each do |w|

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -45,5 +45,52 @@ describe ReportController do
         expect(miq_widget_set.members).to match_array(MiqWidget.all)
       end
     end
+
+    describe "#db_fields_validation" do
+      before do
+        @widget1 = FactoryGirl.create(:miq_widget)
+        @widget2 = FactoryGirl.create(:miq_widget)
+        @miq_widget_set = FactoryGirl.create(:miq_widget_set,
+                                             :owner       => user.current_group,
+                                             :name        => "fred",
+                                             :description => "FRED",
+                                             :set_data    => {:col1 => [@widget1.id], :col2 => [], :col3 => []})
+        FactoryGirl.create(:miq_widget_set,
+                           :owner       => user.current_group,
+                           :name        => "wilma",
+                           :description => "WILMA",
+                           :set_data    => {:col1 => [@widget2.id], :col2 => [], :col3 => []})
+        login_as user
+        EvmSpecHelper.local_miq_server
+      end
+
+      it 'display flash message for uniqueness of tab title of dashboard within a group' do
+        controller.instance_variable_set(:@sb, :nodes => ["xx", "g_g", "#{user.current_group.id}_", @miq_widget_set.id])
+        controller.instance_variable_set(:@edit, :db_id => @miq_widget_set.id, :read_only => false, :type => "db_edit", :key => "db_edit__#{@miq_widget_set.id}",
+                                                  :new => {:name => "fred", :description => "WILMA", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []},
+                                                  :current => {:name => "fred", :description => "FRED", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []})
+        controller.send(:db_fields_validation)
+        expect(assigns(:flash_array).first[:message]).to include("Tab Title must be unique for this group")
+      end
+
+      it 'No flash message set when tab title is unique within a group' do
+        controller.instance_variable_set(:@sb, :nodes => ["xx", "g_g", "#{user.current_group.id}_", @miq_widget_set.id])
+        controller.instance_variable_set(:@edit, :db_id => @miq_widget_set.id, :read_only => false, :type => "db_edit", :key => "db_edit__#{@miq_widget_set.id}",
+                                                 :new => {:name => "fred", :description => "NEW TAB TITLE", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []},
+                                                 :current => {:name => "fred", :description => "FRED", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []})
+        controller.send(:db_fields_validation)
+        expect(assigns(:flash_array)).to be_nil
+      end
+
+      it 'No flash message set when tab title is changed for Default Dashboard' do
+        default_dashboard = FactoryGirl.create(:miq_widget_set, :read_only => true, :name => "default", :description => "Default Dashboard", :set_data => {:col1 => [@widget1.id], :col2 => [], :col3 => []})
+        controller.instance_variable_set(:@sb, :nodes => ["xx", default_dashboard.id])
+        controller.instance_variable_set(:@edit, :db_id => @miq_widget_set.id, :read_only => true, :type => "db_edit", :key => "db_edit__#{@miq_widget_set.id}",
+                                                 :new => {:name => "default", :description => "NEW Default Dashboard", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []},
+                                                 :current => {:name => "default", :description => "Default Dashboard", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []})
+        controller.send(:db_fields_validation)
+        expect(assigns(:flash_array)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixed condition, Only need a check for tab title uniqueness within a group for selected dashboard

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614872

@yrudman cc

@skateman please review, condition that is being fixed always returns true. This is difficult to recreate, i had to make changes in the database table to be able to recreate. Ping me on gitter, I can help you with that.