### PR TITLE
[WIP] Webpack - add @ alias to app/javascript

### DIFF
--- a/app/javascript/http_api/fetch.js
+++ b/app/javascript/http_api/fetch.js
@@ -1,4 +1,4 @@
-import { sendDataWithRx } from '../miq_observable';
+import { sendDataWithRx } from '@/miq_observable';
 
 const { redirectLogin } = window;
 

--- a/app/javascript/miq-redux/store.js
+++ b/app/javascript/miq-redux/store.js
@@ -1,7 +1,7 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import createReducer from './reducer';
 import createMiddlewares from './middleware';
-import { history } from '../miq-component/react-history.ts';
+import { history } from '@/miq-component/react-history.ts';
 
 const initialState = {};
 

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -9,18 +9,18 @@
 import 'proxy-polyfill';
 import { Spinner } from 'spin.js';
 import 'spin.js/spin.css';
-import { API, http } from '../http_api';
+import { API, http } from '@/http_api';
 
-import * as newRegistry from '../miq-component/registry.ts';
-import reactBlueprint from '../miq-component/react-blueprint.tsx';
-import * as helpers from '../miq-component/helpers';
+import * as newRegistry from '@/miq-component/registry.ts';
+import reactBlueprint from '@/miq-component/react-blueprint.tsx';
+import * as helpers from '@/miq-component/helpers';
 
-import { rxSubject, sendDataWithRx, listenToRx } from '../miq_observable';
+import { rxSubject, sendDataWithRx, listenToRx } from '@/miq_observable';
 
-import { initializeStore } from '../miq-redux';
-import { history } from '../miq-component/react-history.ts';
-import createReduxRoutingActions from '../miq-redux/redux-router-actions';
-import { formButtonsActionTypes, createFormButtonsActions } from '../forms/form-buttons-reducer';
+import { initializeStore } from '@/miq-redux';
+import { history } from '@/miq-component/react-history.ts';
+import createReduxRoutingActions from '@/miq-redux/redux-router-actions';
+import { formButtonsActionTypes, createFormButtonsActions } from '@/forms/form-buttons-reducer';
 
 ManageIQ.component = {
   ...newRegistry,

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { TagGroup, TableListView, GenericGroup } from '@manageiq/react-ui-components/dist/textual_summary';
-import TextualSummaryWrapper from '../react/textual_summary_wrapper';
-import TableListViewWrapper from '../react/table_list_view_wrapper';
-import GenericGroupWrapper from '../react/generic_group_wrapper';
-import VmSnapshotFormComponent from '../components/vm-snapshot-form-component';
-import FormButtonsRedux from '../forms/form-buttons-redux';
-import MiqAboutModal from '../components/miq-about-modal';
+import TextualSummaryWrapper from '@/react/textual_summary_wrapper';
+import TableListViewWrapper from '@/react/table_list_view_wrapper';
+import GenericGroupWrapper from '@/react/generic_group_wrapper';
+import VmSnapshotFormComponent from '@/components/vm-snapshot-form-component';
+import FormButtonsRedux from '@/forms/form-buttons-redux';
+import MiqAboutModal from '@/components/miq-about-modal';
 
 /**
 * Add component definitions to this file.

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderModal from '../provider-dialogs/modal';
+import renderModal from '@/provider-dialogs/modal';
 
 ManageIQ.angular.app.component('providerDialogUser', {
   bindings: {

--- a/app/javascript/packs/toolbar-actions-common.js
+++ b/app/javascript/packs/toolbar-actions-common.js
@@ -1,5 +1,5 @@
-import { onDelete } from '../toolbar-actions/delete';
-import { onCustomAction } from '../toolbar-actions/custom-action';
+import { onDelete } from '@/toolbar-actions/delete';
+import { onCustomAction } from '@/toolbar-actions/custom-action';
 
 function transformResource(resource) {
   return ({ id: resource });

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Icon, Modal } from 'patternfly-react';
 import { Provider } from 'react-redux';
-import FormButtonsRedux from '../forms/form-buttons-redux';
+import FormButtonsRedux from '@/forms/form-buttons-redux';
 
 function closeModal(id) {
   /**

--- a/app/javascript/spec/miq-component/helpers.spec.js
+++ b/app/javascript/spec/miq-component/helpers.spec.js
@@ -1,5 +1,5 @@
-import { define } from '../../miq-component/registry.ts';
-import { cleanVirtualDom } from '../../miq-component/helpers';
+import { define } from '@/miq-component/registry.ts';
+import { cleanVirtualDom } from '@/miq-component/helpers';
 
 describe('Helpers', () => {
   it('Should call instance destroy method if component mounting element is missing', () => {

--- a/app/javascript/spec/miq-redux/redux-router-actions.spec.js
+++ b/app/javascript/spec/miq-redux/redux-router-actions.spec.js
@@ -1,8 +1,8 @@
 import configureStore from 'redux-mock-store';
 import { connectRouter } from 'connected-react-router';
-import createReduxRoutingActions from '../../miq-redux/redux-router-actions';
-import createMiddlewares from '../../miq-redux/middleware';
-import { history } from '../../miq-component/react-history.ts';
+import createReduxRoutingActions from '@/miq-redux/redux-router-actions';
+import createMiddlewares from '@/miq-redux/middleware';
+import { history } from '@/miq-component/react-history.ts';
 
 describe('Redux routing actions', () => {
   const mockStore = configureStore(createMiddlewares(history));

--- a/app/javascript/spec/toolbar-actions/toolbar-actions-delete.spec.js
+++ b/app/javascript/spec/toolbar-actions/toolbar-actions-delete.spec.js
@@ -1,6 +1,6 @@
 import 'angular-mocks';
-import getGridChecks from '../../packs/toolbar-actions-common';
-import * as deleteActions from '../../toolbar-actions/delete';
+import getGridChecks from '@/packs/toolbar-actions-common';
+import * as deleteActions from '@/toolbar-actions/delete';
 
 describe('Toolbar actions', () => {
   beforeEach(() => {

--- a/app/javascript/spec/toolbar-actions/toolbar-actions-generic.spec.js
+++ b/app/javascript/spec/toolbar-actions/toolbar-actions-generic.spec.js
@@ -1,6 +1,6 @@
 import 'angular-mocks';
-import getGridChecks from '../../packs/toolbar-actions-common';
-import { onCustomAction } from '../../toolbar-actions/custom-action';
+import getGridChecks from '@/packs/toolbar-actions-common';
+import { onCustomAction } from '@/toolbar-actions/custom-action';
 
 describe('Toolbar actions', () => {
   beforeEach(() => {

--- a/app/javascript/toolbar-actions/custom-action.js
+++ b/app/javascript/toolbar-actions/custom-action.js
@@ -1,4 +1,4 @@
-import { API } from '../http_api';
+import { API } from '@/http_api';
 
 export function customActionFunction(payload, resources) {
   throw new Error(`customAction ${payload.action} not yet implemented!`, payload, resources);

--- a/app/javascript/toolbar-actions/delete.js
+++ b/app/javascript/toolbar-actions/delete.js
@@ -1,4 +1,4 @@
-import { API } from '../http_api';
+import { API } from '@/http_api';
 
 export function showMessage(messages, labels = { single: '', multiple: '' }) {
   Object.keys(messages).forEach((msgStatus) => {

--- a/app/javascript/typings/globals.d.ts
+++ b/app/javascript/typings/globals.d.ts
@@ -1,6 +1,6 @@
 import { IModule } from 'angular';
-import { ComponentApi } from '../miq-component/component-typings';
-import { ReduxApi } from '../miq-redux/redux-typings';
+import { ComponentApi } from '@/miq-component/component-typings';
+import { ReduxApi } from '@/miq-redux/redux-typings';
 import 'jasmine';
 
 interface MiqAngular {

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -11,13 +11,13 @@ require('../app/assets/javascripts/miq_application');
 require('../app/assets/javascripts/miq_api');
 require('../app/assets/javascripts/miq_angular_application');
 
-import { API } from '../app/javascript/http_api';
+import { API } from '@/http_api';
 window.vanillaJsAPI = API;
 
-import { rxSubject, sendDataWithRx, listenToRx } from '../app/javascript/miq_observable';
+import { rxSubject, sendDataWithRx, listenToRx } from '@/miq_observable';
 ManageIQ.angular.rxSubject = rxSubject;
 window.sendDataWithRx = sendDataWithRx;
 window.listenToRx = listenToRx;
 
-import getJSONFixture from '../app/javascript/spec/helpers/getJSONFixtures';
+import getJSONFixture from '@/spec/helpers/getJSONFixtures';
 window.getJSONFixture = getJSONFixture;

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -123,7 +123,10 @@ module.exports = {
   },
 
   resolve: {
-    alias: { 'react': resolve(dirname(__filename), '../../node_modules', 'react') },
+    alias: {
+      '@': resolve(__dirname, '../../', 'app/javascript'),
+      'react': resolve(__dirname, '../../', 'node_modules', 'react'),
+    },
     extensions: settings.extensions,
     modules: [],
     plugins: [


### PR DESCRIPTION
to prevent the need of doing a lot of `import * from ../../../../whatever`
we introduce an alias (`@`) which resolves to our `app/javascript/`, from whatever source location.

And updated all imports with `../` to use the alias.
(same-directory imports using `./` are fine)

Cc @Hyperkid123 
(wip for now, expecting jest to break)