### PR TITLE
Fix duplicate in tree after class deletion in miq_ae_class_controller

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1819,7 +1819,7 @@ class MiqAeClassController < ApplicationController
     self.x_node = "#{TreeBuilder.get_prefix_for_model(@edit[:typ])}-#{@record.id}"
     @in_a_form = @changed = session[:changed] = false
     @sb[:action] = @edit = session[:edit] = nil
-    replace_right_cell
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   def copy_reset(typ, ids, button_pressed)


### PR DESCRIPTION
**Description**
A class is still included in the tree after deletion

**Solution**

The tree was not properly updated after copying, so it can not be refreshed.

**Steps to reproduce**

1. Go to Automation -> Automate -> Explorer
2. Create a namespace, create a domain
3. Create a class (1) with a name and a display name
4. Create a class (2) with a name (without a display name)
5. Copy the second class 
6. Delete the copy
7. Repeat 5.+6.
8. You will see the duplicate in the tree
 
**Before** 
![screenshot from 2018-08-30 19-54-46](https://user-images.githubusercontent.com/32869456/44870110-8f57d900-ac8f-11e8-8bc1-ec6cd909e5dd.png)
**After**
![screenshot from 2018-08-30 19-53-45](https://user-images.githubusercontent.com/32869456/44870105-8c5ce880-ac8f-11e8-8e14-479f3f8e80bc.png)