### PR TITLE
Replace `virtualization_tab` references with `kubevirt_tab`

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -285,7 +285,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
 
     if ($scope.emsCommonModel.virtualization_selection === 'disabled') {
-      angular.element('#virtualization_tab').hide();
+      angular.element('#kubevirt_tab').hide();
     }
   };
 
@@ -467,7 +467,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.virtualizationSelectionChanged = function() {
-    $scope.tabSelectionChanged('#virtualization_tab', $scope.emsCommonModel.virtualization_selection);
+    $scope.tabSelectionChanged('#kubevirt_tab', $scope.emsCommonModel.virtualization_selection);
   };
 
   $scope.providerTypeChanged = function() {

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -491,7 +491,7 @@
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#alerts_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
-    miq_tabs_show_hide("#virtualization_tab", false);
+    miq_tabs_show_hide("#kubevirt_tab", false);
     miq_tabs_show_hide("#console_tab", false);
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_show_hide("#smartstate_docker_tab", false);
@@ -559,7 +559,7 @@
   :javascript
     miq_tabs_show_hide("#alerts_tab", true);
     miq_tabs_show_hide("#metrics_tab", true);
-    miq_tabs_show_hide("#virtualization_tab", true);
+    miq_tabs_show_hide("#kubevirt_tab", true);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
 


### PR DESCRIPTION
Replace `virtualization_tab` references with `kubevirt_tab` -- this was missed in 583d776

----------------

Before (shows the tiny and almost invisible tab) -

<img width="832" alt="screen shot 2018-11-27 at 2 52 43 pm" src="https://user-images.githubusercontent.com/1538216/49116984-25ca7500-f254-11e8-8edc-6da47ede5711.png">

---------------

After (no tiny/invisible tabs) -

With `Virtualization` disabled -

<img width="831" alt="screen shot 2018-11-27 at 2 54 55 pm" src="https://user-images.githubusercontent.com/1538216/49117097-7fcb3a80-f254-11e8-9d0e-494377549ae8.png">

With `Virtualization` set to `Kubevirt` -

<img width="880" alt="screen shot 2018-11-27 at 2 55 15 pm" src="https://user-images.githubusercontent.com/1538216/49117100-8194fe00-f254-11e8-9f02-d33d8c722e71.png">


