### PR TITLE
Fix rendering of VMware floppy drive

### DIFF
--- a/app/helpers/vm_helper.rb
+++ b/app/helpers/vm_helper.rb
@@ -55,6 +55,8 @@ module VmHelper
       "Hard Disk (SCSI #{disk.location})"
     when "scsi-passthru"
       "Generic SCSI (#{disk.location})"
+    when "floppy"
+      "Floppy Drive (SIO #{disk.location})"
     else
       "#{disk.controller_type} #{disk.location}"
     end


### PR DESCRIPTION
Before:
![floppy-before](https://user-images.githubusercontent.com/6648365/49455968-655f0700-f7e8-11e8-8bbc-ad6b5354b2d6.jpg)


After:
![floppy-after](https://user-images.githubusercontent.com/6648365/49455975-698b2480-f7e8-11e8-86b7-f61350e50a9c.jpg)

@agrare Would this be correct fix for the linked bz? Thanks.

https://bugzilla.redhat.com/show_bug.cgi?id=1650501