### PR TITLE
Fix error for Datastore custom button

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -76,18 +76,22 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
         if (vm.openUrl === "true") {
           return API.wait_for_task(response.task_id)
             .then(function(response) {
-              return $http.post("open_url_after_dialog", {targetId: vm.targetId})
-                .then(function(response) {
-                  window.open(response.data.open_url);
-                  miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
-                });
+              return $http.post("open_url_after_dialog", {targetId: vm.targetId});
+            })
+            .then(function(response) {
+              window.open(response.data.open_url);
+              miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
+            })
+            .catch(function() {
+              return Promise.reject({data: {error: {message: '-'.concat(__('Automate failed to obtain URL.')) }}});
             });
         } else {
           miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
         }
-    }).catch(function(err) {
-      return Promise.reject(dialogUserSubmitErrorHandlerService.handleError(err));
-    });
+      })
+      .catch(function(err) {
+        dialogUserSubmitErrorHandlerService.handleError(err);
+      });
   }
 
   function cancelClicked(_event) {

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -79,8 +79,13 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
               return $http.post("open_url_after_dialog", {targetId: vm.targetId});
             })
             .then(function(response) {
-              window.open(response.data.open_url);
-              miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
+              if (response.data.open_url) {
+                window.open(response.data.open_url);
+                miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
+              } else {
+                miqService.miqFlash('error', __('Automate failed to obtain URL.'));
+                miqService.sparkleOff();
+              };
             })
             .catch(function() {
               return Promise.reject({data: {error: {message: '-'.concat(__('Automate failed to obtain URL.')) }}});

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -254,7 +254,8 @@ module ApplicationController::Buttons
   end
 
   def open_url_after_dialog
-    url = SystemConsole.find_by(:vm_id => params[:targetId]).url
+    system_console = SystemConsole.find_by(:vm_id => params[:targetId])
+    url = system_console.try(:url)
     render :json => {:open_url => url}
   end
 

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -10,6 +10,7 @@
   - dialog_id ||= @dialog_locals[:dialog_id]
   - resource_action_id ||= @dialog_locals[:resource_action_id]
   - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
+  - open_url ||= @dialog_locals[:open_url]
 
 - force_old_dialog_use ||= true if api_submit_endpoint.nil?
 

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -219,11 +219,11 @@ describe('dialogUserController', function() {
       });
 
       it('delegates to the dialogUserSubmitErrorHandlerService', function(done) {
-        $controller.submitButtonClicked()
-          .catch(function() {
-            expect(dialogUserSubmitErrorHandlerService.handleError).toHaveBeenCalledWith(rejectionData);
-            done();
-          });
+        $controller.submitButtonClicked();
+        setTimeout(function() {
+          expect(dialogUserSubmitErrorHandlerService.handleError).toHaveBeenCalledWith(rejectionData);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
- Add open_url to local_options for non-explorer screens
- Fix error handling when Automate does not return url

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1574403
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635797

Create custom button with dialog but without Open URL for Datastore with `Display for` set to `Single`.

Automation -> Automate -> Customization -> Buttons

Go to Datastore summary page and click the new button.

Before:
```
FATAL -- : Error caught: [ActionView::Template::Error] undefined local variable or method `open_url' for #<#<Class:0x00007fab97d529e8>:0x00007fab89690820>
Did you mean?  ops_url
manageiq-ui-classic/app/views/shared/dialogs/_dialog_provision.html.haml:45:in `__anage___manageiq_ui_classic_app_views_shared_dialogs__dialog_provision_html_haml__1101056942674079458_70187113809480'
```
<img width="1194" alt="screen shot 2018-10-15 at 4 08 59 pm" src="https://user-images.githubusercontent.com/9210860/46956111-c0039e80-d094-11e8-8495-ee9a66b29a44.png">

After:
Without Open URL
<img width="1196" alt="screen shot 2018-10-16 at 10 30 25 am" src="https://user-images.githubusercontent.com/9210860/47002970-841d1780-d12e-11e8-9236-7947b243fed1.png">
With Open URL
<img width="1200" alt="screen shot 2018-10-16 at 4 39 26 pm" src="https://user-images.githubusercontent.com/9210860/47024481-11c62a80-d162-11e8-9535-df7b6b15547e.png">


@miq-bot add_label wip, bug, hammer/yes, gaprindashvili/yes