### PR TITLE
Removed an extra observer from  Edit Selected Element type drop down

### DIFF
--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -56,8 +56,7 @@
               :multiple              => false,
               :class                 => 'selectpicker',
               'data-miq_sparkle_on'  => true,
-              'data-miq_sparkle_off' => true,
-              'data-miq_observe'     => {:url => url}.to_json)
+              'data-miq_sparkle_off' => true)
 
         %br
         - if @edit[@expkey][:exp_typ]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649057

Having two observers was sending up transaction twice when selecting a value in drop down.