### PR TITLE
Rails 5.1: Non-kwargs support in AC::TestCase#post is gone

### DIFF
--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -499,7 +499,7 @@ describe DashboardController do
     end
 
     it 'retains the existing value of session[:edit] after the POST request' do
-      post :csp_report, '{"csp-report":{"document-uri":"https://example.com/foo/bar"}}', :format => 'json'
+      post :csp_report, :body => '{"csp-report":{"document-uri":"https://example.com/foo/bar"}}', :format => 'json'
       expect(session[:edit]).to eq("xyz")
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
https://github.com/rails/rails/commit/98b8309569a326910a723f521911e54994b112fb

Previously, if you passed non-keyword argument String to post, it was
treated as the body of the request.  We need to make this explicit now.

Fixes the following warning on the dashboard_controller_spec on rails
5.0:

```
DEPRECATION WARNING: Using positional arguments in functional tests has been deprecated,
in favor of keyword arguments, and will be removed in Rails 5.1.

Deprecated style:
get :show, { id: 1 }, nil, { notice: "This is a flash message" }

New keyword style:
get :show, params: { id: 1 }, flash: { notice: "This is a flash message" },
  session: nil # Can safely be omitted.
 (called from block (3 levels) in <top (required)> at /Users/joerafaniello/Code/manageiq-ui-classic/spec/controllers/dashboard_controller_spec.rb:502)
 ```

Related to https://github.com/ManageIQ/manageiq/pull/18076