### PR TITLE
Adding back a Tag as a filter to the PhysicalInfra topology

### DIFF
--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -28,6 +28,10 @@
           %label
             %i.pficon.pficon-virtual-machine
             = _("VMs")
+        %kubernetes-topology-filter{tooltipOptions, "filter-property" => "kind", "filter-value" => "Tag"}
+          %label
+            %i.fa.fa-tag
+            = _("Tags")
       .topology-filter-group
         %label#health_state
           = _("Health State: ")


### PR DESCRIPTION
At some point this filter was removed, so I am adding it again
![screenshot-localhost-3000-2018 10 08-17-03-21](https://user-images.githubusercontent.com/3654285/46630805-ad7ce880-cb1b-11e8-9fdb-c6e46df81846.png)



![image](https://user-images.githubusercontent.com/3654285/46630797-a81f9e00-cb1b-11e8-98d0-1553eb1d994f.png)
