### PR TITLE
Allow apostrophes in custom button names

### DIFF
--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -25,7 +25,7 @@
   ManageIQ.angular.app.value('dialogId', '#{dialog_id}');
   ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
-  ManageIQ.angular.app.value('apiAction', '#{api_action}');
+  ManageIQ.angular.app.value('apiAction', '#{html_escape(api_action)}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   ManageIQ.angular.app.value('openUrl', '#{open_url}');
   miq_bootstrap('.wrapper');


### PR DESCRIPTION
1. create a custom button with a dialog, name it so that it contains an apostrophe in its name, such as: `Button l'Muf`
2. click on the custom button (in the place where the custom button shows)

Without this fix, the following javascript error would show:
```
miq_debug.self-aedfe7fb00583f1da479517ffd299e68803b26c55f81d74f9d992127b311a1f9.js?body=1:29 SyntaxError: missing ) after argument list
    at eval (<anonymous>)
    at Function.globalEval (jquery.js:343)
    at domManip (jquery.js:5291)
    at jQuery.fn.init.append (jquery.js:5431)
    at jQuery.fn.init.<anonymous> (jquery.js:5525)
    at access (jquery.js:3614)
    at jQuery.fn.init.html (jquery.js:5492)
    at miq_explorer.self-6b27f1944493f686bd5c589f4f733a8d6a1d0aa627bbfd17545cde40c904044f.js?body=1:113
    at lodash.js:4925
    at baseForOwn (lodash.js:3010)
```

https://bugzilla.redhat.com/show_bug.cgi?id=1646905