### PR TITLE
Fix travis - jest

### DIFF
--- a/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
+++ b/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
@@ -6,7 +6,6 @@ import CloudTenantForm from '../../components/cloud-tenant-form/cloud-tenant-for
 
 require('../helpers/miqSparkle.js');
 require('../helpers/miqAjaxButton.js');
-require('../helpers/mockAsyncRequest.js');
 
 describe('Cloud tenant form component', () => {
   let emsChoices;

--- a/app/javascript/spec/service-form/service-form.spec.js
+++ b/app/javascript/spec/service-form/service-form.spec.js
@@ -7,7 +7,6 @@ import ServiceForm from '../../components/service-form';
 require('../helpers/addFlash.js');
 require('../helpers/miqSparkle.js');
 require('../helpers/miqAjaxButton.js');
-require('../helpers/mockAsyncRequest.js');
 
 describe('Service form component', () => {
   let initialProps;

--- a/app/javascript/spec/set-service-ownership-form/set-service-ownership-form.spec.js
+++ b/app/javascript/spec/set-service-ownership-form/set-service-ownership-form.spec.js
@@ -4,6 +4,8 @@ import FormRenderer from '@data-driven-forms/react-form-renderer';
 import SetServiceOwnershipForm from '../../components/set-service-ownership-form';
 import createSchema from '../../components/set-service-ownership-form/schema';
 import { http } from '../../http_api';
+import '../helpers/miqAjaxButton';
+import '../helpers/addFlash';
 
 describe('Set service ownership form component', () => {
   let initialProps;

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -3,6 +3,8 @@ window.$ = require('jquery');
 window.__ = (x) => x;
 window.n__ = (x) => x;
 
+require('whatwg-fetch');
+
 require('../app/assets/javascripts/miq_global');
 
 import { rxSubject, sendDataWithRx, listenToRx } from '../app/javascript/miq_observable';


### PR DESCRIPTION
Fixes..

```
 FAIL  app/javascript/spec/set-service-ownership-form/set-service-ownership-form.spec.js
  Set service ownership form component
    ✕ encountered a declaration exception (3ms)
  ● Set service ownership form component › encountered a declaration exception
    Cannot spy the miqAjaxButton property because it is not a function; undefined given instead
```

Caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/5046 + https://github.com/ManageIQ/manageiq-ui-classic/pull/5027.

(The latter moved some requires, and the first PR never reran travis after the second was merged.)

CC @ZitaNemeckova @Hyperkid123 