### PR TITLE
Enable selectpicker on all dropdowns when editing a custom button

### DIFF
--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -81,14 +81,14 @@
       .col-md-8
         = select_tag("display_for",
                      options_for_select([[_('Single entity'), 'single'], [_('List'), 'list'], [_('Single and list'), 'both']], @edit[:new][:display_for]),
-                     "data-miq_sparkle_on" => true)
+                     "data-miq_sparkle_on" => true, :class => 'selectpicker')
     .form-group
       %label.control-label.col-md-2
         = _('Submit')
       .col-md-8
         = select_tag("submit_how",
                      options_for_select([[_('Submit all'), 'all'], [_('One by one'), 'one']], @edit[:new][:submit_how]),
-                     "data-miq_sparkle_on" => true)
+                     "data-miq_sparkle_on" => true, :class => 'selectpicker')
 :javascript
   miqInitSelectPicker();
   miqSelectPickerEvent('dialog_id', '#{url}');


### PR DESCRIPTION
This will make the dropdowns to look more consistent with the other ones on the screen for editing a custom button under automate - customization.

**Before:**
![screenshot from 2018-09-12 13-39-03](https://user-images.githubusercontent.com/649130/45422723-5f4a0600-b691-11e8-9292-93f74f1b2a15.png)
**After:**
![screenshot from 2018-09-12 13-37-40](https://user-images.githubusercontent.com/649130/45422730-62dd8d00-b691-11e8-88bd-18c935cb40eb.png)

@miq-bot add_label bug, graphics
@miq-bot add_reviewer @epwinchell 