### PR TITLE
Fix mislabeled Description field on the EmsCloud summary view

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -7,7 +7,7 @@ module EmsCloudHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(provider_region hostname ipaddress type port guid region keystone_v3_domain_id)
+      %i(description hostname ipaddress type port guid region keystone_v3_domain_id)
     )
   end
 
@@ -38,9 +38,9 @@ module EmsCloudHelper::TextualSummary
   #
   # Items
   #
-  def textual_provider_region
-    return nil if @record.provider_region.nil?
-    {:label => _("Region"), :value => @record.description}
+  def textual_description
+    return nil if @record.description.blank?
+    {:label => _("Description"), :value => @record.description}
   end
 
   def textual_region

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -45,7 +45,7 @@ describe EmsCloudHelper::TextualSummary do
       orchestration_stacks
       storage_managers
     )
-    include_examples "textual_group", "Properties", %i(provider_region hostname ipaddress type port guid region keystone_v3_domain_id)
+    include_examples "textual_group", "Properties", %i(description hostname ipaddress type port guid region keystone_v3_domain_id)
 
     include_examples "textual_group", "Status", %i(refresh_status refresh_date)
 


### PR DESCRIPTION
Fixes an apparent copy-paste error that resulted in the EmsCloud description field being labeled as "Region" and using an erroneous display condition.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1392342

![region_description_fix](https://user-images.githubusercontent.com/628956/44541157-18db3a00-a6d7-11e8-9b46-ea160d1c396a.png)
