### PR TITLE
Use the uib-tab parameter for switching tabs on the tasks screen

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -43,7 +43,7 @@ class MiqTaskController < ApplicationController
 
   # New tab was pressed
   def change_tab
-    @tabform = "tasks_#{params[:tab]}"
+    @tabform = "tasks_#{params[:'uib-tab']}"
     jobs
     render :action => "jobs"
   end


### PR DESCRIPTION
This is a regression caused by the angular-bootstrap prefixing, the new parameter includes the `uib-` prefix, but the controller was looking for the `tab` parameter.

**Before:**
![screenshot from 2018-12-06 16-39-02](https://user-images.githubusercontent.com/649130/49594111-738e5e00-f975-11e8-96b5-c64fa555aa4b.png)

**After:**
![screenshot from 2018-12-06 16-38-04](https://user-images.githubusercontent.com/649130/49594060-535e9f00-f975-11e8-8f32-9a4ada86dd02.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1655749

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @himdel 
@miq-bot add_label bug, hammer/yes