### PR TITLE
Showing Location LED state for physical chassis

### DIFF
--- a/app/helpers/physical_chassis_helper/textual_summary.rb
+++ b/app/helpers/physical_chassis_helper/textual_summary.rb
@@ -6,7 +6,7 @@ module PhysicalChassisHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i(name product_name manufacturer serial_number part_number health_state uid_ems description)
+      %i(name product_name manufacturer serial_number part_number health_state uid_ems description location_led_state)
     )
   end
 
@@ -64,6 +64,10 @@ module PhysicalChassisHelper::TextualSummary
 
   def textual_description
     {:label => _("Description"), :value => @record.asset_detail["description"]}
+  end
+
+  def textual_location_led_state
+    {:label => _("Identify LED State"), :value => @record.asset_detail['location_led_state']}
   end
 
   #

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -156,7 +156,7 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_loc_led_state
-    {:label => _("Identify LED State"), :value => @record.location_led_state}
+    {:label => _("Identify LED State"), :value => @record.asset_detail['location_led_state']}
   end
 
   def textual_support_contact

--- a/product/views/PhysicalChassis.yaml
+++ b/product/views/PhysicalChassis.yaml
@@ -13,6 +13,7 @@ cols:
 - name
 - type
 - health_state
+- asset_detail.location_led_state
 - asset_detail.product_name
 - asset_detail.manufacturer
 
@@ -30,6 +31,7 @@ col_order:
 - name
 - type
 - health_state
+- asset_detail.location_led_state
 - asset_detail.product_name
 - asset_detail.manufacturer
 
@@ -41,6 +43,7 @@ headers:
 - Name
 - Type
 - Health State
+- LED State
 - Product Name
 - Manufacturer
 

--- a/product/views/PhysicalServer.yaml
+++ b/product/views/PhysicalServer.yaml
@@ -14,7 +14,6 @@ cols:
 - type
 - health_state
 - power_state
-- location_led_state
 - hostname
 - asset_detail
 
@@ -33,7 +32,7 @@ col_order:
 - type
 - health_state
 - power_state
-- location_led_state
+- asset_detail.location_led_state
 - hostname
 - asset_detail.product_name
 - asset_detail.manufacturer

--- a/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
@@ -11,11 +11,12 @@ describe PhysicalChassisHelper::TextualSummary do
 
   let(:asset_detail) do
     FactoryGirl.create(:asset_detail,
-                       :product_name  => 'Lenovo XYZ Chassis x1000',
-                       :manufacturer  => 'Lenovo',
-                       :serial_number => 'A1B2C3D4E5F6',
-                       :part_number   => 'XXX18',
-                       :description   => 'Physical Chassis used inside site A')
+                       :product_name       => 'Lenovo XYZ Chassis x1000',
+                       :manufacturer       => 'Lenovo',
+                       :serial_number      => 'A1B2C3D4E5F6',
+                       :part_number        => 'XXX18',
+                       :description        => 'Physical Chassis used inside site A',
+                       :location_led_state => 'Off')
   end
 
   let(:network) do
@@ -89,7 +90,7 @@ describe PhysicalChassisHelper::TextualSummary do
 
     it 'shows 8 fields' do
       expect(subject.items).to be_kind_of(Array)
-      expect(subject.items.size).to eq(8)
+      expect(subject.items.size).to eq(9)
     end
 
     it 'shows main properties' do
@@ -101,7 +102,8 @@ describe PhysicalChassisHelper::TextualSummary do
         :part_number,
         :health_state,
         :uid_ems,
-        :description
+        :description,
+        :location_led_state
       )
     end
   end
@@ -224,6 +226,14 @@ describe PhysicalChassisHelper::TextualSummary do
 
     it 'show the chassis description' do
       expect(subject).to eq(:label => 'Description', :value => 'Physical Chassis used inside site A')
+    end
+  end
+
+  describe '.textual_location_led_state' do
+    subject { textual_location_led_state }
+
+    it 'show the chassis location LED state' do
+      expect(subject).to eq(:label => 'Identify LED State', :value => 'Off')
     end
   end
 


### PR DESCRIPTION
__This PR is able to__
- Adapt the physical server pages to retrieve `loc_led_state` from the new place (`asset_detail.location_led_state`);
- Add location LED state to physical chassis pages;

__Depends on__
- ~https://github.com/ManageIQ/manageiq-schema/pull/262~
- ~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/222~