### PR TITLE
Unify grouping option date and vm in chargeback filter tab

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -152,13 +152,12 @@
     %label.control-label.col-md-2
       = _('Group by')
     .col-md-8
-      - opts = [["#{_('Date')}", "date"],["#{_('Date Only')}", "date-only"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
+      - opts = [[(_("Date and %{chargeback_model}")  % {:chargeback_model => @edit[:new][:cb_model]} ), "date"], ["#{_('Date Only')}", "date-only"]]
       - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Tenant')}", "tenant"]] if %w(ChargebackVm MeteringVm).include?(@edit[:new][:model])
-      = select_tag("cb_groupby",
-        options_for_select(opts, @edit[:new][:cb_groupby]),
-        :class                 => "selectpicker")
+      - selected_group_by_option = @edit[:new][:cb_groupby] == 'vm' ? 'date' : @edit[:new][:cb_groupby] # legacy reports can have 'vm', TODO: remove after migration
+      = select_tag("cb_groupby", options_for_select(opts, selected_group_by_option), :class => "selectpicker")
       :javascript
         miqInitSelectPicker();
         miqSelectPickerEvent('cb_groupby', '#{url}', {beforeSend: true, complete: true});


### PR DESCRIPTION
**Reason**: It has identical behaviour, it is grouping by [same key](https://github.com/lpichler/manageiq/blob/ccee53b05b4b06ab037ab53e5597d53202158749/app/models/chargeback.rb#L72) for those both options 

**before** 
![screen shot 2018-08-22 at 12 27 16](https://user-images.githubusercontent.com/14937244/44458534-dc400d80-a606-11e8-958f-442da7c89e1e.png)

**after**
![screen shot 2018-08-22 at 12 25 58](https://user-images.githubusercontent.com/14937244/44458537-dd713a80-a606-11e8-84d4-2a5dccc47f37.png)

Links
----------------

* part of https://bugzilla.redhat.com/show_bug.cgi?id=1530221

cc @gtanzillo 

@miq-bot assign @mzazrivec 
