### PR TITLE
uib-tooltip - respect newlines in tooltips

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -1054,6 +1054,11 @@ table.table-compressed tr td .piechart {
   color: #fff;
 }
 
+/* make sure uib-tooltip respects newlines */
+.tooltip-inner {
+  white-space: pre-wrap;
+}
+
 /// ===================================================================
 /// end misc styling
 /// ===================================================================


### PR DESCRIPTION
This makes sure we can have multiline tooltips that actually show the line breaks.

This should not affect any tooltips which are just one line, but makes it possible for multiline tooltips to look properly:

before:

![tooltipbefore](https://user-images.githubusercontent.com/289743/49448382-b105b680-f7d0-11e8-886d-3070de5d4b33.png)

after:

![tooltipnewline](https://user-images.githubusercontent.com/289743/49448392-b531d400-f7d0-11e8-8f5c-bc8a169161a0.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1655977