### PR TITLE
Configuration - notify backend when `quad_truncate` gets changed

### DIFF
--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -26,9 +26,8 @@
               = select_tag("quad_truncate",
                            options_for_select([[_("Front (...1234)"), "f"],
                                                [_("Middle (AB...34)"), "m"],
-                                               [_("Back (ABCD...)"), "b"]],
-                           @edit[:new][:display][:quad_truncate]),
-                           :class    => "selectpicker")
+                                               [_("Back (ABCD...)"), "b"]], @edit[:new][:display][:quad_truncate]),
+                           :class => "selectpicker")
               :javascript
                 miqSelectPickerEvent('quad_truncate', '#{url}');
 
@@ -43,9 +42,8 @@
                            options_for_select(start_page_options, @edit[:new][:display][:startpage]),
                            "data-live-search" => "true",
                            :class             => "selectpicker")
-
-            :javascript
-              miqSelectPickerEvent("start_page", "#{url}")
+              :javascript
+                miqSelectPickerEvent('start_page', '#{url}');
       .col-md-12.col-lg-6
         %fieldset
           %h3
@@ -58,12 +56,11 @@
               %label.col-md-3.control-label
                 = _(item_per_page[0])
               .col-md-8
-                = select_tag(_(item_per_page[1]),
+                = select_tag(item_per_page[1],
                              options_for_select(pp_choices, @edit[:new][:perpage][item_per_page[2]]),
-                           :class    => "selectpicker")
-
-            :javascript
-              miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")
+                             :class => "selectpicker")
+                :javascript
+                  miqSelectPickerEvent('#{item_per_page[1]}', '#{url}');
         %fieldset
           %h3
             = _('Topology Default Items in View')
@@ -72,11 +69,11 @@
               %label.col-md-3.control-label
                 = _(item_per_page[0])
               .col-md-8
-                = select_tag(_(item_per_page[1]),
+                = select_tag(item_per_page[1],
                              options_for_select([[N_("Unlimited"), 0]].concat(pp_choices), @edit[:new][:topology][item_per_page[2]]),
-                             :class    => "selectpicker")
-            :javascript
-              miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")
+                             :class => "selectpicker")
+                :javascript
+                  miqSelectPickerEvent('#{item_per_page[1]}', '#{url}');
         %fieldset
           %h3
             = _('Display Settings')
@@ -91,9 +88,10 @@
                              options_for_select(display_settings[2], @edit[:new][:display][display_settings[3]]),
                              'data-live-search' => display_settings[4],
                              :class             => "selectpicker")
-
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent("#{display_settings[1]}", "#{url}")
+                :javascript
+                  miqSelectPickerEvent('#{display_settings[1]}', '#{url}');
 
     = render :partial => '/layouts/form_buttons'
+
+:javascript
+  miqInitSelectPicker();

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -29,6 +29,8 @@
                                                [_("Back (ABCD...)"), "b"]],
                            @edit[:new][:display][:quad_truncate]),
                            :class    => "selectpicker")
+              :javascript
+                miqSelectPickerEvent('quad_truncate', '#{url}');
 
         %fieldset
           %h3


### PR DESCRIPTION
without `miqSelectPickerEvent`, any change in `quad_truncate` never gets propagated to the backend
=> adding `miqSelectPickerEvent`

introdued in https://github.com/ManageIQ/manageiq-ui-classic/pull/4034

Also made sure that indent of the javascript always matches the indent of the select itself,
fixed style issues (double quotes to single quotes, added semicolons),
removed useless gettext around field names (not descriptions),
and made sure `miqInitSelectPicker` ends up getting called exactly once.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650461

Cc @skateman 