### PR TITLE
Allow selecting an optional volume type when creating an Openstack cloud volume

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -128,7 +128,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
+    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
@@ -267,7 +267,8 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudTenantChoices = data.parent_manager.cloud_tenants;
     vm.availabilityZoneChoices = data.parent_manager.availability_zones;
     vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
-    if (vm.cloudVolumeModel.emstype !== 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
+    vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
+    if (vm.supportsCinderVolumeTypes) {
       vm.volumeTypes = data.parent_manager.cloud_volume_types;
     }
     miqService.sparkleOff();

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -128,20 +128,22 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots')
+    return API.get('/api/providers/' + id + '?attributes=type,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
 
   vm.sizeChanged = function(size) {
-    // Dynamically update the AWS IOPS only if GP2 volume type is selected.
-    if (vm.cloudVolumeModel.aws_volume_type === 'gp2') {
-      var volumeSize = parseInt(size, 10);
+    if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
+      // Dynamically update the AWS IOPS only if GP2 volume type is selected.
+      if (vm.cloudVolumeModel.volume_type === 'gp2') {
+        var volumeSize = parseInt(size, 10);
 
-      if (isNaN(volumeSize)) {
-        vm.cloudVolumeModel.aws_iops = null;
-      } else {
-        vm.cloudVolumeModel.aws_iops = Math.max(100, Math.min(volumeSize * 3, 10000));
+        if (isNaN(volumeSize)) {
+          vm.cloudVolumeModel.aws_iops = null;
+        } else {
+          vm.cloudVolumeModel.aws_iops = Math.max(100, Math.min(volumeSize * 3, 10000));
+        }
       }
     }
   };
@@ -179,7 +181,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     // can be resized on the fly).
     return vm.newRecord ||
       (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs' &&
-        vm.cloudVolumeModel.aws_volume_type !== 'standard');
+        vm.cloudVolumeModel.volume_type !== 'standard');
   };
 
   vm.awsBaseSnapshotChanged = function(baseSnapshotId) {
@@ -199,7 +201,9 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
   };
 
   function setForm() {
-    loadEBSVolumeTypes();
+    if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
+      loadEBSVolumeTypes();
+    }
 
     vm.modelCopy = angular.copy(vm.cloudVolumeModel);
     vm.afterGet = true;
@@ -213,7 +217,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   var loadEBSVolumeTypes = function() {
     // This ia a fixed list of available cloud volume types for Amazon EBS.
-    vm.awsVolumeTypes = [
+    vm.volumeTypes = [
       { type: 'gp2', name: __('General Purpose SSD (GP2)') },
       { type: 'io1', name: __('Provisioned IOPS SSD (IO1)') },
       { type: 'st1', name: __('Throughput Optimized HDD (ST1)') },
@@ -224,8 +228,8 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     // an existing standard volume. In the latter case, it is only available so
     // that the "Magnetic (standard)" option can be picked in the select that is
     // otherwise disabled.
-    if (vm.newRecord || vm.cloudVolumeModel.aws_volume_type === 'standard') {
-      vm.awsVolumeTypes.push({ type: 'standard', name: __('Magnetic') });
+    if (vm.newRecord || vm.cloudVolumeModel.volume_type === 'standard') {
+      vm.volumeTypes.push({ type: 'standard', name: __('Magnetic') });
     }
   };
 
@@ -240,9 +244,9 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     // We have to display size in GB.
     vm.cloudVolumeModel.size = data.size / 1073741824;
     vm.cloudVolumeModel.cloud_tenant_id = data.cloud_tenant_id;
+    vm.cloudVolumeModel.volume_type = data.volume_type;
     // Currently, this is only relevant for AWS volumes so we are prefixing the
     // model attribute with AWS.
-    vm.cloudVolumeModel.aws_volume_type = data.volume_type;
     vm.cloudVolumeModel.aws_availability_zone_id = data.availability_zone.ems_ref;
     vm.cloudVolumeModel.aws_encryption = data.encrypted;
     vm.cloudVolumeModel.aws_iops = data.iops;
@@ -263,7 +267,9 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudTenantChoices = data.parent_manager.cloud_tenants;
     vm.availabilityZoneChoices = data.parent_manager.availability_zones;
     vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
-
+    if (vm.cloudVolumeModel.emstype !== 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
+      vm.volumeTypes = data.parent_manager.cloud_volume_types;
+    }
     miqService.sparkleOff();
   };
 

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -551,7 +551,7 @@ class CloudVolumeController < ApplicationController
 
   def form_params
     options = copy_params_if_set({}, params, %i(name size cloud_tenant_id vm_id device_path))
-    options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+    options[:volume_type] = params[:volume_type] if params[:volume_type]
     # Only set IOPS if io1 (provisioned IOPS) and IOPS available
     options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
     options
@@ -575,6 +575,7 @@ class CloudVolumeController < ApplicationController
   def cinder_manager_options
     options = {}
     cloud_tenant_id = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+    options[:volume_type] = params[:volume_type] if params[:volume_type]
     cloud_tenant = find_record_with_rbac(CloudTenant, cloud_tenant_id)
     options[:cloud_tenant] = cloud_tenant
     options[:ems] = cloud_tenant.ext_management_system
@@ -583,7 +584,7 @@ class CloudVolumeController < ApplicationController
 
   def aws_ebs_options
     options = {}
-    options[:volume_type] = params[:aws_volume_type] if params[:aws_volume_type]
+    options[:volume_type] = params[:volume_type] if params[:volume_type]
     # Only set IOPS if io1 (provisioned IOPS) and IOPS available
     options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
     options[:availability_zone] = params[:aws_availability_zone_id] if params[:aws_availability_zone_id]

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -62,23 +62,36 @@
     %span.help-block{"ng-show" => "angularForm.name.$error.required"}
       = _("Required")
 
-.form-group{"ng-class" => "{'has-error': angularForm.aws_volume_type.$invalid}",
+.form-group{"ng-class" => "{'has-error': angularForm.volume_type.$invalid}",
             "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
   %label.col-md-2.control-label
     = _('Cloud Volume Type')
   .col-md-8
-    %select{"name"        => "aws_volume_type",
-            "ng-model"    => "vm.cloudVolumeModel.aws_volume_type",
-            "ng-options"  => "voltype.type as voltype.name for voltype in vm.awsVolumeTypes",
-            "ng-change"   => "vm.awsVolumeTypeChanged(vm.cloudVolumeModel.aws_volume_type)",
-            "ng-disabled" => "!vm.newRecord && vm.cloudVolumeModel.aws_volume_type == 'standard'",
+    %select{"name"        => "volume_type",
+            "ng-model"    => "vm.cloudVolumeModel.volume_type",
+            "ng-options"  => "voltype.type as voltype.name for voltype in vm.volumeTypes",
+            "ng-change"   => "vm.awsVolumeTypeChanged(vm.cloudVolumeModel.volume_type)",
+            "ng-disabled" => "!vm.newRecord && vm.cloudVolumeModel.volume_type == 'standard'",
             "required"    => "",
             :checkchange  => true,
             "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
-    %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
+    %span.help-block{"ng-show" => "angularForm.volume_type.$error.required"}
       = _("Required")
+
+.form-group{"ng-class" => "{'has-error': angularForm.volume_type.$invalid}",
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Openstack::StorageManager::CinderManager'"}
+  %label.col-md-2.control-label
+    = _('Cloud Volume Type')
+  .col-md-8
+    %select{"name"        => "volume_type",
+            "ng-model"    => "vm.cloudVolumeModel.volume_type",
+            "ng-options"  => "voltype.name as voltype.name for voltype in vm.volumeTypes",
+            "ng-disabled" => "!vm.newRecord",
+            "pf-select"   => true}
+      %option{"value" => ""}
+        = "<#{_('None')}>"
 
 .form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
   %label.col-md-2.control-label
@@ -104,10 +117,10 @@
                         :name          => "aws_iops",
                         'ng-model'     => "vm.cloudVolumeModel.aws_iops",
                         'ng-maxlength' => 50,
-                        'ng-disabled'  => "vm.cloudVolumeModel.aws_volume_type != 'io1'",
-                        "ng-required"  => "vm.cloudVolumeModel.aws_volume_type == 'io1'",
+                        'ng-disabled'  => "vm.cloudVolumeModel.volume_type != 'io1'",
+                        "ng-required"  => "vm.cloudVolumeModel.volume_type == 'io1'",
                         :checkchange   => true}
-    %span.help-block{"ng-show" => "vm.cloudVolumeModel.aws_volume_type == 'io1' && angularForm.aws_iops.$error.required"}
+    %span.help-block{"ng-show" => "vm.cloudVolumeModel.volume_type == 'io1' && angularForm.aws_iops.$error.required"}
       = _("Required")
 
 .form-group{"ng-if" => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -81,7 +81,7 @@
       = _("Required")
 
 .form-group{"ng-class" => "{'has-error': angularForm.volume_type.$invalid}",
-            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Openstack::StorageManager::CinderManager'"}
+            "ng-if"    => "vm.supportsCinderVolumeTypes"}
   %label.col-md-2.control-label
     = _('Cloud Volume Type')
   .col-md-8

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -271,7 +271,7 @@ describe CloudVolumeController do
       context "for volume type 'gp2'" do
         before do
           # 'gp2' volume type requires only the type
-          @form_params[:aws_volume_type] = "gp2"
+          @form_params[:volume_type] = "gp2"
           @aws_options[:volume_type] = "gp2"
           @aws_options[:encrypted] = nil
         end
@@ -282,7 +282,7 @@ describe CloudVolumeController do
       context "for volume type 'io1'" do
         before do
           # 'io1' volume type requires the IOPS as well.
-          @form_params[:aws_volume_type] = "io1"
+          @form_params[:volume_type] = "io1"
           @form_params[:aws_iops] = "100"
 
           @aws_options[:volume_type] = "io1"
@@ -296,7 +296,7 @@ describe CloudVolumeController do
       context "for encrypted volume" do
         before do
           # 'gp2' volume type requires only the type
-          @form_params[:aws_volume_type] = "gp2"
+          @form_params[:volume_type] = "gp2"
           @form_params[:aws_encryption] = "true"
           @aws_options[:volume_type] = "gp2"
           @aws_options[:encrypted] = "true"


### PR DESCRIPTION
Allows selecting an optional Volume Type when creating an Openstack cloud volume. Generalizes the existing AWS volume type code in the new volume form wherever possible.

Implements https://bugzilla.redhat.com/show_bug.cgi?id=1550008

![select_volume_type](https://user-images.githubusercontent.com/628956/44600646-e51c1500-a7a7-11e8-82ec-e90fcebe44dc.png)
