### PR TITLE
No need to load default search when user is on tagging screen.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1388,7 +1388,7 @@ class ApplicationController < ActionController::Base
        (action_name == "show_list" && !session[:menu_click])
       adv_search_build(db)
     end
-    if @edit && !@edit[:selected] && # Load default search if search @edit hash exists
+    if @edit && !@edit[:selected] && !@edit[:tagging] && # Load default search if search @edit hash exists
        settings(:default_search, db.to_sym) # and item in listnav not selected
       load_default_search(settings(:default_search, db.to_sym))
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -274,6 +274,24 @@ describe ApplicationController do
     end
   end
 
+  describe "#get_view" do
+    before do
+      search = FactoryGirl.create(:miq_search, :name => 'sds')
+      user = FactoryGirl.create(:user_with_group, :settings => {:default_search => {:Host => search.id}})
+      login_as user
+      session[:settings] = {:default_search => {:Host => search.id},
+                            :views          => {:persistentvolume => 'list'},
+                            :perpage        => {:list => 10}}
+      controller.instance_variable_set(:@settings, :default_search => {:Host => search.id})
+    end
+
+    it "does not load default selected search on tagging screen" do
+      controller.instance_variable_set(:@edit, :tagging => "Host")
+      expect(controller).to_not receive(:load_default_search)
+      controller.send(:get_view, "Host", :gtl_dbname => :host)
+    end
+  end
+
   describe "#build_user_emails_for_edit" do
     before :each do
       EvmSpecHelper.local_miq_server


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643458

In order to recreate, Go to List of Hosts and select one of the default filters on the left and set it as default filter.  Then try to apply tags to one or more hosts, when trying to make selection on tagging screen, it should throw an error because call to `load_default_search` method corrupts `@edit` hash.