### PR TITLE
Cloud Volume creation fixes

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -36,6 +36,13 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
         apiPromises.push(loadVolume(cloudVolumeFormId));
         break;
       case 'NEW':
+        // New can be called 
+        //   a) from a list of all storages w/o storageManagerId
+        //   b) from a nested list under a provider w/ storageManagerId
+        // In case a) we need to populate the form or it will never get populated
+        if (storageManagerId) {
+            apiPromises.push(vm.storageManagerChanged(storageManagerId));
+        }
         // Fetch StorageManagers that we can even create the new volume for.
         apiPromises.push(API.get('/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true')
           .then(getStorageManagers));

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -277,6 +277,8 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
     if (vm.supportsCinderVolumeTypes) {
       vm.volumeTypes = data.parent_manager.cloud_volume_types;
+    } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
+      loadEBSVolumeTypes();
     }
     miqService.sparkleOff();
   };

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -36,12 +36,13 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
         apiPromises.push(loadVolume(cloudVolumeFormId));
         break;
       case 'NEW':
-        // New can be called 
+        // New can be called
         //   a) from a list of all storages w/o storageManagerId
         //   b) from a nested list under a provider w/ storageManagerId
+        //   c) from a nested list under a storageManager w/ storageManagerId
         // In case a) we need to populate the form or it will never get populated
         if (storageManagerId) {
-            apiPromises.push(vm.storageManagerChanged(storageManagerId));
+          apiPromises.push(vm.storageManagerChanged(storageManagerId));
         }
         // Fetch StorageManagers that we can even create the new volume for.
         apiPromises.push(API.get('/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true')

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -223,7 +223,7 @@ class CloudVolumeController < ApplicationController
           :name => _("Add New Cloud Volume"),
           :url  => "/cloud_volume/new"
         )
-        javascript_flash
+        javascript_flash(:spinner_off => true)
       end
 
     when "validate"

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -185,7 +185,6 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     assert_privileges("cloud_tenant_show_list")
 
-    @volume = CloudVolume.new
     @in_a_form = true
     if params[:storage_manager_id]
       @storage_manager = find_record_with_rbac(ExtManagementSystem, params[:storage_manager_id])

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -200,6 +200,15 @@ module EmsCommon
     javascript_redirect(polymorphic_path(@record, :display => "ad_hoc_metrics"))
   end
 
+  # provider_id can be either a provider id or a storage manager id, depending on context
+  # this method figures the storage_manager_id.
+  def storage_manager_id(provider_id)
+    manager = find_record_with_rbac(ExtManagementSystem, provider_id)
+    return nil unless manager
+    return manager.id unless manager.respond_to?(:storage_managers)
+    manager.storage_managers.detect { |m| m.supports_block_storage? }&.id
+  end
+
   # handle buttons pressed on the button bar
   def button
     @edit = session[:edit]                                  # Restore @edit for adv search box
@@ -421,7 +430,7 @@ module EmsCommon
     elsif params[:pressed] == "cloud_volume_new"
       javascript_redirect :controller         => "cloud_volume",
                           :action             => "new",
-                          :storage_manager_id => params[:id]
+                          :storage_manager_id => storage_manager_id(params[:id])
     elsif params[:pressed] == "cloud_volume_snapshot_create"
       javascript_redirect :controller => "cloud_volume",
                           :action     => "snapshot_new",

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -201,8 +201,8 @@ module EmsCommon
   end
 
   # provider_id can be either a provider id or a storage manager id, depending on context
-  # this method figures the storage_manager_id.
-  def storage_manager_id(provider_id)
+  # this method figures the block_storage_manager_id.
+  def block_storage_manager_id(provider_id)
     manager = find_record_with_rbac(ExtManagementSystem, provider_id)
     return nil unless manager
     return manager.id unless manager.respond_to?(:storage_managers)
@@ -430,7 +430,7 @@ module EmsCommon
     elsif params[:pressed] == "cloud_volume_new"
       javascript_redirect :controller         => "cloud_volume",
                           :action             => "new",
-                          :storage_manager_id => storage_manager_id(params[:id])
+                          :storage_manager_id => block_storage_manager_id(params[:id])
     elsif params[:pressed] == "cloud_volume_snapshot_create"
       javascript_redirect :controller => "cloud_volume",
                           :action     => "snapshot_new",

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -206,7 +206,7 @@ module EmsCommon
     manager = find_record_with_rbac(ExtManagementSystem, provider_id)
     return nil unless manager
     return manager.id unless manager.respond_to?(:storage_managers)
-    manager.storage_managers.detect { |m| m.supports_block_storage? }&.id
+    manager.storage_managers.detect(&:supports_block_storage?)&.id
   end
 
   # handle buttons pressed on the button bar

--- a/app/helpers/application_helper/button/cloud_volume_backup_create.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_create.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::CloudVolumeBackupCreate < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    !ManageIQ::Providers::CloudManager.any? do |ems|
+    ManageIQ::Providers::CloudManager.none? do |ems|
       Module.const_defined?("#{ems.class}::CloudVolume") &&
         ems.class::CloudVolume.supports?(:backup_create)
     end

--- a/app/helpers/application_helper/button/cloud_volume_backup_create.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_create.rb
@@ -1,5 +1,8 @@
 class ApplicationHelper::Button::CloudVolumeBackupCreate < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_create) rescue false }
+    !ManageIQ::Providers::CloudManager.any? do |ems|
+      Module.const_defined?("#{ems.class}::CloudVolume") &&
+        ems.class::CloudVolume.supports?(:backup_create)
+    end
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_backup_create.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_create.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::CloudVolumeBackupCreate < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_create) }
+    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_create) rescue false }
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
@@ -1,5 +1,8 @@
 class ApplicationHelper::Button::CloudVolumeBackupRestore < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_restore) rescue false }
+    !ManageIQ::Providers::CloudManager.any? do |ems|
+      Module.const_defined?("#{ems.class}::CloudVolume") &&
+        ems.class::CloudVolume.supports?(:backup_restore)
+    end
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::CloudVolumeBackupRestore < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_restore) }
+    ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::CloudVolume.supports?(:backup_restore) rescue false }
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::CloudVolumeBackupRestore < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    !ManageIQ::Providers::CloudManager.any? do |ems|
+    ManageIQ::Providers::CloudManager.none? do |ems|
       Module.const_defined?("#{ems.class}::CloudVolume") &&
         ems.class::CloudVolume.supports?(:backup_restore)
     end

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    !ExtManagementSystem.any? do |ems|
+    ExtManagementSystem.none? do |ems|
       Module.const_defined?("#{ems.class}::CloudVolume") &&
         ems.class::CloudVolume.supports_create?
     end

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -12,6 +12,6 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    ExtManagementSystem.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? }
+    ExtManagementSystem.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? rescue false }
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -12,6 +12,9 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    ExtManagementSystem.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? rescue false }
+    !ExtManagementSystem.any? do |ems|
+      Module.const_defined?("#{ems.class}::CloudVolume") &&
+        ems.class::CloudVolume.supports_create?
+    end
   end
 end

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -7,7 +7,7 @@
             "ng-options"  => "mgr.id as mgr.name for mgr in vm.storageManagers",
             "ng-change"   => "vm.storageManagerChanged(vm.cloudVolumeModel.storage_manager_id)",
             "required"    => "",
-            "disabled"    => !@storage_manager.nil? || !@volume.id.nil?,
+            "disabled"    => @storage_manager.present? || @volume.try(:id).present?,
             :checkchange  => true,
             "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -10,7 +10,7 @@
     = render :partial => "common_new_edit"
 
 :javascript
-  ManageIQ.angular.app.value('cloudVolumeFormId', '#{@volume.id || "new"}');
+  ManageIQ.angular.app.value('cloudVolumeFormId', 'new');
   ManageIQ.angular.app.value('storageManagerId', '#{@storage_manager.try(:id).to_s || "undefined"}');
   ManageIQ.angular.app.value('cloudVolumeFormOperation', 'NEW');
   miq_bootstrap('#form_div');

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -103,11 +103,34 @@ describe CloudVolumeController do
       login_as user
     end
 
-    it "raises exception wheh used have not privilege" do
+    it "raises an exception when the user does not have the privileges" do
       expect do
         bypass_rescue
         post :new, :params => {:button => "new", :format => :js}
       end.to raise_error(MiqException::RbacPrivilegeException)
+    end
+  end
+
+  describe '#new' do
+    render_views
+
+    let(:features) { MiqProductFeature.find_all_by_identifier(%w(cloud_volume_new cloud_tenant_show_list)) }
+    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => features) }
+    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
+    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      EvmSpecHelper.seed_specific_product_features(%w(cloud_volume_new cloud_tenant_show_list))
+
+      login_as user
+    end
+
+    it "renders the correct template when the user has the privileges" do
+      post :new, :params => {:button => "new", :format => :js}
+      expect(assigns(:flash_array)).to be_nil
+      expect(response).to render_template('cloud_volume/_common_new_edit')
+      expect(response.status).to eq(200)
     end
   end
 


### PR DESCRIPTION
Fixes:

https://bugzilla.redhat.com/show_bug.cgi?id=1644310

 * CloudVolume create: Need to turn off the spinner in both if/else branches.
 * Fix a crash when there is a CloudManager that does not have a CloudVolume. Such as Azure.
 * Fix the storage manager is not being loaded when creating a new Volume (and therefor `emstype` (and possibly other) parameters where missing) . Therefor the case when adding a new volume w/o selecting a storage manager did not work.

Part of the problems seem to be coming from 771e97f7251c33d900fa1f244aa6ae294f7995bf .

Populate volume types for EBS. Fixing:
https://bugzilla.redhat.com/show_bug.cgi?id=1644306

I have issues with understanding what are all the possible situations here and what is the expected behavior. Review and more testing is very welcome. Ping @mansam, @miha-plesko, @gberginc 