### PR TITLE
Add babel-polyfill

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -61,6 +61,7 @@ module.exports = {
       'es6-shim',
       'array-includes',
       'whatwg-fetch',
+      'babel-polyfill',
     ],
   },
 


### PR DESCRIPTION
Apparently the current set of shims is not enough for IE11, making it impossible to load Switch from patternfly-react.

Adding babel-polyfill fixes that.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1646362
