### PR TITLE
Increase caching timeout for travis to speed up env setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 cache:
   bundler: true
   yarn: true
+  timeout: 600
 addons:
   postgresql: '9.5'
 env:


### PR DESCRIPTION
Sometimes there's not enough time to zip & upload the cache, increasing this number should speed up the bundle installs in general.