### PR TITLE
Use the machine_state method to determine powerstate icon/color

### DIFF
--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -1,7 +1,7 @@
 module TextualMixins::TextualPowerState
   def textual_power_state_whitelisted(state)
     state = state.blank? ? 'unknown' : state.downcase
-    quad_icon = QuadiconHelper::MACHINE_STATE_QUADRANT[state]
+    quad_icon = QuadiconHelper.machine_state(state)
 
     {
       :label      => _('Power State'),


### PR DESCRIPTION
We :heart: consistency with other places, I don't know why I used the constant. So replacing it with the `QuadiconHelper.machine_state` in textual power state.

@miq-bot add_label technical debt, gaprindashvili/no
@miq-bot add_reviewer @epwinchell 