### PR TITLE
Update 'About Modal' plugin section styling

### DIFF
--- a/app/assets/stylesheets/about_modal_background.scss
+++ b/app/assets/stylesheets/about_modal_background.scss
@@ -8,7 +8,7 @@
 }
 
 .about-modal-pf.whitelabel {
-  background-image: image-url($img-bg-login-whitelabel);
+ background-image: image-url($img-bg-login-whitelabel);
   background-size: 100% 100%;
 }
 
@@ -17,18 +17,18 @@
 }
 
 /* Track */
-.about-visible-scrollbar-track::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 10px #f5f5f5;
-  border-radius: 10px;
+.about-visible-scrollbar::-webkit-scrollbar-track {
+box-shadow: inset 0 0 10px #f5f5f5;
+border-radius: 10px;
 }
 
 /* Handle */
-.about-visible-scrollbar-thumb::-webkit-scrollbar-thumb {
-  background: #f5f5f5;
-  border-radius: 10px;
+.about-visible-scrollbar::-webkit-scrollbar-thumb {
+background: #f5f5f5;
+border-radius: 10px;
 }
 
 /* Handle on hover */
-.about-visible-scrollbar-hover::-webkit-scrollbar-thumb:hover {
-  background: #b305500;
+.about-visible-scrollbar::-webkit-scrollbar-thumb:hover {
+background: #b305500;
 }

--- a/app/views/layouts/_about_modal.html.haml
+++ b/app/views/layouts/_about_modal.html.haml
@@ -20,21 +20,38 @@
                 %strong
                   = session_info[0]
                 = session_info[1]
+        %a#collapsePluginsHandle{"role" => "button", "data-toggle" => "collapse", :href => "#collapsePlugins", "aria-expanded" => "false", "aria-controls" => "collapsePlugins", :style => "color: white" }
           %strong
+            %span.fa.fa-angle-right
             = _("Plugins")
-          %ul.list-unstyled.about-visible-scrollbar.about-visible-scrollbar-thumb.about-visible-scrollbar-track.about-visible-scrollbar-hover{:style => "height: 40px;overflow: auto"}
+        .collapse#collapsePlugins
+          %ul.list-unstyled.about-visible-scrollbar{:style => "height: 200px;overflow: auto"}
             - vmdb_plugins_sha.each do |engine, sha|
-              %div
-                = "#{plugin_name(engine)} #{sha}"
-
+              %li
+                %strong
+                  = plugin_name(engine)
+                &nbsp;
+                = sha
+        .spacer
         .trademark-pf
           = I18n.t("product.copyright")
       .modal-footer
         %img{:src => ::Settings.server.custom_logo ? '/upload/custom_logo.png' : image_path("layout/login-screen-logo.png")}
+
 :javascript
   $(function(){
     $("button[data-dismiss='modal']").off('click');
     $("button[data-dismiss='modal']").on('click', function(){
       $('#aboutModal').modal("hide")
+    });
+
+    $('#collapsePlugins.collapse').on('show.bs.collapse', function() {
+      $('#collapsePluginsHandle span').removeClass('fa-angle-right');
+      $('#collapsePluginsHandle span').addClass('fa-angle-down');
+    });
+
+    $('#collapsePlugins.collapse').on('hide.bs.collapse', function() {
+      $('#collapsePluginsHandle span').removeClass('fa-angle-down');
+      $('#collapsePluginsHandle span').addClass('fa-angle-right');
     });
   });


### PR DESCRIPTION
This PR makes the plugin section expandable and also increases the scrollable area to 10 lines.

This is a follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/4423

<img width="703" alt="screen shot 2018-09-04 at 4 45 44 pm" src="https://user-images.githubusercontent.com/1287144/45056835-06abb500-b062-11e8-9500-260b776d7d2f.png">
<img width="1280" alt="screen shot 2018-09-05 at 9 44 29 am" src="https://user-images.githubusercontent.com/1287144/45097294-77011780-b0f0-11e8-9087-09d210c573fd.png">



