### PR TITLE
Fix display_none typo

### DIFF
--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -1,6 +1,6 @@
 - flash_div_id ||= 'flash_msg_div'
 
-- flash_style ||= @flash_array ? "" : "display_none"
+- flash_style ||= @flash_array ? "" : "display: none"
 %div{:id => flash_div_id, :style => flash_style}
   - if @flash_array
     .flash_text_div


### PR DESCRIPTION
`display: none` seems to have been the intent :)

(Comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/3731.)