### PR TITLE
Fix multi-target Set Ownership

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -156,21 +156,22 @@ module Mixins
 
         def ownership_handle_save_button
           opts = {}
-          opts[:owner] = unless params[:user] == 'dont-change'
-                           if params[:user].blank? # to clear previously set user
+
+          unless params[:user] == 'dont-change'
+            opts[:owner] = if params[:user].blank? # to clear previously set user
                              nil
                            elsif params[:user] != @user
                              User.find(params[:user])
                            end
-                         end
+          end
 
-          opts[:group] = unless params[:group] == 'dont-change'
-                           if params[:group].blank? # to clear previously set group
+          unless params[:group] == 'dont-change'
+            opts[:group] = if params[:group].blank? # to clear previously set group
                              nil
                            elsif params[:group] != @group
                              MiqGroup.find(params[:group])
                            end
-                         end
+          end
 
           klass = get_class_from_controller_param(request.parameters[:controller])
           param_ids = params[:objectIds].map(&:to_i)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -404,6 +404,20 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  context 'Mixins::Actions::VmActions::Ownership' do
+    let(:vm) { FactoryGirl.create(:vm_vmware) }
+
+    it 'handles dont-change vs nil' do
+      expect(VmOrTemplate).to receive(:set_ownership).with([vm.id], {:group => nil})
+      post :ownership_update, :params => {
+        :user => "dont-change",
+        :group => "",
+        :objectIds => [vm.id],
+        :button => 'save',
+      }
+    end
+  end
+
   context 'transform VM dialog' do
     let(:dialog)           { FactoryGirl.create(:dialog, :label => 'Transform VM', :buttons => 'submit') }
     let!(:resource_action) { FactoryGirl.create(:resource_action, :dialog => dialog) }


### PR DESCRIPTION
Since #1578, when doing Set Ownership over multiple items:

* set user to a User, set group to dont-change
... user gets set to User, and group gets reset to nil

* set group to a Group, set user to dont-change
... group gets set to Group, and user gets reset to nil

This makes sure we don't reset groups or users unless asked to.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1657260

---

The difference is that...

`Vm.set_ownership([123], {:user => (User)}` only changes user,
but `Vm.set_ownership([123], {:user => (User), :group => nil}` updates both.