### PR TITLE
Set open_url to be false by default 

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -47,7 +47,8 @@ class DialogLocalService
       :api_submit_endpoint    => api_submit_endpoint,
       :api_action             => "order",
       :finish_submit_endpoint => finish_submit_endpoint,
-      :cancel_endpoint        => "/catalog/explorer"
+      :cancel_endpoint        => "/catalog/explorer",
+      :open_url               => false
     }
   end
 
@@ -67,7 +68,8 @@ class DialogLocalService
       :api_submit_endpoint    => submit_endpoint,
       :api_action             => button_name,
       :finish_submit_endpoint => cancel_endpoint,
-      :cancel_endpoint        => cancel_endpoint
+      :cancel_endpoint        => cancel_endpoint,
+      :open_url               => false
     )
 
     dialog_locals

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -19,7 +19,8 @@ describe DialogLocalService do
         :api_submit_endpoint    => "/api/service_catalogs/123/service_templates/321",
         :api_action             => "order",
         :finish_submit_endpoint => "finishsubmitendpoint",
-        :cancel_endpoint        => "/catalog/explorer"
+        :cancel_endpoint        => "/catalog/explorer",
+        :open_url               => false
       )
     end
 
@@ -33,7 +34,8 @@ describe DialogLocalService do
                                                                                                                                        :api_submit_endpoint    => "/api/service_catalogs/798/service_templates/987",
                                                                                                                                        :api_action             => "order",
                                                                                                                                        :finish_submit_endpoint => "finishsubmitendpoint",
-                                                                                                                                       :cancel_endpoint        => "/catalog/explorer")
+                                                                                                                                       :cancel_endpoint        => "/catalog/explorer",
+                                                                                                                                       :open_url               => false)
     end
   end
 
@@ -55,7 +57,8 @@ describe DialogLocalService do
             :api_submit_endpoint    => "/api/#{collection_name}/123",
             :api_action             => "custom-button-name",
             :finish_submit_endpoint => finish_endpoint,
-            :cancel_endpoint        => finish_endpoint
+            :cancel_endpoint        => finish_endpoint,
+            :open_url               => false,
           )
       end
     end


### PR DESCRIPTION
Fixing issue in Services

Service -> Catalogs -> Service Catalog -> order one

Before:
```
FATAL -- : Error caught: [ActionView::Template::Error] undefined local variable or method `open_url' for #<#<Class:0x00007fb698ba9e78>:0x00007fb698ba3a78>
Did you mean?  ops_url
app/views/shared/dialogs/_dialog_provision.html.haml:45:in 
```
After: It works

@miq-bot add_label bug, gaprindashvili/yes

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/4334

@romanblanco please review. Check #4334 works as well.