### PR TITLE
Add Chassis to PhysicalInfra dashboard and listnav

### DIFF
--- a/app/decorators/physical_chassis_decorator.rb
+++ b/app/decorators/physical_chassis_decorator.rb
@@ -1,6 +1,6 @@
 class PhysicalChassisDecorator < MiqDecorator
   def self.fonticon
-    'pficon pficon-cluster'
+    'pficon pficon-template'
   end
 
   def quadicon

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -14,7 +14,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(physical_racks physical_chassis physical_switches physical_storages physical_servers datastores vms physical_servers_with_host)
+      %i(datastores physical_chassis physical_racks physical_servers physical_servers_with_host physical_storages physical_switches vms)
     )
   end
 

--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -15,6 +15,14 @@
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked
         %li
+          = li_link(:count => @record.number_of(:physical_chassis),
+            :tables        => 'physical_chassis',
+            :record        => @record,
+            :display       => 'physical_chassis')
+          = li_link(:count => @record.number_of(:physical_racks),
+            :tables        => 'physical_racks',
+            :record        => @record,
+            :display       => 'physical_racks')
           = li_link(:count => @record.number_of(:physical_servers),
             :tables        => 'physical_servers',
             :record        => @record,

--- a/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
@@ -10,14 +10,14 @@ describe EmsPhysicalInfraHelper::TextualSummary do
   include_examples "textual_group", "Overview", %i(topology), "topology"
 
   include_examples "textual_group", "Relationships", %i(
-    physical_racks
-    physical_chassis
-    physical_switches
-    physical_storages
-    physical_servers
     datastores
-    vms
+    physical_chassis
+    physical_racks
+    physical_servers
     physical_servers_with_host
+    physical_storages
+    physical_switches
+    vms
   )
 
   include_examples "textual_group_smart_management", %i(zone)


### PR DESCRIPTION
This PR is able to:
  * Add a chassis to PhysicalInfra provider dashboard
  * Add both chassis and rack to PhysicalInfra provider listnav

![screenshot-localhost-3000-2018 08 29-13-51-41](https://user-images.githubusercontent.com/3654285/44803019-98638000-ab93-11e8-9761-bda53b822acb.png)

![screenshot-localhost-3000-2018 08 29-13-54-58](https://user-images.githubusercontent.com/3654285/44802770-f6439800-ab92-11e8-804d-ec924496cb6b.png)
