### PR TITLE
Use report default options for Report screens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1343,7 +1343,14 @@ class ApplicationController < ActionController::Base
   end
 
   def perpage_key(dbname)
-    %w(job miqtask).include?(dbname) ? :job_task : PERPAGE_TYPES[@gtl_type]
+    case dbname
+    when "miqreportresult"
+      :reports
+    when "job", "miqtask"
+      :job_task
+    else
+      PERPAGE_TYPES[dbname]
+    end
   end
 
   # Create view and paginator for a DB records with/without tags

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -39,5 +39,12 @@ describe ApplicationController do
       expect(controller).to receive(:view_to_hash)
       controller.report_data
     end
+
+    it "should have default number of perpage records set for reports" do
+      controller.instance_variable_set(:@_params, :model_name => "MiqReportResult")
+      allow(controller).to receive(:settings_default).with(10, :perpage, :reports).and_return(5)
+      report_data = JSON.parse(controller.report_data)
+      expect(report_data["settings"]["perpage"]).to eql(5)
+    end
   end
 end


### PR DESCRIPTION
Reports on Save Report screen, should use default item count per page which is set in My Settings for Reports. `@gtl_type` variable used from deriving the per page count only can be `grid`, `tile` or `list`

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1616201


Steps for Testing/QA [Optional]
-------------------------------
1. Go to My Settings > Visual.
2. Inside 'Default Items Per Page', set 'Reports' limit to anything except 20.
3. Go to Cloud Intel > Reports > Saved Reports > All Saved Reports.
4. If there aren't any saved reports, queue a report.
5. On the `All Saved Reports`, check the paginator - value remains 20. 


