### PR TITLE
Drop support for IE10 when transpiling javascript using babel

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -11,7 +11,6 @@ module.exports = {
             "> 1%",
             "last 2 versions",
             "Firefox ESR",
-            "IE 10",
             "IE 11",
           ],
         },


### PR DESCRIPTION
Not sure how much this helps, but we definitely don't need IE10 here.

@miq-bot assign @himdel 