### PR TITLE
[GAPRINDASHVILI] - Check for Appliance name only when validating settings tab.

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -577,6 +577,7 @@ module OpsController::Settings::Common
   end
 
   def settings_server_validate
+    return unless @sb[:active_tab] == "settings_server" && @edit[:new][:server]
     if @edit[:new][:server][:name].blank?
       add_flash(_("Appliance name must be entered."), :error)
     end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1654287

changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/4876 caused the issue because Gaprindashvili branch was missing following line of code `return unless @sb[:active_tab] == "settings_server" && @edit[:new][:server]`

@dclarizio please review