### PR TITLE
lodash - move to npm, upgrade to lodash 4

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,7 +26,6 @@
 //= require_tree ./services/
 //= require bower_components/d3/d3
 //= require bower_components/c3/c3
-//= require bower_components/lodash/lodash
 //= require kubernetes-topology-graph/dist/topology-graph
 //= require ./miq_browser_detect
 //= require ./miq_application

--- a/app/assets/javascripts/components/generic_object/generic-object-table-component.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-table-component.js
@@ -120,7 +120,7 @@ function genericObjectTableController($timeout) {
 
   function checkIfTableChanged() {
     if (vm.values && ! angular.equals(_.zipObject(vm.keys, vm.values), vm.origKeysValues)
-      || ! vm.values && _.difference(vm.keys, vm.origKeysValues, _.isEqual).length > 0) {
+      || ! vm.values && _.difference(vm.keys, vm.origKeysValues).length > 0) {
       vm.tableChanged = true;
     } else {
       vm.tableChanged = false;

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
@@ -164,7 +164,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     };
 
     if (vm.customButtonModel.current_visibility === 'role') {
-      vm.customButtonModel.roles = _.pluck(_.filter(vm.customButtonModel.available_roles, function(role) {
+      vm.customButtonModel.roles = _.map(_.filter(vm.customButtonModel.available_roles, function(role) {
         return role.value === true;
       }), 'name');
     }

--- a/app/assets/javascripts/components/generic_object/main-custom-button-group-form-component.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-group-form-component.js
@@ -117,7 +117,7 @@ function mainCustomButtonGroupFormController(API, miqService) {
 
   function getCustomButtonSetGroupIndex(response) {
     vm.afterGet = true;
-    var currentGroupIndex = _.filter(_.pluck(response.resources, 'set_data'), function(setData) {
+    var currentGroupIndex = _.filter(_.map(response.resources, 'set_data'), function(setData) {
       return setData.applies_to_class === 'GenericObject';
     }).length;
     vm.customButtonGroupModel.group_index = currentGroupIndex + 1;

--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -74,7 +74,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
     vm.DialogEditor = DialogEditor;
   }
 
-  var beingCloned = null; // hack that solves recursion problem for cloneDeep
+  var beingCloned = null; // hack that solves recursion problem for cloneDeepWith
   function customizer(value) {
     var keysToDelete = ['active', '$$hashKey', 'href', 'dynamicFieldList', 'id'];
     var useCustomizer =
@@ -89,7 +89,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
     }
 
     beingCloned = value;
-    var copy = _.cloneDeep(value, customizer);
+    var copy = _.cloneDeepWith(value, customizer);
     beingCloned = null;
 
     // remove unnecessary attributes
@@ -117,9 +117,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
           dialog_tabs: [],
         },
       };
-      // once we start using lodash 4.17.4, change to 'cloneDeepWith'
-      // https://lodash.com/docs/4.17.4#cloneDeepWith
-      dialogData.content.dialog_tabs = _.cloneDeep(DialogEditor.getDialogTabs(), customizer);
+      dialogData.content.dialog_tabs = _.cloneDeepWith(DialogEditor.getDialogTabs(), customizer);
     } else {
       action = 'create';
       dialogId = '';
@@ -129,7 +127,7 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
         buttons: 'submit,cancel',
         dialog_tabs: [],
       };
-      dialogData.dialog_tabs = _.cloneDeep(DialogEditor.getDialogTabs(), customizer);
+      dialogData.dialog_tabs = _.cloneDeepWith(DialogEditor.getDialogTabs(), customizer);
     }
 
     DialogEditorHttp.saveDialog(dialogId, action, dialogData).then(saveSuccess, saveFailure);

--- a/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/floating_ip/floating_ip_form_controller.js
@@ -63,16 +63,8 @@ ManageIQ.angular.app.controller('floatingIpFormController', ['$scope', 'floating
     miqService.miqFlash("warn", __("All changes have been reset"));
   };
 
-  // FIXME: in lodash4, this is _.pick(vm.floatingIpModel, vm.fields)
   vm.filteredModel = function() {
-    var model = vm.floatingIpModel;
-    var ret = {};
-
-    vm.fields.forEach(function (key) {
-      _.set(ret, key, _.result(model, key));
-    });
-
-    return ret;
+    return _.pick(vm.floatingIpModel, vm.fields);
   };
 
   vm.filterNetworkManagerChanged = function(id) {

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -63,7 +63,7 @@
     this.$scope = $scope;
     this.$location = $location;
     initEndpoints(this.MiQEndpointsService);
-    this.isList = _.contains(location.pathname, 'show_list');
+    this.isList = location.pathname.includes('show_list');
   };
 
   /**

--- a/app/assets/javascripts/directives/form_changed.js
+++ b/app/assets/javascripts/directives/form_changed.js
@@ -21,7 +21,7 @@ ManageIQ.angular.app.directive('formChanged', function() {
             copy[k] = undefined;
           });
         }
-        // don't compare ng stuff TODO remove in Angular 2/4
+        // don't compare ng stuff
         if (key !== undefined && key[0] === '$') {
           return true;
         }
@@ -33,8 +33,7 @@ ManageIQ.angular.app.directive('formChanged', function() {
       };
 
       var updateDirty = function() {
-        // TODO in lodash 4 it's _.isEqualWith
-        if (_.isEqual(model(), modelCopy(), compare)) {
+        if (_.isEqualWith(model(), modelCopy(), compare)) {
           ctrl.$setPristine();
         } else {
           ctrl.$setDirty();

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1242,7 +1242,7 @@ function miqInitCodemirror(options) {
 function miqSelectPickerEvent(element, url, options) {
   options = options || {};
   options.no_encoding = true;
-  var firstarg = ! _.contains(url, '?');
+  var firstarg = ! url.includes('?');
 
   $('#' + element).on('change', _.debounce(function() {
     var selected = $(this).val();
@@ -1289,7 +1289,7 @@ function miqInitBootstrapSwitch(element, url, options) {
     options = typeof options !== 'undefined' ? options : {};
     options['no_encoding'] = true;
 
-    var firstarg = ! _.contains(url, '?');
+    var firstarg = ! url.includes('?');
     miqObserveRequest(url + (firstarg ? '?' : '&') + element + '=' + state, options);
 
     return true;

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -27,8 +27,8 @@ function load_c3_chart(data, chart_id, height) {
   generate_args.data.onclick = function(data, _i) {
     var index = _.findIndex(generate_args.data.columns, function(col) { return col[0] == data.id; });
     // when not Pie/Donut chart, first column doesn't contain actual data.
-    var seriesIndex = _.contains(['Pie', 'Donut'], generate_args.miqChart) ? index : index - 1;
-    var pointIndex = _.contains(['Pie', 'Donut'], generate_args.miqChart) ? index : data.index;
+    var seriesIndex = ['Pie', 'Donut'].includes(generate_args.miqChart) ? index : index - 1;
+    var pointIndex = ['Pie', 'Donut'].includes(generate_args.miqChart) ? index : data.index;
     var value = data.value;
 
     var parts = chart_id.split('_'); // miq_chart_candu_2

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -140,7 +140,7 @@ function getMinMaxFromChart(chart) {
 
   var max = _.max(_.filter(data, function(o) { return o !== null; }));
   var min = _.min(_.filter(data, function(o) { return o !== null; }));
-  if (max === -Infinity || min === Infinity) {
+  if (max === undefined || min === undefined) {
     return false;
   }
   return [min, max];

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -140,7 +140,7 @@ function eventNotifications($timeout, $window, $httpParamSerializerJQLike, API) 
     });
     if (group) {
       if (group.notifications) {
-        group.notifications.splice(_.sortedIndex(group.notifications, newNotification, function(x) { return -x.timeStamp; }), 0, newNotification);
+        group.notifications.splice(_.sortedIndexBy(group.notifications, newNotification, function(x) { return -x.timeStamp; }), 0, newNotification);
       } else {
         group.notifications = [newNotification];
       }

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -4,5 +4,6 @@
 
 window.$ = window.jQuery = require('jquery');
 
+window._ = require('lodash');
 window.numeral = require('numeral');
 window.sprintf = require('sprintf-js').sprintf;

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
     "jquery-ui": "jqueryui#~1.12.1",
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
-    "lodash": "~3.10.0",
     "manageiq-ui-components": "bower-dev",
     "moment-duration-format": "~1.3.0",
     "moment-strftime": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "history": "^4.7.2",
     "jquery": "~2.2.4",
     "kubernetes-topology-graph": "~0.0.25",
-    "lodash": "^4.17.4",
+    "lodash": "~4.17.10",
     "numeral": "~2.0.6",
     "patternfly": "~3.54.1",
     "patternfly-react": "2.10.1",

--- a/spec/javascripts/controllers/toolbar_controller_spec.js
+++ b/spec/javascripts/controllers/toolbar_controller_spec.js
@@ -63,6 +63,7 @@ describe('toolbarController', function () {
         .each(function(item) {
           expect(item.hasOwnProperty('eventFunction')).toBeTruthy();
         })
+        .value();
      })
    })
 


### PR DESCRIPTION
This moves all lodash to npm - that means we no longer have lodash 3 available anywhere, and are always using lodash 4.

Following https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings to fix any incompatibilities.

Issue #3734 
