### PR TITLE
Save server's zone name in `@edit[:new]`

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -753,6 +753,7 @@ module OpsController::Settings::Common
       new[:server][:custom_support_url] = params[:custom_support_url].strip if params[:custom_support_url]
       new[:server][:custom_support_url_description] = params[:custom_support_url_description] if params[:custom_support_url_description]
       new[:server][:name] = params[:server_name] if params[:server_name]
+      new[:server][:zone] = params[:server_zone] if params[:server_zone]
     when "settings_authentication"                                        # Authentication tab
       auth = new[:authentication]
       @sb[:form_vars][:session_timeout_mins] = params[:session_timeout_mins] if params[:session_timeout_mins]

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -438,5 +438,25 @@ describe OpsController do
         end
       end
     end
+
+    context '#settings_form_field_changed' do
+      it '@changed should be true when server zone is changed' do
+        server = FactoryGirl.create(:miq_server, :zone => Zone.find_by(:name => "default"))
+        current = ::Settings.to_hash
+        new = ::Settings.to_hash
+        controller.instance_variable_set(:@edit,
+                                         :new     => new,
+                                         :current => current,
+                                         :key     => "settings_server_edit__#{server.id}")
+        controller.instance_variable_set(:@sb, :selected_server_id => server.id, :active_tab => "settings_server")
+        controller.instance_variable_set(:@_params,
+                                         :id => 'server', :server_zone => "foo_zone")
+        allow(controller).to receive(:x_node).and_return("svr-#{server.id}")
+        session[:edit] = assigns(:edit)
+        expect(controller).to receive(:render)
+        controller.send(:settings_form_field_changed)
+        expect(assigns[:changed]).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
This was preventing from Save button to be enabled when only Server's zone name was changed on the server settings screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639877