### PR TITLE
Enabled password editing if log protocol has changed.

### DIFF
--- a/app/assets/javascripts/components/auth-credentials.js
+++ b/app/assets/javascripts/components/auth-credentials.js
@@ -60,7 +60,7 @@ ManageIQ.angular.app.component('authCredentials', {
     };
 
     this.showChangePasswordLinks = function(index) {
-      return ! vm.newRecord && vm.modelCopy[index] !== '';
+      return ! vm.newRecord && (vm.modelCopy[vm.prefix + '_protocol'] === vm.formModel[vm.prefix + '_protocol']) && vm.formModel[index];
     };
 
     this.showVerify = function(userid) {


### PR DESCRIPTION
Added condition that checks protocol value. When you change auth protocol, password field is enabled by default.

![bug-password](https://user-images.githubusercontent.com/22619452/48119739-5419ed80-e270-11e8-8d25-383e984f2083.gif)

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1647013
