### PR TITLE
Use widget's title in flash messages

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -76,7 +76,7 @@ module ReportController::Widgets
       if !@widget || @widget.id.blank?
         add_flash(_("Add of new Widget was cancelled by the user"))
       else
-        add_flash(_("Edit of Widget \"%{name}\" was cancelled by the user") % {:name => get_record_display_name(@widget)})
+        add_flash(_("Edit of Widget \"%{title}\" was cancelled by the user") % {:title => @widget.title})
       end
       get_node_info
       @widget = nil
@@ -90,7 +90,7 @@ module ReportController::Widgets
       widget_set_record_vars(@widget)
       if widget_validate_entries && @widget.save_with_shortcuts(@edit[:new][:shortcuts].to_a)
         AuditEvent.success(build_saved_audit(@widget, @edit))
-        add_flash(_("Widget \"%{name}\" was saved") % {:name => get_record_display_name(@widget)})
+        add_flash(_("Widget \"%{title}\" was saved") % {:title => @widget.title})
         params[:id] = @widget.id.to_s # reset id in params for show
         # Build the filter expression and attach widget to schedule filter
         exp = {}


### PR DESCRIPTION
Use widget's title in flash messages

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656413

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/49536477-9dbc1f00-f894-11e8-97d9-850a36ab4241.png)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/49536482-a1e83c80-f894-11e8-9020-2d5811ba2cb5.png)


@miq-bot add-label bug, cloud intel/reporting


