### PR TITLE
Increase memory available to webpacker

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -13,7 +13,6 @@ NODE_ENV = ENV["NODE_ENV"]
 APP_PATH          = File.expand_path("../", __dir__)
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
-WEBPACK_BIN       = File.join(APP_PATH, "node_modules/.bin/webpack")
 
 unless File.exist?(WEBPACK_CONFIG)
   puts "Webpack configuration not found."
@@ -21,9 +20,12 @@ unless File.exist?(WEBPACK_CONFIG)
   exit!
 end
 
-newenv  = {"NODE_PATH" => NODE_MODULES_PATH.shellescape}
-cmdline = ["node", "--max_old_space_size=2048", WEBPACK_BIN, "--config", WEBPACK_CONFIG] + ARGV
+newenv  = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
+cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline
 end
+
+## In case of node OOM errors:
+# NODE_ENV=development node --max_old_space_size=2048 node_modules/.bin/webpack --config config/webpack/development.js

--- a/bin/webpack
+++ b/bin/webpack
@@ -26,6 +26,3 @@ cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline
 end
-
-## In case of node OOM errors:
-# NODE_ENV=development node --max_old_space_size=2048 node_modules/.bin/webpack --config config/webpack/development.js

--- a/bin/webpack
+++ b/bin/webpack
@@ -20,7 +20,10 @@ unless File.exist?(WEBPACK_CONFIG)
   exit!
 end
 
-newenv  = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
+newenv  = {
+  "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
+  "NODE_OPTIONS" => "--max_old_space_size=2048"
+}
 cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -32,8 +32,9 @@ rescue Errno::ENOENT, NoMethodError
 end
 
 newenv = {
-  "NODE_PATH" => NODE_MODULES_PATH.shellescape,
-  "ASSET_HOST" => DEV_SERVER_HOST.shellescape
+  "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
+  "ASSET_HOST"   => DEV_SERVER_HOST.shellescape,
+  "NODE_OPTIONS" => "--max_old_space_size=2048"
 }.freeze
 
 cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV


### PR DESCRIPTION
We were getting following error unless increasing memory available to Node:

```
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [node]
 2: 0x8c21ec [node]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
 5: v8::internal::Factory::NewUninitializedFixedArray(int) [node]
 6: 0xd4b133 [node]
 7: v8::internal::Runtime_GrowArrayElements(int, v8::internal::Object**, v8::internal::Isolate*) [node]
 8: 0x66f38042fd
Aborted (core dumped)
```

Reverting previous approach with WEBPACK_BIN because setting NODE_OPTIONS seems to resolve the issue as well and is more readable.

@miq-bot add_label enhancement
@miq-bot assign @himdel 