### PR TITLE
Remove deprecated VMDB::Config class

### DIFF
--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -88,7 +88,7 @@ module OpsController::Settings
       idx = i if f[:ldaphost] == params[:ldaphost_id]
     end
     @edit[:new][:authentication][:user_proxies].delete_at(idx) unless idx.nil?
-    @changed = (@edit[:new] != @edit[:current].config)
+    @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -124,7 +124,7 @@ module OpsController::Settings
         end
       end
     end
-    @changed = (@edit[:new] != @edit[:current].config)
+    @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
       page << javascript_for_miq_button_visibility(@changed)

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -22,7 +22,7 @@ module OpsController::Settings::Common
     case @sb[:active_tab] # Server, DB edit forms
     when 'settings_server', 'settings_authentication',
          'settings_custom_logos'
-      @changed = (@edit[:new] != @edit[:current].config)
+      @changed = (@edit[:new] != @edit[:current])
       if params[:console_type]
         @refresh_div     = 'settings_server'              # Replace main area
         @refresh_partial = 'settings_server_tab'
@@ -36,8 +36,8 @@ module OpsController::Settings::Common
       end
       @changed = false unless rhn_save_enabled?
     when 'settings_workers'
-      @changed = (@edit[:new].config != @edit[:current].config)
-      if @edit[:new].config[:workers][:worker_base][:ui_worker][:count] != @edit[:current].config[:workers][:worker_base][:ui_worker][:count]
+      @changed = (@edit[:new] != @edit[:current])
+      if @edit[:new][:workers][:worker_base][:ui_worker][:count] != @edit[:current][:workers][:worker_base][:ui_worker][:count]
         add_flash(_("Changing the UI Workers Count will immediately restart the webserver"), :warning)
       end
     when 'settings_advanced'                                # Advanced yaml edit
@@ -147,7 +147,7 @@ module OpsController::Settings::Common
           end
         end
       when 'settings_workers'
-        if @edit[:new].config[:workers][:worker_base][:ui_worker][:count] != @edit[:current].config[:workers][:worker_base][:ui_worker][:count]
+        if @edit[:new][:workers][:worker_base][:ui_worker][:count] != @edit[:current][:workers][:worker_base][:ui_worker][:count]
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
@@ -318,11 +318,11 @@ module OpsController::Settings::Common
     settings_get_form_vars
     return unless @edit
     server_config = MiqServer.find(@sb[:selected_server_id]).settings
-    server_config.config.each_key do |category|
-      server_config.config[category] = @edit[:new][category].dup
+    server_config.each_key do |category|
+      server_config[category] = @edit[:new][category].dup
     end
 
-    valid, errors = MiqLdap.validate_connection(server_config.config)
+    valid, errors = MiqLdap.validate_connection(server_config)
     if valid
       add_flash(_("LDAP Settings validation was successful"))
     else
@@ -338,11 +338,11 @@ module OpsController::Settings::Common
     settings_get_form_vars
     return unless @edit
     server_config = MiqServer.find(@sb[:selected_server_id]).settings
-    server_config.config.each_key do |category|
-      server_config.config[category] = @edit[:new][category].dup
+    server_config.each_key do |category|
+      server_config[category] = @edit[:new][category].dup
     end
 
-    valid, errors = Authenticator::Amazon.validate_connection(server_config.config)
+    valid, errors = Authenticator::Amazon.validate_connection(server_config)
     if valid
       add_flash(_("Amazon Settings validation was successful"))
     else
@@ -389,7 +389,7 @@ module OpsController::Settings::Common
         return
       end
       @edit[:new][:authentication][:ldaphost].reject!(&:blank?) if @edit[:new][:authentication][:ldaphost]
-      @changed = (@edit[:new] != @edit[:current].config)
+      @changed = (@edit[:new] != @edit[:current])
       server = MiqServer.find(@sb[:selected_server_id])
       zone = Zone.find_by_name(@edit[:new][:server][:zone])
       unless zone.nil? || server.zone == zone
@@ -398,8 +398,8 @@ module OpsController::Settings::Common
       end
       @update = server.settings
     when "settings_workers"                                   # Workers Settings
-      @changed = (@edit[:new] != @edit[:current].config)
-      qwb = @edit[:new].config[:workers][:worker_base][:queue_worker_base]
+      @changed = (@edit[:new] != @edit[:current])
+      qwb = @edit[:new][:workers][:worker_base][:queue_worker_base]
       w = qwb[:generic_worker]
       @edit[:new].set_worker_setting!(:MiqGenericWorker, :count, w[:count].to_i)
       @edit[:new].set_worker_setting!(:MiqGenericWorker, :memory_threshold, w[:memory_threshold])
@@ -419,7 +419,7 @@ module OpsController::Settings::Common
       w = qwb[:ems_refresh_worker][:defaults]
       @edit[:new].set_worker_setting!(:MiqEmsRefreshWorker, %i(defaults memory_threshold), w[:memory_threshold])
 
-      wb = @edit[:new].config[:workers][:worker_base]
+      wb = @edit[:new][:workers][:worker_base]
       w = wb[:event_catcher]
       @edit[:new].set_worker_setting!(:MiqEventCatcher, :memory_threshold, w[:memory_threshold])
 
@@ -446,7 +446,7 @@ module OpsController::Settings::Common
 
       @update = MiqServer.find(@sb[:selected_server_id]).settings
     when "settings_custom_logos"                                      # Custom Logo tab
-      @changed = (@edit[:new] != @edit[:current].config)
+      @changed = (@edit[:new] != @edit[:current])
       @update = ::Settings.to_hash
     when "settings_advanced" # Advanced manual yaml editor tab
       nodes = x_node.downcase.split("-")
@@ -462,8 +462,8 @@ module OpsController::Settings::Common
     end
     if !%w(settings_advanced settings_rhn_edit settings_workers).include?(@sb[:active_tab]) &&
        x_node.split("-").first != "z"
-      @update.config.each_key do |category|
-        @update.config[category] = @edit[:new][category].dup
+      @update.each_key do |category|
+        @update[category] = @edit[:new][category].dup
       end
 
       save_ntp_server_settings
@@ -476,7 +476,7 @@ module OpsController::Settings::Common
         else
           @update.save                                              # Save other settings for current server
         end
-        AuditEvent.success(build_config_audit(@edit[:new], @edit[:current].config))
+        AuditEvent.success(build_config_audit(@edit[:new], @edit[:current]))
         if @sb[:active_tab] == "settings_server"
           add_flash(_("Configuration settings saved for %{product} Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\"") %
                       {:name => server.name, :server_id => server.id, :zone => server.my_zone, :product => Vmdb::Appliance.PRODUCT_NAME})
@@ -487,8 +487,8 @@ module OpsController::Settings::Common
           add_flash(_("Configuration settings saved"))
         end
         if @sb[:active_tab] == "settings_server" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
-          session[:customer_name] = @update.config[:server][:company]
-          session[:vmdb_name] = @update.config[:server][:name]
+          session[:customer_name] = @update[:server][:company]
+          session[:vmdb_name] = @update[:server][:name]
         end
         set_user_time_zone if @sb[:active_tab] == "settings_server"
         # settings_set_form_vars
@@ -519,20 +519,20 @@ module OpsController::Settings::Common
         javascript_flash
         return
       end
-      @update.config.each_key do |category|
-        @update.config[category] = @edit[:new].config[category].dup
+      @update.each_key do |category|
+        @update[category] = @edit[:new][category].dup
       end
       if @update.validate                                           # Have VMDB class validate the settings
         server = MiqServer.find(@sb[:selected_server_id])
         server.set_config(@update)
 
-        AuditEvent.success(build_config_audit(@edit[:new].config, @edit[:current].config))
+        AuditEvent.success(build_config_audit(@edit[:new], @edit[:current]))
         add_flash(_("Configuration settings saved for %{product} Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\"") %
                     {:name => server.name, :server_id => @sb[:selected_server_id], :zone => server.my_zone, :product => Vmdb::Appliance.PRODUCT_NAME})
 
         if @sb[:active_tab] == "settings_workers" && @sb[:selected_server_id] == MiqServer.my_server.id  # Reset session variables for names fields, if editing current server config
-          session[:customer_name] = @update.config[:server][:company]
-          session[:vmdb_name] = @update.config[:server][:name]
+          session[:customer_name] = @update[:server][:company]
+          session[:vmdb_name] = @update[:server][:name]
         end
         @changed = false
         get_node_info(x_node)
@@ -562,9 +562,9 @@ module OpsController::Settings::Common
 
   private def save_ntp_server_settings
     if (new_servers = new_ntp_servers).present?
-      @update.config[:ntp] = {:server => new_servers}
+      @update[:ntp] = {:server => new_servers}
     else
-      @update.config.delete(:ntp)
+      @update.delete(:ntp)
       MiqServer.find(@sb[:selected_server_id]).remove_settings_path_for_resource(:ntp)
     end
   end
@@ -693,7 +693,7 @@ module OpsController::Settings::Common
     # WTF? here we can have a Zone or a MiqServer, what about Region? --> rescue from exception
     @selected_server = (cls.find(nodes.last) rescue nil)
 
-    case @sb[:active_tab]                                               # No @edit[:current].config for Filters since there is no config file
+    case @sb[:active_tab] # No @edit[:current] for Filters since there is no config file
     when 'settings_rhn_edit'
       [:proxy_address, :use_proxy, :proxy_userid, :proxy_password, :proxy_verify, :register_to, :server_url, :repo_name,
        :customer_org, :customer_org_display, :customer_userid, :customer_password, :customer_verify].each do |key|
@@ -779,11 +779,11 @@ module OpsController::Settings::Common
       if params[:authentication_mode] && params[:authentication_mode] != auth[:mode]
         if params[:authentication_mode] == "ldap"
           params[:authentication_ldapport] = "389"
-          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:ldap_role]
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current][:authentication][:ldap_role]
           @authldapport_reset = true
         elsif params[:authentication_mode] == "ldaps"
           params[:authentication_ldapport] = "636"
-          @sb[:newrole] = auth[:ldap_role] = @edit[:current].config[:authentication][:ldap_role]
+          @sb[:newrole] = auth[:ldap_role] = @edit[:current][:authentication][:ldap_role]
           @authldapport_reset = true
         else
           @sb[:newrole] = auth[:ldap_role] = false    # setting it to false if database was selected to hide user_proxies box
@@ -824,7 +824,7 @@ module OpsController::Settings::Common
       auth[:default_group_for_users] = params[:authentication_default_group_for_users] if params[:authentication_default_group_for_users]
 
     when "settings_workers"                                       # Workers Settings tab
-      wb  = new.config[:workers][:worker_base]
+      wb  = new[:workers][:worker_base]
       qwb = wb[:queue_worker_base]
 
       w = qwb[:generic_worker]
@@ -876,7 +876,7 @@ module OpsController::Settings::Common
       new[:server][:use_custom_login_text] = (params[:server_uselogintext] == "true") if params[:server_uselogintext]
       if params[:login_text]
         new[:server][:custom_login_text] = params[:login_text]
-        @login_text_changed = new[:server][:custom_login_text] != @edit[:current].config[:server][:custom_login_text].to_s
+        @login_text_changed = new[:server][:custom_login_text] != @edit[:current][:server][:custom_login_text].to_s
       end
     when "settings_smartproxy"                                        # SmartProxy Defaults tab
       @sb[:form_vars][:agent_heartbeat_frequency_mins] = params[:agent_heartbeat_frequency_mins] if params[:agent_heartbeat_frequency_mins]
@@ -900,8 +900,8 @@ module OpsController::Settings::Common
 
     # This section scoops up the config second level keys changed in the UI
     unless %w(settings_advanced settings_rhn_edit settings_smartproxy_affinity).include?(@sb[:active_tab])
-      @edit[:current].config.each_key do |category|
-        @edit[:current].config[category].symbolize_keys.each_key do |key|
+      @edit[:current].each_key do |category|
+        @edit[:current][category].symbolize_keys.each_key do |key|
           if category == :smtp && key == :enable_starttls_auto  # Checkbox is handled differently
             new[category][key] = params["#{category}_#{key}"] == "true" if params.key?("#{category}_#{key}")
           else
@@ -946,15 +946,15 @@ module OpsController::Settings::Common
     @sb[:new_to] = nil
     @sb[:newrole] = false
 
-    @edit[:current].config[:server][:role] = @edit[:current].config[:server][:role] ? @edit[:current].config[:server][:role].split(",").sort.join(",") : ""
-    @edit[:current].config[:server][:timezone] = "UTC" if @edit[:current].config[:server][:timezone].blank?
-    @edit[:current].config[:server][:locale] = "default" if @edit[:current].config[:server][:locale].blank?
-    @edit[:current].config[:server][:remote_console_type] ||= "VNC"
-    @edit[:current].config[:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current].config[:smtp][:enable_starttls_auto].nil?
-    @edit[:current].config[:smtp][:openssl_verify_mode] ||= "none"
-    @edit[:current].config[:ntp] ||= {}
-    @edit[:current].config[:server][:zone] = MiqServer.find(@sb[:selected_server_id]).zone.name
-    @edit[:current].config[:server][:name] = MiqServer.find(@sb[:selected_server_id]).name
+    @edit[:current][:server][:role] = @edit[:current][:server][:role] ? @edit[:current][:server][:role].split(",").sort.join(",") : ""
+    @edit[:current][:server][:timezone] = "UTC" if @edit[:current][:server][:timezone].blank?
+    @edit[:current][:server][:locale] = "default" if @edit[:current][:server][:locale].blank?
+    @edit[:current][:server][:remote_console_type] ||= "VNC"
+    @edit[:current][:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current][:smtp][:enable_starttls_auto].nil?
+    @edit[:current][:smtp][:openssl_verify_mode] ||= "none"
+    @edit[:current][:ntp] ||= {}
+    @edit[:current][:server][:zone] = MiqServer.find(@sb[:selected_server_id]).zone.name
+    @edit[:current][:server][:name] = MiqServer.find(@sb[:selected_server_id]).name
 
     @in_a_form = true
   end
@@ -966,21 +966,21 @@ module OpsController::Settings::Common
     @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
     @edit[:current] = MiqServer.find(@sb[:selected_server_id]).settings
     # Avoid thinking roles change when not yet set
-    @edit[:current].config[:authentication][:ldap_role] ||= false
-    @edit[:current].config[:authentication][:amazon_role] ||= false
-    @edit[:current].config[:authentication][:httpd_role] ||= false
+    @edit[:current][:authentication][:ldap_role] ||= false
+    @edit[:current][:authentication][:amazon_role] ||= false
+    @edit[:current][:authentication][:httpd_role] ||= false
     @sb[:form_vars] = {}
-    @sb[:form_vars][:session_timeout_hours] = @edit[:current].config[:session][:timeout] / 3600
-    @sb[:form_vars][:session_timeout_mins] = (@edit[:current].config[:session][:timeout] % 3600) / 60
-    @edit[:current].config[:authentication][:ldaphost] = @edit[:current].config[:authentication][:ldaphost].to_miq_a
-    @edit[:current].config[:authentication][:user_proxies] ||= [{}]
-    @edit[:current].config[:authentication][:follow_referrals] ||= false
-    @edit[:current].config[:authentication][:sso_enabled] ||= false
-    @edit[:current].config[:authentication][:provider_type] ||= "none"
-    @edit[:current].config[:authentication][:local_login_disabled] ||= false
-    @sb[:newrole] = @edit[:current].config[:authentication][:ldap_role]
-    @sb[:new_amazon_role] = @edit[:current].config[:authentication][:amazon_role]
-    @sb[:new_httpd_role] = @edit[:current].config[:authentication][:httpd_role]
+    @sb[:form_vars][:session_timeout_hours] = @edit[:current][:session][:timeout] / 3600
+    @sb[:form_vars][:session_timeout_mins] = (@edit[:current][:session][:timeout] % 3600) / 60
+    @edit[:current][:authentication][:ldaphost] = @edit[:current][:authentication][:ldaphost].to_miq_a
+    @edit[:current][:authentication][:user_proxies] ||= [{}]
+    @edit[:current][:authentication][:follow_referrals] ||= false
+    @edit[:current][:authentication][:sso_enabled] ||= false
+    @edit[:current][:authentication][:provider_type] ||= "none"
+    @edit[:current][:authentication][:local_login_disabled] ||= false
+    @sb[:newrole] = @edit[:current][:authentication][:ldap_role]
+    @sb[:new_amazon_role] = @edit[:current][:authentication][:amazon_role]
+    @sb[:new_httpd_role] = @edit[:current][:authentication][:httpd_role]
     @in_a_form = true
   end
 
@@ -1006,7 +1006,7 @@ module OpsController::Settings::Common
       @sb[:threshold] << [number_to_human_size(x, :significant => false), x]
     end
 
-    cwb = @edit[:current].config[:workers][:worker_base] ||= {}
+    cwb = @edit[:current][:workers][:worker_base] ||= {}
     qwb = (cwb[:queue_worker_base] ||= {})
     w = (qwb[:generic_worker] ||= {})
     w[:count] = @edit[:current].get_raw_worker_setting(:MiqGenericWorker, :count) || 2
@@ -1051,7 +1051,7 @@ module OpsController::Settings::Common
     (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
     (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
 
-    wb = @edit[:current].config[:workers][:worker_base]
+    wb = @edit[:current][:workers][:worker_base]
     w = (wb[:event_catcher] ||= {})
     w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqEventCatcher, :memory_threshold) || 1.gigabytes
     @sb[:event_catcher_threshold] = []
@@ -1084,7 +1084,7 @@ module OpsController::Settings::Common
     w = (wb[:websocket_worker] ||= {})
     w[:count] = @edit[:current].get_raw_worker_setting(:MiqWebsocketWorker, :count) || 2
 
-    @edit[:new].config = copy_hash(@edit[:current].config)
+    @edit[:new] = copy_hash(@edit[:current])
     session[:log_depot_default_verify_status] = true
     @in_a_form = true
   end
@@ -1094,18 +1094,18 @@ module OpsController::Settings::Common
     @edit[:new] = {}
     @edit[:current] = ::Settings.to_hash
     @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
-    if @edit[:current].config[:server][:custom_logo].nil?
-      @edit[:current].config[:server][:custom_logo] = false # Set default custom_logo flag
+    if @edit[:current][:server][:custom_logo].nil?
+      @edit[:current][:server][:custom_logo] = false # Set default custom_logo flag
     end
-    if @edit[:current].config[:server][:custom_login_logo].nil?
-      @edit[:current].config[:server][:custom_login_logo] = false # Set default custom_logo flag
+    if @edit[:current][:server][:custom_login_logo].nil?
+      @edit[:current][:server][:custom_login_logo] = false # Set default custom_logo flag
     end
-    if @edit[:current].config[:server][:custom_brand].nil?
-      @edit[:current].config[:server][:custom_brand] = false # Set default custom_brand flag
+    if @edit[:current][:server][:custom_brand].nil?
+      @edit[:current][:server][:custom_brand] = false # Set default custom_brand flag
     end
 
-    if @edit[:current].config[:server][:use_custom_login_text].nil?
-      @edit[:current].config[:server][:use_custom_login_text] = false # Set default custom_login_text flag
+    if @edit[:current][:server][:use_custom_login_text].nil?
+      @edit[:current][:server][:use_custom_login_text] = false # Set default custom_login_text flag
     end
     @logo_file = @@logo_file
     @login_logo_file = @@login_logo_file
@@ -1143,8 +1143,8 @@ module OpsController::Settings::Common
     end
     if %w(settings_server settings_authentication settings_custom_logos).include?(@sb[:active_tab]) &&
        x_node.split("-").first != "z"
-      @edit[:current].config.each_key do |category|
-        @edit[:new][category] = copy_hash(@edit[:current].config[category])
+      @edit[:current].each_key do |category|
+        @edit[:new][category] = copy_hash(@edit[:current][category])
       end
       if @sb[:active_tab] == "settings_server"
         session[:selected_roles] = @edit[:new][:server][:role].split(",") if !@edit[:new][:server].nil? && !@edit[:new][:server][:role].nil?

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -472,10 +472,10 @@ module OpsController::Settings::Common
       if config_valid
         if ["settings_server", "settings_authentication"].include?(@sb[:active_tab])
           server = MiqServer.find(@sb[:selected_server_id])
-          server.set_config(@update)
+          server.add_settings_for_resource(@update)
           update_server_name(server)
         else
-          @update.save                                              # Save other settings for current server
+          MiqServer.my_server.add_settings_for_resource(@update)
         end
         AuditEvent.success(build_config_audit(@edit[:new], @edit[:current]))
         if @sb[:active_tab] == "settings_server"
@@ -526,7 +526,7 @@ module OpsController::Settings::Common
       config_valid, config_errors = Vmdb::Settings.validate(@update)
       if config_valid
         server = MiqServer.find(@sb[:selected_server_id])
-        server.set_config(@update)
+        server.add_settings_for_resource(@update)
 
         AuditEvent.success(build_config_audit(@edit[:new], @edit[:current]))
         add_flash(_("Configuration settings saved for %{product} Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\"") %

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1012,42 +1012,42 @@ module OpsController::Settings::Common
     cwb = @edit[:current][:workers][:worker_base] ||= {}
     qwb = (cwb[:queue_worker_base] ||= {})
     w = (qwb[:generic_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqGenericWorker, :count) || 2
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqGenericWorker, :memory_threshold) || 400.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqGenericWorker, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqGenericWorker, :memory_threshold) || 400.megabytes
     @sb[:generic_threshold] = []
     @sb[:generic_threshold] = copy_array(@sb[:threshold])
 
     w = (qwb[:priority_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqPriorityWorker, :count) || 2
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqPriorityWorker, :memory_threshold) || 200.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqPriorityWorker, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqPriorityWorker, :memory_threshold) || 200.megabytes
     @sb[:priority_threshold] = []
     @sb[:priority_threshold] = copy_array(@sb[:threshold])
 
     qwb[:ems_metrics_collector_worker] ||= {}
     qwb[:ems_metrics_collector_worker][:defaults] ||= {}
     w = qwb[:ems_metrics_collector_worker][:defaults]
-    raw = @edit[:current].get_raw_worker_setting(:MiqEmsMetricsCollectorWorker)
+    raw = get_worker_setting(@edit[:current], MiqEmsMetricsCollectorWorker)
     w[:count] = raw[:defaults][:count] || 2
     w[:memory_threshold] = raw[:defaults][:memory_threshold] || 400.megabytes
     @sb[:ems_metrics_collector_threshold] = []
     @sb[:ems_metrics_collector_threshold] = copy_array(@sb[:threshold])
 
     w = (qwb[:ems_metrics_processor_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqEmsMetricsProcessorWorker, :count) || 2
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqEmsMetricsProcessorWorker, :memory_threshold) || 200.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqEmsMetricsProcessorWorker, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqEmsMetricsProcessorWorker, :memory_threshold) || 200.megabytes
     @sb[:ems_metrics_processor_threshold] = []
     @sb[:ems_metrics_processor_threshold] = copy_array(@sb[:threshold])
 
     w = (qwb[:smart_proxy_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqSmartProxyWorker, :count) || 3
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqSmartProxyWorker, :memory_threshold) || 400.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqSmartProxyWorker, :count) || 3
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqSmartProxyWorker, :memory_threshold) || 400.megabytes
     @sb[:smart_proxy_threshold] = []
     @sb[:smart_proxy_threshold] = copy_array(@sb[:threshold])
 
     qwb[:ems_refresh_worker] ||= {}
     qwb[:ems_refresh_worker][:defaults] ||= {}
     w = qwb[:ems_refresh_worker][:defaults]
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqEmsRefreshWorker, %i(defaults memory_threshold)) || 400.megabytes
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqEmsRefreshWorker, :defaults, :memory_threshold) || 400.megabytes
     @sb[:ems_refresh_threshold] = []
     (200.megabytes...550.megabytes).step(50.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
     (600.megabytes..900.megabytes).step(100.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
@@ -1056,40 +1056,45 @@ module OpsController::Settings::Common
 
     wb = @edit[:current][:workers][:worker_base]
     w = (wb[:event_catcher] ||= {})
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqEventCatcher, :memory_threshold) || 1.gigabytes
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqEventCatcher, :memory_threshold) || 1.gigabytes
     @sb[:event_catcher_threshold] = []
     (500.megabytes...1000.megabytes).step(100.megabytes) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
     (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
     (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
 
     w = (wb[:vim_broker_worker] ||= {})
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqVimBrokerWorker, :memory_threshold) || 1.gigabytes
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqVimBrokerWorker, :memory_threshold) || 1.gigabytes
     @sb[:vim_broker_threshold] = []
     (500.megabytes..900.megabytes).step(100.megabytes) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
     (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
     (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
 
     w = (wb[:ui_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqUiWorker, :count) || 2
+    w[:count] = get_worker_setting(@edit[:current], MiqUiWorker, :count) || 2
 
     w = (qwb[:reporting_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqReportingWorker, :count) || 2
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqReportingWorker, :memory_threshold) || 400.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqReportingWorker, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqReportingWorker, :memory_threshold) || 400.megabytes
     @sb[:reporting_threshold] = []
     @sb[:reporting_threshold] = copy_array(@sb[:threshold])
 
     w = (wb[:web_service_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqWebServiceWorker, :count) || 2
-    w[:memory_threshold] = @edit[:current].get_raw_worker_setting(:MiqWebServiceWorker, :memory_threshold) || 400.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqWebServiceWorker, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqWebServiceWorker, :memory_threshold) || 400.megabytes
     @sb[:web_service_threshold] = []
     @sb[:web_service_threshold] = copy_array(@sb[:threshold])
 
     w = (wb[:websocket_worker] ||= {})
-    w[:count] = @edit[:current].get_raw_worker_setting(:MiqWebsocketWorker, :count) || 2
+    w[:count] = get_worker_setting(@edit[:current], MiqWebsocketWorker, :count) || 2
 
     @edit[:new] = copy_hash(@edit[:current])
     session[:log_depot_default_verify_status] = true
     @in_a_form = true
+  end
+
+  private def get_worker_setting(config, klass, *setting)
+    settings = klass.worker_settings(:config => config, :raw => true)
+    setting.empty? ? settings : settings.fetch_path(setting)
   end
 
   def settings_set_form_vars_logos

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -401,48 +401,48 @@ module OpsController::Settings::Common
       @changed = (@edit[:new] != @edit[:current])
       qwb = @edit[:new][:workers][:worker_base][:queue_worker_base]
       w = qwb[:generic_worker]
-      @edit[:new].set_worker_setting!(:MiqGenericWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqGenericWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqGenericWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqGenericWorker, :memory_threshold, w[:memory_threshold])
 
       w = qwb[:priority_worker]
-      @edit[:new].set_worker_setting!(:MiqPriorityWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqPriorityWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqPriorityWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqPriorityWorker, :memory_threshold, w[:memory_threshold])
 
       w = qwb[:ems_metrics_collector_worker][:defaults]
-      @edit[:new].set_worker_setting!(:MiqEmsMetricsCollectorWorker, [:defaults, :count], w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqEmsMetricsCollectorWorker, %i(defaults memory_threshold), w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqEmsMetricsCollectorWorker, :defaults, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqEmsMetricsCollectorWorker, :defaults, :memory_threshold, w[:memory_threshold])
 
       w = qwb[:ems_metrics_processor_worker]
-      @edit[:new].set_worker_setting!(:MiqEmsMetricsProcessorWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqEmsMetricsProcessorWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqEmsMetricsProcessorWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqEmsMetricsProcessorWorker, :memory_threshold, w[:memory_threshold])
 
       w = qwb[:ems_refresh_worker][:defaults]
-      @edit[:new].set_worker_setting!(:MiqEmsRefreshWorker, %i(defaults memory_threshold), w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqEmsRefreshWorker, :defaults, :memory_threshold, w[:memory_threshold])
 
       wb = @edit[:new][:workers][:worker_base]
       w = wb[:event_catcher]
-      @edit[:new].set_worker_setting!(:MiqEventCatcher, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqEventCatcher, :memory_threshold, w[:memory_threshold])
 
       w = wb[:vim_broker_worker]
-      @edit[:new].set_worker_setting!(:MiqVimBrokerWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqVimBrokerWorker, :memory_threshold, w[:memory_threshold])
 
       w = qwb[:smart_proxy_worker]
-      @edit[:new].set_worker_setting!(:MiqSmartProxyWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqSmartProxyWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqSmartProxyWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqSmartProxyWorker, :memory_threshold, w[:memory_threshold])
 
       w = wb[:ui_worker]
-      @edit[:new].set_worker_setting!(:MiqUiWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqUiWorker, :count, w[:count].to_i)
 
       w = qwb[:reporting_worker]
-      @edit[:new].set_worker_setting!(:MiqReportingWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqReportingWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqReportingWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqReportingWorker, :memory_threshold, w[:memory_threshold])
 
       w = wb[:web_service_worker]
-      @edit[:new].set_worker_setting!(:MiqWebServiceWorker, :count, w[:count].to_i)
-      @edit[:new].set_worker_setting!(:MiqWebServiceWorker, :memory_threshold, w[:memory_threshold])
+      set_worker_setting(@edit[:new], MiqWebServiceWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqWebServiceWorker, :memory_threshold, w[:memory_threshold])
 
       w = wb[:websocket_worker]
-      @edit[:new].set_worker_setting!(:MiqWebsocketWorker, :count, w[:count].to_i)
+      set_worker_setting(@edit[:new], MiqWebsocketWorker, :count, w[:count].to_i)
 
       @update = MiqServer.find(@sb[:selected_server_id]).settings
     when "settings_custom_logos"                                      # Custom Logo tab
@@ -550,6 +550,10 @@ module OpsController::Settings::Common
       get_node_info(x_node)
       replace_right_cell(:nodetype => @nodetype)
     end
+  end
+
+  private def set_worker_setting(config, klass, *path, value)
+    config.store_path(klass.config_settings_path + path, value)
   end
 
   private def new_ntp_servers
@@ -986,7 +990,6 @@ module OpsController::Settings::Common
 
   def settings_set_form_vars_workers
     # getting value in "1.megabytes" bytes from backend, converting it into "1 MB" to display in UI, and then later convert it into "1.megabytes" to before saving it back into config.
-    # need to create two copies of config new/current set_worker_setting! is a instance method, need @edit[:new] to be config class to set count/memory_threshold, can't run method against hash
     @edit = {}
     @edit[:new] = {}
     @edit[:current] = {}

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -468,7 +468,8 @@ module OpsController::Settings::Common
 
       save_ntp_server_settings
 
-      if @update.validate                                           # Have VMDB class validate the settings
+      config_valid, config_errors = Vmdb::Settings.validate(@update)
+      if config_valid
         if ["settings_server", "settings_authentication"].include?(@sb[:active_tab])
           server = MiqServer.find(@sb[:selected_server_id])
           server.set_config(@update)
@@ -504,7 +505,7 @@ module OpsController::Settings::Common
           replace_right_cell(:nodetype => @nodetype)
         end
       else
-        @update.errors.each do |field, msg|
+        config_errors.each do |field, msg|
           add_flash("#{field.titleize}: #{msg}", :error)
         end
         @changed = true
@@ -522,7 +523,8 @@ module OpsController::Settings::Common
       @update.each_key do |category|
         @update[category] = @edit[:new][category].dup
       end
-      if @update.validate                                           # Have VMDB class validate the settings
+      config_valid, config_errors = Vmdb::Settings.validate(@update)
+      if config_valid
         server = MiqServer.find(@sb[:selected_server_id])
         server.set_config(@update)
 
@@ -538,7 +540,7 @@ module OpsController::Settings::Common
         get_node_info(x_node)
         replace_right_cell(:nodetype => @nodetype)
       else
-        @update.errors.each do |field, msg|
+        config_errors.each do |field, msg|
           add_flash("#{field.titleize}: #{msg}", :error)
         end
         @changed = true

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -4,8 +4,6 @@ module OpsController::Settings::HelpMenu
   def settings_update_help_menu
     return unless load_edit('customize_help_menu')
 
-    konfig = VMDB::Config.new("vmdb")
-
     begin
       konfig.config = Vmdb::Settings.decrypt_passwords!(Settings.to_hash)
       konfig.config[:help_menu].merge!(@edit[:new])

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -5,8 +5,8 @@ module OpsController::Settings::HelpMenu
     return unless load_edit('customize_help_menu')
 
     begin
-      konfig.config = Vmdb::Settings.decrypt_passwords!(Settings.to_hash)
-      konfig.config[:help_menu].merge!(@edit[:new])
+      konfig = Vmdb::Settings.decrypt_passwords!(Settings.to_hash)
+      konfig[:help_menu].merge!(@edit[:new])
       konfig.validate
     rescue Psych::SyntaxError, StandardError
       add_flash(_('Invalid configuration parameters.'), :error)

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -7,13 +7,13 @@ module OpsController::Settings::HelpMenu
     begin
       konfig = Vmdb::Settings.decrypt_passwords!(Settings.to_hash)
       konfig[:help_menu].merge!(@edit[:new])
-      konfig.validate
+      success, config_errors = Vmdb::Settings.validate(konfig)
     rescue Psych::SyntaxError, StandardError
       add_flash(_('Invalid configuration parameters.'), :error)
       success = false
     end
 
-    success = konfig.errors.blank? if success.nil?
+    success = config_errors.blank? if success.nil?
 
     if success
       konfig.save

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -16,7 +16,7 @@ module OpsController::Settings::HelpMenu
     success = config_errors.blank? if success.nil?
 
     if success
-      konfig.save
+      MiqServer.my_server.add_settings_for_resource(konfig)
       session.delete(:edit)
       add_flash(_('Help menu customization changes successfully stored.'), :success)
     else

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -207,7 +207,7 @@
           .col-md-8
             = select_tag('ems_refresh_worker_threshold',
                           options_for_select(@sb[:ems_refresh_threshold],
-                                              @edit[:new].get_raw_worker_setting(:MiqEmsRefreshWorker, :memory_threshold)),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_refresh_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('ems_refresh_worker_threshold', "#{url}")

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -11,7 +11,7 @@
             = _("Count")
           .col-md-8
             = select_tag('generic_worker_count',
-                          options_for_select((0..9).to_a, @edit[:new].config[:workers][:worker_base][:queue_worker_base][:generic_worker][:count].to_i),
+                          options_for_select((0..9).to_a, @edit[:new][:workers][:worker_base][:queue_worker_base][:generic_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqInitSelectPicker();
@@ -22,7 +22,7 @@
           .col-md-8
             = select_tag('generic_worker_threshold',
                           options_for_select(@sb[:generic_threshold],
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:generic_worker][:memory_threshold]),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:generic_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('generic_worker_threshold', "#{url}")
@@ -37,7 +37,7 @@
           .col-md-8
             = select_tag('ems_metrics_collector_worker_count',
                           options_for_select((0..9).to_a,
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:ems_metrics_collector_worker][:defaults][:count].to_i),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_metrics_collector_worker][:defaults][:count].to_i),
                             :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('ems_metrics_collector_worker_count', "#{url}")
@@ -47,7 +47,7 @@
           .col-md-8
             = select_tag('ems_metrics_collector_worker_threshold',
                           options_for_select(@sb[:ems_metrics_collector_threshold],
-                                            @edit[:new].config[:workers][:worker_base][:queue_worker_base][:ems_metrics_collector_worker][:defaults][:memory_threshold]),
+                                            @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_metrics_collector_worker][:defaults][:memory_threshold]),
                           :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('ems_metrics_collector_worker_threshold', "#{url}")
@@ -61,7 +61,7 @@
           .col-md-8
             = select_tag('event_catcher_threshold',
                           options_for_select(@sb[:event_catcher_threshold],
-                                            @edit[:new].config[:workers][:worker_base][:event_catcher][:memory_threshold]),
+                                            @edit[:new][:workers][:worker_base][:event_catcher][:memory_threshold]),
                           :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('event_catcher_threshold', "#{url}")
@@ -75,7 +75,7 @@
           .col-md-8
             = select_tag('vim_broker_worker_threshold',
                           options_for_select(@sb[:vim_broker_threshold],
-                                              @edit[:new].config[:workers][:worker_base][:vim_broker_worker][:memory_threshold]),
+                                              @edit[:new][:workers][:worker_base][:vim_broker_worker][:memory_threshold]),
                           :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('vim_broker_worker_threshold', "#{url}")
@@ -89,10 +89,10 @@
           .col-md-8
             - uiworker_count_disbaled = Vmdb::Application.config.session_store == :memory_store
             - if uiworker_count_disbaled
-              = h(@edit[:new].config[:workers][:worker_base][:ui_worker][:count].to_i)
+              = h(@edit[:new][:workers][:worker_base][:ui_worker][:count].to_i)
             - else
               = select_tag('ui_worker_count',
-                          options_for_select((0..9).to_a, @edit[:new].config[:workers][:worker_base][:ui_worker][:count].to_i),
+                          options_for_select((0..9).to_a, @edit[:new][:workers][:worker_base][:ui_worker][:count].to_i),
                           :class    => "selectpicker")
             :javascript
               miqSelectPickerEvent('ui_worker_count', "#{url}")
@@ -110,7 +110,7 @@
           .col-md-8
             = select_tag('reporting_worker_count',
                         options_for_select((0..9).to_a,
-                                          @edit[:new].config[:workers][:worker_base][:queue_worker_base][:reporting_worker][:count].to_i),
+                                          @edit[:new][:workers][:worker_base][:queue_worker_base][:reporting_worker][:count].to_i),
                         :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('reporting_worker_count', "#{url}")
@@ -120,7 +120,7 @@
           .col-md-8
             = select_tag('reporting_worker_threshold',
                           options_for_select(@sb[:reporting_threshold],
-                                            @edit[:new].config[:workers][:worker_base][:queue_worker_base][:reporting_worker][:memory_threshold]),
+                                            @edit[:new][:workers][:worker_base][:queue_worker_base][:reporting_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('reporting_worker_threshold', "#{url}")
@@ -134,7 +134,7 @@
           .col-md-8
             = select_tag('web_service_worker_count',
                         options_for_select((0..9).to_a,
-                                          @edit[:new].config[:workers][:worker_base][:web_service_worker][:count].to_i),
+                                          @edit[:new][:workers][:worker_base][:web_service_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('web_service_worker_count', "#{url}")
@@ -144,7 +144,7 @@
           .col-md-8
             = select_tag('web_service_worker_threshold',
                         options_for_select(@sb[:web_service_threshold],
-                                          @edit[:new].config[:workers][:worker_base][:web_service_worker][:memory_threshold]),
+                                          @edit[:new][:workers][:worker_base][:web_service_worker][:memory_threshold]),
                         :class    => "selectpicker")
         :javascript
           miqSelectPickerEvent('web_service_worker_threshold', "#{url}")
@@ -159,7 +159,7 @@
           .col-md-8
             = select_tag('priority_worker_count',
                           options_for_select((0..4).to_a,
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:priority_worker][:count].to_i),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:priority_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('priority_worker_count', "#{url}")
@@ -169,7 +169,7 @@
           .col-md-8
             = select_tag('priority_worker_threshold',
                           options_for_select(@sb[:priority_threshold],
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:priority_worker][:memory_threshold]),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:priority_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('priority_worker_threshold', "#{url}")
@@ -183,7 +183,7 @@
           .col-md-8
             = select_tag('ems_metrics_processor_worker_count',
                           options_for_select((0..4).to_a,
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:ems_metrics_processor_worker][:count].to_i),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_metrics_processor_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('ems_metrics_processor_worker_count', "#{url}")
@@ -193,7 +193,7 @@
           .col-md-8
             = select_tag('ems_metrics_processor_worker_threshold',
                           options_for_select(@sb[:ems_metrics_processor_threshold],
-                                              @edit[:new].config[:workers][:worker_base][:queue_worker_base][:ems_metrics_processor_worker][:memory_threshold]),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_metrics_processor_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('ems_metrics_processor_worker_threshold', "#{url}")
@@ -221,7 +221,7 @@
           .col-md-8
             = select_tag('proxy_worker_count',
                           options_for_select((0..5).to_a,
-                          @edit[:new].config[:workers][:worker_base][:queue_worker_base][:smart_proxy_worker][:count].to_i),
+                          @edit[:new][:workers][:worker_base][:queue_worker_base][:smart_proxy_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('proxy_worker_count', "#{url}")
@@ -231,7 +231,7 @@
           .col-md-8
             = select_tag('proxy_worker_threshold',
                           options_for_select(@sb[:smart_proxy_threshold],
-                          @edit[:new].config[:workers][:worker_base][:queue_worker_base][:smart_proxy_worker][:memory_threshold]),
+                          @edit[:new][:workers][:worker_base][:queue_worker_base][:smart_proxy_worker][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('proxy_worker_threshold', "#{url}")
@@ -245,7 +245,7 @@
           .col-md-8
             = select_tag('websocket_worker_count',
                         options_for_select((0..9).to_a,
-                                          @edit[:new].config[:workers][:worker_base][:websocket_worker][:count].to_i),
+                                          @edit[:new][:workers][:worker_base][:websocket_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('websocket_worker_count', "#{url}")

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -331,7 +331,7 @@ describe MiqRequestController do
   context '#miq_request_initial_options user choice' do
     before(:each) do
       EvmSpecHelper.local_miq_server
-      stub_server_configuration(:server => {}, :session => {})
+      stub_settings(:server => {}, :session => {})
 
       # Create users
       @admin = FactoryGirl.create(:user, :role => "super_administrator")
@@ -371,7 +371,7 @@ describe MiqRequestController do
   context "requester_label" do
     before(:each) do
       EvmSpecHelper.local_miq_server
-      stub_server_configuration(:server => {}, :session => {})
+      stub_settings(:server => {}, :session => {})
 
       # Create user
       @approver = FactoryGirl.create(:user, :role => "approver")

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -167,7 +167,7 @@ describe OpsController do
     context "#settings_get_form_vars" do
       before do
         miq_server = FactoryGirl.create(:miq_server)
-        current = VMDB::Config.new("vmdb")
+        current = ::Settings.to_hash
         current.config[:authentication] = {:ldap_role => true,
                                            :mode      => 'ldap'}
         edit = {:current => current,
@@ -385,8 +385,8 @@ describe OpsController do
                                            :selected_server_id => @miq_server.id)
           controller.instance_variable_set(:@_params,
                                            :id => 'server')
-          @current = VMDB::Config.new("vmdb")
-          @new = @current.config
+          @current = ::Settings.to_hash
+          @new = ::Settings.to_hash
           @new[:server][:name] = ''
           controller.instance_variable_set(:@edit,
                                            :new     => @new,

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -168,10 +168,9 @@ describe OpsController do
       before do
         miq_server = FactoryGirl.create(:miq_server)
         current = ::Settings.to_hash
-        current.config[:authentication] = {:ldap_role => true,
-                                           :mode      => 'ldap'}
+        current[:authentication] = { :ldap_role => true, :mode => 'ldap' }
         edit = {:current => current,
-                :new     => copy_hash(current.config),
+                :new     => copy_hash(current),
                 :key     => "settings_authentication_edit__#{miq_server.id}"}
         controller.instance_variable_set(:@edit, edit)
         session[:edit] = edit
@@ -418,7 +417,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)
-          expect(edit_current[:current].config[:server][:zone]).to eq(zone.name)
+          expect(edit_current[:current][:server][:zone]).to eq(zone.name)
         end
 
         it 'for server in default zone' do
@@ -426,7 +425,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)
-          expect(edit_current[:current].config[:server][:zone]).to eq("default")
+          expect(edit_current[:current][:server][:zone]).to eq("default")
         end
 
         it 'sets the server name' do
@@ -435,7 +434,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)
-          expect(edit_current[:current].config[:server][:name]).to eq(server.name)
+          expect(edit_current[:current][:server][:name]).to eq(server.name)
         end
       end
     end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -205,21 +205,19 @@ describe OpsController do
     end
 
     it "should set session[:changed] as false when config is same" do
-      vmdb = VMDB::Config.new("vmdb")
-      # edit_changed? expects current to be VMDB::Config
       edit = {
-        :new     => vmdb.config,
-        :current => vmdb
+        :new     => ::Settings.to_hash,
+        :current => ::Settings.to_hash
       }
       controller.instance_variable_set(:@edit, edit)
       controller.send(:edit_changed?)
       expect(session[:changed]).to eq(false)
     end
 
-    it "should set session[:changed] as true when config is sadifferentme" do
+    it "should set session[:changed] as true when config is different" do
       edit = {
         :new     => {:workers => 2},
-        :current => VMDB::Config.new("vmdb")
+        :current => ::Settings.to_hash
       }
       controller.instance_variable_set(:@edit, edit)
       controller.send(:edit_changed?)

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -171,7 +171,7 @@ describe OpsController do
                            :basedn   => 'cn=groups,cn=accounts,dc=miq',
                            :bind_dn  => 'uid=admin,cn=users,cn=accounts,dc=miq,dc=e',
                            :bind_pwd => '******'}
-          @vmdb = VMDB::Config.new('vmdb')
+          @vmdb = ::Settings.to_hash
           expect(controller).to receive(:render)
         end
 


### PR DESCRIPTION
This pull request removes all traces of deprecated `VMDB::Config` class usage from the UI repo.

~~Depends on: https://github.com/ManageIQ/manageiq/pull/18024~~