### PR TITLE
Do not store download_summary_pdf using remember tab

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1812,6 +1812,7 @@ class ApplicationController < ActionController::Base
               request.headers['X-Angular-Request'].present?
 
     return if controller_name == 'dashboard' && %(iframe maintab cockpit_redirect).include?(action_name)
+    return if action_name == 'download_summary_pdf'
 
     remember_tab
   end


### PR DESCRIPTION
After ~exporting to PDF~ printing a textual summary of a VM or instance, the ~export to PDF~ printing screen gets remembered as the last action for that particular menu hierarchy. This causes issues when navigating away from the summary screen and then navigating back.

The solution is simple: we should not store the ~export to PDF~ printing screen in the menu hierarchy, but the implementation is ugly and I know it. @martinpovolny I'm terribly sorry for this solution and I promise I will fix it in a followup PR.

![i1-will-refactor-that-code-later-today-and-other-31878628](https://user-images.githubusercontent.com/649130/48759807-9a297500-eca4-11e8-9ebc-dd9df9f4e82c.png)

My long term solution would be to split up the `get_global_session_data` and `set_global_session_data` methods into smaller [`before_action`](https://guides.rubyonrails.org/action_controller_overview.html#filters) methods and use `skip_before_action` in controllers that behave differently from the default one. If you give me the green light, I'll create an issue for this.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649867

@miq-bot add_label bug, gaprindashvili/no
@miq-bot add_reviewer @martinpovolny 