### PR TITLE
Add X-UA-Compatible header

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
     %meta{"http-equiv" => "Pragma", :content => "no-store"}
     %meta{"http-equiv" => "Pragma", :content => "must-revalidate"}
     %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
+    %meta{"http-equiv" => "X-UA-Compatible", :content => "IE=edge"}
 
     = favicon_link_tag
     = stylesheet_link_tag 'application'


### PR DESCRIPTION
in situations where IE11 fails to detect the "document mode" correctly,
this header should ensure that IE uses the "edge" mode.

(this probably doesn't help in any case where IE11 is set to force IE7 mode)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648338

---

But see the comments in the BZ, ~~I'm almost sure this is useless, because the problem is not on our side. It won't hurt though, and will fix the problem if I'm wrong :)~~

EDIT: confirmed in the BZ that this header will indeed override group policy settings
