### PR TITLE
Make physical network visible only for FLAT and VLAN

### DIFF
--- a/app/assets/javascripts/components/cloud_network/cloud-network-form.js
+++ b/app/assets/javascripts/components/cloud_network/cloud-network-form.js
@@ -27,6 +27,7 @@ function cloudNetworkFormController(API, miqService) {
 
     vm.ems = [];
     vm.network_types_for_segmentation = /vlan|vxlan|gre/;
+    vm.network_types_for_physical_network = /vlan|flat/;
     vm.formId = vm.cloudNetworkFormId;
     vm.model = "cloudNetworkModel";
     ManageIQ.angular.scope = vm;

--- a/app/views/static/cloud_network/cloud-network-form.html.haml
+++ b/app/views/static/cloud_network/cloud-network-form.html.haml
@@ -67,7 +67,7 @@
                 'ng-options'                  => "type as key for (key, type) in vm.providers_network_types",
                 "miq-select"                  => true,
                 "selectpicker-for-select-tag" => ""}
-    .form-group{'ng-if' => "vm.cloudNetworkModel.provider_network_type"}
+    .form-group{'ng-if' => "vm.network_types_for_physical_network.test(vm.cloudNetworkModel.provider_network_type)"}
       %label.control-label.col-md-2
         = _('Physical Network')
       .col-md-8


### PR DESCRIPTION
Physical Network field is visible for all types of  RHOS networks, but it makes sanse only for Flat network.

https://bugzilla.redhat.com/show_bug.cgi?id=1540684