### PR TITLE
Rails 5.1: find using AR::Base instance was deprecated/removed

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -18,7 +18,7 @@ module Mixins
           get_reconfig_limits(reconfigure_ids)
 
           if @reconfigitems.size == 1
-            vm = Vm.find(@reconfigitems)
+            vm = @reconfigitems.first
             @vlan_options = get_vlan_options(vm.host_id)
             @avail_adapter_names = vm.try(:available_adapter_names) || []
             @iso_options = get_iso_options(vm)


### PR DESCRIPTION
We already have the object we're finding, so use it.

Fixes warning in seen in spec/controllers/vm_infra_controller_spec.rb:

```
DEPRECATION WARNING: You are passing an instance of ActiveRecord::Base
to `find`. Please pass the id of the object by calling `.id`. (called
from reconfigure at
/Users/joerafaniello/Code/manageiq-ui-classic/app/controllers/mixins/actions/vm_actions/reconfigure.rb:21)
```