### PR TITLE
Add dashboard for cloud tenant

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -1,5 +1,4 @@
 class CloudTenantController < ApplicationController
-  include Mixins::GenericShowMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
@@ -9,6 +8,8 @@ class CloudTenantController < ApplicationController
   include Mixins::GenericButtonMixin
   include Mixins::GenericFormMixin
   include Mixins::GenericSessionMixin
+  include Mixins::DashboardViewMixin
+  include Mixins::GenericShowMixin
 
   # handle buttons pressed on the button bar
   def button

--- a/app/controllers/cloud_tenant_dashboard_controller.rb
+++ b/app/controllers/cloud_tenant_dashboard_controller.rb
@@ -1,0 +1,61 @@
+class CloudTenantDashboardController < ApplicationController
+  extend ActiveSupport::Concern
+
+  before_action :check_privileges
+  before_action :get_session_data
+  before_action :get_tenant, :only => %i(data recent_instances_data recent_images_data aggregate_status_data)
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def show
+    if params[:id].nil?
+      @breadcrumbs.clear
+    end
+  end
+
+  def data
+    render :json => {:data => collect_data}
+  end
+
+  def recent_instances_data
+    render :json => {:data => recent_instances}
+  end
+
+  def recent_images_data
+    render :json => {:data => recent_images}
+  end
+
+  def aggregate_status_data
+    render :json => {:data => aggregate_status}
+  end
+
+  private
+
+  def collect_data
+    CloudTenantDashboardService.new(@tenant, self, EmsCloud).all_data
+  end
+
+  def recent_instances
+    CloudTenantDashboardService.new(@tenant, self, EmsCloud).recent_instances_data
+  end
+
+  def recent_images
+    CloudTenantDashboardService.new(@tenant, self, EmsCloud).recent_images_data
+  end
+
+  def aggregate_status
+    CloudTenantDashboardService.new(@tenant, self, EmsCloud).aggregate_status_data
+  end
+
+  def get_session_data
+    @layout = "cloud_tenant_dashboard"
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+
+  def get_tenant
+    @tenant = find_record_with_rbac(CloudTenant, params[:id])
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud_tenant_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenant_center.rb
@@ -34,4 +34,23 @@ class ApplicationHelper::Toolbar::CloudTenantCenter < ApplicationHelper::Toolbar
       ]
     ),
   ])
+  button_group('ems_cloud', [
+    twostate(
+      :view_dashboard,
+      'fa fa-tachometer fa-1xplus',
+      N_('Dashboard View'),
+      nil,
+      :url       => "/show/",
+      :url_parms => "?display=dashboard",
+      :klass     => ApplicationHelper::Button::ViewDashboard
+    ),
+    twostate(
+      :view_summary,
+      'fa fa-th-list',
+      N_('Summary View'),
+      nil,
+      :url       => "/show/",
+      :url_parms => "?display=main"
+    ),
+  ])
 end

--- a/app/services/cloud_tenant_dashboard_service.rb
+++ b/app/services/cloud_tenant_dashboard_service.rb
@@ -1,0 +1,53 @@
+class CloudTenantDashboardService < EmsCloudDashboardService
+  include Mixins::CheckedIdMixin
+
+  def initialize(tenant, controller, klass)
+    @ems_id = tenant.ext_management_system.id
+    @ems = find_record_with_rbac(klass, @ems_id) if @ems_id.present?
+    @tenant_id = tenant.id
+    @conroller = controller
+  end
+
+  def attributes_data
+    attributes = %i(cloud_object_store_containers miq_templates vms security_groups cloud_networks cloud_subnets network_ports cloud_volumes)
+
+    attr_icon = {
+      :cloud_object_store_containers => "ff ff-cloud-object-store",
+                      :miq_templates => "fa fa-database",
+                                :vms => "pficon pficon-virtual-machine",
+                    :security_groups => "pficon pficon-cloud-security",
+                     :cloud_networks => "ff ff-cloud-network",
+                      :cloud_subnets => "pficon pficon-network",
+                      :network_ports => "ff ff-network-port",
+                      :cloud_volumes => "pficon pficon-volume"
+    }
+
+    attr_url = {
+      :cloud_object_store_containers => "cloud_object_store_containers",
+                      :miq_templates => "images",
+                                :vms => "instances",
+                    :security_groups => "security_groups",
+                     :cloud_networks => "cloud_networks",
+                      :cloud_subnets => "cloud_subnets",
+                      :network_ports => "network_ports",
+                      :cloud_volumes => "cloud_volumes"
+    }
+
+    attr_hsh = {
+      :cloud_object_store_containers => _("Cloud Object Store Containers"),
+                      :miq_templates => _("Images"),
+                                :vms => _("Instances"),
+                    :security_groups => _("Security Groups"),
+                     :cloud_networks => _("Cloud Networks"),
+                      :cloud_subnets => _("Cloud Subnets"),
+                      :network_ports => _("Network Ports"),
+                      :cloud_volumes => _("Cloud Volumes")
+    }
+
+    format_data('cloud_tenant', attributes, attr_icon, attr_url, attr_hsh)
+  end
+
+  def get_url(resource, _ems_id, attr_url)
+    "/#{resource}/show/#{@tenant_id}?display=#{attr_url}"
+  end
+end

--- a/app/services/ems_cloud_dashboard_service.rb
+++ b/app/services/ems_cloud_dashboard_service.rb
@@ -46,14 +46,14 @@ class EmsCloudDashboardService < EmsDashboardService
     }
 
     attr_hsh = {
-      :flavors            => "Flavors",
-      :cloud_tenants      => "Cloud Tenants",
-      :miq_templates      => "Images",
-      :vms                => "Instances",
-      :availability_zones => "Availability Zones",
-      :security_groups    => "Security Groups",
-      :cloud_networks     => "Cloud Networks",
-      :cloud_volumes      => "Cloud Volumes"
+      :flavors            => _("Flavors"),
+      :cloud_tenants      => _("Cloud Tenants"),
+      :miq_templates      => _("Images"),
+      :vms                => _("Instances"),
+      :availability_zones => _("Availability Zones"),
+      :security_groups    => _("Security Groups"),
+      :cloud_networks     => _("Cloud Networks"),
+      :cloud_volumes      => _("Cloud Volumes")
     }
 
     format_data('ems_cloud', attributes, attr_icon, attr_url, attr_hsh)

--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -59,7 +59,7 @@ class EmsDashboardService < DashboardService
          .count
   end
 
-  def format_data(ems_type, attributes, attr_icon, attr_url, attr_hsh)
+  def format_data(resource, attributes, attr_icon, attr_url, attr_hsh)
     attr_data = []
     attributes.each do |attr|
       attr_data.push(
@@ -67,7 +67,7 @@ class EmsDashboardService < DashboardService
         :iconClass    => attr_icon[attr],
         :title        => attr_hsh[attr],
         :count        => @ems.send(attr).count,
-        :href         => get_url(ems_type, @ems_id, attr_url[attr]),
+        :href         => get_url(resource, @ems_id, attr_url[attr]),
       )
     end
     attr_data
@@ -80,7 +80,7 @@ class EmsDashboardService < DashboardService
     }
   end
 
-  def get_url(ems_type, ems_id, attr_url)
-    "/#{ems_type}/#{ems_id}?display=#{attr_url}"
+  def get_url(resource, ems_id, attr_url)
+    "/#{resource}/#{ems_id}?display=#{attr_url}"
   end
 end

--- a/app/views/cloud_tenant/_recent-images-line-chart.html.haml
+++ b/app/views/cloud_tenant/_recent-images-line-chart.html.haml
@@ -1,0 +1,8 @@
+- id = unique_html_id('recent-resource')
+
+%recent-resource{'provider-id' => @record.id,
+                 'url'         => '/cloud_tenant_dashboard/recent_images_data/',
+                 'id'          => id}
+
+:javascript
+  miq_bootstrap('##{id}');

--- a/app/views/cloud_tenant/_recent-instances-line-chart.html.haml
+++ b/app/views/cloud_tenant/_recent-instances-line-chart.html.haml
@@ -1,0 +1,8 @@
+- id = unique_html_id('recent-resource')
+
+%recent-resource{'provider-id' => @record.id,
+                 'url'         => '/cloud_tenant_dashboard/recent_instances_data/',
+                 'id'          => id}
+
+:javascript
+  miq_bootstrap('##{id}');

--- a/app/views/cloud_tenant/_show_dashboard.html.haml
+++ b/app/views/cloud_tenant/_show_dashboard.html.haml
@@ -1,0 +1,12 @@
+= render :partial => "layouts/flash_msg"
+.container-fluid.container-tiles-pf.cloud-tenant-dashboard
+  .row.row-tile-pf
+    %aggregate-status-card{:provider_id => @record.id, :provider_type => "cloud_tenant"}
+  .row.row-tile-pf
+    .col-xs-12.col-sm-12.col-md-6
+      = render :partial => "recent-instances-line-chart"
+    .col-xs-12.col-sm-12.col-md-6
+      = render :partial => "recent-images-line-chart"
+  :javascript
+    ManageIQ.angular.app.value('#{@record.id}');
+    miq_bootstrap('.cloud-tenant-dashboard');

--- a/app/views/cloud_tenant/show_dashboard.html.haml
+++ b/app/views/cloud_tenant/show_dashboard.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => "show_dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -489,6 +489,16 @@ Rails.application.routes.draw do
         save_post
     },
 
+    :cloud_tenant_dashboard      => {
+      :get => %w(
+        show
+        data
+        recent_instances_data
+        recent_images_data
+        aggregate_status_data
+      )
+    },
+
     :cloud_object_store_object => {
       :get => %w(
         download_data

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -80,7 +80,7 @@ describe CloudTenantController do
       get :show, :params => {:id => tenant.id}
 
       expect(response.status).to eq(200)
-      expect(response).to render_template(:partial => "layouts/listnav/_cloud_tenant")
+      expect(response).to render_template(:partial => "cloud_tenant/_show_dashboard")
     end
   end
 


### PR DESCRIPTION
This PR adds the dashboard for Cloud Tenants. This dashboard is the same as the EmsCloud has.

https://bugzilla.redhat.com/show_bug.cgi?id=1487178

![screenshot from 2018-10-12 15-38-39](https://user-images.githubusercontent.com/26881797/46872937-bfb99800-ce35-11e8-845f-2570981ad13c.png)

@himdel 
@terezanovotna 
@aufi 
@alexander-demichev 

