### PR TITLE
Removed dead code in performance controller

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -34,11 +34,6 @@ module ApplicationController::Performance
                   "candu"  => @chart_data,
                   "parent" => @parent_chart_data
                 }.to_json + ';'
-              elsif @compare_vm_chart_data
-                'ManageIQ.charts.chartData = ' + {
-                  "candu"     => @chart_data,
-                  "comparevm" => @compare_vm_chart_data
-                }.to_json + ';'
               else
                 'ManageIQ.charts.chartData = ' + {
                   "candu" => @chart_data
@@ -429,11 +424,6 @@ module ApplicationController::Performance
                 'ManageIQ.charts.chartData = ' + {
                   "candu"  => @chart_data,
                   "parent" => @parent_chart_data
-                }.to_json + ';'
-              elsif @parent_chart_data
-                'ManageIQ.charts.chartData = ' + {
-                  "candu"      => @chart_data,
-                  "compare_vm" => @compare_vm_chart_data
                 }.to_json + ';'
               else
                 'ManageIQ.charts.chartData = ' + {

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -325,7 +325,6 @@ module ApplicationController::Performance
   def timeline_current(chart_click_data, ts)
     @record = identify_tl_or_perf_record
     @perf_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
-    @perf_record = VmOrTemplate.find(@perf_options[:compare_vm]) unless @perf_options[:compare_vm].nil?
     new_opts = tl_session_data(request.parameters["controller"]) || ApplicationController::Timelines::Options.new
     new_opts[:model] = @perf_record.class.base_class.to_s
     new_opts.date.typ = chart_click_data.type

--- a/app/controllers/application_controller/performance/options.rb
+++ b/app/controllers/application_controller/performance/options.rb
@@ -25,7 +25,6 @@ module ApplicationController::Performance
     :top_ts,
     :top_ids,
     :vmtype,            # selected vmtype
-    :compare_vm,        # id of Vm to compare with
     :skip_days,         # which days to skip, based on time_profile_days
     :time_profile,
     :time_profile_days,
@@ -41,7 +40,6 @@ module ApplicationController::Performance
       self.daily_date  = params[:miq_date_1]        if params[:miq_date_1] && typ == 'Daily'
       self.index       = params[:chart_idx] == 'clear' ? nil : params[:chart_idx] if params[:chart_idx]
       self.parent      = params[:compare_to].presence if params.key?(:compare_to)
-      self.compare_vm  = params[:compare_vm].presence if params.key?(:compare_vm)
       self.vmtype      = params[:perf_vmtype] == '<All>' ? nil : params[:perf_vmtype] if params[:perf_vmtype]
       if params[:perf_cat]
         self.cat_model, self.cat = if params[:perf_cat] == '<None>'


### PR DESCRIPTION
reaction on https://github.com/ManageIQ/manageiq-ui-classic/pull/652#discussion_r226995650

instance variable `@compare_vm_chart_data` is not used anywhere in the codebase anymore