### PR TITLE
Added spinner after Value is selected on tagging screen

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -59,7 +59,7 @@ module ApplicationController::Tags
       if params[:tag_add]
         page << jquery_pulsate_element("#{j_str(params[:tag_add])}_tr")
       end
-      page << set_spinner_off if params[:tag_cat]
+      page << set_spinner_off if params[:tag_cat] || params[:tag_add]
     end
   end
 

--- a/app/views/layouts/_tag_edit_cat_tags.html.haml
+++ b/app/views/layouts/_tag_edit_cat_tags.html.haml
@@ -4,10 +4,9 @@
   - options = @entries.empty? ? [[_("<All values are assigned>"), "select"]] : [[_("<Select a value to assign>"), "select"]] + tags
   = select_tag("tag_add",
     options_for_select(options, "select"),
-    "data-miq_observe" => {:url => url}.to_json,
     "data-live-search" => "true",
     "data-container"   => "body",
     "class"            => "selectpicker")
   :javascript
     miqInitSelectPicker();
-    miqSelectPickerEvent("tag_add", "#{url}", {beforeSend: true, complete: true});
+    miqSelectPickerEvent("tag_add", "#{url}", {beforeSend: true});


### PR DESCRIPTION
Stop spinner after transaction is complete, when switching between values too quickly sometimes it leaves drop down open and unresponsive. Removed `data-miq_observe` from drop down value as well similar to what was done for Categories drop down, miqSelectPickerEvent is being called to observe bootstrap dropdowns.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614437
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601915

@dclarizio made similar changes that were made to Category drop down to second drop down that allows users to select tag values on tagging screen. Was able to recreate the issue on slow server where i could change second drop down values quickly while the table was pulsating with the change made in previous transaction.