### PR TITLE
Add delete_flavors method to EmsCloudController

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -866,6 +866,22 @@ module ApplicationController::CiProcessing
     delete_elements(EmsCluster, :process_clusters)
   end
 
+  # Delete all selected or single displayed flavor(s)
+  def delete_flavors
+    assert_privileges('flavor_delete')
+    flavors = find_records_with_rbac(Flavor, checked_or_params)
+    flavors.each do |flavor|
+      begin
+        flavor.delete_flavor_queue(User.current_user.id)
+        add_flash(_("Delete of Flavor \"%{name}\" was successfully initiated.") % {:name => flavor.name})
+      rescue => error
+        add_flash(_("Unable to delete Flavor \"%{name}\": %{details}") % {:name    => flavor.name,
+                                                                          :details => error.message}, :error)
+      end
+    end
+  end
+
+
   # Delete all selected or single displayed RP(s)
   def deleteresourcepools
     assert_privileges("resource_pool_delete")

--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -45,17 +45,7 @@ class FlavorController < ApplicationController
   helper_method :textual_group_list
 
   def delete_flavors
-    assert_privileges('flavor_delete')
-    flavors = find_records_with_rbac(Flavor, checked_or_params)
-    flavors.each do |flavor|
-      begin
-        flavor.delete_flavor_queue(User.current_user.id)
-        add_flash(_("Delete of Flavor \"%{name}\" was successfully initiated.") % {:name => flavor.name})
-      rescue => error
-        add_flash(_("Unable to delete Flavor \"%{name}\": %{details}") % {:name    => flavor.name,
-                                                                          :details => error.message}, :error)
-      end
-    end
+    super
     session[:flash_msgs] = @flash_array
     javascript_redirect(:action => 'show_list')
   end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -1061,3 +1061,24 @@ describe OrchestrationStackController do
     end
   end
 end
+
+describe EmsCloudController do
+  describe "#delete_flavor" do
+    let!(:flavor) { FactoryGirl.create(:flavor) }
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      stub_user(:features => :all)
+    end
+
+    context 'when pressed' do
+      it 'queues deletion of selected flavors' do
+        controller.instance_variable_set(
+          :@_params,
+          :miq_grid_checks => "#{flavor.id}")
+        expect(controller).to receive(:delete_flavors).and_call_original
+        expect_any_instance_of(Flavor).to receive(:delete_flavor_queue)
+        post :button, :params => {:pressed => 'flavor_delete', :miq_grid_checks => flavor.id}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650107

Go to Compute -> Cloud -> Providers -> summary page of a provider -> click Flavors -> select one or more Flavors -> Configuration -> Remove Selected Flavors
Make sure it works from Flavor list view as well: Compute -> Cloud -> Flavors -> select one or more Flavors -> Configuration -> Remove Selected Flavors

Before:
```
FATAL -- : Error caught: [NameError] undefined local variable or method `delete_flavors' for #<EmsCloudController:0x00007faacabca1c0>
Did you mean?  deletevms
/manageiq-ui-classic/app/controllers/ems_common.rb:242:in `button'

```
<img width="1159" alt="screen shot 2018-11-21 at 4 17 10 pm" src="https://user-images.githubusercontent.com/9210860/48850420-ebbb2800-eda8-11e8-84ec-1e2312a32782.png">

After:
<img width="1198" alt="screen shot 2018-11-21 at 4 06 25 pm" src="https://user-images.githubusercontent.com/9210860/48850338-bb738980-eda8-11e8-86cb-026ee6345d63.png">

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/4301

@miq-bot add_label bug, hammer/yes, gaprindashvili/yes