### PR TITLE
Don't webpack:compile for TEST_SUITE=spec

### DIFF
--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -20,3 +20,11 @@ class Webpacker::Env < Webpacker::FileLoader
     end
   end
 end
+
+if Rails.env.test?
+  module Webpacker::Helper
+    def javascript_pack_tag(_)
+      # does nothing in specs
+    end
+  end
+end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -53,19 +53,30 @@ namespace :webpack do
     system(webpack_dev_server) || abort("\n== webpack-dev-server failed ==")
   end
 
-  [:compile, :clobber].each do |webpacker_task|
-    task webpacker_task do
-      # Run the `webpack:compile` tasks without a fully loaded environment,
-      # since when doing an appliance/docker build, a database isn't
-      # available for the :environment task (prerequisite for
-      # 'webpacker:compile') to function.
-      EvmRakeHelper.with_dummy_database_url_configuration do
-        Dir.chdir ManageIQ::UI::Classic::Engine.root do
-          Rake::Task["webpack:paths"].invoke
-          Rake::Task["webpacker:#{webpacker_task}"].invoke
-        end
+  def run_webpack(task)
+    if %w(spec spec:jest).include? ENV['TEST_SUITE']
+      warn "Skipping webpack:#{task} on travis #{ENV['TEST_SUITE']}"
+      return
+    end
+
+    # Run the `webpack:compile` tasks without a fully loaded environment,
+    # since when doing an appliance/docker build, a database isn't
+    # available for the :environment task (prerequisite for
+    # 'webpacker:compile') to function.
+    EvmRakeHelper.with_dummy_database_url_configuration do
+      Dir.chdir ManageIQ::UI::Classic::Engine.root do
+        Rake::Task["webpack:paths"].invoke
+        Rake::Task["webpacker:#{task}"].invoke
       end
     end
+  end
+
+  task :compile do
+    run_webpack(:compile)
+  end
+
+  task :clobber do
+    run_webpack(:clobber)
   end
 
   task :paths do


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/18228

For ruby specs, we don't need to spend time compiling webpack assets just to ignore them.

So... we override `javascript_pack_tag` for specs, to prevent `Can't modify frozen Array` when run with a pack that was not compiled.
    
And change `webpack:compile` to not run `TEST_SUITE=spec`.