### PR TITLE
bower to npm - bootstrap-filestyle

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,6 @@
 //= require bower_components/bootstrap/dist/js/bootstrap
 //= require bower_components/bootstrap-datepicker/dist/js/bootstrap-datepicker
 //= require bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min
-//= require bower_components/bootstrap-filestyle/src/bootstrap-filestyle
 //= require bower_components/bootstrap-select/js/bootstrap-select
 //= require bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown
 //= require bootstrap-switch/dist/js/bootstrap-switch

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -6,6 +6,7 @@ window.$ = window.jQuery = require('jquery');
 require('jquery-ui');
 require('jquery-ujs');
 require('jquery.observe_field');
+require('bootstrap-filestyle');
 
 window.angular = require('angular');
 require('angular-gettext');

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
     "angular-dragdrop": "~1.0.13",
     "angular-patternfly": "~3.26.0",
     "angular-ui-sortable": "~0.16.1",
-    "bootstrap-filestyle": "~1.2.1",
     "bootstrap-hover-dropdown": "~2.2.1",
     "manageiq-ui-components": "bower-dev",
     "patternfly-bootstrap-treeview": "~2.1.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "angular.validators": "~4.4.2",
     "array-includes": "~3.0.3",
     "base64-js": "~1.2.3",
+    "bootstrap-filestyle": "~1.2.1",
     "bootstrap-switch": "~3.3.4",
     "codemirror": "~5.19.0",
     "connected-react-router": "^4.3.0",


### PR DESCRIPTION
Issue #3734 

Nothing special, moving `bootstrap-filestyle` to npm, `$.fn.filestyle` still works, the version is the same.