### PR TITLE
Do not run db setup twice when running travis specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh
 install: true
-before_script: bundle exec rake $TEST_SUITE:setup
 script: bundle exec rake $TEST_SUITE
 after_script: source tools/ci/after_install.sh
 notifications:


### PR DESCRIPTION
This runs in the plugin setup already so no longer necessary, we can win 20 extra seconds in Travis...