### PR TITLE
Add missing quadicon definition for generic object definitions

### DIFF
--- a/app/decorators/generic_object_definition_decorator.rb
+++ b/app/decorators/generic_object_definition_decorator.rb
@@ -6,4 +6,11 @@ class GenericObjectDefinitionDecorator < MiqDecorator
   def fileicon
     try(:picture) ? "/pictures/#{picture.basename}" : nil
   end
+
+  def quadicon
+    {
+      :fileicon => fileicon,
+      :fonticon => fileicon ? nil : fonticon
+    }
+  end
 end


### PR DESCRIPTION
You can find this under Automate -> Generic Objects.

**Before:**
![screenshot from 2018-11-19 16-50-21](https://user-images.githubusercontent.com/649130/48719015-c8fc0880-ec1c-11e8-9fd9-525341451794.png)

**After:**
![screenshot from 2018-11-19 17-00-46](https://user-images.githubusercontent.com/649130/48719019-cbf6f900-ec1c-11e8-9949-9599829395b1.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650146

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, gaprindashvili/yes, hammer/yes