### PR TITLE
Do not run yarn install for ruby tests

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -3,6 +3,11 @@ namespace :update do
     asset_engines.each do |engine|
       Dir.chdir engine.path do
         next unless File.file? 'package.json'
+
+        if ENV['TEST_SUITE'] == 'spec'
+          warn "Skipping yarn install for #{engine.name} on travis #{ENV['TEST_SUITE']}"
+          next
+        end
         system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
       end
     end


### PR DESCRIPTION
Not necessary, we do not serve, compile or use assets in Ruby tests ...