### PR TITLE
Removing button for showing fullscreen report from list view

### DIFF
--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -16,17 +16,6 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
       t,
       :items => [
         button(
-          :report_only,
-          'fa fa-file-text-o fa-lg',
-          t = N_('Show full screen Report'),
-          t,
-          :enabled => false,
-          :onwhen  => "1",
-          :url     => "/report_only",
-          :popup   => true,
-          :confirm => N_("This will show the entire report (all rows) in your browser.  Do you want to proceed?")
-        ),
-        button(
           :saved_report_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Delete selected Saved Reports'),


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1632630
Closes: https://github.com/ManageIQ/manageiq-ui-classic/issues/4733

response to my comment https://github.com/ManageIQ/manageiq-ui-classic/pull/4734#issuecomment-427394095.

Rather than modifying the button so it's never visible for the list view it's better to remove it completely from the toolbar

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/issues/4733
* https://bugzilla.redhat.com/show_bug.cgi?id=1632630

Steps for Testing/QA
-------------------------------

Cloud Intel - Reports - Saved Reports accordion

* the "Show full screen Report" will only be available on the detail of the report