### PR TITLE
Fixes disabled 'Show full screen report' button on Saved Reports page

### DIFF
--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -24,8 +24,8 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
           :onwhen  => "1",
           :url     => "/report_only",
           :popup   => true,
-          :confirm => N_("This will show the entire report (all rows) in your browser.  Do you want to proceed?"),
-          :klass   => ApplicationHelper::Button::ReportOnly),
+          :confirm => N_("This will show the entire report (all rows) in your browser.  Do you want to proceed?")
+        ),
         button(
           :saved_report_delete,
           'pficon pficon-delete fa-lg',


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1632630

**Additional Issue** https://github.com/ManageIQ/manageiq-ui-classic/issues/4733 (the show fullscreen report still won't work properly, but that is a different issue)

### Steps to Reproduce:
1. Queue 2-3 reports. Make sure at least one of them is non-empty.
2. Go to 'Saved Reports' Accordian.
3. Select one of the reports(non-empty report) from the table. 
4. Click on 'Configuration' and check if 'Show full screen report' is enabled/active.

It should be enabled, but it isn't.

### Before

![screenshot from 2018-10-05 11-47-12](https://user-images.githubusercontent.com/32869456/46528589-6d580480-c894-11e8-908e-98c33bd29d6f.png)

### After

![screenshot from 2018-10-05 11-45-18](https://user-images.githubusercontent.com/32869456/46528565-5ca78e80-c894-11e8-9af5-1edd7ab55f14.png)


@miq-bot add_label gaprindashvili/no, hammer/yes, bug, cloud intel/reporting

**Credits**

It was solved by help of @romanblanco 