### PR TITLE
Fix wrapping switch

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -517,6 +517,10 @@ table.table td:not(.table-view-pf-select) {
   word-break: break-all;
 }
 
+table.table td .bootstrap-switch {
+  word-break: keep-all;
+}
+
 #gtl_div table.table td {
   // Enable word wrapping
   word-break: normal !important;


### PR DESCRIPTION
This PR fixes a bug where the bootstrap switches wrapped on some screens.

Old
<img width="1129" alt="screen shot 2018-09-28 at 12 57 44 pm" src="https://user-images.githubusercontent.com/1287144/46222417-375bd300-c31e-11e8-8634-2dce5634b6c7.png">

New
<img width="1120" alt="screen shot 2018-09-28 at 12 54 22 pm" src="https://user-images.githubusercontent.com/1287144/46222419-37f46980-c31e-11e8-83ca-0238d45fba05.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1549076