### PR TITLE
Add missing single_quad definitions for ansible-related entities

### DIFF
--- a/app/decorators/configuration_script_source_decorator.rb
+++ b/app/decorators/configuration_script_source_decorator.rb
@@ -2,4 +2,10 @@ class ConfigurationScriptSourceDecorator < MiqDecorator
   def self.fonticon
     "pficon pficon-repository"
   end
+
+  def single_quad
+    {
+      :fonticon => fonticon
+    }
+  end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers::AnsibleTower
     def self.fonticon
       'pficon pficon-template'
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/automation_manager/playbook_decorator.rb
@@ -7,5 +7,11 @@ module ManageIQ::Providers::AnsibleTower
     def self.fileicon
       'svg/vendor-ansible.svg'
     end
+
+    def single_quad
+      {
+        :fileicon => fileicon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_group_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers
     def self.fonticon
       'pficon pficon-folder-close'
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
+++ b/app/decorators/manageiq/providers/automation_manager/inventory_root_group_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers
     def self.fonticon
       'pficon pficon-folder-close'
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_ansible/automation_manager/playbook_decorator.rb
@@ -7,5 +7,11 @@ module ManageIQ::Providers::EmbeddedAnsible
     def self.fileicon
       'svg/vendor-ansible.svg'
     end
+
+    def single_quad
+      {
+        :fileicon => fileicon
+      }
+    end
   end
 end

--- a/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
+++ b/app/decorators/manageiq/providers/embedded_automation_manager/configuration_script_source_decorator.rb
@@ -3,5 +3,11 @@ module ManageIQ::Providers
     def self.fonticon
       "pficon pficon-repository"
     end
+
+    def single_quad
+      {
+        :fonticon => fonticon
+      }
+    end
   end
 end


### PR DESCRIPTION
**Before:** imagine no quadicons

**After:**
![screenshot from 2018-12-06 14-14-28](https://user-images.githubusercontent.com/649130/49587261-acbdd280-f963-11e8-98da-1f71439331e1.png)
![screenshot from 2018-12-06 14-22-11](https://user-images.githubusercontent.com/649130/49587262-acbdd280-f963-11e8-8c08-425cee8564be.png)
![screenshot from 2018-12-06 14-24-26](https://user-images.githubusercontent.com/649130/49587263-ad566900-f963-11e8-8114-db6e0072017f.png)
![screenshot from 2018-12-06 14-29-17](https://user-images.githubusercontent.com/649130/49587264-ad566900-f963-11e8-99d0-00cad2bad197.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label GTLs, hammer/yes, bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656534