### PR TITLE
Drop dead ManageIQ.react

### DIFF
--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -66,10 +66,6 @@ if (!window.ManageIQ) {
       debounce_counter: 1,
       debounced: {}, // running debounces
     },
-    react: { // react component registry
-      mount: null, // mounter function
-      componentRegistry: null,  // registry
-    },
     record: {
       parentClass: null, // parent record ID for JS function miqGridSort to build URL
       parentId: null, // parent record ID for JS function miqGridSort to build URL


### PR DESCRIPTION
the last use was dropped in https://github.com/ManageIQ/manageiq-ui-classic/pull/4886 , removing this global reference.

Cc @Hyperkid123 