### PR TITLE
Adds authentication_status to Host.yaml

### DIFF
--- a/product/views/Host.yaml
+++ b/product/views/Host.yaml
@@ -32,6 +32,7 @@ cols:
 - ipmi_enabled
 - last_scan_on
 - region_description
+- authentication_status
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -56,6 +57,7 @@ col_order:
 - ipmi_enabled
 - last_scan_on
 - region_description
+- authentication_status
 
 # Column titles, in order
 headers:
@@ -72,6 +74,7 @@ headers:
 - IPMI Enabled
 - Last Analysis Time
 - Region
+- Authentication Status
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
This depends on changes in:  https://github.com/ManageIQ/manageiq/pull/18196

When `authentication_status` is changed to a `virtual_delegate`, we are able to pre-fetch the values as part of the original query, and avoid an N+1.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/18196


Steps for Testing/QA
--------------------

Testing for this can be see in the `manageiq` PR, https://github.com/ManageIQ/manageiq/pull/18196, along with some metrics.