### PR TITLE
Do not run bundle install twice when setting up the build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh
+install: true
 before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE
 after_script: source tools/ci/after_install.sh


### PR DESCRIPTION
The `before_install` runs the `ManageIQ::Environment.manageiq_plugin_update` method from the core repo that runs bundler before travis would call it. This is necessary for the DB setup and some other stuff, however, it is not necessary to call it again.