### PR TITLE
Do not include UiServiceMixin in services where it is not being used

### DIFF
--- a/app/services/container_project_dashboard_service.rb
+++ b/app/services/container_project_dashboard_service.rb
@@ -1,5 +1,4 @@
 class ContainerProjectDashboardService < DashboardService
-  include UiServiceMixin
   include ContainerServiceMixin
   include Mixins::CheckedIdMixin
 

--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -1,5 +1,4 @@
 class EmsDashboardService < DashboardService
-  include UiServiceMixin
   include Mixins::CheckedIdMixin
 
   def initialize(ems_id, controller, klass)

--- a/app/services/ems_physical_infra_dashboard_service.rb
+++ b/app/services/ems_physical_infra_dashboard_service.rb
@@ -1,5 +1,4 @@
 class EmsPhysicalInfraDashboardService < DashboardService
-  include UiServiceMixin
   include Mixins::CheckedIdMixin
 
   def initialize(ems_id, controller)

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -1,6 +1,4 @@
 class HawkularProxyService
-  include UiServiceMixin
-
   TENANT_LABEL_MAX_LEN = 25
   TENANT_LABEL_SPECIAL_CASES = {
     "_system"                      => _("System"),


### PR DESCRIPTION
I am guessing this mixin got copy-pasted from the first container dashboard but it seems that it is not being used in most of the cases. All related dashboards seem working with this change, but I'd ask for a review from some people who did review on this.

@miq-bot add_reviewer @felipedf 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label technical debt, gaprindashvili/no