### PR TITLE
Timeline spec speedup

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -120,11 +120,11 @@ module ReportFormatter
                         rec[:container_node_name]
                       end
           end
-          e_title ||= ems ? ems.name : "No VM, Host, or MS"
         else
           e_title = rec[:name] ? rec[:name] : row[mri.col_order.first].to_s
         end
       end
+      e_title ||= ems ? ems.name : "No VM, Host, or MS"
 
       # manipulating column order to display timestamp at the end of the bubble.
       field = mri.timeline[:field].split("-")

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -154,23 +154,26 @@ describe ReportFormatter::TimelineMessage do
     end
 
     it 'shows correct count of timeline events based on categories' do
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(30)
       expect(JSON.parse(events)[1]["data"][0].length).to eq(15)
     end
 
     it 'shows correct count of timeline events together for report object with no categories' do
       @report.rpt_options = {}
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(45)
     end
 
     it 'shows correct count of timeline events for timeline based report when rpt_options is nil' do
       @report.rpt_options = nil
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(45)
     end
   end
@@ -235,23 +238,26 @@ describe ReportFormatter::TimelineMessage do
     end
 
     it 'shows correct count of timeline events based on categories' do
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(5)
       expect(JSON.parse(events)[1]["data"][0].length).to eq(7)
     end
 
     it 'shows correct count of timeline events together for report object with no categories' do
       @report.rpt_options = {}
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(12)
     end
 
     it 'shows correct count of timeline events for timeline based report when rpt_options is nil' do
       @report.rpt_options = nil
-      allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-      events = ReportFormatter::ReportTimeline.new.build_document_body
+      formatter = ReportFormatter::ReportTimeline.new
+      formatter.options.mri = @report
+      events = formatter.build_document_body
       expect(JSON.parse(events)[0]["data"][0].length).to eq(12)
     end
   end
@@ -291,8 +297,9 @@ describe '#set data for headers that exist in col headers' do
 
   it 'shows headers only if they exist in report col headers' do
     @report.rpt_options = nil
-    allow_any_instance_of(Ruport::Controller::Options).to receive(:mri).and_return(@report)
-    events = ReportFormatter::ReportTimeline.new.build_document_body
+    formatter = ReportFormatter::ReportTimeline.new
+    formatter.options.mri = @report
+    events = formatter.build_document_body
     json = JSON.parse(events)[0]["data"][0][0]["event"]
     expect(json["vm_location"]["text"]).to eq("Source Instance Location")
     expect(json["vm_location"]["value"]).to eq("foo")

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -113,10 +113,10 @@ describe ReportFormatter::TimelineMessage do
   end
 
   describe '#events count for different categories' do
+    let(:ems) { FactoryGirl.create(:ems_redhat, :name => 'foobar') }
+
     def stub_ems_event(event_type)
-      ems = FactoryGirl.create(:ems_redhat)
-      ems_event = EventStream.create!(:event_type => event_type, :ems_id => ems.id)
-      ems_event
+      EventStream.new(:event_type => event_type, :ems_id => ems.id)
     end
 
     before do
@@ -179,9 +179,10 @@ describe ReportFormatter::TimelineMessage do
   end
 
   describe '#events count for regex categories' do
+    let(:ems) { FactoryGirl.create(:ems_redhat) }
+
     def stub_ems_event(event_type)
-      ems = FactoryGirl.create(:ems_redhat)
-      EventStream.create!(:event_type => event_type, :ems_id => ems.id)
+      EventStream.new(:event_type => event_type, :ems_id => ems.id)
     end
 
     before do
@@ -264,10 +265,10 @@ describe ReportFormatter::TimelineMessage do
 end
 
 describe '#set data for headers that exist in col headers' do
+  let(:ems) { FactoryGirl.create(:ems_amazon) }
+
   def stub_ems_event(event_type)
-    ems = FactoryGirl.create(:ems_amazon)
-    ems_event = EventStream.create!(:event_type => event_type, :ems_id => ems.id)
-    ems_event
+    EventStream.create!(:event_type => event_type, :ems_id => ems.id)
   end
 
   before do


### PR DESCRIPTION
before:
```
Finished in 12.19 seconds (files took 7.11 seconds to load)
18 examples, 0 failures
```
after:
```
Finished in 3.49 seconds (files took 7.23 seconds to load)
18 examples, 0 failures
```

There are still some DB writes in the test, but most are avoided.