### PR TITLE
[FINE] Fix Drift VM styling

### DIFF
--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -24,7 +24,8 @@
                 - else
                   %img{:src => image_path('100/template-no-host.png')}
               - else
-                %img{:src => image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")}
+                - state_path = image_path("svg/currentstate-#{h(@drift_obj.current_state.downcase)}.svg")
+                .stretch{:style => "background-image: url('#{state_path}')"}
             %div{:class => "flobj c72"}
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vendor.downcase)}.svg")}
             %div{:class => "flobj a72"}
@@ -49,7 +50,8 @@
               %img{:src => image_path("svg/vendor-#{h(@drift_obj.vmm_vendor_display.downcase)}.svg")}
             - unless @drift_obj.power_state.blank?
               %div{:class => "flobj b72"}
-                %img{:src => image_path("svg/currentstate-#{h(@drift_obj.power_state.downcase)}.svg")}
+                - state_path = image_path("svg/current_state-#{h(@drift_obj.power_state.downcase)}.svg")
+                .stretch{:style => "background-image: url('#{state_path}')"}
             %div{:class => "flobj a72"}
               %p
                 = @drift_obj.vms.count


### PR DESCRIPTION
This PR adjusts the VM Drift power state quad markup to curve the corner of the icon properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1531577

Old
<img width="1020" alt="screen shot 2018-12-04 at 9 39 08 am" src="https://user-images.githubusercontent.com/1287144/49449804-b26fb880-f7a9-11e8-95d8-ff89c12e8251.png">

New
<img width="1017" alt="screen shot 2018-12-04 at 9 38 12 am" src="https://user-images.githubusercontent.com/1287144/49449805-b26fb880-f7a9-11e8-930a-b0258695121c.png">
