### PR TITLE
Use a singleton wrapper around GTLs to avoid using any_instance_of

### DIFF
--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -72,7 +72,13 @@ module GtlHelper
       :report_data_additional_options => @report_data_additional_options,
     }
 
-    render_gtl(options)
+    GtlHelper.render_gtl_wrapper(self, options)
+  end
+
+  # This wrapper method has been created for better testability
+  # Unfortunately the context isn't accessible from request tests and so the method cannot be mocked
+  def self.render_gtl_wrapper(context, *args)
+    context.render_gtl(*args)
   end
 
   # This is a pure function. All the generated markup depends only and fully on the `options`.

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -67,14 +67,14 @@ describe AuthKeyPairCloudController do
     render_views
 
     it 'sets the lastaction correctly' do
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'ManageIQ::Providers::CloudManager::AuthKeyPair',
         :report_data_additional_options => {
           :model      => "ManageIQ::Providers::CloudManager::AuthKeyPair",
           :lastaction => 'show_list',
           :gtl_dbname => :authkeypaircloud
         }
-      )
+      ))
 
       get :show_list
       expect(response.status).to eq(200)

--- a/spec/controllers/cloud_volume_type_controller_spec.rb
+++ b/spec/controllers/cloud_volume_type_controller_spec.rb
@@ -87,12 +87,12 @@ describe CloudVolumeTypeController do
       end
 
       it "render view for list of volume types" do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name      => 'CloudVolumeType',
           :parent_id       => nil,
           :explorer        => nil,
           :gtl_type_string => "list"
-        )
+        ))
 
         get :show_list
       end

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -55,12 +55,12 @@ describe HostController do
                             :display   => {:quad_truncate => 'f'},
                             :quadicons => {:host => 'foo'}}
 
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name       => 'Host',
         :gtl_type_string  => 'grid',
         :parent_id        => nil,
         :selected_records => [h1.id, h2.id]
-      )
+      ))
       get :edit
       expect(response.status).to eq(200)
     end
@@ -243,12 +243,12 @@ describe HostController do
 
     # http://localhost:3000/host/users/10000000000005?db=host
     it "renders a grid of associated Users" do
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name      => 'Account',
         :parent_id       => @host.id.to_s,
         :parent          => @host,
         :gtl_type_string => 'list'
-      )
+      ))
       get :users, :params => {:id => @host.id, :db => 'host'}
       expect(response.status).to eq(200)
     end
@@ -256,12 +256,12 @@ describe HostController do
     # http://localhost:3000/host/guest_applications/10000000000005?db=host
     it "renders a grid of associated GuestApplications" do
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name      => 'GuestApplication',
         :parent_id       => @host.id.to_s,
         :parent          => @host,
         :gtl_type_string => 'list'
-      )
+      ))
       get :guest_applications, :params => {:id => @host.id, :db => 'host'}
       expect(response.status).to eq(200)
     end
@@ -269,7 +269,7 @@ describe HostController do
     # http://localhost:3000/host/filesystems/10000000000005?db=host
     it "renders a grid of all associated Filesystems" do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'Filesystem',
         :parent_id                      => @host.id.to_s,
         :parent                         => @host,
@@ -277,7 +277,7 @@ describe HostController do
         :report_data_additional_options => {
           :named_scope => [[:host_service_group_filesystems, @host_service_group.id]]
         }
-      )
+      ))
       get :filesystems, :params => {:id => @host.id, :db => 'host', :host_service_group => @host_service_group.id}
       expect(response.status).to eq(200)
     end
@@ -285,7 +285,7 @@ describe HostController do
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=all
     it "renders a grid of all associated SystemServices" do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
         :parent                         => @host,
@@ -293,7 +293,7 @@ describe HostController do
         :report_data_additional_options => {
           :named_scope => [[:host_service_group_systemd, @host_service_group.id]]
         }
-      )
+      ))
       get :host_services, :params => {:id => @host.id, :db => 'host', :host_service_group => @host_service_group.id, :status => "all"}
       expect(response.status).to eq(200)
     end
@@ -301,7 +301,7 @@ describe HostController do
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=running
     it "renders a grid of running associated SystemServices" do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
         :parent                         => @host,
@@ -309,7 +309,7 @@ describe HostController do
         :report_data_additional_options => {
           :named_scope => [[:host_service_group_running_systemd, @host_service_group.id]]
         }
-      )
+      ))
       get :host_services, :params => {:id => @host.id, :db => 'host', :host_service_group => @host_service_group.id, :status => 'running'}
       expect(response.status).to eq(200)
     end
@@ -317,7 +317,7 @@ describe HostController do
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=failed
     it "renders a grid of failed associated SystemServices" do
       @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
         :parent                         => @host,
@@ -325,7 +325,7 @@ describe HostController do
         :report_data_additional_options => {
           :named_scope => [[:host_service_group_failed_systemd, @host_service_group.id]]
         }
-      )
+      ))
       get :host_services, :params => {:id => @host.id, :db => 'host', :host_service_group => @host_service_group.id, :status => 'failed'}
       expect(response.status).to eq(200)
     end
@@ -459,13 +459,13 @@ describe HostController do
           {:row => 0, :column => 0, :chart_index => 0, :chart_name => "Display-Hosts-on"}.to_json
         )
 
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Host',
           :report_data_additional_options => {
             :menu_click    => menu_click,
             :sb_controller => 'storage',
           }
-        )
+        ))
 
         # FIXME: This should rather be a POST, but it really is a GET.
         get :show_list, :params => {:menu_click => menu_click, :sb_controller => 'storage'}
@@ -475,13 +475,13 @@ describe HostController do
 
     context 'called with search text' do
       it 'render GTL with and saves search_text in the session' do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Host',
           :parent_id                      => nil,
           :report_data_additional_options => {
             :lastaction => 'show_list',
           },
-        )
+        ))
         get :show_list, :params => {'search[text]' => 'foobar'}
         expect(session.fetch_path(:sandboxes, 'host', :search_text)).to eq('foobar')
         expect(response.status).to eq(200)

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -151,10 +151,10 @@ describe MiqRequestController do
     end
 
     it 'renders GTL with MiqRequest model' do
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name      => 'MiqRequest',
         :gtl_type_string => 'list',
-      )
+      ))
       get :show_list
     end
   end
@@ -256,11 +256,11 @@ describe MiqRequestController do
     # http://localhost:3000/miq_request/show/10000000000342
     it 'shows a grid with affected VMs' do
       expect(controller).to receive(:prov_set_show_vars).once.and_call_original
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name       => 'Vm',
         :gtl_type_string  => 'list',
         :selected_records => [vm.id] # vm.id is here, other_vm.id is not
-      )
+      ))
       get :show, :params => {:id => reconfigure_request.id}
       expect(response.status).to eq(200)
     end
@@ -302,7 +302,7 @@ describe MiqRequestController do
         expect(controller).to receive(:prov_set_show_vars).once.and_call_original
 
         # Verify Rails correctly initializes Angular which will then perform POST /report_data to fetch the VMs.
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(**payload)
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(**payload))
 
         get :show, :params => {:id => request.id}
         expect(response.status).to eq(200)

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -27,8 +27,10 @@ describe PhysicalChassisController do
 
       it 'renders GTL with PhysicalChassis model' do
         physical_chassis
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name      => physical_chassis.class.to_s,
-                                                                                         :gtl_type_string => "list",)
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
+          :model_name      => physical_chassis.class.to_s,
+          :gtl_type_string => "list",
+        ))
         post :show_list
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/physical_rack_controller_spec.rb
+++ b/spec/controllers/physical_rack_controller_spec.rb
@@ -24,8 +24,10 @@ describe PhysicalRackController do
 
       it 'renders GTL with PhysicalRack model' do
         physical_rack
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name      => physical_rack.class.to_s,
-                                                                                         :gtl_type_string => "list",)
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
+          :model_name      => physical_rack.class.to_s,
+          :gtl_type_string => "list",
+        ))
         post :show_list
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -25,8 +25,10 @@ describe PhysicalStorageController do
 
       it 'renders GTL with PhysicalStorage model' do
         physical_storage
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name      => physical_storage.class.to_s,
-                                                                                         :gtl_type_string => "list",)
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
+          :model_name      => physical_storage.class.to_s,
+          :gtl_type_string => "list",
+        ))
         post :show_list
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -33,10 +33,10 @@ describe PhysicalSwitchController do
 
       it 'renders GTL with PhysicalSwitch model' do
         physical_switch
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name      => physical_switch.class.to_s,
           :gtl_type_string => "list",
-        )
+        ))
         post :show_list
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1265,13 +1265,13 @@ describe ReportController do
       end
 
       it "runs report and calls GTL generation" do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'MiqReportResult',
           :report_data_additional_options => {
             :named_scope => [[:with_current_user_groups_and_report, rpt.id.to_s]],
             :model       => 'MiqReportResult'
           }
-        )
+        ))
 
         post :x_button, :params => { :pressed => 'miq_report_run', :id => rpt.id }
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -275,14 +275,14 @@ describe ServiceController do
       render_views
 
       it 'renders GTL of VMs associated to the selected Service' do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Vm',
           :parent_id                      => service.id.to_s,
           :report_data_additional_options => {
             :parent_class_name => 'Service',
             :parent_method     => :all_vms,
           }
-        )
+        ))
         post :tree_select, :params => {:id => "s-#{service.id}"}
         expect(response.status).to eq(200)
       end
@@ -295,12 +295,12 @@ describe ServiceController do
       render_views
 
       it 'renders GTL of Active services' do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Service',
           :report_data_additional_options => {
             :named_scope => [[:retired, false], :displayed]
           }
-        )
+        ))
         post :tree_select, :params => {:id => 'xx-asrv'}
         expect(response.status).to eq(200)
       end
@@ -312,12 +312,12 @@ describe ServiceController do
       render_views
 
       it 'renders GTL of Retired services' do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Service',
           :report_data_additional_options => {
             :named_scope => %i(retired displayed)
           }
-        )
+        ))
         post :tree_select, :params => {:id => 'xx-rsrv'}
         expect(response.status).to eq(200)
       end
@@ -345,13 +345,13 @@ describe ServiceController do
       let(:service_search) { FactoryGirl.create(:miq_search, :description => 'a', :db => 'Service') }
 
       it 'renders GTL of All Services, filtered by choosen filter from accordion' do
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Service',
           :report_data_additional_options => {
             :model       => 'Service',
             :named_scope => nil
           }
-        )
+        ))
         expect(controller).to receive(:process_show_list).once.and_call_original
         post :tree_select, :params => {:id => "ms-#{service_search.id}"}
         expect(response.status).to eq(200)

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -171,13 +171,13 @@ describe StorageController do
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).and_return([@tag1, @tag2])
 
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Storage',
           :report_data_additional_options => {
             :model     => "Storage",
             :clickable => false
           }
-        )
+        ))
 
         post :x_button, :params => {:miq_grid_checks => datastore.id, :pressed => "storage_tag", :format => :js}
 
@@ -261,7 +261,7 @@ describe StorageController do
             :association       => 'all_miq_templates',
           }
         }
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(req)
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(req))
         get :show, :params => { :id => storage_with_miq_templates.id, :display => 'all_miq_templates' }
         expect(response.status).to eq(200)
       end
@@ -307,14 +307,14 @@ describe StorageController do
         storage
         storage_cluster
         seed_session_trees('storage', :storage_pod_tree, 'root')
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name                     => 'Storage',
           :parent_id                      => storage_cluster.id.to_s,
           :report_data_additional_options => {
             :association       => 'storages',
             :parent_class_name => 'StorageCluster',
           }
-        )
+        ))
 
         post :tree_select, :params => {:id => "xx-#{storage_cluster.id}", :format => :js}
         expect(response.status).to eq(200)

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -161,14 +161,14 @@ describe VmCloudController do
     it 'renders instance ownership gtl correctly' do
       post :explorer
       expect(response.status).to eq(200)
-      expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+      expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
         :model_name                     => 'ManageIQ::Providers::CloudManager::Vm',
         :selected_records               => [vm_openstack_tmd.id],
         :report_data_additional_options => {
           :model      => 'ManageIQ::Providers::CloudManager::Vm',
           :lastaction => 'show_list',
         }
-      )
+      ))
       post :x_button, :params => {:pressed => 'instance_ownership', "check_#{vm_openstack_tmd.id}" => "1", "check_#{vm_openstack_tme.id}" => "1"}
       expect(response.status).to eq(200)
     end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -15,13 +15,13 @@ describe VmInfraController do
   render_views
 
   it 'can render the explorer' do
-    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+    expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
       :model_name                     => 'VmOrTemplate',
       :report_data_additional_options => {
         :model      => "VmOrTemplate",
         :lastaction => 'show_list'
       }
-    )
+    ))
 
     get :explorer
     expect(response.status).to eq(200)
@@ -208,13 +208,13 @@ describe VmInfraController do
   end
 
   it 'policy management has no clickable quadicons' do
-    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+    expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
       :model_name                     => 'VmOrTemplate',
       :report_data_additional_options => {
         :model     => "VmOrTemplate",
         :clickable => false
       }
-    )
+    ))
 
     post :x_button, :params => {:pressed => 'vm_protect', :id => vm_vmware.id}
 
@@ -223,13 +223,13 @@ describe VmInfraController do
   end
 
   it 'policy simulation has no clickable quadicons' do
-    expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+    expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
       :model_name                     => 'VmOrTemplate',
       :report_data_additional_options => {
         :model     => "VmOrTemplate",
         :clickable => false
       }
-    )
+    ))
 
     post :x_button, :params => {:pressed => 'vm_policy_sim', :id => vm_vmware.id}
 
@@ -598,11 +598,11 @@ describe VmInfraController do
     describe '#x_search_by_name' do
       it 'render GTL with and saves search_text in the session' do
         seed_session_trees('vm_infra', 'vandt_tree', 'root')
-        expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
+        expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
           :model_name => 'VmOrTemplate',
           :parent_id  => nil,
           :explorer   => true,
-        )
+        ))
 
         post :x_search_by_name, :params => {:search_text => 'foobar'}
         expect(session.fetch_path(:sandboxes, 'vm_infra', :search_text)).to eq('foobar')

--- a/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_block_storage_controller.rb
@@ -42,11 +42,13 @@ shared_examples :shared_examples_for_ems_block_storage_controller do |providers|
         render_views
 
         it 'renders only block storage' do
-          expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name                     => "ManageIQ::Providers::StorageManager",
-                                                                                           :no_flash_div                   => false,
-                                                                                           :gtl_type_string                => "list",
-                                                                                           :report_data_additional_options => {:lastaction                => "show_list",
-                                                                                                                               :supported_features_filter => "supports_block_storage?"})
+          expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
+            :model_name                     => "ManageIQ::Providers::StorageManager",
+            :no_flash_div                   => false,
+            :gtl_type_string                => "list",
+            :report_data_additional_options => {:lastaction                => "show_list",
+                                                :supported_features_filter => "supports_block_storage?"},
+          ))
           post :show_list
           expect(response.status).to eq(200)
         end

--- a/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_object_storage_controller.rb
@@ -42,11 +42,13 @@ shared_examples :shared_examples_for_ems_object_storage_controller do |providers
         render_views
 
         it 'renders only object storage' do
-          expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(:model_name                     => "ManageIQ::Providers::StorageManager",
-                                                                                           :no_flash_div                   => false,
-                                                                                           :gtl_type_string                => "list",
-                                                                                           :report_data_additional_options => {:lastaction                => "show_list",
-                                                                                                                               :supported_features_filter => "supports_object_storage?"})
+          expect(GtlHelper).to receive(:render_gtl_wrapper).with(anything, match_gtl_options(
+            :model_name                     => "ManageIQ::Providers::StorageManager",
+            :no_flash_div                   => false,
+            :gtl_type_string                => "list",
+            :report_data_additional_options => {:lastaction                => "show_list",
+                                                :supported_features_filter => "supports_object_storage?"},
+          ))
           post :show_list
           expect(response.status).to eq(200)
         end


### PR DESCRIPTION
All the GTL-related tests relied on the `GtlHelper#render_gtl` method, but this was only testable by using `any_instance_of` which is kinda slow. So as we discussed with @martinpovolny, until we will not have access to the view context of request specs, a singleton wrapper can solve the problem temporarily. 

@miq-bot assign @martinpovolny 