### PR TITLE
Remove deprecated toplevel constants from the codebase

### DIFF
--- a/app/controllers/flavor_controller.rb
+++ b/app/controllers/flavor_controller.rb
@@ -23,7 +23,7 @@ class FlavorController < ApplicationController
   def ems_list
     assert_privileges('flavor_create')
     ems_list = Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager).select do |ems|
-      ems.class::Flavor.supports?(:create)
+      ems.class::Flavor.supports?(:create) if ems.class.constants.include?(:Flavor)
     end
     ems_list.each do |ems|
       {:name => ems.name, :id => ems.id}

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -61,7 +61,7 @@ class PhysicalServerController < ApplicationController
     return if %w(physical_server_protect physical_server_tag).include?(params[:pressed]) &&
               @flash_array.nil? # Some other screen is showing, so return
     if params[:pressed] == "physical_server_timeline"
-      @record = find_record_with_rbac(ManageIQ::Providers::PhysicalInfraManager::PhysicalServer, params[:id])
+      @record = find_record_with_rbac(PhysicalServer, params[:id])
       show_timeline
       javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
     end
@@ -119,7 +119,7 @@ class PhysicalServerController < ApplicationController
   end
 
   def console_before_task
-    record = find_record_with_rbac(ManageIQ::Providers::PhysicalInfraManager::PhysicalServer, params[:id])
+    record = find_record_with_rbac(PhysicalServer, params[:id])
     task_id = record.remote_console_acquire_resource_queue(session[:userid])
     unless task_id.kind_of?(Integer)
       add_flash(_("Console access failed: Task start failed"), :error)

--- a/app/helpers/application_helper/button/new_flavor.rb
+++ b/app/helpers/application_helper/button/new_flavor.rb
@@ -1,5 +1,7 @@
 class ApplicationHelper::Button::NewFlavor < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
-    super || ManageIQ::Providers::CloudManager.all.none? { |ems| ems.class::Flavor.supports?(:create) }
+    super || ManageIQ::Providers::CloudManager.all.none? do |ems|
+      ems.class.constants.include?(:Flavor) && ems.class::Flavor.supports?(:create)
+    end
   end
 end

--- a/spec/helpers/application_helper/buttons/new_flavor_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_flavor_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationHelper::Button::NewFlavor do
 
     context 'provider available' do
       before do
-        provider = FactoryGirl.create(:ems_cloud)
+        provider = FactoryGirl.create(:ems_openstack)
         allow(provider.class::Flavor).to receive(:create).and_return(true)
         button.calculate_properties
       end

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -64,98 +64,98 @@ describe DialogLocalService do
     end
 
     context "when the object is a AvailabilityZone" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::AvailabilityZone, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "availability_zone", "availability_zones", "/availability_zone"
     end
 
     context "when the object is a CloudNetwork" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudNetwork, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "cloud_network", "cloud_networks", "/cloud_network"
     end
 
     context "when the object is a CloudObjectStoreContainer" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudObjectStoreContainer, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "cloud_object_store_container", "cloud_object_store_containers", "/cloud_object_store_container"
     end
 
     context "when the object is a CloudSubnet" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudSubnet, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "cloud_subnet", "cloud_subnets", "/cloud_subnet"
     end
 
     context "when the object is a CloudTenant" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudTenant, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Openstack::CloudManager::CloudTenant, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "cloud_tenant", "cloud_tenants", "/cloud_tenant"
     end
 
     context "when the object is a CloudVolume" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::CloudVolume, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Openstack::CloudManager::CloudVolume, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "cloud_volume", "cloud_volumes", "/cloud_volume"
     end
 
     context "when the object is a ContainerGroup" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerGroup, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_group", "container_groups", "/container_group"
     end
 
     context "when the object is a ContainerImage" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerImage, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Openshift::ContainerManager::ContainerImage, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_image", "container_images", "/container_image"
     end
 
     context "when the object is a ContainerNode" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerNode, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_node", "container_nodes", "/container_node"
     end
 
     context "when the object is a ContainerProject" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerProject, :id => 123) }
+      let(:obj) { double(:class => ContainerProject, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_project", "container_projects", "/container_project"
     end
 
     context "when the object is a ContainerTemplate" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerTemplate, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplate, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_template", "container_templates", "/container_template"
     end
 
     context "when the object is a ContainerVolume" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ContainerVolume, :id => 123) }
+      let(:obj) { double(:class => ContainerVolume, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "container_volume", "container_volumes", "/container_volume"
     end
 
     context "when the object is an EmsCluster" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::EmsCluster, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Openstack::InfraManager::EmsCluster, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "ems_cluster", "clusters", "/ems_cluster"
     end
 
     context "when the object is a GenericObject" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::GenericObject, :id => 123) }
+      let(:obj) { double(:class => GenericObject, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "generic_object", "generic_objects", "/service/explorer"
@@ -176,84 +176,84 @@ describe DialogLocalService do
     end
 
     context "when the object is a LoadBalancer" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::LoadBalancer, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "load_balancer", "load_balancers", "/load_balancer"
     end
 
     context "when the object is a NetworkRouter" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::NetworkRouter, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::NetworkRouter, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "network_router", "network_routers", "/network_router"
     end
 
     context "when the object is an OrchestrationStack" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::OrchestrationStack, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "orchestration_stack", "orchestration_stacks", "/orchestration_stack"
     end
 
     context "when the object is a SecurityGroup" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::SecurityGroup, :id => 123) }
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "security_group", "security_groups", "/security_group"
     end
 
     context "when the object is a Service" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Service, :id => 123) }
+      let(:obj) { double(:class => Service, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceAnsiblePlaybook" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceAnsiblePlaybook, :id => 123) }
+      let(:obj) { double(:class => ServiceAnsiblePlaybook, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceAnsibleTower" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceAnsibleTower, :id => 123) }
+      let(:obj) { double(:class => ServiceAnsibleTower, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceContainerTemplate" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceContainerTemplate, :id => 123) }
+      let(:obj) { double(:class => ServiceContainerTemplate, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceGeneric" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceGeneric, :id => 123) }
+      let(:obj) { double(:class => ServiceGeneric, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceOrchestration" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::ServiceOrchestration, :id => 123) }
+      let(:obj) { double(:class => ServiceOrchestration, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "service", "services", "/service/explorer"
     end
 
     context "when the object is a Storage" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
+      let(:obj) { double(:class => Storage, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "storage", "data_stores", "/storage/explorer"
     end
 
     context "when the object is a Switch" do
-      let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Switch, :id => 123) }
+      let(:obj) { double(:class => Switch, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
                        "switch", "switches", "/infra_networking/explorer"
@@ -261,7 +261,7 @@ describe DialogLocalService do
 
     context "when the object is a Template" do
       context "when there is a cancel endpoint in the display options" do
-        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::Template, :id => 123) }
         let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
@@ -278,7 +278,7 @@ describe DialogLocalService do
 
     context "when the object is a Vm" do
       context "when there is a cancel endpoint in the display options" do
-        let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
+        let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::Vm, :id => 123) }
         let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",


### PR DESCRIPTION
These toplevel constants now just return with a warning but in Ruby 2.5 it will raise an exception.
https://blog.bigbinary.com/2017/10/18/ruby-2.5-has-removed-top-level-constant-lookup.html

@miq-bot add_label gaprindashvili/no, hammer/no