### PR TITLE
Rename tabs in the haml to match current tab in the controller scope

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -357,7 +357,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
        ($scope.currentTab === "alerts" &&
         $scope.emsCommonModel.prometheus_alerts_hostname !== '' &&
         $scope.emsCommonModel.prometheus_alerts_api_port !== '') ||
-       ($scope.currentTab === "virtualization" &&
+       ($scope.currentTab === "kubevirt" &&
         $scope.emsCommonModel.kubevirt_hostname !== '' &&
         $scope.emsCommonModel.kubevirt_password !== '' &&
         $scope.emsCommonModel.kubevirt_api_port !== '') ||

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -279,7 +279,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
 
     if ($scope.emsCommonModel.metrics_selection === 'disabled') {
-      angular.element("#container_metrics_tab").hide();
+      angular.element("#metrics_tab").hide();
     }
 
     if ($scope.emsCommonModel.virtualization_selection === 'disabled') {
@@ -351,7 +351,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     } else if (($scope.emsCommonModel.ems_controller === "ems_container") &&
       ($scope.emsCommonModel.emstype) &&
       ($scope.emsCommonModel.default_password !== '' && $scope.angularForm.default_password.$valid) &&
-      (($scope.currentTab === "container_metrics" &&
+      (($scope.currentTab === "metrics" &&
         $scope.emsCommonModel.metrics_hostname !== '' &&
         $scope.emsCommonModel.metrics_api_port) ||
        ($scope.currentTab === "alerts" &&
@@ -458,7 +458,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.metricSelectionChanged = function() {
-    $scope.tabSelectionChanged("#container_metrics_tab", $scope.emsCommonModel.metrics_selection);
+    $scope.tabSelectionChanged("#metrics_tab", $scope.emsCommonModel.metrics_selection);
   };
 
   $scope.alertsSelectionChanged = function() {

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -190,6 +190,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
       $scope.emsCommonModel.default_url                     = data.default_url;
 
+      $scope.currentTab                                     = data.non_default_current_tab || 'default';
+
       if ($scope.emsCommonModel.default_userid !== '') {
         $scope.emsCommonModel.default_password = miqService.storedPasswordPlaceholder;
       }

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -437,6 +437,7 @@ module Mixins
                         :console_auth_status           => console_auth_status,
                         :metrics_auth_status           => metrics_auth_status.nil? ? true : metrics_auth_status,
                         :ssh_keypair_auth_status       => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status,
+                        :non_default_current_tab       => @ems.emstype == "kubevirt" ? "kubevirt" : nil,
                         :kubevirt_api_port             => kubevirt_api_port,
                         :kubevirt_hostname             => kubevirt_hostname,
                         :kubevirt_security_protocol    => kubevirt_security_protocol,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -36,7 +36,7 @@
         %div{"ng-if" => "emsCommonModel.alerts_selection == 'prometheus'"}
           %i{"error-on-tab" => "prometheus_alerts", :style => "color:#cc0000"}
           = _("Alerts")
-      = miq_tab_header('virtualization', nil, 'ng-click' => "changeAuthTabToVirtualization('virtualization')") do
+      = miq_tab_header('kubevirt', nil, 'ng-click' => "changeAuthTabToVirtualization('kubevirt')") do
         %div{"ng-if" => "emsCommonModel.virtualization_selection == 'kubevirt'"}
           %i{"error-on-tab" => "kubevirt", :style => "color:#cc0000"}
           = _("Virtualization")
@@ -401,7 +401,7 @@
                                       :verify_title_off  => _("prometheus URL and API port fields are needed to perform validation."),
                                       :basic_info_needed => true}
 
-      = miq_tab_content('virtualization', 'default') do
+      = miq_tab_content('kubevirt', 'default') do
         %div{"ng-if" => "emsCommonModel.virtualization_selection === 'kubevirt'" }
           .form-group
             .col-md-12

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -28,7 +28,7 @@
           %i{"error-on-tab" => "smartstate_docker", :style => "color:#cc0000"}
           = _("SmartState Docker")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('container_metrics', nil, 'ng-click' => "changeAuthTab('container_metrics')") do
+      = miq_tab_header('metrics', nil, 'ng-click' => "changeAuthTab('metrics')") do
         %div{"ng-if" => "emsCommonModel.metrics_selection == 'prometheus' || emsCommonModel.metrics_selection == 'hawkular'"}
           %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
           = _("Metrics")
@@ -328,7 +328,7 @@
             %span{:style => "color:black"}
               = _("Used for VMRC connections to all VMs on this provider. If not set, the VMRC console access will be disabled for this provider.")
     - elsif controller_name == "ems_container"
-      = miq_tab_content('container_metrics', 'default') do
+      = miq_tab_content('metrics', 'default') do
         .form-group
           .col-md-12.col-md-12
             %div{"ng-if" => "emsCommonModel.metrics_selection == 'hawkular'"}
@@ -490,7 +490,7 @@
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#alerts_tab", false);
-    miq_tabs_show_hide("#container_metrics_tab", false);
+    miq_tabs_show_hide("#metrics_tab", false);
     miq_tabs_show_hide("#virtualization_tab", false);
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
@@ -558,7 +558,7 @@
 %div{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
   :javascript
     miq_tabs_show_hide("#alerts_tab", true);
-    miq_tabs_show_hide("#container_metrics_tab", true);
+    miq_tabs_show_hide("#metrics_tab", true);
     miq_tabs_show_hide("#virtualization_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -82,6 +82,10 @@ describe('emsCommonFormController', function() {
     it('sets the api_version to v2', function() {
       expect($scope.emsCommonModel.api_version).toEqual('v2');
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId is an Amazon Id', function() {
@@ -151,6 +155,10 @@ describe('emsCommonFormController', function() {
 
     it('sets the default_url', function() {
       expect($scope.emsCommonModel.default_url).toEqual("http://host.test/abc");
+    });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
     });
 
     it('initializes $scope.postValidationModel with credential objects for only those providers that support validation', function () {
@@ -229,6 +237,10 @@ describe('emsCommonFormController', function() {
     it('sets the default_password', function() {
       expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId is an Azure Id', function() {
@@ -294,6 +306,10 @@ describe('emsCommonFormController', function() {
 
     it('sets the default_password', function() {
       expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
     });
   });
 
@@ -485,6 +501,10 @@ describe('emsCommonFormController in the context of container provider', functio
     it('sets the api_version to v2', function () {
       expect($scope.emsCommonModel.api_version).toEqual('v2');
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId of existing provider', function () {
@@ -535,6 +555,10 @@ describe('emsCommonFormController in the context of container provider', functio
 
     it('sets the provider options to expected value', function () {
       expect($scope.emsOptionsModel.provider_options_original_values).toEqual(basic_options_example);
+    });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
     });
   });
 
@@ -680,6 +704,10 @@ describe('emsCommonFormController in the context of ems infra provider', functio
     it('sets the api_version to v2', function () {
       expect($scope.emsCommonModel.api_version).toEqual('v2');
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId is an SCVMM Id', function () {
@@ -732,6 +760,10 @@ describe('emsCommonFormController in the context of ems infra provider', functio
 
     it('sets the default_password', function () {
       expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
     });
   });
 
@@ -807,6 +839,10 @@ describe('emsCommonFormController in the context of ems infra provider', functio
     it('sets the ssh_keypair_password', function () {
       expect($scope.emsCommonModel.ssh_keypair_password).toEqual(miqService.storedPasswordPlaceholder);
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId is a RHEV Id', function () {
@@ -865,6 +901,10 @@ describe('emsCommonFormController in the context of ems infra provider', functio
     it('sets the default api port', function () {
       expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
+
+    it('sets the current tab to default', function() {
+      expect($scope.currentTab).toEqual('default');
+    });
   });
 
   describe('when the emsCommonFormId is a Kubevirt Id', function () {
@@ -874,6 +914,7 @@ describe('emsCommonFormController in the context of ems infra provider', functio
       kubevirt_hostname: '10.22.33.44',
       emstype: 'kubevirt',
       zone: 'default',
+      non_default_current_tab: 'kubevirt',
       kubevirt_api_port: '8443',
       kubevirt_password_exists: true,
       kubevirt_security_protocol: 'ssl-with-validation-custom-ca',
@@ -927,6 +968,10 @@ describe('emsCommonFormController in the context of ems infra provider', functio
 
     it('sets the kubevirt certificate', function () {
       expect($scope.emsCommonModel.kubevirt_tls_ca_certs).toEqual('-----BEGIN DUMMY...');
+    });
+
+    it('sets the current tab to kubevirt', function() {
+      expect($scope.currentTab).toEqual('kubevirt');
     });
   });
 });


### PR DESCRIPTION
Adjusted Container Provider tab names so that they are consistent with what's specified in the haml and the value passed to the angular controller when Validate is clicked.

This is also a continuation of work for this PR - https://github.com/ManageIQ/manageiq-ui-classic/pull/4768

https://bugzilla.redhat.com/show_bug.cgi?id=1609735
https://bugzilla.redhat.com/show_bug.cgi?id=1640304




