### PR TITLE
Add any product product feature for Customization in menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -236,8 +236,8 @@ module Menu
         Menu::Section.new(:automate, N_("Automate"), 'pficon pficon-automation', [
           Menu::Item.new('miq_ae_class',         N_('Explorer'),        'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},            '/miq_ae_class/explorer'),
           Menu::Item.new('miq_ae_tools',         N_('Simulation'),      'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},       '/miq_ae_tools/resolve'),
-          Menu::Item.new('miq_ae_customization', N_('Customization'),   'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer'}, '/miq_ae_customization/explorer'),
           Menu::Item.new('generic_object_definition', N_('Generic Objects'), 'generic_object_definition', {:feature => 'generic_object_definition'},   '/generic_object_definition/show_list'),
+          Menu::Item.new('miq_ae_customization', N_('Customization'),   'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer', :any => true}, '/miq_ae_customization/explorer'),
           Menu::Item.new('miq_ae_export',        N_('Import / Export'), 'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},    '/miq_ae_tools/import_export'),
           Menu::Item.new('miq_ae_logs',          N_('Log'),             'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},              '/miq_ae_tools/log'),
           Menu::Item.new('miq_request_ae',       N_('Requests'),        'ae_miq_request',                {:feature => 'ae_miq_request_show_list'},      '/miq_request/show_list?typ=ae')

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -149,6 +149,14 @@ describe Menu::DefaultMenu do
           "Log",
           "Requests"
         )
+
+        expect(menu.automate_menu_section.items.map(&:rbac_feature)). to match_array([{:feature => "miq_ae_domain_view"},
+                                                                             {:feature => "miq_ae_class_simulation"},
+                                                                             {:feature => "miq_ae_customization_explorer", :any => true},
+                                                                             {:feature => "generic_object_definition"},
+                                                                             {:feature => "miq_ae_class_import_export"},
+                                                                             {:feature => "miq_ae_class_log"},
+                                                                             {:feature => "ae_miq_request_show_list"}])
       end
     end
   end


### PR DESCRIPTION
depending on:
- [x] missing PR

part of issue https://github.com/ManageIQ/manageiq/issues/18100

display menu Customization if any product feature is checked 
![screenshot 2018-10-16 at 16 26 33](https://user-images.githubusercontent.com/14937244/47023645-5c46a780-d160-11e8-8a24-f46422102de1.png)

and now is enough just to have checked Dialogs 

![screenshot 2018-10-16 at 16 29 34](https://user-images.githubusercontent.com/14937244/47023808-bcd5e480-d160-11e8-83e1-9b3349e32dbd.png)

Links
------

*https://bugzilla.redhat.com/show_bug.cgi?id=1297415

* https://github.com/ManageIQ/manageiq/issues/18100
