### PR TITLE
Corrected logic for rendering custom buttons

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -198,11 +198,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def cb_send_checked_list
-    return true if %w(generic_objects).include?(@display)
-  end
-
-  def cb_enabled_for_nested
-    return true if %w(generic_objects).include?(@display)
+    @display.present? && custom_button_appliable_class?(@display.camelize.singularize)
   end
 
   def cb_enabled_value_for_nested
@@ -220,7 +216,7 @@ class ApplicationHelper::ToolbarBuilder
                 else
                   record.present? ? record.id : 'LIST'
                 end
-    enabled = cb_enabled_for_nested ? cb_enabled_value_for_nested : input[:enabled]
+    enabled = cb_send_checked_list ? cb_enabled_value_for_nested : input[:enabled]
     button = {
       :id        => "custom__custom_#{button_id}",
       :type      => :button,
@@ -233,12 +229,8 @@ class ApplicationHelper::ToolbarBuilder
       :url_parms => "?id=#{record_id}&button_id=#{button_id}&cls=#{model}&pressed=custom_button&desc=#{button_name}",
     }
     button[:text] = button_name if input[:text_display]
-    button[:onwhen] = '1+' if cb_enabled_for_nested
-    if record_id == 'LIST' ||
-       (@display.present? &&
-        custom_button_appliable_class?(@display.camelize.singularize))
-      button[:send_checked] = true
-    end
+    button[:onwhen] = '1+' if cb_send_checked_list
+    button[:send_checked] = true if record_id == 'LIST'
     button
   end
 
@@ -262,7 +254,7 @@ class ApplicationHelper::ToolbarBuilder
     get_custom_buttons(model, record, toolbar_result).collect do |group|
       buttons = group[:buttons].collect { |b| create_custom_button(b, model, record) }
 
-      enabled = if cb_enabled_for_nested
+      enabled = if cb_send_checked_list
                   cb_enabled_value_for_nested
                 else
                   record ? true : buttons.all? { |button| button[:enabled] }
@@ -277,7 +269,7 @@ class ApplicationHelper::ToolbarBuilder
         :items   => buttons
       }
       props[:text] = group[:text] if group[:text_display]
-      props[:onwhen] = '1+' if cb_enabled_for_nested
+      props[:onwhen] = '1+' if cb_send_checked_list
 
       {:name => "custom_buttons_#{group[:text]}", :items => [props]}
     end


### PR DESCRIPTION
Reaction to @himdel's https://github.com/ManageIQ/manageiq-ui-classic/pull/4775#issuecomment-436239378

The condition was moved to a correct place (`cb_send_checked_list` method)

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/4775

Steps for Testing/QA
-------------------------------

*  Create a custom button for any entity
*  Navigate to the entity through the provider relationship screen
*  Custom button should be visible
 
(from: https://github.com/ManageIQ/manageiq-ui-classic/pull/4775#issue-222983728)