### PR TITLE
Fixed console warning method in fetch.

### DIFF
--- a/app/javascript/http_api/fetch.js
+++ b/app/javascript/http_api/fetch.js
@@ -54,7 +54,7 @@ function processData(o) {
   }
 
   // fetch supports more types but we aren't using any of those yet..
-  console.warning('Unknown type for request data - please provide a plain object or a string', o);
+  console.warn('Unknown type for request data - please provide a plain object or a string', o);
   return null;
 }
 


### PR DESCRIPTION
I've stumbled upon a small bug in `fetch.js`. The console was using `warning` method instead of `warn`.
