### PR TITLE
Adds email validation for schedule and alerts forms

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -649,7 +649,13 @@ module MiqPolicyController::Alerts
     if alert.options[:notifications][:email]
       if alert.options[:notifications][:email][:to].blank?
         add_flash(_("At least one E-mail recipient must be configured"), :error)
+      elsif alert.options[:notifications][:email][:to].find { |i| !i.to_s.email? }
+        add_flash(_("One of e-mail addresses 'To' is not valid"), :error)
       end
+    end
+    if alert.options[:notifications][:email][:from].present? &&
+       !alert.options[:notifications][:email][:from].email?
+      add_flash(_("E-mail address 'From' is not valid"), :error)
     end
     if alert.options[:notifications][:snmp]
       validate_snmp_options(alert.options[:notifications][:snmp])

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -264,11 +264,19 @@ module ReportController::Schedules
     valid = true
     if sched.sched_action[:options] &&
        sched.sched_action[:options][:send_email] &&
-       sched.sched_action[:options][:email] &&
-       sched.sched_action[:options][:email][:to].blank?
-      valid = false
-      add_flash(_("At least one To E-mail address must be configured"),
-                :error)
+       sched.sched_action[:options][:email]
+      if sched.sched_action[:options][:email][:from].present? &&
+         !sched.sched_action[:options][:email][:from].email?
+        valid = false
+        add_flash(_("E-mail address 'From' is not valid"), :error)
+      end
+      if sched.sched_action[:options][:email][:to].blank?
+        valid = false
+        add_flash(_("At least one To E-mail address must be configured"), :error)
+      elsif sched.sched_action[:options][:email][:to].find { |i| !i.to_s.email? }
+        valid = false
+        add_flash(_("One of e-mail addresses 'To' is not valid"), :error)
+      end
     end
     unless flash_errors?
       if sched.run_at[:interval][:unit] == "once" &&

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -145,7 +145,7 @@ describe MiqPolicyController do
         @miq_alert = FactoryGirl.create(
           :miq_alert,
           :db         => "Host",
-          :options    => {:notifications => {:email => {:to => "fred@test.com"}}},
+          :options    => {:notifications => {:email => {:to => ["fred@test.com"]}}},
           :expression => expression
         )
         edit = {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651241

**Description of the issue**

Emails fields are missing the pattern validation.

**Steps to Reproduce:**
1. Navigate to `Cloud Intel` > `Reports`.
2. Click on Schedules Accordion, then on `Configuration` and select `Add a new Schedule`.
3. Check `Send an Email` and fill any non-email pattern in the `Add (enter manually)` field, say `XYZ` and click on plus icon.

Same thing can be reproduced with Alert Add/Edit forms.

**Before**
![screenshot from 2018-11-20 16-36-17](https://user-images.githubusercontent.com/32869456/48784201-7b49d380-ece2-11e8-893f-08335c698c22.png)

**After**
![screenshot from 2018-11-20 16-35-13](https://user-images.githubusercontent.com/32869456/48784211-813fb480-ece2-11e8-98f8-b8947d631360.png)


@miq-bot add_label hammer/yes, bug