### PR TITLE
Don't pass local argument to RssFeed.generate()

### DIFF
--- a/app/controllers/alert_controller.rb
+++ b/app/controllers/alert_controller.rb
@@ -44,9 +44,7 @@ class AlertController < ApplicationController
     proto = nil unless [nil, "http", "https"].include?(proto)    # Make sure it's http or https
     proto ||= session[:req_protocol]                             # If nil, use previously discovered value
     session[:req_protocol] ||= proto                             # Save protocol in session
-    feed_data = feed_record.generate(request.host_with_port, false, proto)
-
-    render feed_data
+    render :text => feed_record.generate(request.host_with_port, proto), :content_type => Mime[:rss]
   end
 
   private ###########################


### PR DESCRIPTION
The argument has been removed from the backend routine.

Backend PR: https://github.com/ManageIQ/manageiq/pull/17922

This fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/4559

@martinpovolny 