### PR TITLE
angular.validators - work around nodeValidator=={}

### DIFF
--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -15,7 +15,7 @@ require('patternfly-bootstrap-treeview');
 window.angular = require('angular');
 require('angular-gettext');
 require('angular-sanitize');
-require('angular.validators/angular.validators');
+require('imports-loader?module=>undefined,exports=>undefined,define=>undefined!angular.validators/angular.validators');
 require('ng-annotate-loader!angular-ui-codemirror');
 require('angular-dragdrop');  // ngDragDrop, used by ui-components
 require('angular-ui-sortable'); // ui.sortable, used by ui-components

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-plugin-standard": "~2.0.1",
     "file-loader": "~1.1.11",
     "glob": "~7.1.1",
+    "imports-loader": "~0.8.0",
     "jasmine-jquery": "~2.1.1",
     "jest": "^22.0.6",
     "jest-cli": "^22.0.0",


### PR DESCRIPTION
angular.validators only works correctly when loaded in a browser-like environment - https://github.com/gkaimakas/angular.validators/issues/3

if `module`, `exports` or `define` are defined, the `nodeValidator` service ends up becoming an empty object and an attempt at exporting what would have been the service is made

this is to ensure that no such vars are defined for `angular.validators`

Fixes #4660 (introduced in #4622)

@djberg96 can you confirm this fixes the issue for you please? :)