### PR TITLE
Enable 'Paste' button only if the copied and selected target class are the same

### DIFF
--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,14 +1,20 @@
 #ab_form
   #policy_bar
     - if session[:resolve_object].present?
-      = link_to({:action => "resolve", :button => "paste"},
-        "data-miq_sparkle_on"  => true,
-        "data-miq_sparkle_off" => true,
-        :remote                => true,
-        "data-method"          => :post,
-        :class                 => 'btn btn-default',
-        :title                 => _("Paste object details for use in a Button.")) do
-        %i.fa.fa-clipboard
+      - copied_target_class = Hash[*@resolve[:target_classes].flatten].invert[session[:resolve_object][:new][:target_class]]
+      - current_target_class =  @edit[:new][:target_class]
+      - if copied_target_class == current_target_class
+        = link_to({:action => "resolve", :button => "paste"},
+          "data-miq_sparkle_on"  => true,
+          "data-miq_sparkle_off" => true,
+          :remote                => true,
+          "data-method"          => :post,
+          :class                 => 'btn btn-default',
+          :title                 => _("Paste object details for use in a Button.")) do
+          %i.fa.fa-clipboard
+      - else
+        %button.btn.btn-default.disabled{:title => _("Paste is not available, target class differs from the target class of the object copied from the Simulation screen")}
+          %i.fa.fa-clipboard
     - else
       %button.btn.btn-default.disabled{:title => _("Paste is not available, no object information has been copied from the Simulation screen")}
         %i.fa.fa-clipboard

--- a/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
+++ b/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
@@ -1,0 +1,30 @@
+describe "shared/buttons/_ab_form.html.haml" do
+  before :each do
+    set_controller_for_view("miq_ae_customization")
+    assign(:sb, :active_tab => "ab_options_tab")
+    assign(:edit, :new => {:target_class => "Cloud Network"})
+    assign(:resolve, :target_classes => [
+      ["Availability Zone", "AvailabilityZone"],
+      ["Cloud Network", "CloudNetwork"],
+      ["VM Template and Image", "MiqTemplate"],
+      ["VM and Instance", "Vm"]])
+    stub_template "shared/buttons/_ab_options_form.html.haml" => ""
+    stub_template "shared/buttons/_ab_advanced_form.html.haml" => ""
+  end
+
+  describe "Paste button" do
+    it "is enabled if the copied target class is the same as the current target class" do
+      allow(view).to receive(:session)
+        .and_return(:resolve_object => {:new => {:target_class => "CloudNetwork"}})
+      render
+      expect(rendered).to include("Paste object details for use in a Button.")
+    end
+
+    it "is disabled if the copied target class differs from the current target class" do
+      allow(view).to receive(:session)
+        .and_return(:resolve_object => {:new => {:target_class => "AvailabilityZone"}})
+      render
+      expect(rendered).to include("Paste is not available, target class differs from the target class of the object copied from the Simulation screen")
+    end
+  end
+end


### PR DESCRIPTION
Correction of https://github.com/ManageIQ/manageiq-ui-classic/pull/4513#discussion_r213379575

As @h-kataria mentioned, the buttons is supposed to be disabled, if the copied target class differs from the current target class.

This PR corrects the behaviour

Links
----------------

*    https://github.com/ManageIQ/manageiq-ui-classic/pull/175#discussion_r102018852
*    #4189
*    https://bugzilla.redhat.com/show_bug.cgi?id=1426390