### PR TITLE
Fix incorrect title while displaying Datastore details page

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -328,12 +328,12 @@ class StorageController < ApplicationController
 
   def get_node_info(node, _show_list = true)
     node = valid_active_node(node)
+    session_reset # Reset session to same values as first time in
     case x_active_tree
     when :storage_tree     then storage_get_node_info(node)
     when :storage_pod_tree then storage_pod_get_node_info(node)
     end
-    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
-    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :storage && @edit && @edit[:adv_search_applied]
+    set_right_cell_text
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history
       x_history_add_item(:id     => x_node,
@@ -492,6 +492,18 @@ class StorageController < ApplicationController
   end
 
   private
+
+  def session_reset
+    if @record
+      session[:edit] = @edit = nil
+      session[:adv_search]['Storage'] = nil if session[:adv_search]
+    end
+  end
+
+  def set_right_cell_text
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && @nodetype != 'ds'
+    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :storage && @edit && @edit[:adv_search_applied]
+  end
 
   def textual_group_list
     [

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -271,6 +271,7 @@ describe StorageController do
 
         before do
           allow(controller).to receive(:render).and_return(true)
+          allow(controller).to receive(:build_accordions_and_trees)
 
           controller.instance_variable_set(:@record, datastore)
           controller.instance_variable_set(:@sb, :active_tree => :storage_tree)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1620745

There is a small bug related to Datastores: incorrect title is displayed while displaying Datastore details page: unnecessary 'Names with.. ' and/or 'Filtered by..' is added to the title (right cell text), if any filtering (basic or advanced search) was applied on the list of datastores, before displaying datastore's details page.

**Steps to reproduce:**
1. Go to _Compute > Infra > Datastores_ (you need some Datastores here!)
2. Search for some text using basic search and/or apply some filter
   (click on some filter in accordion or use _Advanced Search_)
3. Click on some datastore to display its details page

---

**Before:**
![incorrect_title_datastore](https://user-images.githubusercontent.com/13417815/44531359-dd4d6980-a6f0-11e8-90f7-9f553dd31f1f.png)

**After:**
![datastore_title_expect](https://user-images.githubusercontent.com/13417815/44531363-e0485a00-a6f0-11e8-8bbe-fcb21cf2e216.png)

---

**Note:**
The fix was inspired by service controller https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/service_controller.rb#L307 and https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/service_controller.rb#L332 which works well.