### PR TITLE
Additional fixes for rubocop warnings

### DIFF
--- a/app/controllers/alert_controller.rb
+++ b/app/controllers/alert_controller.rb
@@ -5,7 +5,7 @@ class AlertController < ApplicationController
   after_action :set_session_data
 
   def index
-    redirect_to :action => 'show_list'
+    redirect_to(:action => 'show_list')
   end
 
   def show_list

--- a/app/controllers/alerts_list_controller.rb
+++ b/app/controllers/alerts_list_controller.rb
@@ -13,7 +13,7 @@ class AlertsListController < ApplicationController
   end
 
   def index
-    redirect_to :action => 'show'
+    redirect_to(:action => 'show')
   end
 
   def class_icons

--- a/app/controllers/alerts_most_recent_controller.rb
+++ b/app/controllers/alerts_most_recent_controller.rb
@@ -13,7 +13,7 @@ class AlertsMostRecentController < ApplicationController
   end
 
   def index
-    redirect_to :action => 'show'
+    redirect_to(:action => 'show')
   end
 
   private

--- a/app/controllers/alerts_overview_controller.rb
+++ b/app/controllers/alerts_overview_controller.rb
@@ -13,7 +13,7 @@ class AlertsOverviewController < ApplicationController
   end
 
   def index
-    redirect_to :action => 'show'
+    redirect_to(:action => 'show')
   end
 
   private

--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -27,9 +27,9 @@ class AnsibleCredentialController < ApplicationController
   def button
     case params[:pressed]
     when 'embedded_automation_manager_credentials_add'
-      javascript_redirect :action => 'new'
+      javascript_redirect(:action => 'new')
     when 'embedded_automation_manager_credentials_edit'
-      javascript_redirect :action => 'edit', :id => params[:miq_grid_checks]
+      javascript_redirect(:action => 'edit', :id => params[:miq_grid_checks])
     when 'embedded_automation_manager_credentials_delete'
       delete_credentials
     when 'ansible_credential_tag'
@@ -79,6 +79,6 @@ class AnsibleCredentialController < ApplicationController
       end
     end
     session[:flash_msgs] = @flash_array
-    javascript_redirect :action => 'show_list'
+    javascript_redirect(:action => 'show_list')
   end
 end

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -32,9 +32,9 @@ class AnsibleRepositoryController < ApplicationController
     case params[:pressed]
     when "embedded_configuration_script_source_edit"
       id = params[:miq_grid_checks]
-      javascript_redirect :action => 'edit', :id => id
+      javascript_redirect(:action => 'edit', :id => id)
     when "embedded_configuration_script_source_add"
-      javascript_redirect :action => 'new'
+      javascript_redirect(:action => 'new')
     when "embedded_configuration_script_source_delete"
       delete_repositories
     when "ansible_repositories_reload"
@@ -80,7 +80,7 @@ class AnsibleRepositoryController < ApplicationController
       end
     end
     session[:flash_msgs] = @flash_array
-    javascript_redirect :action => 'show_list'
+    javascript_redirect(:action => 'show_list')
   end
 
   def edit

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -35,7 +35,7 @@ class AuthKeyPairCloudController < ApplicationController
       delete_auth_key_pairs
       false
     when 'auth_key_pair_cloud_new'
-      javascript_redirect :action => 'new'
+      javascript_redirect(:action => 'new')
       true
     end
   end
@@ -98,8 +98,8 @@ class AuthKeyPairCloudController < ApplicationController
 
     case params[:button]
     when "cancel"
-      javascript_redirect :action    => 'show_list',
-                          :flash_msg => _("Add of new Key Pair was cancelled by the user")
+      javascript_redirect(:action    => 'show_list',
+                          :flash_msg => _("Add of new Key Pair was cancelled by the user"))
     when "save"
       ext_management_system = find_record_with_rbac(ManageIQ::Providers::CloudManager, options[:ems_id])
       kls = kls.class_by_ems(ext_management_system)
@@ -152,7 +152,7 @@ class AuthKeyPairCloudController < ApplicationController
     @breadcrumbs.pop if @breadcrumbs
     session[:edit] = nil
     flash_to_session
-    javascript_redirect :action => "show_list"
+    javascript_redirect(:action => "show_list")
   end
 
   # delete selected auth key pairs

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -158,12 +158,7 @@ class AuthKeyPairCloudController < ApplicationController
   # delete selected auth key pairs
   def delete_auth_key_pairs
     assert_privileges("auth_key_pair_cloud_delete")
-    key_pairs = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "auth_key_pair_cloud")
-                  find_checked_records_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair)
-                else
-                  [find_record_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair, params[:id])]
-                end
-
+    key_pairs = find_records_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair, checked_or_params)
     add_flash(_("No Key Pairs were selected for deletion"), :error) if key_pairs.empty?
 
     key_pairs_to_delete = []

--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -149,7 +149,7 @@ class AuthKeyPairCloudController < ApplicationController
       }, :error)
     end
 
-    @breadcrumbs.pop if @breadcrumbs
+    @breadcrumbs&.pop
     session[:edit] = nil
     flash_to_session
     javascript_redirect(:action => "show_list")
@@ -158,13 +158,11 @@ class AuthKeyPairCloudController < ApplicationController
   # delete selected auth key pairs
   def delete_auth_key_pairs
     assert_privileges("auth_key_pair_cloud_delete")
-    key_pairs = []
-
-    if @lastaction == "show_list" || (@lastaction == "show" && @layout != "auth_key_pair_cloud")
-      key_pairs = find_checked_records_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair)
-    else
-      key_pairs = [find_record_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair, params[:id])]
-    end
+    key_pairs = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "auth_key_pair_cloud")
+                  find_checked_records_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair)
+                else
+                  [find_record_with_rbac(ManageIQ::Providers::CloudManager::AuthKeyPair, params[:id])]
+                end
 
     add_flash(_("No Key Pairs were selected for deletion"), :error) if key_pairs.empty?
 


### PR DESCRIPTION
This PR contains some additional rubocop fixes that I skipped before (in previously merged PRs), mainly addition of parentheses for method calls with arguments.