### PR TITLE
 Fix Ansible Playbook 'New Catalog Item' styling issue

### DIFF
--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -194,21 +194,24 @@
     .form-group
       %label.col-md-3.control-label
         = _("Variables & Default Values")
-      .col-md-9
-        %input{:type         => "text",
+      .col-md-4
+        %input.form-control{:type         => "text",
                'ng-model'    => "#{ng_model}.#{prefix}_key",
                :name         => "#{prefix}_key",
                "placeholder" => _("Variable"),
                "checkchange" => ""}
         %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key === '' && #{ng_model}.#{prefix}_value !== '')"}
           = _("Required")
-        %input{:type         => "text",
+
+      .col-md-4
+        %input.form-control{:type         => "text",
                'ng-model'    => "#{ng_model}.#{prefix}_value",
                :name         => "#{prefix}_value",
                "placeholder" => _("Default value"),
                "checkchange" => ""}
         %span.help-block{"ng-show" => "(#{ng_model}.#{prefix}_key !== '' && #{ng_model}.#{prefix}_value === '')"}
           = _("Required")
+      .col-md-1{:style     => "padding-left: 0"}
         %button{:class     => "btn btn-link",
                 :type      => "button",
                 "ng-click" => "vm.addKeyValue('#{prefix}')",


### PR DESCRIPTION
This PR fixes a problem with the "Variables & Default Values" fields, where the "Required" message did not appear under the appropriate field.

Old
![screen shot 2018-10-18 at 12 54 42 pm](https://user-images.githubusercontent.com/1287144/47170833-0e9f7b80-d2d5-11e8-8c49-7e7f238b08ce.png)

New
![screen shot 2018-10-18 at 12 54 05 pm](https://user-images.githubusercontent.com/1287144/47170834-0e9f7b80-d2d5-11e8-9b32-95da040987bc.png)



https://bugzilla.redhat.com/show_bug.cgi?id=1640608