### PR TITLE
[GAPRINDASHVILI] Add listicon parameter for child stack display

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -25,7 +25,7 @@ class OrchestrationStackController < ApplicationController
   end
 
   def display_children
-    show_association('children', _('Children'), :children, OrchestrationStack)
+    show_association('children', _('Children'), 'orchestration_stack', :children, OrchestrationStack)
   end
 
   def show_list


### PR DESCRIPTION
This is an additional fix for gaprindashvili branch for backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/4464

Without this fix, the following error would show when clicking on child orchestration stacks:
```
FATAL -- : Error caught: [ArgumentError] wrong number of arguments (given 4, expected 5..7)
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/mixins/explorer_show.rb:11:in `show_association'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/orchestration_stack_controller.rb:28:in `display_children'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/mixins/generic_show_mixin.rb:137:in `public_send'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/mixins/generic_show_mixin.rb:137:in `nested_list_call'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/mixins/generic_show_mixin.rb:141:in `display_nested_list'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-52fa82a4ed63/app/controllers/mixins/generic_show_mixin.rb:31:in `show'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1623561