### PR TITLE
Add MenuUpdateMixin

### DIFF
--- a/app/controllers/mixins/menu_update_mixin.rb
+++ b/app/controllers/mixins/menu_update_mixin.rb
@@ -1,0 +1,11 @@
+module Mixins
+  module MenuUpdateMixin
+    def menu_section_url
+      url = CGI.unescape(params[:url])
+      section = Menu::Manager.section(params[:section]) || Menu::Manager.section_for_item_id(params[:section])
+      section.parent_path.each do |sid|
+        session[:tab_url][sid] = url
+      end
+    end
+  end
+end

--- a/spec/controllers/mixins/menu_update_mixin_spec.rb
+++ b/spec/controllers/mixins/menu_update_mixin_spec.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |c|
+  c.infer_base_class_for_anonymous_controllers = false
+end
+
+describe Mixins::MenuUpdateMixin do
+  context 'when included by a controller', :type => :controller do
+    controller do
+      include Mixins::MenuUpdateMixin
+    end
+
+    before do
+      session[:tab_url] = {:vi => '/url/before'}
+    end
+
+    it "updates session[:tab_url]" do
+      controller.instance_variable_set(:@_params, :section => :vi, :url => '/url/after%26')
+      controller.send(:menu_section_url)
+      expect(session[:tab_url][:vi]).to eq('/url/after&')
+    end
+  end
+end


### PR DESCRIPTION
The `MenuUpdateMixin` will be included by `MigrationController` from `manageiq-v2v`. It's aim is to update `session[:tab_url]` whenever we navigate from one v2v menu section to another without doing a proper page reload.

Part of https://github.com/ManageIQ/manageiq-v2v/pull/822