### PR TITLE
Added "Preserve owner?" checkbox on Import report screen 

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -72,6 +72,7 @@ class ReportController < ApplicationController
     end
     if params[:upload] && params[:upload][:file] && params[:upload][:file].respond_to?(:read)
       @sb[:overwrite] = params[:overwrite].present?
+      @sb[:preserve_owner] = params[:preserve_owner].present?
       begin
         _reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite],
                                                             :userid => session[:userid],
@@ -103,7 +104,6 @@ class ReportController < ApplicationController
     when "saved_reports"
       redirect_to(:action => params[:tab])
     when "menueditor"
-      # redirect_to(:controller=>"configuration", :action=>"change_tab", :tab=>6)
       redirect_to(:action => "menu_edit")
     else
       redirect_to(:action => params[:tab], :id => params[:id])

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -73,7 +73,9 @@ class ReportController < ApplicationController
     if params[:upload] && params[:upload][:file] && params[:upload][:file].respond_to?(:read)
       @sb[:overwrite] = params[:overwrite].present?
       begin
-        _reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite], :userid => session[:userid])
+        _reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite],
+                                                            :userid => session[:userid],
+                                                            :preserve_owner => @sb[:preserve_owner])
       rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
         @sb[:flash_msg] = @flash_array
@@ -101,6 +103,7 @@ class ReportController < ApplicationController
     when "saved_reports"
       redirect_to(:action => params[:tab])
     when "menueditor"
+      # redirect_to(:controller=>"configuration", :action=>"change_tab", :tab=>6)
       redirect_to(:action => "menu_edit")
     else
       redirect_to(:action => params[:tab], :id => params[:id])

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -12,14 +12,12 @@
              :class     => "form-horizontal",
              :multipart => true,
              :method    => :post) do
-    - overwrite = @sb[:overwrite] ? true : false
-    - preserve_owner = @sb[:preserve_owner] ? true : false
     .form-group
       .col-md-8
         = check_box_tag("overwrite", "1", @sb[:overwrite])
         = _('Overwrite existing reports?')
       .col-md-8
-        = check_box_tag("preserve_owner", "1", preserve_owner)
+        = check_box_tag("preserve_owner", "1", @sb[:preserve_owner])
         = _('Preserve owner?')
     .form-group
       .col-md-4

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -12,10 +12,15 @@
              :class     => "form-horizontal",
              :multipart => true,
              :method    => :post) do
+    - overwrite = @sb[:overwrite] ? true : false
+    - preserve_owner = @sb[:preserve_owner] ? true : false
     .form-group
       .col-md-8
         = check_box_tag("overwrite", "1", @sb[:overwrite])
         = _('Overwrite existing reports?')
+      .col-md-8
+        = check_box_tag("preserve_owner", "1", preserve_owner)
+        = _('Preserve owner?')
     .form-group
       .col-md-4
         = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}


### PR DESCRIPTION
**Before:** 
We unconditionally overrided `user_id` and `miq_group_id` fields of imported report with value for user who is doing import. 
![before](https://user-images.githubusercontent.com/6556758/49609821-a8e17e80-f96a-11e8-8998-7ee4c5bf27f9.png)

**After:** 
`Preserver owner?` checkbox is controlling if we need to work in old way (override) or preserve `user_id` and `miq_group_id` from imported report
![after](https://user-images.githubusercontent.com/6556758/49659013-498a7980-fa11-11e8-9d1f-e75319414ca6.png)


Depends on https://github.com/ManageIQ/manageiq/pull/18270

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638533

@miq-bot add-label enhancement , cloud intel/reporting, pending core

\cc @gtanzillo 
