### PR TITLE
Add Physical Chassis link to default menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -89,6 +89,7 @@ module Menu
         Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
           Menu::Item.new('physical_infra_overview', N_('Overview'),  'physical_infra_overview', {:feature => 'physical_infra_overview'},               '/physical_infra_overview'),
           Menu::Item.new('ems_physical_infra',      N_('Providers'), 'ems_physical_infra',      {:feature => 'ems_physical_infra_show_list'},          '/ems_physical_infra'),
+          Menu::Item.new('physical_chassis',        N_('Chassis'),   'physical_chassis',        {:feature => 'physical_chassis_show_list'},            '/physical_chassis'),
           Menu::Item.new('physical_rack',           N_('Racks'),     'physical_rack',           {:feature => 'physical_rack_show_list'},               '/physical_rack'),
           Menu::Item.new('physical_server',         N_('Servers'),   'physical_server',         {:feature => 'physical_server_show_list'},             '/physical_server'),
           Menu::Item.new('physical_storage',        N_('Storages'),  'physical_storage',        {:feature => 'physical_storage_show_list'},            '/physical_storage'),


### PR DESCRIPTION
__This PR is able to__
- Add `Chassis` link into `Compute > Physical Infrastructure`

__Before this PR__
![image](https://user-images.githubusercontent.com/8550928/46078176-cbd10480-c169-11e8-9e9b-3f05593841d1.png)


__After this PR__
![image](https://user-images.githubusercontent.com/8550928/46078086-8c0a1d00-c169-11e8-8fcc-a147235e15f0.png)

@miq-bot add_label bug
@miq-bot add_label hammer/yes
@miq-bot assign @mzazrivec 

https://bugzilla.redhat.com/show_bug.cgi?id=1633186