### PR TITLE
Use device_name for cdrom reconfiguration request

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -231,29 +231,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
                             vm.reconfigureModel.vmRemoveNetworkAdapters.length > 0;
   };
 
-  vm.updateCDRomsConnectDisconnect = function() {
-    vm.reconfigureModel.vmConnectCDRoms    = [];
-    vm.reconfigureModel.vmDisconnectCDRoms    = [];
-
-    angular.forEach(vm.reconfigureModel.vmCDRoms, function(cdRom) {
-      if (cdRom.connect_disconnect === 'disconnect') {
-        vm.reconfigureModel.vmDisconnectCDRoms.push({
-          name: cdRom.hdFilename,
-        });
-      }
-      if (cdRom.connect_disconnect === 'connect') {
-        vm.reconfigureModel.vmConnectCDRoms.push({
-          name: cdRom.name,
-          filename: cdRom.filename,
-          storage_id: cdRom.storage_id,
-        });
-      }
-    });
-    vm.cb_cdRoms = vm.reconfigureModel.vmConnectCDRoms.length > 0 ||
-                   vm.reconfigureModel.vmDisconnectCDRoms.length > 0;
-  };
-
-
   vm.resetAddValues = function() {
     vm.reconfigureModel.hdType = vm.disk_default_type;
     vm.reconfigureModel.hdMode = 'persistent';
@@ -441,8 +418,13 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       vm.cancelAddRemoveDisk(disk);
     });
 
+    angular.forEach(vm.reconfigureModel.vmCDRoms, function(cd) {
+      vm.cancelCDRomConnectDisconnect(cd);
+    });
+
     $scope.angularForm.$setPristine(true);
     vm.updateDisksAddRemove();
+    vm.updateCDRomsConnectDisconnect();
 
     miqService.miqFlash('warn', __('All changes have been reset'));
   };
@@ -527,7 +509,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     angular.forEach(vm.reconfigureModel.vmCDRoms, function(cdRom) {
       if (cdRom.connect_disconnect === 'connect') {
         vm.reconfigureModel.vmConnectCDRoms.push(
-          { name: cdRom.name,
+          { device_name: cdRom.device_name,
             filename: cdRom.filename,
             storage_id: cdRom.storage_id,
           }
@@ -535,7 +517,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       }
       if (cdRom.connect_disconnect === 'disconnect') {
         vm.reconfigureModel.vmDisconnectCDRoms.push(
-          { name: cdRom.name });
+          { device_name: cdRom.device_name });
       }
     });
     vm.cb_cdRoms = vm.reconfigureModel.vmConnectCDRoms.length > 0  ||
@@ -568,12 +550,9 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
   vm.cancelCDRomConnectDisconnect = function(vmCDRom) {
     var index = vm.reconfigureModel.vmCDRoms.indexOf(vmCDRom);
-    if (vmCDRom.connect_disconnect === "disconnect") {
-      vmCDRom.filename = vmCDRom.orgFilename;
-    }
+    vmCDRom.filename = vmCDRom.orgFilename;
     vmCDRom.connect_disconnect = '';
     vm.reconfigureModel.vmCDRoms[index].connect_disconnect = '';
-    vm.updateCDRomsConnectDisconnect();
   };
 
   init();

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -323,6 +323,7 @@ module Mixins
         end
 
         def filename_string(name)
+          # an empty cdrom filename can be in the form of a string containing a pair of square brackets
           name.blank? || name == '[]' ? '' : name.to_s
         end
 

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -191,20 +191,20 @@ module Mixins
           connect_disconnect = ''
           cdroms.map do |cd|
             id = cd.id
-            name = cd.device_name
+            device_name = cd.device_name
             type = cd.device_type
             filename = cd.filename
             storage_id = cd.storage_id
-            if cd.filename && @req.options[:cdrom_disconnect]&.find { |d_cd| d_cd[:name] == cd.device_name }
+            if cd.filename && @req.options[:cdrom_disconnect]&.find { |d_cd| d_cd[:device_name] == cd.device_name }
               filename = ''
               connect_disconnect = 'disconnect'
             end
-            conn_cd = @req.options[:cdrom_connect]&.find { |c_cd| c_cd[:name] == cd.device_name }
+            conn_cd = @req.options[:cdrom_connect]&.find { |c_cd| c_cd[:device_name] == cd.device_name }
             if cd.filename && conn_cd
               filename = conn_cd[:filename]
               connect_disconnect = 'connect'
             end
-            vmcdroms << {:id => id, :name => name, :filename => filename, :type => type, :storage_id => storage_id, :connect_disconnect => connect_disconnect}
+            vmcdroms << {:id => id, :device_name => device_name, :filename => filename, :type => type, :storage_id => storage_id, :connect_disconnect => connect_disconnect}
           end
           vmcdroms
         end
@@ -322,17 +322,21 @@ module Mixins
           network_adapters
         end
 
+        def filename_string(name)
+          name.blank? || name == '[]' ? '' : name.to_s
+        end
+
         def build_vmcdrom_list(vm)
           vmcdroms = []
           cdroms = vm.hardware.cdroms
           if cdroms.present?
             cdroms.map do |cd|
               id = cd.id
-              name = cd.device_name
+              device_name = cd.device_name
               type = cd.device_type
-              filename = cd.filename
-              storage_id = cd.storage_id
-              vmcdroms <<  {:id => id, :name => name, :filename => filename, :type => type, :storage_id => storage_id}
+              filename = filename_string(cd.filename)
+              storage_id = cd.storage_id || ''
+              vmcdroms << {:id => id, :device_name => device_name, :filename => filename, :type => type, :storage_id => storage_id}
             end
             vmcdroms
           end

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -395,7 +395,7 @@
         %tr{"ng-repeat" => "cdRom in vm.reconfigureModel.vmCDRoms",
             "ng-class"  => "{'danger': cdRom.connected_status == 'disconnected', 'active': cdRom.connected_status == 'connected'}"}
           %td
-            {{cdRom.name}}
+            {{cdRom.device_name}}
           %td{"ng-if" => "cdRom.connect_disconnect != 'connecting'"}
             {{cdRom.filename}}
           %td{"ng-if" => "cdRom.connect_disconnect == 'connecting'"}

--- a/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
+++ b/spec/javascripts/controllers/reconfigure/reconfigure_form_controller_spec.js
@@ -18,7 +18,7 @@ describe('reconfigureFormController', function() {
       cores_per_socket_count: '3',
       disks:                 [{hdFilename: "test_disk.vmdk", hdType: "thick", hdMode: "persistent", new_controller_type: "VirtualLsiLogicController", hdSize: "0", hdUnit: "MB", add_remove: ""}],
       network_adapters:      [{name: "Network adapter 1", vlan: "test_network", mac: "00:00:00:00:00:00", add_remove: ""}],
-      cdroms:                [{name: "CDROM 1", filename: "test_filename.iso", storage_id: '5', connect_disconnect: ""}],
+      cdroms:                [{device_name: "CDROM 1", filename: "test_filename.iso", storage_id: '5', connect_disconnect: ""}],
       vm_vendor:              'vm-vendor',
       vm_type:                'vm-type',
       disk_default_type:      'disk-default-type'};


### PR DESCRIPTION
Use device_name for cdrom reconfiguration request.
Remove duplicate of updateCDRomsConnectDisconnect.

Links 
-----------

https://bugzilla.redhat.com/show_bug.cgi?id=1533728
Follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/3956

