### PR TITLE
Replaced missing timeline attributes in performance controller.

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -328,8 +328,8 @@ module ApplicationController::Performance
     new_opts = tl_session_data(request.parameters["controller"]) || ApplicationController::Timelines::Options.new
     new_opts[:model] = @perf_record.class.base_class.to_s
     new_opts.date.typ = chart_click_data.type
-    new_opts.date.daily = @perf_options[:daily_date] if chart_click_data.type == "Daily"
-    new_opts.date.hourly = [ts.month, ts.day, ts.year].join("/") if chart_click_data.type == "Hourly"
+    new_opts.date.end_date = @perf_options[:daily_date] if chart_click_data.type == "Daily"
+    new_opts.date.end_date = [ts.month, ts.day, ts.year].join("/") if chart_click_data.type == "Hourly"
     new_opts[:tl_show] = "timeline"
     set_tl_session_data(new_opts, request.parameters["controller"])
     f = @perf_record.first_event


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1647625

caused by: https://github.com/ManageIQ/manageiq-ui-classic/commit/94c979604d207a4f55e8fad51588dbb5ff8a2b79#diff-d2a308103ffc3499b94de33a362bfc74

`daily` and `hourly` attributes were replaced by `end_date` in Timeline::Options. But they were not replaced in Performance controller.

Edit: i think it may also fix https://bugzilla.redhat.com/show_bug.cgi?id=1647632, it seems to me that these are duplicate BZ's. But maybe i've misunderstood the description.