### PR TITLE
Fixed feature id when checking assert_privileges.

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -3,7 +3,7 @@ module ApplicationController::Tags
 
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
-    assert_privileges("#{controller_for_common_methods}_tag") if assert
+    assert_privileges("#{@display ? @display.singularize : controller_for_common_methods}_tag") if assert
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -111,4 +111,21 @@ describe ApplicationController do
       end
     end
   end
+
+  describe EmsInfraController do
+    before do
+      login_as FactoryGirl.create(:user, :features => %w(storage_tag))
+      controller.instance_variable_set(:@_params, params)
+      controller.instance_variable_set(:@display, "storages")
+    end
+
+    context 'check for correct feature id when tagging selected storage thru Provider relationship' do
+      let(:params) { {:db => "Storage", :id => "1"} }
+      it 'sets @tagging properly' do
+        allow(controller).to receive(:tagging_edit_tags_reset)
+        controller.send(:tagging_edit)
+        expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Code was checking for feature id as ems_infra_tag when trying to tag selected storages thru Provider relationship screen. This was causing an issue when user did not have access to ems_infra_tag feature but had access to storage_tag feature. Fixed code to check if `@display` is set to use that when setting feature id to check for.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610957

