### PR TITLE
Encrypt replication subscription's password before queuing save operation

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -281,6 +281,7 @@ module OpsController::Settings::Common
   end
 
   def set_subscription_attributes(subscription, params)
+    params['password'] = MiqPassword.encrypt(params['password'])
     params_for_connection_validation(params).each do |k, v|
       subscription.send("#{k}=".to_sym, v)
     end


### PR DESCRIPTION
Encrypt replication subscription's password before queuing save operation

This PR is follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/4628

There is no need to change model side since encrypted password will be decrypted if needed here: https://github.com/ManageIQ/manageiq/blob/156cd6b949e5bc4837edd1d76e47e643d9250040/app/models/pglogical_subscription.rb#L242

@miq-bot add-label  technical debt

https://bugzilla.redhat.com/show_bug.cgi?id=1562956