### PR TITLE
Alerts - fix bug when severity null

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -667,7 +667,7 @@ function alertsCenterService(API, $q, $timeout, $document, $uibModal, $http) {
           _this.displayFilters.push(summaryItem.displayType);
         }
 
-        if (item.severity === undefined) {
+        if (! item.severity) {
           item.severity = 'info';
         }
         summaryItem[item.severity].push(item);


### PR DESCRIPTION
Monitor > Alerts > Overview

the code going through all the alerts can handle severity being undefined
but that never happens, since it comes from the server as null :)

this leads to an ugly error in the console when opnening Monitor > Alerts > Overview (and nothing showing up)

fixed - any falsy value is wrong and will be rewritten to `info` now
