### PR TITLE
Remove S3 and Swift From List of Log Collection Types

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -894,7 +894,10 @@ module OpsController::Diagnostics
   end
 
   def build_supported_depots_for_select
-    @supported_depots_for_select = FileDepot.supported_depots.values.sort
+    depots_for_select = FileDepot.supported_depots.values.sort
+    # S3 and Swift not currently supported for Log Collection
+    not_supported_depots = ["AWS S3", "OpenStack Swift"]
+    @supported_depots_for_select = depots_for_select - not_supported_depots
   end
 
   def set_credentials


### PR DESCRIPTION
The list of log collection types is currently built by pulling in all valid FileDepot types.
Unfortunately, while AWS S3 and OpenStack Swift were added as FileDepots for Database backups,
no work was done for Log Collection via these depots.  When the list of valid types is built in the
UI therefore, these two need to be removed.

Before:

![screen shot 2018-11-14 at 1 24 01 pm](https://user-images.githubusercontent.com/6118503/48503613-9adb8a80-e810-11e8-9134-9f1b36f00a15.png)

After:

![screen shot 2018-11-14 at 1 26 50 pm](https://user-images.githubusercontent.com/6118503/48503750-f86fd700-e810-11e8-8471-edc2efb393fa.png)

@h-kataria please review and merge when appropriate.  Feel free to add other reviewers as necessary.  Thanks.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643966

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1643966