### PR TITLE
Refactor Edit Domain toolbar selection wording

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
@@ -15,8 +15,8 @@ class ApplicationHelper::Toolbar::MiqAeDomainsCenter < ApplicationHelper::Toolba
         button(
           :miq_ae_domain_edit,
           'pficon pficon-edit fa-lg',
-          N_('Select a single Domains to edit'),
-          N_('Edit Selected Domains'),
+          N_('Select a single Domain to edit'),
+          N_('Edit Selected Domain'),
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,


### PR DESCRIPTION
Refactored wording for toolbar Configuration selection and hover text when editing a Domain.  

https://bugzilla.redhat.com/show_bug.cgi?id=1618743

Screen shot prior to code fix, plural form:
![add and edit domain drop down selections prior to code fix](https://user-images.githubusercontent.com/552686/44605092-fa3f7680-a79c-11e8-9060-eea50db114c7.png)

Screen shot post code fix, singular form:
![add and edit domain drop down selections post code fix](https://user-images.githubusercontent.com/552686/44605112-062b3880-a79d-11e8-92f2-29982e206db3.png)



