### PR TITLE
[GAPRINDASHVILI] Fix failing specs

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -856,9 +856,10 @@ end
 
 describe ServiceController do
   context "#vm_button_operation" do
+    let(:zone) { FactoryGirl.create(:zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+
     before do
-      _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       controller.instance_variable_set(:@lastaction, "show_list")
     end
 
@@ -908,9 +909,10 @@ end
 
 describe VmOrTemplateController do
   context "#vm_button_operation" do
+    let(:zone) { FactoryGirl.create(:zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+
     before do
-      _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
-      allow(MiqServer).to receive(:my_zone).and_return("default")
       controller.instance_variable_set(:@lastaction, "show_list")
     end
 


### PR DESCRIPTION
Fixes following specs:
```
rspec ./spec/controllers/application_controller/ci_processing_spec.rb:865 # ServiceController#vm_button_operation should continue to retire a service and does not render flash message 'xxx does not apply xxx' 
rspec ./spec/controllers/application_controller/ci_processing_spec.rb:934 # VmOrTemplateController#vm_button_operation should continue to retire a vm
```
Related to `Zone` changes in https://github.com/ManageIQ/manageiq/pull/17987

cc @simaishi 

@skateman please have a look, thanks :)

@miq-bot add_label test