### PR TITLE
 Turn off 'open_url' if the button is to be displayed for a list

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -110,6 +110,7 @@ module ApplicationController::Buttons
 
       copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color disabled_text button_type inventory_type))
       @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
+      @edit[:new][:open_url] = false if @edit[:new][:disabled_open_url]
 
       @edit[:new][:dialog_id] = params[:dialog_id] == "" ? nil : params[:dialog_id] if params.keys.include?("dialog_id")
       visibility_box_edit


### PR DESCRIPTION
Problem is, that if the 'Open URL' is checked, and 'Display for' is changed to anything else than `Single`, the 'Open URL' checkbox gets disabled and it's not possible to uncheck it.

After these changes, the checkbox is automatically unchecked, if the button is supposed to be displayed for a list.

Also the checkbox will only be visible for a VM and Instance buttons, as it can only be applied there.

Steps for Testing/QA
-------------------------------

1) Automation - Automate - Customization - Buttons
2) add a Custom Button to a VM and Instance model 