### PR TITLE
Refactored cloud_subnet_controller_spec with using let variables and removing classification mocking

### DIFF
--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,88 +1,80 @@
 describe CloudSubnetController do
-  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon)
+  let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
+  let(:cloud_subnet) { FactoryGirl.create(:cloud_subnet_openstack, :ext_management_system => ems) }
 
-  context "#tags_edit" do
-    let!(:user) { stub_user(:features => :all) }
-    before(:each) do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:cloud_subnet, :name => "cloud-subnet-01")
-      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag1",
-                                 :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
-                                 :name   => "tag2",
-                                 :parent => classification)
-      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
+  before { EvmSpecHelper.create_guid_miq_server_zone }
+
+  describe "#tags_edit" do
+    let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
+    let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
+    let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+    let(:ct) { FactoryGirl.create(:cloud_subnet, :name => "cloud-subnet-01") }
+
+    before do
+      stub_user(:features => :all)
       session[:tag_db] = "CloudSubnet"
-      edit = {
-        :key        => "CloudSubnet_edit_tags__#{@ct.id}",
+      session[:edit] = {
+        :key        => "CloudSubnet_edit_tags__#{ct.id}",
         :tagging    => "CloudSubnet",
-        :object_ids => [@ct.id],
+        :object_ids => [ct.id],
         :current    => {:assignments => []},
-        :new        => {:assignments => [@tag1.id, @tag2.id]}
+        :new        => {:assignments => [tag1.id, tag2.id]}
       }
-      session[:edit] = edit
-    end
-
-    after(:each) do
-      expect(response.status).to eq(200)
     end
 
     it "builds tagging screen" do
-      post :button, :params => { :pressed => "cloud_subnet_tag", :format => :js, :id => @ct.id }
+      post :button, :params => { :pressed => "cloud_subnet_tag", :format => :js, :id => ct.id }
+
       expect(assigns(:flash_array)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "cancels tags edit" do
-      session[:breadcrumbs] = [{:url => "cloud_subnet/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "cloud_subnet/show/#{ct.id}"}, 'placeholder']
+
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => ct.id }
+
       expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
 
     it "save tags" do
-      session[:breadcrumbs] = [{:url => "cloud_subnet/show/#{@ct.id}"}, 'placeholder']
-      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      session[:breadcrumbs] = [{:url => "cloud_subnet/show/#{ct.id}"}, 'placeholder']
+
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => ct.id }
+
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+      expect(response.status).to eq(200)
     end
   end
 
   describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @subnet = FactoryGirl.create(:cloud_subnet)
-      login_as FactoryGirl.create(:user)
-    end
+    let(:subnet) { FactoryGirl.create(:cloud_subnet) }
 
-    subject do
-      get :show, :params => {:id => @subnet.id}
-    end
+    before { login_as FactoryGirl.create(:user) }
 
-    context "render listnav partial" do
-      render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_cloud_subnet")
-      end
+    render_views
+
+    it "renders listnav partial" do
+      get :show, :params => {:id => subnet.id}
+
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:partial => "layouts/listnav/_cloud_subnet")
     end
   end
 
   describe "#new" do
-    let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new)) }
-    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
-    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
-    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
-
     before do
       bypass_rescue
 
-      EvmSpecHelper.create_guid_miq_server_zone
       EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list cloud_network_show_list cloud_tenant_show_list))
 
-      login_as user
+      feature = MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new))
+      role = FactoryGirl.create(:miq_user_role, :miq_product_features => feature)
+      group = FactoryGirl.create(:miq_group, :miq_user_role => role)
+      login_as FactoryGirl.create(:user, :miq_groups => [group])
     end
 
     it "raises exception wheh used have not privilege" do
@@ -107,149 +99,130 @@ describe CloudSubnetController do
   end
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack)
+    let(:cloud_subnet) { FactoryGirl.create(:cloud_subnet_openstack) }
+    let(:task_options) do
+      {
+        :action => "creating Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant) }
+    let(:cloud_network) { FactoryGirl.create(:cloud_network_openstack) }
+    let(:queue_options) do
+      {
+        :class_name  => ems.class.name,
+        :method_name => 'create_cloud_subnet',
+        :instance_id => ems.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{
+          :name         => 'test',
+          :ip_version   => 4,
+          :cloud_tenant => cloud_tenant,
+          :network_id   => cloud_network.ems_ref,
+          :enable_dhcp  => "true"
+        }]
+      }
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
+    before { stub_user(:features => :all) }
 
-      let(:cloud_tenant) do
-        FactoryGirl.create(:cloud_tenant)
-      end
+    it "builds create screen" do
+      post :button, :params => { :pressed => "cloud_subnetnew", :format => :js }
 
-      let(:cloud_network) do
-        FactoryGirl.create(:cloud_network_openstack)
-      end
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      let(:queue_options) do
-        {
-          :class_name  => @ems.class.name,
-          :method_name => 'create_cloud_subnet',
-          :instance_id => @ems.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{
-            :name         => 'test',
-            :ip_version   => 4,
-            :cloud_tenant => cloud_tenant,
-            :network_id   => cloud_network.ems_ref,
-            :enable_dhcp  => "true"
-          }]
-        }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "cloud_subnetnew", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => {
-          :button           => 'add',
-          :controller       => 'cloud_subnet',
-          :format           => :js,
-          :cloud_tenant     => {:id => cloud_tenant.id},
-          :dhcp_enabled     => true,
-          :ems_id           => @ems.id,
-          :id               => 'new',
-          :name             => 'test',
-          :network_protocol => 'ipv4',
-          :network_id       => cloud_network.ems_ref
-        }
-      end
+      post :create, :params => {
+        :button           => 'add',
+        :controller       => 'cloud_subnet',
+        :format           => :js,
+        :cloud_tenant     => {:id => cloud_tenant.id},
+        :dhcp_enabled     => true,
+        :ems_id           => ems.id,
+        :id               => 'new',
+        :name             => 'test',
+        :network_protocol => 'ipv4',
+        :network_id       => cloud_network.ems_ref
+      }
     end
   end
 
   describe "#edit" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "updating Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => cloud_subnet.class.name,
+        :method_name => 'raw_update_cloud_subnet',
+        :instance_id => cloud_subnet.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [{:name => 'test2', :enable_dhcp => false}]
+      }
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
+    before { stub_user(:features => :all) }
 
-      let(:queue_options) do
-        {
-          :class_name  => @cloud_subnet.class.name,
-          :method_name => 'raw_update_cloud_subnet',
-          :instance_id => @cloud_subnet.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => 'test2', :enable_dhcp => false}]
-        }
-      end
+    it "builds edit screen" do
+      post :button, :params => { :pressed => "cloud_subnet_edit", :format => :js, :id => cloud_subnet.id }
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "cloud_subnet_edit", :format => :js, :id => @cloud_subnet.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => {
-          :button => 'save',
-          :format => :js,
-          :id     => @cloud_subnet.id,
-          :name   => 'test2'
-        }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+
+      post :update, :params => {
+        :button => 'save',
+        :format => :js,
+        :id     => cloud_subnet.id,
+        :name   => 'test2'
+      }
     end
   end
 
   describe "#delete" do
+    let(:task_options) do
+      {
+        :action => "deleting Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => cloud_subnet.class.name,
+        :method_name => 'raw_delete_cloud_subnet',
+        :instance_id => cloud_subnet.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      }
+    end
+
     before do
       stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack, :ext_management_system => @ems)
       session[:cloud_subnet_lastaction] = 'show'
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @cloud_subnet.class.name,
-          :method_name => 'raw_delete_cloud_subnet',
-          :instance_id => @cloud_subnet.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @cloud_subnet.id, :pressed => "cloud_subnet_delete", :format => :js }
-      end
+      post :button, :params => { :id => cloud_subnet.id, :pressed => "cloud_subnet_delete", :format => :js }
     end
   end
 
   include_examples '#download_summary_pdf', :cloud_subnet_openstack
+
+  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon)
 end


### PR DESCRIPTION
### Refactoring of `cloud_subnet_controller_spec`

Replaces mocking of `Classification` with **FactoryGirl tagging**
**Let variables** are used instead of `@variables`


Same process as #4634 #4676 #4683

@miq-bot add_label gaprindashvili/no, refactoring, test

@skateman Can you please review it? :pray: It is very similar to #4683