### PR TITLE
[HAMMER] - Fixed reading of ems_refresh_threshold memory_threshold value

### DIFF
--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -207,7 +207,7 @@
           .col-md-8
             = select_tag('ems_refresh_worker_threshold',
                           options_for_select(@sb[:ems_refresh_threshold],
-                                              @edit[:new].get_raw_worker_setting(:MiqEmsRefreshWorker, :memory_threshold)),
+                                              @edit[:new].get_raw_worker_setting(:MiqEmsRefreshWorker, %i(defaults memory_threshold))),
                           :class    => "selectpicker")
           :javascript
             miqSelectPickerEvent('ems_refresh_worker_threshold', "#{url}")


### PR DESCRIPTION
Hammer specific PR for https://github.com/ManageIQ/manageiq-ui-classic/pull/4925

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649799

