### PR TITLE
Fix UI error when migrating virtual machine

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -27,7 +27,7 @@ module ApplicationController::MiqRequestMethods
       changed = (@edit[:new] != @edit[:current])
       @record = if @edit[:new][:src_configured_system_ids].present?
                   PhysicalServer.find(@edit[:new][:src_configured_system_ids].first)
-                else
+                elsif @edit[:new][:src_vm_id].first.present?
                   MiqTemplate.find(@edit[:new][:src_vm_id].first)
                 end
       render :update do |page|


### PR DESCRIPTION
1. Compute ➛ Infra ➛ Virtual Machines ➛ select a VM you can migrate ➛ Lifecycle ➛ Migrate Selected Items
2. Switch tabs in the rendered form

Before, the following error would show:
```
FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqTemplate without an ID.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7/lib/active_record/relation/finder_methods.rb:456:in `find_with_ids'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7/lib/active_record/relation/finder_methods.rb:66:in `find'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7/lib/active_record/querying.rb:3:in `find'
.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7/lib/active_record/core.rb:151:in `find'
manageiq-ui-classic/app/controllers/application_controller/miq_request_methods.rb:31:in `prov_field_changed'
```

It seems that the `@edit[:new][:src_vm_id]` value is properly set only when provisioning a new machine.

https://bugzilla.redhat.com/show_bug.cgi?id=1628718