### PR TITLE
Rename deprecated towhat attribute to resource_type in miq schedules

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -836,9 +836,9 @@ module OpsController::Diagnostics
   def build_backup_schedule_options_for_select
     @backup_schedules = {}
     database_details
-    miq_schedules = MiqSchedule.where(:towhat => 'DatabaseBackup', :adhoc => nil)
+    miq_schedules = MiqSchedule.where(:resource_type => 'DatabaseBackup', :adhoc => nil)
     miq_schedules.sort_by { |s| s.name.downcase }.each do |s|
-      @backup_schedules[s.id] = s.name if s.towhat == "DatabaseBackup"
+      @backup_schedules[s.id] = s.name if s.resource_type == "DatabaseBackup"
     end
   end
 

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -120,7 +120,7 @@ module OpsController::Settings::Schedules
     schedule = MiqSchedule.find_by_id(params[:id])
 
     if schedule_check_compliance?(schedule)
-      action_type = schedule.towhat.underscore + "_" + schedule.sched_action[:method]
+      action_type = schedule.resource_type.underscore + "_" + schedule.sched_action[:method]
     elsif schedule_db_backup?(schedule)
       require 'uri'
       action_type          = schedule.sched_action[:method]
@@ -140,10 +140,10 @@ module OpsController::Settings::Schedules
       action_type = schedule.sched_action[:method]
       automate_request = fetch_automate_request_vars(schedule)
     else
-      if schedule.towhat.nil?
+      if schedule.resource_type.nil?
         action_type = "vm"
       else
-        action_type ||= schedule.towhat == "EmsCluster" ? "emscluster" : schedule.towhat.underscore
+        action_type ||= schedule.resource_type == "EmsCluster" ? "emscluster" : schedule.resource_type.underscore
       end
     end
 
@@ -285,7 +285,7 @@ module OpsController::Settings::Schedules
     schedule.sched_action && schedule.sched_action[:method] && schedule.sched_action[:method] == "automation_request"
   end
 
-  def schedule_towhat_from_params_action
+  def schedule_resource_type_from_params_action
     case params[:action_typ]
     when "db_backup"          then "DatabaseBackup"
     when /check_compliance\z/ then (params[:action_typ].split("_") - params[:action_typ].split("_").last(2)).join("_")
@@ -467,7 +467,7 @@ module OpsController::Settings::Schedules
   end
 
   def schedule_set_record_vars(schedule)
-    schedule.towhat       = schedule_towhat_from_params_action
+    schedule.resource_type = schedule_resource_type_from_params_action
     schedule.sched_action = {:method => schedule_method_from_params_action}
 
     if params[:action_typ] == "db_backup"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -161,7 +161,7 @@ module ReportController::Reports
     end
 
     if @sb[:active_tab] == "report_info"
-      schedules = MiqSchedule.where(:towhat => "MiqReport")
+      schedules = MiqSchedule.where(:resource_type => "MiqReport")
       schedules = schedules.where(:userid => current_userid) unless super_admin_user?
       @schedules = schedules.select { |s| s.filter.exp["="]["value"].to_i == @miq_report.id.to_i }.sort_by(&:name)
 

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -39,9 +39,9 @@ module ReportController::Schedules
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
     if super_admin_user? # Super admins see all user's schedules
-      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"]]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_resource_type, "MiqReport"]]) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"], [:with_userid, session[:userid]]]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_resource_type, "MiqReport"], [:with_userid, session[:userid]]]) # Get the records (into a view) and the paginator
     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
@@ -55,9 +55,9 @@ module ReportController::Schedules
 
   def schedule_new
     assert_privileges("miq_report_schedule_add")
-    @schedule        = MiqSchedule.new(:userid => session[:userid])
-    @in_a_form       = true
-    @schedule.towhat = "MiqReport"
+    @schedule               = MiqSchedule.new(:userid => session[:userid])
+    @in_a_form              = true
+    @schedule.resource_type = "MiqReport"
     if @sb[:tree_typ] == "reports"
       exp                   = {}
       exp["="]              = {"field" => "MiqReport-id", "value" => @sb[:miq_report_id]}
@@ -439,7 +439,7 @@ module ReportController::Schedules
     schedule.name = @edit[:new][:name]
     schedule.description = @edit[:new][:description]
     schedule.enabled = @edit[:new][:enabled]
-    schedule.towhat = "MiqReport" # Default schedules apply to MiqReport model for now
+    schedule.resource_type = "MiqReport" # Default schedules apply to MiqReport model for now
 
     email_url_prefix = url_for_only_path(:controller => "report", :action => "show_saved") + "/"
     schedule_options = {

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -615,12 +615,12 @@ module ReportController::Widgets
     end
 
     # schedule settings
-    @edit[:schedule].name         = widget.title
-    @edit[:schedule].description  = widget.description
-    @edit[:schedule].towhat       = "MiqWidget"
-    @edit[:schedule].sched_action = {:method => "generate_widget"}
-    @edit[:schedule].run_at = @edit[:new][:timer].flush_to_miq_schedule(@edit[:schedule].run_at, @edit[:tz])
-    widget.miq_schedule = @edit[:schedule]
+    @edit[:schedule].name          = widget.title
+    @edit[:schedule].description   = widget.description
+    @edit[:schedule].resource_type = "MiqWidget"
+    @edit[:schedule].sched_action  = {:method => "generate_widget"}
+    @edit[:schedule].run_at        = @edit[:new][:timer].flush_to_miq_schedule(@edit[:schedule].run_at, @edit[:tz])
+    widget.miq_schedule            = @edit[:schedule]
   end
 
   # Validate widget entries before updating record

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -25,9 +25,9 @@ class TreeBuilderReportSchedules < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     objects = if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
                 # Super admins see all report schedules
-                MiqSchedule.where(:towhat => 'MiqReport')
+                MiqSchedule.where(:resource_type => 'MiqReport')
               else
-                MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
+                MiqSchedule.where(:resource_type => 'MiqReport', :userid => User.current_user.userid)
               end
     count_only_or_objects(count_only, objects, 'name')
   end

--- a/app/services/widget_import_service.rb
+++ b/app/services/widget_import_service.rb
@@ -99,8 +99,8 @@ class WidgetImportService
     return if schedule_contents.blank?
 
     new_or_existing_schedule = MiqSchedule.where(
-      :name   => schedule_contents["name"],
-      :towhat => schedule_contents["towhat"]
+      :name          => schedule_contents["name"],
+      :resource_type => schedule_contents["resource_type"]
     ).first_or_initialize
     new_or_existing_schedule.update_attributes(schedule_contents) if new_or_existing_schedule.new_record?
 

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -14,14 +14,14 @@
       .col-md-10
         %p.form-control-static
           - if @selected_schedule.sched_action[:method] && @selected_schedule.sched_action[:method] == "check_compliance"
-            = h(ui_lookup(:model => @selected_schedule.towhat))
+            = h(ui_lookup(:model => @selected_schedule.resource_type))
             = _("Compliance Check")
           - elsif @selected_schedule.sched_action[:method] && @selected_schedule.sched_action[:method] == "db_backup"
             = _("Database Backup")
           - elsif @selected_schedule.sched_action[:method] && @selected_schedule.sched_action[:method] == "automation_request"
             = _("Automate Task")
           - else
-            = h(ui_lookup(:model => @selected_schedule.towhat))
+            = h(ui_lookup(:model => @selected_schedule.resource_type))
             = _("Analysis")
 
     - unless %w(automation_request db_backup).include?(@selected_schedule.sched_action[:method])

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -164,12 +164,12 @@ describe OpsController do
       session[:settings] = {:default_search => ''}
 
       miq_schedule = FactoryGirl.create(:miq_schedule,
-                                        :name        => "test_db_schedule",
-                                        :description => "test_db_schedule_desc",
-                                        :towhat      => "DatabaseBackup",
-                                        :run_at      => {:start_time => "2015-04-19 00:00:00 UTC",
-                                                         :tz         => "UTC",
-                                                         :interval   => {:unit => "once", :value => ""}})
+                                        :name          => "test_db_schedule",
+                                        :description   => "test_db_schedule_desc",
+                                        :resource_type => "DatabaseBackup",
+                                        :run_at        => {:start_time => "2015-04-19 00:00:00 UTC",
+                                                           :tz         => "UTC",
+                                                           :interval   => {:unit => "once", :value => ""}})
       post :db_backup, :params => {
         :backup_schedule => miq_schedule.id,
         :uri             => "nfs://test_location",

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -85,7 +85,7 @@ describe OpsController do
       before do
         EvmSpecHelper.create_guid_miq_server_zone
         expect(controller).to receive(:render)
-        @schedule = FactoryGirl.create(:miq_schedule, :userid => user.userid, :towhat => "Vm")
+        @schedule = FactoryGirl.create(:miq_schedule, :userid => user.userid, :resource_type => "Vm")
         @params = {
           :action      => "schedule_edit",
           :button      => "add",
@@ -119,7 +119,7 @@ describe OpsController do
         @params[:id] = @schedule.id
         @params[:name] = "schedule01"
         controller.instance_variable_set(:@_params, @params)
-        FactoryGirl.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :towhat => "Vm")
+        FactoryGirl.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :resource_type => "Vm")
         controller.send(:schedule_edit)
         expect(controller.send(:flash_errors?)).to be_truthy
         expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")

--- a/spec/services/widget_import_service_spec.rb
+++ b/spec/services/widget_import_service_spec.rb
@@ -69,10 +69,10 @@ describe WidgetImportService do
 
     let(:miq_schedule_contents) do
       {
-        "name"        => "schedule name",
-        "description" => "new schedule description",
-        "towhat"      => "MiqWidget",
-        "run_at"      => {
+        "name"          => "schedule name",
+        "description"   => "new schedule description",
+        "resource_type" => "MiqWidget",
+        "run_at"        => {
           :start_time => Time.now,
           :tz         => "UTC",
           :interval   => {
@@ -255,10 +255,10 @@ describe WidgetImportService do
         context "when the schedule does exist" do
           before do
             MiqSchedule.create!(
-              :name        => "schedule name",
-              :description => "old schedule description",
-              :towhat      => "MiqWidget",
-              :run_at      => {
+              :name          => "schedule name",
+              :description   => "old schedule description",
+              :resource_type => "MiqWidget",
+              :run_at        => {
                 :start_time => Time.now,
                 :tz         => "UTC",
                 :interval   => {:unit => "daily", :value => "6"}


### PR DESCRIPTION
The `towhat` attribute became [deprecated](https://github.com/ManageIQ/manageiq/blob/8829e85ee709b029332a05281bd257d61e9fa9cb/app/models/miq_schedule.rb#L3) for MiqSchedule model, renaming it everywhere to `resource_type`.