### PR TITLE
Disable js-scrutinizer-run as it times out all the time

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,4 +18,3 @@ build:
           -
             command: rubocop-run
             use_website_config: false
-          - js-scrutinizer-run


### PR DESCRIPTION
It times out, makes our PRs yellow and/or then red in the list...i.e. it's unusable.

@miq-bot assign @martinpovolny 
@miq-bot add_label gaprindashvili/no, developer