### PR TITLE
Add top row information into the storage manager quadicons

### DIFF
--- a/app/decorators/manageiq/providers/storage_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/storage_manager_decorator.rb
@@ -21,6 +21,24 @@ class ManageIQ::Providers::StorageManagerDecorator < MiqDecorator
       },
       :bottom_right => QuadiconHelper.provider_status(authentication_status, enabled?)
     }
+
+    # Due to the lack of the separate STI classes this has to be done :(
+    if supports_block_storage?
+      icon[:top_left] = {
+        :text    => t = cloud_volumes.size,
+        :tooltip => n_("%{number} Cloud Volume", "%{number} Cloud Volumes", t) % {:number => t}
+      }
+      icon[:top_right] = {
+        :text    => t = cloud_volume_snapshots.size,
+        :tooltip => n_("%{number} Cloud Volume Snapshot", "%{number} Cloud Volume Snapshots", t) % {:number => t}
+      }
+    elsif supports_object_storage?
+      icon[:top_left] = {
+        :text    => t = cloud_object_store_containers.size,
+        :tooltip => n_("%{number} Cloud Object Store Container", "%{number} Cloud Object Store Containers", t) % {:number => t}
+      }
+    end
+
     icon[:middle] = QuadiconHelper::POLICY_SHIELD if get_policies.present?
     icon
   end

--- a/spec/decorators/manageiq/providers/storage_manager_decorator_spec.rb
+++ b/spec/decorators/manageiq/providers/storage_manager_decorator_spec.rb
@@ -1,0 +1,22 @@
+describe ManageIQ::Providers::StorageManagerDecorator do
+  describe '#quadicon' do
+    subject { model.decorate.quadicon }
+
+    context 'block storage' do
+      let(:model) { FactoryGirl.create(:ems_cinder) }
+
+      it 'includes cloud volumes and snapshots' do
+        expect(subject[:top_left][:tooltip]).to include("Cloud Volume")
+        expect(subject[:top_right][:tooltip]).to include("Cloud Volume Snapshot")
+      end
+    end
+
+    context 'object storage' do
+      let(:model) { FactoryGirl.create(:ems_swift) }
+
+      it 'includes cloud object store containers' do
+        expect(subject[:top_left][:tooltip]).to include("Cloud Object Store Container")
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's no separate STI class for block & object storage managers, so I had to do this ugly hack while adding the missing information to the quadrants.

**Before:**
![screenshot from 2018-11-26 16-45-23](https://user-images.githubusercontent.com/649130/49024829-af1d7100-f19a-11e8-8663-0f6c3c6ec558.png)
![screenshot from 2018-11-26 16-45-46](https://user-images.githubusercontent.com/649130/49024871-bfcde700-f19a-11e8-9a5b-9ff81ad4c061.png)


**After:**
![screenshot from 2018-11-26 16-40-27](https://user-images.githubusercontent.com/649130/49024644-3fa78180-f19a-11e8-8111-3baf4baf35ed.png)
![screenshot from 2018-11-29 16-23-03](https://user-images.githubusercontent.com/649130/49231882-23525180-f3f3-11e8-9403-7a45ebac8274.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650086

@miq-bot add_label GTLs, hammer/yes, bug
@miq-bot add_reviewer @epwinchell 