### PR TITLE
Show acknowledgement when saving replication settings

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -205,19 +205,8 @@ module OpsController::Settings::Common
       task_opts  = {:action => "Set replication type to none", :userid => session[:userid]}
       queue_opts = {:class_name => "MiqRegion", :method_name => "replication_type=", :args => [:none]}
     end
-    task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
-    initiate_wait_for_task(:task_id => task_id, :action => "pglogical_save_finished")
-  end
-
-  def pglogical_save_finished
-    task = MiqTask.find(session[:async][:params][:task_id])
-    if task.nil?
-      add_flash(_("Unknown result of saving replication configuration: task not found"), :error)
-    elsif MiqTask.status_ok?(task.status)
-      add_flash(_("Replication configuration save was successful"))
-    else
-      add_flash(_("Error during replication configuration save: %{message}") % {:message => task.message }, :error)
-    end
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    add_flash(_("Replication configuration save initiated. Check status of task '#{task_opts[:action]}' on MyTasks screen"))
     javascript_flash
   end
 


### PR DESCRIPTION
**Issue**: When queuing saving replication settings there is no confirmation after user clicking on Save button and it is not clear if task queued or not.

**After**:
![screen shot 2018-09-27 at 3 50 48 pm](https://user-images.githubusercontent.com/6556758/46171023-5baba700-c26d-11e8-974f-77e4e7a6a7ab.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1633653

@miq-bot add-label bug, hammer/yes
