### PR TITLE
Fixed to show grouping in drop down only for Ansible Tower type item.

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -108,10 +108,16 @@
           %label.col-md-2.control-label
             = @edit[:new][:st_prov_type] == "generic_ansible_tower" ? _('Ansible Tower Template') : _('Container Template')
           .col-md-8
-            = select_tag('template_id',
-                          grouped_options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
-                          "data-miq_sparkle_on" => true,
-                          :class                => "selectpicker")
+            - if @edit[:new][:st_prov_type] == "generic_ansible_tower"
+              = select_tag('template_id',
+                            grouped_options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
+                            "data-miq_sparkle_on" => true,
+                            :class                => "selectpicker")
+            - else
+              = select_tag('template_id',
+                       options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
+                       "data-miq_sparkle_on" => true,
+                       :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
     .form-group


### PR DESCRIPTION
Trying to use grouped_options_for_select for a drop down that does not have grouping was causing an error in the log and preventing from saving manager_id and template_id fields when adding a Catalog Item type of 'Openshift Template'

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1645676

Without the fix it blows up after Provider is selected
```
[----] I, [2018-11-05T15:51:17.919049 #5616:7e9e394]  INFO -- : Started POST "/catalog/atomic_form_field_changed/new?manager_id=10000000000024" for ::1 at 2018-11-05 15:51:17 -0500
[----] I, [2018-11-05T15:51:17.957088 #5616:7e9e394]  INFO -- : Processing by CatalogController#atomic_form_field_changed as JS
[----] I, [2018-11-05T15:51:17.957210 #5616:7e9e394]  INFO -- :   Parameters: {"manager_id"=>"10000000000024", "id"=>"new"}
[----] I, [2018-11-05T15:51:18.031618 #5616:7e9e394]  INFO -- :   Rendered /home/hkataria/dev/manageiq-ui-classic/app/views/layouts/_tree.html.haml (2.6ms)
[----] I, [2018-11-05T15:51:18.031850 #5616:7e9e394]  INFO -- :   Rendered /home/hkataria/dev/manageiq-ui-classic/app/views/shared/_tree.html.haml (3.8ms)
[----] I, [2018-11-05T15:51:18.032615 #5616:7e9e394]  INFO -- :   Rendered /home/hkataria/dev/manageiq-ui-classic/app/views/layouts/_ae_tree_select.html.haml (5.3ms)
[----] I, [2018-11-05T15:51:18.036896 #5616:7e9e394]  INFO -- :   Rendered /home/hkataria/dev/manageiq-ui-classic/app/views/catalog/_form_basic_info.html.haml (10.3ms)
[----] F, [2018-11-05T15:51:18.037183 #5616:7e9e394] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `map' for 10000000000233:Integer
Did you mean?  tap
/home/hkataria/.rvm/gems/ruby-2.4.4/gems/actionview-5.0.7/lib/action_view/helpers/form_options_helper.rb:358:in `options_for_select'
/home/hkataria/.rvm/gems/ruby-2.4.4/gems/actionview-5.0.7/lib/action_view/helpers/form_options_helper.rb:545:in `block in grouped_options_for_select'
/home/hkataria/.rvm/gems/ruby-2.4.4/gems/actionview-5.0.7/lib/action_view/helpers/form_options_helper.rb:535:in `each'
/home/hkataria/.rvm/gems/ruby-2.4.4/gems/actionview-5.0.7/lib/action_view/helpers/form_options_helper.rb:535:in `grouped_options_for_select'
/home/hkataria/dev/manageiq-ui-classic/app/views/catalog/_form_basic_info.html.haml:111:in `__home_hkataria_dev_manageiq_ui_classic_app_views_catalog__form_basic_info_html_haml___430276081243073132_69842926874900'
```

before:
![before](https://user-images.githubusercontent.com/3450808/48026060-06d43980-e113-11e8-81e4-1a8cdac0713a.png)

after:
![after](https://user-images.githubusercontent.com/3450808/48026055-03d94900-e113-11e8-9bc3-25fa8b249a0a.png)
