### PR TITLE
Add physical switches to the Physical Server page Relationships table

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -10,7 +10,7 @@ class PhysicalServerController < ApplicationController
   after_action :set_session_data
 
   def self.display_methods
-    %w(network_devices storage_devices)
+    %w(network_devices storage_devices physical_switches)
   end
 
   def display_network_devices

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i(host ext_management_system physical_rack physical_chassis)
+      %i(host ext_management_system physical_rack physical_chassis physical_switches)
     )
   end
 
@@ -58,6 +58,15 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_ext_management_system
     textual_link(ExtManagementSystem.find(@record.ems_id))
+  end
+
+  def textual_physical_switches
+    physical_switches_count = @record.physical_switches.count
+    physical_switches = {:label => _("Physical Switches"), :value => physical_switches_count, :icon => PhysicalSwitchDecorator.fonticon}
+    if physical_switches_count.positive?
+      physical_switches[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'physical_switches')
+    end
+    physical_switches
   end
 
   def textual_physical_rack

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -62,7 +62,7 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_physical_switches
     physical_switches_count = @record.physical_switches.count
-    physical_switches = {:label => _("Physical Switches"), :value => physical_switches_count, :icon => PhysicalSwitchDecorator.fonticon}
+    physical_switches = {:label => _("Physical Switches"), :value => physical_switches_count, :icon => PhysicalSwitch.decorate.fonticon}
     if physical_switches_count.positive?
       physical_switches[:link] = url_for_only_path(:action => 'show', :id => @record, :display => 'physical_switches')
     end

--- a/app/views/physical_server/show.html.haml
+++ b/app/views/physical_server/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if %w(network_devices physical_servers storage_devices).include?(@display)
+  - if %w(network_devices physical_servers storage_devices physical_switches).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - else
     - case @showtype

--- a/spec/helpers/physical_server_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_server_helper/textual_summary_spec.rb
@@ -53,7 +53,7 @@ describe PhysicalServerHelper::TextualSummary do
     loc_led_state
   )
 
-  include_examples "textual_group", "Relationships", %i(host ext_management_system physical_rack physical_chassis)
+  include_examples "textual_group", "Relationships", %i(host ext_management_system physical_rack physical_chassis physical_switches)
 
   include_examples "textual_group", "Management Networks", %i(mac ipv4 ipv6), "management_networks"
 


### PR DESCRIPTION
This PR adds the physical switches relationship to the Relationships table on the Physical Server Summary page.

![image](https://user-images.githubusercontent.com/23690141/47317373-657bbc80-d617-11e8-840a-20fe92b3fd99.png)

![image](https://user-images.githubusercontent.com/23690141/47317416-804e3100-d617-11e8-9edd-76021690a15b.png)
