### PR TITLE
Travis - remove sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
 - 2.4.4
 - 2.3.6
-sudo: false
 cache:
   bundler: true
   yarn: true


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for details,
the gist is, we should remove it because Travis says so :).

Also related: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures