### PR TITLE
Fix toolbar buttons for Hosts displayed thru Host Aggregate's details page

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -253,6 +253,13 @@ module EmsCommon
       when "host_manageable"                  then sethoststomanageable
       when "host_introspect"                  then introspecthosts
       when "host_provide"                     then providehosts
+      # Host Aggregates
+      when 'host_aggregate_new'               then javascript_redirect(:action => 'new')
+      when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_item_id)
+      when 'host_aggregate_delete'            then delete_host_aggregates
+      when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_item_id)
+      when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_item_id)
+      when 'host_aggregate_tag'               then tag(HostAggregate)
       # Storages
       when "storage_delete"                   then deletestorages
       when "storage_scan"                     then scanstorage

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -8,6 +8,7 @@ class HostAggregateController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::MoreShowActions
+  include EmsCommon
 
   def self.display_methods
     %w(instances hosts)
@@ -20,84 +21,6 @@ class HostAggregateController < ApplicationController
       :name    => host_aggregate.name,
       :ems_id  => host_aggregate.ems_id
     }
-  end
-
-  # handle buttons pressed on the button bar
-  def button
-    @edit = session[:edit] # Restore @edit for adv search box
-
-    params[:display] = @display if %w(images instances).include?(@display) # Were we displaying vms/hosts/storages
-    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
-
-    if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
-                                     "instance_")
-
-      pfx = pfx_for_vm_button_pressed(params[:pressed])
-      process_vm_buttons(pfx)
-
-      # Control transferred to another screen, so return
-      return if ["#{pfx}_policy_sim", "#{pfx}_compare", "#{pfx}_tag",
-                 "#{pfx}_retire", "#{pfx}_protect", "#{pfx}_ownership",
-                 "#{pfx}_refresh", "#{pfx}_right_size",
-                 "#{pfx}_reconfigure"].include?(params[:pressed]) &&
-                @flash_array.nil?
-
-      unless ["#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-              "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-        @refresh_div = "main_div"
-        @refresh_partial = "layouts/gtl"
-        show # Handle VMs buttons
-      end
-    else
-      tag(HostAggregate) if params[:pressed] == "host_aggregate_tag"
-      return if ["host_aggregate_tag"].include?(params[:pressed]) &&
-                @flash_array.nil? # Tag screen showing, so return
-    end
-
-    if params[:pressed] == "host_aggregate_new"
-      javascript_redirect :action => "new"
-      return
-    elsif params[:pressed] == "host_aggregate_edit"
-      javascript_redirect :action => "edit", :id => checked_item_id
-      return
-    elsif params[:pressed] == 'host_aggregate_delete'
-      delete_host_aggregates
-      render_flash
-      return
-    elsif params[:pressed] == "host_aggregate_add_host"
-      javascript_redirect :action => "add_host_select", :id => checked_item_id
-      return
-    elsif params[:pressed] == "host_aggregate_remove_host"
-      javascript_redirect :action => "remove_host_select", :id => checked_item_id
-      return
-    elsif params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                   "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
-      render_or_redirect_partial(pfx)
-    elsif @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
-    else
-      render :update do |page|
-        page << javascript_prologue
-        unless @refresh_partial.nil?
-          if @refresh_div == "flash_msg_div"
-            page.replace(@refresh_div, :partial => @refresh_partial)
-          elsif %w(images instances).include?(@display) # If displaying vms, action_url s/b show
-            page << "miqSetButtons(0, 'center_tb');"
-            page.replace_html("main_div",
-                              :partial => "layouts/gtl",
-                              :locals  => {:action_url => @breadcrumbs.last[:url]})
-          else
-            page.replace_html(@refresh_div, :partial => @refresh_partial)
-          end
-        end
-      end
-    end
-
-    unless @refresh_partial # if no button handler ran, show not implemented msg
-      add_flash(_("Button not yet implemented"), :error)
-      @refresh_partial = "layouts/flash_msg"
-      @refresh_div = "flash_msg_div"
-    end
   end
 
   def new

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -30,37 +30,35 @@ describe HostAggregateController do
       @aggregate = FactoryGirl.create(:host_aggregate_openstack)
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "create_aggregate",
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@ems.id, {:name => "foo", :ems_id => @ems.id.to_s }]
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "creating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @aggregate.class.name,
+        :method_name => "create_aggregate",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => @ems.my_zone,
+        :args        => [@ems.id, {:name => "foo", :ems_id => @ems.id.to_s }]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "host_aggregate_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds create screen" do
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
     end
   end
 
-  describe "#edit" do
+  describe "#update" do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
@@ -69,34 +67,32 @@ describe HostAggregateController do
                                       :ext_management_system => @ems)
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "update_aggregate",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo"}]
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "updating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @aggregate.class.name,
+        :method_name => "update_aggregate",
+        :instance_id => @aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => @ems.my_zone,
+        :args        => [{:name => "foo"}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "host_aggregate_edit", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds edit screen" do
+      post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
     end
   end
 


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1625274

There is a problem with toolbar buttons: they don't work for Hosts' list displayed thru Host Aggregate's details page.


TODO:
- fix failing specs (builds edit and create screen)

---

**Steps to reproduce:**
1. Go to _Compute > Clouds > Host Aggregates_
2. Display some Host Aggregate's details page
3. In _Relationships_ table, click on _Hosts_ (display nested list of hosts)
4. Check the checkboxes of some Host(s)
5. Click on some button under _Configuration/Policy/Power_
=> Nothing happens, buttons don't work, the screen does not change

**Before:** (for example tagging of some host - nothing happens)
![host_tag_before](https://user-images.githubusercontent.com/13417815/45093032-78920600-b117-11e8-8dbe-cd908e269ce3.png)

**After:**(tagging screen displayed and everything works well)
![host_tag_after](https://user-images.githubusercontent.com/13417815/45093033-7a5bc980-b117-11e8-8d35-490625a2031a.png)

**Note:**
I added `include EmsCommon` to host aggregate controller and moved button operations to ems common module as `button` method in the module better handles all the remaining button operations (which were missing in host aggregate controller in `button` method and adding another cases to that method did not solve the problems at all), especially for hosts - which can be displayed thru Host Aggregate's details page. Now all the operations with host aggregates should work, too.
