### PR TITLE
Remove full_ids from infra networking tree to fix error in selection

### DIFF
--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -10,7 +10,6 @@ class TreeBuilderInfraNetworking < TreeBuilder
     {
       :leaf     => "Switch",
       :open_all => true,
-      :full_ids => true
     }
   end
 


### PR DESCRIPTION
Steps to reproduce:
Compute -> Infrastructure -> Networking -> select a switch in summary of another node like root

(You need to have some `Switch` with `shared` set to `true`.)

**Before:**
Switch node isn't selected but summary of the switch is displayed
<img width="1203" alt="screen shot 2018-10-03 at 12 07 03 pm" src="https://user-images.githubusercontent.com/9210860/46404238-e163a280-c704-11e8-8fe1-b79ffe530c9f.png">

**After:**
Summary and selected node match each other.
<img width="1208" alt="screen shot 2018-10-03 at 12 05 17 pm" src="https://user-images.githubusercontent.com/9210860/46404264-f04a5500-c704-11e8-9ed7-5ce52be68b4a.png">

@miq-bot add_label bug, trees

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460992