### PR TITLE
Display Provider dropdown while creating Orchestration Catalog Item

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1350,10 +1350,7 @@ class CatalogController < ApplicationController
     @edit[:new][:catalog_id] = @record.service_template_catalog.try(:id)
     @edit[:new][:st_prov_type] ||= @record.prov_type
     @edit[:new][:generic_subtype] = @record.generic_subtype || "custom" if @edit[:new][:st_prov_type] == 'generic'
-    @edit[:new][:available_catalogs] = Rbac.filtered(ServiceTemplateCatalog.all).collect do |stc|
-      [stc.tenant.present? && stc.tenant.ancestors.present? ? stc.name + " (#{stc.tenant.name})" : stc.name, stc.id]
-    end
-    @edit[:new][:available_catalogs] = @edit[:new][:available_catalogs].sort
+    @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
     available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower)
     available_container_managers if @record.kind_of?(ServiceTemplateContainerTemplate)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -820,7 +820,6 @@ class CatalogController < ApplicationController
     prov_type = params[:st_prov_type] ? params[:st_prov_type] : @record.prov_type
     ansible_playbook = prov_type == "generic_ansible_playbook"
     @current_region = MiqRegion.my_region.region if ansible_playbook
-    @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     ansible_playbook
   end
   helper_method :ansible_playbook?
@@ -1491,6 +1490,7 @@ class CatalogController < ApplicationController
     @edit[:st_prov_type] = @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]
 
+    @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
     fetch_form_vars_ansible_or_ct if %w(generic_ansible_tower generic_container_template).include?(@edit[:new][:st_prov_type])
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,5 +1,5 @@
 describe CatalogController do
-  describe "tests that needs all rbac features access" do
+  context "tests that needs all rbac features access" do
     let(:user)                { FactoryGirl.create(:user_with_group) }
     let(:admin_user)          { FactoryGirl.create(:user, :role => "super_administrator") }
     let(:root_tenant)         { user.current_tenant }
@@ -56,7 +56,7 @@ describe CatalogController do
       controller.send(:x_edit_tags_reset, "ServiceTemplate")
     end
 
-    context 'get_view' do
+    describe '#get_view' do
       it "returns all catalog items related to current tenant and root tenant when non-self service user is logged" do
         login_as child_tenant_user
         view, _pages = controller.send(:get_view, ServiceTemplate, {:named_scope => :public_service_templates}, true)
@@ -85,12 +85,12 @@ describe CatalogController do
       end.to raise_error AbstractController::ActionNotFound
     end
 
-    describe 'x_button' do
+    describe '#x_button' do
       before do
         ApplicationController.handle_exceptions = true
       end
 
-      describe 'corresponding methods are called for allowed actions' do
+      context 'corresponding methods are called for allowed actions' do
         CatalogController::CATALOG_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, actual_method|
           it "calls the appropriate method: '#{actual_method}' for action '#{action_name}'" do
             expect(controller).to receive(actual_method)
@@ -105,7 +105,7 @@ describe CatalogController do
       end
     end
 
-    context "#atomic_form_field_changed" do
+    describe "#atomic_form_field_changed" do
       before :each do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@record, ServiceTemplate.new(:prov_type => "generic"))
@@ -135,7 +135,7 @@ describe CatalogController do
       end
     end
 
-    describe 'replace_right_cell' do
+    describe '#replace_right_cell' do
       it "Can build all the trees" do
         seed_session_trees('catalog', :sandt_tree, '-Unassigned')
         session_to_sb
@@ -153,7 +153,7 @@ describe CatalogController do
       end
     end
 
-    context "#atomic_st_edit" do
+    describe "#atomic_st_edit" do
       it "Atomic Service Template and its valid Resource Actions are saved" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "save")
@@ -221,7 +221,7 @@ describe CatalogController do
       end
     end
 
-    context "#x_button catalogitem_edit" do
+    describe "#x_button catalogitem_edit" do
       before do
         vm = FactoryGirl.create(:vm_vmware,
                                 :ext_management_system => FactoryGirl.create(:ems_vmware),
@@ -245,7 +245,7 @@ describe CatalogController do
       end
     end
 
-    context "#st_edit" do
+    describe "#st_edit" do
       it "@record is cleared out after Service Template is added" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "add")
@@ -269,7 +269,7 @@ describe CatalogController do
       end
     end
 
-    context "#st_upload_image" do
+    describe "#st_upload_image" do
       before do
         ApplicationController.handle_exceptions = true
 
@@ -318,7 +318,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_edit" do
+    describe "#ot_edit" do
       before(:each) do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "save")
@@ -418,7 +418,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_copy" do
+    describe "#ot_copy" do
       before(:each) do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "add")
@@ -459,7 +459,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_copy" do
+    describe "#ot_copy" do
       it "Orchestration Template is copied but name is changed" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
@@ -495,7 +495,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_delete" do
+    describe "#ot_delete" do
       before(:each) do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :pressed => "orchestration_template_remove")
@@ -526,7 +526,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_create" do
+    describe "#ot_create" do
       before(:each) do
         @new_name = "New Name"
         new_description = "New Description"
@@ -640,7 +640,7 @@ describe CatalogController do
       end
     end
 
-    context "#service_dialog_create_from_ot" do
+    describe "#service_dialog_create_from_ot" do
       before(:each) do
         @ot = FactoryGirl.create(:orchestration_template_amazon_in_json)
         @dialog_label = "New Dialog 01"
@@ -668,7 +668,7 @@ describe CatalogController do
       end
     end
 
-    context "#ot_rendering" do
+    describe "#ot_rendering" do
       render_views
       before(:each) do
         EvmSpecHelper.create_guid_miq_server_zone
@@ -718,7 +718,7 @@ describe CatalogController do
       end
     end
 
-    context "#set_resource_action" do
+    describe "#set_resource_action" do
       before do
         @st = FactoryGirl.create(:service_template)
         dialog = FactoryGirl.create(:dialog,
@@ -752,7 +752,7 @@ describe CatalogController do
       end
     end
 
-    context "#st_set_record_vars" do
+    describe "#st_set_record_vars" do
       before do
         @st = FactoryGirl.create(:service_template)
         @catalog = FactoryGirl.create(:service_template_catalog,
@@ -776,7 +776,7 @@ describe CatalogController do
       end
     end
 
-    context "#st_set_form_vars" do
+    describe "#st_set_form_vars" do
       before do
         bundle = FactoryGirl.create(:service_template)
         controller.instance_variable_set(:@record, bundle)
@@ -789,7 +789,7 @@ describe CatalogController do
       end
     end
 
-    context "#st_catalog_new" do
+    describe "#st_catalog_new" do
       it "renders views successfully after button is pressed" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :pressed => 'st_catalog_new', :action => 'x_button')
@@ -809,7 +809,7 @@ describe CatalogController do
       end
     end
 
-    context "#need_ansible_locals?" do
+    describe "#need_ansible_locals?" do
       before do
         controller.instance_variable_set(:@nodetype, 'st')
         st = FactoryGirl.create(:service_template,
@@ -849,7 +849,7 @@ describe CatalogController do
       end
     end
 
-    context "#get_available_resources" do
+    describe "#get_available_resources" do
       it "list of available resources should not include Ansible Playbook Service Templates" do
         FactoryGirl.create(:service_template, :type => "ServiceTemplateAnsiblePlaybook")
         controller.instance_variable_set(:@edit, :new => {:selected_resources => []})
@@ -905,7 +905,7 @@ describe CatalogController do
       end
     end
 
-    context "#fetch_playbook_details" do
+    describe "#fetch_playbook_details" do
       let(:auth) { FactoryGirl.create(:authentication, :name => "machine_cred", :manager_ref => 6, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential") }
       let(:repository) { FactoryGirl.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
       let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
@@ -1035,7 +1035,7 @@ describe CatalogController do
       end
     end
 
-    context "#atomic_req_submit" do
+    describe "#atomic_req_submit" do
       let(:ems) { FactoryGirl.create(:ems_openshift) }
       let(:container_template) do
         FactoryGirl.create(:container_template,
@@ -1077,7 +1077,7 @@ describe CatalogController do
       end
     end
 
-    context "#fetch_ct_details" do
+    describe "#fetch_ct_details" do
       let(:ems) { FactoryGirl.create(:ems_openshift) }
       let(:container_template) do
         FactoryGirl.create(:container_template,
@@ -1179,8 +1179,8 @@ describe CatalogController do
     end
   end
 
-  describe "tests that need only specific rbac feature access" do
-    context "#st_tags_edit" do
+  context "tests that need only specific rbac feature access" do
+    describe "#st_tags_edit" do
       before(:each) do
         user = FactoryGirl.create(:user, :features => "catalogitem_tag")
         login_as user

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1240,4 +1240,32 @@ describe CatalogController do
       end
     end
   end
+
+  describe '#set_form_vars' do
+    before do
+      allow(controller).to receive(:build_ae_tree)
+      controller.instance_variable_set(:@edit, :new => {})
+      controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+    end
+
+    context 'getting all available catalogs with tenants and ancestors' do
+      it 'sets @available_catalogs' do
+        controller.send(:set_form_vars)
+        expect(controller.instance_variable_get(:@available_catalogs)).not_to be_nil
+      end
+    end
+  end
+
+  describe '#get_form_vars' do
+    before do
+      controller.instance_variable_set(:@edit, :new => {})
+    end
+
+    context 'getting all available catalogs with tenants and ancestors' do
+      it 'sets @available_catalogs' do
+        controller.send(:get_form_vars)
+        expect(controller.instance_variable_get(:@available_catalogs)).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -4,7 +4,7 @@ describe "catalog/_form.html.haml" do
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful
-    @edit = {:new => {:available_catalogs => [], :available_dialogs => {}}}
+    @edit = {:new => {:available_dialogs => {}}}
     @sb = {:st_form_active_tab => "Basic", :trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
     user = FactoryGirl.create(:user_with_group)
     login_as user


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1628384
Introduced in: https://github.com/ManageIQ/manageiq-ui-classic/pull/4278

Fix displaying the dropdown which was not displayed after setting some
_Orchestration Template_, while creating a new Orchestration _Catalog Item_.

**Steps to reproduce:**
1. Go to _Services > Catalogs > Catalog Items_ accordion
2. _Configuration > Add a New Catalog Item_
3. For _Catalog Item Type_, choose _Orchestration_
4. Fill in the _Name_, choose some _Catalog, Dialog_ and _Orchestration Template_
=> after making a selection in _Orchestration Template_ drop down, _Provider_ drop down is not displayed and it should display; after clicking on _Save_ button, error occurs but no _Provider_ drop down in the screen, no possibility to select any from the list

Also there is an error in log, after making a selection in _Orchestration Template_ drop down:
```
[----] F, [2018-09-14T20:29:09.500783 #21945:2b172de1ca84] FATAL -- : Error caught: [ActionView::Template::Error] no implicit conversion of nil into Array
/home/hstastna/manageiq/manageiq-ui-classic/app/views/catalog/_form_basic_info.html.haml:34:in `+'
/home/hstastna/manageiq/manageiq-ui-classic/app/views/catalog/_form_basic_info.html.haml:34:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_catalog__form_basic_info_html_haml___1446521240299786944_70138091241700'
```

---

**Before:**
![provider_before](https://user-images.githubusercontent.com/13417815/45569323-80605180-b85f-11e8-9b3f-6b0a2f7811e2.png)

**After:**
_Provider_ drop down appeared, after making a selection of some _Orchestration Template_:
![provider_after1](https://user-images.githubusercontent.com/13417815/45569327-835b4200-b85f-11e8-8f29-8a2f52054e14.png)
After clicking on _Save_ button, new Catalog Item successfully saved:
![provider_after2](https://user-images.githubusercontent.com/13417815/45569330-85bd9c00-b85f-11e8-9e08-452b717620e3.png)

---

**Note:**
The problem was that `@available_catalogs` in catalog controller were not set, after making a selection in the Orchestration Template drom down. Originally, they were set only once, when choosing some Catalog Item Type (step 3 from Steps to reproduce above). When adding an Orchestration Catalog Item, once user selects Orchestration Template, transaction is sent upto server that in return does a page replace to populate and display Provider drop down, we need to make sure that `@available_catalogs` gets set when page is being redrawn.