### PR TITLE
Show widget's title as page title when editing widget

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -715,7 +715,7 @@ class ReportController < ApplicationController
             presenter[:miq_widget_dd_url] = 'report/widget_shortcut_dd_done'
             presenter[:init_dashboard] = true
           end
-          @right_cell_text = @widget.id ? _("Editing Widget \"%{name}\"") % {:name => @widget.name} : _("Adding a new Widget")
+          @right_cell_text = @widget.id ? _("Editing Widget \"%{title}\"") % {:title => @widget.title} : _("Adding a new Widget")
         end
       end
     elsif nodetype == "g"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653796

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/49159644-fa4a9780-f2f2-11e8-8860-0f4faf44b00d.png)

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/49159663-02a2d280-f2f3-11e8-835f-e8af4e862c6a.png)

@miq-bot add-label bug
