### PR TITLE
fix icon font family class

### DIFF
--- a/app/decorators/miq_action_decorator.rb
+++ b/app/decorators/miq_action_decorator.rb
@@ -16,7 +16,7 @@ class MiqActionDecorator < MiqDecorator
     when 'inherit_parent_tags'
       'fa fa-tags'
     when 'reconfigure_cpus'
-      'fa pficon-cpu'
+      'pficon pficon-cpu'
     when 'reconfigure_memory'
       'pficon pficon-memory'
     when 'remove_tags'

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -103,7 +103,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
     included_class.button_group('vm_access', [
       included_class.select(
         :vm_remote_access_choice,
-        'fa pficon-screen fa-lg',
+        'pficon pficon-screen fa-lg',
         N_('VM Remote Access'),
         N_('Access'),
         :items => [

--- a/app/helpers/application_helper/toolbar/container_project_view.rb
+++ b/app/helpers/application_helper/toolbar/container_project_view.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::Toolbar::ContainerProjectView < ApplicationHelper::Tool
     ),
     twostate(
       :view_topology,
-      'fa pficon-topology',
+      'pficon pficon-topology',
       N_('Topology View'),
       nil,
       :url       => "/show",

--- a/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
+++ b/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::Toolbar::DashboardSummaryToggleView < ApplicationHelper
     ),
     twostate(
       :view_topology,
-      'fa pficon-topology',
+      'pficon pficon-topology',
       N_('Topology View'),
       nil,
       :url       => "/",

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
           :klass   => ApplicationHelper::Button::EmsRefresh),
         button(
           :ems_container_capture_metrics,
-          'fa pficon-import fa-lg',
+          'pficon pficon-import fa-lg',
           N_('Capture metrics related to this Containers Provider'),
           N_('Capture metrics'),
           :confirm => N_("Capture metrics related to this Containers Provider?"),

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
           :onwhen       => "1+"),
         button(
           :ems_container_capture_metrics,
-          'fa pficon-import fa-lg',
+          'pficon pficon-import fa-lg',
           N_('Capture metrics for selected Containers Providers'),
           N_('Capture metrics'),
           :confirm      => N_("Capture metrics for selected Containers Providers?"),

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -80,7 +80,7 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
   button_group('ems_physical_infra_console_access', [
     select(
       :ems_physical_infra_console_choice,
-      'fa pficon-screen fa-lg',
+      'pficon pficon-screen fa-lg',
       N_('Remote Access'),
       N_('Access'),
       :items => [

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -110,7 +110,7 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
     [
       select(
         :physical_server_remote_access_choice,
-        'fa pficon-screen fa-lg',
+        'pficon pficon-screen fa-lg',
         N_('Physical Server Remote Access'),
         N_('Access'),
         :enabled => true,

--- a/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
+++ b/app/helpers/application_helper/toolbar/stack_orchestration_template_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::StackOrchestrationTemplateCenter < Application
           :klass => ApplicationHelper::Button::OrchestrationTemplateOrderable),
         button(
           :orchestration_templates_view,
-          'fa pficon-info fa-lg',
+          'pficon pficon-info fa-lg',
           t = N_('View this Orchestration Template in Catalogs'),
           t,
           :klass => ApplicationHelper::Button::OrchestrationTemplateViewInCatalog),

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -250,7 +250,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
   button_group('vm_access', [
     select(
       :vm_remote_access_choice,
-      'fa pficon-screen fa-lg',
+      'pficon pficon-screen fa-lg',
       N_('VM Remote Access'),
       N_('Access'),
       :items => [

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -21,7 +21,7 @@
         - if menu_section.visible?
           %li.dropdown
             %a#help-menu.dropdown-toggle.nav-item-iconic{"data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}
-              %span.fa.pficon-help{:title => _("Help")}
+              %span.pficon.pficon-help{:title => _("Help")}
               %span.caret
             %ul.dropdown-menu{"aria-labelledby" => "help-menu"}
               - menu_section.items.each do |menu_item|

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -1,7 +1,7 @@
 - if current_user
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu2", "data-toggle" => "dropdown", "aria-haspopup" => "true"}
-      %span.fa.pficon-user
+      %span.pficon.pficon-user
       %p.navbar__user-name{"data-userid" => current_user.userid, :id => "username_display"}
         = "#{current_user.name} | #{appliance_name}"
       %span.caret


### PR DESCRIPTION
Several PF font icons  were using the "fa" class instead of "pficon" for some reason. It works fine on master but is broken when doing PF4 testing.  This PR corrects that.