### PR TITLE
CloudTenant spec - add back a listnav spec

### DIFF
--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -76,11 +76,18 @@ describe CloudTenantController do
 
     render_views
 
-    it "render listnav partial" do
+    it "renders dashboard" do
       get :show, :params => {:id => tenant.id}
 
       expect(response.status).to eq(200)
       expect(response).to render_template(:partial => "cloud_tenant/_show_dashboard")
+    end
+
+    it "renders listnav partial" do
+      get :show, :params => {:id => tenant.id, :display => 'main'}
+
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:partial => "layouts/listnav/_cloud_tenant")
     end
   end
 


### PR DESCRIPTION
In #4767 `CloudTenant` got its own dashboard view, which takes precedence over the textual summary.
It also changed the spec to test for the dashboard view only.

Adding back the original listnav spec, when `@display = 'main'`.

Cc @evgeny-chufarov 