### PR TITLE
Fix adding a new Service Catalog Item for Vmware Catalog Item Type

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -937,7 +937,7 @@ class CatalogController < ApplicationController
     # set request for non generic ST
     if @edit[:wf] && need_prov_dialogs?(@edit[:new][:st_prov_type])
       request = @edit[:wf].make_request(@edit[:req_id], @edit[:new])
-      if request&.errors.present?
+      if request && request&.errors.present?
         request.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1630385

**What:**
There was a problem while adding a new Service Catalog Item for _Vmware_ Catalog Item Type: nothing happened in the UI, no change, Catalog Item was not saved; no error message; error in log occurred.

**Steps to reproduce:**
1. Go to _Services > Catalogs > Catalog Items_ accordion
2. _Configuration > Add a New Catalog Item_
3. Choose _Catalog Item Type_: _VMware_
4. Fill in the _Name_, choose some _Dialog_ (yes, you need to create some Dialog before these steps if there are no ones), no matter if you choose some _Catalog_ or not
5. Click on _Add_ button
=> error:
```
[1] pry(#<ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow>)> 
[----] F, [2018-10-09T16:17:08.243588 #18459:2b22530a6b6c] FATAL -- : Error caught: [NoMethodError] undefined method `errors' for false:FalseClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:940:in `atomic_req_submit'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:94:in `atomic_st_edit'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:74:in `servicetemplate_edit'
```

**Note:**
You can check _Display in Catalog_ checkbox, while creating a Catalog Item, but it does not matter. It does not have any influence (comparing to what the BZ says).

---

**Before:** (nothing happens in the ui, no flash message, error in log)
![cat_item_before](https://user-images.githubusercontent.com/13417815/46675685-41fc4f00-cbdf-11e8-8691-d9ce81219227.png)

**After:** (another required info was not filled in so flash messages occur)
![cat_item-after](https://user-images.githubusercontent.com/13417815/46675690-445ea900-cbdf-11e8-83ee-135380bc223d.png)

---

**Note2:** (see the commit https://github.com/ManageIQ/manageiq-ui-classic/pull/4750/commits/56e02919db1a7d07bb07d18c07d9188ac75efdb6)
Since `request` can be boolean or an object, I added `request &&` to the appropriate line.
See this:
```
[1] pry(#<CatalogController>)> request&.errors.present?
NoMethodError: undefined method `errors' for false:FalseClass
from (pry):4:in `atomic_req_submit'
```
vs.
```
[2] pry(#<CatalogController>)> 
[3] pry(#<CatalogController>)> request && request&.errors.present?
=> false
```
https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_workflow.rb#L84 returns `false`