### PR TITLE
Bug 1480819: Fix labels for Scale Infrastructure Provider form

### DIFF
--- a/app/helpers/ems_infra_helper.rb
+++ b/app/helpers/ems_infra_helper.rb
@@ -1,3 +1,23 @@
 module EmsInfraHelper
   include_concern 'TextualSummary'
+
+  def scaling_field_label(param_name)
+    field_name = param_name.dup
+    case field_name
+    when 'BlockStorageCount'
+      _('Number of Block Storage Hosts')
+    when 'ObjectStorageCount'
+      _('Number of Object Storage Hosts')
+    when 'CephStorageCount'
+      _('Number of Ceph Storage Hosts')
+    when 'ComputeCount'
+      _('Number of Compute Hosts')
+    when 'ControllerCount'
+      _('Number of Controller Hosts')
+    else
+      field_name.sub!("Count", "")
+      field_name.sub!("::count", "")
+      _("Number of %{host_type} Hosts") % {:host_type => field_name.underscore.humanize.titleize}
+    end
+  end
 end

--- a/app/views/ems_infra/scaling.html.haml
+++ b/app/views/ems_infra/scaling.html.haml
@@ -16,7 +16,7 @@
     - @count_parameters.each do |parameter|
       .form-group
         %label.col-md-2.control-label
-          = parameter.name
+          = scaling_field_label(parameter.name)
         .col-md-8
           = text_field_tag(parameter.name, parameter.value, :maxlength => 5)
   %table{:width => "100%"}


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1480819

This commit changes the labels on the Scale Infrastructure Provider form
from the user-unfriendly parameter names (i.e. "ControllerCount") to
more descriptive labels (i.e. "Number of Controller Hosts").
