### PR TITLE
Pass normalized_state into textual summaries for consistency

### DIFF
--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -12,6 +12,6 @@ module TextualMixins::TextualPowerState
   end
 
   def textual_power_state_whitelisted_with_template
-    textual_power_state_whitelisted(@record.template? ? 'template' : @record.current_state)
+    textual_power_state_whitelisted(@record.normalized_state)
   end
 end


### PR DESCRIPTION
The `normalized_state` method should be used for full consistency with quadicons.

**Before:**
![screen-shot-2018-09-25-at-3 05 25-pm](https://user-images.githubusercontent.com/649130/46083579-06569380-c1a2-11e8-9540-c45f0dcec5da.png)

**After:**
![screenshot from 2018-09-26 15-36-15](https://user-images.githubusercontent.com/649130/46083567-00f94900-c1a2-11e8-90f1-6fdd60ce6cd0.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, gaprindashvili/no, hammer/yes
