### PR TITLE
UI for images CRUD actions

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -224,6 +224,7 @@ module EmsCommon
                                      "miq_template_",
                                      "network_port_",
                                      "network_router_",
+                                     "template_",
                                      "orchestration_stack_",
                                      "security_group_",
                                      "storage_",
@@ -270,6 +271,8 @@ module EmsCommon
       when "network_router_tag"               then tag(NetworkRouter)
       when "orchestration_stack_tag"          then tag(OrchestrationStack)
       when "security_group_tag"               then tag(SecurityGroup)
+      # TemplateCloud
+      when 'template_delete'                  then delete_templates
 
       when "physical_server_protect"          then assign_policies(PhysicalServer)
       when "physical_server_tag"              then tag(PhysicalServer)
@@ -298,7 +301,7 @@ module EmsCommon
                   @flash_array.nil?
 
         unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
+                "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete', 'template_delete'].include?(params[:pressed])
           @refresh_div = "main_div"
           @refresh_partial = "layouts/gtl"
           show                                                        # Handle EMS buttons

--- a/app/controllers/template_cloud_controller.rb
+++ b/app/controllers/template_cloud_controller.rb
@@ -1,0 +1,51 @@
+class TemplateCloudController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include Mixins::GenericSessionMixin
+  include EmsCommon
+
+  private
+
+  def textual_group_list
+    [%i(properties relationships), %i(tags)]
+  end
+  helper_method :textual_group_list
+
+  def delete_templates
+    assert_privileges('template_delete')
+    templates = find_records_with_rbac(TemplateCloud, checked_or_params)
+
+    archived_templates = []
+    other_templates = []
+
+    templates.each do |template|
+      if template.archived
+        archived_templates << template
+      else
+        other_templates << template
+      end
+    end
+
+    process_objects(archived_templates.map(&:id), 'destroy', _('Delete')) unless archived_templates.empty?
+
+    other_templates.each do |template|
+      begin
+        template.delete_image_queue(User.current_user.id)
+        add_flash(_("Delete of Template \"%{name}\" was successfully initiated.") % {:name => template.name})
+      rescue => error
+        add_flash(_("Unable to delete Template \"%{name}\": %{details}") % {:name    => template.name,
+                                                                            :details => error.message}, :error)
+      end
+    end
+
+    session[:flash_msgs] = @flash_array
+    javascript_redirect(:action => 'show_list')
+  end
+
+  menu_section :clo
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -844,6 +844,7 @@ module ApplicationHelper
        host
        host_aggregate
        load_balancer
+       manageiq/providers/cloud_manager/template
        middleware_deployment
        middleware_domain
        middleware_server
@@ -1139,6 +1140,7 @@ module ApplicationHelper
                         host
                         host_aggregate
                         load_balancer
+                        manageiq/providers/cloud_manager/template
                         manageiq/providers/embedded_ansible/automation_manager/playbook
                         manageiq/providers/embedded_automation_manager/authentication
                         manageiq/providers/embedded_automation_manager/configuration_script_source

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -41,6 +41,7 @@ module ApplicationHelper
         host
         host_aggregate
         load_balancer
+        manageiq/providers/cloud_manager/template
         middleware_deployment
         middleware_domain
         middleware_server

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -187,6 +187,7 @@ module ApplicationHelper::PageLayouts
       host
       host_aggregate
       load_balancer
+      manageiq/providers/cloud_manager/template
       middleware_deployment
       middleware_domain
       middleware_server

--- a/app/helpers/application_helper/toolbar/templates_center.rb
+++ b/app/helpers/application_helper/toolbar/templates_center.rb
@@ -1,0 +1,109 @@
+class ApplicationHelper::Toolbar::TemplatesCenter < ApplicationHelper::Toolbar::Basic
+  button_group('template_configuration', [
+    select(
+      :image_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items   => [
+        button(
+          :image_create,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Add a new Image'),
+          t,
+          :enabled   => false
+        ),
+        button(
+          :image_edit,
+          'pficon pficon-edit fa-lg',
+          N_('Select a single item to edit'),
+          N_('Edit Selected item'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+        ),
+        separator,
+        button(
+          :template_delete,
+          'pficon pficon-delete fa-lg',
+          t = N_('Remove selected Images'),
+          t,
+          :url_parms => "main_div",
+          :send_checked => true,
+          :confirm   => N_("Warning: The selected Images will be permanently removed!"),
+          :enabled   => false,
+          :onwhen    => "1+"
+        )
+      ]
+    ),
+  ])
+  button_group('image_lifecycle', [
+    select(
+      :image_lifecycle_choice,
+      'pficon pficon-add-circle-o fa-lg',
+      t = N_('Lifecycle'),
+      t,
+      :items => [
+        button(
+          :image_miq_request_new,
+          'ff ff-clone fa-lg',
+          N_('Select a single Image to Provision Instances'),
+          N_('Provision Instances using selected Image'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1",
+          :klass        => ApplicationHelper::Button::ButtonNewDiscover),
+      ]
+    ),
+  ])
+  button_group('image_policy', [
+    select(
+      :image_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :image_protect,
+          'pficon pficon-edit fa-lg',
+          N_('Manage Policies for the selected items'),
+          N_('Manage Policies'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1+"),
+        button(
+          :image_policy_sim,
+          'fa fa-play-circle-o fa-lg',
+          N_('View Policy Simulation for the selected items'),
+          N_('Policy Simulation'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1+"),
+        button(
+          :image_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit tags for the selected items'),
+          N_('Edit Tags'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1+"),
+        button(
+          :image_check_compliance,
+          'fa fa-search fa-lg',
+          N_('Check Compliance of the last known configuration for the selected items'),
+          N_('Check Compliance of Last Known Configuration'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :confirm      => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
+          :enabled      => false,
+          :onwhen       => "1+"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -460,6 +460,8 @@ class ApplicationHelper::ToolbarChooser
       return "drifts_center_tb"
     elsif @lastaction == "drift"
       return "drift_center_tb"
+    elsif @layout == 'manageiq/providers/cloud_manager/template'
+      return "templates_center_tb"
     else
       return nil if @in_a_form
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -61,6 +61,7 @@ module Menu
           Menu::Item.new('host_aggregate',      N_('Host Aggregates'),    'host_aggregate',      {:feature => 'host_aggregate_show_list'},        '/host_aggregate'),
           Menu::Item.new('cloud_tenant',        N_('Tenants'),            'cloud_tenant',        {:feature => 'cloud_tenant_show_list'},          '/cloud_tenant'),
           Menu::Item.new('flavor',              N_('Flavors'),            'flavor',              {:feature => 'flavor_show_list'},                '/flavor'),
+          Menu::Item.new('template_cloud',      N_('Images'),             'template',            {:feature => 'template_cloud_show_list'},        '/template_cloud'),
           Menu::Item.new('vm_cloud',            N_('Instances'),          'vm_cloud_explorer',   {:feature => 'vm_cloud_explorer', :any => true}, '/vm_cloud/explorer'),
           Menu::Item.new('orchestration_stack', N_('Stacks'),             'orchestration_stack', {:feature => 'orchestration_stack_show_list'},   '/orchestration_stack'),
           Menu::Item.new('auth_key_pair_cloud', N_('Key Pairs'),          'auth_key_pair_cloud', {:feature => 'auth_key_pair_cloud_show_list'},   '/auth_key_pair_cloud'),

--- a/app/views/template_cloud/show_list.html.haml
+++ b/app/views/template_cloud/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1725,6 +1725,34 @@ Rails.application.routes.draw do
         dialog_runner_post
     },
 
+    :template_cloud            => {
+      :get  => %w(
+        download_data
+        download_summary_pdf
+        index
+        protect
+        show
+        show_list
+        tagging_edit
+      ) +
+        compare_get,
+      :post => %w(
+        button
+        listnav_search_selected
+        protect
+        quick_search
+        sections_field_changed
+        show
+        show_list
+        tag_edit_form_field_changed
+        tagging_edit
+      ) +
+               adv_search_post +
+               compare_post +
+               exp_post +
+               save_post
+    },
+
     :network_port             => {
       :get  => %w(
         download_data


### PR DESCRIPTION
This PR add show_list for images. Create and edit buttons are disabled while we don't have working API calls for this actions, delete button is working is expected.
Clicking on image routes to explorer page with selected image.
![screen shot 2018-09-19 at 15 16 03](https://user-images.githubusercontent.com/20123872/45755639-43a9a700-bc1f-11e8-9b93-1fda869af199.png)
<img width="729" alt="screen shot 2018-09-19 at 15 15 17" src="https://user-images.githubusercontent.com/20123872/45755647-4906f180-bc1f-11e8-9269-5427ddf2cb37.png">
<img width="727" alt="screen shot 2018-09-19 at 15 14 20" src="https://user-images.githubusercontent.com/20123872/45755662-4e643c00-bc1f-11e8-9392-1e021fcf2327.png">


https://github.com/ManageIQ/manageiq-ui-classic/issues/3944