### PR TITLE
Drop jQuery calls from the webpack-compiled JS codebase

### DIFF
--- a/app/javascript/http_api/fetch.js
+++ b/app/javascript/http_api/fetch.js
@@ -34,7 +34,8 @@ function processOptions(options) {
   }
 
   if (o.csrf) {
-    o.headers['X-CSRF-Token'] = $('meta[name=csrf-token]').attr('content');
+    const elem = document.querySelector("meta[name=csrf-token]");
+    o.headers['X-CSRF-Token'] = elem ? elem.getAttribute('content') : '';
     delete o.csrf;
   }
 

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -79,17 +79,17 @@ function apiCall(buttonData, dialogData) {
 
 // careful: the dialogDefinigion is string, not an object here
 function dialogModal(dialogDefinition, buttonData) {
-  const elem = $('<provider-dialog-user></provider-dialog-user>');
-  elem.attr('dialog', dialogDefinition);
-  elem.attr('action-name', buttonData.action_name);
-  elem.attr('entity-name', buttonData.entity_name);
-  elem.attr('success-message', buttonData.success_message);
+  const elem = document.createElement('provider-dialog-user');
+  elem.setAttribute('dialog', dialogDefinition);
+  elem.setAttribute('action-name', buttonData.action_name);
+  elem.setAttribute('entity-name', buttonData.entity_name);
+  elem.setAttribute('success-message', buttonData.success_message);
 
   const id = 'angular-provider-dialog';
 
   const inner = class extends React.Component {
     componentDidMount() {
-      elem.appendTo(`#${id}`);
+      document.querySelector(`#${id}`).appendChild(elem);
       miq_bootstrap(`#${id}`);
     }
 

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -13,20 +13,21 @@ function closeModal(id) {
    * yay
    */
 
-
+  // FIXME: rewrite it without using jQuery and add some tests
   const divs = $(`#${id}`).parents('div');
   divs[divs.length - 1].remove(); // the div closest to body
 }
 
 export default function renderModal(title = __('Modal'), Inner = () => <div>Empty?</div>) {
-  const div = $('<div></div>').appendTo('body');
+  const div = document.createElement('div');
+  document.body.appendChild(div);
   const removeId = 'provider-dialogs';
 
   const close = () => closeModal(removeId);
 
   const output = modal(title, Inner, close, removeId);
 
-  ReactDOM.render(output, div[0]);
+  ReactDOM.render(output, div);
 }
 
 function modal(title, Inner, closed, removeId) {

--- a/app/javascript/react/textual_summary_click.js
+++ b/app/javascript/react/textual_summary_click.js
@@ -8,8 +8,9 @@ export default function textualSummaryGenericClick(item, event) {
   if (item.external) {
     window.open(item.link, '_blank');
   } else if (item.explorer) {
+    const tokenElement = document.querySelector("meta[name=csrf-token]");
     $.ajax({
-      data: `authenticity_token=${encodeURIComponent($('meta[name=csrf-token]').attr('content'))}`,
+      data: `authenticity_token=${encodeURIComponent(tokenElement ? tokenElement.getAttribute('content') : '')}`,
       dataType: 'script',
       type: 'post',
       url: item.link,


### PR DESCRIPTION
We should not use jQuery under the `app/javscripts` folder as it should be modern javascript only and modern means without using jQuery :wink: 

@miq-bot add_reviewer @himdel 
@miq-bot add_label refactoring, hammer/no