### PR TITLE
Use EmsCloud.authentication_for_providers to determine topology view status

### DIFF
--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -36,7 +36,7 @@ class CloudTopologyService < TopologyService
 
   def entity_status(entity)
     if entity.kind_of?(ManageIQ::Providers::CloudManager)
-      entity.authentications.blank? ? 'Unknown' : entity.authentications.first.status.try(:capitalize)
+      entity.authentications.blank? ? 'Unknown' : entity.authentication_for_providers.first.status.try(:capitalize)
     elsif entity.kind_of?(Vm)
       entity.power_state.nil? ? 'Unknown' : entity.power_state.capitalize
     elsif entity.kind_of?(AvailabilityZone)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502857

Openstack CloudManagers often show up with status 'null' and grey rings on the topology view. This is because the CloudTopologyService chooses the first item from the `authentications` list, which is frequently an arbitrary keypair instead of the provider credentials. This PR changes CloudTopologyService to use `authentication_for_providers` like the EmsCloud summary screen, which fixes the problem.

![image](https://user-images.githubusercontent.com/628956/48231840-8feea900-e37d-11e8-9c90-dea9981e4f60.png)
