### PR TITLE
When redirecting to a specific storage, RBAC check storage_show

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -45,7 +45,7 @@ class StorageController < ApplicationController
 
       # redirect user back to where they came from if they dont have access to any of vm explorers
       # or redirect them to the one they have access to
-      redirect_controller = role_allows?(:feature => "storage") ? "storage" : nil
+      redirect_controller = role_allows?(:feature => "storage_show") ? "storage" : nil
 
       if redirect_controller
         action = "explorer"


### PR DESCRIPTION
When accessing the datastores of a given provider as a user of the EvmGroup-operator group, the RBAC check fails because it is invalid. Testing against the top level feature for a non-admin will always return `nil` and also it doesn't even describe the operation properly. The correct feature to test against is `storage_show`, so I'm replacing it. cc @PanSpagetka this was implemented by you

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653709

@miq-bot add_label bug