### PR TITLE
Fixed JS error, bottlenecks timeline does not have group levels.

### DIFF
--- a/app/assets/javascripts/miq_timeline.js
+++ b/app/assets/javascripts/miq_timeline.js
@@ -82,10 +82,17 @@
       warning: '#E17B1C'
     };
 
+    if (typeof eventData === 'undefined' || typeof eventData.events === 'undefined') {
+      return colors.detail;
+    }
+
     if (eventData.hasOwnProperty('events')) {
       var severity = 'detail';
       var eventList = eventData.events;
       for (var i = 0; i < eventList.length; i++) {
+        if (typeof eventList[0].data.group_level === 'undefined') {
+          return colors.detail;
+        }
         severity = selectSevereer(eventList[i].data.group_level.value, severity);
       }
       return colors[severity];


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648450

before:
![before](https://user-images.githubusercontent.com/3450808/48292531-b594b480-e448-11e8-83aa-8fd4b283b33a.png)

after:
![after](https://user-images.githubusercontent.com/3450808/48292527-b2012d80-e448-11e8-8796-6ed5380bafac.png)

Issue introduced with changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/4217
cc @CharlleDaniel 
