### PR TITLE
Fix basic search for Datastores

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -222,7 +222,6 @@ class StorageController < ApplicationController
     self.x_node        = params[:id]
 
     load_or_clear_adv_search
-    apply_node_search_text if x_active_tree == :storage_tree
     replace_right_cell(:nodetype => x_node)
   end
 
@@ -399,23 +398,6 @@ class StorageController < ApplicationController
   def search_text_type(node)
     return "storage" if storage_record?(node)
     node
-  end
-
-  def apply_node_search_text
-    setup_search_text_for_node
-    previous_nodetype = search_text_type(@sb[:storage_search_text][:previous_node])
-    current_nodetype = search_text_type(@sb[:storage_search_text][:current_node])
-
-    @sb[:storage_search_text]["#{previous_nodetype}_search_text"] = @search_text
-    @search_text = @sb[:storage_search_text]["#{current_nodetype}_search_text"] || @sb[:search_text]
-    @sb[:storage_search_text]["#{x_active_accord}_search_text"] = @search_text
-  end
-
-  def setup_search_text_for_node
-    @sb[:storage_search_text] ||= {}
-    @sb[:storage_search_text][:current_node] ||= x_node
-    @sb[:storage_search_text][:previous_node] = @sb[:storage_search_text][:current_node]
-    @sb[:storage_search_text][:current_node] = x_node
   end
 
   def update_partials(record_showing, presenter)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1615826

**What:**
There is a bug in Datastores screen: previous basic search is not erased for last selected filter (node in the tree) before applying another basic search. This happens because basic search text is saved for each node in the tree, not for actual explorer screen.

**Details:**
Code should remember search text/string per explorer, not for each node/filter selected in the tree. I tried the same steps to reproduce in other explorer screens and I was not able to reproduce the behavior. It seems to be working correctly in other screens, search string is only being remembered per explorer. The behavior implemented in Datastores screen is a bug. The right search string is always set by calling `process_show_list` method here https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/storage_controller/storage_d.rb#L27 or https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/storage_controller/storage_d.rb#L41, no need to implement anything else.

**Note:**
The fix in this PR works also in the Datastore screen displayed through other screens (provider's details page) and also if going away to some totally different screen and going back to Datastores screen. 

---

**Steps to reproduce:**
1. Go to _Compute > Infra > Datastores_ (you need some Datastores there, of course)
2. Try to search for some text using basic search
3. Click on some node in the tree, apply some filter on datastores
4. Click on some other filter in the tree
5. Try to search for some another text using basic search
6. Click on the filter applied as a first one, from step 3
=> basic search changed to the previous one!!!

---

Step 3 from steps to reproduce (_Provisioning Scope/All_ global filter - the 1st applied one):
![data1_before](https://user-images.githubusercontent.com/13417815/44529053-6eb9dd00-a6eb-11e8-861b-1c6e8eb51067.png)

Step 4 from steps to reproduce (_Store Type/FCP_ global filter - the 2nd applied one):
![data2_before](https://user-images.githubusercontent.com/13417815/44529378-3e267300-a6ec-11e8-892e-e2eced0ce9a9.png)

**Before:** (clicking on the filter applied as the 1st one)
![data1_before_result](https://user-images.githubusercontent.com/13417815/44529502-89408600-a6ec-11e8-8094-e99e29667929.png)

**After:**
![data1_after_result](https://user-images.githubusercontent.com/13417815/44529745-1d125200-a6ed-11e8-9e78-814efe9f1d55.png)

