### PR TITLE
Fix typo cvsfs -> csvfs in storage decorator

### DIFF
--- a/app/decorators/storage_decorator.rb
+++ b/app/decorators/storage_decorator.rb
@@ -51,7 +51,7 @@ class StorageDecorator < MiqDecorator
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
     when 'iscsi'
       {:fonticon => 'ff ff-network-interface fa-rotate-180', :color => '#0099cc'}
-    when 'cvsfs', 'ntfs', 'refs', 'storagefileshare'
+    when 'csvfs', 'ntfs', 'refs', 'storagefileshare'
       {:fileicon => 'svg/vendor-microsoft.svg'}
     when 'glusterfs'
       {:fileicon => 'svg/vendor-gluster.svg'}


### PR DESCRIPTION
Fixing the typo based on [this suggestion](https://bugzilla.redhat.com/show_bug.cgi?id=1615441#c4) for [CsvFS](https://en.wikipedia.org/wiki/Cluster_Shared_Volumes),

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615441

@miq-bot add_label bug, gaprindashvili/no