### PR TITLE
Allow apostrophes in custom button names

### DIFF
--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -25,7 +25,7 @@
   ManageIQ.angular.app.value('dialogId', '#{dialog_id}');
   ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');
-  ManageIQ.angular.app.value('apiAction', '#{html_escape(api_action)}');
+  ManageIQ.angular.app.value('apiAction', '#{j_str(api_action)}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   ManageIQ.angular.app.value('openUrl', '#{open_url}');
   miq_bootstrap('.wrapper');


### PR DESCRIPTION
This is updated fix for https://github.com/ManageIQ/manageiq-ui-classic/pull/4900

In the problematic situation, we want to escape using `j_str()` rather than `html_escape()` 

https://bugzilla.redhat.com/show_bug.cgi?id=1646905