### PR TITLE
Disable Open URL for all models that don't have remote_console_url

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -89,7 +89,7 @@ module ApplicationController::Buttons
     group_create_update("update")
   end
 
-  MODEL_WITH_OPEN_URL = ["VM and Instance"]
+  MODEL_WITH_OPEN_URL = ["VM and Instance"].freeze
 
   def automate_button_field_changed
     unless params[:target_class]

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -89,6 +89,8 @@ module ApplicationController::Buttons
     group_create_update("update")
   end
 
+  MODEL_WITH_OPEN_URL = ["VM and Instance"]
+
   def automate_button_field_changed
     unless params[:target_class]
       @edit = session[:edit]
@@ -105,7 +107,10 @@ module ApplicationController::Buttons
       end
       @edit[:new][:display] = params[:display] == "1" if params[:display]
       @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
+
       copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color disabled_text button_type inventory_type))
+      @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
+
       @edit[:new][:dialog_id] = params[:dialog_id] == "" ? nil : params[:dialog_id] if params.keys.include?("dialog_id")
       visibility_box_edit
 
@@ -1038,6 +1043,7 @@ module ApplicationController::Buttons
     (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
     @edit[:new][:starting_object] ||= "SYSTEM/PROCESS"
     @edit[:new][:instance_name] ||= "Request"
+    @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
 
     @edit[:new].update(
       :target_class   => @resolve[:target_class],

--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -73,8 +73,10 @@
       %label.control-label.col-md-2
         = _('Open URL')
       .col-md-8
-        = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
-
+        = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json, disabled: @edit[:new][:disabled_open_url])
+        - if @edit[:new][:disabled_open_url]
+          .note
+            = _("Only available for VM with \"Display for\" set to \"Single\"")
     .form-group
       %label.control-label.col-md-2
         = _('Display for')


### PR DESCRIPTION
It's possible to create a custom button with an Open URL for entities that don't support it. This will prevent it. Only entity that allows it is VM (checked with @pkomanek).

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1635797 but fix for that error is https://github.com/ManageIQ/manageiq-ui-classic/pull/4745 .

**Before:**
User could create a custom button with Open URL for any entity. After clicking the button it kinda failed.
<img width="1196" alt="screen shot 2018-10-15 at 2 21 49 pm" src="https://user-images.githubusercontent.com/9210860/46950776-32b94d80-d086-11e8-92b1-4923d6934e32.png">

**After:**
User isn't allowed to create a custom button with Open URL for entity that doesn't support `remote_console_url` (only VM does) with `Display for` not set to `Single`. Like this for Datastore.
<img width="828" alt="screen shot 2018-10-15 at 2 23 06 pm" src="https://user-images.githubusercontent.com/9210860/46950871-7f048d80-d086-11e8-812a-f690f6b196e8.png">

 @miq-bot add_label enhancement, hammer/no, automation/automate, ux/review

@terezanovotna please check it from UX point of view, thanks :)