### PR TITLE
Make print button consistent on VM infra and cloud screens

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1330,7 +1330,7 @@ module VmCommon
 
     presenter[:right_cell_text] = @right_cell_text
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
+    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :custom => cb_tb, :view => v_tb)
 
     presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
 

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -27,6 +27,8 @@ class ApplicationHelper::ToolbarChooser
       @report ? "report_view_tb" : nil
     elsif @layout == 'provider_foreman'
       @showtype == 'main' ? "x_summary_view_tb" : "x_gtl_view_tb"
+    elsif %w(vm_infra vm_cloud).include?(@layout)
+      @showtype == 'main' ? 'x_summary_view_tb' : nil
     elsif @layout == 'automation_manager'
       @record.try(:kind_of?, ManageIQ::Providers::AutomationManager::InventoryRootGroup) && @sb[:active_tab] == 'summary' ? "x_summary_view_tb" : "x_gtl_view_tb"
     else


### PR DESCRIPTION
The toolbar on vm cloud and infra screens was behaving differently when doing a full page reload and a `replace_right_cell` call. Basically the full page reload did not display the printer icon. However, when doing a `replace_right_cell` the printer icon was rendered on the wrong location.

**Before:**
Full page reload:
![screenshot from 2018-11-19 15-33-29](https://user-images.githubusercontent.com/649130/48713476-a7951f80-ec10-11e8-90b1-2c2dd7aba52d.png)
Calling `replace_right_cell`:
![screenshot from 2018-11-19 15-34-20](https://user-images.githubusercontent.com/649130/48713478-aa901000-ec10-11e8-905b-21f92ab79b08.png)

**After:**
![screenshot from 2018-11-19 15-23-49](https://user-images.githubusercontent.com/649130/48713282-2b024100-ec10-11e8-8ca1-10a3cd7f7428.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649881

@miq-bot add_label bug, hammer/yes
@miq-bot add_reviewer @mzazrivec, @epwinchell 