### PR TITLE
Show CloudTenants in network manager's topology view

### DIFF
--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -27,13 +27,23 @@ class NetworkTopologyService < TopologyService
           :floating_ips => :writable_classification_tags
         ]
       ]
+    ],
+    :cloud_tenants      => [
+      :network_routers => [
+        :floating_ips,
+        :security_groups,
+        :cloud_subnets
+      ],
+      :cloud_subnets   => [
+        :security_groups
+      ]
     ]
   ]
 
   @kinds = %i(NetworkRouter CloudSubnet Vm NetworkManager FloatingIp CloudNetwork NetworkPort CloudTenant SecurityGroup LoadBalancer Tag AvailabilityZone)
 
   def entity_type(entity)
-    if entity.kind_of?(CloudNetwork)
+    if entity.kind_of?(CloudNetwork) || entity.kind_of?(CloudSubnet)
       entity.class.base_class.name.demodulize
     else
       super


### PR DESCRIPTION
With this commit we let NetworkManager's topology view render CloudTenants with basic entities beneath them in order for Nuage provider to display a meaningful topology view.

Since Nuage provider subclasses CloudSubnets into

```
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L2
ManageIQ::Providers::Nuage::NetworkManager::CloudSubnet::L3
```

we also make sure those get appropriate class name assigned (i.e. base class name) or else nothing is shown.

### Before
Amazon provider:
![image](https://user-images.githubusercontent.com/8102426/44836576-9fdc6500-ac37-11e8-8098-714096197801.png)

Nuage provider:
![image](https://user-images.githubusercontent.com/8102426/44836616-b4206200-ac37-11e8-8b6f-11c1b2f99841.png)


### After:
Amazon provider (proof that nothing has changed):
![image](https://user-images.githubusercontent.com/8102426/44836297-d8c80a00-ac36-11e8-8b1e-751690838dbb.png)

Nuage provider:
![image](https://user-images.githubusercontent.com/8102426/44836477-5724ac00-ac37-11e8-854e-72e98be1c251.png)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/4316

@miq-bot add_label enhancement
@miq-bot assign @himdel 
