### PR TITLE
Replaced obsolete method for record fetching with RBAC in ops controller

### DIFF
--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -383,7 +383,7 @@ module OpsController::Settings::AnalysisProfiles
     scanitemsets = find_records_with_rbac(ScanItemSet, checked_or_params)
     scanitemsets.each do |scan_item_set|
       if scan_item_set.read_only
-        scanitemsets.delete(scan_item_set)
+        scanitemsets -= [scan_item_set]
         add_flash(_("Default Analysis Profile \"%{name}\" can not be deleted") % {:name => scan_item_set.name}, :error)
       else
         tmp_flash_array = @flash_array

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -379,7 +379,7 @@ module OpsController::Settings::AnalysisProfiles
   # Delete all selected or single displayed scanitemset(s)
   def ap_delete
     assert_privileges("ap_delete")
-    @single_delete = true if params[:id]
+    @single_delete = params[:id].present?
     scanitemsets = find_records_with_rbac(ScanItemSet, checked_or_params)
     scanitemsets.each do |scan_item_set|
       if scan_item_set.read_only
@@ -392,7 +392,7 @@ module OpsController::Settings::AnalysisProfiles
         scan_item_set.remove_all_members
       end
     end
-    @flash_error = true if scanitemsets.empty?
+    @flash_error = scanitemsets.empty?
     ap_process_scanitemsets(scanitemsets, "destroy") unless scanitemsets.empty?
     self.x_node = "xx-sis"
     get_node_info(x_node)


### PR DESCRIPTION
Cleaning up the code by replacing obsolete methods for record fetching with RBAC

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/issues/1134

Steps for Testing/QA
-------------------------------

1) go to Top menu - Configuration - Settings (accordion) - Analysis Profiles
2) try to remove / copy Analysis Profiles