### PR TITLE
Load correct Mixins::CustomButtons::Result when browser is refreshed

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -736,7 +736,7 @@ class OpsController < ApplicationController
       elsif @lastaction == "show_list"
         Mixins::CustomButtons::Result.new(:list)
       elsif x_tree[:tree] == :rbac_tree
-        Mixins::CustomButtons::Result.new(:single)
+        @record ? Mixins::CustomButtons::Result.new(:single) : Mixins::CustomButtons::Result.new(:list)
       else
         'blank_view_tb'
       end


### PR DESCRIPTION
Load custom buttons toolbar when returning or refreshing list view for User/Tenant/Groups in Access Control accordion

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1642939

before
![before](https://user-images.githubusercontent.com/3450808/47510325-f1732b80-d845-11e8-95c3-2d1dc2b43960.png)

after
![after](https://user-images.githubusercontent.com/3450808/47510332-f46e1c00-d845-11e8-9908-643eb6c99d4c.png)

