### PR TITLE
Allow a maximum of 500 characters in a service dialog text box

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -52,7 +52,7 @@ module ApplicationHelper::Dialogs
 
   def textbox_tag_options(field, url, auto_refresh_options_hash)
     tag_options = {
-      :maxlength => 50,
+      :maxlength => 500,
       :class     => "dynamic-text-box-#{field.id} form-control"
     }
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -134,7 +134,7 @@ describe ApplicationHelper::Dialogs do
 
       it "returns the tag options with a disabled true" do
         expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
-          :maxlength => 50,
+          :maxlength => 500,
           :class     => "dynamic-text-box-100 form-control",
           :disabled  => true,
           :title     => "This element is disabled because it is read only"
@@ -150,7 +150,7 @@ describe ApplicationHelper::Dialogs do
 
         it "returns the tag options with a data-miq-observe" do
           expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
-            :maxlength         => 50,
+            :maxlength         => 500,
             :class             => "dynamic-text-box-100 form-control",
             "data-miq_observe" => '{"url":"url"}'
           )
@@ -162,7 +162,7 @@ describe ApplicationHelper::Dialogs do
 
         it "returns the tag options with a data-miq-observe" do
           expect(helper.textbox_tag_options(dialog_field, "url", auto_refresh_options_hash)).to eq(
-            :maxlength         => 50,
+            :maxlength         => 500,
             :class             => "dynamic-text-box-100 form-control",
             "data-miq_observe" => {
               :url                             => "url",


### PR DESCRIPTION
The service dialog text box has a maxlength of 50. This is too short. This is bothering people for years now: https://github.com/ManageIQ/manageiq/issues/1226.
The best solution would be to add a 'maxlength' option to the dialog editor but the hereby proposed solution would make it workeable and would prevent people using a Text Area where they would prefer a text Box just because of the enforced maxlength of 50 characters for the text Box.