### PR TITLE
Fix for javascript error when attempting to edit a service dialog based on orchestration template

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -83,10 +83,7 @@
                                              options_for_select(val.collect(&:reverse), field.default_value),
                                              drop_down_options(field, "someURL"))
                                 :javascript
-                                  dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}',
-                                                                                  '#{field.id}',
-                                                                                  undefined,
-                                                                                  '#{field.trigger_auto_refresh}');
+                                  miqInitSelectPicker();
 
                             - else
                               - val.each_with_index do |rb, i|


### PR DESCRIPTION
The issue states that there was an infinite spinner when clicking on the dialog to edit in the Automate -> Customization section, which uses the sample page to initially show the dialog.  However, the sample page has no reason to call the offending method `initializeDialogSelectPicker` since that method sets up the field to call to a url and/or trigger refreshes which make no sense on the sample page. Thus, we should simply use `miqInitSelectPicker` to give us the patternfly styling we want without the unnecessary setup.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638420

@miq-bot assign @h-kataria 
@miq-bot add_label bug
