### PR TITLE
Move form buttons reducer to separate file.

### DIFF
--- a/app/javascript/forms/form-buttons-reducer.js
+++ b/app/javascript/forms/form-buttons-reducer.js
@@ -1,32 +1,30 @@
 import FormButtons from './form-buttons';
 
-const REDUX_FORM_BUTTON_INIT = 'FormButtons.init';
-const REDUX_FORM_BUTTON_CUSTOM_LABEL = 'FormButtons.customLabel';
-const REDUX_FORM_BUTTON_NEW_RECORD = 'FormButtons.newRecord';
-const REDUX_FORM_BUTTON_PRISTINE = 'FormButtons.pristine';
-const REDUX_FORM_BUTTON_SAVEABLE = 'FormButtons.saveable';
-const REDUX_FORM_BUTTON_CALLBACKS = 'FormButtons.callbacks';
-
-export const formButtonsActions = {
-  REDUX_FORM_BUTTON_INIT,
-  REDUX_FORM_BUTTON_CUSTOM_LABEL,
-  REDUX_FORM_BUTTON_NEW_RECORD,
-  REDUX_FORM_BUTTON_PRISTINE,
-  REDUX_FORM_BUTTON_SAVEABLE,
-  REDUX_FORM_BUTTON_CALLBACKS,
+export const formButtonsActionTypes = {
+  init: 'FormButtons.init',
+  customLabel: 'FormButtons.customLabel',
+  newRecord: 'FormButtons.newRecord',
+  pristine: 'FormButtons.pristine',
+  saveable: 'FormButtons.saveable',
+  callbacks: 'FormButtons.callbacks',
 };
 
 const formsButtonsActions = {
-  [REDUX_FORM_BUTTON_INIT]: (_state, payload) => ({ ...FormButtons.defaultProps, ...payload }),
-  [REDUX_FORM_BUTTON_CUSTOM_LABEL]: (state, payload) => ({ ...state, customLabel: payload || '' }),
-  [REDUX_FORM_BUTTON_NEW_RECORD]: (state, payload) => ({ ...state, newRecord: !!payload }),
-  [REDUX_FORM_BUTTON_PRISTINE]: (state, payload) => ({ ...state, pristine: !!payload }),
-  [REDUX_FORM_BUTTON_SAVEABLE]: (state, payload) => ({ ...state, saveable: !!payload }),
-  [REDUX_FORM_BUTTON_CALLBACKS]: (state, payload) => ({ ...state, ...payload }),
+  [formButtonsActionTypes.init]: (_state, payload) => ({ ...FormButtons.defaultProps, ...payload }),
+  [formButtonsActionTypes.customLabel]: (state, payload) => ({ ...state, customLabel: payload || '' }),
+  [formButtonsActionTypes.newRecord]: (state, payload) => ({ ...state, newRecord: !!payload }),
+  [formButtonsActionTypes.pristine]: (state, payload) => ({ ...state, pristine: !!payload }),
+  [formButtonsActionTypes.saveable]: (state, payload) => ({ ...state, saveable: !!payload }),
+  [formButtonsActionTypes.callbacks]: (state, payload) => ({ ...state, ...payload }),
 };
+
+export const createFormButtonsActions = ({ dispatch }) =>
+  Object.keys(formButtonsActionTypes).reduce((acc, key) => ({
+    ...acc,
+    [key]: payload => dispatch({ type: formButtonsActionTypes[key], payload }),
+  }), {});
 
 export default (state = FormButtons.defaultProps, action) => {
   const mutator = formsButtonsActions[action.type];
   return mutator ? mutator(state, action.payload) : state;
 };
-

--- a/app/javascript/forms/form-buttons-reducer.js
+++ b/app/javascript/forms/form-buttons-reducer.js
@@ -1,0 +1,32 @@
+import FormButtons from './form-buttons';
+
+const REDUX_FORM_BUTTON_INIT = 'FormButtons.init';
+const REDUX_FORM_BUTTON_CUSTOM_LABEL = 'FormButtons.customLabel';
+const REDUX_FORM_BUTTON_NEW_RECORD = 'FormButtons.newRecord';
+const REDUX_FORM_BUTTON_PRISTINE = 'FormButtons.pristine';
+const REDUX_FORM_BUTTON_SAVEABLE = 'FormButtons.saveable';
+const REDUX_FORM_BUTTON_CALLBACKS = 'FormButtons.callbacks';
+
+export const formButtonsActions = {
+  REDUX_FORM_BUTTON_INIT,
+  REDUX_FORM_BUTTON_CUSTOM_LABEL,
+  REDUX_FORM_BUTTON_NEW_RECORD,
+  REDUX_FORM_BUTTON_PRISTINE,
+  REDUX_FORM_BUTTON_SAVEABLE,
+  REDUX_FORM_BUTTON_CALLBACKS,
+};
+
+const formsButtonsActions = {
+  [REDUX_FORM_BUTTON_INIT]: (_state, payload) => ({ ...FormButtons.defaultProps, ...payload }),
+  [REDUX_FORM_BUTTON_CUSTOM_LABEL]: (state, payload) => ({ ...state, customLabel: payload || '' }),
+  [REDUX_FORM_BUTTON_NEW_RECORD]: (state, payload) => ({ ...state, newRecord: !!payload }),
+  [REDUX_FORM_BUTTON_PRISTINE]: (state, payload) => ({ ...state, pristine: !!payload }),
+  [REDUX_FORM_BUTTON_SAVEABLE]: (state, payload) => ({ ...state, saveable: !!payload }),
+  [REDUX_FORM_BUTTON_CALLBACKS]: (state, payload) => ({ ...state, ...payload }),
+};
+
+export default (state = FormButtons.defaultProps, action) => {
+  const mutator = formsButtonsActions[action.type];
+  return mutator ? mutator(state, action.payload) : state;
+};
+

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -8,7 +8,6 @@ import formButtonsReducer from './form-buttons-reducer';
 ManageIQ.redux.addReducer({ FormButtons: formButtonsReducer });
 
 function FormButtonsRedux(props) {
-  console.warn('If you are using plain strings form FormButtons action types, please use defined constants from ManageIQ.redux.formButtonsActions to avoid inconsistencies.');
   return <FormButtons {...props} />;
 }
 

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -3,47 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import FormButtons from './form-buttons';
+import formButtonsReducer from './form-buttons-reducer';
 
-function initReducer() {
-  if (initReducer.done) {
-    // don't init twice
-    return;
-  }
-  initReducer.done = true;
-
-
-  const initialState = { ...FormButtons.defaultProps };
-
-  const actions = {
-    'FormButtons.init': (_state, payload) => ({ ...initialState, ...payload }),
-    'FormButtons.customLabel': (state, payload) => ({ ...state, customLabel: payload || '' }),
-    'FormButtons.newRecord': (state, payload) => ({ ...state, newRecord: !!payload }),
-    'FormButtons.pristine': (state, payload) => ({ ...state, pristine: !!payload }),
-    'FormButtons.saveable': (state, payload) => ({ ...state, saveable: !!payload }),
-
-    'FormButtons.callbacks': (state, payload) => ({ ...state, ...payload }),
-  };
-
-
-  ManageIQ.redux.addReducer({
-    FormButtons: function FormButtonsReducer(state = initialState, action) {
-      if (actions[action.type]) {
-        return actions[action.type](state, action.payload);
-      } else if (action.type.match(/^FormButtons\./)) {
-        console.warn(`FormButtonsReducer - unknown action type: ${action.type}`, action);
-      }
-
-      return state;
-    },
-  });
-}
-/**
- * This was causing inifinite loop in production ENV
- * We should probably refactor it into proper reducer file and initialize as default store
- */
-initReducer();
+ManageIQ.redux.addReducer({ FormButtons: formButtonsReducer });
 
 function FormButtonsRedux(props) {
+  console.warn('If you are using plain strings form FormButtons action types, please use defined constants from ManageIQ.redux.formButtonsActions to avoid inconsistencies.');
   return <FormButtons {...props} />;
 }
 

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -21,6 +21,7 @@ import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
 import { initializeStore } from '../miq-redux';
 import { history } from '../miq-component/react-history.ts';
 import createReduxRoutingActions from '../miq-redux/redux-router-actions';
+import { formButtonsActions } from '../forms/form-buttons-reducer';
 
 ManageIQ.react = {
   mount,
@@ -40,6 +41,7 @@ ManageIQ.redux = {
   addReducer: store.injectReducers,
   history,
   ...createReduxRoutingActions(store),
+  formButtonsActions: { ...formButtonsActions },
 };
 
 ManageIQ.angular.rxSubject = rxSubject;

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -21,7 +21,7 @@ import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
 import { initializeStore } from '../miq-redux';
 import { history } from '../miq-component/react-history.ts';
 import createReduxRoutingActions from '../miq-redux/redux-router-actions';
-import { formButtonsActions } from '../forms/form-buttons-reducer';
+import { formButtonsActionTypes, createFormButtonsActions } from '../forms/form-buttons-reducer';
 
 ManageIQ.react = {
   mount,
@@ -41,7 +41,8 @@ ManageIQ.redux = {
   addReducer: store.injectReducers,
   history,
   ...createReduxRoutingActions(store),
-  formButtonsActions: { ...formButtonsActions },
+  formButtonsActions: createFormButtonsActions(store),
+  formButtonsActionTypes: { ...formButtonsActionTypes },
 };
 
 ManageIQ.angular.rxSubject = rxSubject;


### PR DESCRIPTION
As discussed in https://github.com/ManageIQ/manageiq-ui-classic/pull/4840, i've moved the reducer to separate file.

I've also created constants for action types and exposed them to `ManageIQ.redux` interface. This should prevent any bugs, if we need to change these constants in the future (if consumers will use them instead of strings)