### PR TITLE
[WIP] Fix restoring a Volume backup when only one cloud volume exists

### DIFF
--- a/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
+++ b/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
@@ -56,19 +56,12 @@ function cloudVolumeBackupFormController(miqService, $http) {
 
   function getVolumeFormDataComplete(response) {
     vm.volume_choices = response.data.volume_choices;
-    if (foundVolumes()) {
-      vm.cloudVolumeBackupModel.volume = vm.volume_choices[0];
-    }
     vm.modelCopy = angular.copy(vm.cloudVolumeBackupModel);
     miqService.sparkleOff();
   }
 
   function resetModel() {
     vm.cloudVolumeBackupModel = angular.copy(vm.modelCopy);
-  }
-
-  function foundVolumes() {
-    return vm.volume_choices.length > 0;
   }
 
   vm.$onInit = init;

--- a/app/views/static/cloud_volume_backup/volume_select.html.haml
+++ b/app/views/static/cloud_volume_backup/volume_select.html.haml
@@ -11,11 +11,11 @@
       %label.col-md-2.control-label
         = _('Volume')
       .col-md-8
-        = select_tag('volume_id',
-                '',
+        %select{:id          => 'volume_id',
+                :name        => 'volume_id',
                 'ng-model'   => 'vm.cloudVolumeBackupModel.volume',
                 'ng-options' => 'volume.name for volume in vm.volume_choices track by volume.id',
                 :required    => '',
-                'miq-select' => true)
+                'miq-select' => '{ noneSelectedText: "&lt;#{_('Choose a volume')}&gt;" }'}
 
   = render :partial => 'layouts/angular/generic_form_buttons'


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1647437

**What:**
Fix the drop down and _Save_ button while restoring a volume backup.

**Steps to reproduce:**
1. Make sure only one Cloud volume exists (but it is possible that this is not required),
    at _Storage > Block Storage > Volumes_
2. Create a backup for that volume, go to
   _Storage > Block Storage > Volume Backups_, _Configuration > ..._
3. Restore volume backup onto volume

---

**Before:**
![vol_before](https://user-images.githubusercontent.com/13417815/49453926-62621780-f7e4-11e8-9e2a-da4742bd2ba0.png)

**After:**
![vol_after](https://user-images.githubusercontent.com/13417815/49453788-19aa5e80-f7e4-11e8-9685-751ab6bdf952.png)

---

Not good for reproducing the BZ, step 1:
![many_volumes](https://user-images.githubusercontent.com/13417815/51851022-4f228280-2323-11e9-8fd3-f901cb0dd53f.png)

**Note:**
In fact, there wasn't any problem with Save button, this PR only sets _Choose a volume_ option, the text that is displayed when a select has no selected options. And Save button is disabled, when first time in and nothing selected, which is correct.