### PR TITLE
Remove invalid compliances references

### DIFF
--- a/product/views/PhysicalChassis.yaml
+++ b/product/views/PhysicalChassis.yaml
@@ -23,7 +23,6 @@ include:
 
 include_for_find:
   :ext_management_system: {}
-  :compliances: {}
   :tags: {}
 
 

--- a/product/views/PhysicalRack.yaml
+++ b/product/views/PhysicalRack.yaml
@@ -18,7 +18,6 @@ include:
 
 include_for_find:
   :ext_management_system: {}
-  :compliances: {}
   :tags: {}
 
 

--- a/product/views/PhysicalServer.yaml
+++ b/product/views/PhysicalServer.yaml
@@ -23,7 +23,6 @@ include:
 
 include_for_find:
   :ext_management_system: {}
-  :compliances: {}
   :tags: {}
 
 


### PR DESCRIPTION
I'm not totally sure how compliances work.
But these models do not have a `has_many compliances`

`has_many :compliances` comes in via `include ComplianceMixin`
And this mixin is only used in ems/vms/hosts or some containers.

But not `PhysicalChassis`, `PhysicalRack`, and `PhysicalServer`. 

I believe they are invalid `includes()` references.
The older version of rails was more lenient with `includes()` that references invalid relationships.

@bzwei or @lfu Could you verify that these references don't make sense?
Thanks

@miq-bot add_label rails51