### PR TITLE
Reset session on failed CSRF token verification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     # web service worker processes.
     protect_from_forgery(:secret => SecureRandom.hex(64),
                          :except => %i(authenticate external_authenticate kerberos_authenticate saml_login initiate_saml_login oidc_login initiate_oidc_login csp_report),
-                         :with   => :exception)
+                         :with   => :reset_session)
 
   end
 


### PR DESCRIPTION
1. Navigate to Compute ➛ Infrastructure ➛ Providers ➛ choose a provider ➛ provider summary page
2. Clear memcached
3. On the provider summary page, click on refresh

Before, the failed CSRF token validation would render an exception.

With this fix in place, failed CSRF token validation will void the session and redirect user to login screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1642948