### PR TITLE
Fix missing flash_msg_div in ops/settings/zone_form

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -607,6 +607,7 @@ class OpsController < ApplicationController
         @right_cell_text = _("Adding a new Zone")
       else
         partial_div = :settings_evm_servers
+        @editing = !!@edit
         @right_cell_text = @edit ?
           _("Editing Zone \"%{name}\"") % {:name => @zone.description} :
           _("Zone \"%{name}\"") % {:name => @zone.description}

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -1,5 +1,6 @@
 - url = url_for_only_path(:action => 'zone_field_changed', :id => (@zone.id || "new"))
-- disabled_name = !@zone.name.nil? && !@edit[:current][:name].nil?
+- unless @editing
+  = render :partial => "layouts/flash_msg"
 %h3
   = _("Zone Information")
 .form-horizontal
@@ -10,7 +11,7 @@
       = text_field_tag("name",
                         @edit[:new][:name],
                         :maxlength => 50,
-                        :disabled => disabled_name,
+                        :disabled => @editing,
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       - unless @zone.id

--- a/spec/views/ops/_zone_form.html.haml_spec.rb
+++ b/spec/views/ops/_zone_form.html.haml_spec.rb
@@ -50,6 +50,7 @@ describe "ops/_zone_form.html.haml" do
       @edit[:current][:name] = 'Test Zone'
       @zone.name = 'Test Zone'
       @zone.id = nil
+      @editing = true
       render :partial => "ops/zone_form"
       expect(response.body).to include('<input type="text" name="name" id="name" maxlength="50" disabled="disabled" class="form-control" data-miq_observe="{&quot;interval&quot;:&quot;.5&quot;,&quot;url&quot;:&quot;/ops/zone_field_changed/new&quot;}" />')
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1623912

**Description of problem:**
No error message when creating duplicate zone in the same region

**Steps to Reproduce:**
1. Create a domain and a namespace
2. Create a class (1) within the namespace that has both name and display name
3. Create an another class (2) within the same namespace, this time only with name and NO display name
4. Copy the class only with name (2) within the same domain and namespace, just give it a new name (3), safest way to do it right is to lock all domains except the one you work with right now.

1. There's no error message when trying to add zone with empty name.
Should be "Name can't be blank".

2. There's no error message when trying to add zone with empty description.
Should be "Description is required".

**Before**
![screenshot from 2018-09-03 11-55-44](https://user-images.githubusercontent.com/32869456/44980820-3af37880-af71-11e8-9013-56fdf50d8ea4.png)

**After**
![screenshot from 2018-09-03 11-53-55](https://user-images.githubusercontent.com/32869456/44980814-37f88800-af71-11e8-9aeb-27c683849ad1.png)


Caused by #4405

@miq-bot add_label gaprindashvili/no, bug