### PR TITLE
Do not show tooltip on listicons in GTLs when they're not clickable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -987,10 +987,17 @@ class ApplicationController < ActionController::Base
       icon, icon2, image = fonticon_or_fileicon(item)
       # FIXME: adding exceptions here is a wrong approach
       icon = nil if params[:controller] == 'pxe'
-      new_row[:cells] << {:title => _('View this item'),
-                          :image   => ActionController::Base.helpers.image_path(image.to_s),
-                          :icon    => icon,
-                          :icon2   => icon2}
+
+      # Clickable should be false only when it's explicitly set to false
+      not_clickable = if params
+                        (params.fetch_path(:additional_options, :clickable) == false)
+                      else
+                        false
+                      end
+      new_row[:cells] << {:title => not_clickable ? nil : _('View this item'),
+                          :image => ActionController::Base.helpers.image_path(image.to_s),
+                          :icon  => icon,
+                          :icon2 => icon2}.compact
 
       view.col_order.each_with_index do |col, col_idx|
         next if view.column_is_hidden?(col)


### PR DESCRIPTION
When displaying custom button events for a record, the listicon had a `View Details` tooltip even if the table wasn't even clickable. Through the `params` in `view_to_hash` it is possible to determine if it's clickable, so the tooltip can be hidden based on this boolean.

@miq-bot add_label bug, gaprindashvili/no
@miq-bot add_reviewer @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628245