### PR TITLE
ServiceForm spec - fix by disabling disableSubmit and making sure the validator can pass

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -4,7 +4,6 @@ import { formFieldsMapper, layoutMapper } from '@data-driven-forms/pf3-component
 
 const MiqFormRenderer = props => (
   <FormRender
-    disableSubmit
     formFieldsMapper={formFieldsMapper}
     layoutMapper={layoutMapper}
     {...props}

--- a/app/javascript/spec/service-form/service-form.spec.js
+++ b/app/javascript/spec/service-form/service-form.spec.js
@@ -11,8 +11,8 @@ describe('Cloud tenant form component', () => {
 
   beforeEach(() => {
     initialProps = {
-      maxNameLen: 1,
-      maxDescLen: 2,
+      maxNameLen: 10,
+      maxDescLen: 20,
       serviceFormId: 3,
     };
     submitSpy = jest.spyOn(window, 'miqAjaxButton');

--- a/app/javascript/spec/service-form/service-form.spec.js
+++ b/app/javascript/spec/service-form/service-form.spec.js
@@ -4,7 +4,7 @@ import fetchMock from 'fetch-mock';
 import FormRender from '@data-driven-forms/react-form-renderer';
 import ServiceForm from '../../components/service-form';
 
-describe('Cloud tenant form component', () => {
+describe('Service form component', () => {
   let initialProps;
   let submitSpy;
   let flashSpy;


### PR DESCRIPTION
fixes

```
    ✕ should enable submit button and call submit callback (30ms)

  ● Cloud tenant form component › should enable submit button and call submit callback

    expect(jest.fn()).toHaveBeenCalledWith(expected)

    Expected mock function to have been called with:
      {"description": "bar", "name": "foo"} as argument 2, but it was called with {"description": "bar", "name": "bar"}.
```

Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/4985.
Cc @Hyperkid123 , @martinpovolny 