### PR TITLE
Add validation for cloud_networks and subnets

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -22,12 +22,15 @@ module HostHelper::TextualSummary
   end
 
   def textual_group_relationships
+    additions = []
+    additions.push(:cloud_networks) if @record.respond_to?(:cloud_networks)
+    additions.push(:cloud_subnets) if @record.respond_to?(:cloud_subnets)
     TextualGroup.new(
       _("Relationships"),
       %i(
         ems cluster availability_zone used_tenants storages resource_pools vms templates drift_history
-        physical_server network_manager custom_button_events cloud_networks cloud_subnets
-      )
+        physical_server network_manager custom_button_events
+      ) + additions
     )
   end
 


### PR DESCRIPTION
Added conditions, validating if `cloud_networks` and `cloud_subnets` are present for infra host
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635126