### PR TITLE
Enable JSX for eslint - codeclimate & yarn run lint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -59,6 +59,9 @@ engines:
         enabled: false
     config:
       ignore_warnings: true
+      extensions:
+      - .js
+      - .jsx
   fixme:
     # let's enable later
     enabled: false

--- a/app/javascript/.eslintrc.json
+++ b/app/javascript/.eslintrc.json
@@ -34,6 +34,7 @@
     }],
     "no-use-before-define": ["error", { "functions": false, "classes": false }],
     "react/jsx-filename-extension": "off",
+    "react/destructuring-assignment": [1, "always"],
     "space-before-function-paren": [2, "never"],
     "no-extra-boolean-cast": "off"
   }

--- a/app/javascript/components/miq-about-modal.jsx
+++ b/app/javascript/components/miq-about-modal.jsx
@@ -66,11 +66,13 @@ class MiqAboutModal extends React.Component {
     const browser = window.miqBrowserDetect();
     const plugins = Object.keys(data.server_info.plugins).map((key) => {
       const val = data.server_info.plugins[key];
-      return (<AboutModal.VersionItem
-        label={val.display_name}
-        versionText={val.version}
-        key={key}
-      />);
+      return (
+        <AboutModal.VersionItem
+          label={val.display_name}
+          versionText={val.version}
+          key={key}
+        />
+      );
     });
 
     return (
@@ -94,7 +96,10 @@ class MiqAboutModal extends React.Component {
           <AboutModal.VersionItem label={__('Browser OS')} versionText={browser.OS} />
           <br />
           <a style={{ color: 'white' }} onClick={() => this.setState({ expand: !this.state.expand })} href="javascript:void(0);">
-            <strong><i className={this.state.expand ? 'fa fa-angle-down' : 'fa fa-angle-right'} /> Plugins</strong>
+            <strong>
+              <i className={this.state.expand ? 'fa fa-angle-down' : 'fa fa-angle-right'} />
+              Plugins
+            </strong>
           </a>
           <div className={this.state.expand ? 'about-visible-scrollbar' : 'hidden'} style={{ height: '200px', overflow: 'auto' }}>
             {plugins}

--- a/app/javascript/components/service-form/index.jsx
+++ b/app/javascript/components/service-form/index.jsx
@@ -13,12 +13,14 @@ class ServiceForm extends Component {
       schema: createSchema(props.maxNameLen, props.maxDescLen),
     };
   }
+
   componentDidMount() {
     cleanVirtualDom();
     miqSparkleOn();
     http.get(`/service/service_form_fields/${this.props.serviceFormId}`)
       .then(data => this.setState({ initialValues: { ...data } }, miqSparkleOff()));
   }
+
   render() {
     const { serviceFormId } = this.props;
     const cancelUrl = `/service/service_edit/${serviceFormId}?button=cancel`;

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -38,4 +38,3 @@ function mapStateToProps(state, ownProps) {
 }
 
 export default connect(mapStateToProps)(FormButtonsRedux);
-

--- a/app/javascript/forms/form-buttons-redux.jsx
+++ b/app/javascript/forms/form-buttons-redux.jsx
@@ -12,7 +12,12 @@ function FormButtonsRedux(props) {
 }
 
 FormButtonsRedux.propTypes = {
-  callbackOverrides: PropTypes.object,
+  callbackOverrides: PropTypes.shape({
+    addClicked: PropTypes.func,
+    saveClicked: PropTypes.func,
+    resetClicked: PropTypes.func,
+    cancelClicked: PropTypes.func,
+  }),
 };
 
 FormButtonsRedux.defaultProps = {

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -12,11 +12,11 @@ function FormButtons(props) {
 
   return (
     <React.Fragment>
-      <div className="clearfix"></div>
+      <div className="clearfix" />
       <div className="pull-right button-group edit_buttons">
-        <MiqButton name={primaryTitle} title={primaryTitle} enabled={props.saveable} onClick={primaryHandler} primary={true} />
+        <MiqButton name={primaryTitle} title={primaryTitle} enabled={props.saveable} onClick={primaryHandler} primary />
         {props.newRecord || <MiqButton name={resetTitle} title={resetTitle} enabled={! props.pristine} onClick={props.resetClicked} />}
-        <MiqButton name={cancelTitle} title={cancelTitle} enabled={true} onClick={props.cancelClicked} />
+        <MiqButton name={cancelTitle} title={cancelTitle} enabled onClick={props.cancelClicked} />
 
       </div>
     </React.Fragment>

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -36,7 +36,7 @@ FormButtons.propTypes = {
 
 const noop = () => null;
 
-FormButtons.defaultProps =  {
+FormButtons.defaultProps = {
   newRecord: false,
   customLabel: '',
   saveable: false,
@@ -45,6 +45,6 @@ FormButtons.defaultProps =  {
   saveClicked: noop,
   resetClicked: noop,
   cancelClicked: noop,
-}
+};
 
 export default FormButtons;

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import MiqButton from './miq-button';
 
 function FormButtons(props) {
-  let primaryTitle = props.customLabel || (props.newRecord ? __('Add') : __('Save'));
-  let primaryHandler = (props.newRecord ? props.addClicked : props.saveClicked) || props.addClicked || props.saveClicked;
+  const primaryTitle = props.customLabel || (props.newRecord ? __('Add') : __('Save'));
+  const primaryHandler = (props.newRecord ? props.addClicked : props.saveClicked) || props.addClicked || props.saveClicked;
 
-  let resetTitle = __("Reset");
-  let cancelTitle = __("Cancel");
+  const resetTitle = __('Reset');
+  const cancelTitle = __('Cancel');
 
   return (
     <React.Fragment>

--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -29,10 +29,12 @@ function MiqButton(props) {
   };
 
   return (
-    <button className={klass}
+    <button
+      className={klass}
       onClick={buttonClicked}
       title={title}
-      alt={title}>
+      alt={title}
+    >
       {props.name}
     </button>
   );

--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -11,7 +11,7 @@ function MiqButton(props) {
     title = props.disabledTitle;
   }
 
-  let klass = ClassNames({
+  const klass = ClassNames({
     'btn': true,
     'btn-xs': props.xs,
     'btn-primary': props.primary,
@@ -19,7 +19,7 @@ function MiqButton(props) {
     'disabled': !props.enabled,
   });
 
-  let buttonClicked = (event) => {
+  const buttonClicked = (event) => {
     if (props.enabled) {
       props.onClick();
     }

--- a/app/javascript/react/generic_group_wrapper.jsx
+++ b/app/javascript/react/generic_group_wrapper.jsx
@@ -5,4 +5,4 @@ import textualSummaryGenericClick from './textual_summary_click';
 export default (props) => {
   const onClick = props.onClick || textualSummaryGenericClick;
   return <GenericGroup onClick={onClick} {...props} />;
-}
+};

--- a/app/javascript/react/textual_summary_wrapper.jsx
+++ b/app/javascript/react/textual_summary_wrapper.jsx
@@ -5,4 +5,4 @@ import textualSummaryGenericClick from './textual_summary_click';
 export default (props) => {
   const onClick = props.onClick || textualSummaryGenericClick;
   return <TextualSummary onClick={onClick} {...props} />;
-}
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:current": "jest --watch",
-    "lint": "eslint -c app/javascript/.eslintrc.js --fix app/javascript || exit 0",
+    "lint": "eslint --ext=js,jsx .",
     "stylelint": "stylelint 'app/**/*css'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "base64-js": "~1.2.3",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-switch": "~3.3.4",
+    "classnames": "~2.2.6",
     "codemirror": "~5.19.0",
     "connected-react-router": "^4.3.0",
     "eonasdan-bootstrap-datetimepicker": "~4.17.47",


### PR DESCRIPTION
Eslint can lint jsx files just fine, but does not do so by default (https://github.com/eslint/eslint/pull/8515 and related).

So.. enabling jsx linting on code climate (cc @Hyperkid123) ([docs](https://docs.codeclimate.com/docs/eslint#section-extensions)),
and fixing the old `lint` task to do the same.

(The lint task currently fails because of changes to configfile locations in https://github.com/ManageIQ/manageiq-ui-classic/pull/5023.)