### PR TITLE
angular.validators - update and remove imports-loader workaround

### DIFF
--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -1,6 +1,6 @@
 ManageIQ.angular.app = angular.module('ManageIQ', [
   'ManageIQ.fonticonPicker',
-  'angular.validators',
+  'angular.validators', // FIXME: require('angular.validators'),
   'frapontillo.bootstrap-switch',
   'gettext', // FIXME: require('angular-gettext'),
   'kubernetesUI',

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -15,7 +15,7 @@ require('patternfly-bootstrap-treeview');
 window.angular = require('angular');
 require('angular-gettext');
 require('angular-sanitize');
-require('imports-loader?module=>undefined,exports=>undefined,define=>undefined!angular.validators/angular.validators');
+require('angular.validators');
 require('ng-annotate-loader!angular-ui-codemirror');
 require('angular-dragdrop');  // ngDragDrop, used by ui-components
 require('angular-ui-sortable'); // ui.sortable, used by ui-components

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angular-sanitize": "~1.6.6",
     "angular-ui-codemirror": "~0.3.0",
     "angular-ui-sortable": "~0.16.1",
-    "angular.validators": "~4.4.2",
+    "angular.validators": "~4.4.3",
     "array-includes": "~3.0.3",
     "base64-js": "~1.2.3",
     "bootstrap-filestyle": "~1.2.1",


### PR DESCRIPTION
we had a workaround (#4667) for loading angular.validators in a browser-like context to prevent the validator service becoming empty (#4660)

this is needed when using angular.validators < 4.4.3 with webpack

but 4.4.3 just got released (https://github.com/gkaimakas/angular.validators/issues/7), removing the workaround

4.4.3 contains the following changes from 4.4.2:

* https://github.com/gkaimakas/angular.validators/pull/4 - removed export/global boilerplate (the fix)
* https://github.com/gkaimakas/angular.validators/pull/5 - a README fix
* https://github.com/gkaimakas/angular.validators/pull/6 - allow `require('angular.validators')` (added index.js)

---

This essentially reverts https://github.com/ManageIQ/manageiq-ui-classic/pull/4667, but it does *not* remove `imports-loader` beause it is needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/4641#issuecomment-422066728