### PR TITLE
Only update report name in group reports menu when editing a report

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -95,7 +95,7 @@ module ReportController::Reports::Editor
       end
       if @rpt.save
         # update report name in menu if name is edited
-        menu_repname_update(@edit[:current][:name], @edit[:new][:name]) if @edit[:current][:name] != @edit[:new][:name]
+        menu_repname_update(@edit[:current][:name], @edit[:new][:name]) if @edit[:rpt_id] && @edit[:current][:name] != @edit[:new][:name]
         AuditEvent.success(build_saved_audit(@rpt, @edit))
         @edit[:rpt_id] ?
           add_flash(_("Report \"%{name}\" was saved") % {:name => @rpt.name}) :


### PR DESCRIPTION
Only update report name for user's group menu when editing an existing report. Since report are saved by name in user's group record for menus, updating report name while copying a report was causing an issue of showing incorrect reports in user created custom folders. Newly added and copied reports by default get added into My Company/Custom folder.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1641771