### PR TITLE
Add option Date Only for chargeback grouping

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -152,7 +152,7 @@
     %label.control-label.col-md-2
       = _('Group by')
     .col-md-8
-      - opts = [["#{_('Date')}", "date"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
+      - opts = [["#{_('Date')}", "date"],["#{_('Date Only')}", "date-only"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
       - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Tenant')}", "tenant"]] if %w(ChargebackVm MeteringVm).include?(@edit[:new][:model])


### PR DESCRIPTION
BackEnd PR https://github.com/ManageIQ/manageiq/pull/17893:

Highlighted options is the new one.

<img width="694" alt="screen shot 2018-08-22 at 15 44 54" src="https://user-images.githubusercontent.com/14937244/44467786-0e139d00-a624-11e8-9386-d29721d72431.png">


Links
----------------
* part of https://bugzilla.redhat.com/show_bug.cgi?id=1530221
* related (without depedency) PR https://github.com/ManageIQ/manageiq-ui-classic/pull/4517

@miq-bot assign @mzazrivec 
cc @gtanzillo 
@miq-bot add_label chargeback, gapridashvili/yes
