### PR TITLE
Remove all validation specific code from Proxy/Advanced tabs

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -362,8 +362,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
        ($scope.currentTab === "kubevirt" &&
         $scope.emsCommonModel.kubevirt_hostname !== '' &&
         $scope.emsCommonModel.kubevirt_password !== '' &&
-        $scope.emsCommonModel.kubevirt_api_port !== '') ||
-      ($scope.currentTab === "proxy_settings") || ($scope.currentTab === "advanced_settings"))) {
+        $scope.emsCommonModel.kubevirt_api_port !== ''))) {
       return true;
     } else if($scope.emsCommonModel.emstype == "gce" && $scope.emsCommonModel.project != '' &&
       ($scope.currentTab == "default" ||

--- a/app/views/layouts/angular/_per_provider_settings.html.haml
+++ b/app/views/layouts/angular/_per_provider_settings.html.haml
@@ -2,13 +2,11 @@
   %h3
     = _("Settings")
   %ul.nav.nav-tabs
-    = miq_tab_header('proxy_settings', nil, 'ng-click' => "changeAuthTab('proxy_settings')",
+    = miq_tab_header('proxy_settings', nil,
       'ng-if' => "emsOptionsModel.provider_options.hasOwnProperty('proxy_settings')") do
-      %i{"error-on-tab" => "proxy_settings", :style => "color:#cc0000"}
       = _("Proxy")
-    = miq_tab_header('advanced_settings', nil, 'ng-click' => "changeAuthTab('advanced_settings')",
+    = miq_tab_header('advanced_settings', nil,
       'ng-if' => "emsOptionsModel.provider_options.hasOwnProperty('advanced_settings')") do
-      %i{"error-on-tab" => "advanced_settings", :style => "color:#cc0000"}
       = _("Advanced")
 
   .tab-content


### PR DESCRIPTION
Proxy/Advanced tabs are just extra settings to be filled in and not related to validation, therefore remove all validation specific code associated with these tabs.

https://bugzilla.redhat.com/show_bug.cgi?id=1645176

