### PR TITLE
Use fonticon+background for powerstate icons in textual summaries

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,4 +25,5 @@
  *= require ./remote_console
  *= require graphiql/graphiql.css
  *= require piecharts
+ *= require @manageiq/react-ui-components/dist/textual_summary
 */

--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -1,19 +1,14 @@
 module TextualMixins::TextualPowerState
-  VALID_POWER_STATE = %w(
-    archived connecting disconnected image_locked install_failed maintenance
-    migrating never non_operational not_responding off on orphaned paused
-    powering_down powering-down powering_up powering-up preparing_for_maintenance
-    reboot_in_progress retired shelved_offloaded shelved standby suspended
-    template terminated unknown wait_for_launch
-  ).freeze
-
-  def power_state_to_image(state)
-    "svg/currentstate-#{state}.svg" if VALID_POWER_STATE.include?(state)
-  end
-
   def textual_power_state_whitelisted(state)
     state = state.blank? ? 'unknown' : state.downcase
-    {:label => _('Power State'), :value => state, :image => power_state_to_image(state)}
+    quad_icon = QuadiconHelper::MACHINE_STATE_QUADRANT[state]
+
+    {
+      :label      => _('Power State'),
+      :value      => state,
+      :icon       => quad_icon[:fonticon],
+      :background => quad_icon[:background]
+    }
   end
 
   def textual_power_state_whitelisted_with_template

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@manageiq/react-ui-components": "~0.10.7",
+    "@manageiq/react-ui-components": "~0.10.8",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",


### PR DESCRIPTION
For now we were using SVG icons for powerstate, however, in the quadicons we already changed this to a fonticon+background combo. This PR brings the same thing for textual summaries :tada: 

![screenshot from 2018-08-23 16-55-01](https://user-images.githubusercontent.com/649130/44534029-23a5c700-a6f7-11e8-89d0-3a8f321786e6.png)

Note that there might be a floating point issue on certain linux-based browsers (maybe even CPU family related, not sure), however, if you zoom in on the image, it will be perfectly centered.

![screenshot from 2018-08-23 17-06-05](https://user-images.githubusercontent.com/649130/44534101-4afc9400-a6f7-11e8-8642-592efaf34c63.png)

@miq-bot add_label graphics, textual summaries, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 