### PR TITLE
GTL - use miqSparkle-style spinner when loading

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -285,9 +285,21 @@
       this.initObject.showUrl = false;
     }
     this.gtlType = initObject.gtlType || DEFAULT_VIEW;
-    this.settings.isLoading = true;
+    this.loading();
     ManageIQ.gridChecks = [];
     this.$window.sendDataWithRx({setCount: 0});
+  };
+
+  ReportDataController.prototype.loading = function() {
+    this.$window.ManageIQ.gtl.loading = true;
+    this.settings.isLoading = true;
+    miqSparkleOn();
+  };
+
+  ReportDataController.prototype.loaded = function() {
+    this.$window.ManageIQ.gtl.loading = false;
+    this.settings.isLoading = false;
+    miqSparkleOff();
   };
 
   /**
@@ -307,8 +319,7 @@
   * @returns {Object} promise of fetched data.
   */
   ReportDataController.prototype.initController = function(initObject) {
-    this.$window.ManageIQ.gtl = this.$window.ManageIQ.gtl || {};
-    this.$window.ManageIQ.gtl.loading = true;
+    this.loading();
     initObject.modelName = decodeURIComponent(initObject.modelName);
     this.initObjects(initObject);
     this.setExtraClasses(initObject.gtlType);
@@ -336,7 +347,7 @@
         }
 
         this.$timeout(function() {
-          this.$window.ManageIQ.gtl.loading = false;
+          this.loaded();
           this.$window.ManageIQ.gtl.isFirst = this.settings.current === 1;
           this.$window.ManageIQ.gtl.isLast = this.settings.current === this.settings.total;
         }.bind(this));
@@ -355,7 +366,6 @@
   ReportDataController.prototype.setDefaults = function() {
     this.settings.selectAllTitle = __('Select All');
     this.settings.sortedByTitle = __('Sorted By');
-    this.settings.isLoading = false;
     this.settings.dropdownClass = ['dropup'];
     this.settings.translateTotalOf = function(start, end, total) {
       if (typeof start !== 'undefined' && typeof end !== 'undefined' && typeof total !== 'undefined') {

--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -285,21 +285,15 @@
       this.initObject.showUrl = false;
     }
     this.gtlType = initObject.gtlType || DEFAULT_VIEW;
-    this.loading();
+    this.setLoading(true);
     ManageIQ.gridChecks = [];
     this.$window.sendDataWithRx({setCount: 0});
   };
 
-  ReportDataController.prototype.loading = function() {
-    this.$window.ManageIQ.gtl.loading = true;
-    this.settings.isLoading = true;
-    miqSparkleOn();
-  };
-
-  ReportDataController.prototype.loaded = function() {
-    this.$window.ManageIQ.gtl.loading = false;
-    this.settings.isLoading = false;
-    miqSparkleOff();
+  ReportDataController.prototype.setLoading = function(state) {
+    this.$window.ManageIQ.gtl.loading = state;
+    this.settings.isLoading = state;
+    state ? miqSparkleOn() : miqSparkleOff();
   };
 
   /**
@@ -319,7 +313,7 @@
   * @returns {Object} promise of fetched data.
   */
   ReportDataController.prototype.initController = function(initObject) {
-    this.loading();
+    this.setLoading(true);
     initObject.modelName = decodeURIComponent(initObject.modelName);
     this.initObjects(initObject);
     this.setExtraClasses(initObject.gtlType);
@@ -347,10 +341,11 @@
         }
 
         this.$timeout(function() {
-          this.loaded();
+          this.setLoading(false);
           this.$window.ManageIQ.gtl.isFirst = this.settings.current === 1;
           this.$window.ManageIQ.gtl.isLast = this.settings.current === this.settings.total;
         }.bind(this));
+
         return data;
       }.bind(this));
   };

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -258,6 +258,11 @@ function miqSparkleOn() {
 }
 
 function miqSparkleOff() {
+  // this prevents ajax requests on GTL screens from disabling the spinner too early
+  if (ManageIQ.gtl.loading) {
+    return;
+  }
+
   miqSpinner(false);
   if (miqDomElementExists('searching_spinner_center')) {
     miqSearchSpinner(false);

--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -107,6 +107,7 @@ module GtlHelper
     parent_id_escaped = (h(j_str(options[:parent_id])) unless options[:display].nil?)
 
     javascript_tag <<EOJ
+      ManageIQ.gtl.loading = true;
       sendDataWithRx({unsubscribe: 'reportDataController'});
       miq_bootstrap('#miq-gtl-view', 'ManageIQ.report_data');
       sendDataWithRx({initController: {


### PR DESCRIPTION
this changes the GTL spinner code to show the ManageIQ spinner when the content is loading
this should prevent timing issues when trying to switch views (tree_select) when a GTL view is being loaded

using `ManageIQ.gtl.loading` in `miqSparkleOff` is ...sub-optimal,
but I'm currently seeing no way not to do that without the spinner disappearing and reapearring when the ajax request finishes but before the angular gtl code finishes initializing

Probably needs quite some testing :).

https://bugzilla.redhat.com/show_bug.cgi?id=1626627