### PR TITLE
Fix the view details link on notifications that were retrieved via API

### DIFF
--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -116,6 +116,12 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.markRead(notification, group);
   };
 
+  vm.customScope.viewNotificationDetails = function(notification, group) {
+    if (notification.data.link) {
+      eventNotifications.viewDetails(notification, group);
+    }
+  };
+
   vm.customScope.clearNotification = function(notification, group) {
     eventNotifications.clear(notification, group);
   };

--- a/app/views/static/notification_drawer/notification-body.html.haml
+++ b/app/views/static/notification_drawer/notification-body.html.haml
@@ -8,7 +8,7 @@
       %span.fa.fa-ellipsis-v
     %ul.dropdown-menu.dropdown-menu-right{'aria-labelledby' => 'dropdownKebabRight-{{ notification.id }}'}
       %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.data.link}"}
-        %a.secondary-action{:title => _('View details'), 'ng-click' => 'notification.actionCallback(notification)'}
+        %a.secondary-action{:title => _('View details'), 'ng-click' => 'customScope.viewNotificationDetails(notification)'}
           = _('View details')
       %li.divider{:role => 'separator'}
       %li{:role => 'menuitem', 'ng-class' => "{'disabled': !notification.unread}"}


### PR DESCRIPTION
I missed this, my bad :cry: this function in the controller is necessary for the notifications retrieved via API.

Fixes #4686

@miq-bot add_reviewer @AparnaKarve 
@miq-bot assign @himdel 
@miq-bot add_label bug, gaprindashvili/no