### PR TITLE
[WIP] From Jasmine to Jest conversion

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -239,7 +239,7 @@ function miqSparkle(status) {
   }
 }
 
-function miqSparkleOn() {
+window. miqSparkleOn = function() {
   if (miqDomElementExists('advsearchModal') &&
       ($('#advsearchModal').hasClass('modal fade in'))) {
     if (miqDomElementExists('searching_spinner_center')) {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -449,9 +449,9 @@ function miqResetSizeTimer() {
 }
 
 // Pass fields to server given a URL and fields in name/value pairs
-function miqPassFields(url, args) {
+window.miqPassFields = function (url, args) {
   return url + '?' + $.param(args);
-}
+};
 
 function miqChartLinkData(col, row, value, category, series, id, message) {
   // Create the context menu

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1124,8 +1124,8 @@ function miqObserveRequest(url, options) {
   return deferred.promise;
 }
 
-function miqJqueryRequest(url, options) {
-  if ((ManageIQ.observe.processing || ManageIQ.observe.queue.length) && (!options || !options.observe)) {
+window.miqJqueryRequest = function(url, options) {
+  if ((ManageIQ.observe.processing || ManageIQ.observe.queue.length) && (! options || ! options.observe)) {
     console.debug('Postponing miqJqueryRequest - waiting for the observe queue to empty first');
 
     return new Promise(function(resolve, reject) {

--- a/app/assets/javascripts/miq_flash.js
+++ b/app/assets/javascripts/miq_flash.js
@@ -1,6 +1,6 @@
 // add a flash message to an existing #flash_msg_div
 // levels are error, warning, info, success
-function add_flash(msg, level, options) {
+window.add_flash = function(msg, level, options) {
   level = level || 'success';
   options = options || {};
   var cls = { alert: '', icon: '' };
@@ -68,7 +68,7 @@ function add_flash(msg, level, options) {
   }
 }
 
-function clearFlash() {
+window.clearFlash = function() {
   $('#flash_msg_div').empty();
 }
 

--- a/app/assets/javascripts/miq_list_grid.js
+++ b/app/assets/javascripts/miq_list_grid.js
@@ -13,7 +13,7 @@ function miqRowClick(row_id, row_url, row_url_ajax) {
   }
 }
 
-function checkboxItemId($elem) {
+window.checkboxItemId  = function($elem) {
   var val = $elem.val();
   var name = $elem.attr('name');
 
@@ -25,7 +25,7 @@ function checkboxItemId($elem) {
 }
 
 // returns a list of checked row ids
-function miqGridGetCheckedRows(grid) {
+window.miqGridGetCheckedRows = function(grid) {
   grid = grid || 'list_grid';
   var crows = [];
 
@@ -70,7 +70,7 @@ function miqGridOnCheck(elem, button_div, grid) {
 }
 
 // Handle sort
-function miqGetSortUrl(col_id) {
+window.miqGetSortUrl = function(col_id) {
   var controller = null;
   var action = ManageIQ.actionUrl;
   var id = null;

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -11,7 +11,7 @@ function miqTreeObject(tree) {
   }
 }
 
-function miqTreeFindNodeByKey(tree, key) {
+window.miqTreeFindNodeByKey = function(tree, key) {
   var tree = miqTreeObject(tree);
 
   if (!tree) {
@@ -470,7 +470,7 @@ function miqTreeClearState(tree) {
   }
 }
 
-function miqInitTree(options, tree) {
+window.miqInitTree = function(options, tree) {
   if (options.check_url) {
     ManageIQ.tree.checkUrl = options.check_url;
   }

--- a/app/javascript/spec/helpers/miq_formatters_helper.js
+++ b/app/javascript/spec/helpers/miq_formatters_helper.js
@@ -1,0 +1,8 @@
+global.window = global;
+window.moment = require('moment');
+require('moment-strftime');
+require('moment-timezone');
+require('moment-duration-format')(window.moment);
+window.numeral = require('numeral');
+require('../../../assets/javascripts/miq_formatters.js');
+

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -1,0 +1,2 @@
+global.window = global;
+require('../../../assets/javascripts/miq_application.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -7,3 +7,4 @@ require('../../../assets/javascripts/resizable_sidebar.js');
 require('../../../assets/javascripts/miq_global.js');
 require('../../../assets/javascripts/miq_grid.js');
 require('../../../assets/javascripts/miq_tree.js');
+require('../../../assets/javascripts/miq_toolbar.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -1,7 +1,9 @@
 global.window = global;
 window.$ = window.jQuery = require('jquery');
+require('patternfly-bootstrap-treeview');
 require('../../../assets/javascripts/miq_application.js');
 require('../../../assets/javascripts/miq_flash.js');
 require('../../../assets/javascripts/resizable_sidebar.js');
 require('../../../assets/javascripts/miq_global.js');
 require('../../../assets/javascripts/miq_grid.js');
+require('../../../assets/javascripts/miq_tree.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -1,5 +1,7 @@
 global.window = global;
+window.$ = window.jQuery = require('jquery');
 require('../../../assets/javascripts/miq_application.js');
 require('../../../assets/javascripts/miq_flash.js');
 require('../../../assets/javascripts/resizable_sidebar.js');
 require('../../../assets/javascripts/miq_global.js');
+require('../../../assets/javascripts/miq_grid.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -1,2 +1,4 @@
 global.window = global;
 require('../../../assets/javascripts/miq_application.js');
+require('../../../assets/javascripts/miq_flash.js');
+

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -2,3 +2,4 @@ global.window = global;
 require('../../../assets/javascripts/miq_application.js');
 require('../../../assets/javascripts/miq_flash.js');
 require('../../../assets/javascripts/resizable_sidebar.js');
+require('../../../assets/javascripts/miq_global.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -8,3 +8,4 @@ require('../../../assets/javascripts/miq_global.js');
 require('../../../assets/javascripts/miq_grid.js');
 require('../../../assets/javascripts/miq_tree.js');
 require('../../../assets/javascripts/miq_toolbar.js');
+require('../../../assets/javascripts/miq_list_grid.js');

--- a/app/javascript/spec/helpers/old_js_file_require_helper.js
+++ b/app/javascript/spec/helpers/old_js_file_require_helper.js
@@ -1,4 +1,4 @@
 global.window = global;
 require('../../../assets/javascripts/miq_application.js');
 require('../../../assets/javascripts/miq_flash.js');
-
+require('../../../assets/javascripts/resizable_sidebar.js');

--- a/app/javascript/spec/helpers/set_fixtures_helper.js
+++ b/app/javascript/spec/helpers/set_fixtures_helper.js
@@ -1,0 +1,4 @@
+global.window = global;
+window.setFixtures = function(html) {
+  $('html').html(html);
+};

--- a/app/javascript/spec/old_js/fields.spec.js
+++ b/app/javascript/spec/old_js/fields.spec.js
@@ -1,5 +1,7 @@
-describe('Pass fields  to server', function() {
-  it('returns url fields in name/value pairs', function() {
+require('../helpers/old_js_file_require_helper.js');
+
+describe('Pass fields  to server', () => {
+  it('returns url fields in name/value pairs', () => {
     var url = '/path/to/infinity';
     var args = {'foo': 'bar', 'lorem': 'ipsum'};
     expect(miqPassFields(url, args)).toEqual('/path/to/infinity?foo=bar&lorem=ipsum');

--- a/app/javascript/spec/old_js/miq_api.spec.js
+++ b/app/javascript/spec/old_js/miq_api.spec.js
@@ -1,8 +1,8 @@
-describe('miq_api.js', function() {
-  it("can base64 encode utf8 passwords", function(done) {
+describe('miq_api.js', () => {
+  it("can base64 encode utf8 passwords", done => {
     var getArgs;
 
-    spyOn(vanillaJsAPI, 'get').and.callFake(function(_url, args) {
+    jest.spyOn(vanillaJsAPI, 'get').mockImplementation(function(_url, args) {
       getArgs = args;
       return Promise.resolve({});
     });

--- a/app/javascript/spec/old_js/miq_flash.spec.js
+++ b/app/javascript/spec/old_js/miq_flash.spec.js
@@ -1,29 +1,32 @@
-describe('miq_flash.js', function() {
-  describe('clearFlash', function() {
-    beforeEach(function() {
+require('../helpers/set_fixtures_helper.js');
+require('../helpers/old_js_file_require_helper.js');
+
+describe('miq_flash.js', () => {
+  describe('clearFlash', () => {
+    beforeEach(() => {
       var html = '<html><head></head><body><div id="flash_msg_div">test</div></body></html>';
       setFixtures(html);
     });
 
-    it('clears the flash_msg_div', function() {
+    it('clears the flash_msg_div', () => {
       clearFlash();
       expect($('#flash_msg_div').html()).toEqual('');
     });
   });
-  describe('longAlert', function() {
-    beforeEach(function() {
+  describe('longAlert', () => {
+    beforeEach(() => {
       var html = '<html><head></head><body><div id="flash_msg_div"></div></body></html>';
       setFixtures(html);
     });
 
-    it('displays flash_msg_div "View More" button', function() {
+    it('displays flash_msg_div "View More" button', () => {
       // Expect alert msg div to add the "See More" button to the div.
       add_flash("Lorem ipsum dolor sit amet, usu ei mollis vivendum, ancillae indoctum philosophia an pri, affert partiendo cum ne. Nec animal tincidunt philosophia ea. Ne mea liber gloriatur, ignota dictas mei ne. Omittam eleifend consequuntur vix eu, everti accusata accommodare et eam. Ut vidit semper instructior duo, usu in autem inermis. Viris pertinax constituto per id, at debet apeirian persecuti has. Nostrum expetenda qui ad, mazim iriure id duo, est alii wisi at.", 'error' , {long_alert: true});
       var flash_msg_div = '<div class="flash_text_div"><div class="alert alert-danger text-overflow-pf"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button><span class="pficon pficon-error-circle-o"></span><strong>Lorem ipsum dolor sit amet, usu ei mollis vivendum, ancillae indoctum philosophia an pri, affert partiendo cum ne. Nec animal tincidunt philosophia ea. Ne mea liber gloriatur, ignota dictas mei ne. Omittam eleifend consequuntur vix eu, everti accusata accommodare et eam. Ut vidit semper instructior duo, usu in autem inermis. Viris pertinax constituto per id, at debet apeirian persecuti has. Nostrum expetenda qui ad, mazim iriure id duo, est alii wisi at.</strong><div class="alert_expand_link" style="display: none;"><strong><a href="#">View More</a></strong></div></div></div>'
       expect($('#flash_msg_div').html()).toEqual(flash_msg_div);
     });
 
-    it('does not display flash_msg_div "See More" button', function() {
+    it('does not display flash_msg_div "See More" button', () => {
       // Expect alert msg div to *not add* the "See More" button to the div.
       add_flash("This is a really long alert!", 'error');
       var flash_msg_div = '<div class="flash_text_div"><div class="alert alert-danger"><button class="close" data-dismiss="alert"><span class="pficon pficon-close"></span></button><span class="pficon pficon-error-circle-o"></span><strong>This is a really long alert!</strong></div></div>'

--- a/app/javascript/spec/old_js/miq_formatters.spec.js
+++ b/app/javascript/spec/old_js/miq_formatters.spec.js
@@ -1,5 +1,7 @@
-describe('ManageIQ.charts.formatters', function() {
-  describe('curried/uncurried', function() {
+require('../helpers/miq_formatters_helper.js');
+
+describe('ManageIQ.charts.formatters', () => {
+  describe('curried/uncurried', () => {
     var options = {
       description: 'Number (1,234)',
       name: 'number_with_delimiter',
@@ -7,19 +9,19 @@ describe('ManageIQ.charts.formatters', function() {
       precision: 0,
     };
 
-    it('foo(val, opt)', function() {
+    it('foo(val, opt)', () => {
       var fn = ManageIQ.charts.formatters[options.name];
       expect(fn(1234, options)).toEqual('1,234');
     });
 
-    it('foo.c3(opt)(val)', function() {
+    it('foo.c3(opt)(val)', () => {
       var fn = ManageIQ.charts.formatters[options.name].c3(options);
       expect(fn(1234)).toEqual('1,234');
     });
   });
 
-  describe('.number_with_delimiter', function() {
-    it('Number (1,234)', function() {
+  describe('.number_with_delimiter', () => {
+    it('Number (1,234)', () => {
       var options = {
         description: 'Number (1,234)',
         name: 'number_with_delimiter',
@@ -31,7 +33,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(1234, options)).toEqual('1,234');
     });
 
-    it('Number (1,234.0)', function() {
+    it('Number (1,234.0)', () => {
       var options = {
         description: 'Number (1,234.0)',
         name: 'number_with_delimiter',
@@ -43,7 +45,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(1234, options)).toEqual('1,234.0');
     });
 
-    it('Number, 2 Decimals (1,234.00)', function() {
+    it('Number, 2 Decimals (1,234.00)', () => {
       var options = {
         description: 'Number, 2 Decimals (1,234.00)',
         name: 'number_with_delimiter',
@@ -55,7 +57,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(1234, options)).toEqual('1,234.00');
     });
 
-    it('Kilobytes per Second (10 KBps)', function() {
+    it('Kilobytes per Second (10 KBps)', () => {
       var options = {
         description: 'Kilobytes per Second (10 KBps)',
         name: 'number_with_delimiter',
@@ -68,7 +70,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(10, options)).toEqual('10 KBps');
     });
 
-    it('Percentage (99%)', function() {
+    it('Percentage (99%)', () => {
       var options = {
         description: 'Percentage (99%)',
         name: 'number_with_delimiter',
@@ -81,7 +83,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(99, options)).toEqual('99%');
     });
 
-    it('Percent, 1 Decimal (99.0%)', function() {
+    it('Percent, 1 Decimal (99.0%)', () => {
       var options = {
         description: 'Percent, 1 Decimal (99.0%)',
         name: 'number_with_delimiter',
@@ -94,7 +96,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(99, options)).toEqual('99.0%');
     });
 
-    it('Percent, 2 Decimals (99.00%)', function() {
+    it('Percent, 2 Decimals (99.00%)', () => {
       var options = {
         description: 'Percent, 2 Decimals (99.00%)',
         name: 'number_with_delimiter',
@@ -108,8 +110,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.currency_with_delimiter', function() {
-    it('Currency, 2 Decimals ($1,234.00)', function() {
+  describe('.currency_with_delimiter', () => {
+    it('Currency, 2 Decimals ($1,234.00)', () => {
       var options = {
         description: 'Currency, 2 Decimals ($1,234.00)',
         name: 'currency_with_delimiter',
@@ -122,8 +124,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.bytes_to_human_size', function() {
-    it('Suffixed Bytes (B, KB, MB, GB)', function() {
+  describe('.bytes_to_human_size', () => {
+    it('Suffixed Bytes (B, KB, MB, GB)', () => {
       var options = {
         description: 'Suffixed Bytes (B, KB, MB, GB)',
         name: 'bytes_to_human_size',
@@ -135,8 +137,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.bytes_to_human_size', function() {
-    it('Suffixed Bytes (B, KB, MB, GB)', function() {
+  describe('.bytes_to_human_size', () => {
+    it('Suffixed Bytes (B, KB, MB, GB)', () => {
       var options = {
         description: 'Suffixed Bytes (B, KB, MB, GB)',
         name: 'bytes_to_human_size',
@@ -148,8 +150,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.kbytes_to_human_size', function() {
-    it('Suffixed Kilobytes (KB, MB, GB)', function() {
+  describe('.kbytes_to_human_size', () => {
+    it('Suffixed Kilobytes (KB, MB, GB)', () => {
       var options = {
         description: 'Suffixed Kilobytes (KB, MB, GB)',
         name: 'kbytes_to_human_size',
@@ -161,8 +163,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.kbytes_to_human_size', function() {
-    it('Suffixed Kilobytes (KB, MB, GB)', function() {
+  describe('.kbytes_to_human_size', () => {
+    it('Suffixed Kilobytes (KB, MB, GB)', () => {
       var options = {
         description: 'Suffixed Kilobytes (KB, MB, GB)',
         name: 'kbytes_to_human_size',
@@ -174,8 +176,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.mbytes_to_human_size', function() {
-    it('Suffixed Megabytes (MB, GB)', function() {
+  describe('.mbytes_to_human_size', () => {
+    it('Suffixed Megabytes (MB, GB)', () => {
       var options = {
         description: 'Suffixed Megabytes (MB, GB)',
         name: 'mbytes_to_human_size',
@@ -187,8 +189,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.mbytes_to_human_size', function() {
-    it('Suffixed Megabytes (MB, GB)', function() {
+  describe('.mbytes_to_human_size', () => {
+    it('Suffixed Megabytes (MB, GB)', () => {
       var options = {
         description: 'Suffixed Megabytes (MB, GB)',
         name: 'mbytes_to_human_size',
@@ -200,8 +202,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.mbytes_to_human_size', function() {
-    it('Suffixed Megabytes (MB, GB)', function() {
+  describe('.mbytes_to_human_size', () => {
+    it('Suffixed Megabytes (MB, GB)', () => {
       var options = {
         description: 'Suffixed Megabytes (MB, GB)',
         name: 'mbytes_to_human_size',
@@ -213,8 +215,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.gbytes_to_human_size', function() {
-    it('Suffixed Gigabytes (GB)', function() {
+  describe('.gbytes_to_human_size', () => {
+    it('Suffixed Gigabytes (GB)', () => {
       var options = {
         description: 'Suffixed Gigabytes (GB)',
         name: 'gbytes_to_human_size',
@@ -226,8 +228,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.gbytes_to_human_size', function() {
-    it('Suffixed Gigabytes (GB)', function() {
+  describe('.gbytes_to_human_size', () => {
+    it('Suffixed Gigabytes (GB)', () => {
       var options = {
         description: 'Suffixed Gigabytes (GB)',
         name: 'gbytes_to_human_size',
@@ -239,8 +241,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.mhz_to_human_size', function() {
-    it('Megahertz (12 Mhz)', function() {
+  describe('.mhz_to_human_size', () => {
+    it('Megahertz (12 Mhz)', () => {
       var options = {
         description: 'Megahertz (12 Mhz)',
         name: 'mhz_to_human_size',
@@ -252,7 +254,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(12.1, options)).toEqual('12 MHz');
     });
 
-    it('Megahertz Avg (12.1 Mhz)', function() {
+    it('Megahertz Avg (12.1 Mhz)', () => {
       var options = {
         description: 'Megahertz Avg (12.1 Mhz)',
         name: 'mhz_to_human_size',
@@ -265,8 +267,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.boolean', function() {
-    it('Boolean (True/False)', function() {
+  describe('.boolean', () => {
+    it('Boolean (True/False)', () => {
       var options = {
         description: 'Boolean (True/False)',
         name: 'boolean',
@@ -277,7 +279,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(false, options)).toEqual('False');
     });
 
-    it('Boolean (T/F)', function() {
+    it('Boolean (T/F)', () => {
       var options = {
         description: 'Boolean (T/F)',
         name: 'boolean',
@@ -289,7 +291,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(false, options)).toEqual('F');
     });
 
-    it('Boolean (Yes/No)', function() {
+    it('Boolean (Yes/No)', () => {
       var options = {
         description: 'Boolean (Yes/No)',
         name: 'boolean',
@@ -301,7 +303,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(false, options)).toEqual('No');
     });
 
-    it('Boolean (Y/N)', function() {
+    it('Boolean (Y/N)', () => {
       var options = {
         description: 'Boolean (Y/N)',
         name: 'boolean',
@@ -313,7 +315,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(false, options)).toEqual('N');
     });
 
-    it('Boolean (Pass/Fail)', function() {
+    it('Boolean (Pass/Fail)', () => {
       var options = {
         description: 'Boolean (Pass/Fail)',
         name: 'boolean',
@@ -326,8 +328,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.datetime', function() {
-    it('Date (M/D/YYYY)', function() {
+  describe('.datetime', () => {
+    it('Date (M/D/YYYY)', () => {
       var options = {
         description: 'Date (M/D/YYYY)',
         name: 'datetime',
@@ -335,10 +337,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('03/14/2015');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('03/14/2015');
     });
 
-    it('Date (M/D/YY)', function() {
+    it('Date (M/D/YY)', () => {
       var options = {
         description: 'Date (M/D/YY)',
         name: 'datetime',
@@ -346,10 +348,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('03/14/15');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('03/14/15');
     });
 
-    it('Date (M/D)', function() {
+    it('Date (M/D)', () => {
       var options = {
         description: 'Date (M/D)',
         name: 'datetime',
@@ -357,10 +359,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('03/14');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('03/14');
     });
 
-    it('Time (HM:S Z)', function() {
+    it('Time (HM:S Z)', () => {
       var options = {
         description: 'Time (H:M:S Z) ',
         name: 'datetime',
@@ -371,7 +373,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11:22 UTC');
     });
 
-    it('Date/Time (M/D/Y HM:S Z)', function() {
+    it('Date/Time (M/D/Y HM:S Z)', () => {
       var options = {
         description: 'Date/Time (M/D/Y H:M:S Z)',
         name: 'datetime',
@@ -382,7 +384,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11:22:05 UTC');
     });
 
-    it('Date/Hour (M/D/Y H:00 Z)', function() {
+    it('Date/Hour (M/D/Y H:00 Z)', () => {
       var options = {
         description: 'Date/Hour (M/D/Y H:00 Z)',
         name: 'datetime',
@@ -393,7 +395,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11:00 UTC');
     });
 
-    it('Date/Hour (M/D/Y H AM|PM Z)', function() {
+    it('Date/Hour (M/D/Y H AM|PM Z)', () => {
       var options = {
         description: 'Date/Hour (M/D/Y H AM|PM Z)',
         name: 'datetime',
@@ -404,7 +406,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('03/14/15 11 AM UTC');
     });
 
-    it('Hour (H:00 Z)', function() {
+    it('Hour (H:00 Z)', () => {
       var options = {
         description: 'Hour (H:00 Z)',
         name: 'datetime',
@@ -415,7 +417,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11:00 UTC');
     });
 
-    it('Hour (H AM|PM Z)', function() {
+    it('Hour (H AM|PM Z)', () => {
       var options = {
         description: 'Hour (H AM|PM Z)',
         name: 'datetime',
@@ -426,7 +428,7 @@ describe('ManageIQ.charts.formatters', function() {
       expect(fn(moment.utc('2015-03-14T11:22:05Z'), options)).toEqual('11 AM UTC');
     });
 
-    it('Hour of Day (24)', function() {
+    it('Hour of Day (24)', () => {
       var options = {
         description: 'Hour of Day (24)',
         name: 'datetime',
@@ -434,10 +436,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('11');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('11');
     });
 
-    it('Day Full (Monday)', function() {
+    it('Day Full (Monday)', () => {
       var options = {
         description: 'Day Full (Monday)',
         name: 'datetime',
@@ -445,10 +447,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('Saturday');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('Saturday');
     });
 
-    it('Day Short (Mon)', function() {
+    it('Day Short (Mon)', () => {
       var options = {
         description: 'Day Short (Mon)',
         name: 'datetime',
@@ -456,10 +458,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('Sat');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('Sat');
     });
 
-    it('Day of Week (1)', function() {
+    it('Day of Week (1)', () => {
       var options = {
         description: 'Day of Week (1)',
         name: 'datetime',
@@ -467,10 +469,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('6');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('6');
     });
 
-    it('Day of Month (27)', function() {
+    it('Day of Month (27)', () => {
       var options = {
         description: 'Day of Month (27)',
         name: 'datetime',
@@ -478,10 +480,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('14');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('14');
     });
 
-    it('Month and Year (January 2011)', function() {
+    it('Month and Year (January 2011)', () => {
       var options = {
         description: 'Month and Year (January 2011)',
         name: 'datetime',
@@ -489,10 +491,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('March 2015');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('March 2015');
     });
 
-    it('Month and Year Short (Jan 11)', function() {
+    it('Month and Year Short (Jan 11)', () => {
       var options = {
         description: 'Month and Year Short (Jan 11)',
         name: 'datetime',
@@ -500,10 +502,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('Mar 15');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('Mar 15');
     });
 
-    it('Month Full (January)', function() {
+    it('Month Full (January)', () => {
       var options = {
         description: 'Month Full (January)',
         name: 'datetime',
@@ -511,10 +513,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('March');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('March');
     });
 
-    it('Month Short (Jan)', function() {
+    it('Month Short (Jan)', () => {
       var options = {
         description: 'Month Short (Jan)',
         name: 'datetime',
@@ -522,10 +524,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('Mar');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('Mar');
     });
 
-    it('Month of Year (12)', function() {
+    it('Month of Year (12)', () => {
       var options = {
         description: 'Month of Year (12)',
         name: 'datetime',
@@ -533,10 +535,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('03');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('03');
     });
 
-    it('Week of Year (52)', function() {
+    it('Week of Year (52)', () => {
       var options = {
         description: 'Week of Year (52)',
         name: 'datetime',
@@ -544,10 +546,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('11');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('11');
     });
 
-    it('Year (YYYY)', function() {
+    it('Year (YYYY)', () => {
       var options = {
         description: 'Year (YYYY)',
         name: 'datetime',
@@ -555,12 +557,12 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('2015');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('2015');
     });
   });
 
-  describe('.datetime_range', function() {
-    it('Date Range (M/D/Y - M/D/Y)', function() {
+  describe('.datetime_range', () => {
+    it('Date Range (M/D/Y - M/D/Y)', () => {
       var options = {
         description: 'Date Range (M/D/Y - M/D/Y)',
         name: 'datetime_range',
@@ -569,10 +571,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('(03/01/15 - 03/31/15)');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('(03/01/15 - 03/31/15)');
     });
 
-    it('Day Range (M/D - M/D)', function() {
+    it('Day Range (M/D - M/D)', () => {
       var options = {
         description: 'Day Range (M/D - M/D)',
         name: 'datetime_range',
@@ -581,10 +583,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('(03/08 - 03/14)');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('(03/08 - 03/14)');
     });
 
-    it('Day Range Start (M/D)', function() {
+    it('Day Range Start (M/D)', () => {
       var options = {
         description: 'Day Range Start (M/D)',
         name: 'datetime_range',
@@ -593,12 +595,12 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 05), options)).toEqual('01/01');
+      expect(fn(new Date(2015, 3 - 1, 14, 11, 22, 5), options)).toEqual('01/01');
     });
   });
 
-  describe('.set', function() {
-    it('Comma seperated list', function() {
+  describe('.set', () => {
+    it('Comma seperated list', () => {
       var options = {
         description: 'Comma seperated list',
         name: 'set',
@@ -610,8 +612,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.datetime_ordinal', function() {
-    it('Day of Month (27th)', function() {
+  describe('.datetime_ordinal', () => {
+    it('Day of Month (27th)', () => {
       var options = {
         description: 'Day of Month (27th)',
         name: 'datetime_ordinal',
@@ -619,10 +621,10 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 7 - 1, 27, 00, 00, 00), options)).toEqual('27th');
+      expect(fn(new Date(2015, 7 - 1, 27, 0, 0, 0), options)).toEqual('27th');
     });
 
-    it('Week of Year (52nd)', function() {
+    it('Week of Year (52nd)', () => {
       var options = {
         description: 'Week of Year (52nd)',
         name: 'datetime_ordinal',
@@ -630,12 +632,12 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(new Date(2015, 12 - 1, 21, 00, 00, 00), options)).toEqual('52nd');
+      expect(fn(new Date(2015, 12 - 1, 21, 0, 0, 0), options)).toEqual('52nd');
     });
   });
 
-  describe('.elapsed_time_human', function() {
-    it('"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"', function() {
+  describe('.elapsed_time_human', () => {
+    it('"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"', () => {
       var options = {
         description: '"Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"',
         name: 'elapsed_time_human',
@@ -646,8 +648,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.string_truncate', function() {
-    it('String Truncated to 50 Characters with Elipses (...)', function() {
+  describe('.string_truncate', () => {
+    it('String Truncated to 50 Characters with Elipses (...)', () => {
       var options = {
         description: 'String Truncated to 50 Characters with Elipses (...)',
         name: 'string_truncate',
@@ -659,8 +661,8 @@ describe('ManageIQ.charts.formatters', function() {
     });
   });
 
-  describe('.large_number_to_exponential_form', function() {
-    it('Convert Numbers Larger than 1.0e+15 to Exponential Form', function() {
+  describe('.large_number_to_exponential_form', () => {
+    it('Convert Numbers Larger than 1.0e+15 to Exponential Form', () => {
       var options = {
         description: 'Convert Numbers Larger than 1.0e+15 to Exponential Form',
         name: 'large_number_to_exponential_form',

--- a/app/javascript/spec/old_js/miq_grid.spec.js
+++ b/app/javascript/spec/old_js/miq_grid.spec.js
@@ -1,36 +1,39 @@
-describe('miq_grid.js', function () {
-  beforeEach(function () {
+require('../helpers/old_js_file_require_helper.js');
+require('../helpers/set_fixtures_helper.js');
+
+describe('miq_grid.js', () => {
+  beforeEach(() => {
     window.miqSetButtons = function() {}; // mock toolbar
     var html = "<table class=\"table-clickable table-checkable\"><thead><tr><th><input type=\"checkbox\" class=\"checkall\"/></th><th>Title</th></tr></thead><tbody data-click-url=\"/test/\"><tr data-click-id=\"check_1\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_1\"/></td><td>Item 1</td></tr><tr data-click-id=\"check_2\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_2\" /></td><td>Item 2</td></tr><tr data-click-id=\"check_3\"><td class=\"noclick\"><input type=\"checkbox\" value=\"check_3\" /></td><td>Item 3</td></tr></tbody></table>";
     setFixtures(html);
     $('table').miqGrid();
   });
 
-  describe('.checkall', function () {
-    it('checks itself if all checkboxes were checked', function () {
+  describe('.checkall', () => {
+    it('checks itself if all checkboxes were checked', () => {
       $('.checkall').trigger('click');
       expect($('.checkall').prop('checked')).toEqual(true);
     })
 
-    it('unchecks itself if at least one checkbox was unchecked', function () {
+    it('unchecks itself if at least one checkbox was unchecked', () => {
       $('.checkall').trigger('click');
       $(".noclick > input[type='checkbox']").first().trigger('click');
       expect($('.checkall').prop('checked')).toEqual(false);
     });
 
-    it('checks all the checkboxes when none is checked', function () {
+    it('checks all the checkboxes when none is checked', () => {
       $('.checkall').trigger('click');
       expect($(".noclick > input[type='checkbox']:checked").length).toEqual(3);
     });
 
-    it('unchecks all the checkboxes when each is checked', function () {
+    it('unchecks all the checkboxes when each is checked', () => {
       $('.checkall').trigger('click');
       expect($(".noclick > input[type='checkbox']:checked").length).toEqual(3);
       $('.checkall').trigger('click');
       expect($(".noclick > input[type='checkbox']:not(:checked)").length).toEqual(3);
     });
 
-    it('checks the remaining checkboxes when not all are checked', function () {
+    it('checks the remaining checkboxes when not all are checked', () => {
       $(".noclick > input[type='checkbox']").first().trigger('click');
       expect($(".noclick > input[type='checkbox']:checked").length).toEqual(1);
       $('.checkall').trigger('click');
@@ -38,15 +41,16 @@ describe('miq_grid.js', function () {
     });
   })
 
-  it('appends checked elements to the list of selected items', function () {
+  it('appends checked elements to the list of selected items', () => {
     $(".noclick > input[type='checkbox']").first().trigger('click');
+debugger;
     expect(ManageIQ.gridChecks.join(',')).toEqual('check_1');
     $(".noclick > input[type='checkbox']").last().trigger('click');
     expect(ManageIQ.gridChecks.join(',')).toEqual('check_1,check_3');
   });
 
-  it('sends an ajax POST request when clicking on a table row', function () {
-    spyOn(window, 'miqJqueryRequest');
+  it('sends an ajax POST request when clicking on a table row', () => {
+    jest.spyOn(window, 'miqJqueryRequest').mockImplementation(() => {});
     $("tbody > tr > td:not(.noclick)").last().trigger('click');
     expect(miqJqueryRequest).toHaveBeenCalledWith('/test/?id=check_3');
   })

--- a/app/javascript/spec/old_js/miq_list_grid.spec.js
+++ b/app/javascript/spec/old_js/miq_list_grid.spec.js
@@ -1,6 +1,9 @@
-describe('miq_list_grid.js', function() {
-  describe('#miqGridSort', function() {
-    it('returns url with no double id', function() {
+require('../helpers/set_fixtures_helper.js');
+require('../helpers/old_js_file_require_helper.js');
+
+describe('miq_list_grid.js', () => {
+  describe('#miqGridSort', () => {
+    it('returns url with no double id', () => {
       ManageIQ.actionUrl = 'show/1000000000015';
       ManageIQ.record.parentClass = 'ems_infra';
       ManageIQ.record.parentId = '1000000000015';
@@ -8,7 +11,7 @@ describe('miq_list_grid.js', function() {
     });
   });
 
-  describe('#checkboxItemId', function() {
+  describe('#checkboxItemId', () => {
     // helper to create a fake jquery object
     var kvToElem = function(name, value) {
       return {
@@ -17,21 +20,21 @@ describe('miq_list_grid.js', function() {
       };
     };
 
-    it('correctly parses name=check_#{id} checkboxes', function() {
+    it('correctly parses name=check_#{id} checkboxes', () => {
       expect(checkboxItemId(kvToElem('check_1r2345', '1'))).toEqual('1r2345');
       expect(checkboxItemId(kvToElem('check_12345', '12345'))).toEqual('12345');
       expect(checkboxItemId(kvToElem('check_1', '0'))).toEqual('1');
     });
 
-    it('correctly parses value=#{id} checkboxes', function() {
+    it('correctly parses value=#{id} checkboxes', () => {
       expect(checkboxItemId(kvToElem('whatever', '1r2345'))).toEqual('1r2345');
       expect(checkboxItemId(kvToElem('whatever', '12345'))).toEqual('12345');
       expect(checkboxItemId(kvToElem('whatever', '0'))).toEqual('0');
     });
   });
 
-  describe('#miqGridGetCheckedRows', function() {
-    beforeEach(function() {
+  describe('#miqGridGetCheckedRows', () => {
+    beforeEach(() => {
       var html = "";
       html += '<div id="test_grid_1">';
       html += '  <input type="checkbox" class="list-grid-checkbox" name="check_1r2345" value="1" checked>';
@@ -42,7 +45,7 @@ describe('miq_list_grid.js', function() {
       setFixtures(html);
     });
 
-    it("picks checked checkboxes from the chosen grid", function() {
+    it("picks checked checkboxes from the chosen grid", () => {
       expect(miqGridGetCheckedRows('test_grid_1')).toEqual(['1r2345', '12345', '1']);
     });
   });

--- a/app/javascript/spec/old_js/miq_toolbar.spec.js
+++ b/app/javascript/spec/old_js/miq_toolbar.spec.js
@@ -1,5 +1,8 @@
-describe('miq_toolbar.js', function () {
-  beforeEach(function () {
+require('../helpers/set_fixtures_helper.js');
+require('../helpers/old_js_file_require_helper.js');
+
+describe('miq_toolbar.js', () => {
+  beforeEach(() => {
     setFixtures('<div id="test_tb">' +
                 '  <div class="btn-group dropdown">' +
                 '    <button id="button0" data-explorer="true" name="vm_power_choice" title="VM Power Functions" data-click="vm_power_choice" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">' +
@@ -28,20 +31,20 @@ describe('miq_toolbar.js', function () {
                 '</div>');
   });
 
-  it('initializes ManageIQ.toolbars', function () {
+  it('initializes ManageIQ.toolbars', () => {
     expect(typeof ManageIQ.toolbars).toEqual('object');
   });
 
-  describe('.findByDataClick', function () {
-    it('finds a dropdown button', function () {
+  describe('.findByDataClick', () => {
+    it('finds a dropdown button', () => {
       expect( ManageIQ.toolbars.findByDataClick('#test_tb', 'vm_power_choice')[0].id ).toEqual('button0');
     });
 
-    it('finds a dropdown item', function () {
+    it('finds a dropdown item', () => {
       expect( ManageIQ.toolbars.findByDataClick('#test_tb', 'vm_power_choice__vm_guest_shutdown')[0].id ).toEqual('button1');
     });
 
-    it('finds an ordinary button', function () {
+    it('finds an ordinary button', () => {
       expect( ManageIQ.toolbars.findByDataClick('#test_tb', 'vm_vnc_console')[0].id ).toEqual('button3');
     });
   })

--- a/app/javascript/spec/old_js/miq_tree.spec.js
+++ b/app/javascript/spec/old_js/miq_tree.spec.js
@@ -1,9 +1,10 @@
 require('../helpers/set_fixtures_helper.js');
+require('../helpers/old_js_file_require_helper.js');
 
-describe('miq_tree', function() {
-  describe('miqInitTree', function () {
-    describe('post_check', function () {
-      it('checks child nodes', function () {
+describe('miq_tree', () => {
+  describe('miqInitTree', () => {
+    describe('post_check', () => {
+      it('checks child nodes', () => {
         $('body').append($('<miq-tree-view name="test"><div id="testbox" class="treeview"/></miq-tree-view>'));
 
         miqInitTree({tree_name: "test", tree_id: "testbox", post_check: true, hierarchical_check: true}, [

--- a/app/javascript/spec/old_js/resizable_sidebar.spec.js
+++ b/app/javascript/spec/old_js/resizable_sidebar.spec.js
@@ -1,4 +1,5 @@
 require('../helpers/set_fixtures_helper.js');
+require('../helpers/old_js_file_require_helper.js');
 
 describe('resizable-sidebar.js', () => {
   beforeEach(() => {
@@ -35,44 +36,43 @@ describe('resizable-sidebar.js', () => {
 
   it('hide sidebar', () => {
     $('.resize-left').click();
+    expect($('#left').hasClass('col-md-2')).toBe(false);
+    expect($('#left').hasClass('col-md-pull-10')).toBe(false);
+    expect($('#left').hasClass('hidden-lg')).toBe(true);
+    expect($('#left').hasClass('hidden-md')).toBe(true);
 
-    expect($('#left')).not.toHaveClass('col-md-2');
-    expect($('#left')).not.toHaveClass('col-md-pull-10');
-    expect($('#left')).toHaveClass('hidden-lg');
-    expect($('#left')).toHaveClass('hidden-md');
-
-    expect($('#right')).not.toHaveClass('col-md-10');
-    expect($('#right')).not.toHaveClass('col-md-push-2');
-    expect($('#right')).toHaveClass('col-md-12');
-    expect($('#right')).toHaveClass('col-md-push-0');
+    expect($('#right').hasClass('col-md-10')).toBe(false);
+    expect($('#right').hasClass('col-md-push-2')).toBe(false);
+    expect($('#right').hasClass('col-md-12')).toBe(true);
+    expect($('#right').hasClass('col-md-push-0')).toBe(true);
   });
 
   it('show sidebar', () => {
     $('.resize-left').click();
     $('.resize-right').click();
 
-    expect($('#left')).not.toHaveClass('hidden-md');
-    expect($('#left')).not.toHaveClass('hidden-lg');
-    expect($('#left')).toHaveClass('col-md-2');
-    expect($('#left')).toHaveClass('col-md-pull-10');
+    expect($('#left').hasClass('hidden-md')).toBe(false);
+    expect($('#left').hasClass('hidden-lg')).toBe(false);
+    expect($('#left').hasClass('col-md-2')).toBe(true);
+    expect($('#left').hasClass('col-md-pull-10')).toBe(true);
 
-    expect($('#right')).not.toHaveClass('col-md-12');
-    expect($('#right')).not.toHaveClass('col-md-push-0');
-    expect($('#right')).toHaveClass('col-md-10');
-    expect($('#right')).toHaveClass('col-md-push-2');
+    expect($('#right').hasClass('col-md-12')).toBe(false);
+    expect($('#right').hasClass('col-md-push-0')).toBe(false);
+    expect($('#right').hasClass('col-md-10')).toBe(true);
+    expect($('#right').hasClass('col-md-push-2')).toBe(true);
   });
 
   it('broaden sidebar', () => {
     for (var i=2; i<=5; i++) {
-      expect($('#left')).not.toHaveClass('col-md-' + (i-1));
-      expect($('#left')).not.toHaveClass('col-md-pull-' + (11-i));
-      expect($('#left')).toHaveClass('col-md-' + i);
-      expect($('#left')).toHaveClass('col-md-pull-' + (12-i));
+      expect($('#left').hasClass('col-md-' + (i-1))).toBe(false);
+      expect($('#left').hasClass('col-md-pull-' + (11-i))).toBe(false);
+      expect($('#left').hasClass('col-md-' + i)).toBe(true);
+      expect($('#left').hasClass('col-md-pull-' + (12-i))).toBe(true);
 
-      expect($('#right')).not.toHaveClass('col-md-' + (13-i));
-      expect($('#right')).not.toHaveClass('col-md-push-' + (i+1));
-      expect($('#right')).toHaveClass('col-md-' + (12-i));
-      expect($('#right')).toHaveClass('col-md-push-' + i);
+      expect($('#right').hasClass('col-md-' + (13-i))).toBe(false);
+      expect($('#right').hasClass('col-md-push-' + (i+1))).toBe(false);
+      expect($('#right').hasClass('col-md-' + (12-i))).toBe(true);
+      expect($('#right').hasClass('col-md-push-' + i)).toBe(true);
 
       $('.resize-right').click();
     }
@@ -84,15 +84,15 @@ describe('resizable-sidebar.js', () => {
     }
 
     for (var i=5; i>=2; i--) {
-      expect($('#left')).not.toHaveClass('col-md-' + (i+1));
-      expect($('#left')).not.toHaveClass('col-md-pull-' + (13-i));
-      expect($('#left')).toHaveClass('col-md-' + i);
-      expect($('#left')).toHaveClass('col-md-pull-' + (12-i));
+      expect($('#left').hasClass('col-md-' + (i+1))).toBe(false);
+      expect($('#left').hasClass('col-md-pull-' + (13-i))).toBe(false);
+      expect($('#left').hasClass('col-md-' + i)).toBe(true);
+      expect($('#left').hasClass('col-md-pull-' + (12-i))).toBe(true);
 
-      expect($('#right')).not.toHaveClass('col-md-' + (11-i));
-      expect($('#right')).not.toHaveClass('col-md-push-' + (i-1));
-      expect($('#right')).toHaveClass('col-md-' + (12-i));
-      expect($('#right')).toHaveClass('col-md-push-' + i);
+      expect($('#right').hasClass('col-md-' + (11-i))).toBe(false);
+      expect($('#right').hasClass('col-md-push-' + (i-1))).toBe(false);
+      expect($('#right').hasClass('col-md-' + (12-i))).toBe(true);
+      expect($('#right').hasClass('col-md-push-' + i)).toBe(true);
 
       $('.resize-left').click();
     }
@@ -102,10 +102,9 @@ describe('resizable-sidebar.js', () => {
     for (var i=0; i<5; i++) {
       $('.resize-right').click();
     }
-    expect($('#left')).toHaveClass('col-md-5');
-    expect($('#left')).toHaveClass('col-md-pull-7');
-    expect($('#right')).toHaveClass('col-md-7');
-    expect($('#right')).toHaveClass('col-md-push-5');
+    expect($('#left').hasClass('col-md-5')).toBe(true);
+    expect($('#left').hasClass('col-md-pull-7')).toBe(true);
+    expect($('#right').hasClass('col-md-7')).toBe(true);
+    expect($('#right').hasClass('col-md-push-5')).toBe(true);
   });
-
 });

--- a/app/javascript/spec/old_js/resizable_sidebar.spec.js
+++ b/app/javascript/spec/old_js/resizable_sidebar.spec.js
@@ -1,5 +1,7 @@
-describe('resizable-sidebar.js', function () {
-  beforeEach(function () {
+require('../helpers/set_fixtures_helper.js');
+
+describe('resizable-sidebar.js', () => {
+  beforeEach(() => {
     var html = ''
     html += '<div class="container-fluid resizable-sidebar">'
     html += '  <div class="row">'
@@ -31,7 +33,7 @@ describe('resizable-sidebar.js', function () {
     });
   });
 
-  it('hide sidebar', function () {
+  it('hide sidebar', () => {
     $('.resize-left').click();
 
     expect($('#left')).not.toHaveClass('col-md-2');
@@ -45,7 +47,7 @@ describe('resizable-sidebar.js', function () {
     expect($('#right')).toHaveClass('col-md-push-0');
   });
 
-  it('show sidebar', function () {
+  it('show sidebar', () => {
     $('.resize-left').click();
     $('.resize-right').click();
 
@@ -60,7 +62,7 @@ describe('resizable-sidebar.js', function () {
     expect($('#right')).toHaveClass('col-md-push-2');
   });
 
-  it('broaden sidebar', function () {
+  it('broaden sidebar', () => {
     for (var i=2; i<=5; i++) {
       expect($('#left')).not.toHaveClass('col-md-' + (i-1));
       expect($('#left')).not.toHaveClass('col-md-pull-' + (11-i));
@@ -76,7 +78,7 @@ describe('resizable-sidebar.js', function () {
     }
   });
 
-  it('narrow sidebar', function () {
+  it('narrow sidebar', () => {
     for (var i=2; i<5; i++) {
       $('.resize-right').click();
     }
@@ -96,7 +98,7 @@ describe('resizable-sidebar.js', function () {
     }
   });
 
-  it('extend sidebar limit', function () {
+  it('extend sidebar limit', () => {
     for (var i=0; i<5; i++) {
       $('.resize-right').click();
     }

--- a/spec/javascripts/miq_tree_spec.js
+++ b/spec/javascripts/miq_tree_spec.js
@@ -1,3 +1,5 @@
+require('../helpers/set_fixtures_helper.js');
+
 describe('miq_tree', function() {
   describe('miqInitTree', function () {
     describe('post_check', function () {


### PR DESCRIPTION
@miq-bot add_label wip

Tools/guides:
https://jestjs.io/docs/en/migration-guide
https://github.com/skovhus/jest-codemods

Run:
bundle exec rake spec:jest

Possible problems:
- `templateUrl` -> convert a component to new js and use HTML file

TODO:
Move all angular stuff from `config/jest.setup.js` to specs that need it. Extra PR https://github.com/ManageIQ/manageiq-ui-classic/pull/5027
`Spinner`
`git cherry-pick 71a3ef4c1567c39aa45c9931f1c4e2c484666898`
Clean-up issues:
- `toHaveClass` make our own function or rewrite to use jQuery's `hasClass`?
- codeclimate issues
- clean up commits

