### PR TITLE
VM CLoud: floating ips to associate must be a list

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/associate_floating_ip.rb
+++ b/app/controllers/mixins/actions/vm_actions/associate_floating_ip.rb
@@ -47,7 +47,7 @@ module Mixins
         def associate_floating_ip_form_fields
           assert_privileges("instance_associate_floating_ip")
           @record = find_record_with_rbac(VmCloud, params[:id])
-          floating_ips = @record.cloud_tenant.nil? ? [] : @record.cloud_tenant.floating_ips.find_by(:vm_id => nil)
+          floating_ips = @record.cloud_tenant.nil? ? [] : @record.cloud_tenant.floating_ips.where(:vm_id => nil)
 
           render :json => {
             :floating_ips => floating_ips


### PR DESCRIPTION
Fix drop down list of floating IPs.
Using `where` to return a list versus `find_by` which return only one item 

https://bugzilla.redhat.com/show_bug.cgi?id=1595767
https://bugzilla.redhat.com/show_bug.cgi?id=1623562
