### PR TITLE
Use v_total_vms for HostDecorator

### DIFF
--- a/app/decorators/host_decorator.rb
+++ b/app/decorators/host_decorator.rb
@@ -10,7 +10,7 @@ class HostDecorator < MiqDecorator
   def quadicon
     icon = {
       :top_left     => {
-        :text    => t = vms.size,
+        :text    => t = v_total_vms,
         :tooltip => n_("%{number} Virtual Machine", "%{number} Virtual Machines", t) % {:number => t}
       },
       :top_right    => {


### PR DESCRIPTION
Instead of using `vms.size`, use `v_total_vms`, which will do the same thing, unless the attribute exists on the model, in which it will avoid making a call to the database.

This also means that the call for the size can be done in a single query for an entire collection, instead of a N+1 manner.  This is already done in views like `Host.yaml`, where `v_total_vms` is already in the `cols`.

Metrics
-------
An example set of runs I had with a 47 `Host` provider:

**Before**

`/ems_infra/report_data`

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2993 |     154 |     1853.6 | 3644 |
| 2471 |     154 |     1759.1 | 3644 |
| 1869 |     154 |     1780.7 | 3644 |


**After**

`/ems_infra/report_data`

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 5617 |     107 |     2001.2 | 3644 |
| 2873 |     108 |       1966 | 3645 |
| 2417 |     107 |     1658.2 | 3644 |


Links
-----

* Related:
  - https://github.com/ManageIQ/manageiq/pull/17475
  - https://github.com/ManageIQ/manageiq/pull/18196
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/4924


Steps for Testing/QA
--------------------

Here is a script to generate test data that I was using:

https://gist.github.com/NickLaMuro/225833358423723ed17ff294415fa6b4

For testing, I did the following:

* Seed with the above script from `manageiq`: `bin/rails r bz_1580569_db_replication_script.rb`
* Spin up a server:  `bin/rails s`
* Do the following in a browser:
  - Login
  - Navigate to `Compute -> Infrastructure -> Providers` in the side menu
  - Up the `per_page` to 1k (just to load all of the records in a single page
  - Select a provider (one with the most `Host` records, ideally)
  - Select the `Hosts` button

Between `master`, and this change, you should see the number of queries per request for the last portion in the above drop by the number of `Host` records for that provider.  The `Metrics` section above used this process.