### PR TITLE
[HAMMER] select: use @pf3/select instead of bootstrap-select

### DIFF
--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -6,7 +6,7 @@ window.$ = window.jQuery = require('jquery');
 require('bootstrap');
 require('bootstrap-datepicker');
 require('bootstrap-filestyle');
-require('bootstrap-select');
+require('@pf3/select');
 require('bootstrap-switch');
 require('bootstrap-touchspin');
 require('eonasdan-bootstrap-datetimepicker');

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -12,6 +12,7 @@
           :multiple          => true,
           "data-width"       => "850px",
           "data-live-search" => "true",
+          "data-live-search-focus" => "false",
           :class             => 'selectpicker',
           :style             => "overflow-x: scroll;",
           :id                => "available_fields",

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -123,7 +123,10 @@ module.exports = {
   },
 
   resolve: {
-    alias: { 'react': resolve(dirname(__filename), '../../node_modules', 'react') },
+    alias: {
+      'react': resolve(dirname(__filename), '../../node_modules', 'react'),
+      'bootstrap-select': '@pf3/select',  // never use vanilla bootstrap-select
+    },
     extensions: settings.extensions,
     modules: [],
     plugins: [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.1.18",
+    "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",
     "angular-animate": "~1.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,7 +52,7 @@
     redux-form-validators "^2.7.0"
     redux-mock-store "^1.5.1"
 
-"@manageiq/ui-components@1.1.18":
+"@manageiq/ui-components@~1.1.18":
   version "1.1.18"
   resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.1.18.tgz#e8ee8325fb0f7aa8d5d173fbd4fabd7d2b35c2db"
   integrity sha512-7xtGx091jlsQMKKUZ3eBXhFFqbNPNjI4X2xfKRJdZxv15Lvnu08GS6t5gtXrqTpYpfEdhBHvvy74es8jXzN4IQ==
@@ -65,6 +65,11 @@
     es7-shim "^6.0.0"
     eslint "~3.9.1"
     sprintf-js "^1.1.1"
+
+"@pf3/select@~1.12.6":
+  version "1.12.6"
+  resolved "https://registry.yarnpkg.com/@pf3/select/-/select-1.12.6.tgz#8beec7e016e2c501b8ff1222c2c673e57b24de43"
+  integrity sha512-xWGufPx1+H8LFMgmTPzmdgSiv9Zo7y/quFneo6Qon6yJcYdZtaJ+rv5oBzQoTgZNxIqEzVozJ+cykKGrGsxDZQ==
 
 "@pf3/timeline@~1.0.8":
   version "1.0.8"


### PR DESCRIPTION
This is a hammer version of #5029 

---

this replaces bootstrap-select 1.12.2 with 1.12.5,
except that 1.12.5 comes from my fork, as upstream is nonresponsive

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648115

EDIT: 1.12.6, 5 had bad paths in dist/

---

The practical difference should be https://github.com/himdel/bootstrap-select/pull/1 :

multiselect with search should not scroll up to the search bar whenever an item is chosen in the dropdown, when data-live-search-focus is set to false.

---

This also sets `data-live-search-focus` to false for available fields in the Report form, fixing the BZ :).