### PR TITLE
Do not try to display icon as image on Monitoring -> Alerts cards

### DIFF
--- a/app/views/shared/views/_show_alerts_overview.html.haml
+++ b/app/views/shared/views/_show_alerts_overview.html.haml
@@ -34,8 +34,7 @@
           .card-pf.card-pf-aggregate-status{"ng-repeat" => "item in group.itemsList track by item.name"}
             %a{"href" => "#", "ng-click" => "vm.showGroupAlerts(item)"}
               %span.h2.card-pf-title
-                %img.card-view-type-img{"ng-if" => "item.objectTypeImg",
-                                        "ng-src" => "{{item.objectTypeImg}}"}
+                %i{:class => "{{item.objectTypeImg}}", "ng-if" => "item.objectTypeImg"}
                 {{item.name}}
             .card-pf-body
               %p.card-pf-aggregate-status-notifications


### PR DESCRIPTION
**Before:**
![screenshot from 2018-12-06 20-46-00](https://user-images.githubusercontent.com/649130/49608121-2a9bd100-f998-11e8-8fc5-741c629b2c45.png)
**After:**
![screenshot from 2018-12-06 20-19-00](https://user-images.githubusercontent.com/649130/49608130-2e2f5800-f998-11e8-94b9-6952dc42eead.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656990

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, gaprindashvili/yes, hammer/yes