### PR TITLE
Remove catching flash messages in report_data_controller.js

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -492,9 +492,6 @@
             this.initObject.showUrl = splitUrl.join('/');
           }
         }
-        gtlData.messages && gtlData.messages.forEach(function(oneMessage) {
-          add_flash(oneMessage.msg, oneMessage.level);
-        });
         // Apply gettext __() on column headers
         for (var i = 0;  i < gtlData.cols.length; i++) {
           var column = gtlData.cols[i];


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639213

### Steps to Reproduce:
1. Add infra or cloud provider
2. Navigate to **Compute -> Infrastructure -> Virtual Machines**
   or **Compute -> Clouds -> Instances**
3. Click on **Lifecycle -> Provision VMs**
   or **Lifecycle -> Provision Instances**
4. Click **Cancel**

### Actual results:
Two success messages appear, one without text

### Expected results:
One success message appears

###  Before / After

![screenshot from 2018-10-17 19-46-01](https://user-images.githubusercontent.com/32869456/47105842-5aa2df80-d245-11e8-86a6-ccb17762a621.png)

![screenshot from 2018-10-17 19-44-30](https://user-images.githubusercontent.com/32869456/47105808-3cd57a80-d245-11e8-911b-22d3cd16fddb.png)


### NOTES

- This is a just a a suggestion how to solve it. I would appreciate any help!

The `oneMessage.msg` ( [here](https://github.com/karelhala/manageiq-ui-classic/blob/bf4f5803149b4e7393452acec2b4f3899858e793/app/assets/javascripts/controllers/report_data_controller.js#L496) , introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/1245 ) is undefined, so it's causing empty messages. It should be `oneMessage.message`, but then it's causing double messages. 

I don't know if `msg` is used somewhere else, but I checked issues from https://github.com/ManageIQ/manageiq-ui-classic/issues/1273 (which should be fixed by this piece of code) after I had removed the function and they are fixed anyway. So I think the function actually doesn't work right now. Maybe there was another change which fixed all these thing. I don't know.

@karelhala @himdel @skateman Pinging you, because you were involved in that PR.


