### PR TITLE
Fix GCE validation

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -480,6 +480,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
       return;
     }
+    if ($scope.emsCommonModel.emstype === 'gce') {
+      $scope.currentTab = 'service_account';
+      return;
+    }
     $scope.emsCommonModel.default_api_port = '';
     $scope.emsCommonModel.provider_region = '';
     $scope.emsCommonModel.default_security_protocol = '';

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -400,6 +400,7 @@ module Mixins
                          :amqp_auth_status                => amqp_auth_status,
                          :ssh_keypair_auth_status         => ssh_keypair_auth_status.nil? ? true : ssh_keypair_auth_status,
                          :service_account_auth_status     => service_account_auth_status,
+                         :non_default_current_tab         => @ems.emstype == "gce" ? "service_account" : nil,
                          :amqp_fallback_hostname1         => amqp_fallback_hostname1 ? amqp_fallback_hostname1 : "",
                          :amqp_fallback_hostname2         => amqp_fallback_hostname2 ? amqp_fallback_hostname2 : "",
                          :default_url                     => @ems.endpoints.first.url}

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -313,6 +313,18 @@ describe('emsCommonFormController', function() {
     });
   });
 
+  describe('#providerTypeChanged', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+      $scope.emsCommonModel.emstype = 'gce';
+      $scope.providerTypeChanged();
+    });
+
+    it('sets currentTab to service_account', function() {
+      expect($scope.currentTab).toEqual('service_account');
+    });
+  });
+
   describe('#resetClicked', function() {
     beforeEach(function() {
       $httpBackend.flush();


### PR DESCRIPTION
The GCE provider form does not follow the recommended tab naming convention of naming the first tab as "default" -- instead it calls it's one and only tab as `service_account`. 
As a result, the `currentTab` value in the JS which is "default" (and is correct), is not being honored and this specific use case for GCE has to be explicitly handled.

https://bugzilla.redhat.com/show_bug.cgi?id=1649806