### PR TITLE
Put background under archived/orphaned tree node icons in VMs

### DIFF
--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -13,9 +13,12 @@ module TreeBuilderArchived
   end
 
   def x_get_tree_arch_orph_nodes(model_name)
+    archived = QuadiconHelper.machine_state('archived').values_at(:fonticon, :background)
+    orphaned = QuadiconHelper.machine_state('orphaned').values_at(:fonticon, :background)
+
     [
-      {:id => "arch", :text => _("<Archived>"), :icon => "fa fa-archive", :tip => _("Archived %{model}") % {:model => model_name}},
-      {:id => "orph", :text => _("<Orphaned>"), :icon => "ff ff-orphaned", :tip => _("Orphaned %{model}") % {:model => model_name}}
+      {:id => "arch", :text => _("<Archived>"), :icon => archived[0], :icon_background => archived[1], :tip => _("Archived %{model}") % {:model => model_name}},
+      {:id => "orph", :text => _("<Orphaned>"), :icon => orphaned[0], :icon_background => orphaned[1], :tip => _("Orphaned %{model}") % {:model => model_name}}
     ]
   end
 end

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -9,14 +9,16 @@ describe TreeBuilderArchived do
 
   it '#x_get_tree_arch_orph_nodes' do
     nodes = archived.x_get_tree_arch_orph_nodes('VMs/Templates')
-    expect(nodes).to eq([{:id   => "arch",
-                          :text => "<Archived>",
-                          :icon => "fa fa-archive",
-                          :tip  => "Archived VMs/Templates"},
-                         {:id   => "orph",
-                          :text => "<Orphaned>",
-                          :icon => "ff ff-orphaned",
-                          :tip  => "Orphaned VMs/Templates"}])
+    expect(nodes).to eq([{:id              => "arch",
+                          :text            => "<Archived>",
+                          :icon            => "fa fa-archive",
+                          :icon_background => "#336699",
+                          :tip             => "Archived VMs/Templates"},
+                         {:id              => "orph",
+                          :text            => "<Orphaned>",
+                          :icon            => "ff ff-orphaned",
+                          :icon_background => "#336699",
+                          :tip             => "Orphaned VMs/Templates"}])
   end
 
   it '#x_get_tree_custom_kids with hidden Infra VMs returns empty Array' do

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -34,14 +34,16 @@ describe TreeBuilderImages do
   it 'sets providers nodes correctly' do
     providers = @images_tree.x_get_tree_roots(false, nil)
     expect(providers).to eq([@template_cloud_with_az.ext_management_system,
-                             {:id   => "arch",
-                              :text => "<Archived>",
-                              :icon => "fa fa-archive",
-                              :tip  => "Archived Images"},
-                             {:id   => "orph",
-                              :text => "<Orphaned>",
-                              :icon => "ff ff-orphaned",
-                              :tip  => "Orphaned Images"}])
+                             {:id              => "arch",
+                              :text            => "<Archived>",
+                              :icon            => "fa fa-archive",
+                              :icon_background => "#336699",
+                              :tip             => "Archived Images"},
+                             {:id              => "orph",
+                              :text            => "<Orphaned>",
+                              :icon            => "ff ff-orphaned",
+                              :icon_background => "#336699",
+                              :tip             => "Orphaned Images"}])
   end
 
   it 'sets Templates nodes to empty Array if VMs/Templates are hidden' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -40,14 +40,16 @@ describe TreeBuilderInstances do
 
     expect(providers).to eq([@vm_cloud_with_az.ext_management_system,
                              @vm_cloud_without_az.ext_management_system,
-                             {:id   => "arch",
-                              :text => "<Archived>",
-                              :icon => "fa fa-archive",
-                              :tip  => "Archived Instances"},
-                             {:id   => "orph",
-                              :text => "<Orphaned>",
-                              :icon => "ff ff-orphaned",
-                              :tip  => "Orphaned Instances"}])
+                             {:id              => "arch",
+                              :text            => "<Archived>",
+                              :icon            => "fa fa-archive",
+                              :icon_background => "#336699",
+                              :tip             => "Archived Instances"},
+                             {:id              => "orph",
+                              :text            => "<Orphaned>",
+                              :icon            => "ff ff-orphaned",
+                              :icon_background => "#336699",
+                              :tip             => "Orphaned Instances"}])
   end
 
   it 'sets availability zones correctly if vms are hidden' do


### PR DESCRIPTION
This will make the tree nodes fully consistent with the quads.

**Before:**
![screenshot from 2018-09-27 15-57-56](https://user-images.githubusercontent.com/649130/46150993-23f12f00-c26e-11e8-8b65-e30fe05a0eda.png)

**After:**
![screenshot from 2018-09-27 15-53-43](https://user-images.githubusercontent.com/649130/46150996-26538900-c26e-11e8-86a0-3b5a2b2dd43f.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label gaprindashvili/no, hammer/yes, graphics