### PR TITLE
[WIP] Fix losing focus of the form while renaming a VM

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/rename.rb
+++ b/app/controllers/mixins/actions/vm_actions/rename.rb
@@ -35,7 +35,6 @@ module Mixins
           @changed = changed = session[:changed] = @edit[:new] != @edit[:current]
           render :update do |page|
             page << javascript_prologue
-            page.replace_html('main_div', :partial => 'vm_common/rename')
             page << javascript_for_miq_button_visibility(changed)
             page << "miqSparkle(false);"
           end

--- a/app/views/vm_common/_rename.html.haml
+++ b/app/views/vm_common/_rename.html.haml
@@ -1,21 +1,19 @@
-#main_div
-  - url = url_for_only_path(:action => 'name_changed', :id => @record.id)
-  = render :partial => 'layouts/flash_msg'
+- url = url_for_only_path(:action => 'name_changed', :id => @record.id)
+= render :partial => 'layouts/flash_msg'
 
-  %h3
-    = _('Basic Information')
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Name')
-      .col-md-8
-        = text_field_tag('name',
-                          @edit[:new][:name],
-                          :class           => 'form-control',
-                          "data-miq_focus" => true,
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+%h3
+  = _('Basic Information')
+.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
+      = _('Name')
+    .col-md-8
+      = text_field_tag('name',
+                        @edit[:new][:name],
+                        :class             => 'form-control',
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 
-- if @changed.nil? && !@edit[:explorer]
+- if @changed.nil?
   = render(:partial => '/layouts/edit_form_buttons',
            :locals  => {:action_url   => 'rename_vm',
                         :ajax_buttons => true,


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1628723

This PR fixes losing focus of the form while renaming a VM under _Compute > Infra > VMs_ and also any VM from any nested list of VMs (for example VMs displayed thru provider's details page).

**Note:**
Renaming VMs is supported only for VMs of vmWare provider.

---

**Before:**

**After:**
![rename-after](https://user-images.githubusercontent.com/13417815/46287589-53ac7980-c583-11e8-94d7-841cc05cc16b.png)
