### PR TITLE
Service catalog  icon fix

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -6,7 +6,7 @@
         - if @record.picture
           %img{:src => "#{@record.picture.url_path}?#{rand(99_999_999)}"}/
         - else
-          %i.pficon.pficon-template
+          %i.fa.fa-cube.fa-4x
         %br
         %br
       .col-md-9


### PR DESCRIPTION
The Service Catalog Order screen was showing "pficon-template" as the default icon rather than "fa-cube." This PR corrects that and also resizes the icon.

Old
<img width="931" alt="screen shot 2018-11-30 at 10 17 54 am" src="https://user-images.githubusercontent.com/1287144/49297636-4b8c8f80-f489-11e8-8505-d2f638057454.png">

New
<img width="950" alt="screen shot 2018-11-30 at 10 17 31 am" src="https://user-images.githubusercontent.com/1287144/49297637-4b8c8f80-f489-11e8-84f8-07ad768b1cf8.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1518867
