### PR TITLE
select: use @pf3/select instead of bootstrap-select

### DIFF
--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -7,7 +7,7 @@ window.$ = window.jQuery = require('jquery'); // eslint-disable-line no-multi-as
 require('bootstrap');
 require('bootstrap-datepicker');
 require('bootstrap-filestyle');
-require('bootstrap-select');
+require('@pf3/select');
 require('bootstrap-switch');
 require('bootstrap-touchspin');
 require('eonasdan-bootstrap-datetimepicker');

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -12,6 +12,7 @@
           :multiple          => true,
           "data-width"       => "850px",
           "data-live-search" => "true",
+          "data-live-search-focus" => "false",
           :class             => 'selectpicker',
           :style             => "overflow-x: scroll;",
           :id                => "available_fields",

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -122,7 +122,10 @@ module.exports = {
   },
 
   resolve: {
-    alias: { 'react': resolve(dirname(__filename), '../../node_modules', 'react') },
+    alias: {
+      'react': resolve(dirname(__filename), '../../node_modules', 'react'),
+      'bootstrap-select': '@pf3/select',  // never use vanilla bootstrap-select
+    },
     extensions: settings.extensions,
     modules: [],
     plugins: [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@data-driven-forms/react-form-renderer": "^1.1.3",
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.2.0",
+    "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",


### PR DESCRIPTION
this replaces bootstrap-select 1.12.2 with 1.12.5,
except that 1.12.5 comes from my fork, as upstream is nonresponsive

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648115

EDIT: 1.12.6, 5 had bad paths in dist/

---

The practical difference should be https://github.com/himdel/bootstrap-select/pull/1 :

multiselect with search should not scroll up to the search bar whenever an item is chosen in the dropdown, when data-live-search-focus is set to false.

---

This also sets `data-live-search-focus` to false for available fields in the Report form, fixing the BZ :).