### PR TITLE
Spec: Do not call MiqProductFeature.seed - speedup of 1m

### DIFF
--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -4,7 +4,6 @@ describe MiqAeCustomizationController do
       before do
         EvmSpecHelper.local_miq_server
         login_as FactoryGirl.create(:user, :features => "dialog_delete")
-        MiqProductFeature.seed
         allow(controller).to receive(:check_privileges).and_return(true)
       end
 

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -4,7 +4,6 @@ describe OpsController do
   before(:each) do
     EvmSpecHelper.local_miq_server
     MiqRegion.seed
-    MiqProductFeature.seed
     stub_admin
 
     controller.instance_variable_set(:@sb, {})


### PR DESCRIPTION
@lpichler : reverting your change from https://github.com/ManageIQ/manageiq-ui-classic/pull/4858

The test is passing for me even after `db:reset`. Trying travis...

Also: if seeding is really needed, can we either seed only what is needed or seed once for all tests?