### PR TITLE
bower: remove QS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -67,7 +67,6 @@
 //= require ./resizable_sidebar
 //= require ./miq_c3
 //= require ./miq_explorer
-//= require bower_components/qs/dist/qs.min
 //= require ./miq_timeline
 //= require bower_components/angular-ui-sortable/sortable
 //= require bower_components/angular-dragdrop/src/angular-dragdrop

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1,4 +1,4 @@
-/* global add_flash dialogFieldRefresh getChartColumnDataValues getChartFormatedValue QS miqBrowserDetect miqExpressionPrefill miqFlashLater miqFlashSaved miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqTreeObject miqValueStylePrefill performFiltering recalculateChartYAxisLabels */
+/* global add_flash dialogFieldRefresh getChartColumnDataValues getChartFormatedValue miqBrowserDetect miqExpressionPrefill miqFlashLater miqFlashSaved miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqTreeObject miqValueStylePrefill performFiltering recalculateChartYAxisLabels */
 
 // MIQ specific JS functions
 
@@ -1721,8 +1721,6 @@ function miqScrollToSelected(div_name) {
     $('#' + div_name).scrollTop(rowpos.top);
   }
 }
-
-function queryParam(name) { return QS(window.location.href).get(name); }
 
 function miqFormatNotification(text, bindings) {
   if (! text) {

--- a/bower.json
+++ b/bower.json
@@ -34,8 +34,7 @@
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",
     "patternfly-bootstrap-treeview": "~2.1.5",
-    "patternfly-timeline": "~1.0.5",
-    "qs": "~0.3.10"
+    "patternfly-timeline": "~1.0.5"
   },
   "resolutions": {
     "d3": "~3.5.0",


### PR DESCRIPTION
this was only used by the `queryParam` function
..which is useful, but the last use was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/426

removing, we may want to consider just wrapping the new URL standard,
(the package was https://github.com/nire0510/qs , and is available on npm under the name qs-parser)

Issue #3734