### PR TITLE
Enable Dialog only for "Display for" set to "Single"

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -111,6 +111,7 @@ module ApplicationController::Buttons
       copy_params_if_set(@edit[:new], params, %i(name target_attr_name display_for submit_how description button_icon button_color disabled_text button_type inventory_type))
       @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
       @edit[:new][:open_url] = false if @edit[:new][:disabled_open_url]
+      @edit[:new][:dialog_id] = nil if params[:display_for].present? && params[:display_for] != 'single'
 
       @edit[:new][:dialog_id] = params[:dialog_id] == "" ? nil : params[:dialog_id] if params.keys.include?("dialog_id")
       visibility_box_edit

--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -67,8 +67,12 @@
         .col-md-8
           = select_tag('dialog_id',
                         options_for_select([[_("<None>"), nil]] + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
+                        disabled: @edit[:new][:display_for] != 'single',
                         "data-miq_sparkle_on" => true,
                         :class => "selectpicker")
+          - if @edit[:new][:display_for] != 'single'
+            .note
+              = _("Only available when \"Display for\" is set to \"Single\"")
     .form-group
       %label.control-label.col-md-2
         = _('Open URL')


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/4142

Go to Automate -> Automation -> Custumization -> Buttons -> create/edit one -> set Dialog to something -> set `Display for` to `List` or `Single and List`-> save it

Before:
<img width="887" alt="screen shot 2018-11-02 at 12 44 28 pm" src="https://user-images.githubusercontent.com/9210860/47913731-717c3f80-de9d-11e8-93ae-06c3ff428877.png">

After:
<img width="739" alt="screen shot 2018-11-02 at 12 07 03 pm" src="https://user-images.githubusercontent.com/9210860/47913735-750fc680-de9d-11e8-8859-55b07c99c5db.png">

Also sets Dialog to `nil` when `List` or `Single and List` is selected.

@miq-bot add_label bug, hammer/no

@romanblanco please review, thanks :)
