### PR TITLE
Do not invoke view details callback on notifications without links

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -116,10 +116,6 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.markRead(notification, group);
   };
 
-  vm.customScope.viewSubjectDetails = function(notification) {
-    eventNotifications.viewDetails(notification);
-  }
-
   vm.customScope.clearNotification = function(notification, group) {
     eventNotifications.clear(notification, group);
   };

--- a/app/views/static/notification_drawer/notification-body.html.haml
+++ b/app/views/static/notification_drawer/notification-body.html.haml
@@ -8,7 +8,7 @@
       %span.fa.fa-ellipsis-v
     %ul.dropdown-menu.dropdown-menu-right{'aria-labelledby' => 'dropdownKebabRight-{{ notification.id }}'}
       %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.data.link}"}
-        %a.secondary-action{:title => _('View details'), 'ng-click' => 'customScope.viewSubjectDetails(notification)'}
+        %a.secondary-action{:title => _('View details'), 'ng-click' => 'notification.actionCallback(notification)'}
           = _('View details')
       %li.divider{:role => 'separator'}
       %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.unread}"}


### PR DESCRIPTION
When clicking on a disabled `View Details` link in the notification drawer, it displays an error. By preferring the `notification.actionCallback` over `customScope.viewSubjectDetails` this problem is gone as the `actionCallback` is only set when the link is enabled. This makes the `viewSubjectDetails` function obsolete.

Fixes #4648

@miq-bot add_label bug, gaprindashvili/no