### PR TITLE
Allow nesting physical chassis

### DIFF
--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -11,6 +11,7 @@ class PhysicalInfraTopologyService < TopologyService
     ),
     :physical_chassis  => %i(
       writable_classification_tags
+      child_physical_chassis
       physical_servers
     ),
     :physical_servers  => [


### PR DESCRIPTION
This change teaches topology creation process about chassis nesting
that can be produced by Redfish physical infrastructure provider.

~~Depends on #4593~~
~~Depends on https://github.com/ManageIQ/manageiq/pull/17940~~

@miq-bot add_label wip