### PR TITLE
Fix applying filter from Advanced Search in My Services

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -129,7 +129,7 @@ module ApplicationController::AdvancedSearch
     @edit[:adv_search_applied][:exp] = {}
     adv_search_set_text # Set search text filter suffix
     @edit[:selected] = true
-    @edit[:adv_search_applied][:exp] = @edit[:new][@expkey]   # Save the expression to be applied
+    @edit[:adv_search_applied][:exp] = copy_hash(@edit[:new][@expkey]) # Save the expression to be applied
     @edit[@expkey].exp_token = nil                            # Remove any existing atom being edited
     @edit[:adv_search_open] = false                           # Close the adv search box
     if MiqExpression.quick_search?(@edit[:adv_search_applied][:exp])


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1627078

There is a problem in _My Services_ page while applying filter from _Advanced Search_: error occurs and the filter is not applied.

**Steps to reproduce:**
1. Go to _Services > My Services_ page
2. Open _Advanced Search_ and create some new expression, commit it
3. Apply the expression, no need to save it. If you save the filter before applying it, apply the filter using Advanced Search, too.
=> error:
```
[----] F, [2018-09-11T18:00:16.007675 #29073:2b18a138e138] FATAL -- : Error caught: [RuntimeError] operator 'token' is not supported
/home/hstastna/manageiq/manageiq/lib/miq_expression.rb:1435:in `to_arel'
/home/hstastna/manageiq/manageiq/lib/miq_expression.rb:289:in `to_sql'
/home/hstastna/manageiq/manageiq/lib/rbac/filterer.rb:242:in `search'
/home/hstastna/manageiq/manageiq/lib/rbac/filterer.rb:131:in `search'
/home/hstastna/manageiq/manageiq/lib/rbac.rb:3:in `search'
/home/hstastna/manageiq/manageiq/app/models/miq_report/search.rb:110:in `paged_view_search'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:1469:in `get_view'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:434:in `report_data'
```

**How reproducible:**
not always, I have figured out that it also depends on which fields we choose in expression editor in Adv Search or how the expression looks like (sometimes we have more options to choose or more fields to set up, sometimes we choose only true/false for some specific fields)

---

**Before:**
![filter_before](https://user-images.githubusercontent.com/13417815/45374871-a4b7f600-b5f3-11e8-980f-c00c725458d9.png)

**After:**
![filter_after](https://user-images.githubusercontent.com/13417815/45419935-f8c0ea00-b688-11e8-948e-7ffa7b9152cc.png)

**Note:**
The problem happens here https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1517 where we set the `filter` which is about to be applied, and `@edit[:adv_search_applied][:exp]` contains `:token` key which is unnecessary here and it only causes problems here: https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report/search.rb#L108 because `options` contain the expression with the `:token` key (and its value). The solution is to set `@edit[:adv_search_applied][:exp]` properly by using `copy_hash` to make a proper copy of `@edit[:new][@expkey]`, otherwise if `@edit[:new][@expkey]` changes (token is added in `exp_build_table` method), `@edit[:adv_search_applied][:exp]` changes, too, so that it also contains unnecessary token.