### PR TITLE
Fix CatalogItem tree_select()

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2006,7 +2006,8 @@ class CatalogController < ApplicationController
 
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
-                     params[:action] == "x_show"
+                     params[:action] == "x_show" ||
+                     (%w(accordion_select tree_select).include?(params[:action]) && @record.present? && type == 'st')
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record


### PR DESCRIPTION
1. create & order a catalog item
2. delete the template used in the above catalog item
3. Services ➛ Catalogs ➛ Service Catalogs
4. In the tree view click on the created catalog item
5. In the rendered GTL click on the created catalog item

Clicking in the GTL view would render the catalogs item summary screen correctly.
Clicking in the tree view would render just list of VMs. 

https://bugzilla.redhat.com/show_bug.cgi?id=1652858