### PR TITLE
[GAPRINDASHVILI] Fix editing tags for VMs, Hosts and others

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -18,13 +18,6 @@ module ApplicationController::Tags
     end
   end
 
-  # Get the string with proper feature name for asserting privileges
-  def feature_name
-    is_nested_list = @display && @display != 'main'
-    display_or_controller = is_nested_list ? @display.singularize : controller_for_common_methods
-    "#{display_or_controller}_tag"
-  end
-
   def service_tag
     tagging_edit('Service')
   end
@@ -71,6 +64,13 @@ module ApplicationController::Tags
   end
 
   private ############################
+
+  # Get the string with proper feature name for asserting privileges
+  def feature_name
+    is_nested_list = @display && @display != 'main'
+    display_or_controller = is_nested_list ? @display.singularize : controller_for_common_methods
+    "#{display_or_controller}_tag"
+  end
 
   def tag_set_vars_from_params
     if params[:tag_cat]

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -3,7 +3,7 @@ module ApplicationController::Tags
 
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
-    assert_privileges("#{@display ? @display.singularize : controller_for_common_methods}_tag") if assert
+    assert_privileges(feature_name) if assert
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db
@@ -16,6 +16,13 @@ module ApplicationController::Tags
     when "reset", nil # Reset or first time in
       tagging_edit_tags_reset
     end
+  end
+
+  # Get the string with proper feature name for asserting privileges
+  def feature_name
+    is_nested_list = @display && @display != 'main'
+    display_or_controller = is_nested_list ? @display.singularize : controller_for_common_methods
+    "#{display_or_controller}_tag"
   end
 
   def service_tag

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -121,10 +121,38 @@ describe ApplicationController do
 
     context 'check for correct feature id when tagging selected storage thru Provider relationship' do
       let(:params) { {:db => "Storage", :id => "1"} }
+
       it 'sets @tagging properly' do
         allow(controller).to receive(:tagging_edit_tags_reset)
         controller.send(:tagging_edit)
         expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+    end
+  end
+
+  describe VmInfraController do
+    before do
+      login_as FactoryGirl.create(:user, :features => %w(vm_tag))
+      allow(controller).to receive(:tagging_edit_tags_reset)
+      controller.instance_variable_set(:@display, 'main')
+      controller.instance_variable_set(:@_params, params)
+    end
+
+    context 'check for correct feature id when tagging a VM' do
+      let(:params) { {:id => '1'} }
+
+      it 'sets @tagging properly' do
+        controller.send(:tagging_edit, VmOrTemplate)
+        expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+
+      context 'VM selected in a list of All VMs & Templates' do
+        let(:params) { {:miq_grid_checks => '1'} }
+
+        it 'sets @tagging properly' do
+          controller.send(:tagging_edit, VmOrTemplate)
+          expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1648658

**What:**
Fix editing tags for VMs, Hosts and others (Clusters... see the BZ) by fixing the string of a feature name for `assert_privileges` method while editing tags.
Error:
```
I, [2018-11-14T16:27:05.394595 #19669]  INFO -- : Started POST "/vm_infra/x_button?pressed=vm_tag" for ::1 at 2018-11-14 16:27:05 +0100
I, [2018-11-14T16:27:05.431705 #19669]  INFO -- : Processing by VmInfraController#x_button as JS
I, [2018-11-14T16:27:05.431827 #19669]  INFO -- :   Parameters: {"miq_grid_checks"=>"26", "pressed"=>"vm_tag"}
F, [2018-11-14T16:27:05.448036 #19669] FATAL -- : Error caught: [MiqException::RbacPrivilegeException] The user is not authorized for this task or item.
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller.rb:2167:in `assert_privileges'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/tags.rb:6:in `tagging_edit'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:119:in `x_button'
```

**Why:**
The problem was that `"main_tag"` was set as a name of a feature while calling `assert_privileges` in `tagging_edit` method. So this PR adds logic for the changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/4843, for the situation if`@display` is set to `"main"`.

---

**Before:** (nothing happens)
![tags_before](https://user-images.githubusercontent.com/13417815/48492609-75f41100-e82a-11e8-967f-3024f5cb6c2b.png)

**After:** (screen for editing tags is displayed)
![tags_after](https://user-images.githubusercontent.com/13417815/48492314-cc148480-e829-11e8-8809-453d2621fe12.png)
