### PR TITLE
Fix creation of internal rss widget

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -435,11 +435,7 @@ module ReportController::Widgets
       @edit[:new][:pivot].options = @edit[:new][:fields].dup
       @edit[:new][:row_count] = @widget.row_count
     elsif @sb[:wtype] == "rf"
-      @edit[:rss_feeds] = {}
-      rss_feeds = RssFeed.all
-      rss_feeds.each do |rf|
-        @edit[:rss_feeds][rf.title] = rf.id
-      end
+      @edit[:rss_feeds] = RssFeed.pluck(:title, :id).sort.to_h
       @edit[:new][:feed_type] = @widget.options && @widget.options[:url] ? "external" : "internal"
       if @widget.options && @widget.options[:url]
         self.class::RSS_FEEDS.each do |r|

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -446,7 +446,7 @@ module ReportController::Widgets
         @edit[:new][:txt_url] = @widget.options[:url] if @edit[:new][:url].blank?
       end
       @edit[:new][:row_count]   = @widget.row_count
-      @edit[:new][:rss_feed_id] = @widget.resource_id         if @widget.resource_id && @widget.resource_type == "RssFeed"
+      @edit[:new][:rss_feed_id] = @widget.resource_type == "RssFeed" ? @widget.resource_id : @edit[:rss_feeds].first.second
     end
     @edit[:current] = copy_hash(@edit[:new])
   end

--- a/app/views/report/_widget_form_rss.html.haml
+++ b/app/views/report/_widget_form_rss.html.haml
@@ -23,7 +23,7 @@
         = _('Internal RSS Feed')
       .col-md-8
         = select_tag("rss_feed",
-          options_for_select(@edit[:rss_feeds].sort, @edit[:new][:rss_feed_id]),
+          options_for_select(@edit[:rss_feeds], @edit[:new][:rss_feed_id]),
           :disabled => @edit[:read_only],
           :class    => "selectpicker")
         :javascript


### PR DESCRIPTION
1. Cloud Intel ➛ Reports ➛ Dashboard Widgets ➛ RSS Feeds ➛ Add a New Widget
2. Fill in Name & Description, leave other fields untouched (i.e. feed type: internal)
3. Add

Click on the created widget: you'll see the widget shows as external.

The problem was caused by the fact that we were passing `nil` as `rss_feed_id` to the `set_rss_properties()` routine.
