### PR TITLE
bower to npm: angular-dragdrop & angular-ui-sortable

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -55,7 +55,6 @@
 //= require ./miq_explorer
 //= require ./miq_timeline
 //= require bower_components/angular-ui-sortable/sortable
-//= require bower_components/angular-dragdrop/src/angular-dragdrop
 //= require bower_components/manageiq-ui-components/dist/js/ui-components
 //= require bower_components/patternfly-timeline/dist/timeline
 //= require ui-select/dist/select

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -54,7 +54,6 @@
 //= require ./miq_c3
 //= require ./miq_explorer
 //= require ./miq_timeline
-//= require bower_components/angular-ui-sortable/sortable
 //= require bower_components/manageiq-ui-components/dist/js/ui-components
 //= require bower_components/patternfly-timeline/dist/timeline
 //= require ui-select/dist/select

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -17,6 +17,7 @@ require('angular-sanitize');
 require('angular.validators/angular.validators');
 require('ng-annotate-loader!angular-ui-codemirror');
 require('angular-dragdrop');  // ngDragDrop, used by ui-components
+require('angular-ui-sortable'); // ui.sortable, used by ui-components
 
 window._ = require('lodash');
 window.numeral = require('numeral');

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -16,6 +16,7 @@ require('angular-gettext');
 require('angular-sanitize');
 require('angular.validators/angular.validators');
 require('ng-annotate-loader!angular-ui-codemirror');
+require('angular-dragdrop');  // ngDragDrop, used by ui-components
 
 window._ = require('lodash');
 window.numeral = require('numeral');

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "angular-patternfly": "~3.26.0",
-    "angular-ui-sortable": "~0.16.1",
     "manageiq-ui-components": "bower-dev",
     "patternfly-bootstrap-treeview": "~2.1.5",
     "patternfly-timeline": "~1.0.5"

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular-dragdrop": "~1.0.13",
     "angular-patternfly": "~3.26.0",
     "angular-ui-sortable": "~0.16.1",
     "manageiq-ui-components": "bower-dev",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",
+    "angular-dragdrop": "~1.0.13",
     "angular-gettext": "^2.4.1",
     "angular-sanitize": "~1.6.6",
     "angular-ui-codemirror": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular-gettext": "^2.4.1",
     "angular-sanitize": "~1.6.6",
     "angular-ui-codemirror": "~0.3.0",
+    "angular-ui-sortable": "~0.16.1",
     "angular.validators": "~4.4.2",
     "array-includes": "~3.0.3",
     "base64-js": "~1.2.3",


### PR DESCRIPTION
2 angular libraries not directly used by ui-classic but depended on by ui-components.
Both in same version.

testing
```
angular.element('.ng-scope').injector().get('ngDragDropService')
angular.element('.ng-scope').injector().get('uiSortableConfig')
```

Issue #3734 