### PR TITLE
Fix referrer -> referer

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -136,8 +136,8 @@ module VmCommon
     @showtype = "config"
     @record = identify_record(id || params[:id], VmOrTemplate)
     if @record.nil?
-      referrer = Rails.application.routes.recognize_path(request.referer)
-      redirect_to(:controller => referrer[:controller], :action => referrer[:action])
+      referer = Rails.application.routes.recognize_path(request.referer)
+      redirect_to(:controller => referer[:controller], :action => referer[:action])
       return
     end
     return if record_no_longer_exists?(@record)

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -495,7 +495,7 @@
             #{options[:start_min]}m
       - elsif [:sysprep_upload_file].include?(field)
         .col-md-8
-          - path = Rails.application.routes.recognize_path request.referrer
+          - path = Rails.application.routes.recognize_path request.referer
           - if path[:controller] == "miq_request"
             = form_tag({:action    => "prov_edit",
                         :req_id    => @edit[:req_id].to_s},

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -113,7 +113,7 @@ describe VmOrTemplateController do
       expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
     end
 
-    it "Redirects user to the referrer controller/action" do
+    it "Redirects user to the referer controller/action" do
       login_as FactoryGirl.create(:user)
       request.env["HTTP_REFERER"] = "http://localhost:3000/dashboard/show"
       allow(controller).to receive(:find_record_with_rbac).and_return(nil)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -576,8 +576,8 @@ describe VmInfraController do
     end
   end
 
-  it "gets explorer when the request.referrer action is of type 'post'" do
-    allow(request).to receive(:referrer).and_return("http://localhost:3000/configuration/update")
+  it "gets explorer when the request.referer action is of type 'post'" do
+    allow(request).to receive(:referer).and_return("http://localhost:3000/configuration/update")
     get :explorer
     expect(response.status).to eq(200)
   end


### PR DESCRIPTION
Rubocop seems to prefer `request.referer` to the `request.referrer` alias,
and while "referrer" is the correct spelling in real world,
"referer" is the HTTP spelling.
Consistency.

(Addresses https://github.com/ManageIQ/manageiq-ui-classic/pull/5002#discussion_r237480626 )