### PR TITLE
Fixed Schedules accordion swapping logic.

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -183,8 +183,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   ManageIQ.explorer.miqButtons(data);
 
   if (_.isString(data.clearTreeCookies)) { miqDeleteTreeCookies(data.clearTreeCookies); }
-
-  if (_.isString(data.accordionSwap) && ! data.activateNode.activeTree.includes(data.accordionSwap)) {
+  if (_.isString(data.accordionSwap)) {
     miqAccordionSwap('#accordion .panel-collapse.collapse.in', '#' + data.accordionSwap + '_accord');
   }
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -847,6 +847,7 @@ class ReportController < ApplicationController
       end
       presenter.show(:paging_div)
     else
+      presenter.hide(:form_buttons_div)
       presenter.hide(:paging_div)
     end
     if (@sb[:active_tab] == 'report_info' && x_node.split('-').length == 5 && !@in_a_form) || %w(xx-exportwidgets xx-exportcustomreports).include?(x_node)

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -223,11 +223,10 @@ module ReportController::Schedules
         # ensure we land in the right accordion with the right tree and
         # with the listing opened even when entering 'add' from the reports
         # menu
-
+        @_params[:accord] = "schedules" unless x_active_accord == :schedules
         self.x_active_tree   = "schedules_tree"
         self.x_active_accord = "schedules"
         self.x_node = "msc-#{schedule.id}"
-        @_params[:accord] = "schedules"
         replace_right_cell(:replace_trees => [:schedules])
       else
         schedule.errors.each do |field, msg|

--- a/spec/controllers/report_controller/schedules_spec.rb
+++ b/spec/controllers/report_controller/schedules_spec.rb
@@ -3,6 +3,7 @@ describe ReportController do
     let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
 
     let(:schedule) { FactoryGirl.create(:miq_schedule, :name => "tester1") }
+    let(:report) { FactoryGirl.create(:miq_report, :name => "report1") }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -14,6 +15,15 @@ describe ReportController do
       allow(controller).to receive(:assert_privileges)
       allow(controller).to receive(:checked_or_params).and_return(MiqSchedule.all.ids)
       allow(controller).to receive(:replace_right_cell).and_return(true)
+
+      timer = ReportHelper::Timer.new('hourly', 1, 1, 1, 1, Time.now.utc, '00', '00')
+      edit = {:key      => "schedule_edit__#{schedule.id}",
+              :sched_id => schedule.id,
+              :new      => {:name => "foo", :description => "Foo", :repfilter => report.id, :timer => timer}}
+      controller.instance_variable_set(:@edit, edit)
+      controller.instance_variable_set(:@sb, {})
+      session[:edit] = edit
+      allow(controller).to receive(:drop_breadcrumb)
     end
 
     it "reset rbac testing" do
@@ -21,6 +31,27 @@ describe ReportController do
       controller.instance_variable_set(:@_params, :button => "reset")
       expected_id = controller.instance_variable_get(:@schedule).id
       expect(expected_id).to eq(schedule.id)
+    end
+
+    it "sets params accord only when schedule is added from Reports accordion" do
+      allow(controller).to receive(:x_active_accord).and_return(:reports)
+      post :schedule_edit, :params => { :button => "add", :id => schedule.id }
+      params = ActionController::Parameters.new('button'     => 'add',
+                                                'id'         => schedule.id.to_s,
+                                                'controller' => 'report',
+                                                'action'     => 'schedule_edit',
+                                                'accord'     => 'schedules')
+      expect(controller.params).to eq(params)
+    end
+
+    it "does not set params accord when adding/editing schedule from Schedules accordion" do
+      allow(controller).to receive(:x_active_accord).and_return(:schedules)
+      post :schedule_edit, :params => { :button => "add", :id => schedule.id }
+      params = ActionController::Parameters.new('button'     => 'add',
+                                                'id'         => schedule.id.to_s,
+                                                'controller' => 'report',
+                                                'action'     => 'schedule_edit')
+      expect(controller.params).to eq(params)
     end
   end
 end


### PR DESCRIPTION
Only need to set params[:accord] when add button is pressed from Reports accordion, setting of acord parameter causes acoridon to be swapped to Schedule accordion by Explorer presenter code. Undid code changes made in https://github.com/ManageIQ/manageiq-ui-classic/pull/3399 this was causing issues when adding a schedule from Reports accordion.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1624248

@hstastna please test/review.

before:
![before](https://user-images.githubusercontent.com/3450808/45168136-98353700-b1c8-11e8-86cc-b71dc602cdc3.png)

after:
![after](https://user-images.githubusercontent.com/3450808/45168637-c404ec80-b1c9-11e8-87ba-210fc5d3af0e.png)

