### PR TITLE
Remove open_url from GOD's custom buttons

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form-component.js
@@ -36,7 +36,6 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       resource_action: {},
       visibility: {},
       dialog_id: undefined,
-      open_url: false,
       display_for: 'single',
       submit_how: 'one',
       ae_instance: 'Request',
@@ -144,7 +143,6 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       button_color: vm.customButtonModel.button_color,
       button_type: vm.customButtonModel.button_type,
       display: vm.customButtonModel.display,
-      open_url: vm.customButtonModel.open_url,
       display_for: vm.customButtonModel.display_for,
       submit_how: vm.customButtonModel.submit_how,
     };
@@ -211,7 +209,6 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     vm.customButtonModel.button_color = response.options.button_color;
     vm.customButtonModel.button_type = response.options.button_type;
     vm.customButtonModel.display = response.options.display;
-    vm.customButtonModel.open_url = response.options.open_url;
     vm.customButtonModel.display_for = response.options.display_for;
     vm.customButtonModel.submit_how = response.options.submit_how;
 

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -36,18 +36,6 @@
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.dialog_id.$error.required"}
         = _("Required")
-  .form-group{"ng-class" => "{'has-error': angularForm.display.$invalid}"}
-    %label.col-md-2.control-label{"for" => "custom_button_open_url"}
-      = _("Open URL")
-    .col-md-8
-      %input.form-control{"type"            => "checkbox",
-                          "id"              => "custom_button_open_url",
-                          "name"            => "open_url",
-                          "bs-switch"       => "",
-                          "switch-on-text"  => _('Yes'),
-                          "switch-off-text" => _('No'),
-                          :data             => {:size => 'mini'},
-                          "ng-model"        => "vm.customButtonModel.open_url"}
   .form-group{"ng-class" => "{'has-error': angularForm.display_for.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_display_for"}
       = _("Display for")


### PR DESCRIPTION
`open_url` is implemented only for VMs so it's not needed here. Trying to prevent people getting confused it's not working :D And keep this form in sync with the original https://github.com/ManageIQ/manageiq-ui-classic/pull/4773

Before:
<img width="756" alt="screen shot 2018-11-21 at 10 31 08 am" src="https://user-images.githubusercontent.com/9210860/48832062-96672280-ed78-11e8-80f7-4bd02424bf4b.png">

After:
<img width="755" alt="screen shot 2018-11-21 at 10 27 22 am" src="https://user-images.githubusercontent.com/9210860/48831966-5738d180-ed78-11e8-985a-1863d3208861.png">

@miq-bot add_label technical debt, hammer/no, automation/automate

@AparnaKarve please have a look, thanks :)