### PR TITLE
Increase memory limit for NodeJS to 4G

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -22,7 +22,7 @@ end
 
 newenv  = {
   "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
-  "NODE_OPTIONS" => "--max_old_space_size=2048"
+  "NODE_OPTIONS" => "--max_old_space_size=4096"
 }
 cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
 

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -34,7 +34,7 @@ end
 newenv = {
   "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
   "ASSET_HOST"   => DEV_SERVER_HOST.shellescape,
-  "NODE_OPTIONS" => "--max_old_space_size=2048"
+  "NODE_OPTIONS" => "--max_old_space_size=4096"
 }.freeze
 
 cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV


### PR DESCRIPTION
I think there's something seriously wrong with the whole thing if we need 4GB of memory to compile our JS code to JS :laughing: :rofl: :trollface: but this is what @himdel suggested and it works.

@AlexanderZagaynov can you please verify if it fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/4857?