### PR TITLE
Fix jquery-ui includes

### DIFF
--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -4,6 +4,9 @@
 
 window.$ = window.jQuery = require('jquery');
 require('jquery-ui');
+require('jquery-ui/ui/widgets/draggable');
+require('jquery-ui/ui/widgets/droppable');
+require('jquery-ui/ui/widgets/sortable');
 require('jquery-ujs');
 require('jquery.observe_field');
 

--- a/app/views/vm_common/console_webmks.html.haml
+++ b/app/views/vm_common/console_webmks.html.haml
@@ -5,7 +5,13 @@
       = _('%{product_name} WebMKS Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
     = favicon_link_tag
     = stylesheet_link_tag '/webmks/css/wmks-all.css', 'application'
-    = javascript_include_tag 'jquery/dist/jquery.js', 'bower_components/jquery-ui/jquery-ui.js', '/webmks/wmks.min.js', 'remote_console'
+    = javascript_include_tag 'jquery/dist/jquery.js',
+                             'jquery-ui/ui/unique-id.js',
+                             'jquery-ui/ui/widget.js',
+                             'jquery-ui/ui/widgets/dialog.js',
+                             'jquery-ui/ui/widgets/button.js',
+                             '/webmks/wmks.min.js',
+                             'remote_console'
     :javascript
       $(function () {
         var mksOpts = {};

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,7 +9,8 @@ Rails.application.config.assets.precompile += %w(
   bower_components/codemirror/modes/*.js
   bower_components/codemirror/themes/*.css
   jquery/dist/jquery.js
-  bower_components/jquery-ui/jquery-ui.js
+  jquery-ui/ui/*.js
+  jquery-ui/ui/widgets/*.js
 
   jquery_overrides.js
   remote_consoles/*.js


### PR DESCRIPTION
Moving jquery-ui to npm (#4617) caused us to only include the core, with no widgets.

From what I can tell, we only need 3 widgets:

* draggable & droppable - used by ui-components, dialog-editor
* sortable - used for configuring dashboard layout

including just the 3.

Also removing the `jquery-ui` require in webmks console, introduced in #410 - doesn't seem to have been needed, @skateman do you know if we still need jquery-ui there? (the view doesn't use it)

(Related to #3734)