### PR TITLE
Fix multi-tab endpoint credential validation by passing the right credential type when user hits "Enter"

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -674,9 +674,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
-  $scope.validateClicked = function($event, authType, formSubmit) {
-    $scope.authType = authType;
-    miqService.validateWithREST($event, authType, $scope.actionUrl, formSubmit)
+  $scope.validateClicked = function($event, _authType, formSubmit) {
+    miqService.validateWithREST($event, $scope.currentTab, $scope.actionUrl, formSubmit)
       .then(function success(data) {
         // check if data object is a JSON, otherwise (recieved JS or HTML) output a warning to the user.
         if (data === Object(data)) {
@@ -699,7 +698,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.updateAuthStatus = function(updatedValue) {
-    $scope.angularForm[$scope.authType + '_auth_status'].$setViewValue(updatedValue);
+    $scope.angularForm[$scope.currentTab + '_auth_status'].$setViewValue(updatedValue);
   };
 
   $scope.updateHostname = function(value) {

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -12,6 +12,7 @@ describe('emsCommonFormController', function() {
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
     spyOn(API, 'options').and.callFake(function(url){ return Promise.resolve({}); });
+    spyOn(miqService, 'validateWithREST').and.callFake(function(url){ return Promise.resolve({}); });
     $scope = $rootScope.$new();
 
     var emsCommonFormResponse = {
@@ -366,6 +367,23 @@ describe('emsCommonFormController', function() {
 
     it('delegates to miqService.restAjaxButton', function() {
       expect(miqService.restAjaxButton).toHaveBeenCalledWith('/ems_cloud?button=cancel', $.Event.target);
+    });
+  });
+
+  describe('#validateClicked', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+      $scope.currentTab = "console";
+      $scope.actionUrl = "/xyz";
+      $scope.validateClicked($.Event, "default", true);
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('delegates to miqService.validateClicked', function() {
+      expect(miqService.validateWithREST).toHaveBeenCalledWith($.Event, "console", "/xyz", true);
     });
   });
 


### PR DESCRIPTION
In a multi-tab form, when user hits the Enter key (and not the "Validate" button), the credential type passed down to the backend is always `default`, which leads to incorrect validation if the active tab is not "default", as described in the BZ

To fix this, we need to always refer to the `currentTab` value that accurately gives us the actual credential type for the currently active tab.

https://bugzilla.redhat.com/show_bug.cgi?id=1609735