### PR TITLE
Fixing the overview background color

### DIFF
--- a/app/controllers/physical_infra_overview_controller.rb
+++ b/app/controllers/physical_infra_overview_controller.rb
@@ -9,6 +9,7 @@ class PhysicalInfraOverviewController < ApplicationController
   after_action :set_session_data
 
   def show
+    @lastaction = 'show_dashboard'
     if params[:id].nil?
       @breadcrumbs.clear
     end


### PR DESCRIPTION
The background color of the PhysicalInfra Overview page was a little off, this is a fix for that.

https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_center_div_no_listnav.html.haml#L9
Here it adds the style for the background only if the `@lastaction` is `show_dashboard`