### PR TITLE
Make filters saved in Templates & Images screen displayed in accordion

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -217,6 +217,7 @@ module ApplicationController::AdvancedSearch
        svcs_tree
        storage_tree
        templates_filter_tree
+       templates_images_filter_tree
        vms_filter_tree
        vms_instances_filter_tree).include?(x_active_tree.to_s)
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1626579

There is a problem in _Workloads Templates & Images_ screen: new created filter is not displayed until Workloads page is refreshed.

**Steps to reproduce:**
1. Go to _Services > Workloads > Templates & Images_ accordion
2. Open _Advanced Search_ and create a new expression, commit it
3. Name and save a new filter
=> the new filter is not displayed in accordion in _Global/My Filters_ folder! (need to refresh the page)

---

**Before:**
![temp_before](https://user-images.githubusercontent.com/13417815/45438371-42282e00-b6b7-11e8-9c03-bc5139203f05.png)

**After:**
![temp_after](https://user-images.githubusercontent.com/13417815/45437767-cb3e6580-b6b5-11e8-95c8-d7ab7f946b85.png)

---

**Notes:**
In `adv_search_redraw_left_div` method, we need `tree_for_building_accordions?` to return `true` to display the new filter in accordion properly, immediately after its creation, because we are in explorer screen. No need to refresh the page.