### PR TITLE
Display the web console for OpenStack instances

### DIFF
--- a/app/helpers/application_helper/button/cockpit_console.rb
+++ b/app/helpers/application_helper/button/cockpit_console.rb
@@ -1,12 +1,6 @@
 class ApplicationHelper::Button::CockpitConsole < ApplicationHelper::Button::Basic
   needs :@record
 
-  def visible?
-    # disabled for Openstack as discussed in https://github.com/ManageIQ/manageiq-ui-classic/pull/4212
-    # FIXME: there should be some supports_? based check instead.
-    !@record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
-  end
-
   def disabled?
     if !MiqRegion.my_region.role_active?('cockpit_ws')
       @error_message = _("The web-based console is not available because the 'Cockpit' role is not enabled.")


### PR DESCRIPTION
There was a little confusion around web console, after a discussion with @aufi he stated that it needs to be visible for OpenStack instances as well, so removing the piece of code that hides it.

**Before:**
![screenshot from 2018-11-22 10-13-24](https://user-images.githubusercontent.com/649130/48892856-4606c800-ee3f-11e8-91ec-3b69f47d2233.png)

**After:**
![screenshot from 2018-11-22 10-12-38](https://user-images.githubusercontent.com/649130/48892833-3dae8d00-ee3f-11e8-878d-7b1f8ae14e74.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650470

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label gaprindashvili/no, hammer/yes, bug