### PR TITLE
Upgrade node-sass to a current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jest": "^22.0.6",
     "jest-cli": "^22.0.0",
     "js-yaml": "~3.8.3",
-    "node-sass": "~4.5.2",
+    "node-sass": "~4.9.3",
     "path-complete-extname": "~0.1.0",
     "postcss-loader": "~2.1.5",
     "postcss-smart-import": "~0.6.11",


### PR DESCRIPTION
this solves the problem of 4.5.* not having any pre-built binaries for node8+

(https://github.com/sass/node-sass/releases?after=v4.6.0 vs https://github.com/sass/node-sass/releases (51 [means](https://github.com/sass/node-sass/blob/master/lib/extensions.js#L74) node 7, 57 node 8, 64 node 10))

@GregP I really hope this helps the problems you've been seeing with node-sass.