### PR TITLE
Show correct VMs upon Service retirement

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -793,6 +793,11 @@ module ApplicationController::MiqRequestMethods
         end
         @options[:wf] = options[:wf]
       end
+    elsif @miq_request.resource_type == 'ServiceRetireRequest'
+      @view, @pages = nil
+      if (service_id = @miq_request.options[:src_ids].first) && (service = Service.find_by(:id => service_id)) && Rbac.filtered_object(service)
+        @view, @pages = get_view(Vm, :parent => service, :view_suffix => 'OrchestrationStackRetireRequest')
+      end
     else
       @options = @miq_request.options
       @options[:memory], @options[:mem_typ] = reconfigure_calculations(@options[:vm_memory][0]) if @options[:vm_memory]

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -123,6 +123,8 @@
     = render :partial => "st_prov_show"
   - elsif @miq_request.type == 'ServiceReconfigureRequest'
     = render :partial => "service_reconfigure_show"
+  - elsif @miq_request.type == "ServiceRetireRequest"
+    = render :partial => "service_retire_show"
   - elsif @miq_request.type == "AutomationRequest"
     = render :partial => "ae_prov_show"
   - else

--- a/app/views/miq_request/_service_retire_show.html.haml
+++ b/app/views/miq_request/_service_retire_show.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  %h3
+    = _("Affected VMs")
+  - if @view
+    - @embedded = true
+    - @gtl_type = "list"
+    = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}


### PR DESCRIPTION
With this commit we make sure correct VMs are shown as part of service retirement request. Talking about "Affected VMs" section that now looks like:

![image](https://user-images.githubusercontent.com/8102426/46149043-b3481380-c269-11e8-9ac1-3eb24d217c3a.png)

Prior to this commit there was always only a single VM displayed in there, and it was not the right one. Happened to see AWS EC2 VM on a vCloud vApp retirement request details!

![image](https://user-images.githubusercontent.com/8102426/46149243-2baed480-c26a-11e8-808e-268d56104a83.png)

The reason for all this was that

```
@miq_request.options[:src_ids]
```

was treated as it's a list of VM ids whereas it infact was a list of Service ids. If we were lucky enough, some Service id collided with random VM id and BUUUM, wrong VM was shown.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1632239

Related PRs:
- https://github.com/ManageIQ/manageiq/pull/18023
- https://github.com/ManageIQ/manageiq-content/pull/432
- https://github.com/ManageIQ/manageiq-providers-vmware/pull/324

@miq-bot assign @mzazrivec 
@miq-bot add_label enhancement,gaprindashvili/yes,hammer/yes

/cc @tinaafitz @d-m-u 