### PR TITLE
Display custom buttons after comming from relationship table

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,7 @@ class ApplicationController < ActionController::Base
   include Mixins::CustomButtons
   include Mixins::CheckedIdMixin
   include ParamsHelper
+  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   helper ToolbarHelper
   helper JsHelper

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -1,5 +1,6 @@
 module ApplicationController::Buttons
   extend ActiveSupport::Concern
+  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   included do
     include Mixins::PlaybookOptions
@@ -262,28 +263,6 @@ module ApplicationController::Buttons
   private
 
   BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
-  APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
-                                    CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
-                                    ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
-                                    GenericObject GenericObjectDefinition Host LoadBalancer
-                                    MiqGroup MiqTemp MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
-                                    ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
-  def applies_to_class_model(applies_to_class)
-    # TODO: Give a better name for this concept, including ServiceTemplate using Service
-    # This should probably live in the model once this concept is defined.
-    unless APPLIES_TO_CLASS_BASE_MODELS.include?(applies_to_class)
-      raise ArgumentError, "Received: #{applies_to_class}, expected one of #{APPLIES_TO_CLASS_BASE_MODELS}"
-    end
-
-    case applies_to_class
-    when "ServiceTemplate"
-      Service
-    when "GenericObjectDefinition"
-      GenericObject
-    else
-      applies_to_class.constantize
-    end
-  end
 
   def custom_button_done
     url = SystemConsole.find_by(:vm => params[:id]).try(:url)
@@ -321,7 +300,7 @@ module ApplicationController::Buttons
 
   def custom_buttons(ids = nil, display_options = {})
     button = CustomButton.find(params[:button_id])
-    cls = applies_to_class_model(button.applies_to_class)
+    cls = custom_button_class_model(button.applies_to_class)
     @explorer = true if BASE_MODEL_EXPLORER_CLASSES.include?(cls)
     ids ||= params[:id]
     if ids.to_s == 'LIST'

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -302,14 +302,16 @@ module ApplicationController::Buttons
     button = CustomButton.find(params[:button_id])
     cls = custom_button_class_model(button.applies_to_class)
     @explorer = true if BASE_MODEL_EXPLORER_CLASSES.include?(cls)
-    ids ||= params[:id]
-    if ids.to_s == 'LIST'
-      objs = Rbac.filtered(cls.where(:id => find_checked_items))
-      obj = objs.first
-    else
-      obj = Rbac.filtered_object(cls.find(ids.to_i))
-      objs = [obj]
+    ids ||= params[:id] unless relationship_table_screen? && @record.nil?
+    ids = find_checked_items if ids == 'LIST' || ids.nil?
+
+    if ids.blank?
+      render_flash(_("Error executing custom button: No item was selected."), :error)
+      return
     end
+
+    objs = Rbac.filtered(cls.where(:id => ids))
+    obj = objs.first
 
     if objs.empty?
       render_flash(_("Error executing custom button: No item was selected."), :error)

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -1,6 +1,5 @@
 module ApplicationController::Buttons
   extend ActiveSupport::Concern
-  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   included do
     include Mixins::PlaybookOptions

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -1,6 +1,5 @@
 module Mixins::CustomButtons
   extend ActiveSupport::Concern
-  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   def custom_toolbar
     return nil unless self.class.instance_eval { @custom_buttons }

--- a/app/controllers/mixins/custom_buttons.rb
+++ b/app/controllers/mixins/custom_buttons.rb
@@ -1,5 +1,6 @@
 module Mixins::CustomButtons
   extend ActiveSupport::Concern
+  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   def custom_toolbar
     return nil unless self.class.instance_eval { @custom_buttons }
@@ -23,6 +24,8 @@ module Mixins::CustomButtons
     if @record && %w(show show_dashboard).include?(@lastaction) && %w(dashboard main).include?(@display)
       Mixins::CustomButtons::Result.new(:single)
     elsif @lastaction == "show_list"
+      Mixins::CustomButtons::Result.new(:list)
+    elsif relationship_table_screen?
       Mixins::CustomButtons::Result.new(:list)
     elsif @display == 'generic_objects'
       @lastaction == 'generic_object' ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list)

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -3,10 +3,14 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
                                     GenericObject GenericObjectDefinition Host LoadBalancer
-                                    MiqGroup MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
+                                    MiqGroup MiqTemplate NetworkRouter OrchestrationStack
+                                    PersistentVolume SecurityGroup Service
                                     ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
 
   def custom_button_appliable_class?(model)
+    model = "MiqTemplate" if model == "Image"
+    model = "Vm" if model == "Instance"
+    model = "ExtManagementSystem" if model == "StorageManager"
     APPLIES_TO_CLASS_BASE_MODELS.include?(model)
   end
 
@@ -22,6 +26,12 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
       Service
     when "GenericObjectDefinition"
       GenericObject
+    when "Instance"
+      Vm
+    when "Image"
+      MiqTemplate
+    when "StorageManager"
+      ExtManagementSystem
     else
       applies_to_class.constantize
     end
@@ -39,7 +49,7 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
     return false unless custom_button_appliable_class?(display_class)
 
     show_action = @lastaction == "show"
-    display_model = display_class.constantize
+    display_model = custom_button_class_model(display_class)
     # method is accessed twice from a different location - from toolbar builder
     # and custom button mixin - and so controller class changes
     ctrl = self.class == ApplicationHelper::ToolbarBuilder ? controller : self

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -30,7 +30,9 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
   # Indicates, whether the user has came from providers relationship screen
   # or not
   #
-  # Used to indicate if the custom buttons should be rendered
+  # Used to
+  # - indicate if the custom buttons should be rendered
+  # - decide where to look for id of checked records
   def relationship_table_screen?
     return false if @display.nil?
     display_class = @display.camelize.singularize

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -1,21 +1,26 @@
 module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
+  # FIXME: replace with CustomButton.button_classes
+  # (ServiceTemplate, VmOrTemplate, GenericObjectDefinition are exceptions)
   APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
                                     GenericObject GenericObjectDefinition Host LoadBalancer
                                     MiqGroup MiqTemplate NetworkRouter OrchestrationStack
-                                    PersistentVolume SecurityGroup Service
-                                    ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
+                                    SecurityGroup Service ServiceTemplate Storage Switch Tenant
+                                    User Vm VmOrTemplate).freeze
 
   def custom_button_appliable_class?(model)
+    # FIXME: merge with model replacement in 'custom_button_class_model'
     model = "MiqTemplate" if model == "Image"
     model = "Vm" if model == "Instance"
+    model = "ContainerVolume" if model == "PersistentVolume"
     model = "ExtManagementSystem" if model == "StorageManager"
     APPLIES_TO_CLASS_BASE_MODELS.include?(model)
   end
 
   def custom_button_class_model(applies_to_class)
     # TODO: Give a better name for this concept, including ServiceTemplate using Service
+    #       'custom_button_appliable_class' -> 'display_to_model'
     # This should probably live in the model once this concept is defined.
     unless custom_button_appliable_class?(applies_to_class)
       raise ArgumentError, "Received: #{applies_to_class}, expected one of #{APPLIES_TO_CLASS_BASE_MODELS}"
@@ -24,6 +29,8 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
     case applies_to_class
     when "ServiceTemplate"
       Service
+    when "PersistentVolume"
+      ContainerVolume
     when "GenericObjectDefinition"
       GenericObject
     when "Instance"

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -32,18 +32,17 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
   #
   # Used to indicate if the custom buttons should be rendered
   def relationship_table_screen?
-    return false if @display.nil? || @record.nil?
+    return false if @display.nil?
+    display_class = @display.camelize.singularize
+    return false unless custom_button_appliable_class?(display_class)
 
-    display_model = @display.camelize.singularize
-    providers = (EmsCloud.descendants +
-                 EmsInfra.descendants +
-                 EmsPhysicalInfra.descendants +
-                 ManageIQ::Providers::ContainerManager.descendants)
-
-    custom_button_model = custom_button_appliable_class?(display_model)
-    provider_screen = providers.any? { |provider| @record.instance_of?(provider) }
     show_action = @lastaction == "show"
+    display_model = display_class.constantize
+    # method is accessed twice from a different location - from toolbar builder
+    # and custom button mixin - and so controller class changes
+    ctrl = self.class == ApplicationHelper::ToolbarBuilder ? controller : self
+    controller_model = ctrl.class.model
 
-    custom_button_model && provider_screen && show_action
+    display_model != controller_model && show_action
   end
 end

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -3,7 +3,7 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
                                     CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
                                     ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
                                     GenericObject GenericObjectDefinition Host LoadBalancer
-                                    MiqGroup MiqTemp MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
+                                    MiqGroup MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
                                     ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
 
   def custom_button_appliable_class?(model)

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -1,0 +1,49 @@
+module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
+  APPLIES_TO_CLASS_BASE_MODELS = %w(AvailabilityZone CloudNetwork CloudObjectStoreContainer CloudSubnet CloudTenant
+                                    CloudVolume ContainerGroup ContainerImage ContainerNode ContainerProject
+                                    ContainerTemplate ContainerVolume EmsCluster ExtManagementSystem
+                                    GenericObject GenericObjectDefinition Host LoadBalancer
+                                    MiqGroup MiqTemp MiqTemplate NetworkRouter OrchestrationStack SecurityGroup Service
+                                    ServiceTemplate Storage Switch Tenant User Vm VmOrTemplate).freeze
+
+  def custom_button_appliable_class?(model)
+    APPLIES_TO_CLASS_BASE_MODELS.include?(model)
+  end
+
+  def custom_button_class_model(applies_to_class)
+    # TODO: Give a better name for this concept, including ServiceTemplate using Service
+    # This should probably live in the model once this concept is defined.
+    unless custom_button_appliable_class?(applies_to_class)
+      raise ArgumentError, "Received: #{applies_to_class}, expected one of #{APPLIES_TO_CLASS_BASE_MODELS}"
+    end
+
+    case applies_to_class
+    when "ServiceTemplate"
+      Service
+    when "GenericObjectDefinition"
+      GenericObject
+    else
+      applies_to_class.constantize
+    end
+  end
+
+  # Indicates, whether the user has came from providers relationship screen
+  # or not
+  #
+  # Used to indicate if the custom buttons should be rendered
+  def relationship_table_screen?
+    return false if @display.nil? || @record.nil?
+
+    display_model = @display.camelize.singularize
+    providers = (EmsCloud.descendants +
+                 EmsInfra.descendants +
+                 EmsPhysicalInfra.descendants +
+                 ManageIQ::Providers::ContainerManager.descendants)
+
+    custom_button_model = custom_button_appliable_class?(display_model)
+    provider_screen = providers.any? { |provider| @record.instance_of?(provider) }
+    show_action = @lastaction == "show"
+
+    custom_button_model && provider_screen && show_action
+  end
+end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -289,7 +289,7 @@ class ApplicationHelper::ToolbarBuilder
       model = GenericObjectDefinition
       record = GenericObject.find_by(:id => @sb[:rec_id])
     elsif relationship_table_screen?
-      model = @display.camelize.singularize.constantize
+      model = custom_button_class_model(@display.camelize.singularize)
     else
       model = @record ? @record.class : model_for_custom_toolbar
     end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -234,7 +234,11 @@ class ApplicationHelper::ToolbarBuilder
     }
     button[:text] = button_name if input[:text_display]
     button[:onwhen] = '1+' if cb_enabled_for_nested
-    button[:send_checked] = true if record_id == 'LIST'
+    if record_id == 'LIST' ||
+       (@display.present? &&
+        custom_button_appliable_class?(@display.camelize.singularize))
+      button[:send_checked] = true
+    end
     button
   end
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1,6 +1,7 @@
 class ApplicationHelper::ToolbarBuilder
   include MiqAeClassHelper
   include RestfulControllerMixin
+  include ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
 
   def call(toolbar_name)
     build_toolbar(toolbar_name)
@@ -283,6 +284,8 @@ class ApplicationHelper::ToolbarBuilder
     if @display == 'generic_objects'
       model = GenericObjectDefinition
       record = GenericObject.find_by(:id => @sb[:rec_id])
+    elsif relationship_table_screen?
+      model = @display.camelize.singularize.constantize
     else
       model = @record ? @record.class : model_for_custom_toolbar
     end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -726,4 +726,9 @@ describe EmsCloudController do
       expect(response.body).not_to have_selector("button[title*='Select a filter to set it as my default']", :text => "Set Default")
     end
   end
+
+  %w(availability_zones cloud_tenants security_groups instances images
+     orchestration_stacks storage_managers).each do |custom_button_class|
+    include_examples "relationship table screen with custom buttons", custom_button_class
+  end
 end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -375,4 +375,8 @@ describe EmsContainerController do
   end
 
   include_examples '#download_summary_pdf', :ems_kubernetes
+  %w(container_projects container_nodes container_images container_volumes
+     container_templates).each do |custom_button_class|
+    include_examples "relationship table screen with custom buttons", custom_button_class
+  end
 end

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -2,4 +2,8 @@ describe EmsNetworkController do
   include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google amazon)
 
   it_behaves_like "controller with custom buttons"
+  %w(cloud_tenants cloud_networks cloud_subnets network_routers security_groups
+     load_balancers).each do |custom_button_class|
+    include_examples "relationship table screen with custom buttons", custom_button_class
+  end
 end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -667,4 +667,8 @@ describe VmInfraController do
     controller.report_data
     expect(assigns(:edit)[:new]).to_not include(:expression)
   end
+
+  %w(ems_clusters hosts storages vms miq_templates).each do |custom_button_class|
+    include_examples "relationship table screen with custom buttons", custom_button_class
+  end
 end

--- a/spec/shared/controllers/shared_example_for_custom_buttons.rb
+++ b/spec/shared/controllers/shared_example_for_custom_buttons.rb
@@ -88,3 +88,14 @@ shared_examples 'explorer controller with custom buttons' do
     expect(controller.custom_toolbar).to be_a_kind_of Mixins::CustomButtons::Result
   end
 end
+
+shared_examples 'relationship table screen with custom buttons' do |display|
+  context "displayed entity is #{display}" do
+    it "has custom toolbar when navigating through relationship table" do
+      controller.instance_variable_set(:@display, display)
+      controller.instance_variable_set(:@lastaction, 'show')
+      controller.instance_variable_set(:@record, true) # @record is the provider
+      expect(controller.custom_toolbar).to be_a_kind_of Mixins::CustomButtons::Result
+    end
+  end
+end


### PR DESCRIPTION
The code displays the custom buttons if the previous screen was a
provider screen (`@record`) and displayed item (`@display`) is from the list
of classes supported by custom buttons (`APPLIES_TO_CLASS_BASE_MODELS`)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1635738

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1635738
* #4772

Steps for Testing/QA
-------------------------------
*  Create a custom button for any entity
*  Navigate to the entity through the provider relationship screen
*  Custom button should be visible

