### PR TITLE
Increase limit of email text field to 254 characters

### DIFF
--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -86,7 +86,7 @@
           = text_field_tag("email",
                            @edit[:new][:email],
                            :autocomplete      => 'off',
-                           :maxlength         => 50,
+                           :maxlength         => 253,
                            :class => "form-control",
                            "data-miq_observe" => observe_url_json)
     - unless @edit


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/3677

The emails are limited to 51 characters, however they can be 254 characters long (according to documentation mentioned in the issue). Of course I don't think there could be anyone with so long email address, but it's not bad idea to support it.

@miq-bot add_label hammer/no, rbac, 

