### PR TITLE
Fix error while creating Catalog Item of Ansible Playbook type

### DIFF
--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -132,7 +132,7 @@ function playbookReusableCodeMixin(API, $q, miqService) {
           vm.catalogs = data.resources;
           // edit the name of each catalog to get all tenant ancestors in the name if they exist
           for (var i = 0; i < vm.catalogs.length; i++) {
-            vm.catalogs[i].name = _.find(formOptsCatalogTenants(vm.allCatalogs), {id: vm.catalogs[i].id}).name;
+            vm.catalogs[i].name = _.find(formOptsCatalogTenants(vm.all_catalogs), {id: vm.catalogs[i].id}).name;
           }
           vm.catalogs.unshift({"href": "", "id": "", "name": "<Unassigned>"});
           vm._catalog = _.find(vm.catalogs, {id: vm[vm.model].catalog_id});


### PR DESCRIPTION
There is an error while creating _Catalog Item_ of _Ansible Playbook_ type. It is not possible to create catalog item of this type. Introduced by: https://github.com/ManageIQ/manageiq-ui-classic/pull/4278

**Steps to reproduce:**
1. Go to _Services > Catalogs > Catalog Items_
2. _Configuration > Add a New Catalog Item_
3.  For _Catalog Item Type_, choose _Ansible Playbook_
=> error!

---

**Before:**
![playbook_before](https://user-images.githubusercontent.com/13417815/44901654-4728cd00-ad08-11e8-97fa-fcdc7dcc7417.png)

**After:**
![playbook_after](https://user-images.githubusercontent.com/13417815/44901659-4b54ea80-ad08-11e8-97ff-e8cc6d0d90f8.png)
