### PR TITLE
[GAPRINDASHVILI] Fix vm_cloud image custom button return and cancel endpoints

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -113,8 +113,10 @@ class DialogLocalService
       cancel_endpoint = "/storage/explorer"
     when /Template/
       api_collection_name = "templates"
-      cancel_endpoint = "/vm_or_template/explorer"
-    when /Tenant/
+      cancel_endpoint = display_options[:cancel_endpoint] || "/vm_or_template/explorer"
+
+    # ^ is necessary otherwise we match CloudTenant
+    when /^Tenant/
       api_collection_name = "tenants"
       cancel_endpoint = "/ops/explorer"
     when /User/

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -296,19 +296,24 @@ describe DialogLocalService do
     context "when the object is a Storage" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
 
-      it "returns a hash" do
-        expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action)).to eq(
-          :resource_action_id     => 321,
-          :target_id              => 123,
-          :target_type            => 'storage',
-          :dialog_id              => 654,
-          :force_old_dialog_use   => false,
-          :api_submit_endpoint    => "/api/datastores/123",
-          :api_action             => "custom-button-name",
-          :finish_submit_endpoint => "/storage/explorer",
-          :cancel_endpoint        => "/storage/explorer",
-          :open_url               => false,
-        )
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "storage", "datastores", "/storage/explorer"
+    end
+
+    context "when the object is a Template" do
+      context "when there is a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+        let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
+
+        include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                         "miq_template", "templates", "/vm_cloud/explorer"
+      end
+
+      context "when there is not a cancel endpoint in the display options" do
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+
+        include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                         "miq_template", "templates", "/vm_or_template/explorer"
       end
     end
 


### PR DESCRIPTION
Cherry-pick from https://github.com/ManageIQ/manageiq-ui-classic/pull/4795 while fixing the conflicts.

There are `Template` objects that are available to have custom buttons attached to them on the Compute -> Clouds -> Instances -> Images screen, which corresponds to `vm_cloud/explorer` in the url, but the code was incorrectly assuming all templates would be nested under `vm_or_template/explorer`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643263

@miq-bot assign @simaishi 
@miq-bot add_label bug