### PR TITLE
Show only servers in current region in Diagnostics

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -420,7 +420,7 @@ module OpsController::Diagnostics
       zone = Zone.find_by_id(x_node.split("-").last)
       @view, @pages = get_view(MiqServer, :named_scope => [[:with_zone_id, zone.id]]) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(MiqServer) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqServer, :named_scope => [:in_my_region]) # Get the records (into a view) and the paginator
     end
     @no_checkboxes = @showlinks = true
     @items_per_page = ApplicationController::ONE_MILLION


### PR DESCRIPTION
Closes #4719 .

Have two Regions each with one or more servers.
Configuration -> Diagnostics -> select Region -> select Servers tab -> see that number of servers in tree and in GTL isn't same

Before:
<img width="1197" alt="screen shot 2018-10-30 at 2 29 54 pm" src="https://user-images.githubusercontent.com/9210860/47721710-02aaa680-dc51-11e8-9e7e-511bfd914f4a.png">
After:
<img width="1200" alt="screen shot 2018-10-30 at 2 26 17 pm" src="https://user-images.githubusercontent.com/9210860/47721704-00484c80-dc51-11e8-8677-016408ae17d5.png">

@miq-bot add_label bug, hammer/no