### PR TITLE
Added i18n form data-driven-forms default validation messages.

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import FormRender from '@data-driven-forms/react-form-renderer';
+import FormRender, { Validators } from '@data-driven-forms/react-form-renderer';
 import { formFieldsMapper, layoutMapper } from '@data-driven-forms/pf3-component-mapper';
+
+Validators.messages = {
+  ...Validators.messages,
+  required: __('Required'),
+};
 
 const buttonLabels = {
   submitLabel: __('Save'),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "^0.1.3",
-    "@data-driven-forms/react-form-renderer": "^1.2.1",
+    "@data-driven-forms/react-form-renderer": "^1.4.2",
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.2.0",
     "@pf3/select": "~1.12.6",


### PR DESCRIPTION
Added validators translation config for data-driven-forms. Every validator has its default message. So far, we are using only `Required` validation in forms. But that will soon change.

![screenshot from 2018-12-10 09-05-25](https://user-images.githubusercontent.com/22619452/49718582-d5431680-fc5a-11e8-862d-8786ca1673fc.png)
