### PR TITLE
Fix bottom tooltip placement for notifications in the drawer

### DIFF
--- a/app/views/static/notification_drawer/_notification-body.html.haml
+++ b/app/views/static/notification_drawer/_notification-body.html.haml
@@ -22,7 +22,7 @@
   .drawer-pf-notification-content{'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}
     %span.drawer-pf-notification-message{'uib-tooltip-append'      => true,
                                          'uib-tooltip-popup-delay' => 500,
-                                         'uib-tooltip-placement'   => 'bottom',
+                                         'tooltip-placement'       => 'bottom',
                                          'uib-tooltip'             => '{{ notification.message }}'}
       {{ notification.message }}
     .drawer-pf-notification-info{'ng-click' => 'customScope.markNotificationRead(notification, notificationGroup)'}


### PR DESCRIPTION
This is a regression caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/4057 and a bug in `angular-bootstrap` as it does not behave for all prefixes as it should.

**Before:**
![screenshot from 2018-10-24 16-02-27](https://user-images.githubusercontent.com/649130/47436483-de5d4e80-d7a6-11e8-92ff-013d0327f3fb.png)

**After:**
![screenshot from 2018-10-24 16-04-19](https://user-images.githubusercontent.com/649130/47436495-e3220280-d7a6-11e8-9d94-8c5e965f7b66.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635597
@miq-bot add_label bug
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @himdel 