### PR TITLE
Rescue error when canceling job

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -93,7 +93,11 @@ class MiqTaskController < ApplicationController
               elsif task.state.downcase == "finished"
                 _("Finished Task cannot be cancelled")
               else
-                task.process_cancel
+                begin
+                  task.process_cancel
+                rescue RuntimeError => e
+                  e.message
+                end
               end
     add_flash(message, :error)
     jobs

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -832,6 +832,22 @@ describe MiqTaskController do
       end
     end
 
+    describe ".cancel_task" do
+      before do
+        allow(controller).to receive(:jobs_info)
+        allow(controller).to receive(:role_allows?).and_return(true)
+
+        task = double("MiqTask")
+        allow(MiqTask).to receive(:find_by).and_return(task)
+        allow(task).to receive(:state).and_return("starting")
+        allow(task).to receive(:process_cancel).and_raise("Not Permitted Signal")
+      end
+
+      it "does not raise error if not alowed signal sent" do
+        expect { controller.cancel_task }.not_to raise_error
+      end
+    end
+
     def get_time_period(period)
       t = format_timezone(period.to_i != 0 ? period.days.ago : Time.now, Time.zone, "raw")
       ret = []


### PR DESCRIPTION
**Issue**: not rescued Runtime Error shown in UI when not permitted signal sent to Smart State Analysis state machine.
Bug was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/242

**Fix**: `rescue` error raised by state machine

**Before:**
![before](https://user-images.githubusercontent.com/6556758/47745495-2e7e5a00-dc5a-11e8-9cb7-eda52990591d.png)

**After:**

<img width="1212" alt="after" src="https://user-images.githubusercontent.com/6556758/47745502-33430e00-dc5a-11e8-971a-27d44f298e11.png">


@miq-bot add-label bug, blocker, hammer/yes, gaprindashvili/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1640704

\cc @h-kataria 