### PR TITLE
[GAPRINDASHVILI] Fix spec failures

### DIFF
--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -1,7 +1,8 @@
 describe ReportController do
   context "::Dashboards" do
+    let(:user) { FactoryGirl.create(:user, :features => "db_edit") }
+
     context "#db_edit" do
-      let(:user) { FactoryGirl.create(:user, :features => "db_edit") }
       before :each do
         login_as user
         @db = FactoryGirl.create(:miq_widget_set,

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -1,3 +1,4 @@
+require "util/miq-hash_struct"
 describe OpsController do
   context "OpsController::Settings::Common" do
     context "SmartProxy Affinity" do
@@ -220,7 +221,10 @@ describe OpsController do
     end
 
     describe '#settings_get_info' do
-      before { MiqRegion.seed }
+      before do
+        MiqRegion.seed
+        EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+      end
 
       let(:edit) { controller.instance_variable_get(:@edit) }
 


### PR DESCRIPTION
```
rspec ./spec/controllers/ops_controller/settings/common_spec.rb:236 # OpsController OpsController::Settings::Common #settings_get_info zone node sets ntp server info for display
rspec ./spec/controllers/miq_report_controller/dashboards_spec.rb:54 # ReportController::Dashboards #db_fields_validation No flash message set when tab title is unique within a group
rspec ./spec/controllers/miq_report_controller/dashboards_spec.rb:63 # ReportController::Dashboards #db_fields_validation No flash message set when tab title is changed for Default Dashboard
rspec ./spec/controllers/miq_report_controller/dashboards_spec.rb:45 # ReportController::Dashboards #db_fields_validation display flash message for uniqueness of tab title of dashboard within a group
```
and 
sporadic failure
```
  1) OpsController OpsController::Settings::Common #settings_update won't render form buttons after rhn settings submission
     Failure/Error:
       ::MiqHashStruct.new(
         :registered        => !username.blank?,
         :registration_type => db.registration_type,
         :user_name         => username,
         :server            => db.registration_server,
         :company_name      => db.registration_organization_name,
         :subscription      => rhn_subscription_map[db.registration_type] || 'None',
         :update_repo_name  => db.update_repo_name,
         :version_available => db.cfme_version_available
       )
     
     NameError:
       uninitialized constant MiqHashStruct
     # ./app/controllers/ops_controller/settings/rhn.rb:92:in `rhn_subscription'
     # ./app/controllers/ops_controller/settings/common.rb:1162:in `settings_get_info'
     # ./app/controllers/ops_controller/settings/rhn.rb:145:in `rhn_save_subscription'
     # ./app/controllers/ops_controller/settings/common.rb:353:in `settings_update_save'
     # ./app/controllers/ops_controller/settings/common.rb:163:in `settings_update'

```
when `bundle exec rspec  ./spec/controllers/ops_controller/settings/common_spec.rb -s 13740` is run

@miq-bot add_label test, bug/sporadic test failure