### PR TITLE
Include cloud tenant name column in Security Group list view

### DIFF
--- a/product/views/SecurityGroup.yaml
+++ b/product/views/SecurityGroup.yaml
@@ -28,6 +28,9 @@ include:
   ext_management_system:
     columns:
     - name
+  cloud_tenant:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -37,6 +40,7 @@ col_order:
 - name
 - description
 - total_vms
+- cloud_tenant.name
 - ext_management_system.name
 
 # Column titles, in order
@@ -44,6 +48,7 @@ headers:
 - Name
 - Description
 - Instances
+- Cloud Tenant
 - Cloud Provider
 
 # Condition(s) string for the SQL query


### PR DESCRIPTION
Accessible through `Networks -> Security Groups` and the view type should be `list`.

**Before:**
![screenshot from 2018-12-04 14-43-10](https://user-images.githubusercontent.com/649130/49445850-207ca580-f7d3-11e8-98b1-d3ab0ace256e.png)
**Afer:**
![screenshot from 2018-12-04 14-42-52](https://user-images.githubusercontent.com/649130/49445858-23779600-f7d3-11e8-917a-dac19287e04f.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1516912

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label GTLs