### PR TITLE
Refactored auth_key_pair_cloud_controller_spec with using let variables and removing classification mocking

### DIFF
--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -1,61 +1,55 @@
 describe AuthKeyPairCloudController do
-  context "#button" do
-    before(:each) do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+  let(:kp) { FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01") }
+  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
+  let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+
+  before do
+    stub_user(:features => :all)
+    EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => kp)
+    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => kp)
   end
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @kp = FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01")
-      allow(@kp).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@kp).and_return([@tag1, @tag2])
+  describe "#tags_edit" do
+    before do
       session[:tag_db] = "ManageIQ::Providers::CloudManager::AuthKeyPair"
-      edit = {
-        :key        => "ManageIQ::Providers::CloudManager::AuthKeyPair_edit_tags__#{@kp.id}",
+      session[:edit] = {
+        :key        => "ManageIQ::Providers::CloudManager::AuthKeyPair_edit_tags__#{kp.id}",
         :tagging    => "ManageIQ::Providers::CloudManager::AuthKeyPair",
-        :object_ids => [@kp.id],
+        :object_ids => [kp.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
-      session[:edit] = edit
-    end
-
-    after(:each) do
-      expect(response.status).to eq(200)
     end
 
     it "builds tagging screen" do
-      post :button, :params => { :pressed => "auth_key_pair_cloud_tag", :format => :js, :id => @kp.id }
+      post :button, :params => { :pressed => "auth_key_pair_cloud_tag", :format => :js, :id => kp.id }
+
       expect(assigns(:flash_array)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "auth_key_pair_cloud/show/#{@kp.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @kp.id }
+      session[:breadcrumbs] = [{:url => "auth_key_pair_cloud/show/#{kp.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => kp.id }
+
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "auth_key_pair_cloud/show/#{@kp.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @kp.id }
+      session[:breadcrumbs] = [{:url => "auth_key_pair_cloud/show/#{kp.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => kp.id }
+
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
   end
 
-  context "#parse error messages" do
+  describe "parse error messages" do
     it "simplifies fog error message" do
       raw_msg = "Expected(200) <=> Actual(400 Bad Request)\nexcon.error.response\n  :body          => "\
                 "\"{\\\"badRequest\\\": {\\\"message\\\": \\\"Keypair data is invalid: failed to generate "\
@@ -70,11 +64,6 @@ describe AuthKeyPairCloudController do
   end
 
   describe '#show_list' do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-
     render_views
 
     it 'sets the lastaction correctly' do
@@ -93,13 +82,6 @@ describe AuthKeyPairCloudController do
   end
 
   describe '#report_data' do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-
-    let(:kp) { FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01") }
-
     context 'when tile mode is selected' do
       it 'returns key pairs with quadicons' do
         kp
@@ -111,6 +93,7 @@ describe AuthKeyPairCloudController do
           :gtl_dbname => :authkeypaircloud,
         )
         results = assert_report_data_response
+
         expect(results['data']['rows'].length).to eq(1)
         expect(results['data']['rows'][0]['long_id']).to eq(kp.id.to_s)
         expect(results['data']['rows'][0]['quad']).to have_key('fonticon')


### PR DESCRIPTION
Replaces mocking of `Classification` with **FactoryGirl tagging**
**Let variables are used** instead of `@variables`

Same process as #4634 

@miq-bot add_label gaprindashvili/no, refactoring

@skateman Can you please review it? :pray: 


