### PR TITLE
Remove include pointing in invalid

### DIFF
--- a/product/views/GuestDevice.yaml
+++ b/product/views/GuestDevice.yaml
@@ -16,13 +16,6 @@ cols:
 - field_replaceable_unit
 
 
-include:
-
-
-include_for_find:
-  :ext_management_system: {}
-
-
 col_order:
 - device_name
 - location

--- a/product/views/PhysicalNetworkPort.yaml
+++ b/product/views/PhysicalNetworkPort.yaml
@@ -14,14 +14,6 @@ cols:
 - port_type
 - peer_mac_address
 
-
-include:
-
-
-include_for_find:
-  :ext_management_system: {}
-
-
 col_order:
 - port_name
 - port_type

--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -41,8 +41,7 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :picture:
-    :binary_blob: {}
+  :picture: {}
 
 # Order of columns (from all tables)
 col_order:


### PR DESCRIPTION
`Picture` has no association `binary_blob` - removed from ServiceTemplates

`PhysicalNetworkPort` has no association `ext_management_system`
`GuestDevice` has no association `ext_management_system`

Updated views to remove the bad `includes()`


@miq-bot add_label rails51