### PR TITLE
Allow Service retirement over Centralized Administration

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -280,11 +280,13 @@ module ApplicationController::CiProcessing
 
     display_name ||= task.titleize
     case klass_str
-    when 'OrchestrationStack', 'Service', 'CloudObjectStoreContainer', 'CloudObjectStoreObject'
-      objs, _objs_out_reg = filter_ids_in_region(objs, klass.to_s)
+    when 'CloudObjectStoreContainer', 'CloudObjectStoreObject'
+      objs, _objs_out_reg = filter_ids_in_region(objs, klass_str)
     when 'VmOrTemplate'
       objs, _objs_out_reg = filter_ids_in_region(objs, "VM") unless VmOrTemplate::REMOTE_REGION_TASKS.include?(task)
       klass = Vm
+    when 'OrchestrationStack', 'Service'
+      objs, _objs_out_reg = filter_ids_in_region(objs, klass_str) unless task == "retire_now"
     end
     return if objs.empty?
 


### PR DESCRIPTION
**Issue**: in multiregion environment attempt to retire service replicated to Global region will fail with "The selected Service is not in the current region"

**This PR:**  allow `retire_now` task to be processed via Centralized Administration for `Service` and `OrchestrationStack`

**BEFORE**:
<img width="1088" alt="before2" src="https://user-images.githubusercontent.com/6556758/47225583-6d73fc00-d38c-11e8-8288-f7f78ed46934.png">

**AFTER**:
![after2](https://user-images.githubusercontent.com/6556758/47225614-7f559f00-d38c-11e8-816e-9fac555dec22.png)



Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1633142


@miq-bot add-label bug, gaprindashvili/yes, hammer/yes