### PR TITLE
Fixed links for vm/templates to instances/images on cloud dashboard

### DIFF
--- a/app/services/ems_cloud_dashboard_service.rb
+++ b/app/services/ems_cloud_dashboard_service.rb
@@ -37,8 +37,8 @@ class EmsCloudDashboardService < EmsDashboardService
     attr_url = {
       :flavors            => "flavors",
       :cloud_tenants      => "cloud_tenants",
-      :miq_templates      => "miq_templates",
-      :vms                => "vms",
+      :miq_templates      => "images",
+      :vms                => "instances",
       :availability_zones => "availability_zones",
       :security_groups    => "security_groups",
       :cloud_networks     => "cloud_networks",


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1636160

before:
![before](https://user-images.githubusercontent.com/3450808/46572103-50800780-c94e-11e8-8c32-6bde7899e2ce.png)

after:
![after](https://user-images.githubusercontent.com/3450808/46572104-54138e80-c94e-11e8-9f08-c2208ce1919a.png)

