### PR TITLE
Fix ems_cloud description textual summary

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -40,7 +40,7 @@ module EmsCloudHelper::TextualSummary
   # Items
   #
   def textual_description
-    return nil if @record.description.blank?
+    return nil if @record.try(:description).blank?
     {:label => _("Description"), :value => @record.description}
   end
 

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -52,4 +52,21 @@ describe EmsCloudHelper::TextualSummary do
 
     include_examples "textual_group_smart_management", %i(zone)
   end
+
+  describe '#textual_description' do
+    let(:ems) { FactoryGirl.create(:ems_cloud) }
+
+    before do
+      instance_variable_set(:@record, ems)
+    end
+
+    context "EMS instance doesn't support :description" do
+      include_examples 'textual_description', nil
+    end
+
+    context "EMS instance has :description" do
+      before { allow(ems).to receive(:description).and_return('EmsCloud instance description') }
+      include_examples 'textual_description', :label => _("Description"), :value => 'EmsCloud instance description'
+    end
+  end
 end

--- a/spec/shared/helpers/textual_summary_helper_methods.rb
+++ b/spec/shared/helpers/textual_summary_helper_methods.rb
@@ -30,3 +30,11 @@ shared_examples_for 'textual_group' do |title, items, suffix = nil|
     end
   end
 end
+
+shared_examples_for 'textual_description' do |value|
+  describe "#textual_description" do
+    subject { send("textual_description") }
+
+    it { is_expected.to eq(value) }
+  end
+end


### PR DESCRIPTION
Since `:description` is not a required method for `ExtManagementSystem` instance, this may break summary screen for some providers (resulting into 500). For example Google. Adding a fallback to class method.

Regression brought by: https://github.com/ManageIQ/manageiq-ui-classic/pull/4532
Possibly reopening: https://bugzilla.redhat.com/show_bug.cgi?id=1563600 ?

cc @himdel, @bronaghs, @ZitaNemeckova 
@miq-bot add_label bug, gaprindashvili/yes, compute/cloud