### PR TITLE
Refactored cloud_object_store_object_spec with using let variables and removing classification mocking

### DIFF
--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -1,63 +1,58 @@
 describe CloudObjectStoreObjectController do
+  let(:object) { FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-container-01") }
+  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
+  let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
+    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => object)
+    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => object)
+    stub_user(:features => :all)
   end
 
-  let :object do
-    FactoryGirl.create(:cloud_object_store_object)
-  end
-
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @object = FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-container-01")
-      allow(@object).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@container).and_return([@tag1, @tag2])
+  describe "#tags_edit" do
+    before do
       session[:tag_db] = "CloudObjectStoreObject"
-      edit = {
-        :key        => "CloudObjectStoreObject_edit_tags__#{@object.id}",
+      session[:edit] = {
+        :key        => "CloudObjectStoreObject_edit_tags__#{object.id}",
         :tagging    => "CloudObjectStoreObject",
-        :object_ids => [@object.id],
+        :object_ids => [object.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
-      session[:edit] = edit
-    end
-
-    after(:each) do
-      expect(response.status).to eq(200)
     end
 
     it "builds tagging screen" do
-      post :button, :params => { :pressed => "cloud_object_store_object_tag", :format => :js, :id => @object.id }
+      post :button, :params => { :pressed => "cloud_object_store_object_tag", :format => :js, :id => object.id }
+
       expect(assigns(:flash_array)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "cloud_object_store_object/show/#{@object.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @object.id }
+      session[:breadcrumbs] = [{:url => "cloud_object_store_object/show/#{object.id}"}, 'placeholder']
+
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => object.id }
+
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "cloud_object_store_object/show/#{@object.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @object.id }
+      session[:breadcrumbs] = [{:url => "cloud_object_store_object/show/#{object.id}"}, 'placeholder']
+
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => object.id }
+
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
   end
 
-  context "delete object store object" do
+  describe "delete object store object" do
     before do
       login_as FactoryGirl.create(:user, :features => "everything")
       request.parameters["controller"] = "cloud_object_store_object"
@@ -67,6 +62,7 @@ describe CloudObjectStoreObjectController do
 
     it "delete invokes process_cloud_object_storage_buttons" do
       expect(controller).to receive(:process_cloud_object_storage_buttons)
+
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }
@@ -77,6 +73,7 @@ describe CloudObjectStoreObjectController do
         CloudObjectStoreObject,
         'delete'
       )
+
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }
@@ -84,7 +81,9 @@ describe CloudObjectStoreObjectController do
 
     it "delete redirects to previous breadcrumb if on object's details page" do
       session[:cloud_object_store_object_display] = "main"
+
       expect(controller).to receive(:javascript_redirect).with("previous-url")
+
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }
@@ -92,6 +91,7 @@ describe CloudObjectStoreObjectController do
 
     it "delete does not redirect if on object list page" do
       session[:cloud_object_store_object_display] = "show_list"
+
       expect(controller).not_to receive(:javascript_redirect)
 
       post :button, :params => {


### PR DESCRIPTION
### Refactoring of `cloud_object_store_object_spec`

Replaces mocking of `Classification` with **FactoryGirl tagging**
**Let variables** are used instead of `@variables`


Same process as #4634 #4676 #4683

@miq-bot add_label gaprindashvili/no, refactoring, test

@skateman Can you please review it? :pray: 