### PR TITLE
Add React textual summary for PXE images

### DIFF
--- a/app/views/pxe/_pxe_server_details.html.haml
+++ b/app/views/pxe/_pxe_server_details.html.haml
@@ -60,8 +60,7 @@
         = render(:partial => "pxe_img_form")
       - else
         = render(:partial => "layouts/flash_msg")
-        = render :partial => "shared/summary/textual",
-          :locals  => {:title => _("Basic Information"), :items => textual_pxe_img_basicinfo}
+        = react 'GenericGroupWrapper', expand_generic_group(TextualGroup.new(_('Basic Information'), textual_pxe_img_basicinfo), @record)
 
   -# Windows Image is selected
   - if @wimg
@@ -70,5 +69,4 @@
         = render(:partial => "pxe_wimg_form")
       - else
         = render(:partial => "layouts/flash_msg")
-        = render :partial => "shared/summary/textual",
-          :locals  => {:title => _("Basic Information"), :items => textual_win_img_basicinfo}
+        = react 'GenericGroupWrapper', expand_generic_group(TextualGroup.new(_('Basic Information'), textual_win_img_basicinfo), @record)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626983

Missed in https://github.com/ManageIQ/manageiq-ui-classic/pull/3420

How to reproduce:

- Go to Compute -> Infrastructure -> PXE

- If there's no PXE server with images create some in console
```
PxeServer.create!(:name => 'PXE Server', :uri => "http://test.example.com/pxe_server_112211")
PxeImage.create!(:name => 'Pxe Image', :pxe_server_id => PxeServer.first.id, :description => 'Pxe Image from Hell', :kernel => 'ubuntu-10.10-desktop-i386/vmlinuz', :kernel_options => "vga=788 -- quiet")
WindowsImage.create!(:name => "Window Image", :description => "Window Image", :pxe_server_id => PxeServer.first.id)
```
- click on Pxe Image and Windows Image

Before:
```
Error caught: [ActionView::Template::Error] Missing partial shared/summary/_textual with {:locale=>[:en], :formats=>[:js, "application/ecmascript", "application/x-ecmascript", :html, :text, :js, :css, :ics, :csv, :vcf, :png, :jpeg, :gif, :bmp, :tiff, :svg, :mpeg, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :gzip], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee, :haml, :rjs]}. Searched in:
  * "/ManageIQ/manageiq/app/views"
  * "/ManageIQ/manageiq-ui-classic/app/views"
  * "/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/bundler/gems/manageiq-v2v-de610127be38/app/views"

/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/path_set.rb:46:in `find'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/lookup_context.rb:122:in `find'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:420:in `find_template'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:415:in `find_partial'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/partial_renderer.rb:297:in `render'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/renderer.rb:47:in `render_partial'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/renderer/renderer.rb:21:in `render'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/actionview-5.0.7/lib/action_view/helpers/rendering_helper.rb:32:in `render'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/haml-4.0.7/lib/haml/helpers/action_view_mods.rb:12:in `render_with_haml'
ManageIQ/manageiq-ui-classic/app/views/pxe/_pxe_server_details.html.haml:63:in `___sers_zita__esktop__anage___manageiq_ui_classic_app_views_pxe__pxe_server_details_html_haml__4074327853774494466_70288532390320'
```
After:
<img width="1196" alt="screen shot 2018-09-14 at 12 56 10 pm" src="https://user-images.githubusercontent.com/9210860/45546444-96e5b900-b81d-11e8-8a45-5b932e09e6d2.png">

cc: @martinpovolny 

@miq-bot add_label gaprindashvili/no, bug