### PR TITLE
[GAPRINDASHVILI] Hide disabled tabs

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -201,6 +201,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       miqService.sparkleOff();
 
+      $scope.hideDisabledTabs();
+
       $scope.emsOptionsModel.provider_options_original_values = data.provider_options;
       $scope.updateProviderOptionsDescription();
     }
@@ -237,11 +239,21 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.vmware_cloud_api_version        = '9.0';
 
       miqService.sparkleOff();
-
+      $scope.hideDisabledTabs();
       $scope.afterGet  = true;
       $scope.modelCopy = angular.copy( $scope.emsCommonModel );
     }
   };
+
+  $scope.hideDisabledTabs = function() {
+    if ($scope.emsCommonModel.alerts_selection === 'disabled') {
+      angular.element("#alerts_tab").hide();
+    }
+
+    if ($scope.emsCommonModel.metrics_selection === 'disabled') {
+      angular.element("#container_metrics_tab").hide();
+    }
+  }
 
   $scope.changeAuthTab = function(id) {
     $scope.currentTab = id;
@@ -405,7 +417,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.metricSelectionChanged = function() {
-    $scope.tabSelectionChanged("#metrics_tab", $scope.emsCommonModel.metrics_selection);
+    $scope.tabSelectionChanged("#container_metrics_tab", $scope.emsCommonModel.metrics_selection);
   };
 
   $scope.alertsSelectionChanged = function() {

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -29,7 +29,7 @@
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
           = _("SmartState Docker")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
+      = miq_tab_header('container_metrics', nil, 'ng-click' => "changeAuthTab('container_metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}
           %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
           = _("Metrics")
@@ -308,7 +308,7 @@
             %span{:style => "color:black"}
               = _("Used for VMRC connections to all VMs on this provider. If not set, the VMRC console access will be disabled for this provider.")
     - elsif controller_name == "ems_container"
-      = miq_tab_content('metrics', 'default') do
+      = miq_tab_content('container_metrics', 'default') do
         .form-group
           .col-md-12.col-md-12
             %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular'"}
@@ -435,7 +435,8 @@
                 "#{ng_model}.emstype == 'hawkular'"}                    |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
-    miq_tabs_show_hide("#metrics_tab", false);
+    miq_tabs_show_hide("#alerts_tab", false);
+    miq_tabs_show_hide("#container_metrics_tab", false);
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
@@ -494,7 +495,8 @@
     $('#auth_tabs').show();
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
   :javascript
-    miq_tabs_show_hide("#metrics_tab", true);
+    miq_tabs_show_hide("#alerts_tab", true);
+    miq_tabs_show_hide("#container_metrics_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 


### PR DESCRIPTION
Gaprindashvili Backport commit from:

    #3511 

Original SHA:
   486e30ac49d8796d010c718b0a5a44688cda46c7

The metrics & alerts tabs where partially visible.

This PR hides any of the tabs if aren't used in Add/Edit provider.

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/3498
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1550405
Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/3511

![selection_863](https://user-images.githubusercontent.com/316242/47264543-e35d9c00-d521-11e8-902b-9822797ae403.png)
