### PR TITLE
Convert all pf-select directives to miq-select

### DIFF
--- a/app/assets/javascripts/angular_modules/module_alerts_center.js
+++ b/app/assets/javascripts/angular_modules/module_alerts_center.js
@@ -2,5 +2,6 @@ miqHttpInject(angular.module('alertsCenter', [
   'ui.bootstrap',
   'patternfly',
   'miq.util',
-  'miq.api'
+  'miq.api',
+  'miqStaticAssets.miqSelect'
 ]));

--- a/app/assets/javascripts/components/ansible-credential-options.js
+++ b/app/assets/javascripts/components/ansible-credential-options.js
@@ -46,7 +46,7 @@ ManageIQ.angular.app.component('ansibleCredentialOptions', {
          '<a href="" ng-switch-when="password" ng-hide="!vm[name] || vm.newRecord" ng-click="vm.cancelPassword(name)">{{__("Cancel")}}</a>',
          // select
          '<div ng-switch-when="choice" class="col-md-8">',
-            '<select id="{{name}}" pf-select ng-options="opt as opt for opt in attr.choices" class="form-control" ng-model="vm.model[name]" />',
+            '<select id="{{name}}" miq-select ng-options="opt as opt for opt in attr.choices" class="form-control" ng-model="vm.model[name]" />',
           '</div>',
          // text
          '<div ng-switch-when="string" class="col-md-8">',

--- a/app/views/ansible_credential/_credential_form.html.haml
+++ b/app/views/ansible_credential/_credential_form.html.haml
@@ -34,7 +34,7 @@
                   'id'          => 'type',
                   'ng-disabled' => 'vm.credentialModel.manager_resource === null',
                   'required'    => 'true',
-                  'pf-select'   => 'true'}
+                  'miq-select'  => 'true'}
       - else
         .col-md-8
           {{ vm.credential_options[vm.credentialModel.type].label }}

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -41,7 +41,7 @@
                      options_for_select([[_("GIT"), "git"]], 'git'),
                      "ng-model"   => "vm.repositoryModel.scm_type",
                      :disabled    => true,
-                     'pf-select'  => true)
+                     'miq-select' => true)
     .form-group{"ng-class" => "{'has-error': angularForm.scm_url.$error.required || angularForm.scm_url.$error.urlValidation}"}
       %label.col-md-2.control-label
         = _('URL')
@@ -65,7 +65,7 @@
                 'ng-model'    => 'vm.repositoryModel.authentication_id',
                 'ng-options'  => 'scm_credential.value as scm_credential.name for scm_credential in vm.scm_credentials',
                 'ng-disabled' => 'vm.repositoryModel.manager_resource === null',
-                'pf-select'   => true}
+                'miq-select'  => true}
     .form-group
       %label.col-md-2.control-label
         = _('SCM Branch')

--- a/app/views/auth_key_pair_cloud/_form.html.haml
+++ b/app/views/auth_key_pair_cloud/_form.html.haml
@@ -46,7 +46,7 @@
                   'ng-options'                 => 'ems.name for ems in vm.ems_choices',
                   :id                          => 'ems_id',
                   :required                    => '',
-                  'pf-select'                  => true)
+                  'miq-select'                 => true)
           :javascript
             miqInitSelectPicker();
     = render :partial => 'layouts/angular/generic_form_buttons'

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -64,7 +64,7 @@
                   "name"             => "catalog_id",
                   'ng-options'       => 'catalog as catalog.name for catalog in vm.catalogs',
                   "data-live-search" => "true",
-                  'pf-select'        => true}
+                  'miq-select'        => true}
 
     = render :partial => "layouts/angular/multi_tab_ansible_form_options",
             :locals  => {:record => @record, :ng_model => "vm.catalogItemModel"}

--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -18,7 +18,7 @@
                 "required"    => "",
                 "disabled"    => !@storage_manager.nil?,
                 :checkchange  => true,
-                "pf-select"   => true}
+                "miq-select"  => true}
           %option{"value" => "", "disabled" => ""}
             = "<#{_('Choose')}>"
         %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}

--- a/app/views/cloud_tenant/new.html.haml
+++ b/app/views/cloud_tenant/new.html.haml
@@ -14,9 +14,9 @@
       .col-md-8
         = select_tag("ems_id",
           options_for_select([["<#{_('Choose')}>", nil]] + @ems_choices.sort),
-                      "ng-model"  => "vm.cloudTenantModel.ems_id",
-                      "required"  => "",
-                      "pf-select" => "")
+                      "ng-model"   => "vm.cloudTenantModel.ems_id",
+                      "required"   => "",
+                      "miq-select" => "")
   .form-horizontal
     .form-group
       %label.col-md-2.control-label

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -9,7 +9,7 @@
             "required"    => "",
             "disabled"    => !@storage_manager.nil? || !@volume.id.nil?,
             :checkchange  => true,
-            "pf-select"   => true}
+            "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
     %span.help-block{"ng-show" => "angularForm.storage_manager_id.$error.required"}
@@ -26,7 +26,7 @@
             "ng-disabled" => "!vm.newRecord",
             "required"    => "",
             :checkchange  => true,
-            "pf-select"   => true}
+            "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
     %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
@@ -43,7 +43,7 @@
             "required"    => "",
             "ng-disabled" => "!vm.newRecord",
             :checkchange  => true,
-            "pf-select"   => true}
+            "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
     %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
@@ -74,7 +74,7 @@
             "ng-disabled" => "!vm.newRecord && vm.cloudVolumeModel.aws_volume_type == 'standard'",
             "required"    => "",
             :checkchange  => true,
-            "pf-select"   => true}
+            "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
     %span.help-block{"ng-show" => "angularForm.aws_volume_type.$error.required"}
@@ -121,7 +121,7 @@
             "ng-disabled"      => "!vm.newRecord",
             :checkchange       => true,
             "data-live-search" => "true",
-            "pf-select"        => true}
+            "miq-select"       => true}
       %option{"value" => "", "enabled" => ""}
         = _('No snapshot')
 

--- a/app/views/cloud_volume/backup_select.html.haml
+++ b/app/views/cloud_volume/backup_select.html.haml
@@ -13,10 +13,10 @@
       .col-md-8
         = select_tag("backup_id",
           options_for_select([["<#{_('Choose')}>", nil]] + @backup_choices.sort),
-                      "ng-model"   => "vm.cloudVolumeModel.backup_id",
-                      "required"   => "",
-                      :checkchange => true,
-                      "pf-select"  => true)
+                      "ng-model"    => "vm.cloudVolumeModel.backup_id",
+                      "required"    => "",
+                      :checkchange  => true,
+                      "miq-select"  => true)
 
   .clearfix
   .pull-right.button-group.edit_buttons

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -15,10 +15,10 @@
       .col-md-8
         = select_tag("vm_id",
                       options_for_select([["<#{_('Choose')}>", nil]] + @vm_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
-                      "ng-model"   => "vm.cloudVolumeModel.vm_id",
-                      "required"   => true,
-                      :checkchange => true,
-                      "pf-select"  => true)
+                      "ng-model"    => "vm.cloudVolumeModel.vm_id",
+                      "required"    => true,
+                      :checkchange  => true,
+                      "miq-select"  => true)
 
   .clearfix
   .pull-right.button-group.edit_buttons

--- a/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_chart_view_form.html.haml
@@ -17,7 +17,7 @@
         %button.btn.btn-default.bootstrap-touchspin-up{"ng-click" => "dash.countIncrement()",
                                                        "type"     => "button"} +
 
-    %select.pull-left{"pf-select"  => "",
+    %select.pull-left{"miq-select" => "",
                       "id"         => "timeRange",
                       "ng-model"   => "dash.timeFilter.time_range",
                       "ng-options" => "range.value as range.title for range in dash.timeRanges"}

--- a/app/views/ems_container/ad_hoc/_list_view_form.html.haml
+++ b/app/views/ems_container/ad_hoc/_list_view_form.html.haml
@@ -1,6 +1,6 @@
 .col-md-12.tenant-filter-bar
   .form-group.pull-left.ad-hoc-tenant
-    %select.selectpicker.tenants-selector{"pf-select"              => "",
+    %select.selectpicker.tenants-selector{"miq-select"             => "",
                                           "id"                     => "tenant-slector",
                                           "ng-options"             => "o.label for o in dash.tenantList",
                                           "ng-model"               => "dash.tenant",

--- a/app/views/flavor/_flavor_form.html.haml
+++ b/app/views/flavor/_flavor_form.html.haml
@@ -21,7 +21,7 @@
                 'ng-options'                 => 'ems.name for ems in vm.ems_list',
                 :id                          => 'ems_id',
                 :required                    => '',
-                'pf-select'                  => true)
+                'miq-select'                 => true)
         :javascript
           miqInitSelectPicker();
     .form-group

--- a/app/views/floating_ip/_common_new_edit.html.haml
+++ b/app/views/floating_ip/_common_new_edit.html.haml
@@ -22,7 +22,7 @@
                 'ng-change'                   => 'vm.filterNetworkManagerChanged(vm.floatingIpModel.ems_id)',
                 'ng-model'                    => 'vm.floatingIpModel.ems_id',
                 'ng-options'                  => 'ems.id as ems.name for ems in vm.ems',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => ''}
           %option{"value" => ""}
             = "<#{_('Choose')}>"
@@ -44,7 +44,7 @@
         %select{'name'                        => 'cloud_network_id',
                 'ng-model'                    => 'vm.floatingIpModel.cloud_network_id',
                 'ng-options'                  => 'network.id as network.name for network in vm.available_networks',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{"value" => ""}
@@ -67,7 +67,7 @@
         %select{'name'                        => 'cloud_tenant_id',
                 'ng-model'                    => 'vm.floatingIpModel.cloud_tenant_id',
                 'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{"value" => ""}

--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -5,11 +5,11 @@
       %label.col-md-2.control-label{"for" => "instance_name"}
         = _("System/Process")
       .col-md-8
-        %select#instance_name{"ng-model"      => "scheduleModel.instance_name",
+        %select#instance_name{"ng-model"    => "scheduleModel.instance_name",
                               "name"        => "instance_name",
                               "ng-options"  => "instance for instance in scheduleModel.instance_names",
                               "checkchange" => "",
-                              "pf-select" => true}
+                              "miq-select " => true}
 
     .form-group
       %label.col-md-2.control-label{"for" => "object_message"}
@@ -45,7 +45,7 @@
                              "ng-options"  => "target_class[1] as target_class[0]  for target_class in scheduleModel.target_classes",
                              "ng-change"   => "targetClassChanged()",
                              "checkchange" => "",
-                             "pf-select"   => true}
+                             "miq-select"  => true}
           %option{"value" => ""}
             = "<#{_('Choose')}>"
     .form-group{"ng-class" => "{'has-error': angularForm.target_id.$invalid}", "ng-show" => "scheduleModel.target_class"}
@@ -57,7 +57,7 @@
                           "ng-options"  => "target[1] as target[0] for target in scheduleModel.targets",
                           "ng-required" => "scheduleModel.target_class",
                           "checkchange" => "",
-                          "pf-select"   => true}
+                          "miq-select"  => true}
           %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
         %span.help-block{"ng-show" => "angularForm.target_id.$error.miqrequired"}
           = _("Required")

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -25,7 +25,7 @@
                 "name"        => "#{prefix}_repository_id",
                 'ng-options'  => 'repository as repository.name for repository in vm.repositories',
                 "ng-required" => "vm.fieldsRequired('#{prefix}')",
-                'pf-select'   => true}
+                'miq-select'  => true}
           %option{"value" => ""}
             = "<#{_('Choose')}>"
 
@@ -40,7 +40,7 @@
                   "required"         => "",
                   :miqrequired       => true,
                   "data-live-search" => "true",
-                  'pf-select'        => true}
+                  'miq-select'       => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
 
@@ -55,7 +55,7 @@
                     "required"         => "",
                     :miqrequired       => true,
                     "data-live-search" => "true",
-                    'pf-select'        => true}
+                    'miq-select'       => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
         .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_vault_credential_id.$invalid}"}
@@ -66,7 +66,7 @@
                     "name"             => "#{prefix}_vault_credential_id",
                     'ng-options'       => 'vault_credential as vault_credential.name for vault_credential in vm.vault_credentials',
                     "data-live-search" => "true",
-                    'pf-select'        => true}
+                    'miq-select'       => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
         -#.form-group
@@ -78,7 +78,7 @@
         -#            'ng-options'       => 'network_credential as network_credential.name for network_credential in vm.network_credentials',
         -#            :checkchange       => true,
         -#            "data-live-search" => "true",
-        -#            'pf-select'        => true}
+        -#            'miq-select'       => true}
         -#      %option{"value" => ""}
         -#        = "<#{_('Choose')}>"
 
@@ -89,7 +89,7 @@
             %select{"ng-model"    => "vm._#{prefix}_cloud_type",
                     "name"        => "#{prefix}_cloud_type",
                     'ng-options'  => "k as v for (k,v) in vm.cloudTypes",
-                    "pf-select"   => true}
+                    "miq-select"  => true}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"
         #cloud_credentials_div{"ng-show" => "vm.#{prefix}_cloud_type !== ''"}
@@ -101,7 +101,7 @@
                       "name"             => "#{prefix}_cloud_credential_id",
                       'ng-options'       => "cloud_credential as cloud_credential.name for cloud_credential in vm.#{prefix}_cloud_credentials",
                       "data-live-search" => "true",
-                      'pf-select'        => true}
+                      'miq-select'       => true}
                 %option{"value" => ""}
                   = "<#{_('Choose')}>"
 
@@ -155,7 +155,7 @@
                 "name"        => "#{prefix}_log_output",
                 'ng-options'  => 'v as k for (v, k) in vm.log_output_types',
                 "checkchange" => "",
-                'pf-select'   => true}
+                'miq-select'  => true}
     #escalate_privilege{"ng-if" => "(#{ng_model}.#{prefix}_become_enabled!=='undefined' || vm.retirement_playbook_selected('#{prefix}'))"}
       .form-group
         %label.col-md-3.control-label
@@ -177,7 +177,7 @@
                 "name"        => "#{prefix}_verbosity",
                 'ng-options'  => 'v as k for (v, k) in vm.verbosity_types',
                 "checkchange" => "",
-                'pf-select'   => true}
+                'miq-select'  => true}
 
     - if prefix == "retirement"
       .form-group
@@ -188,7 +188,7 @@
                   "name"        => "retirement_remove_resources",
                   'ng-options'  => "v as k for (k, v) in vm.remove_resources_types",
                   'checkchange' => "",
-                  "pf-select"   => true}
+                  "miq-select"  => true}
 
   .col-md-12.col-lg-6{'ng-if' => "#{ng_model}.#{prefix}_variables!==undefined"}
     .form-group
@@ -274,7 +274,7 @@
                   "ng-required"      => "vm.fieldsRequired('#{prefix}') && #{ng_model}.#{prefix}_dialog_existing == 'existing'",
                   :checkchange       => true,
                   "data-live-search" => "true",
-                  'pf-select'        => true}
+                  'miq-select'       => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
             %span.help-block{"ng-show" => "angularForm.#{prefix}_dialog_id.$error.$invalid"}

--- a/app/views/miq_ae_class/_angular_inputs_form.html.haml
+++ b/app/views/miq_ae_class/_angular_inputs_form.html.haml
@@ -18,7 +18,7 @@
                   "name"       => "#{prefix}_type",
                   'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
                   'ng-change'  => '',
-                  "pf-select"  => true}
+                  "miq-select" => true}
         %td
           %input{:type         => "text",
                  'ng-model'    => "#{ng_model}.#{prefix}_value",
@@ -70,7 +70,7 @@
                                      "name"       => "key_type",
                                      'ng-options' => "v as v for v in #{ng_model}.available_datatypes",
                                      "ng-change"  => '',
-                                     "pf-select"  => true}
+                                     "miq-select" => true}
               %td{"ng-if" => "!#{ng_model}.#{prefix}_editMode || (#{ng_model}.#{prefix}_editMode && $index !== #{ng_model}.s_index)"}
                 {{arr[2] == 'password' ? '******' : arr[1]}}
               %td{"ng-if" => "#{ng_model}.#{prefix}_editMode && $index === #{ng_model}.s_index"}

--- a/app/views/network_router/_common_new_edit.haml
+++ b/app/views/network_router/_common_new_edit.haml
@@ -22,7 +22,7 @@
                 'ng-change'  => 'vm.filterNetworkManagerChanged(vm.networkRouterModel.ems_id)',
                 'ng-model'   => 'vm.networkRouterModel.ems_id',
                 'ng-options' => 'ems.id as ems.name for ems in vm.ems',
-                'pf-select'  => true,
+                'miq-select' => true,
                 'required'   => ''}
           %option{:value => ''}
             = "<#{_('Choose')}>"
@@ -43,7 +43,7 @@
         %select{'name'                        => 'cloud_tenant_id',
                 'ng-model'                    => 'vm.networkRouterModel.cloud_tenant.id',
                 'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}
@@ -113,7 +113,7 @@
                 'ng-model'                    => 'vm.networkRouterModel.cloud_network_id',
                 'ng-options'                  => 'network.id as network.name for network in vm.available_networks',
                 'ng-change'                   => 'vm.getCloudSubnetsByNetworkID(vm.networkRouterModel.cloud_network_id)',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'ng-selected'                 => 'vm.networkRouterModel.cloud_network_id',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}
@@ -128,7 +128,7 @@
         %select{'name'                        => 'cloud_subnet_id',
                 'ng-model'                    => 'vm.networkRouterModel.cloud_subnet_id',
                 'ng-options'                  => 'subnet.id as subnet.name for subnet in vm.available_subnets',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'ng-selected'                 => 'vm.networkRouterModel.cloud_subnet_id',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}

--- a/app/views/security_group/_fw_rules.haml
+++ b/app/views/security_group/_fw_rules.haml
@@ -27,20 +27,20 @@
           %select{"name"                        => "direction",
                   "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].direction",
                   "ng-options"                  => "direction for direction in vm.directions",
-                  'pf-select'                   => true,
+                  'miq-select'                  => true,
                   "required"                    => ""}
         %td
           %select{"name"                        => "network_protocol",
                   "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].network_protocol",
                   "ng-options"                  => "network_protocol for network_protocol in vm.networkProtocols",
-                  'pf-select'                   => true}
+                  'miq-select'                  => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td
           %select{"name"                        => "host_protocol",
                   "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].host_protocol",
                   "ng-options"                  => "host_protocol for host_protocol in vm.hostProtocols",
-                  'pf-select'                   => true}
+                  'miq-select'                  => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td
@@ -48,7 +48,7 @@
                   "ng-model"                    => "vm.securityGroupModel.firewall_rules[$index].source_security_group_id",
                   "ng-options"                  => "sg.id as sg.name + ' - ' + sg.ems_ref for sg in vm.security_groups_list",
                   "ng-change"                   => "vm.securityGroupModel.firewall_rules[$index].source_ip_range = null",
-                  'pf-select'                   => true}
+                  'miq-select'                  => true}
             %option{"value" => ""}
               = "<#{_('Choose')}>"
         %td

--- a/app/views/security_group/new.html.haml
+++ b/app/views/security_group/new.html.haml
@@ -21,7 +21,7 @@
                 'ng-change'  => "vm.filterNetworkManagerChanged(vm.securityGroupModel.ems_id)",
                 'ng-model'   => "vm.securityGroupModel.ems_id",
                 'ng-options' => 'ems.id as ems.name for ems in vm.ems',
-                'pf-select'  => true,
+                'miq-select' => true,
                 'required'   => ''}
           %option{:value => ""}
             = "<#{_('Choose')}>"
@@ -40,7 +40,7 @@
         %select{:name                         => "cloud_tenant_id",
                 "ng-model"                    => "vm.securityGroupModel.cloud_tenant_id",
                 "ng-options"                  => "tenant.id as tenant.name for tenant in vm.available_tenants",
-                "pf-select"                   => true,
+                "miq-select"                  => true,
                 "required"                    => "",
                 "selectpicker-for-select-tag" => ""}
           %option{"value" => ""}

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -13,8 +13,8 @@
       .col-md-4{"ng-init" => "formMode = 'date'"}
         = select_tag("formMode",
                      options_for_select(_("Specific Date and Time") => 'date', _("Time Delay from Now") => 'delay'),
-                     "ng-model"  => "formMode",
-                     "pf-select" => true)
+                     "ng-model"   => "formMode",
+                     "miq-select" => true)
     .form-group{"ng-if" => "formMode == 'date'"}
       %label.col-md-3.control-label
         = _('Retirement Date and Time')
@@ -44,7 +44,7 @@
                      "ng-options"  => "item.value as item.label for item in #{select_options.to_json.gsub('"', '\'')}",
                      "ng-model"    => "vm.retirementInfo.retirementWarning",
                      "ng-disabled" => "!vm.retirementInfo.retirementDate",
-                     "pf-select"   => true)
+                     "miq-select"  => true)
         :javascript
           miqInitSelectPicker();
   %div{"ng-if" => "formMode == 'date'"}

--- a/app/views/shared/views/_show_alerts_most_recent.html.haml
+++ b/app/views/shared/views/_show_alerts_most_recent.html.haml
@@ -14,10 +14,10 @@
         %actions.recent-toolbar-actions
           %span
             = _("Show")
-          %select{"pf-select" => "true",
-                  "ng-model" => "vm.showCount",
+          %select{"miq-select" => "true",
+                  "ng-model"   => "vm.showCount",
                   "ng-options" => "o as o for o in vm.showCounts",
-                  "ng-change" => "vm.filterChange()"}
+                  "ng-change"  => "vm.filterChange()"}
           %span
             = _("alerts")
     = render :partial => "shared/views/alerts_list"

--- a/app/views/shared/views/_show_alerts_overview.html.haml
+++ b/app/views/shared/views/_show_alerts_overview.html.haml
@@ -13,16 +13,16 @@
       %actions.group-toolbar-actions
         %span
           = _("Group By")
-        %select{"pf-select" => "true",
-                "ng-model" => "vm.category",
+        %select{"miq-select" => "true",
+                "ng-model"   => "vm.category",
                 "ng-options" => "o as o for o in vm.categories",
-                "ng-change" => "vm.filterChange()"}
+                "ng-change"  => "vm.filterChange()"}
         %span
           = _("Display")
-        %select{"pf-select" => "true",
-                "ng-model" => "vm.displayFilter",
+        %select{"miq-select" => "true",
+                "ng-model"   => "vm.displayFilter",
                 "ng-options" => "o as o for o in vm.displayFilters",
-                "ng-change" => "vm.filterChange()"}
+                "ng-change"  => "vm.filterChange()"}
   .row.row-tile-pf.init-hidden{"ng-class" => "{'initialized': vm.loadingDone}"}
     %ul.list-group
       %li.list-group-item.alerts-group-item{"ng-repeat" => "group in vm.groups track by $index"}

--- a/app/views/static/ae_resolve_options/ae-resolve-options-component.html.haml
+++ b/app/views/static/ae_resolve_options/ae-resolve-options-component.html.haml
@@ -9,7 +9,7 @@
                             'name'       => 'instance_name',
                             'ng-options' => 'instance for instance in $ctrl.instanceOptions',
                             'ng-change'  => '$ctrl.instanceNameChange({instanceName: $ctrl.instanceName})',
-                            'pf-select'  => true}
+                            'miq-select' => true}
 
   .form-group{'ng-class' => '{"has-error": aeResolveOptionsForm.object_message.$invalid}'}
     %label.col-md-2.control-label{'for' => 'object_message'}
@@ -48,7 +48,7 @@
                              'ng-options'     => 'target_class[1] as target_class[0]  for target_class in $ctrl.targetClassOptions',
                              'ng-change'      => '$ctrl.targetClassChange({targetClass: $ctrl.targetClass})',
                              'data-container' => 'body',
-                             'pf-select'      => true}
+                             'miq-select'     => true}
           %option{'value' => ''}
             = "<#{_('Choose')}>"
     .form-group{'ng-class' => "{'has-error': aeResolveOptionsForm.target_id.$invalid}",
@@ -61,7 +61,7 @@
                           'ng-options'  => 'target[1] as target[0] for target in $ctrl.targetIdOptions',
                           'ng-required' => '$ctrl.targetClass',
                           'ng-change'   => '$ctrl.targetIdChange({targetId: $ctrl.targetId})',
-                          'pf-select'   => true}
+                          'miq-select'  => true}
           %option{'disabled' => '', 'value' => ''} &lt;Choose&gt;
         %span.help-block{'ng-show' => 'aeResolveOptionsForm.target_id.$error.miqrequired'}
           = _('Required')

--- a/app/views/static/cloud_network/cloud-network-form.html.haml
+++ b/app/views/static/cloud_network/cloud-network-form.html.haml
@@ -18,7 +18,7 @@
                 'ng-change'                   => "vm.filterNetworkManagerChanged(vm.cloudNetworkModel.ems_id)",
                 'ng-model'                    => "vm.cloudNetworkModel.ems_id",
                 'ng-options'                  => 'ems.id as ems.name for ems in vm.ems',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => ""}
           %option{'value' => ""}
             = "<#{_('Choose')}>"
@@ -41,7 +41,7 @@
         %select{'name'                        => "cloud_tenant_id",
                 'ng-model'                    => "vm.cloudNetworkModel.cloud_tenant.id",
                 'ng-options'                  => "tenant.id as tenant.name for tenant in vm.available_tenants",
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => "",
                 'selectpicker-for-select-tag' => ""}
           %option{'value' => ""}
@@ -65,7 +65,7 @@
                 'ng-disabled'                 => "!vm.newRecord",
                 'ng-model'                    => "vm.cloudNetworkModel.provider_network_type",
                 'ng-options'                  => "type as key for (key, type) in vm.providers_network_types",
-                "pf-select"                   => true,
+                "miq-select"                  => true,
                 "selectpicker-for-select-tag" => ""}
     .form-group{'ng-if' => "vm.cloudNetworkModel.provider_network_type"}
       %label.control-label.col-md-2

--- a/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
+++ b/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
@@ -17,7 +17,7 @@
                 'ng-change'                   => 'vm.filterNetworkManagerChanged(vm.cloudSubnetModel.ems_id)',
                 'ng-model'                    => 'vm.cloudSubnetModel.ems_id',
                 'ng-options'                  => 'ems.id as ems.name for ems in vm.available_ems',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}
@@ -38,7 +38,7 @@
         %select{'name'                        => 'cloud_tenant_id',
                 'ng-model'                    => 'vm.cloudSubnetModel.cloud_tenant.id',
                 'ng-options'                  => 'tenant.id as tenant.name for tenant in vm.available_tenants',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}
@@ -61,7 +61,7 @@
         %select{'name'                        => 'network_id',
                 'ng-model'                    => 'vm.cloudSubnetModel.network_id',
                 'ng-options'                  => 'network.ems_ref as network.name for network in vm.available_networks',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
           %option{'value' => ''}
@@ -108,7 +108,7 @@
                 'ng-model'                    => 'vm.cloudSubnetModel.network_protocol',
                 'ng-disabled'                 => '!vm.newRecord',
                 'ng-options'                  => 'protocol as protocol for protocol in vm.networkProtocols',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'required'                    => '',
                 'selectpicker-for-select-tag' => ''}
         %span.help-block{'ng-show' => 'angularForm.network_protocol.$error.required'}

--- a/app/views/static/cloud_volume_backup/volume_select.html.haml
+++ b/app/views/static/cloud_volume_backup/volume_select.html.haml
@@ -13,9 +13,9 @@
       .col-md-8
         = select_tag('volume_id',
                 '',
-                'ng-model'                   => 'vm.cloudVolumeBackupModel.volume',
-                'ng-options'                 => 'volume.name for volume in vm.volume_choices track by volume.id',
-                :required                    => '',
-                'pf-select'                  => true)
+                'ng-model'   => 'vm.cloudVolumeBackupModel.volume',
+                'ng-options' => 'volume.name for volume in vm.volume_choices track by volume.id',
+                :required    => '',
+                'miq-select' => true)
 
   = render :partial => 'layouts/angular/generic_form_buttons'

--- a/app/views/static/deploy_containers_provider/deploy-provider-details-create-vms.html.haml
+++ b/app/views/static/deploy_containers_provider/deploy-provider-details-create-vms.html.haml
@@ -20,7 +20,7 @@
       "pf-label-class" => "miq-input-label-class miq-input-label-class-lg", :required => ""}
         %select#masterCreationTemplate{"ng-change" => "applyMasterTemplate()",
         "ng-model" => "data.masterCreationTemplateId",
-        "ng-options" => "template.id as template.name for template in data.nodeCreationTemplates", "pf-select" => ""}
+        "ng-options" => "template.id as template.name for template in data.nodeCreationTemplates", "miq-select" => ""}
       %div{"pf-form-group" => "", "pf-input-class" => "miq-input-class", "pf-label" => _("Memory"),
       "pf-label-class" => "miq-input-label-class miq-input-label-class-lg", :required => ""}
         %input{"ng-blur" => "updateNodesLikeMaster()", "ng-change" => "validateForm()",
@@ -56,7 +56,7 @@
       "pf-label-class" => "miq-input-label-class miq-input-label-class-lg", :required => ""}
         %select#nodeCreationTemplate{"ng-change" => "applyNodeTemplate()",
         "ng-disabled" => "data.createNodesLikeMasters", "ng-model" => "data.nodeCreationTemplateId",
-        "ng-options" => "template.id as template.name for template in data.nodeCreationTemplates", "pf-select" => ""}
+        "ng-options" => "template.id as template.name for template in data.nodeCreationTemplates", "miq-select" => ""}
       %div{"pf-form-group" => "", "pf-input-class" => "miq-input-class", "pf-label" => _("Memory"),
       "pf-label-class" => "miq-input-label-class miq-input-label-class-lg", :required => ""}
         %input{"ng-change" => "validateForm()", "ng-disabled" => "data.createNodesLikeMasters",

--- a/app/views/static/deploy_containers_provider/deploy-provider-details-general.html.haml
+++ b/app/views/static/deploy_containers_provider/deploy-provider-details-general.html.haml
@@ -22,13 +22,13 @@
             = _("Use existing VMs from an existing provider")
         .form-group.sub-group
           %select#exitingProviderType{"ng-disabled" => "data.provisionOn != 'existingVms'",
-          "ng-model" => "data.existingProviderId", "ng-options" => "provider.id as provider.name for provider in existingProviders", "pf-select" => ""}
+          "ng-model" => "data.existingProviderId", "ng-options" => "provider.id as provider.name for provider in existingProviders", "miq-select" => ""}
         %label.radio
           %input{"ng-model" => "data.provisionOn", :type => "radio", :value => "newVms"}
             = _("Create new VMs on provider")
         .form-group.sub-group
           %select#newVmProviders{"ng-disabled" => "data.provisionOn != 'newVms'", "ng-model" => "data.newVmProviderId",
-           "ng-options" => "provider.id as provider.name for provider in newVmProviders", "pf-select" => ""}
+           "ng-options" => "provider.id as provider.name for provider in newVmProviders", "miq-select" => ""}
         %label.radio
           %input{"ng-model" => "data.provisionOn", :type => "radio", :value => "noProvider"}
             = _("Specify a list of machines to deploy on (No existing provider)")

--- a/app/views/static/edit_alert_dialog.html.haml
+++ b/app/views/static/edit_alert_dialog.html.haml
@@ -16,10 +16,10 @@
         %label.col-sm-2.control-label
           = _("Owner")
         .col-sm-5
-          %select#assign-select{"ng-if" => "vm.editData.showAssign",
+          %select#assign-select{"ng-if"      => "vm.editData.showAssign",
                                 "ng-model"   => "vm.editData.owner",
                                 "ng-options" => "user as user.name for user in vm.editData.existingUsers",
-                                "pf-select"  => ""}
+                                "miq-select" => ""}
           %label{"ng-if" => "!vm.editData.showAssign && vm.editData.owner"}
             {{vm.editData.owner.name}}
           %label{"ng-if" => "!vm.editData.showAssign && !vm.editData.owner"}

--- a/app/views/static/generic_object/generic_object_table.html.haml
+++ b/app/views/static/generic_object/generic_object_table.html.haml
@@ -42,7 +42,7 @@
                   "ng-options"                  => "valueOption.id as valueOption.name for valueOption in vm.valueOptions",
                   "data-live-search"            => "true",
                   "selectpicker-for-select-tag" => "",
-                  "pf-select"                   => true,}
+                  "miq-select"                  => true,}
             %option{"value" => "", "disabled" => ""}
               = "<#{_('Choose')}>"
         %td.form-group{"ng-if" => "vm.addValueColumn", "ng-class" => "{'has-error': vm.angularForm['Value_{{vm.keyType}}{{$index}}'].$invalid}"}

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -15,7 +15,7 @@
               "ng-options"                  => "button_type.id as button_type.name for button_type in vm.button_types",
               "required"                    => "",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.button_type.$error.required"}
@@ -31,7 +31,7 @@
               "ng-options"                  => "dialog.id as dialog.label for dialog in vm.dialogs",
               "data-live-search"            => "true",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.dialog_id.$error.required"}
@@ -56,7 +56,7 @@
               "ng-model"                    => "vm.customButtonModel.display_for",
               "ng-options"                  => "display_for.id as display_for.name for display_for in vm.display_for",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.display_for.$error.required"}
@@ -69,7 +69,7 @@
               "ng-model"                    => "vm.customButtonModel.submit_how",
               "ng-options"                  => "submit_how.id as submit_how.name for submit_how in vm.submit_how",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.submit_how.$error.required"}
@@ -82,7 +82,7 @@
               "ng-model"                    => "vm.customButtonModel.ae_instance",
               "ng-options"                  => "ae_instance.id as ae_instance.name for ae_instance in vm.ae_instances",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.ae_instance.$error.required"}
@@ -136,7 +136,7 @@
               "ng-model"                    => "vm.customButtonModel.current_visibility",
               "ng-options"                  => "visibility.id as visibility.name for visibility in vm.visibilities",
               "selectpicker-for-select-tag" => "",
-              "pf-select"                   => true,}
+              "miq-select"                  => true,}
       %span.help-block{"ng-show" => "angularForm.visibility.$error.required"}
         = _("Required")
   %br

--- a/app/views/static/miq-request-options.html.haml
+++ b/app/views/static/miq-request-options.html.haml
@@ -7,9 +7,9 @@
       = _("Requester:")
     .col-md-8.requester
       %select{'ng-if' => "$ctrl.options.users.length > 1", 'name' => 'user_choice',
-        'ng-options' => "user.value as user.label for user in $ctrl.options.users",
-        'ng-model' => '$ctrl.options.selectedUser',
-        'pf-select' => ''}
+        'ng-options'  => "user.value as user.label for user in $ctrl.options.users",
+        'ng-model'    => '$ctrl.options.selectedUser',
+        'miq-select'  => ''}
       %div{'ng-if' => "$ctrl.options.users.length === 1"}
         {{$ctrl.options.users[0].label}}
       %div{'ng-if' => "$ctrl.options.users.length === 0"}
@@ -28,17 +28,17 @@
       %span{'ng-if' => '$ctrl.options.types.length === 1'}
         {{$ctrl.options.types[0].label}}
       %select{'ng-if' => '$ctrl.options.types.length > 1', :name => 'type_choice',
-        'ng-options' => 'type.value as type.label for type in $ctrl.options.types',
-        'ng-model' => '$ctrl.options.selectedType',
-        'pf-select' => ''}
+        'ng-options'  => 'type.value as type.label for type in $ctrl.options.types',
+        'ng-model'    => '$ctrl.options.selectedType',
+        'miq-select'  => ''}
   .form-group
     %label.col-md-2.control-label
       = _("Request Date:")
     .col-md-8
-      %select{:name => 'time_period',
+      %select{:name  => 'time_period',
         'ng-options' => 'period.value as period.label for period in $ctrl.options.timePeriods',
-        'ng-model' => '$ctrl.options.selectedPeriod',
-        'pf-select' => ''}
+        'ng-model'   => '$ctrl.options.selectedPeriod',
+        'miq-select' => ''}
   .form-group
     %label.col-md-2.control-label
       = _("Reason:")

--- a/app/views/static/vm_cloud/add_security_group.html.haml
+++ b/app/views/static/vm_cloud/add_security_group.html.haml
@@ -17,7 +17,7 @@
         %select{"name"                        => "security_group",
                 "ng-model"                    => "vm.vmCloudModel.security_group",
                 "ng-options"                  => "security_group.name as security_group.name for security_group in vm.security_groups",
-                "pf-select"                   => true,
+                "miq-select"                  => true,
                 "required"                    => "",
                 "selectpicker-for-select-tag" => ""}
 

--- a/app/views/static/vm_cloud/remove_security_group.html.haml
+++ b/app/views/static/vm_cloud/remove_security_group.html.haml
@@ -17,7 +17,7 @@
         %select{"name"                        => "security_group",
                 "ng-model"                    => "vm.vmCloudModel.security_group",
                 "ng-options"                  => "security_group.name as security_group.name for security_group in vm.security_groups",
-                "pf-select"                   => true,
+                "miq-select"                  => true,
                 "required"                    => "",
                 "selectpicker-for-select-tag" => ""}
 

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -359,7 +359,7 @@
             %select{'name'                    => 'adapterNetwork',
                 'ng-model'                    => 'vm.reconfigureModel.adapterNetwork',
                 'ng-options'                  => 'network for network in vm.reconfigureModel.availableAdapterNetworks',
-                'pf-select'                   => true,
+                'miq-select'                  => true,
                 'selectpicker-for-select-tag' => ''}
               %option{"value" => ""}
                 = "<#{_('Choose')}>"


### PR DESCRIPTION
If we want to move to angular-patternfly v4, this is necessary and according to @himdel the safest solution that can even be backported if needed.

@miq-bot assign @himdel 