### PR TITLE
[RFE] Display current zone name and region number in the about modal

### DIFF
--- a/app/javascript/components/miq-about-modal.jsx
+++ b/app/javascript/components/miq-about-modal.jsx
@@ -15,9 +15,11 @@ const showModal = () => (dispatch, getState) => {
   }
 
   // Request the modal data from the API
-  return API.get('/api')
-    .then(data => dispatch({ type: LOAD_ABOUT_MODAL, data }))
-    .then(() => dispatch({ type: SHOW_ABOUT_MODAL }));
+  return API.get('/api').then(root =>
+    API.get(root.server_info.region_href).then(region =>
+      API.get(root.server_info.zone_href).then(zone => ({ ...root, region, zone })).then(data =>
+        dispatch({ type: LOAD_ABOUT_MODAL, data })).then(() =>
+        dispatch({ type: SHOW_ABOUT_MODAL }))));
 };
 
 const hideModal = () => ({ type: HIDE_ABOUT_MODAL });
@@ -83,6 +85,8 @@ class MiqAboutModal extends React.Component {
         <AboutModal.Versions>
           <AboutModal.VersionItem label={__('Version')} versionText={`${data.server_info.version}.${data.server_info.build}`} />
           <AboutModal.VersionItem label={__('Server Name')} versionText={data.server_info.appliance || ''} />
+          <AboutModal.VersionItem label={__('Region')} versionText={data.region.region.toString()} />
+          <AboutModal.VersionItem label={__('Zone')} versionText={data.zone.name || ''} />
           <AboutModal.VersionItem label={__('User Name')} versionText={data.identity.name} />
           <AboutModal.VersionItem label={__('User Role')} versionText={data.identity.role} />
           <AboutModal.VersionItem label={__('Browser')} versionText={browser.browser} />


### PR DESCRIPTION
The `region_href` and `zone_href` attributes from the `server_info` have been used in two consecutive API requests to retrieve the required extra data. Maybe I'm not doing the assignments *The Right Way&trade;*, but IMO there's no such thing in the JS world, so I'll just let @Hyperkid123 review this.

![screenshot from 2018-10-22 21-05-35](https://user-images.githubusercontent.com/649130/47313064-43496500-d63e-11e8-9178-42fed47796c5.png)

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @epwinchell 
@miq-bot add_label enhancement

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1402112