### PR TITLE
Replaced obsolete method for record fetching with RBAC in ci_processing

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -830,7 +830,10 @@ module ApplicationController::CiProcessing
   def deletestorages
     assert_privileges("storage_delete")
     storages = find_records_with_rbac(Storage, checked_or_params)
-    return unless records_support_feature?(storages, 'delete')
+    unless records_support_feature?(storages, 'delete')
+      add_flash(_("Only storage without VMs and Hosts can be removed"), :error)
+      return
+    end
     storages.each do |storage|
       next if !storage.vms_and_templates.length.positive? &&
               !storage.hosts.length.positive?

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -42,27 +42,6 @@ module Mixins
     end
 
     # !============================================!
-    # PLEASE PREFER find_records_with_rbac OVER THIS
-    # !============================================!
-    #
-    # Test RBAC in case there is only one record
-    # Params:
-    #   klass - class of accessed object
-    #   id    - accessed object id
-    # Returns:
-    #   id of checked item. If user does not have rights for it,
-    #   raises an exception
-    def find_id_with_rbac(klass, id)
-      assert_rbac(klass, Array.wrap(id))
-      id
-    end
-
-    def find_id_with_rbac_no_exception(klass, id)
-      record = Rbac.filtered(klass.where(:id => id))
-      record.present? ? id : nil
-    end
-
-    # !============================================!
     # PLEASE PREFER checked_or_params OVER THIS
     # !============================================!
     #

--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -32,22 +32,6 @@ module Mixins
     # Params:
     #   klass - class of accessed objects
     # Returns:
-    #   array of checked items. If user does not have rigts for it,
-    #   raises exception
-    def find_checked_ids_with_rbac(klass, prefix = nil)
-      items = find_checked_items(prefix)
-      assert_rbac(klass, items)
-      items
-    end
-
-    # !============================================!
-    # PLEASE PREFER find_records_with_rbac OVER THIS
-    # !============================================!
-    #
-    # Test RBAC on every item checked
-    # Params:
-    #   klass - class of accessed objects
-    # Returns:
     #   array of records. If user does not have rigts for it,
     #   raises exception
     def find_checked_records_with_rbac(klass, ids = nil)

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -161,18 +161,9 @@ describe ApplicationController do
         controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
       end
 
-      it "does not invoke process_tasks overall when nothing selected" do
+      it "raises an error when nothing selected" do
         controller.params[:miq_grid_checks] = ''
-        expect(CloudObjectStoreContainer).not_to receive(:process_tasks)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-      end
-
-      it "flash - nothing selected" do
-        controller.params[:miq_grid_checks] = ''
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Delete"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -238,10 +229,7 @@ describe ApplicationController do
       end
 
       it "flash - container no longer exists" do
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Delete"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -321,15 +309,12 @@ describe ApplicationController do
       it "does not invoke process_tasks overall when nothing selected" do
         controller.params[:miq_grid_checks] = ""
         expect(CloudObjectStoreObject).not_to receive(:process_tasks)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - nothing selected" do
         controller.params[:miq_grid_checks] = ""
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Delete"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -368,7 +353,7 @@ describe ApplicationController do
       it "invokes process_objects" do
         controller.params[:id] = object.id.to_s
         expect(controller).to receive(:process_objects).with(
-          [object.id.to_s],
+          [object.id],
           "cloud_object_store_object_delete",
           "Delete"
         )
@@ -388,7 +373,7 @@ describe ApplicationController do
       it "invokes process_tasks overall" do
         controller.params[:id] = object.id.to_s
         expect(CloudObjectStoreObject).to receive(:process_tasks).with(
-          :ids    => [object.id.to_s],
+          :ids    => [object.id],
           :task   => "cloud_object_store_object_delete",
           :userid => anything
         )
@@ -397,10 +382,7 @@ describe ApplicationController do
 
       it "flash - container no longer exists" do
         object.destroy
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Delete"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -510,15 +492,12 @@ describe ApplicationController do
       it "does not invoke process_tasks overall when nothing selected" do
         controller.params[:miq_grid_checks] = ''
         expect(CloudObjectStoreContainer).not_to receive(:process_tasks)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - nothing selected" do
         controller.params[:miq_grid_checks] = ''
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Clear"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -584,10 +563,7 @@ describe ApplicationController do
       end
 
       it "flash - container no longer exists" do
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "No items were selected for Clear"
-        )
+        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
       end
 
       it "flash - task not supported" do
@@ -1071,7 +1047,7 @@ describe OrchestrationStackController do
       expect(controller).to receive(:show_list)
       controller.send('orchestration_stack_delete')
       flash_messages = assigns(:flash_array)
-      expect(flash_messages.first).to eq(:message => "Error during deletion: Unauthorized object or action",
+      expect(flash_messages.first).to eq(:message => "Error during deletion: Can't access selected records",
                                          :level   => :error)
     end
 

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -232,7 +232,6 @@ describe CloudNetworkController do
         controller.instance_variable_set(:@_params,
                                          :pressed => "cloud_network_delete",
                                          :id      => @network.id)
-        allow(controller).to receive(:find_id_with_rbac).and_return([@network])
         controller.instance_variable_set(:@breadcrumbs, [{:url => "cloud_network/show_list"}, 'placeholder'])
         expect(controller).to receive(:render)
         controller.send(:button)

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -232,7 +232,6 @@ describe CloudNetworkController do
         controller.instance_variable_set(:@_params,
                                          :pressed => "cloud_network_delete",
                                          :id      => @network.id)
-        allow(controller).to receive(:find_checked_ids_with_rbac).and_return([@network])
         allow(controller).to receive(:find_id_with_rbac).and_return([@network])
         controller.instance_variable_set(:@breadcrumbs, [{:url => "cloud_network/show_list"}, 'placeholder'])
         expect(controller).to receive(:render)

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -135,10 +135,7 @@ describe CloudObjectStoreContainerController do
         :pressed => "cloud_object_store_container_delete", :format => :js, :id => @container.id
       }
 
-      expect(assigns(:flash_array).first[:message]).to include(
-        "No items were selected for Delete"
-      )
-      expect(response.status).to eq(200)
+      expect(response.body).to match(/throw "error"/)
     end
   end
 

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -117,10 +117,7 @@ describe CloudObjectStoreObjectController do
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }
 
-      expect(assigns(:flash_array).first[:message]).to include(
-        "No items were selected for Delete"
-      )
-      expect(response.status).to eq(200)
+      expect(response.body).to match(/throw "error"/)
     end
   end
 

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -252,7 +252,6 @@ describe NetworkRouterController do
                                          :id      => @router.id)
         controller.instance_variable_set(:@lastaction, "show")
         controller.instance_variable_set(:@layout, "network_router")
-        allow(controller).to receive(:find_checked_ids_with_rbac).and_return([@router])
         allow(controller).to receive(:find_id_with_rbac).and_return([@router])
         controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
         expect(controller).to receive(:render)

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -252,7 +252,6 @@ describe NetworkRouterController do
                                          :id      => @router.id)
         controller.instance_variable_set(:@lastaction, "show")
         controller.instance_variable_set(:@layout, "network_router")
-        allow(controller).to receive(:find_id_with_rbac).and_return([@router])
         controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
         expect(controller).to receive(:render)
         controller.send(:button)


### PR DESCRIPTION
This PR removes the last bits of obsolete methods `find_checked_ids_with_rbac` and `find_id_with_rbac`.

Marking this as _WIP_ until PRs #4598 and #4601 are merged.

Links
----------------

* #1134

Steps for Testing/QA
-------------------------------

Delete a Datastore
