### PR TITLE
Allow restoring backups to new volumes

### DIFF
--- a/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
+++ b/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
@@ -17,6 +17,7 @@ function cloudVolumeBackupFormController(miqService, $http) {
 
     vm.cloudVolumeBackupModel = {
       volume: '',
+      name: '',
     };
 
     vm.model = 'cloudVolumeBackupModel';

--- a/app/controllers/cloud_volume_backup_controller.rb
+++ b/app/controllers/cloud_volume_backup_controller.rb
@@ -41,7 +41,10 @@ class CloudVolumeBackupController < ApplicationController
       cancel_action(_("Restore to Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @backup.name})
 
     when "restore"
-      task_id = @backup.restore_queue(session[:userid], params[:volume][:ems_ref])
+      # volume_id to restore to is optional
+      volume_id = params[:volume].try(:fetch, :ems_ref, nil)
+      new_volume_name = params[:name]
+      task_id = @backup.restore_queue(session[:userid], volume_id, new_volume_name)
 
       if task_id.kind_of?(Integer)
         initiate_wait_for_task(:task_id => task_id, :action => "backup_restore_finished")

--- a/app/views/static/cloud_volume_backup/volume_select.html.haml
+++ b/app/views/static/cloud_volume_backup/volume_select.html.haml
@@ -11,11 +11,19 @@
       %label.col-md-2.control-label
         = _('Volume')
       .col-md-8
-        = select_tag('volume_id',
-                '',
-                'ng-model'   => 'vm.cloudVolumeBackupModel.volume',
-                'ng-options' => 'volume.name for volume in vm.volume_choices track by volume.id',
-                :required    => '',
-                'miq-select' => true)
+        %select{"name"        => "volume_id",
+                "ng-model"    => "vm.cloudVolumeBackupModel.volume",
+                "ng-options"  => "volume.name for volume in vm.volume_choices track by volume.id",
+                "miq-select"   => true}
+          %option{"value" => ""}
+            = "<#{_('New Volume')}>"
+    .form-group{"ng-if"    => "vm.cloudVolumeBackupModel.volume == null"}
+      %label.col-md-2.control-label
+        = _('New Volume Name')
+      .col-md-8
+        %input.form-control{:type          => "text",
+                            :name          => "name",
+                            'ng-model'     => "vm.cloudVolumeBackupModel.name",
+                            'ng-maxlength' => 128}
 
   = render :partial => 'layouts/angular/generic_form_buttons'

--- a/spec/javascripts/components/cloud_volume_backup/cloud_volume_backup_form_spec.js
+++ b/spec/javascripts/components/cloud_volume_backup/cloud_volume_backup_form_spec.js
@@ -24,6 +24,7 @@ describe('cloud-volume-backup-form', function() {
   describe('#init', function() {
     var expectedValue = {
       volume: { name: "original value" },
+      name: ''
     };
 
     it('sets model correctly', function() {


### PR DESCRIPTION
Allows choosing to restore a volume backup to a newly created volume, and adds a field for optionally naming that volume.

Partially implements https://bugzilla.redhat.com/show_bug.cgi?id=1514970
Depends on core and openstack provider PRs, as well as a new fog-openstack release.

![restore_volume](https://user-images.githubusercontent.com/628956/45179068-6d0d1080-b1e5-11e8-9f5c-e242a927fb5a.png)
