### PR TITLE
Fix vm_cloud image custom button return and cancel endpoints

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -109,7 +109,7 @@ class DialogLocalService
     # ^ is necessary otherwise we match on ContainerTemplates
     when /^Template/
       api_collection_name = "templates"
-      cancel_endpoint = "/vm_or_template/explorer"
+      cancel_endpoint = display_options[:cancel_endpoint] || "/vm_or_template/explorer"
 
     # ^ is necessary otherwise we match CloudTenant
     when /^Tenant/

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -260,10 +260,20 @@ describe DialogLocalService do
     end
 
     context "when the object is a Template" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+      context "when there is a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+        let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
-      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "miq_template", "templates", "/vm_or_template/explorer"
+        include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                         "miq_template", "templates", "/vm_cloud/explorer"
+      end
+
+      context "when there is not a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+
+        include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                         "miq_template", "templates", "/vm_or_template/explorer"
+      end
     end
 
     context "when the object is a Vm" do


### PR DESCRIPTION
There are `Template` objects that are available to have custom buttons attached to them on the Compute -> Clouds -> Instances -> Images screen, which corresponds to `vm_cloud/explorer` in the url, but the code was incorrectly assuming all templates would be nested under `vm_or_template/explorer`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1640592

@miq-bot assign @h-kataria 
@miq-bot add_label bug, gaprindashvili/yes, hammer/yes