### PR TITLE
Load ui-components for printing with asset pipeline require

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,8 @@
-@import '@manageiq/ui-components/dist/css/ui-components.css';
+/*
+ * Unfortunately ui-components needs to be loaded like this :(
+ * This is due to the fact that we have ui-components through yarn
+ *= require @manageiq/ui-components/dist/css/ui-components
+ */
 
 @import 'patternfly-sprockets';
 @import 'patternfly/variables';


### PR DESCRIPTION
This is a production-only issue, the SASS `@import` doesn't have the yarn packages in its load path. By calling the `require` this is solved. To reproduce it, click on the printer icon on any VM's summary screen.

**Before:**
![screenshot from 2018-11-19 18-16-37](https://user-images.githubusercontent.com/649130/48723575-4593e480-ec27-11e8-8e03-d402065f57fa.png)

**After:**
![screenshot from 2018-11-19 18-12-16](https://user-images.githubusercontent.com/649130/48723359-b38bdc00-ec26-11e8-9c73-c92f9758d8e3.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651194

@miq-bot add_reviewer @himdel 
@miq-bot add_label bug, hammer/yes