### PR TITLE
Added import of lodash for fetch.

### DIFF
--- a/app/javascript/http_api/fetch.js
+++ b/app/javascript/http_api/fetch.js
@@ -1,3 +1,4 @@
+import { isString, isPlainObject } from 'lodash';
 import { sendDataWithRx } from '../miq_observable';
 
 const { redirectLogin } = window;
@@ -46,11 +47,11 @@ function processOptions(options) {
 }
 
 function processData(o) {
-  if (!o || _.isString(o)) {
+  if (!o || isString(o)) {
     return o;
   }
 
-  if (_.isPlainObject(o)) {
+  if (isPlainObject(o)) {
     return JSON.stringify(o);
   }
 


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq-ui-classic/pull/5027, thete were an issue, that lodash was not available in tests.

```diff
- window._ = require('lodash');
```

I've imported lodash functions directly to the fetch file (it was using it from window).

This probably gonna get resolved in https://github.com/ManageIQ/manageiq-ui-classic/pull/4988/files, but i think its better idea not to use globals if we don't need to.

