### PR TITLE
Move connected physical servers to the Relationships table

### DIFF
--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -31,7 +31,7 @@ class PhysicalSwitchController < ApplicationController
   def textual_group_list
     [
       %i(properties management_networks relationships),
-      %i(power_management firmware_details connected_components),
+      %i(power_management firmware_details),
     ]
   end
   helper_method(:textual_group_list)

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module PhysicalSwitchHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(ext_management_system)
+      %i(ext_management_system connected_physical_servers)
     )
   end
 
@@ -28,13 +28,6 @@ module PhysicalSwitchHelper::TextualSummary
 
   def textual_group_firmware_details
     TextualTable.new(_("Firmwares"), firmware_details, [_("Name"), _("Version")])
-  end
-
-  def textual_group_connected_components
-    TextualGroup.new(
-      _("Connected Components"),
-      %i(connected_physical_servers)
-    )
   end
 
   def textual_ports

--- a/spec/helpers/physical_switch_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_switch_helper/textual_summary_spec.rb
@@ -11,9 +11,7 @@ describe PhysicalSwitchHelper::TextualSummary do
     description
   )
 
-  include_examples "textual_group", "Relationships", %i(ext_management_system)
+  include_examples "textual_group", "Relationships", %i(ext_management_system connected_physical_servers)
 
   include_examples "textual_group", "Power Management", %i(power_state), "power_management"
-
-  include_examples "textual_group", "Connected Components", %i(connected_physical_servers), "connected_components"
 end


### PR DESCRIPTION
This PR moves the connected physical servers from the Connected Components table on the Switch Summary page to the Relationships table. Also this PR removes the Connected Components table since it is now empty and no longer used.

![image](https://user-images.githubusercontent.com/23690141/47047030-9023cc00-d164-11e8-83f9-a09e2ca6becf.png)
