### PR TITLE
[GAPRINDASHVILI] Fixed action order field name to be consistent with observer

### DIFF
--- a/app/views/catalog/_form_resources_info.html.haml
+++ b/app/views/catalog/_form_resources_info.html.haml
@@ -63,7 +63,7 @@
                   - if @edit[:new][:selected_resources].length <= 1
                     = h(@edit[:new][:selected_resources].length)
                   - else
-                    = select_tag("gidx_#{to_cid(sr[:id])}",
+                    = select_tag("gidx_#{sr[:id]}",
                       options_for_select((1..@edit[:new][:rsc_groups].length).to_a, (i + 1).to_s),
                       "data-miq_sparkle_on" => true)
                     :javascript


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/4488 broke the observer for Action order drop down. In https://github.com/ManageIQ/manageiq-ui-classic/pull/2482 use of compressed ids was removed from https://github.com/ManageIQ/manageiq-ui-classic/pull/2482/files#diff-10a8b10a2fee4a8ed7444f35479d9444L66 causing the observer and field name to not match.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618836

