### PR TITLE
Fixed code to show Bottlenecks report download buttons.

### DIFF
--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -24,7 +24,7 @@ class BottlenecksController < ApplicationController
 
     # build timeline data when coming back to Summary tab for bottlenecks
     displaying_timeline = @sb[:active_tab] == "summary"
-    bottleneck_get_node_info(x_node) if displaying_timeline
+    get_node_info(x_node) if displaying_timeline
 
     render :update do |page|
       page << javascript_prologue
@@ -32,6 +32,22 @@ class BottlenecksController < ApplicationController
       page.replace("tl_div", :partial => "bottlenecks_tl_detail") if displaying_timeline
       page << Charting.js_load_statement
       page << "miqSparkle(false);"
+    end
+  end
+
+  # Send the current utilization report data in text, CSV, or PDF
+  def report_download
+    filename = "Bottlenecks Event Details"
+    disable_client_cache
+    case params[:typ]
+    when "txt"
+      send_data(@sb[:report].to_text,
+                :filename => "#{filename}.txt")
+    when "csv"
+      send_data(@sb[:report].to_csv,
+                :filename => "#{filename}.csv")
+    when "pdf"
+      render_pdf(@sb[:report])
     end
   end
 

--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -39,16 +39,7 @@ class BottlenecksController < ApplicationController
   def report_download
     filename = "Bottlenecks Event Details"
     disable_client_cache
-    case params[:typ]
-    when "txt"
-      send_data(@sb[:report].to_text,
-                :filename => "#{filename}.txt")
-    when "csv"
-      send_data(@sb[:report].to_csv,
-                :filename => "#{filename}.csv")
-    when "pdf"
-      render_pdf(@sb[:report])
-    end
+    download_file(params[:typ], @sb[:report], filename)
   end
 
   def tree_select

--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -146,16 +146,7 @@ class PlanningController < ApplicationController
     @sb[:rpt].title = _("Counts of VMs (%{profile})") % {:profile => profile.join(", ")}
     filename = "VM Counts per #{ui_lookup(:model => @sb[:options][:target_typ])}"
     disable_client_cache
-    case params[:typ]
-    when "txt"
-      send_data(@sb[:rpt].to_text,
-                :filename => "#{filename}.txt")
-    when "csv"
-      send_data(@sb[:rpt].to_csv,
-                :filename => "#{filename}.csv")
-    when "pdf"
-      render_pdf(@sb[:rpt])
-    end
+    download_file(params[:typ], @sb[:rpt], filename)
   end
 
   def reset

--- a/app/helpers/application_helper/button/utilization_download.rb
+++ b/app/helpers/application_helper/button/utilization_download.rb
@@ -9,6 +9,9 @@ class ApplicationHelper::Button::UtilizationDownload < ApplicationHelper::Button
     # b) we are in the "Utilization" and have trend report and summary
     return false if @sb.fetch_path(:util, :trend_rpt) && @sb.fetch_path(:util, :summary)
 
+    # c) we are in the "Bottlenecks" on 'Report' tab and have report data available
+    return false if @layout == 'miq_capacity_bottlenecks' && @sb[:active_tab] == 'report' && !@sb[:report].table.data.empty?
+
     # otherwise the button is off
     @error_message = _('No records found for this report')
     @error_message.present?

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::ToolbarChooser
   def x_view_toolbar_filename
     if x_gtl_view_tb_render?
       'x_gtl_view_tb'
-    elsif %w(miq_capacity_planning miq_capacity_utilization).include?(@layout)
+    elsif %w(miq_capacity_bottlenecks miq_capacity_planning miq_capacity_utilization).include?(@layout)
       'miq_capacity_view_tb'
     elsif @record && @explorer && (%w(services catalogs).include?(@layout) || %w(performance timeline).include?(@display))
       nil

--- a/app/helpers/optimize_helper.rb
+++ b/app/helpers/optimize_helper.rb
@@ -24,4 +24,17 @@ module OptimizeHelper
       @record = Storage.find_by(:id => nodeid)
     end
   end
+
+  def download_file(typ, report, filename)
+    case typ
+    when "txt"
+      send_data(report.to_text,
+                :filename => "#{filename}.txt")
+    when "csv"
+      send_data(report.to_csv,
+                :filename => "#{filename}.csv")
+    when "pdf"
+      render_pdf(report)
+    end
+  end
 end

--- a/app/views/bottlenecks/_bottlenecks_tabs.html.haml
+++ b/app/views/bottlenecks/_bottlenecks_tabs.html.haml
@@ -11,4 +11,4 @@
       = render :partial => "bottlenecks_report"
 
 :javascript
-  miq_tabs_init('bottlenecks_tabs', '/bottlenecks/change_tab/');
+  miq_tabs_init('#bottlenecks_tabs', '/bottlenecks/change_tab/');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2238,9 +2238,11 @@ Rails.application.routes.draw do
     :bottlenecks              => {
       :get  => %w(
         index
+        report_download
         timeline_data
       ),
       :post => %w(
+        change_tab
         reload
         tl_chooser
         tree_autoload

--- a/spec/helpers/application_helper/buttons/utilization_download_spec.rb
+++ b/spec/helpers/application_helper/buttons/utilization_download_spec.rb
@@ -1,0 +1,28 @@
+describe ApplicationHelper::Button::UtilizationDownload do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:report) { FactoryGirl.create(:miq_report, :miq_report_results => []) }
+  let(:button) { described_class.new(view_context, {}, {'layout' => 'miq_capacity_bottlenecks'}, {}) }
+
+  before do
+    button.instance_variable_set(:@sb, :active_tab => "report", :report => report)
+    allow(view_context).to receive(:x_active_tree).and_return(:bottlenecks_tree)
+  end
+
+  context '#disabled?' do
+    it 'when report tab has no data available' do
+      report.table = OpenStruct.new(:data => [])
+      expect(button.disabled?).to be_truthy
+    end
+
+    it 'when report tab has data' do
+      report.table = OpenStruct.new(:data => [:foo => 'bar'])
+      expect(button.disabled?).to be_falsey
+    end
+
+    it 'when on summary tab' do
+      button.instance_variable_set(:@sb, :active_tab => "summary", :report => report)
+      report.table = OpenStruct.new(:data => [:foo => 'bar'])
+      expect(button.disabled?).to be_truthy
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -172,5 +172,12 @@ describe ApplicationHelper, "ToolbarChooser" do
         expect(ApplicationHelper::ToolbarChooser.new(nil, nil, :record => @record, :explorer => true, :layout => 'automation_manager', :sb => @sb).send(:x_view_toolbar_filename)).to eq("x_gtl_view_tb")
       end
     end
+
+    context 'when in bottlenecks explorer' do
+      it "displays toolbar" do
+        @sb = {:active_tab => 'summary'}
+        expect(ApplicationHelper::ToolbarChooser.new(nil, nil, :record => @record, :explorer => true, :layout => 'miq_capacity_bottlenecks', :sb => @sb).send(:x_view_toolbar_filename)).to eq("miq_capacity_view_tb")
+      end
+    end
   end
 end

--- a/spec/routing/bottlenecks_routing_spec.rb
+++ b/spec/routing/bottlenecks_routing_spec.rb
@@ -9,6 +9,12 @@ describe BottlenecksController do
     end
   end
 
+  describe '#report_download' do
+    it 'routes with GET' do
+      expect(get('/bottlenecks/report_download')).to route_to('bottlenecks#report_download')
+    end
+  end
+
   describe '#timeline_data' do
     it 'routes with GET' do
       expect(get('/bottlenecks/timeline_data')).to route_to('bottlenecks#timeline_data')
@@ -30,6 +36,12 @@ describe BottlenecksController do
   describe '#tree_select' do
     it 'routes with POST' do
       expect(post('/bottlenecks/tree_select')).to route_to('bottlenecks#tree_select')
+    end
+  end
+
+  describe '#change_tab' do
+    it 'routes with POST' do
+      expect(post('/bottlenecks/change_tab')).to route_to('bottlenecks#change_tab')
     end
   end
 


### PR DESCRIPTION
multiple issues fixed:

1 Download button toolbar was not being rendered for Bottlenecks explorer
2 `change_tab` transaction was not working because the tab id being passed in miq_tabs_init had typo, also fixed typo in method name `bottleneck_get_node_info` it should be `get_node_info`
3 download button was always disabled, added condition to enable download buttons on report tab
4 added missing routes for `change_tab` and `report_download`
5 `report_download` method was missing in controller
Issue was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/1966

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648500

before
![before](https://user-images.githubusercontent.com/3450808/48296137-1e882680-e461-11e8-9f03-d0c14f5c7b01.png)

after
![after](https://user-images.githubusercontent.com/3450808/48296133-1c25cc80-e461-11e8-83a8-a3c80c9c3cdb.png)
