### PR TITLE
Rescue error messages when executing retire action

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -77,8 +77,11 @@ module Mixins
           # Check RBAC for all items in session[:retire_items]
           @retireitems = find_records_with_rbac(kls.order(:name), session[:retire_items])
           if params[:button]
-            flash = retire_handle_form_buttons(kls)
-            add_flash(flash)
+            begin
+              add_flash(retire_handle_form_buttons(kls))
+            rescue RuntimeError => e
+              add_flash(e.message, :error)
+            end
             if @sb[:explorer]
               replace_right_cell
             else


### PR DESCRIPTION
**Issue:**
There is not rescued exception for error raised on backend during execution of retire operation.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1579017

@miq-bot add-label gaprindashvili/yes,  hammer/yes, services, bug

**BEFORE**: there is no any confirmation or error messages when saving new retirement date

**AFTER:**  (if remote server is down)
<img width="1321" alt="before1" src="https://user-images.githubusercontent.com/6556758/48025396-4568f480-e111-11e8-9d42-4ca05fafa476.png">


