### PR TITLE
npm - add validator, dependency of angular.validators

### DIFF
--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -23,6 +23,7 @@ require('angular-ui-sortable'); // ui.sortable, used by ui-components
 window._ = require('lodash');
 window.numeral = require('numeral');
 window.sprintf = require('sprintf-js').sprintf;
+window.validator = require('validator'); // used by angular.validators
 
 window.moment = require('moment');
 require("moment-strftime");

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "sprintf-js": "~1.1.1",
     "text-encoder-lite": "git://github.com/coolaj86/TextEncoderLite.git#e1e031b",
     "ui-select": "0.19.8",
+    "validator": "~10.7.1",
     "whatwg-fetch": "~2.0.4",
     "xml_display": "~0.1.1"
   },


### PR DESCRIPTION
angular.validators is special:
  when loaded in the context of the browser, it bundles its own copy of the validator library
  when loaded via require, it expects a global `validator` object and uses that

=> adding an explicit validator dependency and making sure the object exists

this also allows us to use a more recent version of validator

Fixes #4660 (introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/4622)

@djberg96 can you confirm this fixes the issue for you please? :)