### PR TITLE
Reset `exp_tag` key when discard button is pressed.

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -27,6 +27,7 @@ module ApplicationController::Filter
       # Copy back the latest expression or empty expression, if nil
       @edit[@expkey].val1 = nil
       @edit[@expkey].val2 = nil
+      @edit[@expkey][:exp_tag] = nil if @edit[@expkey][:exp_tag]
       @edit[@expkey][:expression] = @edit[:new][@expkey].nil? ? {"???" => "???"} : copy_hash(@edit[:new][@expkey])
       @edit.delete(:edit_exp)
     else

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -44,6 +44,23 @@ describe ApplicationController, "::Filter" do
       end
     end
 
+    it "resets exp_tag when discard button is pressed" do
+      exp = ApplicationController::Filter::Expression.new.tap do |e|
+        e.val1 = {}
+        e.val2 = {}
+        e.expression = {}
+        e.exp_tag = "managed-aws_reservation_statud"
+      end
+      edit = {:filter_expression => exp}
+      edit[:new] = {:filter_expression => {:test => "foo", :token => 1}}
+      session[:edit] = edit
+      controller.instance_variable_set(:@_params, :pressed => "discard")
+      controller.instance_variable_set(:@expkey, :filter_expression)
+      expect(controller).to receive(:render)
+      controller.send(:exp_button)
+      expect(assigns(:edit)[:filter_expression][:exp_tag]).to be_nil
+    end
+
     it "removes tokens if present" do
       exp = {'???' => '???'}
       edit = {:expression => expression, :edit_exp => exp}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650483

before:
![before](https://user-images.githubusercontent.com/3450808/49112320-721bb200-f260-11e8-9f2c-d2589fb3de3f.png)

after:
![after](https://user-images.githubusercontent.com/3450808/49112121-ee61c580-f25f-11e8-8135-2e96224348ca.png)

@lgalis please review/test