### PR TITLE
Fixed a typo in parameter name

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -358,8 +358,8 @@ module ApplicationController::Filter
       end
 
       # Check for suffixes changed
-      self.val1_suffix = MiqExpression::BYTE_FORMAT_WHITELIST[params[:choosen_suffix]] if params[:choosen_suffix]
-      self.val2_suffix = MiqExpression::BYTE_FORMAT_WHITELIST[params[:choosen_suffix2]] if params[:choosen_suffix2]
+      self.val1_suffix = MiqExpression::BYTE_FORMAT_WHITELIST[params[:chosen_suffix]] if params[:chosen_suffix]
+      self.val2_suffix = MiqExpression::BYTE_FORMAT_WHITELIST[params[:chosen_suffix2]] if params[:chosen_suffix2]
     end
 
     def update_from_exp_tree(exp)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1627284

before:
![screenshot from 2018-09-10 12-41-08](https://user-images.githubusercontent.com/3450808/45311492-41489e00-b4f7-11e8-809e-954772d1b704.png)

![screenshot from 2018-09-10 12-41-21](https://user-images.githubusercontent.com/3450808/45311498-44438e80-b4f7-11e8-89e7-06ad675c2947.png)


after:
![screenshot from 2018-09-10 12-36-41](https://user-images.githubusercontent.com/3450808/45311481-37bf3600-b4f7-11e8-8861-fe31285df422.png)

![screenshot from 2018-09-10 12-36-55](https://user-images.githubusercontent.com/3450808/45311486-3aba2680-b4f7-11e8-9de3-a2663c000c57.png)
