### PR TITLE
Remove start_rss()

### DIFF
--- a/app/controllers/alert_controller.rb
+++ b/app/controllers/alert_controller.rb
@@ -34,8 +34,7 @@ class AlertController < ApplicationController
     end
   end
 
-  # Render an RSS feed back to either a local or non-local reader
-  def rss(feed = nil, local = false)
+  def rss
     feed = params[:feed] if params[:feed]
     feed_record = RssFeed.find_by(:name => feed)
     if feed_record.nil?
@@ -45,10 +44,9 @@ class AlertController < ApplicationController
     proto = nil unless [nil, "http", "https"].include?(proto)    # Make sure it's http or https
     proto ||= session[:req_protocol]                             # If nil, use previously discovered value
     session[:req_protocol] ||= proto                             # Save protocol in session
-    feed_data = feed_record.generate(request.host_with_port, local, proto)
+    feed_data = feed_record.generate(request.host_with_port, false, proto)
 
-    return feed_data if local
-    render feed_data unless local
+    render feed_data
   end
 
   private ###########################

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,7 +132,6 @@ Rails.application.routes.draw do
       ),
       :post => %w(
         role_selected
-        start_rss
       ),
     },
 

--- a/spec/routing/alert_routing_spec.rb
+++ b/spec/routing/alert_routing_spec.rb
@@ -22,10 +22,4 @@ describe 'routes for AlertController' do
       expect(post('/alert/role_selected')).to route_to('alert#role_selected')
     end
   end
-
-  describe '#start_rss' do
-    it 'routes' do
-      expect(post('/alert/start_rss')).to route_to('alert#start_rss')
-    end
-  end
 end


### PR DESCRIPTION
This PR:
* removes remnants of removed `start_rss()` routine (removed in 252bea13402808b9d704d04675908dc886b83840)
* removes arguments from `rss()` route. The `rss()` routine was invoked from `start_rss()` only, which has been removed a while ago. Hence, `rss()` doesn't need any parameters of its own. 