### PR TITLE
Fixed reading of ems_refresh_threshold memory_threshold value

### DIFF
--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -207,7 +207,7 @@
           .col-md-8
             = select_tag('ems_refresh_worker_threshold',
                           options_for_select(@sb[:ems_refresh_threshold],
-                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_refresh_worker][:memory_threshold]),
+                                              @edit[:new][:workers][:worker_base][:queue_worker_base][:ems_refresh_worker][:defaults][:memory_threshold]),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('ems_refresh_worker_threshold', "#{url}")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649799

Value was getting saved properly but need to point to right key in the hash while reading it back to populate the drop down with correct saved value