### PR TITLE
Handle Alerts with no resources

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -564,8 +564,9 @@ function alertsCenterService(API, $q, $timeout, $document, $uibModal, $http) {
       if (newTypes.indexOf(objectType) == -1) {
         newTypes.push(objectType);
       }
-
-      alerts.push(convertAlert(item, objectName, objectClassifiedType, objectType, retrievalTime));
+      if (item.resource) {
+        alerts.push(convertAlert(item, objectName, objectClassifiedType, objectType, retrievalTime));
+      }
     });
 
     newTypes.sort();


### PR DESCRIPTION
An alert can point to an invalid resource if the resource is deleted
We tend to avoid this, but in one case, `Container Replicators` can go away


If there is another way to solve this on the ruby end, please let me know