### PR TITLE
Fix error flash messages when creating tasks

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -57,7 +57,7 @@ class CloudNetworkController < ApplicationController
         options.delete(:ems_id)
         task_id = ems.create_cloud_network_queue(session[:userid], options)
         unless task_id.kind_of?(Integer)
-          add_flash(_("Cloud Network creation failed: Task start failed: ID [%{id}]") % {:id => task_id.to_s}, :error)
+          add_flash(_("Cloud Network creation failed: Task start failed"), :error)
         end
         if @flash_array
           javascript_flash(:spinner_off => true)
@@ -155,7 +155,7 @@ class CloudNetworkController < ApplicationController
       if @network.supports_update?
         task_id = @network.update_cloud_network_queue(session[:userid], options)
         unless task_id.kind_of?(Integer)
-          add_flash(_("Cloud Network update failed: Task start failed: ID [%{id}]") % {:id => task_id.to_s}, :error)
+          add_flash(_("Cloud Network update failed: Task start failed"), :error)
         end
         if @flash_array
           javascript_flash(:spinner_off => true)

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -70,7 +70,7 @@ class CloudSubnetController < ApplicationController
           initiate_wait_for_task(:task_id => task_id, :action => "create_finished")
         else
           javascript_flash(
-            :text        => _("Cloud Subnet creation: Task start failed: ID [%{id}]") % {:id => task_id.to_s},
+            :text        => _("Cloud Subnet creation: Task start failed"),
             :severity    => :error,
             :spinner_off => true
           )
@@ -162,7 +162,7 @@ class CloudSubnetController < ApplicationController
           initiate_wait_for_task(:task_id => task_id, :action => "update_finished")
         else
           javascript_flash(
-            :text        => _("Cloud Subnet update failed: Task start failed: ID [%{id}]") % {:id => task_id.to_s},
+            :text        => _("Cloud Subnet update failed: Task start failed"),
             :severity    => :error,
             :spinner_off => true
           )

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -85,8 +85,7 @@ class CloudTenantController < ApplicationController
 
       task_id = CloudTenant.create_cloud_tenant_queue(session[:userid], ems, options)
 
-      add_flash(_("Cloud tenant creation failed: Task start failed: ID [%{id}]") %
-                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+      add_flash(_("Cloud tenant creation failed: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
       if @flash_array
         javascript_flash(:spinner_off => true)
@@ -141,8 +140,7 @@ class CloudTenantController < ApplicationController
       options = form_params
       task_id = @tenant.update_cloud_tenant_queue(session[:userid], options)
 
-      add_flash(_("Cloud tenant creation failed: Task start failed: ID [%{id}]") %
-                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+      add_flash(_("Cloud tenant creation failed: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
       if @flash_array
         javascript_flash(:spinner_off => true)

--- a/app/controllers/cloud_volume_backup_controller.rb
+++ b/app/controllers/cloud_volume_backup_controller.rb
@@ -46,9 +46,7 @@ class CloudVolumeBackupController < ApplicationController
       if task_id.kind_of?(Integer)
         initiate_wait_for_task(:task_id => task_id, :action => "backup_restore_finished")
       else
-        add_flash(_("Cloud volume restore failed: Task start failed: ID [%{id}]") %
-        {:id => task_id.to_s}, :error)
-
+        add_flash(_("Cloud volume restore failed: Task start failed"), :error)
         javascript_flash(:spinner_off => true)
       end
     end

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -56,8 +56,7 @@ class FloatingIpController < ApplicationController
         task_id = ems.create_floating_ip_queue(session[:userid], options)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Floating IP creation failed: Task start failed: ID [%{id}]") %
-            {:id => task_id.to_s}, :error)
+          add_flash(_("Floating IP creation failed: Task start failed"), :error)
         end
 
         if @flash_array
@@ -143,8 +142,7 @@ class FloatingIpController < ApplicationController
         task_id = @floating_ip.update_floating_ip_queue(session[:userid], options)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Floating IP update failed: Task start failed: ID [%{id}]") %
-            {:id => task_id.to_s}, :error)
+          add_flash(_("Floating IP update failed: Task start failed"), :error)
         end
 
         if @flash_array

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -130,8 +130,7 @@ class HostAggregateController < ApplicationController
       if ext_management_system.supports?(:create_host_aggregate)
         task_id = ext_management_system.create_host_aggregate_queue(session[:userid], options)
 
-        add_flash(_("Host Aggregate creation failed: Task start failed: ID [%{id}]") %
-                  {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+        add_flash(_("Host Aggregate creation failed: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
         if @flash_array
           javascript_flash(:spinner_off => true)
@@ -193,9 +192,8 @@ class HostAggregateController < ApplicationController
         task_id = @host_aggregate.update_aggregate_queue(session[:userid], options)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Edit of Host Aggregate \"%{name}\" failed: Task start failed: ID [%{id}]") % {
+          add_flash(_("Edit of Host Aggregate \"%{name}\" failed: Task start failed") % {
             :name => @host_aggregate.name,
-            :id   => task_id.to_s
           }, :error)
         end
 
@@ -327,9 +325,8 @@ class HostAggregateController < ApplicationController
         task_id = @host_aggregate.add_host_queue(session[:userid], host)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Add Host to Host Aggregate \"%{name}\" failed: Task start failed: ID [%{id}]") % {
+          add_flash(_("Add Host to Host Aggregate \"%{name}\" failed: Task start failed") % {
             :name => @host_aggregate.name,
-            :id   => task_id.to_s
           }, :error)
         end
 
@@ -421,9 +418,8 @@ class HostAggregateController < ApplicationController
         task_id = @host_aggregate.remove_host_queue(session[:userid], host)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Remove Host to Host Aggregate \"%{name}\" failed: Task start failed: ID [%{id}]") % {
+          add_flash(_("Remove Host to Host Aggregate \"%{name}\" failed: Task start failed") % {
             :name => @host_aggregate.name,
-            :id   => task_id.to_s
           }, :error)
         end
 

--- a/app/controllers/mixins/actions/vm_actions/rename.rb
+++ b/app/controllers/mixins/actions/vm_actions/rename.rb
@@ -122,7 +122,7 @@ module Mixins
             initiate_wait_for_task(:task_id => task_id, :action => 'rename_finished')
           else
             add_flash(
-              :text        => _("VM rename: Task start failed: ID [%{id}]") % {:id => task_id.to_s},
+              :text        => _("VM rename: Task start failed"),
               :severity    => :error,
               :spinner_off => true
             )

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -73,8 +73,7 @@ class NetworkRouterController < ApplicationController
       ems = ExtManagementSystem.find(params[:ems_id])
       task_id = ems.create_network_router_queue(session[:userid], options)
 
-      add_flash(_("Network Router creation failed: Task start failed: ID [%{id}]") %
-                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+      add_flash(_("Network Router creation failed: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
       if @flash_array
         javascript_flash(:spinner_off => true)
@@ -160,8 +159,7 @@ class NetworkRouterController < ApplicationController
       end
       task_id = @router.update_network_router_queue(session[:userid], options)
 
-      add_flash(_("Router update failed: Task start failed: ID [%{id}]") %
-                {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+      add_flash(_("Router update failed: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
       if @flash_array
         javascript_flash(:spinner_off => true)
@@ -233,9 +231,8 @@ class NetworkRouterController < ApplicationController
         task_id = @router.add_interface_queue(session[:userid], cloud_subnet)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Add Interface on Subnet to Router \"%{name}\" failed: Task start failed: ID [%{id}]") % {
+          add_flash(_("Add Interface on Subnet to Router \"%{name}\" failed: Task start failed") % {
             :name => @router.name,
-            :id   => task_id.inspect
           }, :error)
         end
 
@@ -327,9 +324,8 @@ class NetworkRouterController < ApplicationController
         task_id = @router.remove_interface_queue(session[:userid], cloud_subnet)
 
         unless task_id.kind_of?(Integer)
-          add_flash(_("Remove Interface on Subnet from Router \"%{name}\" failed: Task start failed: ID [%{id}]") % {
+          add_flash(_("Remove Interface on Subnet from Router \"%{name}\" failed: Task start failed") % {
             :name => @router.name,
-            :id   => task_id.inspect
           }, :error)
         end
 

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -122,8 +122,7 @@ class PhysicalServerController < ApplicationController
     record = find_record_with_rbac(ManageIQ::Providers::PhysicalInfraManager::PhysicalServer, params[:id])
     task_id = record.remote_console_acquire_resource_queue(session[:userid])
     unless task_id.kind_of?(Integer)
-      add_flash(_("Console access failed: Task start failed: ID [%{id}]") %
-                  {:id => task_id.to_s}, :error)
+      add_flash(_("Console access failed: Task start failed"), :error)
     end
 
     if @flash_array

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -69,8 +69,7 @@ class SecurityGroupController < ApplicationController
         options.delete(:ems_id)
         task_id = ems.create_security_group_queue(session[:userid], options)
 
-        add_flash(_("Security Group creation: Task start failed: ID [%{id}]") %
-                  {:id => task_id.to_s}, :error) unless task_id.kind_of?(Integer)
+        add_flash(_("Security Group creation: Task start failed"), :error) unless task_id.kind_of?(Integer)
 
         if @flash_array
           javascript_flash(:spinner_off => true)
@@ -275,7 +274,7 @@ class SecurityGroupController < ApplicationController
 
   def task_started(task_id, message)
     unless task_id.kind_of?(Integer)
-      add_flash(_("%{message}: Task start failed: ID [%{id}]") % {:message => message, :id => task_id.to_s}, :error)
+      add_flash(_("%{message}: Task start failed") % {:message => message}, :error)
       return nil
     end
     true

--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -95,8 +95,7 @@ module VmRemote
 
     task_id = record.remote_console_acquire_ticket_queue(ticket_type, session[:userid])
     unless task_id.kind_of?(Integer)
-      add_flash(_("Console access failed: Task start failed: ID [%{id}]") %
-                  {:id => task_id.to_s}, :error)
+      add_flash(_("Console access failed: Task start failed"), :error)
     end
 
     if @flash_array

--- a/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
@@ -61,7 +61,7 @@ describe Mixins::Actions::VmActions::Rename do
       before { allow(vm).to receive(:rename_queue).with('admin', 'new_vm_name').and_return(nil) }
 
       it 'adds flash message about failing task start' do
-        expect(controller).to receive(:add_flash).with(:text        => _("VM rename: Task start failed: ID []") % {:id => nil},
+        expect(controller).to receive(:add_flash).with(:text        => _("VM rename: Task start failed"),
                                                        :severity    => :error,
                                                        :spinner_off => true)
         controller.send(:rename_save)


### PR DESCRIPTION
In several places in our code we use the following logic:

```ruby
task_id = ems.create_some_kind_of_queue(session[:userid], options)
unless task_id.kind_of?(Integer)
  add_flash(_("Some kind of creation failed: Task start failed: ID [%{id}]") % {:id => task_id.to_s}, :error)
end
```

This is obviously incorrect: since task creation failed, `task_id` is not an integer and we cannot treat it as integer in the flash error message.

@martinpovolny 