### PR TITLE
Add a shared example and tests for nested lists under EmsCloudControl…

### DIFF
--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -727,8 +727,12 @@ describe EmsCloudController do
     end
   end
 
-  %w(availability_zones cloud_tenants security_groups instances images
-     orchestration_stacks storage_managers).each do |custom_button_class|
+  nested_lists = %w(availability_zones cloud_tenants cloud_volumes security_groups instances images
+     orchestration_stacks storage_managers)
+
+  nested_lists.each do |custom_button_class|
     include_examples "relationship table screen with custom buttons", custom_button_class
   end
+
+  it_behaves_like "relationship table screen with GTL", nested_lists, :ems_amazon
 end

--- a/spec/shared/controllers/shared_examples_for_nested_lists.rb
+++ b/spec/shared/controllers/shared_examples_for_nested_lists.rb
@@ -1,0 +1,18 @@
+shared_examples 'relationship table screen with GTL' do |displays, parent_factory|
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryGirl.create(:user, :features => "none")
+    @parent = FactoryGirl.create(parent_factory)
+  end
+
+  render_views
+  context "for a parent #{parent_factory}" do
+    displays.each do |display|
+      it "displays the GTL for #{display}" do
+        get :show, :params => { :display => display, :id => @parent.id, :format => :js }
+        expect(response).to render_template('layouts/angular/_gtl')
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  * Create a shared example test for nested lists.
  * Add a simple test for each nested list under cloud providers. 
  * Add a missing Custom button test for cloud_volume.

Example usage for the shared example:
```
  it_behaves_like "relationship table screen with GTL", %w(cloud_volumes instances), :ems_amazon
```