### PR TITLE
Replace grapql explorer react mounter with react macro.

### DIFF
--- a/app/assets/stylesheets/graphql_explorer.scss
+++ b/app/assets/stylesheets/graphql_explorer.scss
@@ -1,3 +1,3 @@
-#graphql-explorer {
+.graphql-explorer {
   height: 90vh;
 }

--- a/app/views/graphql_explorer/index.html.haml
+++ b/app/views/graphql_explorer/index.html.haml
@@ -1,6 +1,1 @@
-= javascript_pack_tag "manageiq-graphql/graphql-explorer"
-
-#graphql-explorer
-  = _("Loading...")
-
-= mount_react_component("graphql_explorer", "#graphql-explorer")
+= react('GraphQLExplorer', {}, :class => 'graphql-explorer')


### PR DESCRIPTION
Replace older mounting mechanism for React components with the new one.

This affects graphlql pluggin and should be merge alongside with https://github.com/ManageIQ/manageiq-graphql/pull/62