### PR TITLE
Remove allow_message_expectations_on_nil

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -931,7 +931,6 @@ describe ApplicationHelper do
     context "when the given parameter is a hash" do
       before do
         get "/vm/show_list/100", :params => "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5&page=2&sb_controller=host"
-        allow_any_instance_of(Object).to receive(:query_string).and_return(@request.query_string)
       end
 
       it "updates the query string with the given hash value and returns the full url path" do
@@ -944,7 +943,6 @@ describe ApplicationHelper do
         FactoryGirl.create(:ems_cloud, :zone => Zone.seed)
         @record = ManageIQ::Providers::CloudManager.first
         get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
-        allow_any_instance_of(Object).to receive(:query_string).and_return(@request.query_string)
       end
 
       it "uses restful paths for pages" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -928,26 +928,19 @@ describe ApplicationHelper do
       EvmSpecHelper.local_guid_miq_server_zone
     end
 
-    context "when the given parameter is a hash" do
-      before do
-        get "/vm/show_list/100", :params => "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5&page=2&sb_controller=host"
-      end
+    it "updates the query string with the given hash value and returns the full url path" do
+      get "/vm/show_list/100", :params => "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5&page=2&sb_controller=host"
 
-      it "updates the query string with the given hash value and returns the full url path" do
-        expect(helper.update_paging_url_parms("show_list", :page => 1)).to eq("/vm/show_list/100?bc=VMs+running+on+2014-08-25"\
-          "&menu_click=Display-VMs-on_2-6-5&page=1&sb_controller=host")
-      end
+      expect(helper.update_paging_url_parms("show_list", :page => 1)).to eq("/vm/show_list/100?bc=VMs+running+on+2014-08-25"\
+        "&menu_click=Display-VMs-on_2-6-5&page=1&sb_controller=host")
     end
-    context "when the controller uses restful paths" do
-      before do
-        FactoryGirl.create(:ems_cloud, :zone => Zone.seed)
-        @record = ManageIQ::Providers::CloudManager.first
-        get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
-      end
 
-      it "uses restful paths for pages" do
-        expect(helper.update_paging_url_parms("show", :page => 2)).to eq("/ems_cloud/#{@record.id}?display=images&page=2")
-      end
+    it "uses restful paths for pages" do
+      FactoryGirl.create(:ems_cloud, :zone => Zone.seed)
+      @record = ManageIQ::Providers::CloudManager.first
+      get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
+
+      expect(helper.update_paging_url_parms("show", :page => 2)).to eq("/ems_cloud/#{@record.id}?display=images&page=2")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -934,8 +934,7 @@ describe ApplicationHelper do
     end
 
     it "uses restful paths for pages" do
-      FactoryGirl.create(:ems_cloud, :zone => zone)
-      @record = ManageIQ::Providers::CloudManager.first
+      @record = FactoryGirl.create(:ems_cloud, :zone => zone)
       get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
 
       expect(helper.update_paging_url_parms("show", :page => 2)).to eq("/ems_cloud/#{@record.id}?display=images&page=2")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -932,7 +932,6 @@ describe ApplicationHelper do
       before do
         get "/vm/show_list/100", :params => "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5&page=2&sb_controller=host"
         allow_any_instance_of(Object).to receive(:query_string).and_return(@request.query_string)
-        allow_message_expectations_on_nil
       end
 
       it "updates the query string with the given hash value and returns the full url path" do
@@ -946,7 +945,6 @@ describe ApplicationHelper do
         @record = ManageIQ::Providers::CloudManager.first
         get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
         allow_any_instance_of(Object).to receive(:query_string).and_return(@request.query_string)
-        allow_message_expectations_on_nil
       end
 
       it "uses restful paths for pages" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -924,9 +924,7 @@ describe ApplicationHelper do
   end
 
   describe "update_paging_url_parms", :type => :request do
-    before do
-      EvmSpecHelper.local_guid_miq_server_zone
-    end
+    let!(:zone) { EvmSpecHelper.local_guid_miq_server_zone[2] }
 
     it "updates the query string with the given hash value and returns the full url path" do
       get "/vm/show_list/100", :params => "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5&page=2&sb_controller=host"
@@ -936,7 +934,7 @@ describe ApplicationHelper do
     end
 
     it "uses restful paths for pages" do
-      FactoryGirl.create(:ems_cloud, :zone => Zone.seed)
+      FactoryGirl.create(:ems_cloud, :zone => zone)
       @record = ManageIQ::Providers::CloudManager.first
       get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
 


### PR DESCRIPTION
This PR removes calls to `allow_message_expectations_on_nil` and unnecessary calls to `allow_any_instance_of` as well as does some cleanup of unnecessary contexts and before blocks.

/cc @skateman I noticed this shiny object when looking at your PR to fix the zone issue earlier today.