### PR TITLE
Fix focus of text field changes 1 or 2 seconds after host edit page is loaded

### DIFF
--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -4,90 +4,90 @@
   %form#form_div{"name"            => "angularForm",
                  "ng-controller"   => "hostFormController",
                  'ng-cloak'        => '',
-                 "ng-show"         => "afterGet",
                  "form-fields-url" => "/#{controller_name}/host_form_fields/",
                  "create-url"      => "/#{controller_name}/create/",
                  "update-url"      => "/#{controller_name}/update/",
                  "novalidate"      => true}
     = render :partial => "layouts/flash_msg"
-    - if session[:host_items].nil?
-      %div
+    %div{"ng-if" => "afterGet"}
+      - if session[:host_items].nil?
         %div
-          .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
-            %label.col-md-2.control-label{"for" => "name"}
-              = _("Name")
-            .col-md-8
-              %input.form-control{"type"        => "text",
-                                  "id"          => "name",
-                                  "name"        => "name",
-                                  "ng-model"    => "hostModel.name",
-                                  "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",
-                                  "miqrequired" => "",
-                                  "checkchange" => "",
-                                  "auto-focus"  => ""}
-              %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
-                = _("Required")
-          .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}"}
-            %label.col-md-2.control-label{"for" => "hostname"}
-              = _("Hostname (or IPv4 or IPv6 address)")
-            .col-md-4
-              %input.form-control{"type"        => "text",
-                                  "id"          => "hostname",
-                                  "name"        => "hostname",
-                                  "ng-model"    => "hostModel.hostname",
-                                  "maxlength"   => "#{ViewHelper::MAX_HOSTNAME_LEN}",
-                                  "miqrequired" => "",
-                                  "checkchange" => ""}
-              %span.help-block{"ng-show" => "angularForm.hostname.$error.miqrequired"}
-                = _("Required")
-          .form-group{"ng-class" => "{'has-error': angularForm.user_assigned_os.$invalid}", "ng-hide" => "hostModel.operating_system"}
-            %label.col-md-2.control-label
-              = _("Host platform")
-            .col-md-8
-              = select_tag('user_assigned_os',
-                           options_for_select([["<#{_('Choose')}>", nil]] + Host.host_create_os_types.to_a, disabled: ["<#{_('Choose')}>", nil]),
-                           "ng-model"                    => "hostModel.user_assigned_os",
-                           "checkchange"                 => "",
-                           "ng-required"                 => "!hostModel.operating_system",
-                           "selectpicker-for-select-tag" => "")
-              %span.help-block{"ng-show" => "angularForm.user_assigned_os.$error.required"}
-                = _("Required")
-          .form-group
-            %label.col-md-2.control-label
-              = _("Custom Identifier")
-            .col-md-8
-              %input#custom_1.form-control{"type"        => "text",
-                                           "name"        => "custom_1",
-                                           "ng-model"    => "hostModel.custom_1",
-                                           "maxlength"   => 50,
-                                           "checkchange" => ""}
-          .form-group{"ng-class" => "{'has-error': angularForm.ipmi_address.$error.requiredDependsOn}"}
-            %label.col-md-2.control-label{"for" => "ipmi_address"}
-              = _("IPMI IP Address")
-            .col-md-8
-              %input.form-control#ipmi_address{"type"                => "text",
-                                               "id"                  => "ipmi_address",
-                                               "name"                => "ipmi_address",
-                                               "ng-model"            => "hostModel.ipmi_address",
-                                               "required-depends-on" => "hostModel.ipmi_userid",
-                                               "required-if-exists"  => "ipmi_userid",
-                                               "maxlength"           => 15,
-                                               "checkchange"         => ""}
-              %span.help-block{"ng-show" => "angularForm.ipmi_address.$error.requiredDependsOn"}
-                = _("Required")
-          .form-group
-            %label.col-md-2.control-label
-              = _("MAC Address")
-            .col-md-8
-              %input#mac_address.form-control{"type"        => "text",
-                                              "name"        => "mac_address",
-                                              "ng-model"    => "hostModel.mac_address",
-                                              "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",
-                                              "checkchange" => ""}
-    %hr
-    = render(:partial => "/layouts/angular/multi_auth_credentials",
-             :locals  => {:record => @host, :ng_model => "hostModel"})
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+          %div
+            .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+              %label.col-md-2.control-label{"for" => "name"}
+                = _("Name")
+              .col-md-8
+                %input.form-control{"type"        => "text",
+                                    "id"          => "name",
+                                    "name"        => "name",
+                                    "ng-model"    => "hostModel.name",
+                                    "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",
+                                    "miqrequired" => "",
+                                    "checkchange" => "",
+                                    "auto-focus"  => ""}
+                %span.help-block{"ng-show" => "angularForm.name.$error.miqrequired"}
+                  = _("Required")
+            .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}"}
+              %label.col-md-2.control-label{"for" => "hostname"}
+                = _("Hostname (or IPv4 or IPv6 address)")
+              .col-md-4
+                %input.form-control{"type"        => "text",
+                                    "id"          => "hostname",
+                                    "name"        => "hostname",
+                                    "ng-model"    => "hostModel.hostname",
+                                    "maxlength"   => "#{ViewHelper::MAX_HOSTNAME_LEN}",
+                                    "miqrequired" => "",
+                                    "checkchange" => ""}
+                %span.help-block{"ng-show" => "angularForm.hostname.$error.miqrequired"}
+                  = _("Required")
+            .form-group{"ng-class" => "{'has-error': angularForm.user_assigned_os.$invalid}", "ng-hide" => "hostModel.operating_system"}
+              %label.col-md-2.control-label
+                = _("Host platform")
+              .col-md-8
+                = select_tag('user_assigned_os',
+                            options_for_select([["<#{_('Choose')}>", nil]] + Host.host_create_os_types.to_a, disabled: ["<#{_('Choose')}>", nil]),
+                            "ng-model"                    => "hostModel.user_assigned_os",
+                            "checkchange"                 => "",
+                            "ng-required"                 => "!hostModel.operating_system",
+                            "selectpicker-for-select-tag" => "")
+                %span.help-block{"ng-show" => "angularForm.user_assigned_os.$error.required"}
+                  = _("Required")
+            .form-group
+              %label.col-md-2.control-label
+                = _("Custom Identifier")
+              .col-md-8
+                %input#custom_1.form-control{"type"        => "text",
+                                            "name"        => "custom_1",
+                                            "ng-model"    => "hostModel.custom_1",
+                                            "maxlength"   => 50,
+                                            "checkchange" => ""}
+            .form-group{"ng-class" => "{'has-error': angularForm.ipmi_address.$error.requiredDependsOn}"}
+              %label.col-md-2.control-label{"for" => "ipmi_address"}
+                = _("IPMI IP Address")
+              .col-md-8
+                %input.form-control#ipmi_address{"type"                => "text",
+                                                "id"                  => "ipmi_address",
+                                                "name"                => "ipmi_address",
+                                                "ng-model"            => "hostModel.ipmi_address",
+                                                "required-depends-on" => "hostModel.ipmi_userid",
+                                                "required-if-exists"  => "ipmi_userid",
+                                                "maxlength"           => 15,
+                                                "checkchange"         => ""}
+                %span.help-block{"ng-show" => "angularForm.ipmi_address.$error.requiredDependsOn"}
+                  = _("Required")
+            .form-group
+              %label.col-md-2.control-label
+                = _("MAC Address")
+              .col-md-8
+                %input#mac_address.form-control{"type"        => "text",
+                                                "name"        => "mac_address",
+                                                "ng-model"    => "hostModel.mac_address",
+                                                "maxlength"   => "#{ViewHelper::MAX_NAME_LEN}",
+                                                "checkchange" => ""}
+      %hr
+      = render(:partial => "/layouts/angular/multi_auth_credentials",
+              :locals  => {:record => @host, :ng_model => "hostModel"})
+      = render :partial => "layouts/angular/x_edit_buttons_angular"
 
   - unless session[:host_items].nil?
     %h3


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1618359#c2

**Description of problem**

When navigating to Host edit page, after about 1 or 2 seconds the first text field 'Name' is focused.

This is especially annoying when you get to the page with the intention to validate credentials and you end up writing username to the 'Name' field instead. 

**Steps to Reproduce**
1. go to Host edit page
2. start immediately typing withing 1 or 2 seconds to some text field except the first one
3. wait for changing of focus on name field

@miq-bot add_label gaprindashvili/no, bug