### PR TITLE
Use fonticon + background for data collection in textual summaries

### DIFF
--- a/app/helpers/textual_mixins/textual_data_collection_state.rb
+++ b/app/helpers/textual_mixins/textual_data_collection_state.rb
@@ -1,12 +1,12 @@
 module TextualMixins::TextualDataCollectionState
   def textual_data_collection_state
     state = @record.enabled?
-    h = {:label => _("Data Collection"), :value => state ? _("Running") : _("Paused")}
-    h[:image] = if state
-                  "svg/currentstate-on.svg"
-                else
-                  "svg/currentstate-paused.svg"
-                end
-    h
+    quad_icon = QuadiconHelper.machine_state(state ? 'on' : 'paused')
+    quad_icon[:icon] = quad_icon.delete(:fonticon)
+
+    {
+      :label => _("Data Collection"),
+      :value => state ? _("Running") : _("Paused")
+    }.merge(quad_icon)
   end
 end


### PR DESCRIPTION
Leverage the `QuadiconHelper.machine_state` similarly to the textual power states. It is currently available on container provider summary screens only.

![screenshot from 2018-09-07 11-23-48](https://user-images.githubusercontent.com/649130/45210676-84550800-b290-11e8-8dbb-010bd1861844.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label technical debt, gaprindashvili/no