### PR TITLE
Rails 5.1:  each_with_object was deprecated / removed on params

### DIFF
--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -14,13 +14,16 @@ module Mixins
         params[:miq_grid_checks].split(",").collect(&:to_i)
       else
         prefix = "check" if prefix.nil?
-        params.each_with_object([]) do |(var, val), items|
+
+        items = []
+        params.each do |var, val|
           vars = var.to_s.split("_")
           if vars[0] == prefix && val == "1"
             ids = vars[1..-1]
             items << ids.join("_")
           end
         end
+        items
       end
     end
 


### PR DESCRIPTION
The ActionController#params method return ActionController::Parameter objects which do not respond to all hash methods.
Reimplement each_with_object using each.

rails PR: #20868

Fixes the following warning that happens a lot when testing `spec/controllers/vm_infra_controller_spec.rb`

```
DEPRECATION WARNING: Method each_with_object is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7/classes/ActionController/Parameters.html (called from find_checked_items at /Users/joerafaniello/Code/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:17)
```

Related to https://github.com/ManageIQ/manageiq/pull/18076