### PR TITLE
Fix failing creating new Alert in Control > Explorer

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -645,11 +645,10 @@ module MiqPolicyController::Alerts
         add_flash(_("At least one E-mail recipient must be configured"), :error)
       elsif alert.options[:notifications][:email][:to].find { |i| !i.to_s.email? }
         add_flash(_("One of e-mail addresses 'To' is not valid"), :error)
+      elsif alert.options[:notifications][:email][:from].present? &&
+            !alert.options[:notifications][:email][:from].email?
+        add_flash(_("E-mail address 'From' is not valid"), :error)
       end
-    end
-    if alert.options[:notifications][:email][:from].present? &&
-       !alert.options[:notifications][:email][:from].email?
-      add_flash(_("E-mail address 'From' is not valid"), :error)
     end
     if alert.options[:notifications][:snmp]
       validate_snmp_options(alert.options[:notifications][:snmp])

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -1,11 +1,9 @@
 describe MiqPolicyController do
   context "::Alerts" do
     describe '#alert_delete' do
-      before do
-        login_as FactoryGirl.create(:user, :features => "alert_delete")
-      end
-
       let(:alert) { FactoryGirl.create(:miq_alert, :read_only => readonly) }
+
+      before { login_as FactoryGirl.create(:user, :features => "alert_delete") }
 
       context 'read only alert' do
         let(:readonly) { true }
@@ -25,16 +23,13 @@ describe MiqPolicyController do
     context "alert edit" do
       before do
         login_as FactoryGirl.create(:user, :features => "alert_admin")
-      end
-
-      before do
         @miq_alert = FactoryGirl.create(:miq_alert)
         controller.instance_variable_set(:@sb,
                                          :trees       => {:alert_tree => {:active_node => "al-#{@miq_alert.id}"}},
                                          :active_tree => :alert_tree)
       end
 
-      context "#alert_build_edit_screen" do
+      describe "#alert_build_edit_screen" do
         it "it should skip id when copying all attributes of an existing alert" do
           controller.instance_variable_set(:@_params, :id => @miq_alert.id, :copy => "copy")
           controller.send(:alert_build_edit_screen)
@@ -48,7 +43,7 @@ describe MiqPolicyController do
         end
       end
 
-      context "#alert_field_changed" do
+      describe "#alert_field_changed" do
         before do
           controller.params = {:id => 0, :exp_name => ""}
           session[:edit] = {:key => "alert_edit__0", :new => {}}
@@ -80,10 +75,8 @@ describe MiqPolicyController do
         end
       end
 
-      context "#alert_edit_cancel" do
-        before do
-          allow(controller).to receive(:replace_right_cell).and_return(true)
-        end
+      describe "#alert_edit_cancel" do
+        before { allow(controller).to receive(:replace_right_cell).and_return(true) }
 
         it "it should correctly cancel edit screen of existing alert" do
           session[:edit] = {:alert_id => @miq_alert.id}
@@ -135,12 +128,9 @@ describe MiqPolicyController do
       end
     end
 
-    context "alert_valid_record?" do
+    describe "#alert_valid_record?" do
       before do
         login_as FactoryGirl.create(:user, :features => "alert_admin")
-      end
-
-      before do
         expression = MiqExpression.new("=" => {:tag => "name", :value => "Test"}, :token => 1)
         @miq_alert = FactoryGirl.create(
           :miq_alert,
@@ -174,6 +164,23 @@ describe MiqPolicyController do
         controller.instance_variable_set(:@edit, edit)
         controller.send(:alert_valid_record?, @miq_alert)
         expect(assigns(:flash_array)).to be_nil
+      end
+
+      context 'not choosing Send an E-mail option while adding new Alert' do
+        let(:alert) do
+          FactoryGirl.create(:miq_alert,
+                             :expression         => {:eval_method => 'nothing'},
+                             :options            => {:notifications => {:delay_next_evaluation => 3600, :evm_event => {}}},
+                             :responds_to_events => '_hourly_timer_')
+        end
+        let(:edit) { {:new => {:db => 'ContainerNode', :expression => {:eval_method => 'nothing'}}} }
+
+        before { controller.instance_variable_set(:@edit, edit) }
+
+        it 'returns empty flash array' do
+          controller.send(:alert_valid_record?, alert)
+          expect(assigns(:flash_array)).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
**Fixes BZ:**
 https://bugzilla.redhat.com/show_bug.cgi?id=1654896

Related PR:
https://github.com/ManageIQ/manageiq-ui-classic/pull/4947

**What:**
This PR fixes failing creating a new _Alert_ in _Control > Explorer_ page. 

**Steps to reproduce:**
1. Go to _Control > Explorer > Alerts_ accordion _> All Alerts_
2. Select _Configuration > Add new alert_
3. Fill in some info (_Description_ and _Driving Event_ are required),
   check the _Show on Timeline_ checkbox, in _Timeline Event_ section instead of _Send an E-mail_, for example
4. Click on _Add_ button
=> error:
```
[----] I, [2018-12-06T17:22:47.963847 #3514:2abc52c6f44c]  INFO -- : Started POST "/miq_policy/alert_edit?button=add" for ::1 at 2018-12-06 17:22:47 +0100
[----] I, [2018-12-06T17:22:48.011375 #3514:2abc52c6f44c]  INFO -- : Processing by MiqPolicyController#alert_edit as JS
[----] I, [2018-12-06T17:22:48.011707 #3514:2abc52c6f44c]  INFO -- :   Parameters: {"button"=>"add"}
[----] F, [2018-12-06T17:22:48.032725 #3514:2abc52c6f44c] FATAL -- : Error caught: [NoMethodError] undefined method `[]' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/miq_policy_controller/alerts.rb:650:in `alert_valid_record?'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/miq_policy_controller/alerts.rb:26:in `alert_edit_save_add'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/miq_policy_controller/alerts.rb:60:in `alert_edit'
```

**Notes:**
Failing depends on which info is (not) filled in while creating a new alert - it does not happen always.
Mostly failing does not occur if all the info is filled in properly, including the emails.

---

**Before:** (not able to create a new Alert, nothing happens in the UI)
![alert_before](https://user-images.githubusercontent.com/13417815/49597206-3c6f7b00-f97c-11e8-9d68-35dfd1e27817.png)

**After:**(creating a new Alert successful)
![alert_after](https://user-images.githubusercontent.com/13417815/49597210-3f6a6b80-f97c-11e8-8662-2e89a6fb7b35.png)
