### PR TITLE
Travis - change postgresql to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   bundler: true
   yarn: true
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 env:
   matrix:
   - TEST_SUITE=spec


### PR DESCRIPTION
This changes the version of postgresql we're using on travis to 9.5.

Matches core: https://github.com/ManageIQ/manageiq/pull/15994

This fixes the current travis breakage:

```
PG::UndefinedFunction: ERROR:  function array_position(bigint[], bigint) does not exist
```

(introduced in https://github.com/ManageIQ/manageiq/pull/18060, but only because we no longer support 9.4).

Discussion in https://github.com/ManageIQ/manageiq/pull/18060
(more changes to clean up 9.4 mentions will follow in separate PRs)