### PR TITLE
Fix variable name and extra semicolon in VMDB summary view

### DIFF
--- a/app/views/ops/_db_summary.html.haml
+++ b/app/views/ops/_db_summary.html.haml
@@ -1,12 +1,13 @@
 - groups = [%i(vmdb_connection_properties vmdb_connection_capacity_data), %i(vmdb_tables_most_rows vmdb_tables_largest_size vmdb_tables_most_wasted_space)]
 #textual_summary
+
 :javascript
   var summary_props = {
-    summary: #{process_textual_info(textual_group_list, @record).to_json},
+    summary: #{process_textual_info(groups, @record).to_json},
     onClick: function(item, event) {
       event.preventDefault();
       if (!item.link) return;
       miqTreeActivateNode('vmdb_tree', item.link);
-    };
+    }
   };
   ManageIQ.component.componentFactory('TextualSummaryWrapper', '#textual_summary', summary_props);


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1623091

Wrong variable name was assigned to the component props, that is why it was not showing the summary screen.

Also the JS errors were caused by extra semicolon in props JSON definition.
