### PR TITLE
Add globals pack - before asset pipeline, after vendor

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require ./miq_global
-//= require jquery/dist/jquery.js
 //= require ./jquery_overrides
 //= require ./i18n
 //= require patternfly

--- a/app/helpers/application_helper/webpack.rb
+++ b/app/helpers/application_helper/webpack.rb
@@ -16,6 +16,10 @@ module ApplicationHelper
     def javascript_dependencies
       capture do
         concat(javascript_essential_dependencies)
+
+        concat(javascript_pack_tag('manageiq-ui-classic/globals.js'))
+        concat "\n"
+
         concat(javascript_include_tag('application'))
         concat(javascript_common_packs)
       end

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -44,8 +44,6 @@ ManageIQ.angular.rxSubject = rxSubject;
 window.sendDataWithRx = sendDataWithRx;
 window.listenToRx = listenToRx;
 
-window.sprintf = require('sprintf-js').sprintf;
-
 // compatibility: vanillaJsAPI should be considered deprecated
 // the new convention is: API is for vanilla/react, $API is for angular
 window.API = API;

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -1,0 +1,4 @@
+// all the globals should end up here
+// this is the first pack loaded after runtime&shims&vendor
+// and the only pack loaded before the asset pipeline
+

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -2,3 +2,6 @@
 // this is the first pack loaded after runtime&shims&vendor
 // and the only pack loaded before the asset pipeline
 
+window.$ = window.jQuery = require('jquery');
+
+window.sprintf = require('sprintf-js').sprintf;

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -16,6 +16,7 @@ src_files:
 - packs/runtime.js
 - packs/shims.js
 - packs/vendor.js
+- packs/manageiq-ui-classic/globals.js
 - assets/application
 - assets/bower_components/jasmine-jquery/lib/jasmine-jquery
 - assets/angular-mocks


### PR DESCRIPTION
Right now, any global dependencies (like jquery, angular, etc.) are either in the asset pipeline, or in application-common.js, which happens right after.

But for some packages, that's not enough as they have to go through webpack, but are depended on by code in asset pipeline.

---

Also moving jquery (to make sure this works, but also because jQuery should really go before any of the other non-shim dependencies) and sprintf from their respective places to the new pack.

(Depended on by #4442 - numeral is the case where moving from bower to npm means webpack, but ui-components code is trying to use numeral sooner than it would be available from application-common.)


Issue #3734