### PR TITLE
Use existing Zone not 'default' for MiqServer.my_zone or in request

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -1,4 +1,7 @@
 describe ApplicationController do
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.create(:zone) }
+
   before do
     EvmSpecHelper.local_miq_server
     login_as FactoryGirl.create(:user, :features => "everything")
@@ -744,14 +747,12 @@ describe ApplicationController do
   context "#process_elements" do
     it "shows passed in display name in flash message" do
       pxe = FactoryGirl.create(:pxe_server)
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue', 'Refresh Relationships')
       expect(assigns(:flash_array).first[:message]).to include("Refresh Relationships successfully initiated")
     end
 
     it "shows task name in flash message when display name is not passed in" do
       pxe = FactoryGirl.create(:pxe_server)
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue')
       expect(assigns(:flash_array).first[:message])
         .to include("synchronize_advertised_images_queue successfully initiated")
@@ -820,6 +821,9 @@ describe ApplicationController do
 end
 
 describe HostController do
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.create(:zone) }
+
   context "#show_association" do
     before(:each) do
       stub_user(:features => :all)
@@ -883,7 +887,6 @@ describe HostController do
       @host1 = FactoryGirl.create(:host)
       @host2 = FactoryGirl.create(:host)
       allow(controller).to receive(:filter_ids_in_region).and_return([[@host1, @host2], nil])
-      allow(MiqServer).to receive(:my_zone).and_return("default")
     end
 
     it "initiates host destroy" do

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -1,8 +1,10 @@
 describe ApplicationController do
   context "#perf_planning_gen_data" do
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+    let(:zone) { FactoryGirl.create(:zone) }
+
     it "should not get nil error when submitting up Manual Input data" do
       _enterprise = FactoryGirl.create(:miq_enterprise)
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       sb = {
         :options => {
           :target_typ => "EmsCluster",

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -85,7 +85,7 @@ describe EmsCloudController do
         "name"             => "foo_ec2",
         "emstype"          => "ec2",
         "provider_region"  => "ap-southeast-1",
-        "zone"             => "default",
+        "zone"             => zone.name,
         "default_userid"   => "foo",
         "default_password" => "[FILTERED]",
         "default_url"      => ""

--- a/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
@@ -42,9 +42,10 @@ describe Mixins::Actions::VmActions::Rename do
 
   describe '#rename_save' do
     let(:controller) { VmInfraController.new }
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+    let(:zone) { FactoryGirl.create(:zone) }
 
     before do
-      allow(MiqServer).to receive(:my_zone).and_return('default')
       allow(controller).to receive(:session).and_return(:userid => 'admin')
       controller.instance_variable_set(:@record, vm)
       controller.instance_variable_set(:@edit, :new => {:name => 'new_vm_name'})

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -23,6 +23,9 @@ describe PxeController do
   end
 
   describe 'x_button' do
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+    let(:zone) { FactoryGirl.create(:zone) }
+
     before do
       ApplicationController.handle_exceptions = true
     end
@@ -42,7 +45,6 @@ describe PxeController do
 
     it "Pressing Refresh button should show display name in the flash message" do
       pxe = FactoryGirl.create(:pxe_server)
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       controller.instance_variable_set(:@_params, :id => pxe.id)
       controller.instance_variable_set(:@sb,
                                        :trees       => {

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -4,13 +4,13 @@ describe "shared/views/ems_common/show" do
     TestSetup.new(:ems_openstack, EmsCloudHelper::TextualSummary),
     TestSetup.new(:ems_vmware,    EmsInfraHelper::TextualSummary),
   ].each do |setup|
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
     let(:zone) { FactoryGirl.create(:zone) }
     let(:ems) { FactoryGirl.create(setup.ems_type, :hostname => '1.1.1.1', :zone => zone) }
     let(:action) { 'index' }
 
     before do
       view.extend setup.helper
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       allow(controller).to receive(:controller_name).and_return("ems_cloud")
       creds = {}
       creds[:amqp] = {:userid => "amqp_user", :password => "amqp_password"}


### PR DESCRIPTION
Fixing failures introduced by https://github.com/ManageIQ/manageiq/pull/17987

@miq-bot add_label test