### PR TITLE
Lazy load StorageManagers upon volume creation

### DIFF
--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -56,5 +56,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'ATTACH');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/backup_new.html.haml
+++ b/app/views/cloud_volume/backup_new.html.haml
@@ -62,5 +62,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'BACKUP_NEW');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/backup_select.html.haml
+++ b/app/views/cloud_volume/backup_select.html.haml
@@ -39,5 +39,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'BACKUP_SELECT');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -36,5 +36,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'DETACH');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -13,5 +13,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'EDIT');
   miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -11,5 +11,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
-  ManageIQ.angular.app.value('storageManagerId', #{@storage_manager.try(:id) || "undefined"});
+  ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id).to_s || "undefined"}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'NEW');
   miq_bootstrap('#form_div');

--- a/app/views/cloud_volume/snapshot_new.html.haml
+++ b/app/views/cloud_volume/snapshot_new.html.haml
@@ -39,5 +39,6 @@
 
 :javascript
   ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id}');
-  ManageIQ.angular.app.value('storageManagerId', #{@volume.ext_management_system.id});
+  ManageIQ.angular.app.value('storageManagerId', '#{@volume.ext_management_system.id.to_s}');
+  ManageIQ.angular.app.value('cloudVolumeFormOperation', 'SNAPSHOT_NEW');
   miq_bootstrap(jQuery('#form_div'));


### PR DESCRIPTION
When creating a new volume user has to pick what StorageManager is volume supposed to be created with, hence we perform API request to fetch those. Problem is we share angular controller with other volume operations (attach, detach) that don't need this list of all managers and fetching those anyway results in permission denied error due to fine-grained permission setting.

For example if we give user only permission to attach/detach volume, but not to view StorageManagers:

![image](https://user-images.githubusercontent.com/8102426/44709590-4bf04580-aaaa-11e8-84cd-d50dd442f653.png)

then we must not perform the API call as it results in 403 with red popup:

![image](https://user-images.githubusercontent.com/8102426/44709856-f0728780-aaaa-11e8-9505-570a48c5e748.png)

With this commit we refactor controller so that it now only performs the API call "fetch storage managers" when we're creating a new volume, and not just always by default. Attaching/detaching volume therefore doesn't trigger the problematic API call anymore:

![image](https://user-images.githubusercontent.com/8102426/44709967-4e9f6a80-aaab-11e8-8612-c3c31793d1cf.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1571224

@miq-bot add_label bug,fine/yes,gaprindashvili/yes
@miq-bot assign @h-kataria 

BZ is reported for Fine, therefore we have to reach that far.

/cc @AparnaKarve 