### PR TITLE
[RFE] Display Vm power state in the related grid views

### DIFF
--- a/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
@@ -24,6 +24,7 @@ cols:
 - last_compliance_status
 - allocated_disk_storage
 - last_scan_on
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -46,6 +47,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - availability_zone.name
 - flavor.name
 - ipaddresses
@@ -57,6 +59,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Availability Zone
 - Flavor
 - IP Addresses

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
@@ -24,6 +24,7 @@ cols:
 - last_compliance_status
 - allocated_disk_storage
 - last_scan_on
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -46,6 +47,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - availability_zone.name
 - flavor.name
 - ipaddresses
@@ -57,6 +59,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Availability Zone
 - Flavor
 - IP Addresses

--- a/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
@@ -26,6 +26,7 @@ cols:
 - last_scan_on
 - load_balancer_health_check_state
 - region_description
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -51,6 +52,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ext_management_system.name
 - availability_zone.name
 - flavor.name
@@ -65,6 +67,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Provider
 - Availability Zone
 - Flavor

--- a/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
@@ -26,6 +26,7 @@ cols:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -50,6 +51,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ext_management_system.name
 - ems_cluster_name
 - host.name
@@ -63,6 +65,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Provider
 - Cluster
 - Host

--- a/product/views/Vm-all_vms.yaml
+++ b/product/views/Vm-all_vms.yaml
@@ -24,6 +24,7 @@ cols:
 - last_compliance_status
 - v_total_snapshots
 - last_scan_on
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -45,6 +46,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ems_cluster_name
 - host.name
 - storage.name
@@ -55,6 +57,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Cluster
 - Host
 - Datastore

--- a/product/views/Vm.yaml
+++ b/product/views/Vm.yaml
@@ -26,6 +26,7 @@ cols:
 - allocated_disk_storage
 - last_scan_on
 - cloud
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -41,6 +42,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ipaddresses
 - last_compliance_status
 - v_total_snapshots
@@ -51,6 +53,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - IP Addresses
 - Compliant
 - Total Snapshots

--- a/product/views/VmOrTemplate-all_vms_and_templates.yaml
+++ b/product/views/VmOrTemplate-all_vms_and_templates.yaml
@@ -26,6 +26,7 @@ cols:
 - v_total_snapshots
 - allocated_disk_storage
 - last_scan_on
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -47,6 +48,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ems_cluster_name
 - host.name
 - ipaddresses
@@ -59,6 +61,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Cluster
 - Host
 - IP Addresses

--- a/product/views/VmOrTemplate.yaml
+++ b/product/views/VmOrTemplate.yaml
@@ -27,6 +27,7 @@ cols:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -51,6 +52,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ext_management_system.name
 - ems_cluster_name
 - host.name
@@ -65,6 +67,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - Provider
 - Cluster
 - Host

--- a/product/views/Vm__restricted.yaml
+++ b/product/views/Vm__restricted.yaml
@@ -26,6 +26,7 @@ cols:
 - mem_cpu
 - allocated_disk_storage
 - used_disk_storage
+- normalized_state
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -44,6 +45,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- normalized_state
 - ipaddresses
 - evm_owner.name
 - miq_group.description
@@ -56,6 +58,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Power State
 - IP Addresses
 - Owner
 - Group

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -27,8 +27,9 @@ describe ApplicationController do
       expect(headder[0]).to eql("is_narrow" => true)
       expect(headder[1]).to eql("is_narrow"=>true)
       expect(headder[2]).to eql("text" => "Name", "sort" => "str", "col_idx" => 0, "align" => "left")
-      expect(headder[3]).to eql("text" => "Provider", "sort" => "str", "col_idx" => 1, "align" => "left")
-      expect(headder[4]).to eql("text" => "Cluster", "sort" => "str", "col_idx" => 2, "align" => "left")
+      expect(headder[3]).to eql("text" => "Power State", "sort" => "str", "col_idx" => 1, "align" => "left")
+      expect(headder[4]).to eql("text" => "Provider", "sort" => "str", "col_idx" => 2, "align" => "left")
+      expect(headder[5]).to eql("text" => "Cluster", "sort" => "str", "col_idx" => 3, "align" => "left")
     end
 
     it "should call specific functions" do


### PR DESCRIPTION
I looked for all the yaml reports containing `Vm` in their filename:
```
$ find product/views | grep Vm
product/views/VmdbIndex.yaml - irrelevant
product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
product/views/VmdbDatabaseSetting.yaml - irrelevant
product/views/Vm.yaml
product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
product/views/Vm-all_vms.yaml
product/views/ManageIQ_Providers_Vmware_CloudManager_OrchestrationTemplate.yaml - irrelevant
product/views/VmOrTemplate.yaml
product/views/ManageIQ_Providers_InfraManager_Vm.yaml
product/views/VmOrTemplate-all_vms_and_templates.yaml
product/views/VmdbTableEvm.yaml - irrelevant
product/views/VmdbDatabaseConnection.yaml - irrelevant
product/views/VmOrTemplate-all_orphaned.yaml - orphaned is a power state
product/views/Vm-VmReconfigureRequest.yaml - reconfiguration doesn't need powerstate
product/views/ManageIQ_Providers_CloudManager_Vm.yaml
product/views/VmOrTemplate-all_archived.yaml - archived is a power state
product/views/Vm__restricted.yaml
```

Some of them were irrelevant, but all the others should be affected by this change.

**Before:**
![screenshot from 2018-10-22 18-18-59](https://user-images.githubusercontent.com/649130/47304440-f7d78c80-d626-11e8-8a46-88427928ddca.png)

**After:**
![screenshot from 2018-10-22 18-18-04](https://user-images.githubusercontent.com/649130/47304419-e7271680-d626-11e8-9cb1-90b84fd12d95.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label enhancement, GTLs

Depends on: https://github.com/ManageIQ/manageiq/pull/18126
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460798