### PR TITLE
Setting `@in_a_form`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -552,7 +552,7 @@ class CatalogController < ApplicationController
       options[:dialog_locals] = DialogLocalService.new.determine_dialog_locals_for_svc_catalog_provision(
         ra, st, svc_catalog_provision_finish_submit_endpoint
       )
-
+      @in_a_form = true
       if Settings.product.old_dialog_user_ui
         dialog_initialize(ra, options)
       else


### PR DESCRIPTION
Need to set `@in_a_form` for the code to go thru correct path and hide paging bar when ordering a catalog from list view screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1642595

before
![before](https://user-images.githubusercontent.com/3450808/47464266-af4ed900-d7b6-11e8-9c66-38adb42de113.png)


after
![after](https://user-images.githubusercontent.com/3450808/47464119-436c7080-d7b6-11e8-8447-7e514bc7ed7b.png)
