### PR TITLE
Show relation "security group belongs to router and subnet"

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -11,7 +11,7 @@ class CloudSubnetController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets network_ports)
+    %w(instances cloud_subnets network_ports security_groups)
   end
 
   def button

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -11,7 +11,7 @@ class NetworkRouterController < ApplicationController
   include Mixins::GenericFormMixin
 
   def self.display_methods
-    %w(instances cloud_subnets floating_ips)
+    %w(instances cloud_subnets floating_ips security_groups)
   end
 
   def button

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -10,7 +10,7 @@ class SecurityGroupController < ApplicationController
   include Mixins::GenericShowMixin
 
   def self.display_methods
-    %w(instances network_ports)
+    %w(instances network_ports network_routers cloud_subnets)
   end
 
   menu_section :net

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module CloudSubnetHelper::TextualSummary
       _("Relationships"),
       %i(
         parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network
-        network_router parent_subnet managed_subnets network_ports
+        network_router parent_subnet managed_subnets network_ports security_groups
       )
     )
   end
@@ -109,5 +109,9 @@ module CloudSubnetHelper::TextualSummary
 
   def textual_network_ports
     textual_link(@record.network_ports, :label => _('Network Ports'))
+  end
+
+  def textual_security_groups
+    textual_link(@record.security_groups, :label => _('Security Groups'))
   end
 end

--- a/app/helpers/network_router_helper/textual_summary.rb
+++ b/app/helpers/network_router_helper/textual_summary.rb
@@ -13,7 +13,10 @@ module NetworkRouterHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances cloud_subnets external_gateway floating_ips)
+      %i(
+        parent_ems_cloud ems_network cloud_tenant instances cloud_subnets external_gateway floating_ips
+        security_groups
+      )
     )
   end
 
@@ -89,5 +92,9 @@ module NetworkRouterHelper::TextualSummary
 
   def textual_floating_ips
     textual_link(@record.floating_ips, :label => _('Floating IPs'))
+  end
+
+  def textual_security_groups
+    textual_link(@record.security_groups, :label => _('Security Groups'))
   end
 end

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -13,7 +13,10 @@ module SecurityGroupHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(parent_ems_cloud ems_network cloud_tenant instances orchestration_stack network_ports)
+      %i(
+        parent_ems_cloud ems_network cloud_tenant instances orchestration_stack network_ports network_router
+        cloud_subnet
+      )
     )
   end
 
@@ -68,6 +71,14 @@ module SecurityGroupHelper::TextualSummary
 
   def textual_network_ports
     @record.network_ports
+  end
+
+  def textual_network_router
+    @record.network_router
+  end
+
+  def textual_cloud_subnet
+    @record.cloud_subnet
   end
 
   def port_range_helper(rule)

--- a/app/views/cloud_subnet/show.html.haml
+++ b/app/views/cloud_subnet/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "cloud_subnets", "network_ports"].include?(@display) && @showtype != "compare"
+  - if ["instances", "cloud_subnets", "network_ports", "security_groups"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/app/views/network_router/show.html.haml
+++ b/app/views/network_router/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(instances cloud_subnets floating_ips).include?(@display) && @showtype != "compare"
+  - if %w(instances cloud_subnets floating_ips security_groups).include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"

--- a/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
@@ -21,5 +21,6 @@ describe CloudSubnetHelper::TextualSummary do
     parent_subnet
     managed_subnets
     network_ports
+    security_groups
   )
 end

--- a/spec/helpers/network_router_helper/textual_summary_spec.rb
+++ b/spec/helpers/network_router_helper/textual_summary_spec.rb
@@ -9,5 +9,6 @@ describe NetworkRouterHelper::TextualSummary do
     cloud_subnets
     external_gateway
     floating_ips
+    security_groups
   )
 end

--- a/spec/helpers/security_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/security_group_helper/textual_summary_spec.rb
@@ -24,5 +24,7 @@ describe SecurityGroupHelper::TextualSummary do
     instances
     orchestration_stack
     network_ports
+    network_router
+    cloud_subnet
   )
 end


### PR DESCRIPTION
Two foreign keys have been added to the SecurityGroup model recently:

```
security_group.network_router
security_group.cloud_subnet
```

With this commit we show them both on UI (in both directions).

SecurityGroup view:
![image](https://user-images.githubusercontent.com/8102426/44657722-2279e000-a9fe-11e8-9ad6-e6823c7a03af.png)

NetworkRouter view:
![image](https://user-images.githubusercontent.com/8102426/44658359-d41a1080-aa00-11e8-8945-ce2940dd125c.png)

![image](https://user-images.githubusercontent.com/8102426/44658400-ff9cfb00-aa00-11e8-8a1a-3b892131e88f.png)

CloudSubnet view:
![image](https://user-images.githubusercontent.com/8102426/44658448-29eeb880-aa01-11e8-85b2-4fb12bab95b4.png)

![image](https://user-images.githubusercontent.com/8102426/44658475-40950f80-aa01-11e8-9159-9612ffaac631.png)

Depends on: https://github.com/ManageIQ/manageiq/pull/17900

@miq-bot add_label enhancement
@miq-bot assign @mzazrivec 

