### PR TITLE
Add getJSONFixture helper to jest config.

### DIFF
--- a/app/javascript/spec/.eslintrc.json
+++ b/app/javascript/spec/.eslintrc.json
@@ -1,6 +1,10 @@
 {
+  "globals": {
+    "getJSONFixture": true
+  },
   "rules": {
     "max-lines": "off",
-    "max-lines-per-function": "off"
+    "max-lines-per-function": "off",
+    "import/no-dynamic-require": "off"
   }
 }

--- a/app/javascript/spec/helpers/getJSONFixtures.js
+++ b/app/javascript/spec/helpers/getJSONFixtures.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+const fixturesPath = '../fixtures/json';
+
+const getJSONFixture = fixturePath =>
+  require(path.join(__dirname, fixturesPath, fixturePath)); // eslint-disable-line global-require
+
+export default getJSONFixture;

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -18,3 +18,6 @@ import { rxSubject, sendDataWithRx, listenToRx } from '../app/javascript/miq_obs
 ManageIQ.angular.rxSubject = rxSubject;
 window.sendDataWithRx = sendDataWithRx;
 window.listenToRx = listenToRx;
+
+import getJSONFixture from '../app/javascript/spec/helpers/getJSONFixtures';
+window.getJSONFixture = getJSONFixture;

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@
 module.exports = {
   verbose: true,
   globals: {
-    __testing__: true
+    __testing__: true,
+    getJSONFixture: true,
   },
   roots: ['app/javascript'],
   setupFiles: ['./config/jest.setup.js'],


### PR DESCRIPTION
Added helper that will load contents of json files to jest. It mimics getJSONFixture from jasmine.

@himdel i have added the current fixtures path. That should probably change to jest specific location. But i don't know if some fixtures are shared in multiple spec files and if moving them is feasible right now.