### PR TITLE
Fixed some inconsistencies on provider dashboards.

### DIFF
--- a/app/assets/javascripts/controllers/ems_container_dashboard/aggregate_status_card_controller.js
+++ b/app/assets/javascripts/controllers/ems_container_dashboard/aggregate_status_card_controller.js
@@ -67,6 +67,7 @@ angular.module( 'patternfly.card' ).controller('aggregateStatusCardContainerCont
             "iconClass": data.alerts.notifications[0].iconClass,
             "href": data.alerts.href,
             "count": data.alerts.notifications[0].count,
+            "dataAvailable": data.alerts.dataAvailable,
           },
         ],
       };
@@ -80,10 +81,6 @@ angular.module( 'patternfly.card' ).controller('aggregateStatusCardContainerCont
           "title": attrHsh[attributes[i]],
           "count": dataStatus.count,
           "href": dataStatus.href,
-          "notification": {
-            "iconClass": "pficon pficon-error-circle-o",
-            "count": 0,
-          },
         });
       }
       vm.loadingDone = true;

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -13,6 +13,7 @@ class ContainerDashboardController < ApplicationController
     if params[:id].nil?
       @breadcrumbs.clear
     end
+    @title = title
   end
 
   def index

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -141,6 +141,8 @@ class ContainerDashboardService < DashboardService
     warnings_struct = warnings > 0 ? {:iconClass => "pficon pficon-warning-triangle-o", :count => warnings} : nil
     notifications = if (errors + warnings) > 0
                       [errors_struct, warnings_struct].compact
+                    elsif alerts_status == [nil, nil]
+                      [{}]
                     else
                       [{:iconClass => "pficon-large pficon-ok"}]
                     end

--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -68,10 +68,6 @@ class EmsDashboardService < DashboardService
         :title        => attr_hsh[attr],
         :count        => @ems.send(attr).count,
         :href         => get_url(ems_type, @ems_id, attr_url[attr]),
-        :notification => {
-          :iconClass => 'pficon pficon-error-circle-o',
-          :count     => 0,
-        },
       )
     end
     attr_data

--- a/app/views/container_dashboard/show.html.haml
+++ b/app/views/container_dashboard/show.html.haml
@@ -1,1 +1,3 @@
+%h1
+  = @title
 = render :partial => "ems_container/show_dashboard"

--- a/app/views/static/pf_charts/aggregate-status-card.html.haml
+++ b/app/views/static/pf_charts/aggregate-status-card.html.haml
@@ -29,6 +29,7 @@
           %image{"ng-if" => "notification.iconImage", "ng-src" => "{{notification.iconImage}}", :alt => "", :class => "card-pf-icon-image"}
           %span{:class => "{{notification.iconClass}}"}
           {{ notification.count }}
+    %pf-empty-chart{'ng-if' => "$ctrl.status.notifications[0].dataAvailable === false"}
 
 %div{"ng-if" => "$ctrl.isMiniLayout", :class => "card-pf card-pf-aggregate-status card-pf-aggregate-status-mini", "ng-class" => "{'card-pf-accented': $ctrl.shouldShowTopBorder}"}
   %h2{:class => "card-pf-title"}
@@ -47,7 +48,7 @@
   %div{:class => "card-pf-body"}
     %p{"ng-if" => "$ctrl.status.notification.iconImage || $ctrl.status.notification.iconClass || $ctrl.status.notification.count", :class => "card-pf-aggregate-status-notifications"}
       %span{:class => "card-pf-aggregate-status-notification", :title => "{{$ctrl.status.notification.tooltip}}" }
-        %a{"ng-if" => "$ctrl.status.notification.href", :href => "{{$ctrl$ctrl.status.notification.href}}"}
+        %a{"ng-if" => "$ctrl.status.notification.href && !$ctrl.status.notification.count", :href => "{{$ctrl$ctrl.status.notification.href}}"}
           %image{"ng-if" => "$ctrl.status.notification.iconImage", "ng-src" => "{{$ctrl.status.notification.iconImage}}", :alt => "", :class => "card-pf-icon-image"}
           %span{"ng-if" => "$ctrl.status.notification.iconClass", :class => "{{$ctrl.status.notification.iconClass}}"}
           %span{"ng-if" => "$ctrl.status.notification.count"}


### PR DESCRIPTION
- Red crosses were added as part of https://github.com/ManageIQ/manageiq-ui-classic/pull/4453 that caused them to show up on all aggregate status cards on all provider dashboards, fixed the condition and removed setting of redundant notification hash for providers when it is not needed.
- Show status icon under Alerts in aggregate card if Alerts are configured for a container provider, otherwise show "No data available" empty pf card.
- On Containers Overview dashboard, Fixed to not show provider icon in Provider status aggregate card, it should only show count of providers with a link to list view to Container Providers show list.
- Added a title on Container Overview dashboard screen, since that's the only screen on that subtab there are no breadcrumbs on the screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626199
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626427

before:
Container Overview
![screenshot from 2018-09-13 13-42-08](https://user-images.githubusercontent.com/3450808/45505652-1cecfb80-b75b-11e8-813c-9a17acb02bc7.png)

Infrastructure Provider Dashboard
![screenshot from 2018-09-13 13-42-38](https://user-images.githubusercontent.com/3450808/45505649-19f20b00-b75b-11e8-8518-1e0080c7a314.png)

Container Provider Dashboard
![screenshot from 2018-09-13 13-43-04](https://user-images.githubusercontent.com/3450808/45505641-13fc2a00-b75b-11e8-8cad-6527d458253c.png)

after:
Container Overview
![screenshot from 2018-09-13 13-39-07](https://user-images.githubusercontent.com/3450808/45505420-92a49780-b75a-11e8-9e57-65a180df9362.png)

Infrastructure Provider Dashboard
![screenshot from 2018-09-13 13-21-37](https://user-images.githubusercontent.com/3450808/45505426-9801e200-b75a-11e8-8a07-33047c3f2d17.png)

Container Provider Dashboard
![screenshot from 2018-09-13 13-21-08](https://user-images.githubusercontent.com/3450808/45505433-9df7c300-b75a-11e8-81f0-b7dae4841c20.png)


