### PR TITLE
Fix adding a new Service Catalog Item

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1298,7 +1298,7 @@ class CatalogController < ApplicationController
     st.long_description = @edit[:new][:display] ? @edit[:new][:long_description] : nil
     st.provision_cost = @edit[:new][:provision_cost]
     st.display = @edit[:new][:display]
-    st.service_template_catalog = if @edit[:new][:catalog_id].nil?
+    st.service_template_catalog = if @edit[:new][:catalog_id].blank?
                                     nil
                                   else
                                     ServiceTemplateCatalog.find(@edit[:new][:catalog_id])

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1268,4 +1268,31 @@ describe CatalogController do
       end
     end
   end
+
+  describe '#common_st_record_vars' do
+    let(:st) { FactoryGirl.create(:service_template) }
+
+    before { controller.instance_variable_set(:@edit, edit) }
+
+    context 'Service Catalog Item without any Catalog' do
+      let(:edit) { {:new => {:catalog_id => ""}} }
+
+      it 'sets service_template_catalog for Service Catalog Item to nil' do
+        controller.send(:common_st_record_vars, st)
+
+        expect(st.service_template_catalog).to be_nil
+      end
+    end
+
+    context 'Service Catalog Item with Catalog' do
+      let(:edit) { {:new => {:catalog_id => stc.id}} }
+      let(:stc) { FactoryGirl.create(:service_template_catalog) }
+
+      it 'sets service_template_catalog for Service Catalog Item to nil' do
+        controller.send(:common_st_record_vars, st)
+
+        expect(st.service_template_catalog).to eq(stc)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1630385
https://bugzilla.redhat.com/show_bug.cgi?id=1631035

There was a problem while adding a new _Service Catalog Item_: nothing happened in the UI, no change, Catalog Item was not saved; no error message; error in log occurred.

**Steps to reproduce:**
1. Go to _Services > Catalogs > Catalog Items_ accordion
2. _Configuration > Add a New Catalog Item_
3. Choose some _Catalog Item Type_ (for example _Generic_)
4. Fill in the _Name_, choose some _Dialog_ (yes, you need to create some Dialog before these steps if there are no ones)
5. Click on _Add_ button
=> error:
```
[----] I, [2018-09-19T15:23:20.118597 #15419:2ac596b87b54]  INFO -- : Started POST "/catalog/servicetemplate_edit?button=add" for ::1 at 2018-09-19 15:23:20 +0200
[----] I, [2018-09-19T15:23:20.146811 #15419:2ac596b87b54]  INFO -- : Processing by CatalogController#servicetemplate_edit as JS
[----] I, [2018-09-19T15:23:20.147030 #15419:2ac596b87b54]  INFO -- :   Parameters: {"ignore_form_changes"=>"", "name"=>"Service Catalog Item", "description"=>"", "catalog_id"=>"", "dialog_id"=>"16", "generic_subtype"=>"custom", "fqname"=>"/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization", "reconfigure_fqname"=>"", "retire_fqname"=>"/Service/Retirement/StateMachines/ServiceRetirement/Default", "long_description"=>"", "button"=>"add"}
[----] W, [2018-09-19T15:23:20.159455 #15419:2ac596b87b54]  WARN -- : DEPRECATION WARNING: Method each_with_object is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7/classes/ActionController/Parameters.html (called from find_checked_items at /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:17)
[----] F, [2018-09-19T15:23:23.138304 #15419:2ac596b87b54] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find ServiceTemplateCatalog with 'id'=
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7/lib/active_record/core.rb:173:in `find'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:1304:in `common_st_record_vars'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:966:in `atomic_req_submit'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:94:in `atomic_st_edit'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:74:in `servicetemplate_edit'
```

**Note:**
You can check _Display in Catalog_ checkbox while creating a Catalog Item but it does not matter. It does not have any influence (comparing to what the BZ says).

---

**Before:**
![item_before](https://user-images.githubusercontent.com/13417815/45756046-3214cf00-bc20-11e8-924b-c8c0f396957f.png)

**After:**
![item_after](https://user-images.githubusercontent.com/13417815/45756382-080fdc80-bc21-11e8-9b7b-c17557024574.png)

---

**Note2:**
`@edit[:new][:catalog_id]` was set to `""` which is not `nil`, obviously. This is why it went to the `else` block https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Service_Catalogs_Cannot_add_new_Service_Catalog_Item?expand=1#diff-956e46b33fb5307990c4e1a4b5fd86ccR1304 and crashed.