### PR TITLE
Describe better chargeback metric in Rate Editor

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -510,6 +510,7 @@ class ChargebackController < ApplicationController
 
     rate_details.each_with_index do |detail, detail_index|
       temp = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
+      temp[:report_column_name] = Dictionary.gettext(detail.chargeable_field.metric_key, :type => :column, :notfound => :titleize)
       temp[:group] = detail.chargeable_field.group
       temp[:per_time] ||= "hourly"
 

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -4,7 +4,10 @@
   %thead
     %tr
       %th{:rowspan => "2"}= _('Group')
-      %th{:rowspan => "2"}= _('Description')
+      %th{:rowspan => "2"}
+        = _('Description')
+        %br
+        = _('(Column Name in Report)')
       - if breakdown_present
         %th{:rowspan => '2'}= _('Sub Metric')
       %th{:rowspan => "2"}= _('Per Time')
@@ -33,6 +36,8 @@
           = h(rate_detail_group(detail[:group]))
         %td{:rowspan => num_tiers}
           = detail[:description]
+          %br
+          = "(#{detail[:report_column_name]})"
         - if breakdown_present
           %td{:rowspan => num_tiers}
             - sub_metrics = detail[:sub_metrics]

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -5,6 +5,8 @@
   .form-group
     %label.col-md-2.control-label
       = _('Description')
+      %br
+      = _('(Column Name in Report)')
     .col-md-8
       %p.form-control-static
         = h(@record.description)
@@ -41,6 +43,8 @@
           = h(rate_detail_group(detail.chargeable_field[:group]))
         %td{:rowspan => num_tiers}
           = detail.chargeable_field[:description]
+          %br
+          = Dictionary.gettext(detail.chargeable_field.metric_key, :type => :column, :notfound => :titleize)
           - if breakdown_present
             %td{:rowspan => num_tiers}
               - if detail.sub_metrics.present?


### PR DESCRIPTION
Report column name added to rate editor

Reason: We are using different names in report and in report editor and it is confusing. 


cc @gtanzillo 

@miq-bot chargeback, enhancement
@miq-bot assign @mzazrivec 

**After** - highlighted are new ones
![screen shot 2018-09-04 at 14 59 49](https://user-images.githubusercontent.com/14937244/45033253-3bb10b00-b054-11e8-9fc2-0d072252f6ee.png)
