### PR TITLE
bower to npm: patternfly-timeline (@pf3/timeline)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,5 +40,4 @@
 //= require ./miq_explorer
 //= require ./miq_timeline
 //= require bower_components/manageiq-ui-components/dist/js/ui-components
-//= require bower_components/patternfly-timeline/dist/timeline
 //= require ui-select/dist/select

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,7 +19,7 @@
  *= require ./physical_infra_topology
  *= require ./metrics
  *= require ./service_dialogs
- *= require bower_components/patternfly-timeline/dist/timeline
+ *= require @pf3/timeline/style
  *= require bower_components/manageiq-ui-components/dist/css/ui-components
  *= require ui-select/dist/select
  *= require ./remote_console

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -40,3 +40,5 @@ window.moment = require('moment');
 require("moment-strftime");
 require("moment-timezone");
 require("moment-duration-format")(window.moment);
+
+require('@pf3/timeline');

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "tests"
   ],
   "dependencies": {
-    "manageiq-ui-components": "bower-dev",
-    "patternfly-timeline": "~1.0.5"
+    "manageiq-ui-components": "bower-dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
     "@manageiq/react-ui-components": "~0.10.8",
+    "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",
     "angular-bootstrap-switch": "~0.5.2",

--- a/spec/javascripts/globals_pack_spec.js
+++ b/spec/javascripts/globals_pack_spec.js
@@ -46,4 +46,12 @@ describe('packs/global.js', function() {
       expect(angular.module('ui.bootstrap')).toBeDefined();
     });
   });
+
+  context('d3 plugins', function() {
+    it('loads patternfly-timeline', function() {
+      expect(d3.chart.timeline).toBeDefined();
+      expect(d3.chart.timeline().start).toBeDefined();
+      expect(d3.chart.timeline().end).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
~~Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/4641~~

With patternfly-timeline, we need to use a commit version, as 1.0.7 is impossible to install,
and the fix (https://github.com/patternfly/patternfly-timeline/pull/42) was never released (issue https://github.com/patternfly/patternfly-timeline/issues/52).

So, using the current master tip for now.

Issue: #3734 