### PR TITLE
spec - fix eslint warnings in report & toolbar specs

### DIFF
--- a/spec/javascripts/.eslintrc.json
+++ b/spec/javascripts/.eslintrc.json
@@ -1,14 +1,16 @@
 {
   "globals": {
-    "describe": false,
-    "context": false,
-    "it": false,
-    "beforeEach": false,
     "afterEach": false,
-    "inject": false,
-    "spyOn": false,
+    "beforeEach": false,
+    "context": false,
+    "describe": false,
     "expect": false,
+    "getJSONFixture": false,
+    "inject": false,
+    "it": false,
     "jasmine": false,
-    "setFixtures": false
+    "module": false,
+    "setFixtures": false,
+    "spyOn": false
   }
 }

--- a/spec/javascripts/controllers/report_data_controller_spec.js
+++ b/spec/javascripts/controllers/report_data_controller_spec.js
@@ -1,4 +1,4 @@
-describe('reportDataController', function () {
+describe('reportDataController', function() {
   beforeEach(module('ManageIQ.report_data'));
 
   var $controller, $httpBackend, $scope;
@@ -14,14 +14,16 @@ describe('reportDataController', function () {
     sortDir: 'DESC',
     isExplorer: false,
     showUrl: 'some_url/show',
-  }
+  };
 
   beforeEach(inject(function($injector) {
-     $scope = $injector.get('$rootScope').$new();
-     $httpBackend = $injector.get('$httpBackend');
-     var injectedCtrl = $injector.get('$controller');
-     $controller = injectedCtrl('reportDataController', {$scope: $scope});
-   }));
+    $scope = $injector.get('$rootScope').$new();
+    $httpBackend = $injector.get('$httpBackend');
+    var injectedCtrl = $injector.get('$controller');
+    $controller = injectedCtrl('reportDataController', {
+      $scope: $scope,
+    });
+  }));
 
   describe('receive data', function() {
     beforeEach(function() {
@@ -40,30 +42,30 @@ describe('reportDataController', function () {
 
     it('should get data', function(done) {
       var settings = {isLoading: true};
-      var result = $controller
-          .getData(initObject.modelName, initObject.activeTree, initObject.parentId, initObject.isExplorer, settings);
-      result.then(function(data) {
-        expect($controller.gtlData.cols.length).toEqual(report_data.data.head.length);
-        expect(angular.equals($controller.gtlData.rows, report_data.data.rows)).toBeTruthy();
-        expect(angular.equals($controller.settings, report_data.settings)).toBeTruthy();
-        expect(angular.equals($controller.perPage.value, report_data.settings.perpage)).toBeTruthy();
-        expect(angular.equals($controller.perPage.text, report_data.settings.perpage)).toBeTruthy();
-        done();
-      });
+      $controller
+        .getData(initObject.modelName, initObject.activeTree, initObject.parentId, initObject.isExplorer, settings)
+        .then(function() {
+          expect($controller.gtlData.cols.length).toEqual(report_data.data.head.length);
+          expect(angular.equals($controller.gtlData.rows, report_data.data.rows)).toBeTruthy();
+          expect(angular.equals($controller.settings, report_data.settings)).toBeTruthy();
+          expect(angular.equals($controller.perPage.value, report_data.settings.perpage)).toBeTruthy();
+          expect(angular.equals($controller.perPage.text, report_data.settings.perpage)).toBeTruthy();
+          done();
+        });
       $httpBackend.flush();
       $scope.$apply();
     });
 
     it('should init controller', function(done) {
-      var result = $controller.initController(initObject);
-      result.then(function() {
-        expect($controller.settings.isLoading).toBeFalsy();
-        expect(report_data.settings.sort_dir === "ASC").toBe($controller.settings.sortBy.isAscending);
-        expect($controller.settings.sortBy.sortObject.col_idx).toBe(report_data.settings.sort_col);
-        expect($controller.perPage.enabled).toBeTruthy();
-        expect($controller.perPage.hidden).toBeFalsy();
-        done();
-      });
+      $controller.initController(initObject)
+        .then(function() {
+          expect($controller.settings.isLoading).toBeFalsy();
+          expect(report_data.settings.sort_dir === 'ASC').toBe($controller.settings.sortBy.isAscending);
+          expect($controller.settings.sortBy.sortObject.col_idx).toBe(report_data.settings.sort_col);
+          expect($controller.perPage.enabled).toBeTruthy();
+          expect($controller.perPage.hidden).toBeFalsy();
+          done();
+        });
       $httpBackend.flush();
       $scope.$apply();
     });
@@ -125,12 +127,12 @@ describe('reportDataController', function () {
     });
 
     it('should select item and call rowSelect', function() {
-      var itemId = "10";
-      var itemLongId = "10";
+      var itemId = '10';
+      var itemLongId = '10';
       var selected = true;
       spyOn(window, 'sendDataWithRx');
       $controller.onItemSelect({id: itemId, long_id: itemLongId}, selected);
-      selectedItem = $controller.gtlData.rows.filter(function(item) {
+      var selectedItem = $controller.gtlData.rows.filter(function(item) {
         return item.long_id === itemLongId;
       });
       expect(selectedItem[0].checked).toBe(selected);
@@ -140,12 +142,12 @@ describe('reportDataController', function () {
     });
 
     it('should deselect item and call rowSelect', function() {
-      var itemId = "10";
-      var itemLongId = "10";
+      var itemId = '10';
+      var itemLongId = '10';
       var selected = false;
       spyOn(window, 'sendDataWithRx');
       $controller.onItemSelect({id: itemId, long_id: itemLongId}, selected);
-      selectedItem = $controller.gtlData.rows.filter(function(item) {
+      var selectedItem = $controller.gtlData.rows.filter(function(item) {
         return item.long_id === itemLongId;
       });
       expect(selectedItem[0].checked).toBe(selected);
@@ -155,14 +157,13 @@ describe('reportDataController', function () {
     });
 
     it('should create redirect for non explorer click on item', function() {
-      var itemId = "10";
-      var itemLongId = "10";
+      var itemLongId = '10';
       var clickEvent = $.Event('click');
       initObject.isExplorer = false;
       spyOn(clickEvent, 'stopPropagation');
       spyOn(clickEvent, 'preventDefault');
       spyOn(window, 'DoNav');
-      selectedItem = $controller.gtlData.rows.filter(function(item) {
+      var selectedItem = $controller.gtlData.rows.filter(function(item) {
         return item.long_id === itemLongId;
       });
       $controller.onItemClicked(selectedItem[0], clickEvent);

--- a/spec/javascripts/controllers/toolbar_controller_spec.js
+++ b/spec/javascripts/controllers/toolbar_controller_spec.js
@@ -1,61 +1,58 @@
-describe('toolbarController', function () {
+describe('toolbarController', function() {
   beforeEach(module('ManageIQ.toolbar'));
 
   var middleware_toolbar_list = getJSONFixture('toolbar_middleware_server_list.json');
   var middleware_toolbar_detail = getJSONFixture('toolbar_middleware_server_detail.json');
 
-  var responseData;
-  var $controller, $httpBackend, $scope, $q;
+  var $controller, $scope;
 
   beforeEach(inject(function($injector) {
-     $q = $injector.get('$q')
-     $scope = $injector.get('$rootScope').$new();
-     $httpBackend = $injector.get('$httpBackend');
-     var injectedCtrl = $injector.get('$controller');
-     $controller = injectedCtrl('miqToolbarController', {$scope: $scope});
-   }));
+    $scope = $injector.get('$rootScope').$new();
+    var injectedCtrl = $injector.get('$controller');
+    $controller = injectedCtrl('miqToolbarController', {$scope: $scope});
+  }));
 
-   describe('show list toolbar', function() {
-     beforeEach(function(){
-       $controller.initObject(JSON.stringify(middleware_toolbar_list));
-     });
+  describe('show list toolbar', function() {
+    beforeEach(function() {
+      $controller.initObject(JSON.stringify(middleware_toolbar_list));
+    });
 
-     it('toolbar data loaded, toolbar items more than one, 3 toolbar items contain {url_parms: "main_div"}', function() {
-       var allItems = _
-                        .chain($controller.toolbarItems)
-                        .flatten()
-                        .map('items')
-                        .flatten()
-                        .value();
+    it('toolbar data loaded, toolbar items more than one, 3 toolbar items contain {url_parms: "main_div"}', function() {
+      var allItems = _
+        .chain($controller.toolbarItems)
+        .flatten()
+        .map('items')
+        .flatten()
+        .value();
 
-       expect($controller.toolbarItems.length > 0).toBeTruthy();
-       expect(_.filter(allItems, {url_parms: 'main_div'}).length >= 3).toBeTruthy();
-     });
+      expect($controller.toolbarItems.length > 0).toBeTruthy();
+      expect(_.filter(allItems, {url_parms: 'main_div'}).length >= 3).toBeTruthy();
+    });
 
-     it('check one row and observe if toolbar items gets enabled', function() {
-       var inputCheckbox = document.createElement('input')
-       inputCheckbox.setAttribute('type', 'checkbox');
-       inputCheckbox.setAttribute('checked', true);
-       sendDataWithRx({rowSelect: inputCheckbox});
-       var allItems = _
-                        .chain($controller.toolbarItems)
-                        .flatten()
-                        .map('items')
-                        .flatten()
-                        .value();
+    it('check one row and observe if toolbar items gets enabled', function() {
+      var inputCheckbox = document.createElement('input');
+      inputCheckbox.setAttribute('type', 'checkbox');
+      inputCheckbox.setAttribute('checked', true);
+      sendDataWithRx({rowSelect: inputCheckbox});
+      var allItems = _
+        .chain($controller.toolbarItems)
+        .flatten()
+        .map('items')
+        .flatten()
+        .value();
       expect(_.filter(allItems, {enabled: true}).length >= 3).toBeTruthy();
-     });
+    });
 
-     it('Each dataView should have url set automatically', function() {
-       // there's at least one item in $controller.dataViews which means there's at least one object
-       // that has id that starts at view_ in toolbar_middleware_server_list.json
-       expect($controller.dataViews.length).not.toBe(0);
-       $controller.dataViews.forEach(function(dataView) {
-         expect(dataView.url).toBeTruthy();
-       })
-     });
+    it('Each dataView should have url set automatically', function() {
+      // there's at least one item in $controller.dataViews which means there's at least one object
+      // that has id that starts at view_ in toolbar_middleware_server_list.json
+      expect($controller.dataViews.length).not.toBe(0);
+      $controller.dataViews.forEach(function(dataView) {
+        expect(dataView.url).toBeTruthy();
+      });
+    });
 
-     it('Each button should have eventFunction set up', function() {
+    it('Each button should have eventFunction set up', function() {
       _.chain($controller.toolbarItems)
         .flatten()
         .map(function(item) {
@@ -67,28 +64,28 @@ describe('toolbarController', function () {
           expect(item.hasOwnProperty('eventFunction')).toBeTruthy();
         })
         .value();
-     })
-   })
+    });
+  });
 
-   describe('show detail toolbar', function() {
-     beforeEach(function(){
-       $controller.initObject(JSON.stringify(middleware_toolbar_detail));
-     });
+  describe('show detail toolbar', function() {
+    beforeEach(function() {
+      $controller.initObject(JSON.stringify(middleware_toolbar_detail));
+    });
 
-     it('middleware server, it should be different than list toolbar', function() {
-       expect(middleware_toolbar_list !== $controller.toolbarItems).toBeTruthy();
-     });
-   });
+    it('middleware server, it should be different than list toolbar', function() {
+      expect(middleware_toolbar_list !== $controller.toolbarItems).toBeTruthy();
+    });
+  });
 
-   describe('event data toolbar', function() {
-     beforeEach(function() {
-       spyOn($controller, 'onUpdateItem');
-       $controller.initObject(JSON.stringify([[{id: 'someButton', hidden: false, type: 'button'}]]));
-     })
+  describe('event data toolbar', function() {
+    beforeEach(function() {
+      spyOn($controller, 'onUpdateItem');
+      $controller.initObject(JSON.stringify([[{id: 'someButton', hidden: false, type: 'button'}]]));
+    });
 
-     it('should call update toolbar', function() {
-       sendDataWithRx({update: 'someButton', type: 'hidden', value: true});
-       expect($controller.onUpdateItem).toHaveBeenCalled();
-     })
-   });
+    it('should call update toolbar', function() {
+      sendDataWithRx({update: 'someButton', type: 'hidden', value: true});
+      expect($controller.onUpdateItem).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Noticed when reviewing https://github.com/ManageIQ/manageiq-ui-classic/pull/4986,

the toolbar and report specs had over a hundred eslint warning, mostly about weird indentation.

Fixing :)
cc @ZitaNemeckova 

(The change to .eslintrc adds `getJSONFixture` (provided by jasmine) and `module` (angular-mocks) to the list of allowed globals in specs.)