### PR TITLE
Filter tenants and groups in Access Control by current region

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -831,9 +831,9 @@ module OpsController::OpsRbac
       @right_cell_text = _("Access Control Region \"%{name}\"") %
                          {:name => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]"}
       @users_count   = Rbac.filtered(User.in_my_region).count
-      @groups_count  = Rbac.filtered(MiqGroup.non_tenant_groups).count
+      @groups_count  = Rbac.filtered(MiqGroup.non_tenant_groups_in_my_region).count
       @roles_count   = Rbac.filtered(MiqUserRole).count
-      @tenants_count = Rbac.filtered(Tenant).count
+      @tenants_count = Rbac.filtered(Tenant.in_my_region).count
     end
   end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -575,4 +575,43 @@ describe OpsController do
       end
     end
   end
+
+  describe "#rbac_get_info" do
+    let!(:root_tenant) { FactoryGirl.create(:tenant) } # creates first root Tenant in active region
+    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:inactive_region) { FactoryGirl.create(:miq_region) }
+    let!(:root_tenant_in_inactive_region) do
+      root_tenant_in_inactive_region = Tenant.root_tenant.dup
+      root_tenant_in_inactive_region.id = Tenant.id_in_region(Tenant.count + 1_000_000, inactive_region.region)
+      root_tenant_in_inactive_region.save!(:validate => false) # skip validation to create second root Tenant
+      root_tenant_in_inactive_region
+    end
+    let!(:group_in_inactive_region) do
+      group_in_inactive_region = group.dup
+      group_in_inactive_region.id = MiqGroup.id_in_region(MiqGroup.count + 1_000_000, inactive_region.region)
+      group_in_inactive_region.save!
+      group_in_inactive_region
+    end
+    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      login_as admin_user
+      MiqRegion.seed
+    end
+
+    it 'counts only Tenants in active region' do
+      allow(controller).to receive(:x_node).and_return('root')
+      controller.send(:rbac_get_info)
+      expect(controller.instance_variable_get(:@tenants_count)).to eq(Tenant.in_my_region.count)
+      expect(controller.instance_variable_get(:@tenants_count)).not_to eq(Tenant.count)
+    end
+
+    it 'counts only MiqGroups in active region' do
+      allow(controller).to receive(:x_node).and_return('root')
+      controller.send(:rbac_get_info)
+      expect(controller.instance_variable_get(:@groups_count)).to eq(MiqGroup.non_tenant_groups_in_my_region.count)
+      expect(controller.instance_variable_get(:@groups_count)).not_to eq(MiqGroup.count)
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/4720

- Have a bunch of tenants
- If you have all tenants in one region `Tenant.count == Tenant.in_my_region.count` set `id` of one of tenants to something outside current region(multiple its `id` by 3 or something)
- Go to Configuration -> Access Control -> click a region

In this case `cloudusers` tenant is not in `Tenant.in_my_region`

Before:
![image](https://user-images.githubusercontent.com/9210860/47498572-ef1ccb80-d85d-11e8-8596-e59ef957e378.png)


After:
<img width="741" alt="screen shot 2018-10-25 at 1 50 36 pm" src="https://user-images.githubusercontent.com/9210860/47498326-3191d880-d85d-11e8-95b0-6ba79c5a0e6f.png">

@miq-bot add_label bug, hammer/no, 
