### PR TITLE
Move reducer initialization out of the buttons component.

### DIFF
--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -1,13 +1,49 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { combineReducers } from 'redux';
 
 import FormButtons from './form-buttons';
 
-function FormButtonsRedux(props) {
-  initReducer();
+function initReducer() {
+  if (initReducer.done) {
+    // don't init twice
+    return;
+  }
+  initReducer.done = true;
 
+
+  const initialState = { ...FormButtons.defaultProps };
+
+  const actions = {
+    'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),
+    'FormButtons.customLabel': (state, payload) => ({ ...state, customLabel: payload || '' }),
+    'FormButtons.newRecord': (state, payload) => ({ ...state, newRecord: !!payload }),
+    'FormButtons.pristine': (state, payload) => ({ ...state, pristine: !!payload }),
+    'FormButtons.saveable': (state, payload) => ({ ...state, saveable: !!payload }),
+
+    'FormButtons.callbacks': (state, payload) => ({ ...state, ...payload }),
+  };
+
+
+  ManageIQ.redux.addReducer({
+    FormButtons: function FormButtonsReducer(state = initialState, action) {
+      if (actions[action.type]) {
+        return actions[action.type](state, action.payload);
+      } else if (action.type.match(/^FormButtons\./)) {
+        console.warn(`FormButtonsReducer - unknown action type: ${action.type}`, action);
+      }
+
+      return state;
+    },
+  });
+}
+/**
+ * This was causing inifinite loop in production ENV
+ * We should probably refactor it into proper reducer file and initialize as default store
+ */
+initReducer();
+
+function FormButtonsRedux(props) {
   return <FormButtons {...props} />;
 }
 
@@ -21,14 +57,14 @@ FormButtonsRedux.defaultProps = {
 
 
 function mapStateToProps(state, ownProps) {
-  let props = {...state.FormButtons};
+  const props = { ...state.FormButtons };
 
   if (state.FormButtons && ownProps.callbackOverrides) {
     // allow overriding click handlers
     // the original handler is passed as the only argument to the new one
     Object.keys(ownProps.callbackOverrides).forEach((name) => {
       props[name] = () => {
-        let origHandler = state.FormButtons[name];
+        const origHandler = state.FormButtons[name];
         ownProps.callbackOverrides[name](origHandler);
       };
     });
@@ -39,37 +75,3 @@ function mapStateToProps(state, ownProps) {
 
 export default connect(mapStateToProps)(FormButtonsRedux);
 
-function initReducer() {
-  if (initReducer.done) {
-    // don't init twice
-    return;
-  }
-  initReducer.done = true;
-
-
-  const initialState = {...FormButtons.defaultProps};
-
-  const actions = {
-    'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),
-    'FormButtons.customLabel': (state, payload) => ({ ...state, customLabel: payload || ''}),
-    'FormButtons.newRecord': (state, payload) => ({ ...state, newRecord: !! payload }),
-    'FormButtons.pristine': (state, payload) => ({ ...state, pristine: !! payload }),
-    'FormButtons.saveable': (state, payload) => ({ ...state, saveable: !! payload }),
-
-    'FormButtons.callbacks': (state, payload) => ({ ...state, ...payload }),
-  };
-
-
-  ManageIQ.redux.addReducer({
-    FormButtons: function FormButtonsReducer(state = initialState, action) {
-
-      if (actions[action.type]) {
-        return actions[action.type](state, action.payload);
-      } else if (action.type.match(/^FormButtons\./)) {
-        console.warn(`FormButtonsReducer - unknown action type: ${action.type}`, action);
-      }
-
-      return state;
-    },
-  });
-}


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1643436

**The bug is reproducible only in production ENV.** It was causing infinite loop in react component inside the modal. I am not sure why.

Once i've moved redux initialization out of the FormButtonsRedux component, the problem was gone. This is probably due to a small difference in how are reducers registered. Before new reducer was added to the redux store only after some action was dispatched. Now it is visible immediately after registering. This probably cause state updates before the component is mounted and that may cause constant rendering and infinite loop. Probably some magic in PF3 Modal component, but again i am not 100% sure.