### PR TITLE
[WIP] - UI changes to show list of Custom Button Events

### DIFF
--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -159,6 +159,11 @@ module Mixins
       end
     end
 
+    def custom_button_events
+      @lastaction = "custom_button_events"
+      show_association('custom_button_events', _('Custom Button Events'), :custom_button_events, CustomButtonEvent)
+    end
+
     # show a single item from a detail list
     def show_item
       @showtype = "item"
@@ -192,6 +197,7 @@ module Mixins
                                :parent      => @record,
                                :association => association,
                                :named_scope => scopes,
+                               :clickable   => clickable_links?(db),
                                :dbname      => "#{@db}item")  # Get the records into a view & paginator
 
       if @explorer # In explorer?
@@ -216,6 +222,10 @@ module Mixins
       else
         render :action => "show"
       end
+    end
+
+    def clickable_links?(db)
+      db == CustomButtonEvent ? false : true
     end
   end
 end

--- a/app/decorators/custom_button_event_decorator.rb
+++ b/app/decorators/custom_button_event_decorator.rb
@@ -1,0 +1,5 @@
+class CustomButtonEventDecorator < MiqDecorator
+  def fonticon
+    'fa fa-list'
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,6 +163,7 @@ module ApplicationHelper
   }.freeze
 
   HAS_ASSOCATION = {
+    "CustomButtonEvent" => "custom_button_events",
     "groups"           => "groups",
     "users"            => "users",
     "event_logs"       => "event_logs",
@@ -382,6 +383,7 @@ module ApplicationHelper
 
   def view_to_association(view, parent)
     case view.db
+    when "CustomButtonEvent"           then "custom_button_events"
     when "OrchestrationStackOutput"    then "outputs"
     when "OrchestrationStackParameter" then "parameters"
     when "OrchestrationStackResource"  then "resources"

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module HostHelper::TextualSummary
+  include TextualMixins::TextualCustomButtonEvents
   include TextualMixins::TextualDevices
   include TextualMixins::TextualOsInfo
   include TextualMixins::TextualVmmInfo
@@ -23,7 +24,7 @@ module HostHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history physical_server network_manager)
+      %i(ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history physical_server network_manager custom_button_events)
     )
   end
 

--- a/app/helpers/textual_mixins/textual_custom_button_events.rb
+++ b/app/helpers/textual_mixins/textual_custom_button_events.rb
@@ -1,0 +1,14 @@
+module TextualMixins::TextualCustomButtonEvents
+  def textual_custom_button_events
+    return nil unless User.current_user.super_admin_user? || User.current_user.admin_user?
+    # num = CustomButtonEvent.where(:target => @record).length
+    num = @record.number_of(:custom_button_events)
+    label = _("Custom Button Events")
+    h = {:label => label, :icon => "fa fa-list", :value => num}
+    if num > 0
+      h[:title] = _("Show all %{label}") % {:label => label}
+      h[:link]  = url_for_only_path(:controller => controller.controller_name, :action => 'custom_button_events', :id => @record, :db => controller.controller_name)
+    end
+    h
+  end
+end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -1,5 +1,6 @@
 module VmHelper::TextualSummary
   include TextualMixins::TextualAdvancedSettings
+  include TextualMixins::TextualCustomButtonEvents
   include TextualMixins::TextualDescription
   include TextualMixins::TextualDrift
   include TextualMixins::TextualFilesystems
@@ -43,7 +44,7 @@ module VmHelper::TextualSummary
       _("Relationships"),
       %i(
         ems cluster host resource_pool storage service parent_vm genealogy drift scan_history
-        cloud_network cloud_subnet
+        cloud_network cloud_subnet custom_button_events
       )
     )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # default routes for each controller
   default_routes = %w(
     report_data
+    custom_button_events
   )
 
   # grouped routes
@@ -1797,6 +1798,7 @@ Rails.application.routes.draw do
     :host                     => {
       :get  => %w(
         advanced_settings
+        custom_button_events
         dialog_load
         download_data
         download_summary_pdf

--- a/product/views/CustomButtonEvent.yaml
+++ b/product/views/CustomButtonEvent.yaml
@@ -1,0 +1,77 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: CustomButtonEvent
+
+# Menu name
+name: CustomButtonEvent
+
+# Main DB table report is based on
+db: CustomButtonEvent
+
+# Columns to fetch from the main table
+cols:
+- button_name
+- automate_entry_point
+- username
+- created_on
+- message
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- button_name
+- automate_entry_point
+- username
+- created_on
+- message
+
+
+# Column titles, in order
+headers:
+- Button Name
+- Automate Entry Point
+- User Name
+- Created On
+- Message
+
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- Message
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:


### PR DESCRIPTION
Displays link to Custom Button Events list from supported CI summary screens. Currently this link is only visisble to super admin and admin roles. Custom Button Events list renders gtl, links on the list are not clickable.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1511126

