### PR TITLE
Remove phantomjs bind polyfill

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,6 @@
     "moment-timezone": "~0.4.1",
     "patternfly-bootstrap-treeview": "~2.1.5",
     "patternfly-timeline": "~1.0.5",
-    "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10"
   },
   "resolutions": {

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -12,7 +12,6 @@
 #
 src_files:
 - __spec__/helpers/i18n-test.js
-- assets/bower_components/phantomjs-polyfill/bind-polyfill
 - packs/runtime.js
 - packs/shims.js
 - packs/vendor.js


### PR DESCRIPTION
Looks like at some point we lost the jasmine<2 limitation, so the bind polyfill may no longer be needed.
Trying to see if the tests pass when we remove it.
If not, need to move it to npm (https://github.com/ManageIQ/manageiq-ui-classic/issues/3734).

(Polyfill introduced in https://github.com/ManageIQ/manageiq/pull/8421,
phantomjs version restriction in https://github.com/ManageIQ/manageiq/pull/6716,
removed in https://github.com/ManageIQ/manageiq/pull/11834,
and let travis use whatever version it has in https://github.com/ManageIQ/manageiq/pull/11929 (currently 2.1.1 is always used [it seems](https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/423024220#L340)))