### PR TITLE
Do not allow to embed a method into itself in automate

### DIFF
--- a/app/assets/javascripts/controllers/miq_ae_class/ae_inline_method_selection_controller.js
+++ b/app/assets/javascripts/controllers/miq_ae_class/ae_inline_method_selection_controller.js
@@ -8,7 +8,6 @@
     vm.$uibModal = $uibModal;
 
     vm.includeDomain = false;
-    vm.selectable = {key: '^aem-'};
 
     vm.$http.get('/tree/automate_inline_methods').then(function(response) {
       vm.data = response.data;

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -498,6 +498,7 @@ class MiqAeClassController < ApplicationController
       id = x_node.split('-')
     end
     @ae_method = find_record_with_rbac(MiqAeMethod, id[1])
+    @selectable_methods = embedded_method_regex(@ae_method.fqname)
     if @ae_method.location == "playbook"
       angular_form_specific_data
     else
@@ -1639,6 +1640,7 @@ class MiqAeClassController < ApplicationController
 
   def embedded_methods_add
     submit_embedded_method(URI.unescape(params[:fqname]))
+    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname)
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -1651,6 +1653,7 @@ class MiqAeClassController < ApplicationController
 
   def embedded_methods_remove
     @edit[:new][:embedded_methods].delete_at(params[:id].to_i)
+    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname)
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -1692,6 +1695,12 @@ class MiqAeClassController < ApplicationController
   end
 
   private
+
+  # Builds a regular expression that controls the selectable items in the ae_methods tree
+  def embedded_method_regex(fqname)
+    ids = MiqAeMethod.get_homonymic_across_domains(current_user, fqname).map { |m| "(#{m.id})" }
+    ids.join('|')
+  end
 
   def playbook_inputs(method)
     existing_inputs = method.inputs

--- a/app/views/miq_ae_class/_embedded_methods.html.haml
+++ b/app/views/miq_ae_class/_embedded_methods.html.haml
@@ -17,7 +17,7 @@
     %hr
     %h3
       = _('Embedded Methods')
-    #automate-inline-method-select{'ng-controller' => 'aeInlineMethodSelectionController as vm'}
+    #automate-inline-method-select{'ng-controller' => 'aeInlineMethodSelectionController as vm', 'ng-init' => "vm.selectable = {key: '^aem-(?!#{@selectable_methods}$)'};"}
       .pull-right
         %button.btn.btn-primary{:type        => "button",
                                 'ng-click'   => 'vm.openModal();',


### PR DESCRIPTION
Thanks to the `selectable` attribute of the `miq-tree-selector` component, it is possible to prevent to select a specific embedded method(s) in the tree. I am building here a regular expression from all the homonymic methods so the same method in an other domain cannot be selected.

@miq-bot add_reviewer @pkomanek 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label bug, hammer/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1633815