### PR TITLE
Fix CI After Dynamic Product Features

### DIFF
--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -4,6 +4,7 @@ describe MiqAeCustomizationController do
       before do
         EvmSpecHelper.local_miq_server
         login_as FactoryGirl.create(:user, :features => "dialog_delete")
+        MiqProductFeature.seed
         allow(controller).to receive(:check_privileges).and_return(true)
       end
 


### PR DESCRIPTION
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/448783132 caused by https://github.com/ManageIQ/manageiq/pull/18102

We need `MiqProductFeature.seed` to create product tenant features which are part of autorisation process.

@miq-bot assign @mzazrivec 

Not if this should be labled as blocker.

@miq-bot add_label test