### PR TITLE
FactoryGirl to FactoryBot

### DIFF
--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -1,11 +1,11 @@
 describe AnsibleCredentialController do
   before do
     EvmSpecHelper.assign_embedded_ansible_role
-    login_as FactoryGirl.create(:user_admin)
+    login_as FactoryBot.create(:user_admin)
   end
 
   describe "#show" do
-    let(:machine_credential) { FactoryGirl.create(:embedded_ansible_scm_credential, :options=>{}) }
+    let(:machine_credential) { FactoryBot.create(:embedded_ansible_scm_credential, :options=>{}) }
     subject { get :show, :params => {:id => machine_credential.id} }
     render_views
 

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -1,11 +1,11 @@
 describe AnsiblePlaybookController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user_admin)
+    login_as FactoryBot.create(:user_admin)
   end
 
   describe "#show" do
-    let(:playbook) { FactoryGirl.create(:embedded_playbook) }
+    let(:playbook) { FactoryBot.create(:embedded_playbook) }
     subject { get :show, :params => {:id => playbook.id} }
     render_views
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -4,9 +4,9 @@ describe AnsibleRepositoryController do
 
     before do
       EvmSpecHelper.assign_embedded_ansible_role
-      login_as FactoryGirl.create(:user_admin)
+      login_as FactoryBot.create(:user_admin)
       # creating repository takes time, so we do it only once
-      @repository = FactoryGirl.create(:embedded_ansible_configuration_script_source, :name => "Test Repository")
+      @repository = FactoryBot.create(:embedded_ansible_configuration_script_source, :name => "Test Repository")
     end
 
     describe "#show" do
@@ -39,7 +39,7 @@ describe AnsibleRepositoryController do
 
     describe "#show_association" do
       before do
-        @playbook = FactoryGirl.create(:embedded_playbook, :name => 'playbook_name', :configuration_script_source => @repository)
+        @playbook = FactoryBot.create(:embedded_playbook, :name => 'playbook_name', :configuration_script_source => @repository)
       end
 
       it "shows associated playbooks" do

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeCustomizationController, "ApplicationController::Automate" do
   context "#resolve" do
     before do
       stub_user(:features => :all)
-      @custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+      @custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
       target_classes = {}
       CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
       resolve = {
@@ -19,7 +19,7 @@ describe MiqAeCustomizationController, "ApplicationController::Automate" do
     end
 
     it "targets should be set correctly when simulate button is pressed from custom button summary screen" do
-      host = FactoryGirl.create(:host)
+      host = FactoryBot.create(:host)
       expect(controller).to receive(:render)
       controller.send(:resolve_button_simulate)
       expect(assigns(:resolve)[:targets]).to eq([[host.name, host.id.to_s]])
@@ -29,7 +29,7 @@ end
 
 describe MiqAeToolsController, "ApplicationController::Automate" do
   context "#build_results" do
-    let(:custom_button) { FactoryGirl.create(:custom_button, :applies_to_class => "Host") }
+    let(:custom_button) { FactoryBot.create(:custom_button, :applies_to_class => "Host") }
     let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
     before do
       stub_user(:features => :all)

--- a/spec/controllers/application_controller/build_audit_spec.rb
+++ b/spec/controllers/application_controller/build_audit_spec.rb
@@ -20,7 +20,7 @@ describe ApplicationController do
     end
 
     it "tests build_created_audit" do
-      category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
+      category = FactoryBot.create(:classification, :name => 'environment', :description => 'Environment')
       edit = {:new => {:name => "the-name", :changing_value => "test2", :static_value => "same",
                            :hash_value => {:h1 => "first", :h2 => "second", :hash_password => "pw1"},
                            :password => "pw1"}}
@@ -34,7 +34,7 @@ describe ApplicationController do
     end
 
     it "tests build_saved_audit" do
-      category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
+      category = FactoryBot.create(:classification, :name => 'environment', :description => 'Environment')
       edit = {:current => {:name => "the-name", :changing_value => "test",  :static_value => "same",
                            :hash_value => {:h1 => "first", :h2 => "second", :hash_password => "pw1"}},
               :new     => {:name => "the-name", :changing_value => "test2", :static_value => "same",

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -1,10 +1,10 @@
 describe ApplicationController do
   context "#custom_buttons" do
-    let(:resource_action) { FactoryGirl.create(:resource_action, :dialog_id => 1) }
-    let(:button)          { FactoryGirl.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
-    let(:host)            { FactoryGirl.create(:host_vmware) }
-    let(:vm)              { FactoryGirl.create(:vm_vmware, :name => "My VM") }
-    let(:service)         { FactoryGirl.create(:service) }
+    let(:resource_action) { FactoryBot.create(:resource_action, :dialog_id => 1) }
+    let(:button)          { FactoryBot.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
+    let(:host)            { FactoryBot.create(:host_vmware) }
+    let(:vm)              { FactoryBot.create(:vm_vmware, :name => "My VM") }
+    let(:service)         { FactoryBot.create(:service) }
 
     context "with a resource_action dialog" do
       it "Vm button" do
@@ -100,7 +100,7 @@ describe ApplicationController do
 
     context "#button_create_update" do
       it "no need to set @record when add/cancel form buttons are pressed" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
         controller.instance_variable_set(:@_params, :button => "cancel", :id => custom_button.id)
         edit = {
           :new           => {},
@@ -119,7 +119,7 @@ describe ApplicationController do
       end
 
       it "the active tab is Advanced when the button pressed is an expression" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
         controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
         edit = {:new           => {},
                 :current       => {},
@@ -137,7 +137,7 @@ describe ApplicationController do
       end
 
       it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
         controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
         edit = {:new           => {},
                 :current       => {},
@@ -154,7 +154,7 @@ describe ApplicationController do
       end
 
       it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
+        custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
         controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
         edit = {:new           => {},
                 :current       => {},
@@ -178,7 +178,7 @@ describe ApplicationController do
       #   which, in turn, needs *something* to come back from automate
       allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
 
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm", :options => {:display => false, :button_icon => "fa fa-info"})
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Vm", :options => {:display => false, :button_icon => "fa fa-info"})
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "req"
       custom_button.save
@@ -210,7 +210,7 @@ describe ApplicationController do
       e_expression = MiqExpression.new("=" => {:field => "Vm.name", :value => "Test"}, :token => 1)
       v_expression = MiqExpression.new("!=" => {:field => "Vm.description", :value => "DescriptionTest"}, :token => 1)
 
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm", :visibility_expression => v_expression, :enablement_expression => e_expression, :options => {:display => false, :button_icon => "5"})
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Vm", :visibility_expression => v_expression, :enablement_expression => e_expression, :options => {:display => false, :button_icon => "5"})
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "test_req"
       custom_button.resource_action.dialog_id = 42
@@ -240,8 +240,8 @@ describe ApplicationController do
       # button_set_form_vars expects that the simulation screen will be built,
       #   which, in turn, needs *something* to come back from automate
       allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
-      service_template = FactoryGirl.create(:service_template_ansible_playbook, :name => "playbook_test")
-      custom_button = FactoryGirl.create(:custom_button,
+      service_template = FactoryBot.create(:service_template_ansible_playbook, :name => "playbook_test")
+      custom_button = FactoryBot.create(:custom_button,
                                          :applies_to_class => "Vm",
                                          :options          => {:display     => false,
                                                                :button_icon => "fa fa-info",
@@ -311,8 +311,8 @@ describe ApplicationController do
 
   context "#button_set_record_vars" do
     it "sets role visibility for custom button" do
-      role = FactoryGirl.create(:miq_user_role, :name => "foo")
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm", :options => {:display => false, :button_icon => "5"})
+      role = FactoryBot.create(:miq_user_role, :name => "foo")
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Vm", :options => {:display => false, :button_icon => "5"})
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "test_req"
       custom_button.save
@@ -336,8 +336,8 @@ describe ApplicationController do
 
   context "#automate_button_field_changed" do
     context 'sets dialog_id' do
-      let(:resource_action) { FactoryGirl.create(:resource_action, :dialog_id => 1) }
-      let(:button)          { FactoryGirl.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
+      let(:resource_action) { FactoryBot.create(:resource_action, :dialog_id => 1) }
+      let(:button)          { FactoryBot.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
       before do
         controller.instance_variable_set(:@custom_button, button)
         allow(controller).to receive(:render).and_return(nil)
@@ -366,9 +366,9 @@ describe ApplicationController do
     end
 
     context 'sets @edit[:new][:disabled_open_url]' do
-      let(:resource_action) { FactoryGirl.create(:resource_action, :dialog_id => 1) }
-      let(:button_for_vm) { FactoryGirl.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
-      let(:button_for_az) { FactoryGirl.create(:custom_button, :name => "My Button", :applies_to_class => "AvailabilityZone", :resource_action => resource_action) }
+      let(:resource_action) { FactoryBot.create(:resource_action, :dialog_id => 1) }
+      let(:button_for_vm) { FactoryBot.create(:custom_button, :name => "My Button", :applies_to_class => "Vm", :resource_action => resource_action) }
+      let(:button_for_az) { FactoryBot.create(:custom_button, :name => "My Button", :applies_to_class => "AvailabilityZone", :resource_action => resource_action) }
       before do
         allow(controller).to receive(:render).and_return(nil)
         edit = {

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -1,17 +1,17 @@
 describe ApplicationController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.create(:zone) }
+  let(:zone) { FactoryBot.create(:zone) }
 
   before do
     EvmSpecHelper.local_miq_server
-    login_as FactoryGirl.create(:user, :features => "everything")
+    login_as FactoryBot.create(:user, :features => "everything")
     allow(controller).to receive(:role_allows?).and_return(true)
   end
 
   describe "#generic_button_operation" do
-    let(:vm1) { FactoryGirl.create(:vm_redhat) }
-    let(:vm2) { FactoryGirl.create(:vm_microsoft) }
-    let(:vm3) { FactoryGirl.create(:vm_vmware) }
+    let(:vm1) { FactoryBot.create(:vm_redhat) }
+    let(:vm2) { FactoryBot.create(:vm_microsoft) }
+    let(:vm3) { FactoryBot.create(:vm_vmware) }
     let(:controller_name) { VmOrTemplate }
 
     context 'record does not support the action' do
@@ -35,7 +35,7 @@ describe ApplicationController do
   end
 
   describe "action_to_feature" do
-    let(:record) { FactoryGirl.create(:vm_redhat) }
+    let(:record) { FactoryBot.create(:vm_redhat) }
 
     context 'the UI action is also a queryable feature' do
       before do
@@ -105,11 +105,11 @@ describe ApplicationController do
     end
 
     let :container1 do
-      FactoryGirl.create(:cloud_object_store_container)
+      FactoryBot.create(:cloud_object_store_container)
     end
 
     let :container2 do
-      FactoryGirl.create(:cloud_object_store_container)
+      FactoryBot.create(:cloud_object_store_container)
     end
 
     context "from list view" do
@@ -184,7 +184,7 @@ describe ApplicationController do
       end
 
       let :container do
-        FactoryGirl.create(:cloud_object_store_container)
+        FactoryBot.create(:cloud_object_store_container)
       end
 
       it "get_rec_cls" do
@@ -250,11 +250,11 @@ describe ApplicationController do
     end
 
     let :object1 do
-      FactoryGirl.create(:cloud_object_store_object)
+      FactoryBot.create(:cloud_object_store_object)
     end
 
     let :object2 do
-      FactoryGirl.create(:cloud_object_store_object)
+      FactoryBot.create(:cloud_object_store_object)
     end
 
     context "from list view" do
@@ -335,7 +335,7 @@ describe ApplicationController do
       end
 
       let :object do
-        FactoryGirl.create(:cloud_object_store_object)
+        FactoryBot.create(:cloud_object_store_object)
       end
 
       it "get_rec_cls" do
@@ -398,7 +398,7 @@ describe ApplicationController do
 
   context "Delete object store object" do
     let :object1 do
-      FactoryGirl.create(:cloud_object_store_object)
+      FactoryBot.create(:cloud_object_store_object)
     end
 
     before do
@@ -433,11 +433,11 @@ describe ApplicationController do
     end
 
     let :container1 do
-      FactoryGirl.create(:cloud_object_store_container)
+      FactoryBot.create(:cloud_object_store_container)
     end
 
     let :container2 do
-      FactoryGirl.create(:cloud_object_store_container)
+      FactoryBot.create(:cloud_object_store_container)
     end
 
     context "from list view" do
@@ -518,7 +518,7 @@ describe ApplicationController do
       end
 
       let :container do
-        FactoryGirl.create(:cloud_object_store_container)
+        FactoryBot.create(:cloud_object_store_container)
       end
 
       it "get_rec_cls" do
@@ -598,7 +598,7 @@ describe ApplicationController do
   end
 
   it "Certain actions should not be allowed for a MiqTemplate record" do
-    template = FactoryGirl.create(:template_vmware)
+    template = FactoryBot.create(:template_vmware)
     controller.instance_variable_set(:@_params, :id => template.id)
     actions = %i(vm_right_size vm_reconfigure)
     actions.each do |action|
@@ -611,8 +611,8 @@ describe ApplicationController do
 
   it "Certain actions should be allowed only for a VM record" do
     feature = MiqProductFeature.find_all_by_identifier(["everything"])
-    login_as FactoryGirl.create(:user, :features => feature)
-    vm = FactoryGirl.create(:vm_vmware)
+    login_as FactoryBot.create(:user, :features => feature)
+    vm = FactoryBot.create(:vm_vmware)
     controller.instance_variable_set(:@_params, :id => vm.id)
     actions = %i(vm_right_size vm_reconfigure)
     actions.each do |action|
@@ -624,7 +624,7 @@ describe ApplicationController do
 
   context "Verify the reconfigurable flag for VMs" do
     it "Reconfigure VM action should be allowed only for a VM marked as reconfigurable" do
-      vm = FactoryGirl.create(:vm_vmware)
+      vm = FactoryBot.create(:vm_vmware)
       controller.instance_variable_set(:@_params, :id => vm.id)
       record = controller.send(:get_record, "vm")
       action = :vm_reconfigure
@@ -636,7 +636,7 @@ describe ApplicationController do
       end
     end
     it "Reconfigure VM action should not be allowed for a VM marked as reconfigurable" do
-      vm = FactoryGirl.create(:vm_microsoft)
+      vm = FactoryBot.create(:vm_microsoft)
       controller.instance_variable_set(:@_params, :id => vm.id)
       record = controller.send(:get_record, "vm")
       action = :vm_reconfigure
@@ -650,7 +650,7 @@ describe ApplicationController do
   end
 
   describe "#supports_reconfigure_disks?" do
-    let(:vm) { FactoryGirl.create(:vm_redhat) }
+    let(:vm) { FactoryBot.create(:vm_redhat) }
 
     context "when a single is vm selected" do
       let(:supports_reconfigure_disks) { true }
@@ -673,7 +673,7 @@ describe ApplicationController do
     end
 
     context "when multiple vms selected" do
-      let(:vm1) { FactoryGirl.create(:vm_redhat) }
+      let(:vm1) { FactoryBot.create(:vm_redhat) }
       it "disables reconfigure disks" do
         controller.instance_variable_set(:@reconfigitems, [vm, vm1])
         expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
@@ -722,13 +722,13 @@ describe ApplicationController do
 
   context "#process_elements" do
     it "shows passed in display name in flash message" do
-      pxe = FactoryGirl.create(:pxe_server)
+      pxe = FactoryBot.create(:pxe_server)
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue', 'Refresh Relationships')
       expect(assigns(:flash_array).first[:message]).to include("Refresh Relationships successfully initiated")
     end
 
     it "shows task name in flash message when display name is not passed in" do
-      pxe = FactoryGirl.create(:pxe_server)
+      pxe = FactoryBot.create(:pxe_server)
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue')
       expect(assigns(:flash_array).first[:message])
         .to include("synchronize_advertised_images_queue successfully initiated")
@@ -743,7 +743,7 @@ describe ApplicationController do
     end
 
     it "Verify @record is set for passed in ID" do
-      ems = FactoryGirl.create(:ext_management_system)
+      ems = FactoryBot.create(:ext_management_system)
       record = controller.send(:identify_record, ems.id, ExtManagementSystem)
       expect(record).to be_a_kind_of(ExtManagementSystem)
     end
@@ -751,7 +751,7 @@ describe ApplicationController do
 
   context "#get_record" do
     it "use passed in db to set class for identify_record call" do
-      host = FactoryGirl.create(:host)
+      host = FactoryBot.create(:host)
       controller.instance_variable_set(:@_params, :id => host.id)
       record = controller.send(:get_record, "host")
       expect(record).to be_a_kind_of(Host)
@@ -759,31 +759,31 @@ describe ApplicationController do
   end
 
   describe "#build_ownership_info" do
-    let(:child_role)                     { FactoryGirl.create(:miq_user_role, :name => "Role_1") }
-    let(:grand_child_tenant_role)        { FactoryGirl.create(:miq_user_role, :name => "Role_2") }
-    let(:great_grand_child_tenant_role)  { FactoryGirl.create(:miq_user_role, :name => "Role_3") }
+    let(:child_role)                     { FactoryBot.create(:miq_user_role, :name => "Role_1") }
+    let(:grand_child_tenant_role)        { FactoryBot.create(:miq_user_role, :name => "Role_2") }
+    let(:great_grand_child_tenant_role)  { FactoryBot.create(:miq_user_role, :name => "Role_3") }
 
-    let(:child_tenant)             { FactoryGirl.create(:tenant) }
-    let(:grand_child_tenant)       { FactoryGirl.create(:tenant, :parent => child_tenant) }
-    let(:great_grand_child_tenant) { FactoryGirl.create(:tenant, :parent => grand_child_tenant) }
+    let(:child_tenant)             { FactoryBot.create(:tenant) }
+    let(:grand_child_tenant)       { FactoryBot.create(:tenant, :parent => child_tenant) }
+    let(:great_grand_child_tenant) { FactoryBot.create(:tenant, :parent => grand_child_tenant) }
 
     let(:child_group) do
-      FactoryGirl.create(:miq_group, :description => "Child group", :role => child_role, :tenant => child_tenant)
+      FactoryBot.create(:miq_group, :description => "Child group", :role => child_role, :tenant => child_tenant)
     end
 
     let(:grand_child_group) do
-      FactoryGirl.create(:miq_group, :description => "Grand child group", :role => grand_child_tenant_role,
+      FactoryBot.create(:miq_group, :description => "Grand child group", :role => grand_child_tenant_role,
                                      :tenant => grand_child_tenant)
     end
 
     let(:great_grand_child_group) do
-      FactoryGirl.create(:miq_group, :description => "Great Grand Child group", :role => great_grand_child_tenant_role,
+      FactoryBot.create(:miq_group, :description => "Great Grand Child group", :role => great_grand_child_tenant_role,
                                      :tenant => great_grand_child_tenant)
     end
-    let(:admin_user) { FactoryGirl.create(:user_admin) }
+    let(:admin_user) { FactoryBot.create(:user_admin) }
 
     it "lists all non-tenant groups when (admin user is logged)" do
-      @vm_or_template = FactoryGirl.create(:vm_or_template)
+      @vm_or_template = FactoryBot.create(:vm_or_template)
       @ownership_items = [@vm_or_template.id]
       login_as(admin_user)
       controller.instance_variable_set(:@_params, :controller => 'vm_or_template')
@@ -798,15 +798,15 @@ end
 
 describe HostController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.create(:zone) }
+  let(:zone) { FactoryBot.create(:zone) }
 
   context "#show_association" do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @host = FactoryGirl.create(:host)
-      @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
-      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @host = FactoryBot.create(:host)
+      @guest_application = FactoryBot.create(:guest_application, :name => "foo", :host_id => @host.id)
+      @datastore = FactoryBot.create(:storage, :name => 'storage_name')
       @datastore.parent = @host
     end
 
@@ -848,9 +848,9 @@ describe HostController do
 
   context "#process_objects" do
     it "returns array of object ids " do
-      vm1 = FactoryGirl.create(:vm_vmware)
-      vm2 = FactoryGirl.create(:vm_vmware)
-      vm3 = FactoryGirl.create(:vm_vmware)
+      vm1 = FactoryBot.create(:vm_vmware)
+      vm2 = FactoryBot.create(:vm_vmware)
+      vm3 = FactoryBot.create(:vm_vmware)
       vms = [vm1.id, vm2.id, vm3.id]
       controller.send(:process_objects, vms, 'refresh_ems', 'Refresh Provider')
       flash_messages = assigns(:flash_array)
@@ -860,8 +860,8 @@ describe HostController do
 
   context "#process_hosts" do
     before do
-      @host1 = FactoryGirl.create(:host)
-      @host2 = FactoryGirl.create(:host)
+      @host1 = FactoryBot.create(:host)
+      @host2 = FactoryBot.create(:host)
       allow(controller).to receive(:filter_ids_in_region).and_return([[@host1, @host2], nil])
     end
 
@@ -889,8 +889,8 @@ describe HostController do
     end
 
     it "when the vm_or_template supports scan,  returns false" do
-      vm1 =  FactoryGirl.create(:vm_microsoft)
-      vm2 =  FactoryGirl.create(:vm_vmware)
+      vm1 =  FactoryBot.create(:vm_microsoft)
+      vm2 =  FactoryBot.create(:vm_vmware)
       controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm1.id}, #{vm2.id}")
       controller.send(:generic_button_operation,
                       'scan',
@@ -901,9 +901,9 @@ describe HostController do
     end
 
     it "when the vm_or_template supports scan,  returns true" do
-      vm = FactoryGirl.create(:vm_vmware,
-                              :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-                              :storage               => FactoryGirl.create(:storage))
+      vm = FactoryBot.create(:vm_vmware,
+                              :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+                              :storage               => FactoryBot.create(:storage))
       controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
       process_proc = controller.send(:vm_button_action)
       expect(process_proc).to receive(:call)
@@ -917,22 +917,22 @@ end
 
 describe ServiceController do
   context "#vm_button_operation" do
-    let(:user) { FactoryGirl.create(:user_admin) }
+    let(:user) { FactoryBot.create(:user_admin) }
 
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(MiqServer).to receive(:my_zone).and_return("default")
-      allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
+      allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
       controller.instance_variable_set(:@lastaction, "show_list")
       login_as user
       allow(user).to receive(:role_allows?).and_return(true)
     end
 
     it "should continue to retire a service and does not render flash message 'xxx does not apply xxx' " do
-      service = FactoryGirl.create(:service)
-      template = FactoryGirl.create(:template,
-                                    :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-                                    :storage               => FactoryGirl.create(:storage))
+      service = FactoryBot.create(:service)
+      template = FactoryBot.create(:template,
+                                    :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+                                    :storage               => FactoryBot.create(:storage))
       service.update_attribute(:id, template.id)
       service.reload
       controller.instance_variable_set(:@_params, :miq_grid_checks => service.id.to_s)
@@ -957,9 +957,9 @@ describe MiqTemplateController do
     it "should continue to set ownership for a template" do
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:drop_breadcrumb)
-      template = FactoryGirl.create(:template,
-                                    :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-                                    :storage               => FactoryGirl.create(:storage))
+      template = FactoryBot.create(:template,
+                                    :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+                                    :storage               => FactoryBot.create(:storage))
       controller.instance_variable_set(:@_params,
                                        :miq_grid_checks => template.id.to_s,
                                        :pressed         => 'miq_template_set_ownership')
@@ -974,12 +974,12 @@ end
 
 describe VmOrTemplateController do
   context "#vm_button_operation" do
-    let(:user) { FactoryGirl.create(:user_admin) }
+    let(:user) { FactoryBot.create(:user_admin) }
 
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(MiqServer).to receive(:my_zone).and_return("default")
-      allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
+      allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
       allow(controller).to receive(:render)
       controller.instance_variable_set(:@lastaction, "show_list")
       login_as user
@@ -987,15 +987,15 @@ describe VmOrTemplateController do
     end
 
     it "should render flash message when trying to retire a template" do
-      vm = FactoryGirl.create(
+      vm = FactoryBot.create(
         :vm_vmware,
-        :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-        :storage               => FactoryGirl.create(:storage)
+        :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+        :storage               => FactoryBot.create(:storage)
       )
-      template = FactoryGirl.create(
+      template = FactoryBot.create(
         :template,
-        :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-        :storage               => FactoryGirl.create(:storage)
+        :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+        :storage               => FactoryBot.create(:storage)
       )
       controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm.id}, #{template.id}")
       process_proc = controller.send(:vm_button_action)
@@ -1011,10 +1011,10 @@ describe VmOrTemplateController do
     end
 
     it "should continue to retire a vm" do
-      vm = FactoryGirl.create(
+      vm = FactoryBot.create(
         :vm_vmware,
-        :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
-        :storage               => FactoryGirl.create(:storage)
+        :ext_management_system => FactoryBot.create(:ems_openstack_infra),
+        :storage               => FactoryBot.create(:storage)
       )
 
       controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
@@ -1030,12 +1030,12 @@ end
 
 describe OrchestrationStackController do
   context "#orchestration_stack_delete" do
-    let(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_cloud) }
-    let(:orchestration_stack_deleted) { FactoryGirl.create(:orchestration_stack_cloud) }
+    let(:orchestration_stack) { FactoryBot.create(:orchestration_stack_cloud) }
+    let(:orchestration_stack_deleted) { FactoryBot.create(:orchestration_stack_cloud) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user_admin)
+      login_as FactoryBot.create(:user_admin)
       controller.instance_variable_set(:@lastaction, "show_list")
       allow(controller).to receive(:role_allows?).and_return(true)
     end
@@ -1064,7 +1064,7 @@ end
 
 describe EmsCloudController do
   describe "#delete_flavor" do
-    let!(:flavor) { FactoryGirl.create(:flavor) }
+    let!(:flavor) { FactoryBot.create(:flavor) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       stub_user(:features => :all)

--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationController do
   context "#drift_history" do
     it "resets @display to main" do
-      vm = FactoryGirl.create(:vm_vmware, :name => "My VM")
+      vm = FactoryBot.create(:vm_vmware, :name => "My VM")
       controller.instance_variable_set(:@display, "vms")
       controller.instance_variable_set(:@sb, {})
       controller.instance_variable_set(:@drift_obj, vm)

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -135,7 +135,7 @@ describe CatalogController do
 
   describe "#dialog_form_button_pressed" do
     let(:dialog) { double("Dialog") }
-    let(:workflow) { FactoryGirl.build(:miq_provision_workflow) }
+    let(:workflow) { FactoryBot.build(:miq_provision_workflow) }
     let(:wf) { double(:dialog => dialog) }
 
     before do
@@ -160,7 +160,7 @@ describe CatalogController do
 
     it "stay on the current model page after the dialog is submitted if a request is not created" do
       controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
-      st = FactoryGirl.create(:service_template)
+      st = FactoryBot.create(:service_template)
       controller.x_node = "xx-st st-#{st.id}"
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:get_node_info)

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -13,7 +13,7 @@ describe VmInfraController do
       end
 
       it "valid node" do
-        rec = FactoryGirl.create(:service_template_catalog)
+        rec = FactoryBot.create(:service_template_catalog)
         active_node = "stc-#{rec.id}"
 
         controller.instance_variable_set(:@sb, :trees => {active_tree => {:active_node => active_node}}, :active_tree => active_tree)
@@ -23,7 +23,7 @@ describe VmInfraController do
       end
 
       it "node no longer exists" do
-        rec = FactoryGirl.create(:service_template_catalog)
+        rec = FactoryBot.create(:service_template_catalog)
         active_node = "stc-#{rec.id + 1}"
 
         controller.instance_variable_set(:@sb, :trees => {active_tree => {:active_node => active_node}}, :active_tree => active_tree)
@@ -34,10 +34,10 @@ describe VmInfraController do
     end
 
     context "#rbac_filtered_objects" do
-      let(:ems_folder) { FactoryGirl.create(:ems_folder) }
-      let!(:ems) { FactoryGirl.create(:ems_vmware, :ems_folders => [ems_folder]) }
-      let(:user)       { FactoryGirl.create(:user_admin) }
-      let(:vm)         { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
+      let(:ems_folder) { FactoryBot.create(:ems_folder) }
+      let!(:ems) { FactoryBot.create(:ems_vmware, :ems_folders => [ems_folder]) }
+      let(:user)       { FactoryBot.create(:user_admin) }
+      let(:vm)         { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
 
       before do
         EvmSpecHelper.create_guid_miq_server_zone
@@ -106,7 +106,7 @@ end
 describe ReportController do
   context '#tree_add_child_nodes' do
     it 'calls tree_add_child_nodes TreeBuilder method' do
-      widget = FactoryGirl.create(:miq_widget, :description => "Foo", :title => "Foo", :content_type => "report")
+      widget = FactoryBot.create(:miq_widget, :description => "Foo", :title => "Foo", :content_type => "report")
       controller.instance_variable_set(:@sb,
                                        :trees       => {:widgets_tree => {:active_node => "root",
                                                                           :klass_name  => "TreeBuilderReportWidgets",

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -1,8 +1,8 @@
 describe ApplicationController::Filter do
   describe '#available_adv_searches' do
-    let(:user)           { FactoryGirl.create(:user) }
-    let!(:user_search)   { FactoryGirl.create(:miq_search_user, :search_key => user.userid) }
-    let!(:user_search2)  { FactoryGirl.create(:miq_search_user, :search_key => user.userid) }
+    let(:user)           { FactoryBot.create(:user) }
+    let!(:user_search)   { FactoryBot.create(:miq_search_user, :search_key => user.userid) }
+    let!(:user_search2)  { FactoryBot.create(:miq_search_user, :search_key => user.userid) }
     let(:expression)     { ApplicationController::Filter::Expression.new.tap { |e| e.exp_model = 'Vm' } }
 
     before do
@@ -17,8 +17,8 @@ describe ApplicationController::Filter do
     end
 
     context 'with global searches' do
-      let!(:global_search)  { FactoryGirl.create(:miq_search_global) }
-      let!(:global_search2) { FactoryGirl.create(:miq_search_global) }
+      let!(:global_search)  { FactoryBot.create(:miq_search_global) }
+      let!(:global_search2) { FactoryBot.create(:miq_search_global) }
 
       it 'returns global searches and then user searches' do
         expect(expression.available_adv_searches).to eq [
@@ -31,7 +31,7 @@ describe ApplicationController::Filter do
     end
 
     it 'does not include searches from other users' do
-      FactoryGirl.create(:miq_search_user, :search_key => -1) # A search from another "user"
+      FactoryBot.create(:miq_search_user, :search_key => -1) # A search from another "user"
 
       expect(expression.available_adv_searches).to eq [
         [user_search.description,  user_search.id],

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -78,9 +78,9 @@ describe ApplicationController, "::Filter" do
   end
 
   describe "#save_default_search" do
-    let(:user) { FactoryGirl.create(:user_with_group, :settings => {:default_search => {}}) }
+    let(:user) { FactoryBot.create(:user_with_group, :settings => {:default_search => {}}) }
     it "saves settings" do
-      search = FactoryGirl.create(:miq_search, :name => 'sds')
+      search = FactoryBot.create(:miq_search, :name => 'sds')
 
       login_as user
       controller.instance_variable_set(:@settings, {})

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -1,7 +1,7 @@
 describe MiqRequestController do
   describe "#dialog_partial_for_workflow" do
     before do
-      @wf = FactoryGirl.create(:miq_provision_virt_workflow)
+      @wf = FactoryBot.create(:miq_provision_virt_workflow)
     end
 
     it "calculates partial using wf from @edit hash" do
@@ -24,18 +24,18 @@ describe MiqRequestController do
     end
 
     it "calculates partial using wf from @edit hash when both @edit & @options are present" do
-      controller.instance_variable_set(:@edit, :wf => FactoryGirl.create(:miq_provision_configured_system_foreman_workflow))
+      controller.instance_variable_set(:@edit, :wf => FactoryBot.create(:miq_provision_configured_system_foreman_workflow))
       controller.instance_variable_set(:@options, :wf => @wf)
       partial = controller.send(:dialog_partial_for_workflow)
       expect(partial).to eq('prov_configured_system_foreman_dialog')
     end
 
     it "clears the request datacenter name field when the source VM is changed" do
-      datacenter = FactoryGirl.create(:datacenter, :name => 'dcname')
-      ems_folder = FactoryGirl.create(:ems_folder)
-      ems = FactoryGirl.create(:ems_vmware)
-      template = FactoryGirl.create(:template_vmware)
-      vm2 = FactoryGirl.create(:vm_vmware)
+      datacenter = FactoryBot.create(:datacenter, :name => 'dcname')
+      ems_folder = FactoryBot.create(:ems_folder)
+      ems = FactoryBot.create(:ems_vmware)
+      template = FactoryBot.create(:template_vmware)
+      vm2 = FactoryBot.create(:vm_vmware)
       datacenter.ext_management_system = ems
       ems_folder.ext_management_system = ems
       @wf.instance_variable_set(:@dialogs, :dialogs => {:environment => {:fields => {:placement_dc_name => {:values => {datacenter.id.to_s => datacenter.name}}}}})

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -1,10 +1,10 @@
 describe ApplicationController do
   context "#perf_planning_gen_data" do
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryGirl.create(:zone) }
+    let(:zone) { FactoryBot.create(:zone) }
 
     it "should not get nil error when submitting up Manual Input data" do
-      _enterprise = FactoryGirl.create(:miq_enterprise)
+      _enterprise = FactoryBot.create(:miq_enterprise)
       sb = {
         :options => {
           :target_typ => "EmsCluster",
@@ -47,7 +47,7 @@ describe ApplicationController do
     describe 'perf_gen_tag_data_before_wait' do
       %w(Hourly Daily).each do |type|
         it "calls initiate_wait_for_task for '#{type}'" do
-          controller.instance_variable_set(:@perf_record, FactoryGirl.create(:host))
+          controller.instance_variable_set(:@perf_record, FactoryBot.create(:host))
           controller.instance_variable_set(
             :@perf_options,
             :typ          => type,
@@ -76,7 +76,7 @@ describe ApplicationController do
         expect(Classification).to receive(:find_by_name).with('cat').and_return(cat)
 
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@perf_record, FactoryGirl.create(:host))
+        controller.instance_variable_set(:@perf_record, FactoryBot.create(:host))
         controller.instance_variable_set(
           :@perf_options,
           :typ   => 'Hourly',

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationController do
   describe "#assign_policies" do
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-    let(:host)       { FactoryGirl.create(:host) }
+    let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
+    let(:host)       { FactoryBot.create(:host) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/controllers/application_controller/report_downloads_spec.rb
+++ b/spec/controllers/application_controller/report_downloads_spec.rb
@@ -2,8 +2,8 @@ describe ApplicationController do
   context "report downloads" do
     describe "set_summary_pdf_data" do
       before do
-        hw = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
-        @template = FactoryGirl.create(:vm_or_template, :hardware => hw)
+        hw = FactoryBot.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
+        @template = FactoryBot.create(:vm_or_template, :hardware => hw)
         controller.instance_variable_set(:@record, @template)
         controller.instance_variable_set(:@display, "download_pdf")
         allow(controller).to receive(:disable_client_cache).and_return(nil)

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationController do
   describe "#get_tagdata" do
     let(:record) { double("Host") }
-    let(:user) { FactoryGirl.create(:user, :userid => "testuser") }
+    let(:user) { FactoryBot.create(:user, :userid => "testuser") }
 
     before do
       login_as user
@@ -42,7 +42,7 @@ describe ApplicationController do
                      :single_value => cat.single_value,
                      :ns           => cat.ns)
       options[:parent_id] = cat.id # Ugly way to set up a child
-      FactoryGirl.create(:classification, options)
+      FactoryBot.create(:classification, options)
     end
 
     # creating record in different region
@@ -57,12 +57,12 @@ describe ApplicationController do
 
     before do
       # setup classification/entries with same name in different regions
-      clergy = FactoryGirl.create(:classification, :description => "Clergy")
+      clergy = FactoryBot.create(:classification, :description => "Clergy")
       add_entry(clergy, :name => "bishop", :description => "Bishop")
 
       # add another classification with different description,
       # then change description to be same as above after updating region id of record
-      clergy2 = FactoryGirl.create(:classification, :description => "Clergy2")
+      clergy2 = FactoryBot.create(:classification, :description => "Clergy2")
       update_record_region(clergy2)
       clergy2.update_column(:description, "Clergy")
 
@@ -70,7 +70,7 @@ describe ApplicationController do
       update_record_region(clergy_bishop2)
 
       allow(Classification).to receive(:my_region_number).and_return(convert_to_region_id(clergy_bishop2.id))
-      @st = FactoryGirl.create(:service_template, :name => 'foo')
+      @st = FactoryBot.create(:service_template, :name => 'foo')
     end
 
     it "region id of classification/entries should match" do
@@ -114,7 +114,7 @@ describe ApplicationController do
 
   describe EmsInfraController do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(storage_tag))
+      login_as FactoryBot.create(:user, :features => %w(storage_tag))
       controller.instance_variable_set(:@_params, params)
       controller.instance_variable_set(:@display, "storages")
     end

--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -12,8 +12,8 @@ describe DashboardController do
     end
 
     it "uses the user's tenant" do
-      tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
-      user = FactoryGirl.create(:user_with_group, :tenant => tenant)
+      tenant = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
+      user = FactoryBot.create(:user_with_group, :tenant => tenant)
       login_as user
       get :login
       expect(controller.send(:current_tenant)).to eq(tenant)

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationController, "#Timelines" do
   describe EmsInfraController do
     context "#tl_chooser" do
       before do
-        @ems = FactoryGirl.create(:ems_openstack_infra)
+        @ems = FactoryBot.create(:ems_openstack_infra)
         controller.instance_variable_set(:@tl_options,
                                          ApplicationController::Timelines::Options.new)
       end

--- a/spec/controllers/application_controller/timezone_spec.rb
+++ b/spec/controllers/application_controller/timezone_spec.rb
@@ -25,7 +25,7 @@ describe ApplicationController, "#Timezone" do
       end
 
       it "with a timezone" do
-        user = FactoryGirl.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
+        user = FactoryBot.create(:user, :settings => {:display => {:timezone => "Pacific Time (US & Canada)"}})
         Timecop.freeze(Time.utc(2013, 1, 1)) do
           expect(subject.get_timezone_offset(user)).to eq(-8.hours)
         end
@@ -33,7 +33,7 @@ describe ApplicationController, "#Timezone" do
 
       context "without a timezone" do
         it "with a system default" do
-          user = FactoryGirl.create(:user)
+          user = FactoryBot.create(:user)
           stub_settings(:server => {:timezone => "Eastern Time (US & Canada)"})
 
           Timecop.freeze(Time.utc(2013, 1, 1)) do
@@ -49,7 +49,7 @@ describe ApplicationController, "#Timezone" do
         end
 
         it "without a system default" do
-          user = FactoryGirl.create(:user)
+          user = FactoryBot.create(:user)
           stub_settings(:server => {})
 
           expect(subject.get_timezone_offset(user)).to eq(0.hours)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,10 +5,10 @@ describe ApplicationController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       controller.instance_variable_set(:@sb, {})
-      ur = FactoryGirl.create(:miq_user_role)
+      ur = FactoryBot.create(:miq_user_role)
       rptmenu = {:report_menus => [["Configuration Management", ["Hosts", ["Hosts Summary", "Hosts Summary"]]]]}
-      group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
-      login_as FactoryGirl.create(:user, :miq_groups => [group])
+      group = FactoryBot.create(:miq_group, :miq_user_role => ur, :settings => rptmenu)
+      login_as FactoryBot.create(:user, :miq_groups => [group])
     end
 
     it "Verify Invalid input flash error message when invalid id is passed in" do
@@ -20,7 +20,7 @@ describe ApplicationController do
     end
 
     it "Verify record gets set when valid id is passed in" do
-      ems = FactoryGirl.create(:ext_management_system)
+      ems = FactoryBot.create(:ext_management_system)
       expect(controller.send(:find_record_with_rbac, ExtManagementSystem, ems.id)).to eq(ems)
     end
   end
@@ -29,7 +29,7 @@ describe ApplicationController do
     before do
       EvmSpecHelper.seed_specific_product_features("host_new", "host_edit", "perf_reload")
       feature = MiqProductFeature.find_all_by_identifier(["host_new"])
-      login_as FactoryGirl.create(:user, :features => feature)
+      login_as FactoryBot.create(:user, :features => feature)
     end
 
     it "should not raise an error for feature that user has access to" do
@@ -101,7 +101,7 @@ describe ApplicationController do
   end
 
   describe "#prov_redirect" do
-    let(:user) { FactoryGirl.create(:user, :features => "vm_migrate") }
+    let(:user) { FactoryBot.create(:user, :features => "vm_migrate") }
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
       login_as user
@@ -109,8 +109,8 @@ describe ApplicationController do
     end
 
     it "returns flash message when Migrate button is pressed with list containing SCVMM VM" do
-      vm1 = FactoryGirl.create(:vm_vmware)
-      vm2 = FactoryGirl.create(:vm_microsoft)
+      vm1 = FactoryBot.create(:vm_vmware)
+      vm2 = FactoryBot.create(:vm_microsoft)
       controller.instance_variable_set(:@_params, :pressed         => "vm_migrate",
                                                   :miq_grid_checks => "#{vm1.id},#{vm2.id}")
       controller.set_response!(response)
@@ -118,12 +118,12 @@ describe ApplicationController do
       expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
     end
 
-    let(:ems)     { FactoryGirl.create(:ext_management_system) }
-    let(:storage) { FactoryGirl.create(:storage) }
+    let(:ems)     { FactoryBot.create(:ext_management_system) }
+    let(:storage) { FactoryBot.create(:storage) }
 
     it "sets variables when Migrate button is pressed with list of VMware VMs" do
-      vm1 = FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
-      vm2 = FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
+      vm1 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
+      vm2 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
       controller.instance_variable_set(:@_params, :pressed         => "vm_migrate",
                                                   :miq_grid_checks => "#{vm1.id},#{vm2.id}")
       controller.set_response!(response)
@@ -135,14 +135,14 @@ describe ApplicationController do
 
   describe "#prov_redirect" do
     before do
-      login_as FactoryGirl.create(:user, :features => "image_miq_request_new")
+      login_as FactoryBot.create(:user, :features => "image_miq_request_new")
       allow(User).to receive(:server_timezone).and_return("UTC")
       controller.request.parameters[:pressed] = "image_miq_request_new"
       controller.instance_variable_set(:@explorer, true)
     end
 
     it "returns flash message when Provisioning button is pressed from list and selected Image is archived" do
-      template = FactoryGirl.create(:miq_template,
+      template = FactoryBot.create(:miq_template,
                                     :name     => "template 1",
                                     :vendor   => "vmware",
                                     :location => "template1.vmtx")
@@ -155,11 +155,11 @@ describe ApplicationController do
       expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
     end
 
-    let(:ems)     { FactoryGirl.create(:ems_openstack) }
-    let(:storage) { FactoryGirl.create(:storage) }
+    let(:ems)     { FactoryBot.create(:ems_openstack) }
+    let(:storage) { FactoryBot.create(:storage) }
 
     it "sets provisioning data and skips pre provisioning dialog" do
-      template = FactoryGirl.create(:template_openstack,
+      template = FactoryBot.create(:template_openstack,
                                     :name                  => "template 1",
                                     :vendor                => "vmware",
                                     :location              => "template1.vmtx",
@@ -276,8 +276,8 @@ describe ApplicationController do
 
   describe "#get_view" do
     before do
-      search = FactoryGirl.create(:miq_search, :name => 'sds')
-      user = FactoryGirl.create(:user_with_group, :settings => {:default_search => {:Host => search.id}})
+      search = FactoryBot.create(:miq_search, :name => 'sds')
+      user = FactoryBot.create(:user_with_group, :settings => {:default_search => {:Host => search.id}})
       login_as user
       session[:settings] = {:default_search => {:Host => search.id},
                             :views          => {:persistentvolume => 'list'},
@@ -299,14 +299,14 @@ describe ApplicationController do
 
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
 
-      group1 = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Group1")
-      @user1 = FactoryGirl.create(:user, :userid => "User1", :miq_groups => [group1], :email => "user1@test.com")
+      group1 = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Group1")
+      @user1 = FactoryBot.create(:user, :userid => "User1", :miq_groups => [group1], :email => "user1@test.com")
 
-      group2 = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Group2")
-      @user2 = FactoryGirl.create(:user, :userid => "User2", :miq_groups => [group2], :email => "user2@test.com")
+      group2 = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Group2")
+      @user2 = FactoryBot.create(:user, :userid => "User2", :miq_groups => [group2], :email => "user2@test.com")
 
-      current_group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Current Group")
-      @current_user = FactoryGirl.create(:user, :userid => "Current User", :miq_groups => [current_group, group1],
+      current_group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Current Group")
+      @current_user = FactoryBot.create(:user, :userid => "Current User", :miq_groups => [current_group, group1],
                                                 :email => "current_user@test.com")
 
       login_as @current_user

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -1,14 +1,14 @@
 describe AuthKeyPairCloudController do
-  let(:kp) { FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01") }
-  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-  let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
-  let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+  let(:kp) { FactoryBot.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01") }
+  let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
+  let(:tag2) { FactoryBot.create(:classification_tag, :name => "tag2", :parent => classification) }
 
   before do
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
-    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => kp)
-    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => kp)
+    FactoryBot.create(:tagging, :tag => tag1.tag, :taggable => kp)
+    FactoryBot.create(:tagging, :tag => tag2.tag, :taggable => kp)
   end
 
   describe "#tags_edit" do

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -3,9 +3,9 @@ describe AutomationManagerController do
 
   let(:zone) { EvmSpecHelper.local_miq_server.zone }
   let(:tags) { ["/managed/quota_max_memory/2048"] }
-  let(:automation_provider1) { FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest", :url => "10.8.96.107", :zone => zone) }
-  let(:automation_provider2) { FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest2", :url => "10.8.96.108", :zone => zone) }
-  let(:automation_provider3) { FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest_no_cs", :url => "192.0.2.1", :zone => zone) }
+  let(:automation_provider1) { FactoryBot.create(:provider_ansible_tower, :name => "ansibletest", :url => "10.8.96.107", :zone => zone) }
+  let(:automation_provider2) { FactoryBot.create(:provider_ansible_tower, :name => "ansibletest2", :url => "10.8.96.108", :zone => zone) }
+  let(:automation_provider3) { FactoryBot.create(:provider_ansible_tower, :name => "ansibletest_no_cs", :url => "192.0.2.1", :zone => zone) }
 
   before do
     Tag.find_or_create_by(:name => tags.first)
@@ -31,9 +31,9 @@ describe AutomationManagerController do
       cs.tag_with(tags, :namespace => '')
     end
 
-    @ans_job_template1 = FactoryGirl.create(:ansible_configuration_script, :name => "ConfigScript1", :manager_id => @automation_manager1.id)
-    @ans_job_template2 = FactoryGirl.create(:ansible_configuration_script, :name => "ConfigScript2", :manager_id => @automation_manager2.id)
-    @ans_job_template3 = FactoryGirl.create(:ansible_configuration_script, :name => "ConfigScript3", :manager_id => @automation_manager1.id)
+    @ans_job_template1 = FactoryBot.create(:ansible_configuration_script, :name => "ConfigScript1", :manager_id => @automation_manager1.id)
+    @ans_job_template2 = FactoryBot.create(:ansible_configuration_script, :name => "ConfigScript2", :manager_id => @automation_manager2.id)
+    @ans_job_template3 = FactoryBot.create(:ansible_configuration_script, :name => "ConfigScript3", :manager_id => @automation_manager1.id)
   end
 
   it "renders index" do
@@ -57,8 +57,8 @@ describe AutomationManagerController do
 
   it "renders explorer sorted by url" do
     login_as user_with_feature(%w(automation_manager_providers automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest3", :url => "z_url", :zone => zone)
-    FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest4", :url => "a_url", :zone => zone)
+    FactoryBot.create(:provider_ansible_tower, :name => "ansibletest3", :url => "z_url", :zone => zone)
+    FactoryBot.create(:provider_ansible_tower, :name => "ansibletest4", :url => "a_url", :zone => zone)
 
     get :explorer, :params => {:sortby => '2'}
     expect(response.status).to eq(200)
@@ -138,7 +138,7 @@ describe AutomationManagerController do
     end
 
     it "should display the zone field" do
-      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryBot.create(:zone, :name => "TestZone")
       controller.instance_variable_set(:@provider, automation_provider1)
       post :edit, :params => { :id => @automation_manager1.id }
       expect(response.status).to eq(200)
@@ -146,7 +146,7 @@ describe AutomationManagerController do
     end
 
     it "should save the zone field" do
-      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryBot.create(:zone, :name => "TestZone")
       controller.instance_variable_set(:@provider, automation_provider1)
       allow(controller).to receive(:leaf_record).and_return(false)
       post :edit, :params => { :button     => 'save',
@@ -387,7 +387,7 @@ describe AutomationManagerController do
     end
 
     it 'renders tree_select for one job template' do
-      record = FactoryGirl.create(:ansible_configuration_script,
+      record = FactoryBot.create(:ansible_configuration_script,
                                   :name        => "ConfigScriptTest1",
                                   :survey_spec => {'spec' => [{'index' => 0, 'question_description' => 'Survey',
                                                                'type' => 'text'}]})
@@ -440,9 +440,9 @@ describe AutomationManagerController do
     session[:tag_items] = [@ans_configured_system.id]
     session[:assigned_filters] = []
     allow(controller).to receive(:x_active_accord).and_return(:automation_manager_cs_filter)
-    parent = FactoryGirl.create(:classification, :name => "test_category")
-    FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
-    FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
+    parent = FactoryBot.create(:classification, :name => "test_category")
+    FactoryBot.create(:classification_tag,      :name => "test_entry",         :parent => parent)
+    FactoryBot.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
     post :tagging, :params => { :id => @ans_configured_system.id, :format => :js }
     expect(response.status).to eq(200)
   end
@@ -512,7 +512,7 @@ describe AutomationManagerController do
     render_views
 
     it 'can render details for a job template' do
-      @record = FactoryGirl.create(:ansible_configuration_script,
+      @record = FactoryBot.create(:ansible_configuration_script,
                                    :name        => "ConfigScript1",
                                    :survey_spec => {'spec' => [{'index' => 0, 'question_description' => 'Survey',
                                                                 'min' => nil, 'default' => nil, 'max' => nil,
@@ -602,7 +602,7 @@ describe AutomationManagerController do
   context "#configscript_service_dialog" do
     before do
       stub_user(:features => :all)
-      @cs = FactoryGirl.create(:ansible_configuration_script)
+      @cs = FactoryBot.create(:ansible_configuration_script)
       @dialog_label = "New Dialog 01"
       session[:edit] = {
         :new    => {:dialog_name => @dialog_label},
@@ -639,9 +639,9 @@ describe AutomationManagerController do
       session[:assigned_filters] = []
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
       allow(controller).to receive(:tagging_explorer_controller?).and_return(true)
-      parent = FactoryGirl.create(:classification, :name => "test_category")
-      FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
-      FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
+      parent = FactoryBot.create(:classification, :name => "test_category")
+      FactoryBot.create(:classification_tag,      :name => "test_entry",         :parent => parent)
+      FactoryBot.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
       post :tagging, :params => {:id => @cs.id, :format => :js}
       expect(response.status).to eq(200)
       expect(response.body).to include('Template (Ansible Tower) Being Tagged')
@@ -653,11 +653,11 @@ describe AutomationManagerController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       allow(@ans_configured_system).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@ans_configured_system).and_return([@tag1, @tag2])
@@ -697,7 +697,7 @@ describe AutomationManagerController do
 
   def user_with_feature(features)
     features = EvmSpecHelper.specific_product_features(*features)
-    FactoryGirl.create(:user, :features => features)
+    FactoryBot.create(:user, :features => features)
   end
 
   def find_treenode_for_provider(provider, tree_json)

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -2,8 +2,8 @@ describe AvailabilityZoneController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @zone = FactoryGirl.create(:availability_zone)
-      login_as FactoryGirl.create(:user_admin)
+      @zone = FactoryBot.create(:availability_zone)
+      login_as FactoryBot.create(:user_admin)
     end
 
     subject do

--- a/spec/controllers/bottlenecks_controller_spec.rb
+++ b/spec/controllers/bottlenecks_controller_spec.rb
@@ -3,8 +3,8 @@ describe BottlenecksController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       stub_user(:features => :all)
-      FactoryGirl.create(:miq_enterprise)
-      FactoryGirl.create(:miq_region, :description => "My Region")
+      FactoryBot.create(:miq_enterprise)
+      FactoryBot.create(:miq_region, :description => "My Region")
     end
 
     describe '#index' do
@@ -30,11 +30,11 @@ describe BottlenecksController do
 
   describe '#get_node_info' do
     it 'sets correct right cell headers' do
-      mr = FactoryGirl.create(:miq_region, :description => "My Region")
-      e = FactoryGirl.create(:ems_vmware, :name => "My Management System")
-      cl = FactoryGirl.create(:ems_cluster, :name => "My Cluster")
-      host = FactoryGirl.create(:host, :name => "My Host")
-      ds = FactoryGirl.create(:storage_vmware, :name => "My Datastore")
+      mr = FactoryBot.create(:miq_region, :description => "My Region")
+      e = FactoryBot.create(:ems_vmware, :name => "My Management System")
+      cl = FactoryBot.create(:ems_cluster, :name => "My Cluster")
+      host = FactoryBot.create(:host, :name => "My Host")
+      ds = FactoryBot.create(:storage_vmware, :name => "My Datastore")
       title_suffix = 'Bottlenecks Summary'
       tree_nodes = {:region => {:active_node  => "mr-#{mr.id}",
                                 :title_prefix => "Region",

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,16 +1,16 @@
 describe CatalogController do
   context "tests that needs all rbac features access" do
-    let(:user)                { FactoryGirl.create(:user_with_group) }
-    let(:admin_user)          { FactoryGirl.create(:user, :role => "super_administrator") }
+    let(:user)                { FactoryBot.create(:user_with_group) }
+    let(:admin_user)          { FactoryBot.create(:user, :role => "super_administrator") }
     let(:root_tenant)         { user.current_tenant }
-    let(:tenant_role)         { FactoryGirl.create(:miq_user_role) }
-    let(:child_tenant)        { FactoryGirl.create(:tenant, :parent => root_tenant) }
-    let(:child_tenant_group)  { FactoryGirl.create(:miq_group, :tenant => child_tenant, :miq_user_role => tenant_role) }
-    let(:child_tenant_user)   { FactoryGirl.create(:user, :miq_groups => [child_tenant_group]) }
+    let(:tenant_role)         { FactoryBot.create(:miq_user_role) }
+    let(:child_tenant)        { FactoryBot.create(:tenant, :parent => root_tenant) }
+    let(:child_tenant_group)  { FactoryBot.create(:miq_group, :tenant => child_tenant, :miq_user_role => tenant_role) }
+    let(:child_tenant_user)   { FactoryBot.create(:user, :miq_groups => [child_tenant_group]) }
 
-    let!(:service_template_with_root_tenant) { FactoryGirl.create(:service_template, :tenant => root_tenant) }
+    let!(:service_template_with_root_tenant) { FactoryBot.create(:service_template, :tenant => root_tenant) }
     let!(:service_template_with_child_tenant) do
-      FactoryGirl.create(:service_template, :miq_group => child_tenant_group, :tenant => child_tenant)
+      FactoryBot.create(:service_template, :miq_group => child_tenant_group, :tenant => child_tenant)
     end
 
     before do
@@ -157,11 +157,11 @@ describe CatalogController do
       it "Atomic Service Template and its valid Resource Actions are saved" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "save")
-        st = FactoryGirl.create(:service_template)
+        st = FactoryBot.create(:service_template)
         3.times.each do |i|
-          ns = FactoryGirl.create(:miq_ae_namespace, :name => "ns#{i}")
-          cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls#{i}")
-          FactoryGirl.create(:miq_ae_instance, :class_id => cls.id, :name => "inst#{i}")
+          ns = FactoryBot.create(:miq_ae_namespace, :name => "ns#{i}")
+          cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls#{i}")
+          FactoryBot.create(:miq_ae_instance, :class_id => cls.id, :name => "inst#{i}")
         end
         retire_fqname    = 'ns0/cls0/inst0'
         provision_fqname = 'ns1/cls1/inst1'
@@ -191,7 +191,7 @@ describe CatalogController do
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => 'save')
-        st = FactoryGirl.create(:service_template)
+        st = FactoryBot.create(:service_template)
         retire_fqname    = 'ns/cls/inst'
         provision_fqname = 'ns1/cls1/inst1'
         recon_fqname     = 'ns2/cls2/inst2'
@@ -223,10 +223,10 @@ describe CatalogController do
 
     describe "#x_button catalogitem_edit" do
       before do
-        vm = FactoryGirl.create(:vm_vmware,
-                                :ext_management_system => FactoryGirl.create(:ems_vmware),
-                                :storage               => FactoryGirl.create(:storage))
-        @miq_request = FactoryGirl.create(:miq_provision_request, :requester => admin_user, :src_vm_id => vm.id)
+        vm = FactoryBot.create(:vm_vmware,
+                                :ext_management_system => FactoryBot.create(:ems_vmware),
+                                :storage               => FactoryBot.create(:storage))
+        @miq_request = FactoryBot.create(:miq_provision_request, :requester => admin_user, :src_vm_id => vm.id)
         service_template_with_root_tenant.update_attributes(:prov_type => 'vmware')
         service_template_with_root_tenant.add_resource(@miq_request)
         service_template_with_root_tenant.save
@@ -249,7 +249,7 @@ describe CatalogController do
       it "@record is cleared out after Service Template is added" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "add")
-        st = FactoryGirl.create(:service_template)
+        st = FactoryBot.create(:service_template)
         controller.instance_variable_set(:@record, st)
         provision_fqname = 'ns1/cls1/inst1'
         edit = {
@@ -275,11 +275,11 @@ describe CatalogController do
 
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "save")
-        @st = FactoryGirl.create(:service_template)
+        @st = FactoryBot.create(:service_template)
         3.times.each do |i|
-          ns = FactoryGirl.create(:miq_ae_namespace, :name => "ns#{i}")
-          cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls#{i}")
-          FactoryGirl.create(:miq_ae_instance, :class_id => cls.id, :name => "inst#{i}")
+          ns = FactoryBot.create(:miq_ae_namespace, :name => "ns#{i}")
+          cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls#{i}")
+          FactoryBot.create(:miq_ae_instance, :class_id => cls.id, :name => "inst#{i}")
         end
         retire_fqname    = 'ns0/cls0/inst0'
         provision_fqname = 'ns1/cls1/inst1'
@@ -338,7 +338,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template name and description are edited" do
-        ot = FactoryGirl.create(:orchestration_template_amazon)
+        ot = FactoryBot.create(:orchestration_template_amazon)
         controller.instance_variable_set(:@record, ot)
         controller.params.merge!(:id => ot.id, :template_content => @new_content)
         session[:edit][:key] = "ot_edit__#{ot.id}"
@@ -356,7 +356,7 @@ describe CatalogController do
       end
 
       it "Azure Orchestration Template name and description are edited" do
-        ot = FactoryGirl.create(:orchestration_template_azure_in_json)
+        ot = FactoryBot.create(:orchestration_template_azure_in_json)
         controller.instance_variable_set(:@record, ot)
         controller.params.merge!(:id => ot.id, :template_content => @new_content)
         session[:edit][:key] = "ot_edit__#{ot.id}"
@@ -374,7 +374,7 @@ describe CatalogController do
       end
 
       it "Read-only Orchestration Template content cannot be edited" do
-        ot = FactoryGirl.create(:orchestration_template_amazon_with_stacks)
+        ot = FactoryBot.create(:orchestration_template_amazon_with_stacks)
         original_content = ot.content
         controller.params.merge!(:id => ot.id, :template_content => @new_content)
         session[:edit][:key] = "ot_edit__#{ot.id}"
@@ -390,7 +390,7 @@ describe CatalogController do
       it "Orchestration Template content cannot be empty during edit" do
         controller.instance_variable_set(:@_params, :button => "save")
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
-        ot = FactoryGirl.create(:orchestration_template)
+        ot = FactoryBot.create(:orchestration_template)
         session[:edit][:key] = "ot_edit__#{ot.id}"
         session[:edit][:rec_id] = ot.id
         original_content = ot.content
@@ -405,7 +405,7 @@ describe CatalogController do
       end
 
       it "Draft flag is set for an Orchestration Template" do
-        ot = FactoryGirl.create(:orchestration_template)
+        ot = FactoryBot.create(:orchestration_template)
         controller.params.merge!(:id => ot.id, :template_content => @new_content)
         session[:edit][:key] = "ot_edit__#{ot.id}"
         session[:edit][:rec_id] = ot.id
@@ -423,7 +423,7 @@ describe CatalogController do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_params, :button => "add")
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
-        ot = FactoryGirl.create(:orchestration_template_amazon)
+        ot = FactoryBot.create(:orchestration_template_amazon)
         controller.x_node = "xx-otcfn_ot-#{ot.id}"
         @new_name = "New Name"
         new_description = "New Description"
@@ -463,7 +463,7 @@ describe CatalogController do
       it "Orchestration Template is copied but name is changed" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
-        ot = FactoryGirl.create(:orchestration_template_amazon)
+        ot = FactoryBot.create(:orchestration_template_amazon)
         controller.x_node = "xx-otcfn_ot-#{ot.id}"
         name = "New Name"
         description = "New Description"
@@ -507,7 +507,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template is deleted" do
-        ot = FactoryGirl.create(:orchestration_template)
+        ot = FactoryBot.create(:orchestration_template)
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         controller.instance_variable_set(:@_params, :id => ot.id)
         controller.send(:ot_remove_submit)
@@ -517,7 +517,7 @@ describe CatalogController do
       end
 
       it "Read-only Orchestration Template cannot deleted" do
-        ot = FactoryGirl.create(:orchestration_template_with_stacks)
+        ot = FactoryBot.create(:orchestration_template_with_stacks)
         controller.params[:id] = ot.id
         controller.send(:ot_remove_submit)
         expect(controller.send(:flash_errors?)).to be_truthy
@@ -585,13 +585,13 @@ describe CatalogController do
 
     describe "#tags_edit" do
       before do
-        @ot = FactoryGirl.create(:orchestration_template, :name => "foo")
+        @ot = FactoryBot.create(:orchestration_template, :name => "foo")
         allow(@ot).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-        @tag1 = FactoryGirl.create(:classification_tag,
+        classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryBot.create(:classification_tag,
                                    :name   => "tag1",
                                    :parent => classification)
-        @tag2 = FactoryGirl.create(:classification_tag,
+        @tag2 = FactoryBot.create(:classification_tag,
                                    :name   => "tag2",
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).with(@ot).and_return([@tag1, @tag2])
@@ -642,7 +642,7 @@ describe CatalogController do
 
     describe "#service_dialog_create_from_ot" do
       before do
-        @ot = FactoryGirl.create(:orchestration_template_amazon_in_json)
+        @ot = FactoryBot.create(:orchestration_template_amazon_in_json)
         @dialog_label = "New Dialog 01"
         session[:edit] = {
           :new    => {:dialog_name => @dialog_label},
@@ -681,9 +681,9 @@ describe CatalogController do
           }
         }
 
-        FactoryGirl.create(:orchestration_template_amazon_in_json)
-        FactoryGirl.create(:orchestration_template_openstack_in_yaml)
-        FactoryGirl.create(:orchestration_template_azure_in_json)
+        FactoryBot.create(:orchestration_template_amazon_in_json)
+        FactoryBot.create(:orchestration_template_openstack_in_yaml)
+        FactoryBot.create(:orchestration_template_azure_in_json)
       end
 
       after(:each) do
@@ -709,7 +709,7 @@ describe CatalogController do
       end
 
       it "Renders an orchestration template textual summary" do
-        ot = FactoryGirl.create(:orchestration_template_amazon)
+        ot = FactoryBot.create(:orchestration_template_amazon)
         seed_session_trees('catalog', :ot_tree, "xx-otcfn_ot-#{ot.id}")
         post :explorer
 
@@ -720,8 +720,8 @@ describe CatalogController do
 
     describe "#set_resource_action" do
       before do
-        @st = FactoryGirl.create(:service_template)
-        dialog = FactoryGirl.create(:dialog,
+        @st = FactoryBot.create(:service_template)
+        dialog = FactoryBot.create(:dialog,
                                     :label       => "Test Label",
                                     :description => "Test Description",
                                     :buttons     => "submit,reset,cancel")
@@ -754,8 +754,8 @@ describe CatalogController do
 
     describe "#st_set_record_vars" do
       before do
-        @st = FactoryGirl.create(:service_template)
-        @catalog = FactoryGirl.create(:service_template_catalog,
+        @st = FactoryBot.create(:service_template)
+        @catalog = FactoryBot.create(:service_template_catalog,
                                       :name        => "foo",
                                       :description => "FOO")
         edit = {
@@ -778,7 +778,7 @@ describe CatalogController do
 
     describe "#st_set_form_vars" do
       before do
-        bundle = FactoryGirl.create(:service_template)
+        bundle = FactoryBot.create(:service_template)
         controller.instance_variable_set(:@record, bundle)
       end
 
@@ -812,7 +812,7 @@ describe CatalogController do
     describe "#need_ansible_locals?" do
       before do
         controller.instance_variable_set(:@nodetype, 'st')
-        st = FactoryGirl.create(:service_template,
+        st = FactoryBot.create(:service_template,
                                 :type      => "ServiceTemplateAnsiblePlaybook",
                                 :prov_type => "generic_ansible_playbook")
         controller.instance_variable_set(:@record, st)
@@ -833,7 +833,7 @@ describe CatalogController do
       end
 
       it "returns false for any other Service Template in Catalog Items accordions" do
-        controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+        controller.instance_variable_set(:@record, FactoryBot.create(:service_template))
         controller.instance_variable_set(:@sb,
                                          :trees       => {:svccat_tree => {:open_nodes => []}},
                                          :active_tree => :svccat_tree)
@@ -841,7 +841,7 @@ describe CatalogController do
       end
 
       it "returns false for any other Service Template in other accordions" do
-        controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+        controller.instance_variable_set(:@record, FactoryBot.create(:service_template))
         controller.instance_variable_set(:@sb,
                                          :trees       => {:svccat_tree => {:open_nodes => []}},
                                          :active_tree => :svccat_tree)
@@ -851,27 +851,27 @@ describe CatalogController do
 
     describe "#get_available_resources" do
       it "list of available resources should not include Ansible Playbook Service Templates" do
-        FactoryGirl.create(:service_template, :type => "ServiceTemplateAnsiblePlaybook")
+        FactoryBot.create(:service_template, :type => "ServiceTemplateAnsiblePlaybook")
         controller.instance_variable_set(:@edit, :new => {:selected_resources => []})
         controller.send(:get_available_resources, "ServiceTemplate")
         expect(assigns(:edit)[:new][:available_resources].count).to eq(2)
       end
 
       context "#get_available_resources" do
-        let(:user_role) { FactoryGirl.create(:miq_user_role) }
-        let(:miq_group) { FactoryGirl.create(:miq_group, :miq_user_role => user_role, :entitlement => Entitlement.create!) }
+        let(:user_role) { FactoryBot.create(:miq_user_role) }
+        let(:miq_group) { FactoryBot.create(:miq_group, :miq_user_role => user_role, :entitlement => Entitlement.create!) }
 
         before do
-          @st1 = FactoryGirl.create(:service_template, :type => "ServiceTemplate")
-          @st2 = FactoryGirl.create(:service_template, :type => "ServiceTemplate")
-          @st3 = FactoryGirl.create(:service_template, :type => "ServiceTemplate")
+          @st1 = FactoryBot.create(:service_template, :type => "ServiceTemplate")
+          @st2 = FactoryBot.create(:service_template, :type => "ServiceTemplate")
+          @st3 = FactoryBot.create(:service_template, :type => "ServiceTemplate")
           @st1.tag_with('/managed/service_level/one', :ns => '*')
           @st2.tag_with('/managed/service_level/one', :ns => '*')
           @st3.tag_with('/managed/service_level/two', :ns => '*')
         end
 
         it "list of available resources should contain the ones for the group matching tag Rbac" do
-          user = FactoryGirl.create(:user, :miq_groups => [miq_group])
+          user = FactoryBot.create(:user, :miq_groups => [miq_group])
           user.current_group.entitlement = Entitlement.create!
           user.current_group.entitlement.set_managed_filters([["/managed/service_level/one"]])
           user.current_group.save
@@ -882,7 +882,7 @@ describe CatalogController do
         end
 
         it "list of available resources should not contain the ones for the group not matching tag Rbac" do
-          user = FactoryGirl.create(:user, :miq_groups => [miq_group])
+          user = FactoryBot.create(:user, :miq_groups => [miq_group])
           user.current_group.entitlement = Entitlement.create!
           user.current_group.entitlement.set_managed_filters([["/managed/service_level/zero"]])
           user.current_group.save
@@ -893,7 +893,7 @@ describe CatalogController do
         end
 
         it "list of available resources for all tags matching Rbac" do
-          user = FactoryGirl.create(:user, :miq_groups => [miq_group])
+          user = FactoryBot.create(:user, :miq_groups => [miq_group])
           user.current_group.entitlement = Entitlement.create!
           user.current_group.entitlement.set_managed_filters([])
           user.current_group.save
@@ -906,15 +906,15 @@ describe CatalogController do
     end
 
     describe "#fetch_playbook_details" do
-      let(:auth) { FactoryGirl.create(:authentication, :name => "machine_cred", :manager_ref => 6, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential") }
-      let(:repository) { FactoryGirl.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
-      let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
+      let(:auth) { FactoryBot.create(:authentication, :name => "machine_cred", :manager_ref => 6, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential") }
+      let(:repository) { FactoryBot.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
+      let(:inventory_root_group) { FactoryBot.create(:inventory_root_group, :name => 'Demo Inventory') }
       let(:ems) do
-        FactoryGirl.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group], :provider => FactoryGirl.create(:provider_embedded_ansible))
+        FactoryBot.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group], :provider => FactoryBot.create(:provider_embedded_ansible))
       end
-      let(:dialog) { FactoryGirl.create(:dialog, :label => "Some Label") }
+      let(:dialog) { FactoryBot.create(:dialog, :label => "Some Label") }
       let(:playbook) do
-        FactoryGirl.create(:embedded_playbook,
+        FactoryBot.create(:embedded_playbook,
                            :configuration_script_source => repository,
                            :manager                     => ems,
                            :inventory_root_group        => inventory_root_group)
@@ -1036,21 +1036,21 @@ describe CatalogController do
     end
 
     describe "#atomic_req_submit" do
-      let(:ems) { FactoryGirl.create(:ems_openshift) }
+      let(:ems) { FactoryBot.create(:ems_openshift) }
       let(:container_template) do
-        FactoryGirl.create(:container_template,
+        FactoryBot.create(:container_template,
                            :ext_management_system => ems,
                            :name                  => "Test Template")
       end
 
-      let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
-      let(:dialog) { FactoryGirl.create(:dialog) }
+      let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
+      let(:dialog) { FactoryBot.create(:dialog) }
 
       before do
         controller.instance_variable_set(:@sb, {})
-        ns = FactoryGirl.create(:miq_ae_namespace, :name => "ns")
-        cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls")
-        FactoryGirl.create(:miq_ae_instance, :class_id => cls.id, :name => "inst")
+        ns = FactoryBot.create(:miq_ae_namespace, :name => "ns")
+        cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id, :name => "cls")
+        FactoryBot.create(:miq_ae_instance, :class_id => cls.id, :name => "inst")
         edit = {
           :key          => "prov_edit__new",
           :st_prov_type => "generic_container_template",
@@ -1078,15 +1078,15 @@ describe CatalogController do
     end
 
     describe "#fetch_ct_details" do
-      let(:ems) { FactoryGirl.create(:ems_openshift) }
+      let(:ems) { FactoryBot.create(:ems_openshift) }
       let(:container_template) do
-        FactoryGirl.create(:container_template,
+        FactoryBot.create(:container_template,
                            :ext_management_system => ems,
                            :name                  => "Test Template")
       end
 
-      let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
-      let(:dialog) { FactoryGirl.create(:dialog) }
+      let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
+      let(:dialog) { FactoryBot.create(:dialog) }
 
       let(:catalog_item_options) do
         {
@@ -1113,7 +1113,7 @@ describe CatalogController do
       end
 
       describe '#replace_right_cell' do
-        let(:dialog) { FactoryGirl.create(:dialog, :label => 'Transform VM', :buttons => 'submit') }
+        let(:dialog) { FactoryBot.create(:dialog, :label => 'Transform VM', :buttons => 'submit') }
         before do
           allow(controller).to receive(:params).and_return(:action => 'dialog_provision')
           controller.instance_variable_set(:@in_a_form, true)
@@ -1161,11 +1161,11 @@ describe CatalogController do
 
     describe '#available_job_templates' do
       it "" do
-        ems = FactoryGirl.create(:automation_manager_ansible_tower)
-        cs = FactoryGirl.create(:configuration_script,
+        ems = FactoryBot.create(:automation_manager_ansible_tower)
+        cs = FactoryBot.create(:configuration_script,
                                 :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript',
                                 :name => 'fred job template')
-        cf = FactoryGirl.create(:configuration_workflow, :name => 'wilma workflow template')
+        cf = FactoryBot.create(:configuration_workflow, :name => 'wilma workflow template')
         ems.configuration_scripts = [cs, cf]
         controller.instance_variable_set(:@edit, :new => {})
         controller.send(:available_job_templates, ems.id)
@@ -1182,16 +1182,16 @@ describe CatalogController do
   context "tests that need only specific rbac feature access" do
     describe "#st_tags_edit" do
       before do
-        user = FactoryGirl.create(:user, :features => "catalogitem_tag")
+        user = FactoryBot.create(:user, :features => "catalogitem_tag")
         login_as user
 
-        @st = FactoryGirl.create(:service_template, :name => "foo")
+        @st = FactoryBot.create(:service_template, :name => "foo")
         allow(@st).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-        @tag1 = FactoryGirl.create(:classification_tag,
+        classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryBot.create(:classification_tag,
                                    :name   => "tag1",
                                    :parent => classification)
-        @tag2 = FactoryGirl.create(:classification_tag,
+        @tag2 = FactoryBot.create(:classification_tag,
                                    :name   => "tag2",
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).with(@st).and_return([@tag1, @tag2])
@@ -1245,7 +1245,7 @@ describe CatalogController do
     before do
       allow(controller).to receive(:build_ae_tree)
       controller.instance_variable_set(:@edit, :new => {})
-      controller.instance_variable_set(:@record, FactoryGirl.create(:service_template))
+      controller.instance_variable_set(:@record, FactoryBot.create(:service_template))
     end
 
     context 'getting all available catalogs with tenants and ancestors' do
@@ -1270,7 +1270,7 @@ describe CatalogController do
   end
 
   describe '#common_st_record_vars' do
-    let(:st) { FactoryGirl.create(:service_template) }
+    let(:st) { FactoryBot.create(:service_template) }
 
     before { controller.instance_variable_set(:@edit, edit) }
 
@@ -1286,7 +1286,7 @@ describe CatalogController do
 
     context 'Service Catalog Item with Catalog' do
       let(:edit) { {:new => {:catalog_id => stc.id}} }
-      let(:stc) { FactoryGirl.create(:service_template_catalog) }
+      let(:stc) { FactoryBot.create(:service_template_catalog) }
 
       it 'sets service_template_catalog for Service Catalog Item to nil' do
         controller.send(:common_st_record_vars, st)

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -2,9 +2,9 @@ describe ChargebackController do
   before { stub_user(:features => :all) }
 
   context "returns current rate assignments or set them to blank if category/tag is deleted" do
-    let(:category) { FactoryGirl.create(:classification) }
-    let(:tag)      { FactoryGirl.create(:classification, :parent_id => category.id) }
-    let(:entry)    { FactoryGirl.create(:classification, :parent_id => tag.id) }
+    let(:category) { FactoryBot.create(:classification) }
+    let(:tag)      { FactoryBot.create(:classification, :parent_id => category.id) }
+    let(:entry)    { FactoryBot.create(:classification, :parent_id => tag.id) }
 
     describe "#get_tags_all" do
       before { entry }
@@ -21,7 +21,7 @@ describe ChargebackController do
 
     describe "#cb_assign_set_form_vars" do
       before do
-        cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage")
+        cbr = FactoryBot.create(:chargeback_rate, :rate_type => "Storage")
         ChargebackRate.set_assignments(:Storage, [{:cb_rate => cbr, :tag => [tag, "vm"]}])
         sandbox = {:active_tree => :cb_assignments_tree, :trees => {:cb_assignments_tree => {:active_node => 'xx-Storage'}}}
         controller.instance_variable_set(:@sb, sandbox)
@@ -66,7 +66,7 @@ describe ChargebackController do
 
   context "Saved chargeback rendering" do
     it "Saved chargeback reports renders paginagion buttons correctly" do
-      report = FactoryGirl.create(:miq_report_with_results, :miq_group => User.current_user.current_group)
+      report = FactoryBot.create(:miq_report_with_results, :miq_group => User.current_user.current_group)
       report.extras = {:total_html_rows => 100}
       rp_id = report.id
       rr_id = report.miq_report_results[0].id
@@ -93,8 +93,8 @@ describe ChargebackController do
     end
 
     describe "#cb_rpt_build_folder_nodes" do
-      let!(:admin_user)        { FactoryGirl.create(:user_admin) }
-      let!(:chargeback_report) { FactoryGirl.create(:miq_report_chargeback_with_results) }
+      let!(:admin_user)        { FactoryBot.create(:user_admin) }
+      let!(:chargeback_report) { FactoryBot.create(:miq_report_chargeback_with_results) }
 
       before { login_as admin_user }
 
@@ -123,7 +123,7 @@ describe ChargebackController do
 
   describe "#process_cb_rates" do
     it "delete unassigned" do
-      cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage", :description => "Storage Rate")
+      cbr = FactoryBot.create(:chargeback_rate, :rate_type => "Storage", :description => "Storage Rate")
 
       rates = [cbr.id]
       controller.send(:process_cb_rates, rates, "destroy")
@@ -135,8 +135,8 @@ describe ChargebackController do
     end
 
     it "delete assigned" do
-      cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Storage", :description => "Storage Rate")
-      host = FactoryGirl.create(:host)
+      cbr = FactoryBot.create(:chargeback_rate, :rate_type => "Storage", :description => "Storage Rate")
+      host = FactoryBot.create(:host)
       cbr.assign_to_objects(host)
 
       rates = [cbr.id]
@@ -150,8 +150,8 @@ describe ChargebackController do
   end
 
   describe "#get_cis_all" do
-    let!(:storage) { FactoryGirl.create(:storage) }
-    let!(:miq_enterprise) { FactoryGirl.create(:miq_enterprise) }
+    let!(:storage) { FactoryBot.create(:storage) }
+    let!(:miq_enterprise) { FactoryBot.create(:miq_enterprise) }
 
     it "returns names of instances of enterprise" do
       names_miqent = {}
@@ -209,7 +209,7 @@ describe ChargebackController do
 
     render_views
 
-    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate, :with_details, :description => "foo") }
+    let(:chargeback_rate) { FactoryBot.create(:chargeback_rate, :with_details, :description => "foo") }
 
     # this index represent first rate detail( "Allocated Memory in MB") chargeback_rate
     let(:index_to_rate_type) { "0" }
@@ -593,10 +593,10 @@ describe ChargebackController do
     let(:current_user) { User.current_user }
     let(:miq_task)     { MiqTask.new(:name => "Generate Report result", :userid => current_user.userid) }
     let(:miq_report_result) do
-      FactoryGirl.create(:miq_chargeback_report_result, :miq_group => current_user.current_group, :miq_task => miq_task)
+      FactoryBot.create(:miq_chargeback_report_result, :miq_group => current_user.current_group, :miq_task => miq_task)
     end
 
-    let(:chargeback_report) { FactoryGirl.create(:miq_report_chargeback, :miq_report_results => [miq_report_result]) }
+    let(:chargeback_report) { FactoryBot.create(:miq_report_chargeback, :miq_report_results => [miq_report_result]) }
 
     before do
       miq_task.state_finished
@@ -634,7 +634,7 @@ describe ChargebackController do
 
   describe '#cb_rates_delete' do
     let(:params) { {:id => rate.id} }
-    let(:rate) { FactoryGirl.create(:chargeback_rate, :rate_type => "Compute") }
+    let(:rate) { FactoryBot.create(:chargeback_rate, :rate_type => "Compute") }
     let(:sandbox) { {:active_tree => :cb_rates_tree, :trees => {:cb_rates_tree => {:active_node => "xx-#{rate.rate_type}_cr-#{rate.id}"}}} }
 
     before do

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -1,14 +1,14 @@
 describe CloudNetworkController do
-  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-  let(:tag1) { FactoryGirl.create(:classification_tag, :name   => "tag1", :parent => classification) }
-  let(:tag2) { FactoryGirl.create(:classification_tag, :name   => "tag2", :parent => classification) }
-  let(:ct) { FactoryGirl.create(:cloud_network, :name => "cloud-network-01") }
-  let(:network) { FactoryGirl.create(:cloud_network) }
-  let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
+  let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryBot.create(:classification_tag, :name   => "tag1", :parent => classification) }
+  let(:tag2) { FactoryBot.create(:classification_tag, :name   => "tag2", :parent => classification) }
+  let(:ct) { FactoryBot.create(:cloud_network, :name => "cloud-network-01") }
+  let(:network) { FactoryBot.create(:cloud_network) }
+  let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
 
   before do
-    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => ct)
-    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => ct)
+    FactoryBot.create(:tagging, :tag => tag1.tag, :taggable => ct)
+    FactoryBot.create(:tagging, :tag => tag2.tag, :taggable => ct)
     EvmSpecHelper.create_guid_miq_server_zone
   end
 
@@ -56,7 +56,7 @@ describe CloudNetworkController do
   end
 
   describe "#show" do
-    before { login_as FactoryGirl.create(:user) }
+    before { login_as FactoryBot.create(:user) }
 
     context "render listnav partial" do
       render_views
@@ -77,9 +77,9 @@ describe CloudNetworkController do
       EvmSpecHelper.seed_specific_product_features(%w(cloud_network_new ems_network_show_list))
 
       feature = MiqProductFeature.find_all_by_identifier(%w(cloud_network_new))
-      role = FactoryGirl.create(:miq_user_role, :miq_product_features => feature)
-      group = FactoryGirl.create(:miq_group, :miq_user_role => role)
-      login_as FactoryGirl.create(:user, :miq_groups => [group])
+      role = FactoryBot.create(:miq_user_role, :miq_product_features => feature)
+      group = FactoryBot.create(:miq_group, :miq_user_role => role)
+      login_as FactoryBot.create(:user, :miq_groups => [group])
     end
 
     it "raises exception when user don't have privilege" do
@@ -96,14 +96,14 @@ describe CloudNetworkController do
   end
 
   describe "#create" do
-    let(:network) { FactoryGirl.create(:cloud_network_openstack) }
+    let(:network) { FactoryBot.create(:cloud_network_openstack) }
     let(:task_options) do
       {
         :action => "creating Cloud Network for user %{user}" % {:user => controller.current_user.userid},
         :userid => controller.current_user.userid
       }
     end
-    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant) }
+    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant) }
     let(:queue_options) do
       {
         :class_name  => ems.class.name,
@@ -151,7 +151,7 @@ describe CloudNetworkController do
   end
 
   describe "#edit" do
-    let(:network) { FactoryGirl.create(:cloud_network_openstack, :ext_management_system => ems) }
+    let(:network) { FactoryBot.create(:cloud_network_openstack, :ext_management_system => ems) }
     let(:task_options) do
       {
         :action => "updating Cloud Network for user %{user}" % {:user => controller.current_user.userid},
@@ -186,7 +186,7 @@ describe CloudNetworkController do
   end
 
   describe "#delete" do
-    let(:network) { FactoryGirl.create(:cloud_network_openstack, :ext_management_system => ems) }
+    let(:network) { FactoryBot.create(:cloud_network_openstack, :ext_management_system => ems) }
     let(:task_options) do
       {
         :action => "deleting Cloud Network for user %{user}" % {:user => controller.current_user.userid},
@@ -252,7 +252,7 @@ describe CloudNetworkController do
 
   describe "#delete_networks" do
     before do
-      login_as FactoryGirl.create(:user, :role => "super_administrator")
+      login_as FactoryBot.create(:user, :role => "super_administrator")
       controller.instance_variable_set(:@_params, :id => network.id, :pressed => 'cloud_network_delete')
       allow(controller).to receive(:process_cloud_networks).with([network], "destroy")
     end

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -1,7 +1,7 @@
 describe CloudObjectStoreContainerController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    @container = FactoryGirl.create(:cloud_object_store_container, :name => "cloud-object-store-container-01")
+    @container = FactoryBot.create(:cloud_object_store_container, :name => "cloud-object-store-container-01")
     allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
   end
 
@@ -9,11 +9,11 @@ describe CloudObjectStoreContainerController do
     let!(:user) { stub_user(:features => :all) }
     before do
       allow(@container).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "D    epartment")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@container).and_return([@tag1, @tag2])
@@ -54,7 +54,7 @@ describe CloudObjectStoreContainerController do
 
   context "delete object store container" do
     before do
-      login_as FactoryGirl.create(:user, :features => "everything")
+      login_as FactoryBot.create(:user, :features => "everything")
       request.parameters["controller"] = "cloud_object_store_container"
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")
@@ -183,7 +183,7 @@ describe CloudObjectStoreContainerController do
             }
           }
         )
-        @cloud_manager = FactoryGirl.create(:ems_amazon)
+        @cloud_manager = FactoryBot.create(:ems_amazon)
         @ems = @cloud_manager.s3_storage_manager
 
         @form_params = {

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -1,14 +1,14 @@
 describe CloudObjectStoreObjectController do
-  let(:object) { FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-container-01") }
-  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-  let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
-  let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+  let(:object) { FactoryBot.create(:cloud_object_store_object, :name => "cloud-object-store-container-01") }
+  let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
+  let(:tag2) { FactoryBot.create(:classification_tag, :name => "tag2", :parent => classification) }
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
-    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => object)
-    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => object)
+    FactoryBot.create(:tagging, :tag => tag1.tag, :taggable => object)
+    FactoryBot.create(:tagging, :tag => tag2.tag, :taggable => object)
     stub_user(:features => :all)
   end
 
@@ -54,7 +54,7 @@ describe CloudObjectStoreObjectController do
 
   describe "delete object store object" do
     before do
-      login_as FactoryGirl.create(:user, :features => "everything")
+      login_as FactoryBot.create(:user, :features => "everything")
       request.parameters["controller"] = "cloud_object_store_object"
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:previous_breadcrumb_url).and_return("previous-url")

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,14 +1,14 @@
 describe CloudSubnetController do
-  let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
-  let(:cloud_subnet) { FactoryGirl.create(:cloud_subnet_openstack, :ext_management_system => ems) }
+  let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
+  let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack, :ext_management_system => ems) }
 
   before { EvmSpecHelper.create_guid_miq_server_zone }
 
   describe "#tags_edit" do
-    let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-    let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
-    let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
-    let(:ct) { FactoryGirl.create(:cloud_subnet, :name => "cloud-subnet-01") }
+    let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+    let(:tag1) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
+    let(:tag2) { FactoryBot.create(:classification_tag, :name => "tag2", :parent => classification) }
+    let(:ct) { FactoryBot.create(:cloud_subnet, :name => "cloud-subnet-01") }
 
     before do
       stub_user(:features => :all)
@@ -51,9 +51,9 @@ describe CloudSubnetController do
   end
 
   describe "#show" do
-    let(:subnet) { FactoryGirl.create(:cloud_subnet) }
+    let(:subnet) { FactoryBot.create(:cloud_subnet) }
 
-    before { login_as FactoryGirl.create(:user) }
+    before { login_as FactoryBot.create(:user) }
 
     render_views
 
@@ -72,9 +72,9 @@ describe CloudSubnetController do
       EvmSpecHelper.seed_specific_product_features(%w(cloud_subnet_new ems_network_show_list cloud_network_show_list cloud_tenant_show_list))
 
       feature = MiqProductFeature.find_all_by_identifier(%w(cloud_subnet_new))
-      role = FactoryGirl.create(:miq_user_role, :miq_product_features => feature)
-      group = FactoryGirl.create(:miq_group, :miq_user_role => role)
-      login_as FactoryGirl.create(:user, :miq_groups => [group])
+      role = FactoryBot.create(:miq_user_role, :miq_product_features => feature)
+      group = FactoryBot.create(:miq_group, :miq_user_role => role)
+      login_as FactoryBot.create(:user, :miq_groups => [group])
     end
 
     it "raises exception wheh used have not privilege" do
@@ -99,15 +99,15 @@ describe CloudSubnetController do
   end
 
   describe "#create" do
-    let(:cloud_subnet) { FactoryGirl.create(:cloud_subnet_openstack) }
+    let(:cloud_subnet) { FactoryBot.create(:cloud_subnet_openstack) }
     let(:task_options) do
       {
         :action => "creating Cloud Subnet for user %{user}" % {:user => controller.current_user.userid},
         :userid => controller.current_user.userid
       }
     end
-    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant) }
-    let(:cloud_network) { FactoryGirl.create(:cloud_network_openstack) }
+    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant) }
+    let(:cloud_network) { FactoryBot.create(:cloud_network_openstack) }
     let(:queue_options) do
       {
         :class_name  => ems.class.name,

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -1,10 +1,10 @@
 describe CloudTenantController do
-  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-  let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
-  let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
-  let(:ct) { FactoryGirl.create(:cloud_tenant, :name => "cloud-tenant-01") }
-  let(:ems) { FactoryGirl.create(:ems_openstack) }
-  let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+  let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
+  let(:tag2) { FactoryBot.create(:classification_tag, :name => "tag2", :parent => classification) }
+  let(:ct) { FactoryBot.create(:cloud_tenant, :name => "cloud-tenant-01") }
+  let(:ems) { FactoryBot.create(:ems_openstack) }
+  let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
 
   before do
     stub_user(:features => :all)
@@ -70,9 +70,9 @@ describe CloudTenantController do
   end
 
   describe "#show" do
-    let(:tenant) { FactoryGirl.create(:cloud_tenant) }
+    let(:tenant) { FactoryBot.create(:cloud_tenant) }
 
-    before { login_as FactoryGirl.create(:user, :features => "none") }
+    before { login_as FactoryBot.create(:user, :features => "none") }
 
     render_views
 
@@ -92,7 +92,7 @@ describe CloudTenantController do
   end
 
   describe "#create" do
-    let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack) }
+    let(:tenant) { FactoryBot.create(:cloud_tenant_openstack) }
     let(:task_options) do
       {
         :action => "creating Cloud Tenant for user %{user}" % {:user => controller.current_user.userid},

--- a/spec/controllers/cloud_volume_backup_controller_spec.rb
+++ b/spec/controllers/cloud_volume_backup_controller_spec.rb
@@ -1,9 +1,9 @@
 describe CloudVolumeBackupController do
   describe "#tags_edit" do
-    let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-    let(:tag1) { FactoryGirl.create(:classification_tag, :name   => "tag1", :parent => classification) }
-    let(:tag2) { FactoryGirl.create(:classification_tag, :name   => "tag2", :parent => classification) }
-    let(:backup) { FactoryGirl.create(:cloud_volume_backup, :name => "cloud-volume-backup-01") }
+    let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+    let(:tag1) { FactoryBot.create(:classification_tag, :name   => "tag1", :parent => classification) }
+    let(:tag2) { FactoryBot.create(:classification_tag, :name   => "tag2", :parent => classification) }
+    let(:backup) { FactoryBot.create(:cloud_volume_backup, :name => "cloud-volume-backup-01") }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -3,13 +3,13 @@ describe CloudVolumeController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @volume = FactoryGirl.create(:cloud_volume, :name => "cloud-volume-01")
+      @volume = FactoryBot.create(:cloud_volume, :name => "cloud-volume-01")
       allow(@volume).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@volume).and_return([@tag1, @tag2])
@@ -52,11 +52,11 @@ describe CloudVolumeController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @volume = FactoryBot.create(:cloud_volume_openstack,
                                    :name                  => "cloud-volume-01",
                                    :ext_management_system => @ems)
-      @backup = FactoryGirl.create(:cloud_volume_backup)
+      @backup = FactoryBot.create(:cloud_volume_backup)
     end
 
     context "#create_backup" do
@@ -92,9 +92,9 @@ describe CloudVolumeController do
 
   describe "#new" do
     let(:feature) { MiqProductFeature.find_all_by_identifier(%w(cloud_volume_new)) }
-    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
-    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
-    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:role)    { FactoryBot.create(:miq_user_role, :miq_product_features => feature) }
+    let(:group)   { FactoryBot.create(:miq_group, :miq_user_role => role) }
+    let(:user)    { FactoryBot.create(:user, :miq_groups => [group]) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -115,9 +115,9 @@ describe CloudVolumeController do
     render_views
 
     let(:features) { MiqProductFeature.find_all_by_identifier(%w(cloud_volume_new cloud_tenant_show_list)) }
-    let(:role)    { FactoryGirl.create(:miq_user_role, :miq_product_features => features) }
-    let(:group)   { FactoryGirl.create(:miq_group, :miq_user_role => role) }
-    let(:user)    { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:role)    { FactoryBot.create(:miq_user_role, :miq_product_features => features) }
+    let(:group)   { FactoryBot.create(:miq_group, :miq_user_role => role) }
+    let(:user)    { FactoryBot.create(:user, :miq_groups => [group]) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -138,11 +138,11 @@ describe CloudVolumeController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @volume = FactoryBot.create(:cloud_volume_openstack,
                                    :name                  => "cloud-volume-01",
                                    :ext_management_system => @ems)
-      @backup = FactoryGirl.create(:cloud_volume_backup)
+      @backup = FactoryBot.create(:cloud_volume_backup)
     end
 
     context "#restore_backup" do
@@ -180,11 +180,11 @@ describe CloudVolumeController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @volume = FactoryGirl.create(:cloud_volume_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @volume = FactoryBot.create(:cloud_volume_openstack,
                                    :name                  => "cloud-volume-01",
                                    :ext_management_system => @ems)
-      @snapshot = FactoryGirl.create(:cloud_volume_snapshot)
+      @snapshot = FactoryBot.create(:cloud_volume_snapshot)
     end
 
     context "#create_snapshot" do
@@ -255,8 +255,8 @@ describe CloudVolumeController do
 
     context "in OpenStack cloud" do
       before do
-        @ems = FactoryGirl.create(:ems_openstack)
-        @tenant = FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => @ems)
+        @ems = FactoryBot.create(:ems_openstack)
+        @tenant = FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => @ems)
 
         @form_params = { :name => "volume", :size => 1, :cloud_tenant_id => @tenant.id,
                          :emstype => "ManageIQ::Providers::StorageManager::CinderManager" }
@@ -268,9 +268,9 @@ describe CloudVolumeController do
 
     context "in Amazon EBS" do
       before do
-        @cloud_manager = FactoryGirl.create(:ems_amazon)
-        @ems = FactoryGirl.create(:ems_amazon_ebs, :parent_manager => @cloud_manager)
-        @availability_zone = FactoryGirl.create(:availability_zone,
+        @cloud_manager = FactoryBot.create(:ems_amazon)
+        @ems = FactoryBot.create(:ems_amazon_ebs, :parent_manager => @cloud_manager)
+        @availability_zone = FactoryBot.create(:availability_zone,
                                                 :ems_ref               => "us-east-1e",
                                                 :ext_management_system => @cloud_manager)
 

--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -3,13 +3,13 @@ describe CloudVolumeSnapshotController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @snapshot = FactoryGirl.create(:cloud_volume_snapshot, :name => "cloud-volume-snapshot-01")
+      @snapshot = FactoryBot.create(:cloud_volume_snapshot, :name => "cloud-volume-snapshot-01")
       allow(@snapshot).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "D    epartment")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@snapshot).and_return([@tag1, @tag2])
@@ -52,8 +52,8 @@ describe CloudVolumeSnapshotController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @snapshot = FactoryGirl.create(:cloud_volume_snapshot_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @snapshot = FactoryBot.create(:cloud_volume_snapshot_openstack,
                                      :ext_management_system => @ems)
     end
 
@@ -84,8 +84,8 @@ describe CloudVolumeSnapshotController do
   end
 
   describe "#delete_cloud_volume_snapshots" do
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-    let!(:snapshot) { FactoryGirl.create(:cloud_volume_snapshot) }
+    let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
+    let!(:snapshot) { FactoryBot.create(:cloud_volume_snapshot) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
 

--- a/spec/controllers/cloud_volume_type_controller_spec.rb
+++ b/spec/controllers/cloud_volume_type_controller_spec.rb
@@ -3,13 +3,13 @@ describe CloudVolumeTypeController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @volume_type = FactoryGirl.create(:cloud_volume_type, :name => "cloud-volume-type-01")
+      @volume_type = FactoryBot.create(:cloud_volume_type, :name => "cloud-volume-type-01")
       allow(@volume_type).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@volume_type).and_return([@tag1, @tag2])
@@ -51,8 +51,8 @@ describe CloudVolumeTypeController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @volume_type = FactoryGirl.create(:cloud_volume_type)
-      login_as FactoryGirl.create(:user, :features => "none")
+      @volume_type = FactoryBot.create(:cloud_volume_type)
+      login_as FactoryBot.create(:user, :features => "none")
     end
 
     subject do
@@ -71,8 +71,8 @@ describe CloudVolumeTypeController do
   describe "#show_list" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @volume_type = FactoryGirl.create(:cloud_volume_type)
-      login_as FactoryGirl.create(:user, :features => "none")
+      @volume_type = FactoryBot.create(:cloud_volume_type)
+      login_as FactoryBot.create(:user, :features => "none")
     end
 
     subject do
@@ -110,7 +110,7 @@ describe CloudVolumeTypeController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    let(:volume_type) { FactoryGirl.create(:cloud_volume_type) }
+    let(:volume_type) { FactoryBot.create(:cloud_volume_type) }
 
     context 'when tile mode is selected' do
       it 'returns volume types with quadicons' do

--- a/spec/controllers/configuration_controller_spec.rb
+++ b/spec/controllers/configuration_controller_spec.rb
@@ -16,7 +16,7 @@ describe ConfigurationController do
   describe "building tabs" do
     before do
       controller.instance_variable_set(:@tabform, "ui_2")
-      login_as FactoryGirl.create(:user, :features => "everything")
+      login_as FactoryBot.create(:user, :features => "everything")
     end
 
     it 'sets the active tab' do

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -9,7 +9,7 @@ describe ConfigurationJobController do
 
   describe '#show' do
     context "instances" do
-      let(:record) { FactoryGirl.create(:ansible_tower_job) }
+      let(:record) { FactoryBot.create(:ansible_tower_job) }
 
       before do
         session[:settings] = {
@@ -40,13 +40,13 @@ describe ConfigurationJobController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @cj = FactoryGirl.create(:ansible_tower_job, :name => "testJob")
+      @cj = FactoryBot.create(:ansible_tower_job, :name => "testJob")
       allow(@cj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@cj).and_return([@tag1, @tag2])

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerBuildController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openshift)
+    ems = FactoryBot.create(:ems_openshift)
     container_build = ContainerBuild.create(:ext_management_system => ems, :name => "Test Build")
     get :show, :params => { :id => container_build.id }
     expect(response.status).to eq(200)
@@ -38,7 +38,7 @@ describe ContainerBuildController do
 
   it "renders grid view" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openshift)
+    ems = FactoryBot.create(:ems_openshift)
     container_build = ContainerBuild.create(:ext_management_system => ems, :name => "Test Build")
 
     session[:settings] = {

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -12,12 +12,12 @@ describe ContainerController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_project = ContainerProject.create(:ext_management_system => ems)
     container_group = ContainerGroup.create(:ext_management_system => ems,
                                             :container_project     => container_project,
                                             :name                  => "Test Group")
-    container = FactoryGirl.create(:container, :container_group => container_group, :name => "Test Container")
+    container = FactoryBot.create(:container, :container_group => container_group, :name => "Test Container")
 
     get :show, :params => { :id => container.id }
     expect(response.status).to eq(200)
@@ -31,14 +31,14 @@ describe ContainerController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
 
-      ems = FactoryGirl.create(:ems_kubernetes)
+      ems = FactoryBot.create(:ems_kubernetes)
       container_project = ContainerProject.create(:ext_management_system => ems)
       container_group = ContainerGroup.create(:ext_management_system => ems,
                                               :container_project     => container_project,
                                               :name                  => "Test Group")
-      @container = FactoryGirl.create(:container, :container_group => container_group, :name => "Test Container")
+      @container = FactoryBot.create(:container, :container_group => container_group, :name => "Test Container")
     end
 
     subject { get :show, :params => { :id => @container.id } }

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerGroupController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_project = ContainerProject.create(:ext_management_system => ems)
     container_group = ContainerGroup.create(:ext_management_system => ems,
                                             :container_project     => container_project,
@@ -40,8 +40,8 @@ describe ContainerGroupController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @container_group = FactoryGirl.create(:container_group_with_assoc)
-      login_as FactoryGirl.create(:user)
+      @container_group = FactoryBot.create(:container_group_with_assoc)
+      login_as FactoryBot.create(:user)
     end
 
     subject { get :show, :params => { :id => @container_group.id } }

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -35,7 +35,7 @@ describe ContainerImageController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_image = ContainerImage.create(:ext_management_system => ems, :name => "Test Image")
     get :show, :params => { :id => container_image.id }
     expect(response.status).to eq(200)
@@ -49,8 +49,8 @@ describe ContainerImageController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @image = FactoryGirl.create(:container_image)
+      login_as FactoryBot.create(:user)
+      @image = FactoryBot.create(:container_image)
     end
 
     subject { get :show, :params => { :id => @image.id } }

--- a/spec/controllers/container_image_registry_controller_spec.rb
+++ b/spec/controllers/container_image_registry_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerImageRegistryController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_image_registry =
       ContainerImageRegistry.create(:ext_management_system => ems, :name => "Test Image Registry")
     get :show, :params => { :id => container_image_registry.id }
@@ -27,8 +27,8 @@ describe ContainerImageRegistryController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @image_registry = FactoryGirl.create(:container_image_registry)
+      login_as FactoryBot.create(:user)
+      @image_registry = FactoryBot.create(:container_image_registry)
     end
 
     subject { get :show, :params => { :id => @image_registry.id } }

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -13,8 +13,8 @@ describe ContainerNodeController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
-    container_node = FactoryGirl.create(:container_node, :ext_management_system => ems, :name => "Test Node")
+    ems = FactoryBot.create(:ems_kubernetes)
+    container_node = FactoryBot.create(:container_node, :ext_management_system => ems, :name => "Test Node")
     get :show, :params => { :id => container_node.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty
@@ -27,8 +27,8 @@ describe ContainerNodeController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @node = FactoryGirl.create(:container_node)
+      login_as FactoryBot.create(:user)
+      @node = FactoryBot.create(:container_node)
     end
 
     subject { get :show, :params => { :id => @node.id } }
@@ -45,12 +45,12 @@ describe ContainerNodeController do
   end
 
   describe "#button" do
-    let(:node) { FactoryGirl.create(:container_node) }
+    let(:node) { FactoryBot.create(:container_node) }
 
     context "container_node_check_compliance" do
       before do
         EvmSpecHelper.create_guid_miq_server_zone
-        login_as FactoryGirl.create(:user)
+        login_as FactoryBot.create(:user)
       end
 
       it 'displays a flash message' do

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerProjectController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_project = ContainerProject.create(:ext_management_system => ems, :name => "Test Project")
     get :show, :params => { :id => container_project.id, :display => 'main' }
     expect(response.status).to eq(200)
@@ -26,8 +26,8 @@ describe ContainerProjectController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @project = FactoryGirl.create(:container_project)
+      login_as FactoryBot.create(:user)
+      @project = FactoryBot.create(:container_project)
     end
 
     subject { get :show, :params => { :id => @project.id, :display => 'main' } }

--- a/spec/controllers/container_replicator_controller_spec.rb
+++ b/spec/controllers/container_replicator_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerReplicatorController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_replicator = ContainerReplicator.create(
       :ext_management_system => ems,
       :container_project     => ContainerProject.create(:ext_management_system => ems, :name => "test"),
@@ -30,8 +30,8 @@ describe ContainerReplicatorController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @replicator = FactoryGirl.create(:replicator_with_assoc)
+      login_as FactoryBot.create(:user)
+      @replicator = FactoryBot.create(:replicator_with_assoc)
     end
 
     subject { get :show, :params => { :id => @replicator.id } }

--- a/spec/controllers/container_route_controller_spec.rb
+++ b/spec/controllers/container_route_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerRouteController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_route = ContainerRoute.create(:ext_management_system => ems, :name => "Test Route")
     get :show, :params => { :id => container_route.id }
     expect(response.status).to eq(200)
@@ -26,8 +26,8 @@ describe ContainerRouteController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @route = FactoryGirl.create(:container_route)
+      login_as FactoryBot.create(:user)
+      @route = FactoryBot.create(:container_route)
     end
 
     subject { get :show, :params => { :id => @route.id } }

--- a/spec/controllers/container_service_controller_spec.rb
+++ b/spec/controllers/container_service_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerServiceController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     container_service = ContainerService.create(:ext_management_system => ems, :name => "Test Service")
     get :show, :params => { :id => container_service.id }
     expect(response.status).to eq(200)
@@ -26,8 +26,8 @@ describe ContainerServiceController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @service = FactoryGirl.create(:container_service)
+      login_as FactoryBot.create(:user)
+      @service = FactoryBot.create(:container_service)
     end
 
     subject { get :show, :params => { :id => @service.id } }

--- a/spec/controllers/container_template_controller_spec.rb
+++ b/spec/controllers/container_template_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerTemplateController do
 
   it "renders show screen" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openshift)
+    ems = FactoryBot.create(:ems_openshift)
     container_template = ContainerTemplate.create(:ext_management_system => ems, :name => "Test Template")
     get :show, :params => { :id => container_template.id }
     expect(response.status).to eq(200)
@@ -38,7 +38,7 @@ describe ContainerTemplateController do
 
   it "renders grid view" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openshift)
+    ems = FactoryBot.create(:ems_openshift)
     container_template = ContainerTemplate.create(:ext_management_system => ems, :name => "Test Template")
 
     session[:settings] = {

--- a/spec/controllers/dashboard_controller/verify_user_spec.rb
+++ b/spec/controllers/dashboard_controller/verify_user_spec.rb
@@ -1,6 +1,6 @@
 describe DashboardController do
   let(:user) do
-    FactoryGirl.create(:user_with_email, :password => "smartvm", :role => "super_administrator")
+    FactoryBot.create(:user_with_email, :password => "smartvm", :role => "super_administrator")
   end
 
   before do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -5,7 +5,7 @@ describe DashboardController do
     end
 
     let(:user_with_role) do
-      FactoryGirl.create(:user, :role => "random")
+      FactoryBot.create(:user, :role => "random")
     end
 
     it "has secure headers" do
@@ -39,7 +39,7 @@ describe DashboardController do
 
     it "remembers group" do
       group1 = user_with_role.current_group
-      group2 = FactoryGirl.create(:miq_group)
+      group2 = FactoryBot.create(:miq_group)
       user_with_role.update_attributes(:miq_groups => [group1, group2])
 
       skip_data_checks
@@ -59,7 +59,7 @@ describe DashboardController do
       expect_successful_login(user_with_role)
 
       # no longer has access to this group
-      group2 = FactoryGirl.create(:miq_group)
+      group2 = FactoryBot.create(:miq_group)
       user_with_role.update_attributes(:current_group => group2, :miq_groups => [group2])
 
       controller.instance_variable_set(:@current_user, nil) # force the controller to lookup the user record again
@@ -68,13 +68,13 @@ describe DashboardController do
     end
 
     it "requires group" do
-      user = FactoryGirl.create(:user, :current_group => nil)
+      user = FactoryBot.create(:user, :current_group => nil)
       post :authenticate, :params => { :user_name => user.userid, :user_password => "dummy" }
       expect_failed_login('Group')
     end
 
     it "requires role" do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       post :authenticate, :params => { :user_name => user.userid, :user_password => "dummy" }
       expect_failed_login('Role')
     end
@@ -116,7 +116,7 @@ describe DashboardController do
 
     %i(saml oidc).each do |protocol|
       it "#{protocol.upcase} protected page should render the #{protocol}_login page with the proper validation_url and api token" do
-        user           = FactoryGirl.create(:user, :userid => "johndoe", :role => "test")
+        user           = FactoryBot.create(:user, :userid => "johndoe", :role => "test")
         auth_token     = "aabbccddeeff"
         validation_url = "/user_validation_url"
 
@@ -147,21 +147,21 @@ describe DashboardController do
     end
 
     it "returns flash message when user's group is missing" do
-      user = FactoryGirl.create(:user)
+      user = FactoryBot.create(:user)
       allow(User).to receive(:authenticate).and_return(user)
       validation = controller.send(:validate_user, user)
       expect(validation.flash_msg).to include('User\'s Group is missing')
     end
 
     it "returns flash message when user's role is missing" do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       allow(User).to receive(:authenticate).and_return(user)
       validation = controller.send(:validate_user, user)
       expect(validation.flash_msg).to include('User\'s Role is missing')
     end
 
     it "returns flash message when user does not have access to any features" do
-      user = FactoryGirl.create(:user, :role => "test")
+      user = FactoryBot.create(:user, :role => "test")
       allow(User).to receive(:authenticate).and_return(user)
       validation = controller.send(:validate_user, user)
       expect(validation.flash_msg).to include("The user's role is not authorized for any access")
@@ -173,14 +173,14 @@ describe DashboardController do
       allow(controller).to receive(:check_privileges).and_return(true)
       EvmSpecHelper.seed_specific_product_features("container")
       feature_id = MiqProductFeature.find_all_by_identifier(["container"])
-      user = FactoryGirl.create(:user, :features => feature_id)
+      user = FactoryBot.create(:user, :features => feature_id)
       allow(User).to receive(:authenticate).and_return(user)
       validation = controller.send(:validate_user, user)
       expect(validation.flash_msg).to be_nil
     end
 
     it "returns url for the user and sets user's group/role id in session" do
-      user = FactoryGirl.create(:user, :role => "test")
+      user = FactoryBot.create(:user, :role => "test")
       allow(User).to receive(:authenticate).and_return(user)
       skip_data_checks('some_url')
       validation = controller.send(:validate_user, user)
@@ -193,19 +193,19 @@ describe DashboardController do
   context "Create Dashboard" do
     it "dashboard show" do
       # create dashboard for a group
-      ws = FactoryGirl.create(:miq_widget_set, :name     => "default",
+      ws = FactoryBot.create(:miq_widget_set, :name     => "default",
                                                :set_data => {:last_group_db_updated => Time.now.utc,
                               :col1 => [1], :col2 => [], :col3 => []})
 
-      ur = FactoryGirl.create(:miq_user_role)
-      group = FactoryGirl.create(:miq_group, :miq_user_role => ur, :settings => {:dashboard_order => [ws.id]})
-      user = FactoryGirl.create(:user, :miq_groups => [group])
+      ur = FactoryBot.create(:miq_user_role)
+      group = FactoryBot.create(:miq_group, :miq_user_role => ur, :settings => {:dashboard_order => [ws.id]})
+      user = FactoryBot.create(:user, :miq_groups => [group])
 
       controller.instance_variable_set(:@sb, :active_db => ws.name)
       controller.instance_variable_set(:@tabs, [])
       login_as user
       # create a user's dashboard using group dashboard name.
-      FactoryGirl.create(:miq_widget_set,
+      FactoryBot.create(:miq_widget_set,
                          :name     => "#{user.userid}|#{group.id}|#{ws.name}",
                          :set_data => {:last_group_db_updated => Time.now.utc, :col1 => [1], :col2 => [], :col3 => []})
       controller.show
@@ -213,11 +213,11 @@ describe DashboardController do
     end
 
     it "widget_add" do
-      ur = FactoryGirl.create(:miq_user_role)
-      group = FactoryGirl.create(:miq_group, :miq_user_role => ur)
-      user = FactoryGirl.create(:user, :miq_groups => [group])
-      wi = FactoryGirl.create(:miq_widget)
-      ws = FactoryGirl.create(:miq_widget_set, :name     => "default",
+      ur = FactoryBot.create(:miq_user_role)
+      group = FactoryBot.create(:miq_group, :miq_user_role => ur)
+      user = FactoryBot.create(:user, :miq_groups => [group])
+      wi = FactoryBot.create(:miq_widget)
+      ws = FactoryBot.create(:miq_widget_set, :name     => "default",
                                                :set_data => {:last_group_db_updated => Time.now.utc,
                                                              :col1 => [], :col2 => [], :col3 => []},
                                                :userid   => user.userid,
@@ -250,7 +250,7 @@ describe DashboardController do
     }
     main_tabs.each do |tab, (feature, url)|
       it "for tab ':#{tab}'" do
-        login_as FactoryGirl.create(:user, :features => feature)
+        login_as FactoryBot.create(:user, :features => feature)
         session[:tab_url] = {}
         post :maintab, :params => { :tab => tab }
         expect(response.body).to include(url)
@@ -264,7 +264,7 @@ describe DashboardController do
       allow(controller).to receive(:check_privileges).and_return(true)
       EvmSpecHelper.seed_specific_product_features("rbac_tenant")
       feature_id = MiqProductFeature.find_all_by_identifier(["rbac_tenant"])
-      login_as FactoryGirl.create(:user, :features => feature_id)
+      login_as FactoryBot.create(:user, :features => feature_id)
     end
 
     it "for Configure maintab" do
@@ -281,7 +281,7 @@ describe DashboardController do
     end
 
     it "retuns start page url that user has set as startpage in settings" do
-      login_as FactoryGirl.create(:user, :features => "everything")
+      login_as FactoryBot.create(:user, :features => "everything")
       controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
 
       allow(controller).to receive(:role_allows?).and_return(true)
@@ -290,7 +290,7 @@ describe DashboardController do
     end
 
     it "returns first url that user has access to as start page when user doesn't have access to startpage set in settings" do
-      login_as FactoryGirl.create(:user, :features => "vm_cloud_explorer")
+      login_as FactoryBot.create(:user, :features => "vm_cloud_explorer")
       controller.instance_variable_set(:@settings, :display => {:startpage => "/dashboard/show"})
       url = controller.send(:start_url_for_user, nil)
       expect(url).to eq("/vm_cloud/explorer?accordion=instances")
@@ -349,7 +349,7 @@ describe DashboardController do
       allow(controller).to receive(:check_privileges).and_return(true)
     end
     it "redirects a restful link correctly" do
-      ems_cloud_amz = FactoryGirl.create(:ems_amazon)
+      ems_cloud_amz = FactoryBot.create(:ems_amazon)
       breadcrumbs = [{:name => "Name", :url => "/controller/action"}]
       session[:breadcrumbs] = breadcrumbs
       session[:tab_url] = {:clo => "/ems_cloud/#{ems_cloud_amz.id}"}
@@ -378,16 +378,16 @@ describe DashboardController do
 
   describe "building tabs" do
     let(:group) do
-      role = FactoryGirl.create(:miq_user_role)
-      FactoryGirl.create(:miq_group, :miq_user_role => role)
+      role = FactoryBot.create(:miq_user_role)
+      FactoryBot.create(:miq_group, :miq_user_role => role)
     end
 
     let(:user) do
-      FactoryGirl.create(:user, :miq_groups => [group])
+      FactoryBot.create(:user, :miq_groups => [group])
     end
 
     let(:wset) do
-      FactoryGirl.create(
+      FactoryBot.create(
         :miq_widget_set,
         :name     => "Widgets",
         :userid   => user.userid,

--- a/spec/controllers/ems_block_storage_controller_spec.rb
+++ b/spec/controllers/ems_block_storage_controller_spec.rb
@@ -3,7 +3,7 @@ describe EmsBlockStorageController do
 
   describe "#check_generic_rbac" do
     let(:feature) { %w(cloud_subnet_new) }
-    let(:user)    { FactoryGirl.create(:user, :features => feature) }
+    let(:user)    { FactoryBot.create(:user, :features => feature) }
 
     before do
       setup_zone
@@ -31,7 +31,7 @@ describe EmsBlockStorageController do
 
     it 'renders the view and the Block Storage Managers toolbar' do
       setup_zone
-      login_as FactoryGirl.create(:user, :features => "everything")
+      login_as FactoryBot.create(:user, :features => "everything")
       expect(ApplicationHelper::Toolbar::GtlView).to receive(:definition).and_call_original
       expect(ApplicationHelper::Toolbar::EmsBlockStoragesCenter).to receive(:definition).and_call_original
       post :show_list

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -1,11 +1,11 @@
 describe EmsCloudController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
   describe "#create" do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_cloud_new")
+      login_as FactoryBot.create(:user, :features => "ems_cloud_new")
     end
 
     it "adds a new provider" do
@@ -17,7 +17,7 @@ describe EmsCloudController do
     render_views
 
     it 'shows the edit page' do
-      get :edit, :params => { :id => FactoryGirl.create(:ems_amazon).id }
+      get :edit, :params => { :id => FactoryBot.create(:ems_amazon).id }
       expect(response.status).to eq(200)
     end
 
@@ -387,11 +387,11 @@ describe EmsCloudController do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_cloud_new")
+      login_as FactoryBot.create(:user, :features => "ems_cloud_new")
     end
 
     it "refresh relationships and power states" do
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :id => ems.id, :pressed => "ems_cloud_refresh" }
       expect(response.status).to eq(200)
     end
@@ -403,13 +403,13 @@ describe EmsCloudController do
     end
 
     it 'edit selected cloud provider' do
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :miq_grid_checks => ems.id, :pressed => "ems_cloud_edit" }
       expect(response.status).to eq(200)
     end
 
     it 'edit cloud provider tags' do
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :miq_grid_checks => ems.id, :pressed => "ems_cloud_tag" }
       expect(response.status).to eq(200)
     end
@@ -417,7 +417,7 @@ describe EmsCloudController do
     it 'manage cloud provider policies' do
       allow(controller).to receive(:protect_build_tree).and_return(nil)
       controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :miq_grid_checks => ems.id, :pressed => "ems_cloud_protect" }
       expect(response.status).to eq(200)
 
@@ -427,7 +427,7 @@ describe EmsCloudController do
     end
 
     it 'edit cloud provider tags' do
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :id => ems.id, :pressed => "ems_cloud_timeline" }
       expect(response.status).to eq(200)
 
@@ -436,7 +436,7 @@ describe EmsCloudController do
     end
 
     it 'edit cloud providers' do
-      ems = FactoryGirl.create(:ems_amazon)
+      ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :miq_grid_checks => ems.id, :pressed => "ems_cloud_edit" }
       expect(response.status).to eq(200)
     end
@@ -447,10 +447,10 @@ describe EmsCloudController do
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
+      login_as FactoryBot.create(:user, :features => "none")
       session[:settings] = {:views     => {:vm_summary_cool => "summary"},
                             :quadicons => {}}
-      @ems = FactoryGirl.create(:ems_amazon)
+      @ems = FactoryBot.create(:ems_amazon)
     end
 
     subject { get :show, :params => { :id => @ems.id } }
@@ -480,8 +480,8 @@ describe EmsCloudController do
     end
 
     it 'displays only associated storage_managers' do
-      FactoryGirl.create(:ems_storage, :name => 'abc', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
-      FactoryGirl.create(:ems_storage, :name => 'xyz', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
+      FactoryBot.create(:ems_storage, :name => 'abc', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
+      FactoryBot.create(:ems_storage, :name => 'xyz', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
       get :show, :params => { :display => "storage_managers", :id => @ems.id, :format => :js }
       expect(response).to render_template('layouts/angular/_gtl')
       expect(response.status).to eq(200)
@@ -493,7 +493,7 @@ describe EmsCloudController do
     let(:wf) { double(:dialog => dialog) }
 
     before do
-      @ems = FactoryGirl.create(:ems_amazon)
+      @ems = FactoryBot.create(:ems_amazon)
       edit = {:rec_id => 1, :wf => wf, :key => 'dialog_edit__foo', :target_id => @ems.id}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, {})
@@ -664,7 +664,7 @@ describe EmsCloudController do
   it_behaves_like "controller with custom buttons"
 
   describe "#sync_users" do
-    let(:ems) { FactoryGirl.create(:ems_openstack_with_authentication) }
+    let(:ems) { FactoryBot.create(:ems_openstack_with_authentication) }
     before do
       stub_user(:features => :all)
     end

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -64,8 +64,8 @@ describe EmsClusterController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @cluster = FactoryGirl.create(:ems_cluster)
-      login_as FactoryGirl.create(:user, :features => "none")
+      @cluster = FactoryBot.create(:ems_cluster)
+      login_as FactoryBot.create(:user, :features => "none")
     end
 
     subject do

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -27,10 +27,10 @@ describe EmsCloudController do
 
       it "when Retire Button is pressed for a Cloud provider Instance" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create(:ems_vmware)
-        vm = FactoryGirl.create(:vm_vmware,
+        ems = FactoryBot.create(:ems_vmware)
+        vm = FactoryBot.create(:vm_vmware,
                                 :ext_management_system => ems,
-                                :storage               => FactoryGirl.create(:storage))
+                                :storage               => FactoryBot.create(:storage))
         post :button, :params => { :pressed => "instance_retire", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
         expect(response.status).to eq 200
         expect(response.body).to include('vm/retire')
@@ -38,8 +38,8 @@ describe EmsCloudController do
 
       it "when Retire Button is pressed for an Orchestration Stack" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create(:ems_amazon)
-        ost = FactoryGirl.create(:orchestration_stack_cloud, :ext_management_system => ems)
+        ems = FactoryBot.create(:ems_amazon)
+        ost = FactoryBot.create(:orchestration_stack_cloud, :ext_management_system => ems)
         post :button, :params => { :pressed => "orchestration_stack_retire", "check_#{ost.id}" => "1", :format => :js, :id => ems.id, :display => 'orchestration_stacks' }
         expect(response.status).to eq 200
         expect(response.body).to include('orchestration_stack/retire')
@@ -47,10 +47,10 @@ describe EmsCloudController do
 
       it "when the Tagging Button is pressed for a Cloud provider Instance" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create(:ems_vmware)
-        vm = FactoryGirl.create(:vm_vmware,
+        ems = FactoryBot.create(:ems_vmware)
+        vm = FactoryBot.create(:vm_vmware,
                                 :ext_management_system => ems,
-                                :storage               => FactoryGirl.create(:storage))
+                                :storage               => FactoryBot.create(:storage))
         post :button, :params => { :pressed => "instance_tag", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
         expect(response.status).to eq 200
         expect(response.body).to include('ems_cloud/tagging_edit')
@@ -58,8 +58,8 @@ describe EmsCloudController do
 
       it "call tagging_edit when tha Tagging Button is pressed for one or more Cloud provider Image(s)" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        ems = FactoryGirl.create(:ems_amazon)
-        vm = FactoryGirl.create(:vm_amazon,
+        ems = FactoryBot.create(:ems_amazon)
+        vm = FactoryBot.create(:vm_amazon,
                                 :ext_management_system => ems)
         post :button, :params => { :pressed => "image_tag", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'images' }
         expect(response.status).to eq 200
@@ -74,8 +74,8 @@ describe EmsCloudController do
   end
 
   describe "#download_summary_pdf" do
-    let(:provider_openstack) { FactoryGirl.create(:provider_openstack, :name => "Undercloud") }
-    let(:ems_openstack) { FactoryGirl.create(:ems_openstack, :name => "overcloud", :provider => provider_openstack) }
+    let(:provider_openstack) { FactoryBot.create(:provider_openstack, :name => "Undercloud") }
+    let(:ems_openstack) { FactoryBot.create(:ems_openstack, :name => "overcloud", :provider => provider_openstack) }
     let(:pdf_options) { controller.instance_variable_get(:@options) }
 
     context "download pdf file" do
@@ -210,25 +210,25 @@ describe EmsContainerController do
 
       it "when VM Migrate is pressed for unsupported type" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_microsoft)
+        vm = FactoryBot.create(:vm_microsoft)
         post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
         expect(controller.send(:flash_errors?)).to be_truthy
         expect(assigns(:flash_array).first[:message]).to include('does not apply')
       end
 
-      let(:ems)     { FactoryGirl.create(:ext_management_system) }
-      let(:storage) { FactoryGirl.create(:storage) }
+      let(:ems)     { FactoryBot.create(:ext_management_system) }
+      let(:storage) { FactoryBot.create(:storage) }
 
       it "when VM Migrate is pressed for supported type" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
+        vm = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
         post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => "1" }
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
 
       it "when VM Migrate is pressed for supported type" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        vm = FactoryGirl.create(:vm_vmware)
+        vm = FactoryBot.create(:vm_vmware)
         post :button, :params => { :pressed => "vm_edit", :format => :js, "check_#{vm.id}" => "1" }
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
@@ -251,7 +251,7 @@ describe EmsContainerController do
           'container_group'      => 'Container Pods'
         }.each do |display_s, items|
           context "displaying #{items}" do
-            let(:item) { FactoryGirl.create(display_s.to_sym) }
+            let(:item) { FactoryBot.create(display_s.to_sym) }
             let(:display) { display_s.pluralize }
 
             context "tagging selected #{items}" do
@@ -286,7 +286,7 @@ describe EmsContainerController do
     end
 
     describe "#download_summary_pdf" do
-      let(:ems_kubernetes_container) { FactoryGirl.create(:ems_kubernetes, :name => "test") }
+      let(:ems_kubernetes_container) { FactoryBot.create(:ems_kubernetes, :name => "test") }
       let(:pdf_options) { controller.instance_variable_get(:@options) }
 
       context "download pdf file" do
@@ -330,7 +330,7 @@ describe EmsNetworkController do
 
       it "when edit is pressed for unsupported network manager type" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        google_net = FactoryGirl.create(:ems_google_network)
+        google_net = FactoryBot.create(:ems_google_network)
         get :edit, :params => { :id => google_net.id}
         expect(response.status).to eq(302)
         expect(session['flash_msgs']).not_to be_empty
@@ -339,7 +339,7 @@ describe EmsNetworkController do
 
       it "when edit is pressed for supported network manager type" do
         allow(controller).to receive(:role_allows?).and_return(true)
-        nuage_net = FactoryGirl.create(:ems_nuage_network)
+        nuage_net = FactoryBot.create(:ems_nuage_network)
         get :edit, :params => { :id => nuage_net.id}
         expect(response.status).to eq(200)
         expect(session['flash_msgs']).to be_nil

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -14,8 +14,8 @@ describe EmsContainerController do
     before do
       session[:settings] = {:views => {}, :quadicons => {}}
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @container = FactoryGirl.create(:ems_kubernetes)
+      login_as FactoryBot.create(:user)
+      @container = FactoryBot.create(:ems_kubernetes)
     end
 
     context "render" do
@@ -60,8 +60,8 @@ describe EmsContainerController do
   end
 
   describe ".update_ems_button_detect" do
-    let(:kubernetes_manager) { FactoryGirl.create(:ems_kubernetes) }
-    let(:openshift_manager) { FactoryGirl.create(:ems_openshift) }
+    let(:kubernetes_manager) { FactoryBot.create(:ems_kubernetes) }
+    let(:openshift_manager) { FactoryBot.create(:ems_openshift) }
     let(:hawkular_route) { RecursiveOpenStruct.new(:spec => {:host => "myhawkularroute.com"}) }
     let(:mock_client) { double('kubeclient') }
 
@@ -158,7 +158,7 @@ describe EmsContainerController do
   end
 
   describe "create with provider options" do
-    let(:zone) { FactoryGirl.build(:zone) }
+    let(:zone) { FactoryBot.build(:zone) }
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
 
     before do
@@ -189,7 +189,7 @@ describe EmsContainerController do
   end
 
   describe "Hawkular Disabled/Enabled" do
-    let(:zone) { FactoryGirl.build(:zone) }
+    let(:zone) { FactoryBot.build(:zone) }
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
 
     before do
@@ -243,7 +243,7 @@ describe EmsContainerController do
   end
 
   describe "Kubevirt Disabled/Enabled" do
-    let(:zone) { FactoryGirl.build(:zone) }
+    let(:zone) { FactoryBot.build(:zone) }
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
 
     before do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -1,6 +1,6 @@
 describe EmsInfraController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
   context "#button" do
     before do
       stub_user(:features => :all)
@@ -10,7 +10,7 @@ describe EmsInfraController do
     end
 
     it "EmsInfra check compliance is called when Compliance is pressed" do
-      ems_infra = FactoryGirl.create(:ems_vmware)
+      ems_infra = FactoryBot.create(:ems_vmware)
       expect(controller).to receive(:check_compliance).and_call_original
       post :button, :params => {:pressed => "ems_infra_check_compliance", :format => :js, :id => ems_infra.id}
       expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -30,8 +30,8 @@ describe EmsInfraController do
     end
 
     it "when VM Migrate is pressed" do
-      ems = FactoryGirl.create(:ems_vmware)
-      vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+      ems = FactoryBot.create(:ems_vmware)
+      vm = FactoryBot.create(:vm_vmware, :ext_management_system => ems)
       post :button, :params => { :pressed => "vm_migrate", :format => :js, "check_#{vm.id}" => 1, :id => ems.id }
       expect(controller.send(:flash_errors?)).not_to be_truthy
       expect(response.body).to include("/miq_request/prov_edit?")
@@ -69,8 +69,8 @@ describe EmsInfraController do
     end
 
     it "should set correct VM for right-sizing when on list of VM's of another CI" do
-      ems_infra = FactoryGirl.create(:ext_management_system)
-      vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems_infra)
+      ems_infra = FactoryBot.create(:ext_management_system)
+      vm = FactoryBot.create(:vm_vmware, :ext_management_system => ems_infra)
       allow(controller).to receive(:find_records_with_rbac) { [vm] }
       post :button, :params => { :pressed => "vm_right_size", :id => ems_infra.id, :display => 'vms', "check_#{vm.id}" => '1' }
       expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -78,14 +78,14 @@ describe EmsInfraController do
     end
 
     it "when Host Analyze then Check Compliance is pressed" do
-      ems_infra = FactoryGirl.create(:ems_vmware)
+      ems_infra = FactoryBot.create(:ems_vmware)
       expect(controller).to receive(:analyze_check_compliance_hosts)
       post :button, :params => {:pressed => "host_analyze_check_compliance", :id => ems_infra.id, :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when vm_transform_mass is pressed" do
-      ems_infra = FactoryGirl.create(:ems_vmware)
+      ems_infra = FactoryBot.create(:ems_vmware)
       expect(controller).to receive(:vm_transform_mass)
       post :button, :params => {:pressed => "vm_transform_mass", :id => ems_infra.id, :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -95,7 +95,7 @@ describe EmsInfraController do
   describe "#create" do
     before do
       # USE: stub_user :features => %w(ems_infra_new ems_infra_edit)
-      user = FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      user = FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
 
       allow(user).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
@@ -119,7 +119,7 @@ describe EmsInfraController do
       stack_parameters = [p1, p2]
       @orchestration_stack = instance_double("mock stack", :id => 1, :parameters => stack_parameters, :update_ready? => true)
       allow(@ems).to receive(:direct_orchestration_stacks).and_return([@orchestration_stack])
-      @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
+      @orchestration_stack_parameter_compute = FactoryBot.create(:orchestration_stack_parameter_openstack_infra_compute)
     end
 
     it "when values are not changed" do
@@ -178,7 +178,7 @@ describe EmsInfraController do
       allow(@ems).to receive(:direct_orchestration_stacks).and_return([@orchestration_stack])
       allow(@ems).to receive(:orchestration_stacks).and_return([@orchestration_stack])
       allow(controller).to receive(:find_record_with_rbac).and_return(@orchestration_stack)
-      @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
+      @orchestration_stack_parameter_compute = FactoryBot.create(:orchestration_stack_parameter_openstack_infra_compute)
     end
 
     it "when no compute hosts are selected" do
@@ -211,7 +211,7 @@ describe EmsInfraController do
     end
 
     it "when no orchestration stack is available" do
-      @ems = FactoryGirl.create(:ems_openstack_infra)
+      @ems = FactoryBot.create(:ems_openstack_infra)
       allow(controller).to receive(:get_infra_provider).and_return(@ems)
       post :scaledown, :params => {:id => @ems.id, :scaledown => "", :orchestration_stack_id => nil}
       expect(controller.send(:flash_errors?)).to be_truthy
@@ -223,7 +223,7 @@ describe EmsInfraController do
   describe "#register_and_configure_nodes" do
     before do
       stub_user(:features => :all)
-      @ems = FactoryGirl.create(:ems_openstack_infra_with_stack_and_compute_nodes)
+      @ems = FactoryBot.create(:ems_openstack_infra_with_stack_and_compute_nodes)
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager)
         .to receive(:openstack_handle).and_return([])
       allow_any_instance_of(EmsInfraController)
@@ -273,8 +273,8 @@ describe EmsInfraController do
     render_views
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
-      @ems = FactoryGirl.create(:ems_vmware)
+      login_as FactoryBot.create(:user, :features => "none")
+      @ems = FactoryBot.create(:ems_vmware)
     end
 
     let(:url_params) { {} }
@@ -283,12 +283,12 @@ describe EmsInfraController do
 
     context "display=hosts" do
       it 'renders custom buttons for hosts accessed from relationship screen' do
-        custom_button = FactoryGirl.create(
+        custom_button = FactoryBot.create(
           :custom_button, :name => "My Button", :applies_to_class => "Host",
           :visibility => {:roles => ["_ALL_"]},
           :options => {:display => true, :open_url => false, :display_for => "both"}
         )
-        custom_button_set = FactoryGirl.create(
+        custom_button_set = FactoryBot.create(
           :custom_button_set, :set_data => {
             :applies_to_class => "Host", :button_order => [custom_button.id]
           }
@@ -336,7 +336,7 @@ describe EmsInfraController do
     end
 
     it "shows associated datastores" do
-      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @datastore = FactoryBot.create(:storage, :name => 'storage_name')
       @datastore.parent = @ems
       controller.instance_variable_set(:@breadcrumbs, [])
       get :show, :params => {:id => @ems.id, :display => 'storages'}
@@ -350,7 +350,7 @@ describe EmsInfraController do
 
     it " can tag associated datastores" do
       stub_user(:features => :all)
-      datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      datastore = FactoryBot.create(:storage, :name => 'storage_name')
       datastore.parent = @ems
       controller.instance_variable_set(:@_orig_action, "x_history")
       get :show, :params => {:id => @ems.id, :display => 'storages'}
@@ -384,7 +384,7 @@ describe EmsInfraController do
   describe "#show_list" do
     before do
       stub_user(:features => :all)
-      FactoryGirl.create(:ems_vmware)
+      FactoryBot.create(:ems_vmware)
       get :show_list
     end
     it { expect(response.status).to eq(200) }
@@ -397,7 +397,7 @@ describe EmsInfraController do
     end
     context "when previous breadcrumbs path contained 'Cloud Providers'" do
       it "shows 'Infrastructure Providers -> (Summary)' breadcrumb path" do
-        ems = FactoryGirl.create(:ems_vmware)
+        ems = FactoryBot.create(:ems_vmware)
         get :show, :params => { :id => ems.id }
         breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
         expect(breadcrumbs).to eq([{:name => "#{ems.name} (Dashboard)", :url => "/ems_infra/#{ems.id}"}])
@@ -407,7 +407,7 @@ describe EmsInfraController do
 
   describe "#build_credentials" do
     before do
-      @ems = FactoryGirl.create(:ems_openstack_infra)
+      @ems = FactoryBot.create(:ems_openstack_infra)
     end
     context "#build_credentials only contains credentials that it supports and has a username for in params" do
       let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
@@ -452,7 +452,7 @@ describe EmsInfraController do
 
   describe "SCVMM - create, update, validate, cancel" do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -542,7 +542,7 @@ describe EmsInfraController do
 
   describe "Openstack - create, update" do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -623,7 +623,7 @@ describe EmsInfraController do
 
   describe "Redhat - create, update" do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
         .to receive(:supported_api_versions).and_return([3, 4])
     end
@@ -726,7 +726,7 @@ describe EmsInfraController do
 
   describe "Kubevirt - update" do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views
@@ -801,7 +801,7 @@ describe EmsInfraController do
 
   describe "VMWare - create, update" do
     before do
-      login_as FactoryGirl.create(:user, :features => %w(ems_infra_new ems_infra_edit))
+      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
     end
 
     render_views

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -1,10 +1,10 @@
 describe EmsPhysicalInfraController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
 
   describe "#create" do
     before do
-      user = FactoryGirl.create(:user, :features => "ems_physical_infra_new")
+      user = FactoryBot.create(:user, :features => "ems_physical_infra_new")
 
       allow(user).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
@@ -23,8 +23,8 @@ describe EmsPhysicalInfraController do
     render_views
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
-      @ems = FactoryGirl.create(:ems_physical_infra)
+      login_as FactoryBot.create(:user, :features => "none")
+      @ems = FactoryBot.create(:ems_physical_infra)
     end
 
     let(:url_params) { {} }
@@ -49,7 +49,7 @@ describe EmsPhysicalInfraController do
     end
 
     it "shows associated datastores" do
-      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @datastore = FactoryBot.create(:storage, :name => 'storage_name')
       @datastore.parent = @ems
       controller.instance_variable_set(:@breadcrumbs, [])
       get :show, :params => {:id => @ems.id, :display => 'storages'}
@@ -64,7 +64,7 @@ describe EmsPhysicalInfraController do
 
     it " can tag associated datastores" do
       stub_user(:features => :all)
-      datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      datastore = FactoryBot.create(:storage, :name => 'storage_name')
       datastore.parent = @ems
       controller.instance_variable_set(:@_orig_action, "x_history")
       get :show, :params => {:id => @ems.id, :display => 'storages'}
@@ -84,7 +84,7 @@ describe EmsPhysicalInfraController do
   describe "#show_list" do
     before do
       stub_user(:features => :all)
-      FactoryGirl.create(:ems_vmware)
+      FactoryBot.create(:ems_vmware)
       get :show_list
     end
     it { expect(response.status).to eq(200) }
@@ -97,7 +97,7 @@ describe EmsPhysicalInfraController do
     end
     context "when previous breadcrumbs path contained 'Cloud Providers'" do
       it "shows 'Physical Infrastructure Providers -> (Dashboard)' breadcrumb path" do
-        ems = FactoryGirl.create(:ems_physical_infra)
+        ems = FactoryBot.create(:ems_physical_infra)
         get :show, :params => { :id => ems.id }
         breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
         expect(breadcrumbs).to eq([{:name => "#{ems.name} (Dashboard)", :url => "/ems_physical_infra/#{ems.id}"}])
@@ -107,7 +107,7 @@ describe EmsPhysicalInfraController do
 
   describe "#build_credentials" do
     before do
-      @ems = FactoryGirl.create(:ems_physical_infra)
+      @ems = FactoryBot.create(:ems_physical_infra)
     end
     context "#build_credentials only contains credentials that it supports and has a username for in params" do
       let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
@@ -132,7 +132,7 @@ describe EmsPhysicalInfraController do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
-      login_as FactoryGirl.create(:user, :features => "ems_physical_infra_new")
+      login_as FactoryBot.create(:user, :features => "ems_physical_infra_new")
     end
 
     render_views

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -5,11 +5,11 @@ describe EmsStorageController do
 
   describe "#check_generic_rbac" do
     let(:feature)        { MiqProductFeature.find_all_by_identifier(%w(ems_block_storage_show ems_block_storage_show_list)) }
-    let(:role)           { FactoryGirl.create(:miq_user_role, :miq_product_features => feature) }
-    let(:group)          { FactoryGirl.create(:miq_group, :miq_user_role => role) }
-    let(:user)           { FactoryGirl.create(:user, :miq_groups => [group]) }
-    let(:object_storage) { FactoryGirl.create(:ems_swift) }
-    let(:block_storage)  { FactoryGirl.create(:ems_cinder) }
+    let(:role)           { FactoryBot.create(:miq_user_role, :miq_product_features => feature) }
+    let(:group)          { FactoryBot.create(:miq_group, :miq_user_role => role) }
+    let(:user)           { FactoryBot.create(:user, :miq_groups => [group]) }
+    let(:object_storage) { FactoryBot.create(:ems_swift) }
+    let(:block_storage)  { FactoryBot.create(:ems_cinder) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -32,7 +32,7 @@ describe EmsStorageController do
 
     it "sets @ems in init_show for a selected record" do
       controller.action_name = 'show'
-      ems_storage = FactoryGirl.create(:ems_storage, :name => "foo")
+      ems_storage = FactoryBot.create(:ems_storage, :name => "foo")
       allow(controller).to receive(:type_feature_role_check).and_return(true)
       controller.instance_variable_set(:@_params, :id => ems_storage.id)
       controller.send(:init_show)

--- a/spec/controllers/flavor_controller_spec.rb
+++ b/spec/controllers/flavor_controller_spec.rb
@@ -2,7 +2,7 @@ describe FlavorController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     stub_user(:features => :all)
-    @flavor = FactoryGirl.create(:flavor)
+    @flavor = FactoryBot.create(:flavor)
   end
 
   describe "#show" do

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -5,13 +5,13 @@ describe FloatingIpController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:floating_ip)
+      @ct = FactoryBot.create(:floating_ip)
       allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
@@ -31,8 +31,8 @@ describe FloatingIpController do
     end
 
     describe "#delete_floating_ips" do
-      let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-      let!(:floating_ip) { FactoryGirl.create(:floating_ip) }
+      let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
+      let!(:floating_ip) { FactoryBot.create(:floating_ip) }
       before do
         EvmSpecHelper.create_guid_miq_server_zone
         login_as admin_user
@@ -70,8 +70,8 @@ describe FloatingIpController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @floating_ip = FactoryGirl.create(:floating_ip)
-      login_as FactoryGirl.create(:user)
+      @floating_ip = FactoryBot.create(:floating_ip)
+      login_as FactoryBot.create(:user)
     end
 
     subject do
@@ -91,8 +91,8 @@ describe FloatingIpController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack)
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @floating_ip = FactoryBot.create(:floating_ip_openstack)
       stub_user(:features => :all)
     end
 
@@ -132,8 +132,8 @@ describe FloatingIpController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :ext_management_system => @ems)
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @floating_ip = FactoryBot.create(:floating_ip_openstack, :ext_management_system => @ems)
     end
 
     context "#edit" do
@@ -172,8 +172,8 @@ describe FloatingIpController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :ext_management_system => @ems)
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @floating_ip = FactoryBot.create(:floating_ip_openstack, :ext_management_system => @ems)
     end
 
     context "#delete" do

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -1,20 +1,20 @@
 describe GenericObjectController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
 
   describe "#show" do
     render_views
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
-      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
-      generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      login_as FactoryBot.create(:user, :features => "none")
+      generic_obj_defn = FactoryBot.create(:generic_object_definition)
+      generic_obj = FactoryBot.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       get :show, :params => {:id => generic_obj.id}
     end
     it { expect(response.status).to eq(200) }
 
     it 'displays Generic Object association in the nested display list' do
-      generic_obj_defn = FactoryGirl.create(
+      generic_obj_defn = FactoryBot.create(
         :generic_object_definition,
         :name       => "test_definition",
         :properties => {
@@ -29,7 +29,7 @@ describe GenericObjectController do
           :methods      => %w(some_method)
         }
       )
-      generic_obj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      generic_obj = FactoryBot.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       get :show, :params => { :display => "cp", :id => generic_obj.id }
       expect(response.status).to eq(200)
 
@@ -41,8 +41,8 @@ describe GenericObjectController do
   describe "#show_list" do
     before do
       stub_user(:features => :all)
-      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
-      FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      generic_obj_defn = FactoryBot.create(:generic_object_definition)
+      FactoryBot.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       get :show_list
     end
     it { expect(response.status).to eq(200) }
@@ -51,16 +51,16 @@ describe GenericObjectController do
   describe "#tags_edit" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       stub_user(:features => :all)
-      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
-      @gobj = FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+      generic_obj_defn = FactoryBot.create(:generic_object_definition)
+      @gobj = FactoryBot.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
       allow(@gobj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag_1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag_2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@gobj).and_return([@tag1, @tag2])

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -1,16 +1,16 @@
 describe GenericObjectDefinitionController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
 
   describe "#show" do
     render_views
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
+      login_as FactoryBot.create(:user, :features => "none")
     end
 
     it "should redirect to #show_list" do
-      generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+      generic_obj_defn = FactoryBot.create(:generic_object_definition)
       get :show, :params => {:id => generic_obj_defn.id}
       expect(response.status).to eq(302)
       expect(response).to redirect_to(:action => 'show_list')
@@ -22,7 +22,7 @@ describe GenericObjectDefinitionController do
         allow_any_instance_of(GenericObjectDefinition).to receive(:generic_objects)
       end
       it "show the generic_object_definition record when display=main" do
-        generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+        generic_obj_defn = FactoryBot.create(:generic_object_definition)
         get :show, :params => {:id => generic_obj_defn.id, :display => "main"}
         expect(response.status).to eq(200)
       end
@@ -30,8 +30,8 @@ describe GenericObjectDefinitionController do
 
     context "#show when @display=generic_objects" do
       it "renders the generic objects list" do
-        generic_obj_defn = FactoryGirl.create(:generic_object_definition)
-        FactoryGirl.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
+        generic_obj_defn = FactoryBot.create(:generic_object_definition)
+        FactoryBot.create(:generic_object, :generic_object_definition_id => generic_obj_defn.id)
         controller.instance_variable_set(:@display, 'generic_objects')
         controller.instance_variable_set(:@breadcrumbs, [])
         controller.instance_variable_set(:@settings, {})
@@ -47,7 +47,7 @@ describe GenericObjectDefinitionController do
   describe "#show_list" do
     before do
       stub_user(:features => :all)
-      FactoryGirl.create(:generic_object_definition)
+      FactoryBot.create(:generic_object_definition)
       allow(controller).to receive(:build_tree)
       allow(controller).to receive(:exp_build_table)
       get :show_list
@@ -66,8 +66,8 @@ describe GenericObjectDefinitionController do
     end
 
     it "when Generic Object Tag is pressed for the generic object nested list" do
-      definition = FactoryGirl.create(:generic_object_definition)
-      go = FactoryGirl.create(:generic_object, :generic_object_definition_id => definition.id)
+      definition = FactoryBot.create(:generic_object_definition)
+      go = FactoryBot.create(:generic_object, :generic_object_definition_id => definition.id)
       get :show, :params => {:id => definition.id, :display => 'generic_objects'}
       post :button, :params => {:pressed => "generic_object_tag", "check_#{go.id}" => "1", :id => definition.id, :display => 'generic_objects', :format => :js}
       expect(response.status).to eq(200)
@@ -78,7 +78,7 @@ describe GenericObjectDefinitionController do
   context "#process_root_node" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
+      login_as FactoryBot.create(:user, :features => "none")
     end
 
     it "renders the toolbar for 'show_list'" do
@@ -101,8 +101,8 @@ describe GenericObjectDefinitionController do
   context "GTL rendering for various node types" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @generic_obj_defn = FactoryGirl.create(:generic_object_definition)
+      login_as FactoryBot.create(:user)
+      @generic_obj_defn = FactoryBot.create(:generic_object_definition)
     end
 
     it "renders the toolbar for root node with gtl icons" do
@@ -127,7 +127,7 @@ describe GenericObjectDefinitionController do
     end
 
     it "renders the toolbar for custom_button_group node with no gtl icons" do
-      custom_button_set = FactoryGirl.create(:custom_button_set, :description => "custom button set description")
+      custom_button_set = FactoryBot.create(:custom_button_set, :description => "custom button set description")
       allow(controller).to receive(:x_node).and_return("cbg-#{custom_button_set.id}")
       controller.send(:show_list)
       gtl_type = controller.instance_variable_get(:@gtl_type)
@@ -135,7 +135,7 @@ describe GenericObjectDefinitionController do
     end
 
     it "renders the toolbar for custom_button node with no gtl icons" do
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "GenericObjectDefinition", :name => "Some Name")
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => "GenericObjectDefinition", :name => "Some Name")
       allow(controller).to receive(:x_node).and_return("cb-#{custom_button.id}")
       controller.send(:show_list)
       gtl_type = controller.instance_variable_get(:@gtl_type)
@@ -154,7 +154,7 @@ describe GenericObjectDefinitionController do
     end
 
     it "does not display toolbar and paging div when custom button is edited" do
-      custom_button = FactoryGirl.create(:custom_button,
+      custom_button = FactoryBot.create(:custom_button,
                                          :applies_to_class => "GenericObjectDefinition",
                                          :name             => "Default",
                                          :options          => {

--- a/spec/controllers/guest_device_controller_spec.rb
+++ b/spec/controllers/guest_device_controller_spec.rb
@@ -2,18 +2,18 @@ describe GuestDeviceController do
   render_views
 
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
 
   before do
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
-    @guest_device = FactoryGirl.create(:guest_device, :id => 1)
+    login_as FactoryBot.create(:user)
+    @guest_device = FactoryBot.create(:guest_device, :id => 1)
   end
 
   describe "#show_list" do
     before do
-      FactoryGirl.create(:guest_device)
+      FactoryBot.create(:guest_device)
     end
 
     subject { get :show_list }

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -2,8 +2,8 @@ describe HostAggregateController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @aggregate = FactoryGirl.create(:host_aggregate)
-      login_as FactoryGirl.create(:user_admin)
+      @aggregate = FactoryBot.create(:host_aggregate)
+      login_as FactoryBot.create(:user_admin)
     end
 
     subject do
@@ -26,8 +26,8 @@ describe HostAggregateController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack)
+      @ems = FactoryBot.create(:ems_openstack)
+      @aggregate = FactoryBot.create(:host_aggregate_openstack)
     end
 
     let(:task_options) do
@@ -62,8 +62,8 @@ describe HostAggregateController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @aggregate = FactoryBot.create(:host_aggregate_openstack,
                                       :ext_management_system => @ems)
     end
 
@@ -100,8 +100,8 @@ describe HostAggregateController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @aggregate = FactoryBot.create(:host_aggregate_openstack,
                                       :ext_management_system => @ems)
     end
 
@@ -135,10 +135,10 @@ describe HostAggregateController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @aggregate = FactoryBot.create(:host_aggregate_openstack,
                                       :ext_management_system => @ems)
-      @host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems)
+      @host = FactoryBot.create(:host_openstack_infra, :ext_management_system => @ems)
     end
 
     context "#add_host" do
@@ -176,10 +176,10 @@ describe HostAggregateController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack)
-      @aggregate = FactoryGirl.create(:host_aggregate_openstack,
+      @ems = FactoryBot.create(:ems_openstack)
+      @aggregate = FactoryBot.create(:host_aggregate_openstack,
                                       :ext_management_system => @ems)
-      @host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems)
+      @host = FactoryBot.create(:host_openstack_infra, :ext_management_system => @ems)
     end
 
     context "#remove_host" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -1,6 +1,6 @@
 describe HostController do
-  let(:h1) { FactoryGirl.create(:host, :name => 'foobar') }
-  let(:h2) { FactoryGirl.create(:host, :name => 'bar') }
+  let(:h1) { FactoryBot.create(:host, :name => 'foobar') }
+  let(:h2) { FactoryBot.create(:host, :name => 'bar') }
 
   describe "#button" do
     render_views
@@ -20,7 +20,7 @@ describe HostController do
 
     it "renders show_list and does not include hidden column" do
       allow(controller).to receive(:render)
-      report = FactoryGirl.create(:miq_report,
+      report = FactoryBot.create(:miq_report,
                                   :name        => 'Hosts',
                                   :title       => 'Hosts',
                                   :cols        => %w(name ipaddress v_total_vms),
@@ -36,7 +36,7 @@ describe HostController do
 
     it "renders show_list and includes all columns" do
       allow(controller).to receive(:render)
-      report = FactoryGirl.create(:miq_report,
+      report = FactoryBot.create(:miq_report,
                                   :name      => 'Hosts',
                                   :title     => 'Hosts',
                                   :cols      => %w(name ipaddress v_total_vms),
@@ -108,12 +108,12 @@ describe HostController do
     end
 
     it "when Custom Button is pressed" do
-      host = FactoryGirl.create(:host)
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
-      d = FactoryGirl.create(:dialog, :label => "Some Label")
-      dt = FactoryGirl.create(:dialog_tab, :label => "Some Tab", :order => 0)
+      host = FactoryBot.create(:host)
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
+      d = FactoryBot.create(:dialog, :label => "Some Label")
+      dt = FactoryBot.create(:dialog_tab, :label => "Some Tab", :order => 0)
       d.dialog_tabs << dt
-      ra = FactoryGirl.create(:resource_action, :dialog_id => d.id)
+      ra = FactoryBot.create(:resource_action, :dialog_id => d.id)
       custom_button.resource_action = ra
       custom_button.save
       post :button, :params => {:pressed => "custom_button", :id => host.id, :button_id => custom_button.id}
@@ -205,9 +205,9 @@ describe HostController do
   describe "#show_association" do
     before do
       stub_user(:features => :all)
-      @host = FactoryGirl.create(:host, :name =>'hostname1')
-      @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
-      @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+      @host = FactoryBot.create(:host, :name =>'hostname1')
+      @guest_application = FactoryBot.create(:guest_application, :name => "foo", :host_id => @host.id)
+      @datastore = FactoryBot.create(:storage, :name => 'storage_name')
       @datastore.parent = @host
     end
 
@@ -238,7 +238,7 @@ describe HostController do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
 
-      @host = FactoryGirl.create(:host, :name =>'hostname1')
+      @host = FactoryBot.create(:host, :name =>'hostname1')
     end
 
     # http://localhost:3000/host/users/10000000000005?db=host
@@ -255,7 +255,7 @@ describe HostController do
 
     # http://localhost:3000/host/guest_applications/10000000000005?db=host
     it "renders a grid of associated GuestApplications" do
-      @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
+      @guest_application = FactoryBot.create(:guest_application, :name => "foo", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name      => 'GuestApplication',
         :parent_id       => @host.id.to_s,
@@ -268,7 +268,7 @@ describe HostController do
 
     # http://localhost:3000/host/filesystems/10000000000005?db=host
     it "renders a grid of all associated Filesystems" do
-      @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
+      @host_service_group = FactoryBot.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'Filesystem',
         :parent_id                      => @host.id.to_s,
@@ -284,7 +284,7 @@ describe HostController do
 
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=all
     it "renders a grid of all associated SystemServices" do
-      @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
+      @host_service_group = FactoryBot.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
@@ -300,7 +300,7 @@ describe HostController do
 
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=running
     it "renders a grid of running associated SystemServices" do
-      @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
+      @host_service_group = FactoryBot.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
@@ -316,7 +316,7 @@ describe HostController do
 
     # http://localhost:3000/host/guest_applications/10000000000005?db=host?status=failed
     it "renders a grid of failed associated SystemServices" do
-      @host_service_group = FactoryGirl.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
+      @host_service_group = FactoryBot.create(:host_service_group, :name => "host_service_group1", :host_id => @host.id)
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name                     => 'SystemService',
         :parent_id                      => @host.id.to_s,
@@ -334,9 +334,9 @@ describe HostController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
-      @host = FactoryGirl.create(:host,
-                                 :hardware => FactoryGirl.create(:hardware,
+      login_as FactoryBot.create(:user, :features => "none")
+      @host = FactoryBot.create(:host,
+                                 :hardware => FactoryBot.create(:hardware,
                                                                  :cpu_sockets          => 2,
                                                                  :cpu_cores_per_socket => 4,
                                                                  :cpu_total_cores      => 8))

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -1,15 +1,15 @@
 describe InfraNetworkingController do
-  let!(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'true') }
-  let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-  let(:tag1) { FactoryGirl.create(:classification_tag, :name   => "tag1", :parent => classification) }
-  let(:tag2) { FactoryGirl.create(:classification_tag, :name   => "tag2", :parent => classification) }
-  let(:ems) { FactoryGirl.create(:ems_vmware) }
-  let(:cluster) { FactoryGirl.create(:ems_cluster, :ems_id => ems.id) }
+  let!(:switch) { FactoryBot.create(:switch, :name => 'test_switch1', :shared => 'true') }
+  let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+  let(:tag1) { FactoryBot.create(:classification_tag, :name   => "tag1", :parent => classification) }
+  let(:tag2) { FactoryBot.create(:classification_tag, :name   => "tag2", :parent => classification) }
+  let(:ems) { FactoryBot.create(:ems_vmware) }
+  let(:cluster) { FactoryBot.create(:ems_cluster, :ems_id => ems.id) }
 
   before do
     stub_user(:features => :all)
-    FactoryGirl.create(:tagging, :tag => tag1.tag, :taggable => switch)
-    FactoryGirl.create(:tagging, :tag => tag2.tag, :taggable => switch)
+    FactoryBot.create(:tagging, :tag => tag1.tag, :taggable => switch)
+    FactoryBot.create(:tagging, :tag => tag2.tag, :taggable => switch)
   end
 
   describe 'render_views' do

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -1,8 +1,8 @@
 describe MiqAeClassController do
   context "#set_record_vars" do
     it "Namespace remains unchanged when a class is edited" do
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+      ns = FactoryBot.create(:miq_ae_namespace)
+      cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
       ns_id = cls.namespace_id
       new = {:name => "New Name", :description => "New Description", :display_name => "Display Name", :inherits => "Some_Class"}
       controller.instance_variable_set(:@sb,
@@ -18,8 +18,8 @@ describe MiqAeClassController do
 
   context "#set_right_cell_text" do
     it "check if correct namespace_path is being set" do
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+      ns = FactoryBot.create(:miq_ae_namespace)
+      cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
       controller.instance_variable_set(:@sb, {})
       id = "aec-#{cls.id}"
       fq_name = cls.fqname
@@ -36,7 +36,7 @@ describe MiqAeClassController do
   context "#domain_lock" do
     it "Marks domain as locked/readonly" do
       stub_user(:features => :all)
-      ns = FactoryGirl.create(:miq_ae_domain_enabled)
+      ns = FactoryBot.create(:miq_ae_domain_enabled)
       controller.instance_variable_set(:@_params, :id => ns.id)
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_lock)
@@ -48,7 +48,7 @@ describe MiqAeClassController do
   context "#domain_unlock" do
     it "Marks domain as unlocked/editable" do
       stub_user(:features => :all)
-      ns = FactoryGirl.create(:miq_ae_domain_disabled)
+      ns = FactoryBot.create(:miq_ae_domain_disabled)
       controller.instance_variable_set(:@_params, :id => ns.id)
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_unlock)
@@ -60,10 +60,10 @@ describe MiqAeClassController do
   context "#domains_priority_edit" do
     it "sets priority of domains" do
       stub_user(:features => :all)
-      FactoryGirl.create(:miq_ae_domain, :name => "test1", :parent => nil, :priority => 1)
-      FactoryGirl.create(:miq_ae_domain, :name => "test2", :parent => nil, :priority => 2)
-      FactoryGirl.create(:miq_ae_domain, :name => "test3", :parent => nil, :priority => 3)
-      FactoryGirl.create(:miq_ae_domain, :name => "test4", :parent => nil, :priority => 4)
+      FactoryBot.create(:miq_ae_domain, :name => "test1", :parent => nil, :priority => 1)
+      FactoryBot.create(:miq_ae_domain, :name => "test2", :parent => nil, :priority => 2)
+      FactoryBot.create(:miq_ae_domain, :name => "test3", :parent => nil, :priority => 3)
+      FactoryBot.create(:miq_ae_domain, :name => "test4", :parent => nil, :priority => 4)
       order = %w(test3 test2 test4 test1)
       edit = {
         :new     => {:domain_order => order},
@@ -85,9 +85,9 @@ describe MiqAeClassController do
   context "#copy_objects" do
     it "do not replace left side explorer tree when copy form is loaded initially" do
       stub_user(:features => :all)
-      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
       node = "aec-#{cls1.id}"
       controller.instance_variable_set(:@sb,
@@ -104,12 +104,12 @@ describe MiqAeClassController do
 
     it "copies class under specified namespace" do
       stub_user(:features => :all)
-      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
-      d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2")
-      ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
+      d2 = FactoryBot.create(:miq_ae_domain, :name => "domain2")
+      ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
 
       new = {:domain => d2.id, :namespace => ns2.fqname, :overwrite_location => false}
       selected_items = {cls1.id => cls1.name}
@@ -134,9 +134,9 @@ describe MiqAeClassController do
 
     it "copy class under same namespace returns error when class exists" do
       stub_user(:features => :all)
-      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
       new = {:domain => d1.id, :namespace => ns1.fqname, :overwrite_location => false}
       selected_items = {cls1.id => cls1.name}
@@ -161,12 +161,12 @@ describe MiqAeClassController do
 
     it "overwrite class under same namespace when class exists" do
       stub_user(:features => :all)
-      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
-      d2 = FactoryGirl.create(:miq_ae_domain)
-      ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
+      d2 = FactoryBot.create(:miq_ae_domain)
+      ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
 
       new = {:domain => d2.id, :namespace => ns2.fqname, :override_existing => true}
       selected_items = {cls1.id => cls1.name}
@@ -190,9 +190,9 @@ describe MiqAeClassController do
 
     it "copies a class with new name under same domain" do
       stub_user(:features => :all)
-      d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-      ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-      cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+      ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+      cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
       new = {:domain => d1.id, :namespace => ns1.fqname, :override_existing => true, :new_name => 'foo'}
       selected_items = {cls1.id => cls1.name}
@@ -273,7 +273,7 @@ describe MiqAeClassController do
     end
 
     before do
-      @user =  FactoryGirl.create(:user_with_group)
+      @user =  FactoryBot.create(:user_with_group)
       login_as @user
       allow(MiqAeDomain).to receive(:find_by_name).with("another_fqname").and_return(miq_ae_domain)
       allow(MiqAeDomain).to receive(:find_by_name).with("another_fqname2").and_return(miq_ae_domain2)
@@ -282,10 +282,10 @@ describe MiqAeClassController do
     context "#node_info" do
       it "collect namespace info" do
         stub_user(:features => :all)
-        d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
-        ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
-        FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => ns1.id)
-        FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+        d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
+        ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
+        FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent_id => ns1.id)
+        FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
         node = "aen-#{ns1.id}"
         controller.instance_variable_set(:@sb,
                                          :active_tree => :ae_tree,
@@ -396,9 +396,9 @@ describe MiqAeClassController do
   end
 
   context "#delete_domain" do
-    let(:domain1) { FactoryGirl.create(:miq_ae_system_domain_enabled) }
-    let(:domain2) { FactoryGirl.create(:miq_ae_domain_enabled) }
-    let(:domain3) { FactoryGirl.create(:miq_ae_git_domain) }
+    let(:domain1) { FactoryBot.create(:miq_ae_system_domain_enabled) }
+    let(:domain2) { FactoryBot.create(:miq_ae_domain_enabled) }
+    let(:domain3) { FactoryBot.create(:miq_ae_git_domain) }
     let(:ids) { "aen-#{domain1.id}, aen-#{domain2.id}, aen-#{domain3.id}, aen-someid" }
     let(:git_service) { double("GitBasedDomainImportService") }
 
@@ -426,12 +426,12 @@ describe MiqAeClassController do
   context "#ae_class_validation" do
     before do
       stub_user(:features => :all)
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
-      @cls.ae_fields << FactoryGirl.create(:miq_ae_field, :name => 'fred',
+      ns = FactoryBot.create(:miq_ae_namespace)
+      @cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
+      @cls.ae_fields << FactoryBot.create(:miq_ae_field, :name => 'fred',
                                            :class_id => @cls.id, :priority => 1)
       @cls.save
-      @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
+      @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
         :language => "ruby", :class_id => @cls.id, :data => "exit MIQ_OK", :location => "inline")
       expect(controller).to receive(:render)
       controller.instance_variable_set(:@sb, :trees       => {:ae_tree => {:active_node => "aec-#{@cls.id}"}},
@@ -538,15 +538,15 @@ describe MiqAeClassController do
   context "save class/method" do
     before do
       stub_user(:features => :all)
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
-      @cls.ae_fields << FactoryGirl.create(:miq_ae_field,
+      ns = FactoryBot.create(:miq_ae_namespace)
+      @cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
+      @cls.ae_fields << FactoryBot.create(:miq_ae_field,
                                            :name          => 'fred',
                                            :class_id      => @cls.id,
                                            :default_value => "Wilma",
                                            :priority      => 1)
       @cls.save
-      @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
+      @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
         :language => "ruby", :class_id => @cls.id, :data => "exit MIQ_OK", :location => "inline")
       allow(controller).to receive(:replace_right_cell)
       controller.instance_variable_set(:@sb, :trees       => {:ae_tree => {:active_node => "aec-#{@cls.id}"}},
@@ -667,10 +667,10 @@ describe MiqAeClassController do
 
   context "#copy_objects_edit_screen" do
     it "sets only current tenant's domains to be displayed in To Domain pull down" do
-      FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      FactoryGirl.create(:miq_ae_domain, :tenant => FactoryGirl.create(:tenant))
+      FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      FactoryBot.create(:miq_ae_domain, :tenant => FactoryBot.create(:tenant))
       controller.instance_variable_set(:@sb, {})
-      ns = FactoryGirl.create(:miq_ae_namespace)
+      ns = FactoryBot.create(:miq_ae_namespace)
       controller.send(:copy_objects_edit_screen, MiqAeNamespace, [ns.id], "miq_ae_namespace_copy")
       expect(assigns(:edit)[:domains].count).to eq(1)
     end
@@ -679,9 +679,9 @@ describe MiqAeClassController do
   context "#delete_namespaces_or_classes" do
     before do
       stub_user(:features => :all)
-      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
-      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => 1)
+      domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryBot.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryBot.create(:miq_ae_class, :name => "foo_class", :namespace_id => 1)
       controller.instance_variable_set(:@sb,
                                        :trees       => {},
                                        :active_tree => :ae_tree)
@@ -723,8 +723,8 @@ describe MiqAeClassController do
   context "#update_namespace" do
     before do
       stub_user(:features => :all)
-      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      @namespace = FactoryGirl.create(:miq_ae_namespace,
+      domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryBot.create(:miq_ae_namespace,
                                       :name        => "foo_namespace",
                                       :description => "foo_description",
                                       :parent      => domain)
@@ -767,9 +767,9 @@ describe MiqAeClassController do
   context "#deleteclasses" do
     before do
       stub_user(:features => :all)
-      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
-      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
+      domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryBot.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryBot.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
       controller.instance_variable_set(:@sb,
                                        :trees       => {},
                                        :active_tree => :ae_tree)
@@ -790,15 +790,15 @@ describe MiqAeClassController do
 
   context "#set_field_vars" do
     it "sets priority of new schema fields" do
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
-      field1 = FactoryGirl.create(:miq_ae_field,
+      ns = FactoryBot.create(:miq_ae_namespace)
+      cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
+      field1 = FactoryBot.create(:miq_ae_field,
                                   "aetype"   => "attribute",
                                   "datatype" => "string",
                                   "name"     => "name01",
                                   "class_id" => cls.id,
                                   "priority" => 1)
-      field2 = FactoryGirl.create(:miq_ae_field,
+      field2 = FactoryBot.create(:miq_ae_field,
                                   "aetype"   => "attribute",
                                   "datatype" => "string",
                                   "name"     => "name02",
@@ -818,15 +818,15 @@ describe MiqAeClassController do
 
   context "#fields_seq_field_changed" do
     before do
-      ns = FactoryGirl.create(:miq_ae_namespace, :name => 'foo')
-      @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
-      FactoryGirl.create(:miq_ae_field,
+      ns = FactoryBot.create(:miq_ae_namespace, :name => 'foo')
+      @cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
+      FactoryBot.create(:miq_ae_field,
                          :aetype   => "attribute",
                          :datatype => "string",
                          :name     => "name01",
                          :class_id => @cls.id,
                          :priority => 1)
-      FactoryGirl.create(:miq_ae_field,
+      FactoryBot.create(:miq_ae_field,
                          :aetype   => "attribute",
                          :datatype => "string",
                          :name     => "name02",
@@ -855,8 +855,8 @@ describe MiqAeClassController do
 
   context "#replace_right_cell" do
     before do
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+      ns = FactoryBot.create(:miq_ae_namespace)
+      cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
       seed_session_trees('miq_ae_class', :ae, "aec-#{cls.id}")
       session_to_sb
     end
@@ -880,7 +880,7 @@ describe MiqAeClassController do
   context "method data edit" do
     before do
       stub_user(:features => :all)
-      @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
+      @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
                                    :language => "ruby", :class_id => "someid", :data => "exit MIQ_OK", :location => "inline")
       controller.instance_variable_set(:@sb, :trees => {:ae_tree => {:active_node => "aec-someid"}},
                                        :active_tree => :ae_tree, :form_vars_set => true)
@@ -912,9 +912,9 @@ describe MiqAeClassController do
 
   context "#open_parent_nodes" do
     it "returns parent nodes hash for newly added item in tree" do
-      ns = FactoryGirl.create(:miq_ae_namespace)
-      cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id, :name => "foo_cls")
-      method = FactoryGirl.create(:miq_ae_method,
+      ns = FactoryBot.create(:miq_ae_namespace)
+      cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id, :name => "foo_cls")
+      method = FactoryBot.create(:miq_ae_method,
                                   :name     => "method01",
                                   :scope    => "class",
                                   :language => "ruby",
@@ -956,13 +956,13 @@ describe MiqAeClassController do
   context "#deleteinstances" do
     before do
       stub_user(:features => :all)
-      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
-      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
+      domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryBot.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryBot.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
       controller.instance_variable_set(:@sb,
                                        :trees       => {},
                                        :active_tree => :ae_tree)
-      @instance = FactoryGirl.create(:miq_ae_instance, :name => "instance01", :class_id => @ae_class.id)
+      @instance = FactoryBot.create(:miq_ae_instance, :name => "instance01", :class_id => @ae_class.id)
       allow(controller).to receive(:replace_right_cell)
     end
 
@@ -993,15 +993,15 @@ describe MiqAeClassController do
   context "#deletemethods" do
     before do
       stub_user(:features => :all)
-      domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
-      @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
-      @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
+      domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
+      @namespace = FactoryBot.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
+      @ae_class = FactoryBot.create(:miq_ae_class, :name => "foo_class", :namespace_id => @namespace.id)
       controller.instance_variable_set(:@sb,
                                        :trees       => {},
                                        :active_tree => :ae_tree)
-      @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
+      @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
                                    :language => "ruby", :class_id => @ae_class.id, :data => "exit MIQ_OK", :location => "inline")
-      @method2 = FactoryGirl.create(:miq_ae_method, :name => "method012", :scope => "class",
+      @method2 = FactoryBot.create(:miq_ae_method, :name => "method012", :scope => "class",
                                    :language => "ruby", :class_id => @ae_class.id, :data => "exit MIQ_OK", :location => "inline")
       allow(controller).to receive(:replace_right_cell)
     end

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -5,7 +5,7 @@ describe MiqAeCustomizationController do
   context "::CustomButtons" do
     context "#ab_get_node_info" do
       it "correct target class gets set when assigned button node is clicked" do
-        custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host", :name => "Some Name")
+        custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host", :name => "Some Name")
         target_classes = {}
         CustomButton.button_classes.each { |db| target_classes[ui_lookup(:model => db)] = db }
         controller.instance_variable_set(:@sb, :target_classes => target_classes)

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -3,12 +3,12 @@ describe MiqAeCustomizationController do
     context "#dialog_delete" do
       before do
         EvmSpecHelper.local_miq_server
-        login_as FactoryGirl.create(:user, :features => "dialog_delete")
+        login_as FactoryBot.create(:user, :features => "dialog_delete")
         allow(controller).to receive(:check_privileges).and_return(true)
       end
 
       it "flash message displays Dialog Label being deleted" do
-        dialog = FactoryGirl.create(:dialog, :label       => "Test Label",
+        dialog = FactoryBot.create(:dialog, :label       => "Test Label",
                                              :description => "Test Description",
                                              :buttons     => "submit,reset,cancel")
 

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -2,10 +2,10 @@ describe MiqAeCustomizationController do
   context "::OldDialogs" do
     context "#old_dialogs_button_operation" do
       it "Only non-default dialogs should get deleted" do
-        dialog1 = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog1",
+        dialog1 = FactoryBot.create(:miq_dialog, :name        => "Test_Dialog1",
                                                   :description => "Test Description 1",
                                                   :default     => true)
-        dialog2 = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog2",
+        dialog2 = FactoryBot.create(:miq_dialog, :name        => "Test_Dialog2",
                                                   :description => "Test Description 2",
                                                   :default     => false)
         controller.instance_variable_set(:@sb,
@@ -30,7 +30,7 @@ describe MiqAeCustomizationController do
       end
 
       it "Default Dialog should not be deleted" do
-        dialog = FactoryGirl.create(:miq_dialog, :name        => "Test_Dialog",
+        dialog = FactoryBot.create(:miq_dialog, :name        => "Test_Dialog",
                                                  :description => "Test Description",
                                                  :default     => true)
         controller.instance_variable_set(:@sb,

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -142,62 +142,62 @@ describe MiqAeCustomizationController do
     end
 
     it "assigns the sandbox active tree" do
-      login_as FactoryGirl.create(:user, :features => "old_dialogs_accord")
+      login_as FactoryBot.create(:user, :features => "old_dialogs_accord")
       get :explorer
       expect(assigns(:sb)[:active_tree]).to eq(:old_dialogs_tree)
     end
 
     it "assigns the sandbox active accord" do
-      login_as FactoryGirl.create(:user, :features => "old_dialogs_accord")
+      login_as FactoryBot.create(:user, :features => "old_dialogs_accord")
       get :explorer
       expect(assigns(:sb)[:active_accord]).to eq(:old_dialogs)
     end
 
     it "assigns the sandbox active node on old dialogs tree to root" do
-      login_as FactoryGirl.create(:user, :features => "old_dialogs_accord")
+      login_as FactoryBot.create(:user, :features => "old_dialogs_accord")
       get :explorer
       expect(controller.x_node).to eq("root")
     end
 
     it "builds the old dialogs tree" do
-      login_as FactoryGirl.create(:user, :features => "old_dialogs_accord")
+      login_as FactoryBot.create(:user, :features => "old_dialogs_accord")
       get :explorer
       expect(assigns(:sb)[:trees]).to include(:old_dialogs_tree)
     end
 
     it "assigns the sandbox active node on dialogs tree to root" do
-      login_as FactoryGirl.create(:user, :features => "dialog_accord")
+      login_as FactoryBot.create(:user, :features => "dialog_accord")
       get :explorer
       expect(controller.x_node).to eq("root")
     end
 
     it "builds the dialog tree" do
-      login_as FactoryGirl.create(:user, :features => "dialog_accord")
+      login_as FactoryBot.create(:user, :features => "dialog_accord")
       get :explorer
       expect(assigns(:sb)[:trees]).to include(:dialogs_tree)
     end
 
     it "assigns the sandbox active node on ab tree to root" do
-      login_as FactoryGirl.create(:user, :features => "dialog_accord")
+      login_as FactoryBot.create(:user, :features => "dialog_accord")
       get :explorer
       expect(expect(controller.x_node).to(eq("root")))
     end
 
     it "builds the ab tree" do
-      login_as FactoryGirl.create(:user, :features => "ab_buttons_accord")
+      login_as FactoryBot.create(:user, :features => "ab_buttons_accord")
       allow(controller).to receive(:get_node_info)
       get :explorer
       expect(assigns(:sb)[:trees]).to include(:ab_tree)
     end
 
     it "assigns the sandbox active node on import/export tree to root" do
-      login_as FactoryGirl.create(:user, :features => "miq_ae_class_import_export")
+      login_as FactoryBot.create(:user, :features => "miq_ae_class_import_export")
       get :explorer
       expect(expect(controller.x_node).to(eq("root")))
     end
 
     it "builds the import/export tree" do
-      login_as FactoryGirl.create(:user, :features => "miq_ae_class_import_export")
+      login_as FactoryBot.create(:user, :features => "miq_ae_class_import_export")
       get :explorer
       expect(assigns(:sb)[:trees]).to include(:dialog_import_export_tree)
     end

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -1,12 +1,12 @@
 describe MiqPolicyController do
   context "::AlertProfiles" do
     before do
-      login_as FactoryGirl.create(:user, :features => "alert_profile_assign")
+      login_as FactoryBot.create(:user, :features => "alert_profile_assign")
     end
 
     context "#alert_profile_assign" do
       before do
-        @ap = FactoryGirl.create(:miq_alert_set)
+        @ap = FactoryBot.create(:miq_alert_set)
         controller.instance_variable_set(:@sb, :trees => {:alert_profile_tree => {:active_node => "xx-Vm_ap-#{@ap.id}"}}, :active_tree => :alert_profile_tree)
         allow(controller).to receive(:replace_right_cell)
       end
@@ -53,7 +53,7 @@ describe MiqPolicyController do
 
     context '#alert_profile_delete' do
       before do
-        @ap = FactoryGirl.create(:miq_alert_set)
+        @ap = FactoryBot.create(:miq_alert_set)
         controller.instance_variable_set(:@sb, :trees => {:alert_profile_tree => {:active_node => "xx-Vm_ap-#{@ap.id}"}}, :active_tree => :alert_profile_tree)
         allow(controller).to receive(:replace_right_cell)
       end

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -1,9 +1,9 @@
 describe MiqPolicyController do
   context "::Alerts" do
     describe '#alert_delete' do
-      let(:alert) { FactoryGirl.create(:miq_alert, :read_only => readonly) }
+      let(:alert) { FactoryBot.create(:miq_alert, :read_only => readonly) }
 
-      before { login_as FactoryGirl.create(:user, :features => "alert_delete") }
+      before { login_as FactoryBot.create(:user, :features => "alert_delete") }
 
       context 'read only alert' do
         let(:readonly) { true }
@@ -22,8 +22,8 @@ describe MiqPolicyController do
 
     context "alert edit" do
       before do
-        login_as FactoryGirl.create(:user, :features => "alert_admin")
-        @miq_alert = FactoryGirl.create(:miq_alert)
+        login_as FactoryBot.create(:user, :features => "alert_admin")
+        @miq_alert = FactoryBot.create(:miq_alert)
         controller.instance_variable_set(:@sb,
                                          :trees       => {:alert_tree => {:active_node => "al-#{@miq_alert.id}"}},
                                          :active_tree => :alert_tree)
@@ -95,16 +95,16 @@ describe MiqPolicyController do
     context 'test click on toolbar button' do
       before do
         EvmSpecHelper.local_miq_server
-        login_as FactoryGirl.create(:user, :features => %w(alert_edit alert_profile_assign alert_delete alert_copy alert_profile_new))
-        # login_as FactoryGirl.create(:user, :features => "alert_admin")
-        @miq_alert = FactoryGirl.create(:miq_alert)
+        login_as FactoryBot.create(:user, :features => %w(alert_edit alert_profile_assign alert_delete alert_copy alert_profile_new))
+        # login_as FactoryBot.create(:user, :features => "alert_admin")
+        @miq_alert = FactoryBot.create(:miq_alert)
         allow(controller).to receive(:x_active_tree).and_return(:alert_tree)
         controller.instance_variable_set(:@sb,
                                          :trees       => {:alert_tree => {:active_node => "al-#{@miq_alert.id}"}},
                                          :active_tree => :alert_tree,)
       end
 
-      let(:alert) { FactoryGirl.create(:miq_alert, :read_only => false) }
+      let(:alert) { FactoryBot.create(:miq_alert, :read_only => false) }
 
       it "alert edit" do
         post :x_button, :params => { :pressed => 'alert_edit', :id => alert.id }
@@ -130,9 +130,9 @@ describe MiqPolicyController do
 
     describe "#alert_valid_record?" do
       before do
-        login_as FactoryGirl.create(:user, :features => "alert_admin")
+        login_as FactoryBot.create(:user, :features => "alert_admin")
         expression = MiqExpression.new("=" => {:tag => "name", :value => "Test"}, :token => 1)
-        @miq_alert = FactoryGirl.create(
+        @miq_alert = FactoryBot.create(
           :miq_alert,
           :db         => "Host",
           :options    => {:notifications => {:email => {:to => ["fred@test.com"]}}},
@@ -168,7 +168,7 @@ describe MiqPolicyController do
 
       context 'not choosing Send an E-mail option while adding new Alert' do
         let(:alert) do
-          FactoryGirl.create(:miq_alert,
+          FactoryBot.create(:miq_alert,
                              :expression         => {:eval_method => 'nothing'},
                              :options            => {:notifications => {:delay_next_evaluation => 3600, :evm_event => {}}},
                              :responds_to_events => '_hourly_timer_')

--- a/spec/controllers/miq_policy_controller/conditions_spec.rb
+++ b/spec/controllers/miq_policy_controller/conditions_spec.rb
@@ -2,9 +2,9 @@ describe MiqPolicyController do
   context "::Conditions" do
     context '#condition_remove' do
       it 'removes condition successfully' do
-        login_as FactoryGirl.create(:user, :features => "condition_remove")
-        condition = FactoryGirl.create(:condition)
-        policy = FactoryGirl.create(:miq_policy, :name => "test_policy", :conditions => [condition])
+        login_as FactoryBot.create(:user, :features => "condition_remove")
+        condition = FactoryBot.create(:condition)
+        policy = FactoryBot.create(:miq_policy, :name => "test_policy", :conditions => [condition])
         controller.instance_variable_set(:@_params, :policy_id => policy.id, :id => condition.id)
         controller.instance_variable_set(:@sb, {})
         controller.x_node = "pp_pp-1r36_p-#{policy.id}_co-#{condition.id}"

--- a/spec/controllers/miq_policy_controller/events_spec.rb
+++ b/spec/controllers/miq_policy_controller/events_spec.rb
@@ -3,9 +3,9 @@ describe MiqPolicyController do
     context "#event_edit" do
       before do
         stub_user(:features => :all)
-        @action = FactoryGirl.create(:miq_action, :name => "compliance_failed")
-        @event = FactoryGirl.create(:miq_event_definition, :name => "vm_compliance_check")
-        @policy = FactoryGirl.create(:miq_policy, :name => "Foo")
+        @action = FactoryBot.create(:miq_action, :name => "compliance_failed")
+        @event = FactoryBot.create(:miq_event_definition, :name => "vm_compliance_check")
+        @policy = FactoryBot.create(:miq_policy, :name => "Foo")
 
         controller.instance_variable_set(:@sb,
                                          :node_ids    => {

--- a/spec/controllers/miq_policy_controller/miq_actions_spec.rb
+++ b/spec/controllers/miq_policy_controller/miq_actions_spec.rb
@@ -2,7 +2,7 @@ describe MiqPolicyController do
   context "::MiqActions" do
     context "#action_edit" do
       before do
-        @action = FactoryGirl.create(:miq_action, :name => "Test_Action")
+        @action = FactoryBot.create(:miq_action, :name => "Test_Action")
         controller.instance_variable_set(:@sb, {})
         allow(controller).to receive(:replace_right_cell)
         allow(controller).to receive(:action_build_cat_tree)
@@ -110,8 +110,8 @@ describe MiqPolicyController do
     end
 
     describe "#action_get_info" do
-      let(:cat1) { FactoryGirl.create(:classification, :description => res.first) }
-      let(:cat2) { FactoryGirl.create(:classification, :description => res.second) }
+      let(:cat1) { FactoryBot.create(:classification, :description => res.first) }
+      let(:cat2) { FactoryBot.create(:classification, :description => res.second) }
 
       before do
         cat1; cat2
@@ -120,7 +120,7 @@ describe MiqPolicyController do
 
       let(:res) { %w(test1 test2) }
       let(:action) do
-        FactoryGirl.create(:miq_action,
+        FactoryBot.create(:miq_action,
                            :action_type => 'inherit_parent_tags',
                            :options     => {:cats => [cat1.name, cat2.name]})
       end

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -7,8 +7,8 @@ describe MiqPolicyController do
       render_views
 
       before do
-        FactoryGirl.create(:miq_event_definition, :name => "containergroup_compliance_check")
-        FactoryGirl.create(:miq_action, :name => "compliance_failed")
+        FactoryBot.create(:miq_event_definition, :name => "containergroup_compliance_check")
+        FactoryBot.create(:miq_action, :name => "compliance_failed")
         allow(controller).to receive(:policy_get_node_info)
         allow(controller).to receive(:get_node_info)
       end

--- a/spec/controllers/miq_policy_controller/rsop_spec.rb
+++ b/spec/controllers/miq_policy_controller/rsop_spec.rb
@@ -9,7 +9,7 @@ describe MiqPolicyController do
     it "first time on RSOP screen, session[:changed] should be false" do
       session[:changed] = true
       controller.instance_variable_set(:@current_user,
-                                       FactoryGirl.create(:user,
+                                       FactoryBot.create(:user,
                                                           :name       => "foo",
                                                           :miq_groups => [],
                                                           :userid     => "foo"))

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -161,7 +161,7 @@ describe MiqPolicyController do
 
     context 'when profile param is valid' do
       it 'renders explorer w/o flash and assigns to x_node' do
-        profile = FactoryGirl.create(:miq_policy_set)
+        profile = FactoryBot.create(:miq_policy_set)
         allow(controller).to receive(:get_node_info).and_return(true)
         post :explorer, :params => { :profile => profile.id }
         expect(response).to render_template('explorer')

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -1,7 +1,7 @@
 describe ReportController do
   context "::Dashboards" do
-    let(:miq_widget_set) { FactoryGirl.create(:miq_widget_set, :owner => user.current_group, :set_data => {:col1 => [], :col2 => [], :col3 => []}) }
-    let(:user)           { FactoryGirl.create(:user, :features => "db_edit") }
+    let(:miq_widget_set) { FactoryBot.create(:miq_widget_set, :owner => user.current_group, :set_data => {:col1 => [], :col2 => [], :col3 => []}) }
+    let(:user)           { FactoryBot.create(:user, :features => "db_edit") }
 
     before do
       login_as user
@@ -25,7 +25,7 @@ describe ReportController do
 
     describe "#db_save_members" do
       let(:set_data) do
-        Array.new(3) { |n| ["col#{(n + 1)}".to_sym, Array.new(2, FactoryGirl.create(:miq_widget))] }.to_h
+        Array.new(3) { |n| ["col#{(n + 1)}".to_sym, Array.new(2, FactoryBot.create(:miq_widget))] }.to_h
       end
 
       before do
@@ -48,14 +48,14 @@ describe ReportController do
 
     describe "#db_fields_validation" do
       before do
-        @widget1 = FactoryGirl.create(:miq_widget)
-        @widget2 = FactoryGirl.create(:miq_widget)
-        @miq_widget_set = FactoryGirl.create(:miq_widget_set,
+        @widget1 = FactoryBot.create(:miq_widget)
+        @widget2 = FactoryBot.create(:miq_widget)
+        @miq_widget_set = FactoryBot.create(:miq_widget_set,
                                              :owner       => user.current_group,
                                              :name        => "fred",
                                              :description => "FRED",
                                              :set_data    => {:col1 => [@widget1.id], :col2 => [], :col3 => []})
-        FactoryGirl.create(:miq_widget_set,
+        FactoryBot.create(:miq_widget_set,
                            :owner       => user.current_group,
                            :name        => "wilma",
                            :description => "WILMA",
@@ -83,7 +83,7 @@ describe ReportController do
       end
 
       it 'No flash message set when tab title is changed for Default Dashboard' do
-        default_dashboard = FactoryGirl.create(:miq_widget_set, :read_only => true, :name => "default", :description => "Default Dashboard", :set_data => {:col1 => [@widget1.id], :col2 => [], :col3 => []})
+        default_dashboard = FactoryBot.create(:miq_widget_set, :read_only => true, :name => "default", :description => "Default Dashboard", :set_data => {:col1 => [@widget1.id], :col2 => [], :col3 => []})
         controller.instance_variable_set(:@sb, :nodes => ["xx", default_dashboard.id])
         controller.instance_variable_set(:@edit, :db_id => @miq_widget_set.id, :read_only => true, :type => "db_edit", :key => "db_edit__#{@miq_widget_set.id}",
                                                  :new => {:name => "default", :description => "NEW Default Dashboard", :locked => false, :col1 => [@widget1.id], :col2 => [], :col3 => []},

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,7 +1,7 @@
 describe ReportController do
   describe "#menu_update" do
-    let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:report) { FactoryGirl.create(:miq_report, :rpt_type => "Default", :rpt_group => 'foo - bar', :miq_group => user.current_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
+    let(:report) { FactoryBot.create(:miq_report, :rpt_type => "Default", :rpt_group => 'foo - bar', :miq_group => user.current_group) }
 
     before do
       controller.instance_variable_set(:@edit, :new => {})

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -33,7 +33,7 @@ describe ReportController do
       let(:user) { stub_user(:features => :all) }
 
       let(:chargeback_report) do
-        FactoryGirl.create(:miq_report,
+        FactoryBot.create(:miq_report,
                            :db         => "ChargebackVm",
                            :name       => 'name',
                            :title      => 'title',
@@ -122,7 +122,7 @@ describe ReportController do
         user.save!
         ApplicationController.handle_exceptions = true
 
-        rep = FactoryGirl.create(
+        rep = FactoryBot.create(
           :miq_report,
           :rpt_type   => "Custom",
           :miq_group  => user.current_group,
@@ -161,12 +161,12 @@ describe ReportController do
       end
 
       it "should allow user with miq_report_edit access to edit a report" do
-        user = FactoryGirl.create(:user, :features => %w(miq_report_edit))
+        user = FactoryBot.create(:user, :features => %w(miq_report_edit))
         login_as user
         EvmSpecHelper.seed_specific_product_features(%w(miq_report_edit))
         ApplicationController.handle_exceptions = true
 
-        rep = FactoryGirl.create(
+        rep = FactoryBot.create(
           :miq_report,
           :rpt_type   => "Custom",
           :miq_group  => user.current_group,
@@ -187,7 +187,7 @@ describe ReportController do
       end
 
       it "should allow user with miq_report_new access to add a new report" do
-        login_as FactoryGirl.create(:user, :features => %w(miq_report_new))
+        login_as FactoryBot.create(:user, :features => %w(miq_report_new))
         EvmSpecHelper.seed_specific_product_features(%w(miq_report_new))
         ApplicationController.handle_exceptions = true
 
@@ -201,9 +201,9 @@ describe ReportController do
     end
 
     describe "set_form_vars" do
-      let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+      let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
       let(:chargeback_report) do
-        FactoryGirl.create(:miq_report, :db => "ChargebackVm", :col_order => ["name"], :headers => ["Name"])
+        FactoryBot.create(:miq_report, :db => "ChargebackVm", :col_order => ["name"], :headers => ["Name"])
       end
 
       let(:fake_id) { 999_999_999 }
@@ -243,14 +243,14 @@ describe ReportController do
     end
 
     def non_empty_category(attrs = {})
-      cat = FactoryGirl.create(:classification, :name => "non_empty", :description => "Has entries", **attrs)
+      cat = FactoryBot.create(:classification, :name => "non_empty", :description => "Has entries", **attrs)
       cat.add_entry(:name => "foo", :description => "Foo")
       cat.add_entry(:name => "bar", :description => "Bar")
       cat
     end
 
     def empty_category(attrs = {})
-      FactoryGirl.create(:classification, :name => "empty", :description => "Zero entries", **attrs)
+      FactoryBot.create(:classification, :name => "empty", :description => "Zero entries", **attrs)
     end
 
     describe "#categories_hash" do
@@ -292,7 +292,7 @@ describe ReportController do
                                                         :cb_show_typ => 'entity',
                                                         :cb_model    => 'ContainerProject'})
       controller.instance_variable_set(:@sb, {})
-      rpt = FactoryGirl.create(:miq_report_chargeback)
+      rpt = FactoryBot.create(:miq_report_chargeback)
       controller.send(:valid_report?, rpt)
       flash_messages = assigns(:flash_array)
       flash_str = 'A specific Container Project or all must be selected'
@@ -307,7 +307,7 @@ describe ReportController do
 
   describe '#build_edit_screen' do
     let(:default_tenant) { Tenant.seed }
-    let(:user) { FactoryGirl.create(:user_with_group, :tenant => default_tenant) }
+    let(:user) { FactoryBot.create(:user_with_group, :tenant => default_tenant) }
     let(:user_group) do
       group = user.miq_groups.first
       group.tenant = default_tenant
@@ -316,7 +316,7 @@ describe ReportController do
     end
 
     let(:chargeback_report) do
-      FactoryGirl.create(:miq_report, :db => 'ChargebackVm', :db_options => {:options => {:owner => user.userid}},
+      FactoryBot.create(:miq_report, :db => 'ChargebackVm', :db_options => {:options => {:owner => user.userid}},
                                     :col_order => ['name'], :headers => ['Name'])
     end
 

--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -1,14 +1,14 @@
 describe ReportController, "::Reports" do
   describe "#miq_report_delete" do
-    let(:user) { FactoryGirl.create(:user, :features => :miq_report_delete) }
+    let(:user) { FactoryBot.create(:user, :features => :miq_report_delete) }
     before do
       EvmSpecHelper.local_miq_server # timezone stuff
       login_as user
     end
 
     it "deletes the report" do
-      FactoryGirl.create(:miq_report)
-      report = FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
+      FactoryBot.create(:miq_report)
+      report = FactoryBot.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
       session['sandboxes'] = {
         controller.controller_name => { :active_tree => 'report_1',
                                         :trees       => {'report_1' => {:active_node => "xx-0_xx-0-0_rep-#{report.id}"}}}
@@ -20,8 +20,8 @@ describe ReportController, "::Reports" do
     end
 
     it "cant delete default reports" do
-      FactoryGirl.create(:miq_report)
-      report = FactoryGirl.create(:miq_report, :rpt_type => "Default")
+      FactoryBot.create(:miq_report)
+      report = FactoryBot.create(:miq_report, :rpt_type => "Default")
       session['sandboxes'] = {
         controller.controller_name => { :active_tree => 'report_1',
                                         :trees       => {'report_1' => {:active_node => "xx-0_xx-0-0_rep-#{report.id}"}}}
@@ -33,8 +33,8 @@ describe ReportController, "::Reports" do
     end
 
     # it "fails if widgets exist" do
-    #   report = FactoryGirl.create(:miq_report)
-    #   FactoryGirl.create(:miq_widget, :resource => report)
+    #   report = FactoryBot.create(:miq_report)
+    #   FactoryBot.create(:miq_widget, :resource => report)
     # end
   end
 end

--- a/spec/controllers/miq_report_controller/schedules_spec.rb
+++ b/spec/controllers/miq_report_controller/schedules_spec.rb
@@ -1,5 +1,5 @@
 describe ReportController, "::Schedules" do
-  let(:user) { FactoryGirl.create(:user, :features => %w(miq_report_schedule_delete)) }
+  let(:user) { FactoryBot.create(:user, :features => %w(miq_report_schedule_delete)) }
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
@@ -14,7 +14,7 @@ describe ReportController, "::Schedules" do
     end
 
     context 'deleting a single schedule' do
-      let(:schedule) { FactoryGirl.create(:miq_schedule) }
+      let(:schedule) { FactoryBot.create(:miq_schedule) }
       let(:schedules) { [schedule] }
 
       it 'returns with the name of the schedule in the flash' do
@@ -24,8 +24,8 @@ describe ReportController, "::Schedules" do
     end
 
     context 'deleting multiple schedules' do
-      let(:schedule1) { FactoryGirl.create(:miq_schedule) }
-      let(:schedule2) { FactoryGirl.create(:miq_schedule) }
+      let(:schedule1) { FactoryBot.create(:miq_schedule) }
+      let(:schedule2) { FactoryBot.create(:miq_schedule) }
       let(:schedules) { [schedule1, schedule2] }
 
       it 'returns with a plural form in the flash' do

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -1,6 +1,6 @@
 describe ReportController do
   render_views
-  let(:user) { FactoryGirl.create(:user, :features => "none") }
+  let(:user) { FactoryBot.create(:user, :features => "none") }
   before do
     login_as user
     EvmSpecHelper.create_guid_miq_server_zone
@@ -25,22 +25,22 @@ describe ReportController do
         session[:settings] = {:perpage => {:reports => 20}}
         controller.instance_variable_set(:@html, "<h1>Test</h1>")
 
-        report = FactoryGirl.create(:miq_report_with_results)
-        task = FactoryGirl.create(:miq_task)
+        report = FactoryBot.create(:miq_report_with_results)
+        task = FactoryBot.create(:miq_task)
         task.update_attributes(:state => "Finished")
         task.reload
 
-        report_result = FactoryGirl.build(:miq_report_result,
+        report_result = FactoryBot.build(:miq_report_result,
                                            :miq_group_id => user.current_group.id,
                                            :miq_task_id  => task.id,
                                            :miq_report   => report)
         report_result.report = report.to_hash.merge(:extras=> {:total_html_rows => 100})
         report_result.save
 
-        binary_blob = FactoryGirl.create(:binary_blob,
+        binary_blob = FactoryBot.create(:binary_blob,
                                          :resource_type => "MiqReportResult",
                                          :resource_id   => report_result.id)
-        FactoryGirl.create(:binary_blob_part,
+        FactoryBot.create(:binary_blob_part,
                            :data           => "--- Quota \xE2\x80\x93 Max CPUs\n...\n",
                            :binary_blob_id => binary_blob.id)
 
@@ -55,7 +55,7 @@ describe ReportController do
       end
 
       it 'renders list of Reports in Reports - Custom tree' do
-        FactoryGirl.create(:miq_report)
+        FactoryBot.create(:miq_report)
         post :tree_select, :params => { :id => 'reports_xx-0', :format => :js }
         expect(response).to render_template('report/_report_list')
       end
@@ -72,14 +72,14 @@ describe ReportController do
       end
 
       it 'renders show of Schedule in Schedules tree' do
-        schedule = FactoryGirl.create(:miq_schedule)
+        schedule = FactoryBot.create(:miq_schedule)
         post :tree_select, :params => { :id => "msc-#{schedule.id}", :format => :js, :accord => 'schedules' }
         expect(response).to render_template('report/_show_schedule')
       end
     end
 
     context "dashboards tree" do
-      let!(:other_group)  { FactoryGirl.create(:miq_group) }
+      let!(:other_group)  { FactoryBot.create(:miq_group) }
       let(:current_group) { User.current_user.current_group }
 
       before do
@@ -110,7 +110,7 @@ describe ReportController do
         ApplicationController.handle_exceptions = true
 
         MiqWidgetSet.seed
-        widget_set = FactoryGirl.create(:miq_widget_set, :group_id => user.current_group.id)
+        widget_set = FactoryBot.create(:miq_widget_set, :group_id => user.current_group.id)
         post :tree_select, :params => { :id => "xx-g_g-#{user.current_group.id}_-#{widget_set.id}", :format => :js, :accord => 'db' }
         expect(response).to render_template('report/_db_show')
       end
@@ -129,18 +129,18 @@ describe ReportController do
       it 'renders show of Dashboard Widget in Widgets tree' do
         ApplicationController.handle_exceptions = true
 
-        widget = FactoryGirl.create(:miq_widget)
+        widget = FactoryBot.create(:miq_widget)
         post :tree_select, :params => { :id => "xx-r_-#{widget.id}", :format => :js, :accord => 'widgets' }
         expect(response).to render_template('report/_widget_show')
       end
 
       let(:default_row_count_value)        { 5 }
       let(:other_row_count_value)          { 7 }
-      let(:widget_with_default_row_value)  { FactoryGirl.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}) }
+      let(:widget_with_default_row_value)  { FactoryBot.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}) }
       let(:widget_options)                 { {:row_count => other_row_count_value} }
 
       let(:widget_with_row_value) do
-        FactoryGirl.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}, :options => widget_options)
+        FactoryBot.create(:miq_widget, :visibility => {:roles => ["_ALL_"]}, :options => widget_options)
       end
 
       let(:params_default_row_value) do
@@ -188,7 +188,7 @@ describe ReportController do
       end
 
       it 'renders form to edit Role in Roles tree' do
-        FactoryGirl.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
+        FactoryBot.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
         post :tree_select, :params => { :id => "g-#{user.current_group.id}", :format => :js, :accord => 'roles' }
         expect(response).to render_template('report/_menu_form1')
       end

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -4,7 +4,7 @@ describe ReportController do
     stub_user(:features => :all)
   end
   describe "#widget_edit" do
-    let(:miq_schedule) { FactoryGirl.build(:miq_schedule, :run_at => {}, :sched_action => {}) }
+    let(:miq_schedule) { FactoryBot.build(:miq_schedule, :run_at => {}, :sched_action => {}) }
     let(:new_widget) { controller.instance_variable_get(:@widget) }
 
     # Configuration Management/Virtual Machines/VMs with Free Space > 50% by Department report
@@ -112,7 +112,7 @@ describe ReportController do
         let(:default_row_count_value) { 5 }
 
         it 'can change type from external to internal' do
-          external_widget = FactoryGirl.create(:miq_widget, :content_type => 'rss')
+          external_widget = FactoryBot.create(:miq_widget, :content_type => 'rss')
           controller.instance_variable_set(:@edit, :schedule  => miq_schedule,
                                                    :widget_id => external_widget.id,
                                                    :new       => {})

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -17,12 +17,12 @@ describe MiqRequestController do
     end
   end
 
-  let(:parent_tenant)      { FactoryGirl.create(:tenant) }
-  let(:child_tenant)       { FactoryGirl.create(:tenant, :parent=> parent_tenant) }
-  let(:user_child_tenant)  { FactoryGirl.create(:user_with_group, :tenant => child_tenant) }
-  let(:user_parent_tenant) { FactoryGirl.create(:user_with_group, :tenant => parent_tenant) }
+  let(:parent_tenant)      { FactoryBot.create(:tenant) }
+  let(:child_tenant)       { FactoryBot.create(:tenant, :parent=> parent_tenant) }
+  let(:user_child_tenant)  { FactoryBot.create(:user_with_group, :tenant => child_tenant) }
+  let(:user_parent_tenant) { FactoryBot.create(:user_with_group, :tenant => parent_tenant) }
 
-  let(:template)     { FactoryGirl.create(:template_amazon) }
+  let(:template)     { FactoryBot.create(:template_amazon) }
   let(:request_body) { {:requester => user_child_tenant, :source_type => 'VmOrTemplate', :source_id => template.id} }
 
   describe "#get_view" do
@@ -30,7 +30,7 @@ describe MiqRequestController do
       EvmSpecHelper.local_miq_server
 
       login_as user_child_tenant
-      FactoryGirl.create(:miq_provision_request, request_body)
+      FactoryBot.create(:miq_provision_request, request_body)
     end
 
     it "displays miq_request for parent_tenant, when request was added by child_parent" do
@@ -44,7 +44,7 @@ describe MiqRequestController do
   end
 
   describe "#prov_scope" do
-    let(:user) { FactoryGirl.create(:user_miq_request_approver, :userid => "Approver") }
+    let(:user) { FactoryBot.create(:user_miq_request_approver, :userid => "Approver") }
     let(:options) { {} }
     subject { controller.send(:prov_scope, options) }
     before { login_as user }
@@ -61,11 +61,11 @@ describe MiqRequestController do
         it { is_expected.not_to include [:with_requester, user.id] }
       end
       context "logged without approval privileges" do
-        let(:user) { FactoryGirl.create(:user, :features => "none") }
+        let(:user) { FactoryBot.create(:user, :features => "none") }
         it { is_expected.to include [:with_requester, user.id] }
       end
       context "selected 'another_user'" do
-        let(:another_user) { FactoryGirl.create(:user) }
+        let(:another_user) { FactoryBot.create(:user) }
         let(:options) do
           { :user_choice => another_user.id }
         end
@@ -160,10 +160,10 @@ describe MiqRequestController do
   end
 
   describe '#report_data' do
-    let(:user1) { FactoryGirl.create(:user) }
+    let(:user1) { FactoryBot.create(:user) }
     let(:user2) { create_user_in_other_region(user1.userid) }
     let(:miq_request1) do
-      FactoryGirl.create(:miq_provision_request, :with_approval,
+      FactoryBot.create(:miq_provision_request, :with_approval,
                          :source_type    => 'VmOrTemplate',
                          :source_id      => template.id,
                          :created_on     => 2.days.ago,
@@ -173,17 +173,17 @@ describe MiqRequestController do
                          :reason         => "abcdef")
     end
     let(:miq_request2) do
-      FactoryGirl.create(:miq_provision_request, :with_approval,
+      FactoryBot.create(:miq_provision_request, :with_approval,
                          :source_type    => 'VmOrTemplate',
                          :source_id      => template.id,
                          :created_on     => 10.days.ago,
-                         :requester      => FactoryGirl.create(:user),
+                         :requester      => FactoryBot.create(:user),
                          :approval_state => "approved",
                          :request_type   => "clone_to_vm",
                          :reason         => "abc")
     end
     let(:miq_request3) do
-      FactoryGirl.create(:miq_provision_request, :with_approval,
+      FactoryBot.create(:miq_provision_request, :with_approval,
                          :source_type    => 'VmOrTemplate',
                          :source_id      => template.id,
                          :created_on     => 45.days.ago,
@@ -246,11 +246,11 @@ describe MiqRequestController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    let(:vm) { FactoryGirl.create(:vm) }
-    let!(:other_vm) { FactoryGirl.create(:vm) }
+    let(:vm) { FactoryBot.create(:vm) }
+    let!(:other_vm) { FactoryBot.create(:vm) }
 
     let(:reconfigure_request) do
-      FactoryGirl.create(:vm_reconfigure_request, :options => {:src_ids => [vm.id]})
+      FactoryBot.create(:vm_reconfigure_request, :options => {:src_ids => [vm.id]})
     end
 
     # http://localhost:3000/miq_request/show/10000000000342
@@ -272,17 +272,17 @@ describe MiqRequestController do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
-    let(:vm1)     { FactoryGirl.create(:vm_cloud) }
-    let(:vm2)     { FactoryGirl.create(:vm_cloud) } # not part of the stack
-    let(:stack)   { FactoryGirl.create(:orchestration_stack).tap { |stack| stack.direct_vms = [vm1] } }
-    let(:service) { FactoryGirl.create(:service_orchestration).tap { |service| service.add_resource!(stack) } }
+    let(:vm1)     { FactoryBot.create(:vm_cloud) }
+    let(:vm2)     { FactoryBot.create(:vm_cloud) } # not part of the stack
+    let(:stack)   { FactoryBot.create(:orchestration_stack).tap { |stack| stack.direct_vms = [vm1] } }
+    let(:service) { FactoryBot.create(:service_orchestration).tap { |service| service.add_resource!(stack) } }
     let(:request) do
-      FactoryGirl.create(:service_retire_request,
+      FactoryBot.create(:service_retire_request,
                          :type      => 'ServiceRetireRequest',
                          :requester => @user,
                          :options   => {:src_ids => [service.id]})
     end
-    # let(:request) { FactoryGirl.create(:miq_service_retirement_request, :options => {:src_ids => [service.id]}) }
+    # let(:request) { FactoryBot.create(:miq_service_retirement_request, :options => {:src_ids => [service.id]}) }
 
     let(:payload) { { :model_name => 'Vm', :parent_id => service.id.to_s, additional_key => additional_val } }
     let(:additional_val) do
@@ -389,19 +389,19 @@ describe MiqRequestController do
       stub_settings(:server => {}, :session => {})
 
       # Create users
-      @admin = FactoryGirl.create(:user, :role => "super_administrator")
+      @admin = FactoryBot.create(:user, :role => "super_administrator")
       allow(@admin).to receive(:role_allows?).with(:identifier => 'miq_request_approval').and_return(true)
-      @vm_user = FactoryGirl.create(:user, :role => "vm_user")
-      @desktop = FactoryGirl.create(:user, :role => "desktop")
-      @approver = FactoryGirl.create(:user, :role => "approver")
+      @vm_user = FactoryBot.create(:user, :role => "vm_user")
+      @desktop = FactoryBot.create(:user, :role => "desktop")
+      @approver = FactoryBot.create(:user, :role => "approver")
       allow(@approver).to receive(:role_allows?).with(:identifier => 'miq_request_approval').and_return(true)
       @users = [@admin, @vm_user, @desktop, @approver]
 
       # Create requests
-      FactoryGirl.create(:vm_migrate_request, :requester => @admin)
-      FactoryGirl.create(:vm_migrate_request, :requester => @vm_user)
-      FactoryGirl.create(:vm_migrate_request, :requester => @desktop)
-      FactoryGirl.create(:vm_migrate_request, :requester => @approver)
+      FactoryBot.create(:vm_migrate_request, :requester => @admin)
+      FactoryBot.create(:vm_migrate_request, :requester => @vm_user)
+      FactoryBot.create(:vm_migrate_request, :requester => @desktop)
+      FactoryBot.create(:vm_migrate_request, :requester => @approver)
     end
 
     subject { controller.send(:miq_request_initial_options) }
@@ -429,11 +429,11 @@ describe MiqRequestController do
       stub_settings(:server => {}, :session => {})
 
       # Create user
-      @approver = FactoryGirl.create(:user, :role => "approver")
+      @approver = FactoryBot.create(:user, :role => "approver")
       allow(@approver).to receive(:role_allows?).with(:identifier => 'miq_request_approval').and_return(true)
 
       # Create request
-      @request = FactoryGirl.create(:vm_migrate_request, :requester => @approver)
+      @request = FactoryBot.create(:vm_migrate_request, :requester => @approver)
     end
 
     it "returns label with requester_name" do
@@ -452,7 +452,7 @@ describe MiqRequestController do
 
   def create_user_in_other_region(userid)
     other_region_id = ApplicationRecord.id_in_region(1, MiqRegion.my_region_number + 1)
-    FactoryGirl.create(:user, :id => other_region_id).tap do |u|
+    FactoryBot.create(:user, :id => other_region_id).tap do |u|
       u.update_column(:userid, userid) # Bypass validation for test purposes
     end
   end

--- a/spec/controllers/miq_task_controller_spec.rb
+++ b/spec/controllers/miq_task_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe MiqTaskController do
   context "#tasks_condition" do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     subject { controller.send(:tasks_condition, @opts) }
     before do
       allow(controller).to receive_messages(:session => user)

--- a/spec/controllers/mixins/actions/host_actions/misc_spec.rb
+++ b/spec/controllers/mixins/actions/host_actions/misc_spec.rb
@@ -3,8 +3,8 @@ describe Mixins::Actions::HostActions::Misc do
     let(:controller) do
       return HostController.new
     end
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-    let!(:host) { FactoryGirl.create(:host) }
+    let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
+    let!(:host) { FactoryBot.create(:host) }
 
     before do
       stub_user(:features => :all)

--- a/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
@@ -1,5 +1,5 @@
 describe Mixins::Actions::VmActions::Rename do
-  let(:vm) { FactoryGirl.create(:vm_vmware) }
+  let(:vm) { FactoryBot.create(:vm_vmware) }
 
   describe '#rename_cancel' do
     before do
@@ -43,7 +43,7 @@ describe Mixins::Actions::VmActions::Rename do
   describe '#rename_save' do
     let(:controller) { VmInfraController.new }
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryGirl.create(:zone) }
+    let(:zone) { FactoryBot.create(:zone) }
 
     before do
       allow(controller).to receive(:session).and_return(:userid => 'admin')

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -3,17 +3,17 @@ describe Mixins::CheckedIdMixin do
     # include tested mixin
     let(:mixin) { Object.new.tap { |s| s.singleton_class.send(:include, described_class) } }
     # create user, user role and group
-    let(:user_role) { FactoryGirl.create(:miq_user_role) }
-    let(:group) { FactoryGirl.create(:miq_group, :miq_user_role => user_role) }
-    let(:current_user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let(:user_role) { FactoryBot.create(:miq_user_role) }
+    let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
+    let(:current_user) { FactoryBot.create(:user, :miq_groups => [group]) }
     before do
       allow(mixin).to receive(:current_user).and_return(current_user)
       allow(current_user).to receive(:get_timezone).and_return("Prague")
     end
     # create records
-    let!(:vm1) { FactoryGirl.create(:vm_or_template) }
-    let!(:vm2) { FactoryGirl.create(:vm_or_template) }
-    let!(:vm3) { FactoryGirl.create(:vm_or_template) }
+    let!(:vm1) { FactoryBot.create(:vm_or_template) }
+    let!(:vm2) { FactoryBot.create(:vm_or_template) }
+    let!(:vm3) { FactoryBot.create(:vm_or_template) }
 
     subject { mixin.send(:find_records_with_rbac, model, id) }
 

--- a/spec/controllers/mixins/ems_common_angular_spec.rb
+++ b/spec/controllers/mixins/ems_common_angular_spec.rb
@@ -1,8 +1,8 @@
 describe Mixins::EmsCommonAngular do
   context '.retrieve_event_stream_selection' do
     let(:network_controller) { EmsNetworkController.new }
-    let(:ems_nuage) { FactoryGirl.create(:ems_nuage_network_with_authentication) }
-    let(:ems_openstack) { FactoryGirl.create(:ems_openstack_with_authentication) }
+    let(:ems_nuage) { FactoryBot.create(:ems_nuage_network_with_authentication) }
+    let(:ems_openstack) { FactoryBot.create(:ems_openstack_with_authentication) }
 
     it 'when amqp' do
       # remove default endpoints
@@ -226,7 +226,7 @@ describe Mixins::EmsCommonAngular do
           :default_password => "abc",
           :default_url      => "http://abc.test/mypath"
         }
-        @ems = FactoryGirl.create(:ems_amazon)
+        @ems = FactoryBot.create(:ems_amazon)
         allow(@ems).to receive(:to_s).and_return('ManageIQ::Providers::Amazon::CloudManager')
       end
 

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -5,13 +5,13 @@ describe NetworkRouterController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @ct = FactoryGirl.create(:network_router, :name => "router-01")
+      @ct = FactoryBot.create(:network_router, :name => "router-01")
       allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
@@ -53,8 +53,8 @@ describe NetworkRouterController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @router = FactoryGirl.create(:network_router)
-      login_as FactoryGirl.create(:user, :features => %w(none))
+      @router = FactoryBot.create(:network_router)
+      login_as FactoryBot.create(:user, :features => %w(none))
     end
 
     subject do
@@ -72,7 +72,7 @@ describe NetworkRouterController do
 
   describe "#new" do
     let(:feature) { "network_router_new" }
-    let(:user)    { FactoryGirl.create(:user, :features => feature) }
+    let(:user)    { FactoryBot.create(:user, :features => feature) }
 
     before do
       bypass_rescue
@@ -97,8 +97,8 @@ describe NetworkRouterController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack)
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @router = FactoryBot.create(:network_router_openstack)
     end
 
     context "#create" do
@@ -110,7 +110,7 @@ describe NetworkRouterController do
       end
 
       let(:cloud_tenant) do
-        FactoryGirl.create(:cloud_tenant)
+        FactoryBot.create(:cloud_tenant)
       end
 
       let(:queue_options) do
@@ -158,8 +158,8 @@ describe NetworkRouterController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @router = FactoryBot.create(:network_router_openstack,
                                    :ext_management_system => @ems)
     end
 
@@ -200,8 +200,8 @@ describe NetworkRouterController do
   end
 
   describe "#delete_network_routers" do
-    let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
-    let(:router) { FactoryGirl.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
+    let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
+    let(:router) { FactoryBot.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
     before do
       stub_user(:features => :all)
       setup_zone
@@ -220,8 +220,8 @@ describe NetworkRouterController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @router = FactoryBot.create(:network_router_openstack,
                                    :ext_management_system => @ems)
       session[:network_router_lastaction] = 'show'
     end
@@ -265,10 +265,10 @@ describe NetworkRouterController do
   describe "#add_interface" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @router = FactoryBot.create(:network_router_openstack,
                                    :ext_management_system => @ems)
-      @subnet = FactoryGirl.create(:cloud_subnet, :ext_management_system => @ems)
+      @subnet = FactoryBot.create(:cloud_subnet, :ext_management_system => @ems)
     end
 
     context "#add_interface" do
@@ -309,8 +309,8 @@ describe NetworkRouterController do
       end
 
       context 'with restricted user' do
-        let!(:subnet_2) { FactoryGirl.create(:cloud_subnet, :ext_management_system => @ems) }
-        let(:user)    { FactoryGirl.create(:user, :features => "network_router_add_interface") }
+        let!(:subnet_2) { FactoryBot.create(:cloud_subnet, :ext_management_system => @ems) }
+        let(:user)    { FactoryBot.create(:user, :features => "network_router_add_interface") }
         let(:tag)     { "/managed/environment/prod" }
 
         before do
@@ -357,10 +357,10 @@ describe NetworkRouterController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_openstack).network_manager
-      @router = FactoryGirl.create(:network_router_openstack,
+      @ems = FactoryBot.create(:ems_openstack).network_manager
+      @router = FactoryBot.create(:network_router_openstack,
                                    :ext_management_system => @ems)
-      @subnet = FactoryGirl.create(:cloud_subnet, :ext_management_system => @ems)
+      @subnet = FactoryBot.create(:cloud_subnet, :ext_management_system => @ems)
     end
 
     context "#remove_interface" do

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -128,7 +128,7 @@ describe OpsController do
       EvmSpecHelper.local_miq_server
       MiqRegion.seed
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
-      @miq_server_to_delete = FactoryGirl.create(:miq_server)
+      @miq_server_to_delete = FactoryBot.create(:miq_server)
       @miq_server_to_delete.last_heartbeat -= 20.minutes
       @miq_server_to_delete.save
     end
@@ -167,14 +167,14 @@ describe OpsController do
     describe '#delete_server' do
       context "server does exist" do
         it 'deletes server and refreshes screen' do
-          server = FactoryGirl.create(:miq_server, :zone => @zone)
+          server = FactoryBot.create(:miq_server, :zone => @zone)
           sb_hash = {
             :trees            => {:diagnostics_tree => {:active_node => "z-#{@zone.id}"}},
             :active_tree      => :diagnostics_tree,
             :diag_selected_id => @miq_server_to_delete.id,
             :active_tab       => "diagnostics_roles_servers"
           }
-          @server_role = FactoryGirl.create(
+          @server_role = FactoryBot.create(
             :server_role,
             :name              => "smartproxy",
             :description       => "SmartProxy",
@@ -182,7 +182,7 @@ describe OpsController do
             :external_failover => false,
             :role_scope        => "zone"
           )
-          @assigned_server_role = FactoryGirl.create(
+          @assigned_server_role = FactoryBot.create(
             :assigned_server_role,
             :miq_server_id  => server.id,
             :server_role_id => @server_role.id,
@@ -254,7 +254,7 @@ describe OpsController do
 
       context "#role_start" do
         before do
-          assigned_server_role = FactoryGirl.create(
+          assigned_server_role = FactoryBot.create(
             :assigned_server_role,
             :miq_server_id  => 1,
             :server_role_id => 1,

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -9,8 +9,8 @@ describe OpsController do
     end
 
     describe "rbac_edit_tags_reset" do
-      let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
-      let(:another_tenant) { FactoryGirl.create(:tenant) }
+      let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
+      let(:another_tenant) { FactoryBot.create(:tenant) }
 
       before do
         allow(controller).to receive(:checked_or_params).and_return(Tenant.all.ids)
@@ -37,7 +37,7 @@ describe OpsController do
       end
 
       it "renders tenants partial when tenant node is selected" do
-        tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        tenant = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
 
         session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
         post :tree_select, :params => { :id => "tn-#{tenant.id}", :format => :js }
@@ -47,7 +47,7 @@ describe OpsController do
       end
 
       it "does not display tenant groups in the details paged" do
-        tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        tenant = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
 
         session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
         post :tree_select, :params => { :id => "tn-#{tenant.id}", :format => :js }
@@ -58,7 +58,7 @@ describe OpsController do
       end
 
       it "renders quota usage table for tenant" do
-        tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        tenant = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
         tenant.set_quotas(:cpu_allocated => {:value => 1024},
                           :vms_allocated => {:value => 27},
                           :mem_allocated => {:value => four_terabytes})
@@ -82,7 +82,7 @@ describe OpsController do
 
     context "#rbac_tenant_get_details" do
       it "sets @tenant record" do
-        t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant, :subdomain => "foo")
+        t = FactoryBot.create(:tenant, :parent => Tenant.root_tenant, :subdomain => "foo")
         controller.send(:rbac_tenant_get_details, t.id)
         expect(assigns(:tenant)).to eq(t)
       end
@@ -91,7 +91,7 @@ describe OpsController do
     context "#rbac_tenant_delete" do
       before do
         allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
-        @t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        @t = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
         sb_hash = {
           :trees       => {:rbac_tree => {:active_node => "tn-#{@t.id}"}},
           :active_tree => :rbac_tree,
@@ -113,7 +113,7 @@ describe OpsController do
       end
 
       it "returns error flash when tenant cannot be deleted" do
-        FactoryGirl.create(:miq_group, :tenant => @t)
+        FactoryBot.create(:miq_group, :tenant => @t)
         controller.send(:rbac_tenant_delete)
 
         expect(response.status).to eq(200)
@@ -124,7 +124,7 @@ describe OpsController do
 
       it "deletes checked tenant records successfully" do
         allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
-        t = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
+        t = FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
         sb_hash = {
           :trees       => {:rbac_tree => {:active_node => "tn-#{t.id}"}},
           :active_tree => :rbac_tree,
@@ -166,7 +166,7 @@ describe OpsController do
 
     context "#rbac_tenant_manage_quotas" do
       before do
-        @tenant = FactoryGirl.create(:tenant,
+        @tenant = FactoryBot.create(:tenant,
                                      :name      => "OneTenant",
                                      :parent    => Tenant.root_tenant,
                                      :domain    => "test",
@@ -222,7 +222,7 @@ describe OpsController do
     describe "#tags_edit" do
       let!(:user) { stub_user(:features => :all) }
       before do
-        @tenant = FactoryGirl.create(:tenant,
+        @tenant = FactoryBot.create(:tenant,
                                      :name      => "OneTenant",
                                      :parent    => Tenant.root_tenant,
                                      :domain    => "test",
@@ -233,11 +233,11 @@ describe OpsController do
         controller.instance_variable_set(:@sb, sb_hash)
         allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
         allow(@tenant).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-        @tag1 = FactoryGirl.create(:classification_tag,
+        classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryBot.create(:classification_tag,
                                    :name   => "tag1",
                                    :parent => classification)
-        @tag2 = FactoryGirl.create(:classification_tag,
+        @tag2 = FactoryBot.create(:classification_tag,
                                    :name   => "tag2",
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).with(@tenant).and_return([@tag1, @tag2])
@@ -300,13 +300,13 @@ describe OpsController do
       Tenant.seed
 
       stub_user(:features => :all)
-      @group = FactoryGirl.create(:miq_group)
+      @group = FactoryBot.create(:miq_group)
       @role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      FactoryGirl.create(
+      FactoryBot.create(
         :classification,
         :name        => "env",
         :description => "Environment",
-        :children    => [FactoryGirl.create(:classification)]
+        :children    => [FactoryBot.create(:classification)]
       )
       @exp = MiqExpression.new("=" => {:tag => "name", :value => "Test"}, :token => 1)
       allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
@@ -458,7 +458,7 @@ describe OpsController do
       MiqGroup.seed
       MiqRegion.seed
       stub_user(:features => :all)
-      @vm_role = FactoryGirl.create(:miq_user_role, :features => %w(embedded_automation_manager))
+      @vm_role = FactoryBot.create(:miq_user_role, :features => %w(embedded_automation_manager))
     end
 
     it "the feature list to edit should contain the children roles" do
@@ -492,17 +492,17 @@ describe OpsController do
       MiqGroup.seed
       MiqRegion.seed
       role = MiqUserRole.find_by(:name => "EvmRole-SuperAdministrator")
-      @t1 = FactoryGirl.create(:tenant, :name => "ten1", :parent => root_tenant)
-      @g1 = FactoryGirl.create(:miq_group, :description => 'group1', :tenant => @t1, :miq_user_role => role)
-      @u1 = FactoryGirl.create(:user, :miq_groups => [@g1])
-      @t2 = FactoryGirl.create(:tenant, :name => "ten2", :parent => root_tenant)
-      @g2a  = FactoryGirl.create(:miq_group, :description => 'gr2a', :tenant => @t2, :miq_user_role => role)
-      @g2b  = FactoryGirl.create(:miq_group, :description => 'gr2b1', :tenant => @t2, :miq_user_role => role)
-      @u2a = FactoryGirl.create(:user, :miq_groups => [@g2a])
-      @u2a2 = FactoryGirl.create(:user, :miq_groups => [@g2a])
-      @u2b = FactoryGirl.create(:user, :miq_groups => [@g2b])
-      @u2b2 = FactoryGirl.create(:user, :miq_groups => [@g2b])
-      @u2b3 = FactoryGirl.create(:user, :miq_groups => [@g2b])
+      @t1 = FactoryBot.create(:tenant, :name => "ten1", :parent => root_tenant)
+      @g1 = FactoryBot.create(:miq_group, :description => 'group1', :tenant => @t1, :miq_user_role => role)
+      @u1 = FactoryBot.create(:user, :miq_groups => [@g1])
+      @t2 = FactoryBot.create(:tenant, :name => "ten2", :parent => root_tenant)
+      @g2a  = FactoryBot.create(:miq_group, :description => 'gr2a', :tenant => @t2, :miq_user_role => role)
+      @g2b  = FactoryBot.create(:miq_group, :description => 'gr2b1', :tenant => @t2, :miq_user_role => role)
+      @u2a = FactoryBot.create(:user, :miq_groups => [@g2a])
+      @u2a2 = FactoryBot.create(:user, :miq_groups => [@g2a])
+      @u2b = FactoryBot.create(:user, :miq_groups => [@g2b])
+      @u2b2 = FactoryBot.create(:user, :miq_groups => [@g2b])
+      @u2b3 = FactoryBot.create(:user, :miq_groups => [@g2b])
       session[:sandboxes] = {"ops" => {:active_tree => :rbac_tree}}
       allow(controller).to receive(:replace_right_cell)
     end
@@ -577,9 +577,9 @@ describe OpsController do
   end
 
   describe "#rbac_get_info" do
-    let!(:root_tenant) { FactoryGirl.create(:tenant) } # creates first root Tenant in active region
-    let(:group) { FactoryGirl.create(:miq_group) }
-    let(:inactive_region) { FactoryGirl.create(:miq_region) }
+    let!(:root_tenant) { FactoryBot.create(:tenant) } # creates first root Tenant in active region
+    let(:group) { FactoryBot.create(:miq_group) }
+    let(:inactive_region) { FactoryBot.create(:miq_region) }
     let!(:root_tenant_in_inactive_region) do
       root_tenant_in_inactive_region = Tenant.root_tenant.dup
       root_tenant_in_inactive_region.id = Tenant.id_in_region(Tenant.count + 1_000_000, inactive_region.region)
@@ -592,7 +592,7 @@ describe OpsController do
       group_in_inactive_region.save!
       group_in_inactive_region
     end
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+    let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
 
     before do
       EvmSpecHelper.local_miq_server

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -14,7 +14,7 @@ describe OpsController do
   end
 
   context 'set record data before calling record.valid?' do
-    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:group) { FactoryBot.create(:miq_group) }
 
     it "calls both record.valid? and rbac_user_set_record_vars or neither" do
       new_user_edit(
@@ -25,7 +25,7 @@ describe OpsController do
         :verify   => "bar",
       )
 
-      user = FactoryGirl.build(:user)
+      user = FactoryBot.build(:user)
       allow(User).to receive(:new).and_return(user)
 
       done_valid = false
@@ -61,8 +61,8 @@ describe OpsController do
   end
 
   context 'don\'t change groups on cancel' do
-    let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
+    let(:group) { FactoryBot.create(:miq_group) }
 
     it "should not unset groups on cancel" do
       old_groups = user.miq_groups.pluck(:id).sort
@@ -103,7 +103,7 @@ describe OpsController do
   end
 
   context 'update record fields when editing' do
-    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
 
     it "updates record even for existing users" do
       existing_user_edit(user, :name => "changed")
@@ -125,8 +125,8 @@ describe OpsController do
   end
 
   context 'set current_group' do
-    let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
+    let(:group) { FactoryBot.create(:miq_group) }
 
     it "should set current_group for new item" do
       new_user_edit(

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -3,7 +3,7 @@ describe OpsController do
   let(:session) { {} }
   let(:zone) { double("Zone", :name => "foo") }
   let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
-  let(:schedule) { FactoryGirl.create(:miq_automate_schedule) }
+  let(:schedule) { FactoryBot.create(:miq_automate_schedule) }
   let(:schedule_new) { MiqSchedule.new }
   let(:user) { stub_user(:features => :all) }
 

--- a/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
+++ b/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
@@ -24,8 +24,8 @@ describe OpsController do
     end
 
     it 'should have tree data set when there are clusters/storage records in db' do
-      FactoryGirl.create(:ems_cluster, :name => "My Cluster")
-      FactoryGirl.create(:storage_vmware, :name => "My Datastore")
+      FactoryBot.create(:ems_cluster, :name => "My Cluster")
+      FactoryBot.create(:storage_vmware, :name => "My Datastore")
       controller.send(:cu_build_edit_screen)
       expect(assigns(:cluster_tree)).to_not eq(nil)
       expect(assigns(:datastore_tree)).to_not eq(nil)

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -8,18 +8,18 @@ describe OpsController do
 
     context "SmartProxy Affinity" do
       before do
-        @zone = FactoryGirl.create(:zone, :name => 'zone1')
+        @zone = FactoryBot.create(:zone, :name => 'zone1')
 
-        @storage1 = FactoryGirl.create(:storage)
-        @storage2 = FactoryGirl.create(:storage)
+        @storage1 = FactoryBot.create(:storage)
+        @storage2 = FactoryBot.create(:storage)
 
-        @host1 = FactoryGirl.create(:host, :name => 'host1', :storages => [@storage1])
-        @host2 = FactoryGirl.create(:host, :name => 'host2', :storages => [@storage2])
+        @host1 = FactoryBot.create(:host, :name => 'host1', :storages => [@storage1])
+        @host2 = FactoryBot.create(:host, :name => 'host2', :storages => [@storage2])
 
-        @ems = FactoryGirl.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @zone)
+        @ems = FactoryBot.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @zone)
 
-        @svr1 = FactoryGirl.create(:miq_server, :name => 'svr1', :zone => @zone)
-        @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @zone)
+        @svr1 = FactoryBot.create(:miq_server, :name => 'svr1', :zone => @zone)
+        @svr2 = FactoryBot.create(:miq_server, :name => 'svr2', :zone => @zone)
 
         @svr1.vm_scan_host_affinity = [@host1]
         @svr2.vm_scan_host_affinity = [@host2]
@@ -166,7 +166,7 @@ describe OpsController do
 
     context "#settings_get_form_vars" do
       before do
-        miq_server = FactoryGirl.create(:miq_server)
+        miq_server = FactoryBot.create(:miq_server)
         current = ::Settings.to_hash
         current[:authentication] = { :ldap_role => true, :mode => 'ldap' }
         edit = {:current => current,
@@ -277,7 +277,7 @@ describe OpsController do
 
       context 'get advanced config settings' do
         it 'for selected server' do
-          miq_server = FactoryGirl.create(:miq_server)
+          miq_server = FactoryBot.create(:miq_server)
           enc_pass = MiqPassword.encrypt('pa$$word')
           Vmdb::Settings.save!(
             miq_server,
@@ -302,7 +302,7 @@ describe OpsController do
         end
 
         it 'for selected zone' do
-          zone = FactoryGirl.create(:zone)
+          zone = FactoryBot.create(:zone)
           enc_pass = MiqPassword.encrypt('pa$$word')
           Vmdb::Settings.save!(
             zone,
@@ -331,7 +331,7 @@ describe OpsController do
     describe '#settings_update_save' do
       context "save config settings" do
         it 'for selected server' do
-          miq_server = FactoryGirl.create(:miq_server)
+          miq_server = FactoryBot.create(:miq_server)
           allow(controller).to receive(:x_node).and_return("svr-#{miq_server.id}")
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
@@ -353,7 +353,7 @@ describe OpsController do
         end
 
         it 'for selected zone' do
-          zone = FactoryGirl.create(:zone)
+          zone = FactoryBot.create(:zone)
           allow(controller).to receive(:x_node).and_return("z-#{zone.id}")
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
@@ -377,7 +377,7 @@ describe OpsController do
 
       context "save server name in server settings" do
         before do
-          @miq_server = FactoryGirl.create(:miq_server)
+          @miq_server = FactoryBot.create(:miq_server)
           allow(controller).to receive(:x_node).and_return("svr-#{@miq_server.id}")
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_server',
@@ -412,8 +412,8 @@ describe OpsController do
     describe '#settings_set_form_vars_server' do
       context 'sets values correctly' do
         it 'for server in non-current zone' do
-          zone = FactoryGirl.create(:zone, :name => 'Foo Zone')
-          server = FactoryGirl.create(:miq_server, :zone => zone)
+          zone = FactoryBot.create(:zone, :name => 'Foo Zone')
+          server = FactoryBot.create(:miq_server, :zone => zone)
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)
@@ -421,7 +421,7 @@ describe OpsController do
         end
 
         it 'for server in default zone' do
-          server = FactoryGirl.create(:miq_server, :zone => Zone.find_by(:name => "default"))
+          server = FactoryBot.create(:miq_server, :zone => Zone.find_by(:name => "default"))
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)
@@ -429,8 +429,8 @@ describe OpsController do
         end
 
         it 'sets the server name' do
-          zone = FactoryGirl.create(:zone, :name => 'Foo Zone')
-          server = FactoryGirl.create(:miq_server, :zone => zone, :name => 'ServerName')
+          zone = FactoryBot.create(:zone, :name => 'Foo Zone')
+          server = FactoryBot.create(:miq_server, :zone => zone, :name => 'ServerName')
           controller.instance_variable_set(:@sb, :selected_server_id => server.id)
           controller.send(:settings_set_form_vars_server)
           edit_current = assigns(:edit)

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -11,7 +11,7 @@ describe OpsController do
     end
 
     context "when the filter_type is 'vm'" do
-      let(:vm) { FactoryGirl.create(:vm_vmware, :name => "vmtest") }
+      let(:vm) { FactoryBot.create(:vm_vmware, :name => "vmtest") }
       let(:filter_type) { "vm" }
 
       before do
@@ -26,7 +26,7 @@ describe OpsController do
     end
 
     context "when the filter_type is 'ems'" do
-      let(:ext_management_system) { FactoryGirl.create(:ext_management_system, :name => "emstest") }
+      let(:ext_management_system) { FactoryBot.create(:ext_management_system, :name => "emstest") }
       let(:filter_type) { "ems" }
 
       before do
@@ -42,7 +42,7 @@ describe OpsController do
 
     context "when the filter_type is 'cluster'" do
       let(:cluster) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :ems_cluster,
           :name => "clustertest"
         )
@@ -50,7 +50,7 @@ describe OpsController do
       let(:filter_type) { "cluster" }
 
       before do
-        cluster.parent = FactoryGirl.create(:datacenter, :name => "datacenter")
+        cluster.parent = FactoryBot.create(:datacenter, :name => "datacenter")
         bypass_rescue
         allow(EmsCluster).to receive(:find).with(:all, {}).and_return([cluster])
         post :schedule_form_filter_type_field_changed, :params => params, :session => session
@@ -63,7 +63,7 @@ describe OpsController do
     end
 
     context "when the filter_type is 'host'" do
-      let(:host) { FactoryGirl.create(:host, :name => "hosttest") }
+      let(:host) { FactoryBot.create(:host, :name => "hosttest") }
       let(:filter_type) { "host" }
 
       before do
@@ -112,8 +112,8 @@ describe OpsController do
     let(:zone) { double("Zone", :name => "foo") }
     let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
     let(:user) { stub_user(:features => :all) }
-    let(:schedule) { FactoryGirl.create(:miq_automate_schedule) }
-    let(:vm) { FactoryGirl.create(:vm_vmware) }
+    let(:schedule) { FactoryBot.create(:miq_automate_schedule) }
+    let(:vm) { FactoryBot.create(:vm_vmware) }
 
     before do
       allow(MiqServer).to receive(:my_server).and_return(server)
@@ -174,7 +174,7 @@ describe OpsController do
     let(:zone) { double("Zone", :name => "foo") }
     let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
     let(:user) { stub_user(:features => :all) }
-    let(:vm) { FactoryGirl.create(:vm_vmware) }
+    let(:vm) { FactoryBot.create(:vm_vmware) }
 
     before do
       allow(MiqServer).to receive(:my_server).and_return(server)
@@ -209,8 +209,8 @@ describe OpsController do
     settings = {}
     it "returns a filtered item list for MiqTemplate" do
       controller.instance_variable_set(:@settings, settings)
-      current_user = FactoryGirl.create(:user)
-      FactoryGirl.create(:miq_search,
+      current_user = FactoryBot.create(:user)
+      FactoryBot.create(:miq_search,
                          :name        => "default_Environment / UAT",
                          :description => "Environment / UAT",
                          :db          => "MiqTemplate",
@@ -222,8 +222,8 @@ describe OpsController do
 
     it "returns a filtered item list for Datastore" do
       controller.instance_variable_set(:@settings, settings)
-      current_user = FactoryGirl.create(:user)
-      FactoryGirl.create(:miq_search,
+      current_user = FactoryBot.create(:user)
+      FactoryBot.create(:miq_search,
                          :name        => "default_Environment_Storage / UAT",
                          :description => "Storage_Environment / UAT",
                          :db          => "Storage",
@@ -235,16 +235,16 @@ describe OpsController do
 
     it "returns a filtered item list for a single Datastore" do
       controller.instance_variable_set(:@settings, settings)
-      storage = FactoryGirl.create(:storage_vmware)
+      storage = FactoryBot.create(:storage_vmware)
       filtered_list = controller.send(:build_filtered_item_list, "storage", "storage")
       expect(filtered_list.first).to include(storage.name)
     end
 
     it "returns a filtered item list for ems providers that have hosts" do
       controller.instance_variable_set(:@settings, settings)
-      ems_cloud = FactoryGirl.create(:ems_cloud)
-      ems_infra_no_hosts = FactoryGirl.create(:ems_openstack_infra)
-      ems_infra_with_hosts = FactoryGirl.create(:ems_openstack_infra_with_stack)
+      ems_cloud = FactoryBot.create(:ems_cloud)
+      ems_infra_no_hosts = FactoryBot.create(:ems_openstack_infra)
+      ems_infra_with_hosts = FactoryBot.create(:ems_openstack_infra_with_stack)
       filtered_list = controller.send(:build_filtered_item_list, "host", "ems")
       expect(filtered_list).not_to include(ems_cloud.name)
       expect(filtered_list).not_to include(ems_infra_no_hosts.name)

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -1,5 +1,5 @@
 describe OpsController do
-  let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
+  let(:user) { FactoryBot.create(:user, :role => "super_administrator") }
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     MiqRegion.seed
@@ -34,7 +34,7 @@ describe OpsController do
 
       context 'with using real user' do
         let(:feature) { %w(rbac_group_edit) }
-        let(:user)    { FactoryGirl.create(:user, :features => feature) }
+        let(:user)    { FactoryBot.create(:user, :features => feature) }
 
         before do
           EvmSpecHelper.seed_specific_product_features(%w(rbac_group_edit))
@@ -140,7 +140,7 @@ describe OpsController do
     end
 
     it 'does not update the user without validation' do
-      user1 = FactoryGirl.create(:user, :name => "User1", :userid => "User1", :miq_groups => [group], :email => "user1@test.com")
+      user1 = FactoryBot.create(:user, :name => "User1", :userid => "User1", :miq_groups => [group], :email => "user1@test.com")
 
       session[:edit] = {:key => "rbac_user_edit__#{user1.id}",
                         :new => {:name     => 'test8',
@@ -163,7 +163,7 @@ describe OpsController do
     it "posts db_backup action" do
       session[:settings] = {:default_search => ''}
 
-      miq_schedule = FactoryGirl.create(:miq_schedule,
+      miq_schedule = FactoryBot.create(:miq_schedule,
                                         :name          => "test_db_schedule",
                                         :description   => "test_db_schedule_desc",
                                         :resource_type => "DatabaseBackup",
@@ -225,7 +225,7 @@ describe OpsController do
   end
 
   it "executes action schedule_edit" do
-    schedule = FactoryGirl.create(:miq_schedule, :name => "test_schedule", :description => "old_schedule_desc")
+    schedule = FactoryBot.create(:miq_schedule, :name => "test_schedule", :description => "old_schedule_desc")
     allow(controller).to receive(:get_node_info)
     allow(controller).to receive(:replace_right_cell)
     allow(controller).to receive(:render)
@@ -253,7 +253,7 @@ describe OpsController do
       it "updates the server's zone" do
         server = MiqServer.first
 
-        zone = FactoryGirl.create(:zone,
+        zone = FactoryBot.create(:zone,
                                   :name        => "not the default",
                                   :description => "Not the Default Zone")
 
@@ -283,7 +283,7 @@ describe OpsController do
   before do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
-    login_as FactoryGirl.create(:user, :features => "ops_rbac")
+    login_as FactoryBot.create(:user, :features => "ops_rbac")
   end
 
   context "#explorer" do
@@ -392,7 +392,7 @@ describe OpsController do
   context '#dialog_replace_right_cell' do
     describe 'for an User' do
       before do
-        user = FactoryGirl.create(:user)
+        user = FactoryBot.create(:user)
         allow(controller).to receive(:x_node).and_return("u-#{user.id}")
       end
 
@@ -403,7 +403,7 @@ describe OpsController do
     end
 
     describe 'for a Group' do
-      let(:group) { FactoryGirl.create(:miq_group) }
+      let(:group) { FactoryBot.create(:miq_group) }
 
       before do
         allow(controller).to receive(:x_node).and_return("g-#{group.id}")

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -1,6 +1,6 @@
 describe OpsController do
   context "OpsSettings::Schedules" do
-    let(:user) { FactoryGirl.create(:user, :features => %w(schedule_enable schedule_disable)) }
+    let(:user) { FactoryBot.create(:user, :features => %w(schedule_enable schedule_disable)) }
     before do
       login_as user
       allow(User).to receive(:server_timezone).and_return("UTC")
@@ -28,7 +28,7 @@ describe OpsController do
         allow(server).to receive_messages(:zone_id => 1)
         allow(MiqServer).to receive(:my_server).and_return(server)
 
-        @sch = FactoryGirl.create(:miq_schedule)
+        @sch = FactoryBot.create(:miq_schedule)
         silence_warnings { OpsController::Settings::Schedules::STGROOT = 'ST'.freeze }
 
         controller.params["check_#{@sch.id}"] = '1'
@@ -85,7 +85,7 @@ describe OpsController do
       before do
         EvmSpecHelper.create_guid_miq_server_zone
         expect(controller).to receive(:render)
-        @schedule = FactoryGirl.create(:miq_schedule, :userid => user.userid, :resource_type => "Vm")
+        @schedule = FactoryBot.create(:miq_schedule, :userid => user.userid, :resource_type => "Vm")
         @params = {
           :action      => "schedule_edit",
           :button      => "add",
@@ -119,7 +119,7 @@ describe OpsController do
         @params[:id] = @schedule.id
         @params[:name] = "schedule01"
         controller.instance_variable_set(:@_params, @params)
-        FactoryGirl.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :resource_type => "Vm")
+        FactoryBot.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :resource_type => "Vm")
         controller.send(:schedule_edit)
         expect(controller.send(:flash_errors?)).to be_truthy
         expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
@@ -130,7 +130,7 @@ describe OpsController do
   render_views
   context "OpsController::Settings" do
     context "zone addition" do
-      let(:user) { FactoryGirl.create(:user, :features => %w(zone_edit zone_new)) }
+      let(:user) { FactoryBot.create(:user, :features => %w(zone_edit zone_new)) }
       before do
         login_as user
       end
@@ -140,7 +140,7 @@ describe OpsController do
         MiqRegion.seed
         EvmSpecHelper.create_guid_miq_server_zone
         expect(controller).to receive(:render)
-        @zone = FactoryGirl.create(:zone, :name => 'zoneName', :description => "description1")
+        @zone = FactoryBot.create(:zone, :name => 'zoneName', :description => "description1")
         allow(controller).to receive(:assert_privileges)
         allow(controller).to receive(:x_node).and_return('root')
 

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -9,7 +9,7 @@ describe OrchestrationStackController do
 
   describe '#show' do
     context "instances" do
-      let(:record) { FactoryGirl.create(:orchestration_stack_cloud) }
+      let(:record) { FactoryBot.create(:orchestration_stack_cloud) }
 
       before do
         session[:settings] = {
@@ -29,7 +29,7 @@ describe OrchestrationStackController do
     end
 
     context "infra" do
-      let(:record) { FactoryGirl.create(:orchestration_stack_openstack_infra) }
+      let(:record) { FactoryBot.create(:orchestration_stack_openstack_infra) }
 
       before do
         session[:settings] = {
@@ -49,8 +49,8 @@ describe OrchestrationStackController do
     end
 
     context "orchestration templates" do
-      let(:ems) { FactoryGirl.create(:ems_cloud) }
-      let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template, :ext_management_system => ems, :name => 'stack01') }
+      let(:ems) { FactoryBot.create(:ems_cloud) }
+      let(:record) { FactoryBot.create(:orchestration_stack_cloud_with_template, :ext_management_system => ems, :name => 'stack01') }
 
       before do
         session[:settings] = {
@@ -91,9 +91,9 @@ describe OrchestrationStackController do
 
     context "orchestration stack listing hides ansible jobs" do
       before do
-        @os_cloud  = FactoryGirl.create(:orchestration_stack_cloud, :name => "cloudstack1")
-        @os_infra  = FactoryGirl.create(:orchestration_stack_openstack_infra, :name => "infrastack1")
-        @tower_job = FactoryGirl.create(:ansible_tower_job, :name => "towerjob1")
+        @os_cloud  = FactoryBot.create(:orchestration_stack_cloud, :name => "cloudstack1")
+        @os_infra  = FactoryBot.create(:orchestration_stack_openstack_infra, :name => "infrastack1")
+        @tower_job = FactoryBot.create(:ansible_tower_job, :name => "towerjob1")
 
         get :show_list
       end
@@ -107,7 +107,7 @@ describe OrchestrationStackController do
 
   describe "#stacks_ot_info" do
     it "returns all the orchestration template attributes" do
-      stack = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+      stack = FactoryBot.create(:orchestration_stack_cloud_with_template)
       get :stacks_ot_info, :params => { :id => stack.id }
       expect(response.status).to eq(200)
       ret = JSON.parse(response.body)
@@ -120,7 +120,7 @@ describe OrchestrationStackController do
   end
 
   describe "#stacks_ot_copy" do
-    let(:record) { FactoryGirl.create(:orchestration_stack_cloud_with_template) }
+    let(:record) { FactoryBot.create(:orchestration_stack_cloud_with_template) }
 
     it "correctly cancels the orchestration template copying form" do
       post :stacks_ot_copy, :params => {:id => record.id, :button => "cancel"}
@@ -152,12 +152,12 @@ describe OrchestrationStackController do
           nil
         end
       end)
-      FactoryGirl.create(:orchestration_template, :type => 'OrchestrationTemplateTest', :orderable => false)
+      FactoryBot.create(:orchestration_template, :type => 'OrchestrationTemplateTest', :orderable => false)
     end
 
     context "make stack's orchestration template orderable" do
       it "won't allow making stack's orchestration template orderable when already orderable" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        record = FactoryBot.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
         expect(record.orchestration_template.orderable?).to be_truthy
         expect(response.status).to eq(200)
@@ -166,7 +166,7 @@ describe OrchestrationStackController do
       end
 
       it "makes stack's orchestration template orderable" do
-        record = FactoryGirl.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
+        record = FactoryBot.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
         post :button, :params => {:id => record.id, :pressed => "make_ot_orderable"}
         expect(record.orchestration_template.orderable?).to be_falsey
         expect(response.status).to eq(200)
@@ -177,7 +177,7 @@ describe OrchestrationStackController do
 
     context "copy stack's orchestration template as orderable" do
       it "won't allow copying stack's orchestration template orderable when already orderable" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        record = FactoryBot.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
         expect(record.orchestration_template.orderable?).to be_truthy
         expect(response.status).to eq(200)
@@ -186,7 +186,7 @@ describe OrchestrationStackController do
       end
 
       it "renders orchestration template copying form" do
-        record = FactoryGirl.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
+        record = FactoryBot.create(:orchestration_stack_cloud, :orchestration_template => non_orderable_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_template_copy"}
         expect(record.orchestration_template.orderable?).to be_falsey
         expect(response.status).to eq(200)
@@ -196,7 +196,7 @@ describe OrchestrationStackController do
 
     context "view stack's orchestration template in catalog" do
       it "redirects to catalog controller" do
-        record = FactoryGirl.create(:orchestration_stack_cloud_with_template)
+        record = FactoryBot.create(:orchestration_stack_cloud_with_template)
         post :button, :params => {:id => record.id, :pressed => "orchestration_templates_view"}
         expect(response.status).to eq(200)
         expect(response.body).to include("window.location.href")
@@ -206,7 +206,7 @@ describe OrchestrationStackController do
 
     context "retire orchestration stack" do
       it "set retirement date redirects to retirement screen" do
-        record = FactoryGirl.create(:orchestration_stack_cloud)
+        record = FactoryBot.create(:orchestration_stack_cloud)
         post :button, :params => {:miq_grid_checks => record.id, :pressed => "orchestration_stack_retire"}
         expect(response.status).to eq(200)
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -214,7 +214,7 @@ describe OrchestrationStackController do
       end
 
       it "retires the orchestration stack now" do
-        record = FactoryGirl.create(:orchestration_stack_cloud)
+        record = FactoryBot.create(:orchestration_stack_cloud)
         session[:orchestration_stack_lastaction] = 'show_list'
         expect(controller).to receive(:render).at_least(:once)
         post :button, :params => {:miq_grid_checks => record.id, :pressed => "orchestration_stack_retire_now"}
@@ -222,7 +222,7 @@ describe OrchestrationStackController do
       end
 
       it "retires the orchestration stack now when called from the summary page" do
-        record = FactoryGirl.create(:orchestration_stack_cloud)
+        record = FactoryBot.create(:orchestration_stack_cloud)
         session[:orchestration_stack_lastaction] = 'show'
         expect(controller).to receive(:render).at_least(:once)
         post :button, :params => {:id => record.id, :pressed => "orchestration_stack_retire_now"}

--- a/spec/controllers/persistent_volume_controller_spec.rb
+++ b/spec/controllers/persistent_volume_controller_spec.rb
@@ -22,7 +22,7 @@ describe PersistentVolumeController do
     expect(response.body).to_not be_empty
   end
 
-  let(:ems) { FactoryGirl.create(:ems_openshift) }
+  let(:ems) { FactoryBot.create(:ems_openshift) }
   let(:persistent_volume) { PersistentVolume.create(:parent => ems, :name => "Test Volume") }
 
   it "renders grid view" do

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -4,16 +4,16 @@ describe PhysicalChassisController do
   render_views
 
   let(:physical_chassis) do
-    ems = FactoryGirl.create(:ems_physical_infra)
-    asset_detail = FactoryGirl.create(:asset_detail)
-    FactoryGirl.create(:physical_chassis, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+    ems = FactoryBot.create(:ems_physical_infra)
+    asset_detail = FactoryBot.create(:asset_detail)
+    FactoryBot.create(:physical_chassis, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
   end
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
+    login_as FactoryBot.create(:user)
   end
 
   describe "#show_list" do

--- a/spec/controllers/physical_rack_controller_spec.rb
+++ b/spec/controllers/physical_rack_controller_spec.rb
@@ -2,15 +2,15 @@ describe PhysicalRackController do
   render_views
 
   let(:physical_rack) do
-    ems = FactoryGirl.create(:ems_physical_infra)
-    FactoryGirl.create(:physical_rack, :ems_id => ems.id, :id => 1)
+    ems = FactoryBot.create(:ems_physical_infra)
+    FactoryBot.create(:physical_rack, :ems_id => ems.id, :id => 1)
   end
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
+    login_as FactoryBot.create(:user)
   end
 
   describe "#show_list" do

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -2,16 +2,16 @@ describe PhysicalServerController do
   render_views
 
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryGirl.build(:zone) }
+  let(:zone) { FactoryBot.build(:zone) }
 
   before do
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
-    ems = FactoryGirl.create(:ems_physical_infra)
-    asset_detail = FactoryGirl.create(:asset_detail)
-    computer_system = FactoryGirl.create(:computer_system, :hardware => FactoryGirl.create(:hardware))
-    @physical_server = FactoryGirl.create(:physical_server,
+    login_as FactoryBot.create(:user)
+    ems = FactoryBot.create(:ems_physical_infra)
+    asset_detail = FactoryBot.create(:asset_detail)
+    computer_system = FactoryBot.create(:computer_system, :hardware => FactoryBot.create(:hardware))
+    @physical_server = FactoryBot.create(:physical_server,
                                           :asset_detail    => asset_detail,
                                           :computer_system => computer_system,
                                           :ems_id          => ems.id,
@@ -28,7 +28,7 @@ describe PhysicalServerController do
 
   describe "#show_list" do
     before do
-      FactoryGirl.create(:physical_server)
+      FactoryBot.create(:physical_server)
     end
 
     subject { get :show_list }

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -2,16 +2,16 @@ describe PhysicalStorageController do
   render_views
 
   let(:physical_storage) do
-    ems = FactoryGirl.create(:ems_physical_infra)
-    asset_detail = FactoryGirl.create(:asset_detail)
-    FactoryGirl.create(:physical_storage, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+    ems = FactoryBot.create(:ems_physical_infra)
+    asset_detail = FactoryBot.create(:asset_detail)
+    FactoryBot.create(:physical_storage, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
   end
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
+    login_as FactoryBot.create(:user)
   end
 
   describe "#show_list" do

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -2,11 +2,11 @@ describe PhysicalSwitchController do
   render_views
 
   let(:physical_switch) do
-    ems = FactoryGirl.create(:ems_physical_infra)
-    hardware = FactoryGirl.create(:hardware)
-    asset_detail = FactoryGirl.create(:asset_detail)
+    ems = FactoryBot.create(:ems_physical_infra)
+    hardware = FactoryBot.create(:hardware)
+    asset_detail = FactoryBot.create(:asset_detail)
 
-    FactoryGirl.create(
+    FactoryBot.create(
       :physical_switch,
       :hardware     => hardware,
       :asset_detail => asset_detail,
@@ -16,10 +16,10 @@ describe PhysicalSwitchController do
   end
 
   before do
-    EvmSpecHelper.local_miq_server(:zone => FactoryGirl.build(:zone))
+    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user)
+    login_as FactoryBot.create(:user)
   end
 
   describe "#show_list" do

--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -1,6 +1,6 @@
 describe PictureController do
   let(:picture_content) { "BINARY IMAGE CONTENT" }
-  let(:picture) { FactoryGirl.create(:picture, :id => 10_000_000_000_005, :extension => "jpg") }
+  let(:picture) { FactoryBot.create(:picture, :id => 10_000_000_000_005, :extension => "jpg") }
 
   before do
     stub_user(:features => :all)

--- a/spec/controllers/planning_controller_spec.rb
+++ b/spec/controllers/planning_controller_spec.rb
@@ -6,13 +6,13 @@ describe PlanningController do
 
   describe "#option_changed" do
     before do
-      @host1 = FactoryGirl.create(:host, :name => 'Host1')
-      @host2 = FactoryGirl.create(:host, :name => 'Host2')
+      @host1 = FactoryBot.create(:host, :name => 'Host1')
+      @host2 = FactoryBot.create(:host, :name => 'Host2')
 
-      @vm1 = FactoryGirl.create(:vm_vmware, :name => 'Name1', :host => @host1)
-      @vm2 = FactoryGirl.create(:vm_vmware, :name => 'Name2', :host => @host2)
-      @vm3 = FactoryGirl.create(:vm_vmware, :name => 'Name3', :host => @host1)
-      @vm4 = FactoryGirl.create(:vm_vmware, :name => 'Name4', :host => @host1)
+      @vm1 = FactoryBot.create(:vm_vmware, :name => 'Name1', :host => @host1)
+      @vm2 = FactoryBot.create(:vm_vmware, :name => 'Name2', :host => @host2)
+      @vm3 = FactoryBot.create(:vm_vmware, :name => 'Name3', :host => @host1)
+      @vm4 = FactoryBot.create(:vm_vmware, :name => 'Name4', :host => @host1)
     end
 
     it 'displays all Vms and no flash message is set' do
@@ -29,8 +29,8 @@ describe PlanningController do
     end
 
     it 'displays Vms with the same name' do
-      ems = FactoryGirl.create(:ems_vmware, :name => "ProviderName")
-      vm5 = FactoryGirl.create(:vm_vmware,  :name => 'Name1', :host => @host2, :ext_management_system => ems)
+      ems = FactoryBot.create(:ems_vmware, :name => "ProviderName")
+      vm5 = FactoryBot.create(:vm_vmware,  :name => 'Name1', :host => @host2, :ext_management_system => ems)
       allow(controller).to receive(:render)
       controller.instance_variable_set(:@sb, :vms => {}, :options => {})
       controller.instance_variable_set(:@_params, :filter_typ => "all")

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -62,8 +62,8 @@ describe ProviderForemanController do
 
   it "renders explorer sorted by url" do
     login_as user_with_feature(%w(providers_accord configured_systems_filter_accord))
-    FactoryGirl.create(:provider_foreman, :name => "foremantest1", :url => "z_url")
-    FactoryGirl.create(:provider_foreman, :name => "foremantest2", :url => "a_url")
+    FactoryBot.create(:provider_foreman, :name => "foremantest1", :url => "z_url")
+    FactoryBot.create(:provider_foreman, :name => "foremantest2", :url => "a_url")
 
     get :explorer, :params => {:sortby => '2'}
     expect(response.status).to eq(200)
@@ -160,7 +160,7 @@ describe ProviderForemanController do
     end
 
     it "should display the zone field" do
-      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryBot.create(:zone, :name => "TestZone")
       controller.instance_variable_set(:@provider, @provider)
       post :edit, :params => { :id => @config_mgr.id }
       expect(response.status).to eq(200)
@@ -168,7 +168,7 @@ describe ProviderForemanController do
     end
 
     it "should save the zone field" do
-      new_zone = FactoryGirl.create(:zone, :name => "TestZone")
+      new_zone = FactoryBot.create(:zone, :name => "TestZone")
       controller.instance_variable_set(:@provider, @provider)
       allow(controller).to receive(:leaf_record).and_return(false)
       post :edit, :params => { :button     => 'save',
@@ -465,7 +465,7 @@ describe ProviderForemanController do
     pending "does not display an automation manger configured system in the Configured Systems accordion" do
       controller.instance_variable_set(:@in_report_data, true)
       stub_user(:features => :all)
-      FactoryGirl.create(:configured_system_ansible_tower)
+      FactoryBot.create(:configured_system_ansible_tower)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_cs_filter)
       allow(controller).to receive(:build_listnav_search_list)
@@ -484,9 +484,9 @@ describe ProviderForemanController do
     session[:tag_items] = [@configured_system.id]
     session[:assigned_filters] = []
     allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_cs_filter)
-    parent = FactoryGirl.create(:classification, :name => "test_category")
-    FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
-    FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
+    parent = FactoryBot.create(:classification, :name => "test_category")
+    FactoryBot.create(:classification_tag,      :name => "test_entry",         :parent => parent)
+    FactoryBot.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
     post :tagging, :params => { :id => @configured_system.id, :format => :js }
     expect(response.status).to eq(200)
   end
@@ -495,9 +495,9 @@ describe ProviderForemanController do
     session[:assigned_filters] = []
     allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_providers)
     allow(controller).to receive(:x_node).and_return(config_profile_key(@config_profile))
-    parent = FactoryGirl.create(:classification, :name => "test_category")
-    FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
-    FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
+    parent = FactoryBot.create(:classification, :name => "test_category")
+    FactoryBot.create(:classification_tag,      :name => "test_entry",         :parent => parent)
+    FactoryBot.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
     post :tagging, :params => { :miq_grid_checks => [@configured_system.id], :id => @config_profile.id, :format => :js }
     expect(response.status).to eq(200)
   end
@@ -655,11 +655,11 @@ describe ProviderForemanController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       allow(@configured_system).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@configured_system).and_return([@tag1, @tag2])
@@ -703,7 +703,7 @@ describe ProviderForemanController do
       allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
       allow(controller).to receive(:tagdata).and_return(nil)
       allow(controller).to receive(:x_node).and_return(config_profile_key(@config_profile))
-      login_as FactoryGirl.create(:user_admin)
+      login_as FactoryBot.create(:user_admin)
       stub_user(:features => :all)
     end
 
@@ -736,7 +736,7 @@ describe ProviderForemanController do
 
   def user_with_feature(features)
     features = EvmSpecHelper.specific_product_features(*features)
-    FactoryGirl.create(:user, :features => features)
+    FactoryBot.create(:user, :features => features)
   end
 
   def find_treenode_for_foreman_provider(tree, provider)

--- a/spec/controllers/pxe_controller/iso_datastores_spec.rb
+++ b/spec/controllers/pxe_controller/iso_datastores_spec.rb
@@ -6,8 +6,8 @@ describe PxeController do
   describe "#iso_datastore_set_form_vars" do
     context "when EMS is available" do
       before do
-        @ems = FactoryGirl.create(:ems_redhat)
-        iso = FactoryGirl.create(:iso_datastore)
+        @ems = FactoryBot.create(:ems_redhat)
+        iso = FactoryBot.create(:iso_datastore)
         controller.instance_variable_set(:@isd, iso)
       end
 
@@ -19,8 +19,8 @@ describe PxeController do
 
     context "when EMS is not available" do
       before do
-        ems = FactoryGirl.create(:ems_redhat)
-        iso = FactoryGirl.create(:iso_datastore, :ems_id => ems.id)
+        ems = FactoryBot.create(:ems_redhat)
+        iso = FactoryBot.create(:iso_datastore, :ems_id => ems.id)
         controller.instance_variable_set(:@isd, iso)
       end
 

--- a/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
+++ b/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
@@ -1,7 +1,7 @@
 describe PxeController do
   context "#template_create_update" do
     it "correct method is being called when reset button is pressed" do
-      customization_template = FactoryGirl.create(:customization_template)
+      customization_template = FactoryBot.create(:customization_template)
       controller.instance_variable_set(:@sb, :trees       => {
                                          :customization_templates_tree => {
                                            :active_node => "xx-xx-#{customization_template.id}"

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -24,7 +24,7 @@ describe PxeController do
 
   describe 'x_button' do
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryGirl.create(:zone) }
+    let(:zone) { FactoryBot.create(:zone) }
 
     before do
       ApplicationController.handle_exceptions = true
@@ -44,7 +44,7 @@ describe PxeController do
     end
 
     it "Pressing Refresh button should show display name in the flash message" do
-      pxe = FactoryGirl.create(:pxe_server)
+      pxe = FactoryBot.create(:pxe_server)
       controller.instance_variable_set(:@_params, :id => pxe.id)
       controller.instance_variable_set(:@sb,
                                        :trees       => {
@@ -75,7 +75,7 @@ describe PxeController do
   end
 
   describe "#tree_select" do
-    before { login_as FactoryGirl.create(:user_admin) }
+    before { login_as FactoryBot.create(:user_admin) }
 
     subject { post :tree_select, :params => {:id => 'root'} }
 

--- a/spec/controllers/report_controller/menu_spec.rb
+++ b/spec/controllers/report_controller/menu_spec.rb
@@ -73,16 +73,16 @@ describe ReportController do
       MiqUserRole.seed
 
       role = MiqUserRole.find_by(:name => "EvmRole-administrator")
-      current_group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Current Group")
-      @current_user = FactoryGirl.create(:user, :userid => "Current User", :miq_groups => [current_group],
+      current_group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Current Group")
+      @current_user = FactoryBot.create(:user, :userid => "Current User", :miq_groups => [current_group],
                                          :email => "current_user@test.com")
 
       login_as @current_user
-      FactoryGirl.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
-      FactoryGirl.create(:miq_report, :name => "Provisioning 1", :rpt_group => "Provisioning - Folder Bar", :rpt_type => "Default")
-      FactoryGirl.create(:miq_report, :name => "Provisioning 2", :rpt_group => "Provisioning - Folder Bar", :rpt_type => "Default")
-      FactoryGirl.create(:miq_report, :name => "custom report 1", :rpt_group => "Custom", :rpt_type => "Custom")
-      FactoryGirl.create(:miq_report, :name => "custom report 2", :rpt_group => "Custom", :rpt_type => "Custom")
+      FactoryBot.create(:miq_report, :name => "VM 1", :rpt_group => "Configuration Management - Folder Foo", :rpt_type => "Default")
+      FactoryBot.create(:miq_report, :name => "Provisioning 1", :rpt_group => "Provisioning - Folder Bar", :rpt_type => "Default")
+      FactoryBot.create(:miq_report, :name => "Provisioning 2", :rpt_group => "Provisioning - Folder Bar", :rpt_type => "Default")
+      FactoryBot.create(:miq_report, :name => "custom report 1", :rpt_group => "Custom", :rpt_type => "Custom")
+      FactoryBot.create(:miq_report, :name => "custom report 2", :rpt_group => "Custom", :rpt_type => "Custom")
 
       controller.instance_variable_set(:@edit,
                                        :new => [

--- a/spec/controllers/report_controller/schedules_spec.rb
+++ b/spec/controllers/report_controller/schedules_spec.rb
@@ -1,16 +1,16 @@
 describe ReportController do
   describe "#schedule_edit" do
-    let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+    let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
 
-    let(:schedule) { FactoryGirl.create(:miq_schedule, :name => "tester1") }
-    let(:report) { FactoryGirl.create(:miq_report, :name => "report1") }
+    let(:schedule) { FactoryBot.create(:miq_schedule, :name => "tester1") }
+    let(:report) { FactoryBot.create(:miq_report, :name => "report1") }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as admin_user
 
       schedule
-      FactoryGirl.create(:miq_schedule, :name => "tester2")
+      FactoryBot.create(:miq_schedule, :name => "tester2")
 
       allow(controller).to receive(:assert_privileges)
       allow(controller).to receive(:checked_or_params).and_return(MiqSchedule.all.ids)

--- a/spec/controllers/report_controller/widget_spec.rb
+++ b/spec/controllers/report_controller/widget_spec.rb
@@ -1,17 +1,17 @@
 describe ReportController do
   context "#widget_set_form_vars" do
     let!(:report) do
-      FactoryGirl.create(:miq_report, :name => "custom report 1", :rpt_group => "Custom", :rpt_type => "Custom", :col_order => [])
+      FactoryBot.create(:miq_report, :name => "custom report 1", :rpt_group => "Custom", :rpt_type => "Custom", :col_order => [])
     end
 
     before do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       allow(user).to receive(:get_timezone).and_return(Time.zone)
       allow(user).to receive(:report_admin_user?).and_return(true)
       login_as user
       allow(controller).to receive(:current_user).and_return(user)
 
-      allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
+      allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
     end
 
     shared_examples "Report Widget @menu" do
@@ -27,12 +27,12 @@ describe ReportController do
     end
 
     context "new" do
-      let(:widget) { FactoryGirl.build(:miq_widget, :content_type => "report") }
+      let(:widget) { FactoryBot.build(:miq_widget, :content_type => "report") }
       it_behaves_like "Report Widget @menu"
     end
 
     context "edit" do
-      let(:widget) { FactoryGirl.create(:miq_widget, :content_type => "report", :resource => report) }
+      let(:widget) { FactoryBot.create(:miq_widget, :content_type => "report", :resource => report) }
       it_behaves_like "Report Widget @menu"
     end
   end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -47,7 +47,7 @@ describe ReportController do
       end
 
       describe "#add_field_to_col_order" do
-        let(:miq_report)               { FactoryGirl.create(:miq_report, :cols => [], :col_order => []) }
+        let(:miq_report)               { FactoryBot.create(:miq_report, :cols => [], :col_order => []) }
         let(:base_model)               { "Vm" }
         let(:virtual_custom_attribute) { "virtual_custom_attribute_kubernetes.io/hostname" }
 
@@ -298,7 +298,7 @@ describe ReportController do
         end
 
         it "sets perf time profile" do
-          time_prof = FactoryGirl.create(:time_profile, :description => "Test", :profile => {:tz => "UTC"})
+          time_prof = FactoryBot.create(:time_profile, :description => "Test", :profile => {:tz => "UTC"})
           chosen_time_prof = time_prof.id.to_s
           controller.instance_variable_set(:@_params, :chosen_time_profile => chosen_time_prof)
           controller.send(:gfv_performance)
@@ -340,7 +340,7 @@ describe ReportController do
         it "sets tag category" do
           tag_cat = "department"
           controller.instance_variable_set(:@_params, :cb_tag_cat => tag_cat)
-          cl_rec = FactoryGirl.create(:classification, :name => "test_name", :description => "Test Description")
+          cl_rec = FactoryBot.create(:classification, :name => "test_name", :description => "Test Description")
           expect(Classification).to receive(:find_by_name).and_return([cl_rec])
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_tag_cat]).to eq(tag_cat)
@@ -712,10 +712,10 @@ describe ReportController do
   end
 
   context "ReportController::Schedules" do
-    let(:miq_report) { FactoryGirl.create(:miq_report) }
+    let(:miq_report) { FactoryBot.create(:miq_report) }
 
     before do
-      @current_user = login_as FactoryGirl.create(:user, :features => %w(miq_report_schedule_enable
+      @current_user = login_as FactoryBot.create(:user, :features => %w(miq_report_schedule_enable
                                                                          miq_report_schedule_disable
                                                                          miq_report_schedule_edit))
       allow(User).to receive(:server_timezone).and_return("UTC")
@@ -741,7 +741,7 @@ describe ReportController do
         allow(server).to receive_messages(:zone_id => 1)
         allow(MiqServer).to receive(:my_server).and_return(server)
 
-        @sch = FactoryGirl.create(:miq_schedule, :enabled => true, :updated_at => 1.hour.ago.utc)
+        @sch = FactoryBot.create(:miq_schedule, :enabled => true, :updated_at => 1.hour.ago.utc)
 
         allow(controller).to receive(:find_records_with_rbac).and_return([@sch])
         expect(controller).to receive(:render).never
@@ -820,7 +820,7 @@ describe ReportController do
     render_views
 
     before do
-      login_as(FactoryGirl.create(:user))
+      login_as(FactoryBot.create(:user))
       allow(controller).to receive(:x_active_tree) { :export_tree }
     end
 
@@ -937,11 +937,11 @@ describe ReportController do
 
       before do
         allow(WidgetImportService).to receive(:new).and_return(widget_import_service)
-        login_as(FactoryGirl.create(:user))
+        login_as(FactoryBot.create(:user))
       end
 
       context "when the widget importer does not raise an error" do
-        let(:ret) { FactoryGirl.build(:import_file_upload, :id => '123') }
+        let(:ret) { FactoryBot.build(:import_file_upload, :id => '123') }
 
         before do
           allow(ret).to receive(:widget_list).and_return([])
@@ -1126,8 +1126,8 @@ describe ReportController do
 
   context "#replace_right_cell" do
     before do
-      FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
-      login_as FactoryGirl.create(:user_admin) # not sure why this needs to be an admin...
+      FactoryBot.create(:tenant, :parent => Tenant.root_tenant)
+      login_as FactoryBot.create(:user_admin) # not sure why this needs to be an admin...
 
       controller.instance_variable_set(:@sb,
                                        :trees       => {'reports_tree'      => {:active_node => "root"},
@@ -1148,7 +1148,7 @@ describe ReportController do
     it "should rebuild trees when last report result is newer than last tree build time" do
       # report is newer, set build_time first
       sb[:rep_tree_build_time] = Time.now.utc
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
 
       expect(controller).to receive(:build_reports_tree)
       expect(controller).to receive(:build_savedreports_tree)
@@ -1161,7 +1161,7 @@ describe ReportController do
     it "should not rebuild trees which weren't previously built, even though newer" do
       # report is newer, set build_time first
       sb[:rep_tree_build_time] = Time.now.utc
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
 
       sb[:trees].delete('db_tree')
       sb[:trees].delete('widgets_tree')
@@ -1176,7 +1176,7 @@ describe ReportController do
 
     it "should not rebuild trees when last report result is older than last tree build time" do
       # report is older, set build_time after
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
       sb[:rep_tree_build_time] = Time.now.utc
 
       expect(controller).not_to receive(:build_reports_tree)
@@ -1192,7 +1192,7 @@ describe ReportController do
       # {:replace_trees => [:reports]} is passed in
 
       # report is older, set build_time after
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
       sb[:rep_tree_build_time] = Time.now.utc
 
       expect(controller).to receive(:build_reports_tree)
@@ -1225,20 +1225,20 @@ describe ReportController do
 
   context "#rebuild_trees" do
     before do
-      login_as FactoryGirl.create(:user_admin) # not sure why this needs to be an admin...
+      login_as FactoryBot.create(:user_admin) # not sure why this needs to be an admin...
     end
 
     it "rebuild trees, latest report result was created after last time tree was built" do
       last_build_time = Time.now.utc
       controller.instance_variable_set(:@sb, :rep_tree_build_time => last_build_time)
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
       res = controller.send(:rebuild_trees)
       expect(res).to be(true)
       expect(assigns(:sb)[:rep_tree_build_time]).not_to eq(last_build_time)
     end
 
     it "don't rebuild trees, latest report result was created before last time tree was built" do
-      FactoryGirl.create(:miq_report_with_results)
+      FactoryBot.create(:miq_report_with_results)
       last_build_time = Time.now.utc
       controller.instance_variable_set(:@sb, :rep_tree_build_time => last_build_time)
       res = controller.send(:rebuild_trees)
@@ -1254,7 +1254,7 @@ describe ReportController do
 
     context "when generating reports" do
       render_views
-      let(:rpt) { FactoryGirl.create(:miq_report) }
+      let(:rpt) { FactoryBot.create(:miq_report) }
 
       before do
         stub_user(:features => :all)
@@ -1297,7 +1297,7 @@ describe ReportController do
       context "User2 generates report under Group1" do
         before do
           os = OperatingSystem.create(:name => "RHEL 7", :product_name => "RHEL7")
-          FactoryGirl.create(:vm_vmware, :operating_system => os)
+          FactoryBot.create(:vm_vmware, :operating_system => os)
           @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
         end
 
@@ -1338,7 +1338,7 @@ describe ReportController do
   end
 
   describe "#populate_reports_menu" do
-    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
     let(:sandbox) { {} }
 
     before do
@@ -1355,7 +1355,7 @@ describe ReportController do
   end
 
   describe '#get_reports_menu' do
-    let(:group) { FactoryGirl.create(:miq_group, :settings => settings) }
+    let(:group) { FactoryBot.create(:miq_group, :settings => settings) }
     let(:settings) { {:report_menus => []} }
 
     before do
@@ -1378,14 +1378,14 @@ describe ReportController do
     end
 
     context 'custom reports included' do
-      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:user) { FactoryBot.create(:user_with_group) }
       let(:menu) { controller.instance_variable_get(:@sb)[:rpt_menu] }
       subject { controller.send(:get_reports_menu, false, user.current_group) }
 
       before do
         EvmSpecHelper.local_miq_server
         login_as user
-        FactoryGirl.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
+        FactoryBot.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
       end
 
       it 'returns with the correct name for custom folder' do
@@ -1395,8 +1395,8 @@ describe ReportController do
   end
 
   describe "#miq_report_edit" do
-    let(:admin_user)   { FactoryGirl.create(:user, :role => "super_administrator") }
-    let(:tenant)       { FactoryGirl.create(:tenant) }
+    let(:admin_user)   { FactoryBot.create(:user, :role => "super_administrator") }
+    let(:tenant)       { FactoryBot.create(:tenant) }
     let(:chosen_model) { "ChargebackVm" }
 
     before do

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -59,8 +59,8 @@ describe ResourcePoolController do
   describe "#show" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user, :features => "none")
-      @resource_pool = FactoryGirl.create(:resource_pool)
+      login_as FactoryBot.create(:user, :features => "none")
+      @resource_pool = FactoryBot.create(:resource_pool)
     end
 
     let(:url_params) { {} }

--- a/spec/controllers/restful_redirect_controller_spec.rb
+++ b/spec/controllers/restful_redirect_controller_spec.rb
@@ -7,14 +7,14 @@ describe RestfulRedirectController do
     end
 
     it "redirects to ems_infra controller" do
-      ems_infra = FactoryGirl.create(:ems_vmware)
+      ems_infra = FactoryBot.create(:ems_vmware)
       link = "/ems_infra/#{ems_infra.id}"
       get :index, :params => { :model => "ExtManagementSystem", :id => ems_infra.id }
       expect(response).to redirect_to(link)
     end
 
     it "redirects to ems_container controller" do
-      ems_container = FactoryGirl.create(:ems_kubernetes)
+      ems_container = FactoryBot.create(:ems_kubernetes)
       link = "/ems_container/#{ems_container.id}"
       get :index, :params => { :model => "ExtManagementSystem", :id => ems_container.id }
       expect(response).to redirect_to(link)
@@ -33,13 +33,13 @@ describe RestfulRedirectController do
     end
 
     it "redirects to vm_infra controller" do
-      vm_infra = FactoryGirl.create(:vm_vmware)
+      vm_infra = FactoryBot.create(:vm_vmware)
       get :index, :params => { :model => "VmOrTemplate", :id => vm_infra.id }
       expect(response).to redirect_to(:controller => "vm_infra", :action => "show", :id => vm_infra.id)
     end
 
     it "redirects to vm_cloud controller" do
-      vm_cloud = FactoryGirl.create(:vm_openstack)
+      vm_cloud = FactoryBot.create(:vm_openstack)
       get :index, :params => { :model => "VmOrTemplate", :id => vm_cloud.id }
       expect(response).to redirect_to(:controller => "vm_cloud", :action => "show", :id => vm_cloud.id)
     end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,7 +1,7 @@
 describe SecurityGroupController do
   include_examples :shared_examples_for_security_group_controller, %w(openstack azure google amazon)
 
-  let(:ems) { FactoryGirl.create(:ems_openstack).network_manager }
+  let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
@@ -9,10 +9,10 @@ describe SecurityGroupController do
   end
 
   describe "#tags_edit" do
-    let(:ct) { FactoryGirl.create(:security_group, :name => "security-group-01") }
-    let(:classification) { FactoryGirl.create(:classification, :name => "department", :description => "Department") }
-    let(:tag1) { FactoryGirl.create(:classification_tag, :name => "tag1", :parent => classification) }
-    let(:tag2) { FactoryGirl.create(:classification_tag, :name => "tag2", :parent => classification) }
+    let(:ct) { FactoryBot.create(:security_group, :name => "security-group-01") }
+    let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+    let(:tag1) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
+    let(:tag2) { FactoryBot.create(:classification_tag, :name => "tag2", :parent => classification) }
 
     before do
       session[:tag_db] = "SecurityGroup"
@@ -54,7 +54,7 @@ describe SecurityGroupController do
   end
 
   describe "#delete_security_groups" do
-    let(:security_group) { FactoryGirl.create(:security_group) }
+    let(:security_group) { FactoryBot.create(:security_group) }
 
     before do
       allow(controller).to receive(:assert_privileges)
@@ -75,7 +75,7 @@ describe SecurityGroupController do
   end
 
   describe "#show" do
-    let(:security_group) { FactoryGirl.create(:security_group_with_firewall_rules) }
+    let(:security_group) { FactoryBot.create(:security_group_with_firewall_rules) }
 
     render_views
     it "render" do
@@ -120,7 +120,7 @@ describe SecurityGroupController do
   end
 
   describe "#edit" do
-    let(:security_group) { FactoryGirl.create(:security_group_with_firewall_rules_openstack, :ext_management_system => ems) }
+    let(:security_group) { FactoryBot.create(:security_group_with_firewall_rules_openstack, :ext_management_system => ems) }
     let(:security_group_task_options) do
       {
         :action => "updating Security Group for user #{controller.current_user.userid}",
@@ -176,7 +176,7 @@ describe SecurityGroupController do
   end
 
   describe "#delete" do
-    let(:security_group) { FactoryGirl.create(:security_group_openstack, :ext_management_system => ems) }
+    let(:security_group) { FactoryBot.create(:security_group_openstack, :ext_management_system => ems) }
     let(:task_options) do
       {
         :action => "deleting Security Group for user #{controller.current_user.userid}",

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -4,13 +4,13 @@ describe ServiceController do
   end
 
   let(:go_definition) do
-    FactoryGirl.create(:generic_object_definition, :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
+    FactoryBot.create(:generic_object_definition, :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
   end
 
   let(:service_with_go) do
-    service = FactoryGirl.create(:service, :name => 'Services with a GO')
+    service = FactoryBot.create(:service, :name => 'Services with a GO')
 
-    go = FactoryGirl.create(
+    go = FactoryBot.create(
       :generic_object,
       :generic_object_definition => go_definition,
       :name                      => 'go_assoc',
@@ -52,8 +52,8 @@ describe ServiceController do
 
   describe "#service_delete" do
     it "display flash message with description of deleted Service" do
-      st  = FactoryGirl.create(:service_template)
-      svc = FactoryGirl.create(:service, :service_template => st, :name => "GemFire", :description => "VMware vFabric GEMFIRE")
+      st  = FactoryBot.create(:service_template)
+      svc = FactoryBot.create(:service, :service_template => st, :name => "GemFire", :description => "VMware vFabric GEMFIRE")
 
       controller.instance_variable_set(:@record, svc)
       controller.instance_variable_set(:@sb,
@@ -76,7 +76,7 @@ describe ServiceController do
     end
 
     it "replaces right cell after service is deleted" do
-      service = FactoryGirl.create(:service)
+      service = FactoryBot.create(:service)
       allow(controller).to receive(:x_build_tree)
       controller.instance_variable_set(:@settings, {})
       controller.instance_variable_set(:@sb, {})
@@ -91,7 +91,7 @@ describe ServiceController do
     end
 
     context 'setting x_node properly after deleting a service from its details page' do
-      let(:service) { FactoryGirl.create(:service) }
+      let(:service) { FactoryBot.create(:service) }
 
       before do
         allow(controller).to receive(:replace_right_cell)
@@ -136,7 +136,7 @@ describe ServiceController do
 
     it 'contains the associated tags for the ansible service template' do
       EvmSpecHelper.local_miq_server
-      record = FactoryGirl.create(:service_ansible_playbook)
+      record = FactoryBot.create(:service_ansible_playbook)
       get :explorer, :params => { :id => "s-#{record.id}" }
       expect(response.status).to eq(200)
       expect(response.body).to include('Smart Management')
@@ -144,8 +144,8 @@ describe ServiceController do
 
     it 'displays the associated custom attributes for the ansible service template' do
       EvmSpecHelper.local_miq_server
-      record = FactoryGirl.create(:service_ansible_playbook)
-      record.custom_attributes << FactoryGirl.build(:miq_custom_attribute,
+      record = FactoryBot.create(:service_ansible_playbook)
+      record.custom_attributes << FactoryBot.build(:miq_custom_attribute,
                                                     :resource_type => "ServiceAnsiblePlaybook",
                                                     :resource_id   => record.id,
                                                     :name          => "custom_attribute_1",
@@ -157,7 +157,7 @@ describe ServiceController do
 
     it 'displays generic objects as a nested list' do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
 
       get :show, :params => { :id => service_with_go.id, :display => 'generic_objects'}
@@ -167,16 +167,16 @@ describe ServiceController do
 
     it 'displays the selected generic object' do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
-      service = FactoryGirl.create(:service, :name => "Abc")
-      go1 = FactoryGirl.create(:generic_object,
+      service = FactoryBot.create(:service, :name => "Abc")
+      go1 = FactoryBot.create(:generic_object,
                                :generic_object_definition => go_definition,
                                :name                      => 'GOTest_1',
                                :services                  => [service])
       go1.add_to_service(service)
 
-      go2 = FactoryGirl.create(:generic_object,
+      go2 = FactoryBot.create(:generic_object,
                                :generic_object_definition => go_definition,
                                :name                      => 'GOTest_2',
                                :services                  => [service])
@@ -189,10 +189,10 @@ describe ServiceController do
 
     it 'redirects to service detail page when Services maintab is clicked right after viewing the GO object' do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
       controller.instance_variable_set(:@breadcrumbs, [])
-      service = FactoryGirl.create(:service, :name => "Abc")
-      go = FactoryGirl.create(
+      service = FactoryBot.create(:service, :name => "Abc")
+      go = FactoryBot.create(
         :generic_object,
         :generic_object_definition => go_definition,
         :name                      => 'GOTest',
@@ -220,8 +220,8 @@ describe ServiceController do
       end
 
       it "when Generic Object Tag is pressed for the generic object nested list" do
-        service = FactoryGirl.create(:service, :name => "Service with Generic Objects")
-        go = FactoryGirl.create(
+        service = FactoryBot.create(:service, :name => "Service with Generic Objects")
+        go = FactoryBot.create(
           :generic_object,
           :generic_object_definition => go_definition,
           :name                      => 'go_assoc',
@@ -247,10 +247,10 @@ describe ServiceController do
   end
 
   context 'displaying a service with associated VMs' do
-    let(:service) { FactoryGirl.create(:service) }
+    let(:service) { FactoryBot.create(:service) }
 
     let!(:vm) do
-      vm = FactoryGirl.create(:vm)
+      vm = FactoryBot.create(:vm)
       vm.add_to_service(service)
       vm
     end
@@ -326,13 +326,13 @@ describe ServiceController do
 
   context "Generic Object instances in Textual Summary" do
     it "displays Generic Objects in Ansible Playbook Service Textual Summary" do
-      record = FactoryGirl.create(:service_ansible_playbook)
+      record = FactoryBot.create(:service_ansible_playbook)
       controller.instance_variable_set(:@record, record)
       expect(controller.send(:textual_group_list)).to include(array_including(:generic_objects))
     end
 
     it "displays Generic Objects for all other Services" do
-      record = FactoryGirl.create(:service)
+      record = FactoryBot.create(:service)
       controller.instance_variable_set(:@record, record)
       expect(controller.send(:textual_group_list)).to include(array_including(:generic_objects))
     end
@@ -342,7 +342,7 @@ describe ServiceController do
     describe '#tree_select' do
       render_views
 
-      let(:service_search) { FactoryGirl.create(:miq_search, :description => 'a', :db => 'Service') }
+      let(:service_search) { FactoryBot.create(:miq_search, :description => 'a', :db => 'Service') }
 
       it 'renders GTL of All Services, filtered by choosen filter from accordion' do
         expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -1,9 +1,9 @@
 describe StorageController do
-  let(:storage) { FactoryGirl.create(:storage, :name => 'test_storage1') }
-  let(:storage_cluster) { FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster1') }
+  let(:storage) { FactoryBot.create(:storage, :name => 'test_storage1') }
+  let(:storage_cluster) { FactoryBot.create(:storage_cluster, :name => 'test_storage_cluster1') }
   let(:storage_with_miq_templates) do
-    st = FactoryGirl.create(:storage)
-    2.times { st.all_miq_templates << FactoryGirl.create(:miq_template) }
+    st = FactoryBot.create(:storage)
+    2.times { st.all_miq_templates << FactoryBot.create(:miq_template) }
     st
   end
   before { stub_user(:features => :all) }
@@ -76,9 +76,9 @@ describe StorageController do
      "host_stop"     => "Power Off",
      "host_reset"    => "Reset"}.each do |button, description|
       it "when Host #{description} button is pressed" do
-        login_as FactoryGirl.create(:user, :features => button)
+        login_as FactoryBot.create(:user, :features => button)
 
-        host = FactoryGirl.create(:host)
+        host = FactoryBot.create(:host)
         command = button.split('_', 2)[1]
         allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
 
@@ -138,14 +138,14 @@ describe StorageController do
       end
 
       it "it handles x_button tagging" do
-        ems = FactoryGirl.create(:ems_vmware)
-        datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+        ems = FactoryBot.create(:ems_vmware)
+        datastore = FactoryBot.create(:storage, :name => 'storage_name')
         datastore.parent = ems
-        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-        @tag1 = FactoryGirl.create(:classification_tag,
+        classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryBot.create(:classification_tag,
                                    :name   => "tag1",
                                    :parent => classification)
-        @tag2 = FactoryGirl.create(:classification_tag,
+        @tag2 = FactoryBot.create(:classification_tag,
                                    :name   => "tag2",
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).and_return([@tag1, @tag2])
@@ -159,14 +159,14 @@ describe StorageController do
       end
 
       it "tagging has no clickable quadicons" do
-        ems = FactoryGirl.create(:ems_vmware)
-        datastore = FactoryGirl.create(:storage, :name => 'storage_name')
+        ems = FactoryBot.create(:ems_vmware)
+        datastore = FactoryBot.create(:storage, :name => 'storage_name')
         datastore.parent = ems
-        classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-        @tag1 = FactoryGirl.create(:classification_tag,
+        classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+        @tag1 = FactoryBot.create(:classification_tag,
                                    :name   => "tag1",
                                    :parent => classification)
-        @tag2 = FactoryGirl.create(:classification_tag,
+        @tag2 = FactoryBot.create(:classification_tag,
                                    :name   => "tag2",
                                    :parent => classification)
         allow(Classification).to receive(:find_assigned_entries).and_return([@tag1, @tag2])
@@ -267,7 +267,7 @@ describe StorageController do
       end
 
       context 'getting the right tags of a datastore' do
-        let(:datastore) { FactoryGirl.create(:storage, :name => 'storage_name') }
+        let(:datastore) { FactoryBot.create(:storage, :name => 'storage_name') }
 
         before do
           allow(controller).to receive(:render).and_return(true)
@@ -344,13 +344,13 @@ describe StorageController do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @ds = FactoryGirl.create(:storage, :name => "Datastore-01")
+      @ds = FactoryBot.create(:storage, :name => "Datastore-01")
       allow(@ds).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
-      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
-      @tag1 = FactoryGirl.create(:classification_tag,
+      classification = FactoryBot.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryBot.create(:classification_tag,
                                  :name   => "tag1",
                                  :parent => classification)
-      @tag2 = FactoryGirl.create(:classification_tag,
+      @tag2 = FactoryBot.create(:classification_tag,
                                  :name   => "tag2",
                                  :parent => classification)
       allow(Classification).to receive(:find_assigned_entries).with(@ds).and_return([@tag1, @tag2])
@@ -398,7 +398,7 @@ describe StorageController do
 
   describe '#get_node_info' do
     context 'resetting session' do
-      let(:datastore) { FactoryGirl.create(:storage, :name => 'storage_name') }
+      let(:datastore) { FactoryBot.create(:storage, :name => 'storage_name') }
 
       before do
         allow(controller).to receive(:session).and_return(:edit => {}, :adv_search => {'Storage' => {}})

--- a/spec/controllers/topology/cloud_topology_controller_spec.rb
+++ b/spec/controllers/topology/cloud_topology_controller_spec.rb
@@ -12,7 +12,7 @@ describe CloudTopologyController do
 
   it "renders show screen per provider id" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openstack)
+    ems = FactoryBot.create(:ems_openstack)
     get :show, :params => { :id => ems.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/spec/controllers/topology/container_topology_controller_spec.rb
+++ b/spec/controllers/topology/container_topology_controller_spec.rb
@@ -12,7 +12,7 @@ describe ContainerTopologyController do
 
   it "renders show screen per provider id" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_kubernetes)
+    ems = FactoryBot.create(:ems_kubernetes)
     get :show, :params => { :id => ems.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/spec/controllers/topology/infra_topology_controller_spec.rb
+++ b/spec/controllers/topology/infra_topology_controller_spec.rb
@@ -12,7 +12,7 @@ describe InfraTopologyController do
 
   it "renders show screen per provider id" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openstack)
+    ems = FactoryBot.create(:ems_openstack)
     get :show, :params => { :id => ems.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/spec/controllers/topology/network_topology_controller_spec.rb
+++ b/spec/controllers/topology/network_topology_controller_spec.rb
@@ -12,7 +12,7 @@ describe NetworkTopologyController do
 
   it "renders show screen per provider id" do
     EvmSpecHelper.create_guid_miq_server_zone
-    ems = FactoryGirl.create(:ems_openstack)
+    ems = FactoryBot.create(:ems_openstack)
     get :show, :params => { :id => ems.network_manager.id }
     expect(response.status).to eq(200)
     expect(response.body).to_not be_empty

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -24,13 +24,13 @@ describe TreeController do
   end
 
   describe '#automate_entrypoint' do
-    let(:record) { FactoryGirl.create(:miq_ae_namespace) }
+    let(:record) { FactoryBot.create(:miq_ae_namespace) }
 
     include_examples 'valid HTTP JSON response', :automate_entrypoint
   end
 
   describe '#automate_inline_methods' do
-    let(:record) { FactoryGirl.create(:miq_ae_namespace) }
+    let(:record) { FactoryBot.create(:miq_ae_namespace) }
 
     include_examples 'valid HTTP JSON response', :automate_inline_methods
   end

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -1,11 +1,11 @@
 describe UtilizationController do
   describe '#get_node_info' do
     it 'sets correct right cell headers' do
-      mr = FactoryGirl.create(:miq_region, :description => "My Region")
-      e = FactoryGirl.create(:ems_vmware, :name => "My Management System")
-      cl = FactoryGirl.create(:ems_cluster, :name => "My Cluster")
-      host = FactoryGirl.create(:host, :name => "My Host")
-      ds = FactoryGirl.create(:storage_vmware, :name => "My Datastore")
+      mr = FactoryBot.create(:miq_region, :description => "My Region")
+      e = FactoryBot.create(:ems_vmware, :name => "My Management System")
+      cl = FactoryBot.create(:ems_cluster, :name => "My Cluster")
+      host = FactoryBot.create(:host, :name => "My Host")
+      ds = FactoryBot.create(:storage_vmware, :name => "My Datastore")
       title_suffix = "Utilization Trend Summary"
       tree_nodes = {:region => {:active_node  => "mr-#{mr.id}",
                                 :title_prefix => "Region",

--- a/spec/controllers/vm_cloud_controller/trees_spec.rb
+++ b/spec/controllers/vm_cloud_controller/trees_spec.rb
@@ -14,8 +14,8 @@ describe VmCloudController do
       %w(Images images_filter_tree)
     ].each do |elements, tree|
       it "renders list of #{elements} for #{tree} root node" do
-        FactoryGirl.create(:vm_openstack)
-        FactoryGirl.create(:template_openstack)
+        FactoryBot.create(:vm_openstack)
+        FactoryBot.create(:template_openstack)
 
         session[:settings] = {}
         seed_session_trees('vm_cloud', tree.to_sym)
@@ -34,7 +34,7 @@ describe VmCloudController do
       %w(vm_amazon Amazon)
     ].each do |instance, name|
       it "renders Instance details for #{name} node" do
-        instance = FactoryGirl.create(instance.to_sym, :with_provider)
+        instance = FactoryBot.create(instance.to_sym, :with_provider)
 
         session[:settings] = {}
         seed_session_trees('vm_cloud', 'instances_tree')

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -1,15 +1,15 @@
 describe VmCloudController do
   let(:vm_openstack) do
-    FactoryGirl.create(:vm_openstack,
-                       :ext_management_system => FactoryGirl.create(:ems_openstack))
+    FactoryBot.create(:vm_openstack,
+                       :ext_management_system => FactoryBot.create(:ems_openstack))
   end
   let(:vm_openstack_tmd) do
-    FactoryGirl.create(:vm_openstack,
-                       :ext_management_system => FactoryGirl.create(:ems_openstack, :tenant_mapping_enabled => false))
+    FactoryBot.create(:vm_openstack,
+                       :ext_management_system => FactoryBot.create(:ems_openstack, :tenant_mapping_enabled => false))
   end
   let(:vm_openstack_tme) do
-    FactoryGirl.create(:vm_openstack,
-                       :ext_management_system => FactoryGirl.create(:ems_openstack, :tenant_mapping_enabled => true))
+    FactoryBot.create(:vm_openstack,
+                       :ext_management_system => FactoryBot.create(:ems_openstack, :tenant_mapping_enabled => true))
   end
 
   before do
@@ -81,7 +81,7 @@ describe VmCloudController do
     end
 
     it 'can resize an instance' do
-      flavor = FactoryGirl.create(:flavor_openstack)
+      flavor = FactoryBot.create(:flavor_openstack)
       allow(controller).to receive(:load_edit).and_return(true)
       allow(controller).to receive(:previous_breadcrumb_url).and_return("/vm_cloud/explorer")
       expect(VmCloudReconfigureRequest).to receive(:make_request)

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -2,8 +2,8 @@ describe VmOrTemplateController do
   context "#snap_pressed" do
     before do
       stub_user(:features => :all)
-      @vm = FactoryGirl.create(:vm_vmware)
-      @snapshot = FactoryGirl.create(:snapshot, :vm_or_template_id => @vm.id,
+      @vm = FactoryBot.create(:vm_vmware)
+      @snapshot = FactoryBot.create(:snapshot, :vm_or_template_id => @vm.id,
                                                 :name              => 'EvmSnapshot',
                                                 :description       => "Some Description")
       @vm.snapshots = [@snapshot]
@@ -48,10 +48,10 @@ describe VmOrTemplateController do
 
   context '#reload ' do
     before do
-      login_as FactoryGirl.create(:user_with_group, :role => "operator")
+      login_as FactoryBot.create(:user_with_group, :role => "operator")
       allow(controller).to receive(:tree_select).and_return(nil)
-      @folder = FactoryGirl.create(:ems_folder)
-      @vm = FactoryGirl.create(:vm_cloud)
+      @folder = FactoryBot.create(:ems_folder)
+      @vm = FactoryBot.create(:vm_cloud)
     end
 
     it 'sets params[:id] to hidden vm if its summary is displayed' do
@@ -77,12 +77,12 @@ describe VmOrTemplateController do
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
       allow(controller).to receive(:check_privileges).and_return(true)
       EvmSpecHelper.seed_specific_product_features("vandt_accord", "vms_instances_filter_accord")
-      @vm = FactoryGirl.create(:vm_vmware)
+      @vm = FactoryBot.create(:vm_vmware)
     end
 
     it "redirects user to explorer that they have access to" do
       feature = MiqProductFeature.find_all_by_identifier(["vandt_accord"])
-      login_as FactoryGirl.create(:user, :features => feature)
+      login_as FactoryBot.create(:user, :features => feature)
       controller.instance_variable_set(:@sb, {})
       get :show, :params => {:id => @vm.id}
       expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
@@ -90,7 +90,7 @@ describe VmOrTemplateController do
 
     it "redirects user to Workloads explorer when user does not have access to Infra Explorer" do
       feature = MiqProductFeature.find_all_by_identifier(["vms_instances_filter_accord"])
-      login_as FactoryGirl.create(:user, :features => feature)
+      login_as FactoryBot.create(:user, :features => feature)
       controller.instance_variable_set(:@sb, {})
       get :show, :params => {:id => @vm.id}
       expect(response).to redirect_to(:controller => "vm_or_template", :action => 'explorer')
@@ -98,7 +98,7 @@ describe VmOrTemplateController do
 
     it "redirects user back to the url they came from when user does not have access to any of VM Explorers" do
       feature = MiqProductFeature.find_all_by_identifier(["dashboard_show"])
-      login_as FactoryGirl.create(:user, :features => feature)
+      login_as FactoryBot.create(:user, :features => feature)
       controller.instance_variable_set(:@sb, {})
       request.env["HTTP_REFERER"] = "http://localhost:3000/dashboard/show"
       get :show, :params => {:id => @vm.id}
@@ -114,7 +114,7 @@ describe VmOrTemplateController do
     end
 
     it "Redirects user to the referer controller/action" do
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
       request.env["HTTP_REFERER"] = "http://localhost:3000/dashboard/show"
       allow(controller).to receive(:find_record_with_rbac).and_return(nil)
       get :show, :params => {:id => @vm.id}
@@ -140,7 +140,7 @@ describe VmOrTemplateController do
       end
 
       it 'to snap_selected.id if a Snapshot exists' do
-        @snapshot = FactoryGirl.create(:snapshot,
+        @snapshot = FactoryBot.create(:snapshot,
                                        :vm_or_template_id => @vm.id,
                                        :name              => 'EvmSnapshot',
                                        :description       => 'Some Description')
@@ -158,8 +158,8 @@ describe VmOrTemplateController do
   end
 
   describe '#console_after_task' do
-    let(:vm) { FactoryGirl.create(:vm_vmware) }
-    let(:task) { FactoryGirl.create(:miq_task, :task_results => task_results) }
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+    let(:task) { FactoryBot.create(:miq_task, :task_results => task_results) }
     subject { controller.send(:console_after_task, 'html5') }
 
     before do
@@ -189,7 +189,7 @@ describe VmOrTemplateController do
 
   context '#replace_right_cell' do
     it 'should display form button on Migrate request screen' do
-      vm = FactoryGirl.create(:vm_infra)
+      vm = FactoryBot.create(:vm_infra)
       allow(controller).to receive(:params).and_return(:action => 'vm_migrate')
       controller.instance_eval { @sb = {:active_tree => :vandt_tree, :action => "migrate"} }
       controller.instance_eval { @record = vm }
@@ -213,53 +213,53 @@ describe VmOrTemplateController do
 
   context '#parent_folder_id' do
     it 'returns id of orphaned folder for orphaned VM/Template' do
-      vm_orph = FactoryGirl.create(:vm_infra, :storage => FactoryGirl.create(:storage))
-      template_orph = FactoryGirl.create(:template_infra, :storage => FactoryGirl.create(:storage))
+      vm_orph = FactoryBot.create(:vm_infra, :storage => FactoryBot.create(:storage))
+      template_orph = FactoryBot.create(:template_infra, :storage => FactoryBot.create(:storage))
       expect(controller.parent_folder_id(vm_orph)).to eq('xx-orph')
       expect(controller.parent_folder_id(template_orph)).to eq('xx-orph')
     end
 
     it 'returns id of archived folder for archived VM/Template' do
-      vm_arch = FactoryGirl.create(:vm_infra)
-      template_arch = FactoryGirl.create(:template_infra)
+      vm_arch = FactoryBot.create(:vm_infra)
+      template_arch = FactoryBot.create(:template_infra)
       expect(controller.parent_folder_id(vm_arch)).to eq('xx-arch')
       expect(controller.parent_folder_id(template_arch)).to eq('xx-arch')
     end
 
     it 'returns id of Availability Zone folder for Cloud VM that has one' do
-      vm_cloud_with_az = FactoryGirl.create(:vm_cloud,
-                                            :ext_management_system => FactoryGirl.create(:ems_google),
-                                            :storage               => FactoryGirl.create(:storage),
-                                            :availability_zone     => FactoryGirl.create(:availability_zone_google))
+      vm_cloud_with_az = FactoryBot.create(:vm_cloud,
+                                            :ext_management_system => FactoryBot.create(:ems_google),
+                                            :storage               => FactoryBot.create(:storage),
+                                            :availability_zone     => FactoryBot.create(:availability_zone_google))
       expect(controller.parent_folder_id(vm_cloud_with_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_with_az.availability_zone))
     end
 
     it 'returns id of Provider folder for Cloud VM without Availability Zone' do
-      vm_cloud_without_az = FactoryGirl.create(:vm_cloud,
-                                               :ext_management_system => FactoryGirl.create(:ems_google),
-                                               :storage               => FactoryGirl.create(:storage),
+      vm_cloud_without_az = FactoryBot.create(:vm_cloud,
+                                               :ext_management_system => FactoryBot.create(:ems_google),
+                                               :storage               => FactoryBot.create(:storage),
                                                :availability_zone     => nil)
       expect(controller.parent_folder_id(vm_cloud_without_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_without_az.ext_management_system))
     end
 
     it 'returns id of Provider folder for Cloud Template' do
-      template_cloud = FactoryGirl.create(:template_cloud,
-                                          :ext_management_system => FactoryGirl.create(:ems_google),
-                                          :storage               => FactoryGirl.create(:storage))
+      template_cloud = FactoryBot.create(:template_cloud,
+                                          :ext_management_system => FactoryBot.create(:ems_google),
+                                          :storage               => FactoryBot.create(:storage))
       expect(controller.parent_folder_id(template_cloud)).to eq(TreeBuilder.build_node_cid(template_cloud.ext_management_system))
     end
 
     it 'returns id of Provider folder for infra VM/Template without blue folder' do
-      vm_infra = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
-      template_infra = FactoryGirl.create(:template_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
+      vm_infra = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
+      template_infra = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_infra))
       expect(controller.parent_folder_id(vm_infra)).to eq(TreeBuilder.build_node_cid(vm_infra.ext_management_system))
       expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_cid(template_infra.ext_management_system))
     end
 
     it 'returns id of Datacenter folder for infra VM/Template without blue folder but with Datacenter parent' do
-      datacenter = FactoryGirl.create(:datacenter, :hidden => true)
-      vm_infra_datacenter = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
-      template_infra_datacenter = FactoryGirl.create(:template_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
+      datacenter = FactoryBot.create(:datacenter, :hidden => true)
+      vm_infra_datacenter = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
+      template_infra_datacenter = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_infra))
       vm_infra_datacenter.with_relationship_type("ems_metadata") { vm_infra_datacenter.parent = datacenter }
       allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
       template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
@@ -269,11 +269,11 @@ describe VmOrTemplateController do
     end
 
     it 'returns id of blue folder for VM/Template with one' do
-      folder = FactoryGirl.create(:ems_folder)
-      vm_infra_folder = FactoryGirl.create(:vm_infra, :ext_management_system => FactoryGirl.create(:ems_infra))
+      folder = FactoryBot.create(:ems_folder)
+      vm_infra_folder = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
       vm_infra_folder.with_relationship_type("ems_metadata") { vm_infra_folder.parent = folder } # add folder
-      template_infra_folder = FactoryGirl.create(:template_infra,
-                                                 :ext_management_system => FactoryGirl.create(:ems_infra))
+      template_infra_folder = FactoryBot.create(:template_infra,
+                                                 :ext_management_system => FactoryBot.create(:ems_infra))
       template_infra_folder.with_relationship_type("ems_metadata") { template_infra_folder.parent = folder } # add folder
       expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
       expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
@@ -287,8 +287,8 @@ describe VmOrTemplateController do
       end
     end
     before do
-      login_as FactoryGirl.create(:user_with_group, :role => "operator")
-      @vm_arch = FactoryGirl.create(:vm)
+      login_as FactoryBot.create(:user_with_group, :role => "operator")
+      @vm_arch = FactoryBot.create(:vm)
     end
 
     it 'when VM hidden select parent in tree but show VMs info' do
@@ -310,7 +310,7 @@ describe VmOrTemplateController do
 
   context '#evm_relationship_get_form_vars' do
     before do
-      @vm = FactoryGirl.create(:vm_vmware)
+      @vm = FactoryBot.create(:vm_vmware)
       edit = {:vm_id => @vm.id, :new => {:server => nil}}
       controller.instance_variable_set(:@edit, edit)
     end

--- a/spec/controllers/vm_controller_spec.rb
+++ b/spec/controllers/vm_controller_spec.rb
@@ -9,7 +9,7 @@ describe VmController do
     # because the branching logic is in app/views/vm/show.html.haml
     render_views
 
-    let(:vm_openstack) { FactoryGirl.create(:vm_openstack) }
+    let(:vm_openstack) { FactoryBot.create(:vm_openstack) }
 
     # Request URL: http://localhost:3000/vm/live_migrate?escape=false
     # FIXME: the espace=false seems unused

--- a/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -8,7 +8,7 @@ describe VmInfraController do
 
   context "VMs & Templates #tree_select" do
     it "renders list Archived nodes in VMs & Templates tree" do
-      FactoryGirl.create(:vm_vmware)
+      FactoryBot.create(:vm_vmware)
 
       session[:settings] = {}
       seed_session_trees('vm_infra', :vandt_tree)
@@ -27,8 +27,8 @@ describe VmInfraController do
       %w(Templates templates_filter_tree),
     ].each do |elements, tree|
       it "renders list of #{elements} for #{tree} root node" do
-        FactoryGirl.create(:vm_vmware)
-        FactoryGirl.create(:template_vmware)
+        FactoryBot.create(:vm_vmware)
+        FactoryBot.create(:template_vmware)
 
         session[:settings] = {}
         seed_session_trees('vm_infra', tree.to_sym)
@@ -41,7 +41,7 @@ describe VmInfraController do
     end
 
     it "renders VM details for VM node" do
-      vm = FactoryGirl.create(:vm_vmware)
+      vm = FactoryBot.create(:vm_vmware)
 
       session[:settings] = {}
       seed_session_trees('vm_infra', 'vandt_tree')
@@ -53,7 +53,7 @@ describe VmInfraController do
     end
 
     it "renders Template details for Template node" do
-      template = FactoryGirl.create(:template_vmware)
+      template = FactoryBot.create(:template_vmware)
 
       session[:settings] = {}
       seed_session_trees('vm_infra', 'vandt_tree')

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -1,7 +1,7 @@
 describe VmInfraController do
-  let(:host_1x1)  { FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB)) }
-  let(:host_2x2)  { FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB)) }
-  let(:vm_vmware) { FactoryGirl.create(:vm_vmware) }
+  let(:host_1x1)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB)) }
+  let(:host_2x2)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu2x2, :ram1GB)) }
+  let(:vm_vmware) { FactoryBot.create(:vm_vmware) }
   before do
     stub_user(:features => :all)
 
@@ -52,7 +52,7 @@ describe VmInfraController do
   end
 
   let(:custom_attr1) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :custom_attribute,
       :resource => vm_vmware,
       :name     => 'Proč by si jeden nepokrad',
@@ -61,7 +61,7 @@ describe VmInfraController do
   end
 
   let(:custom_attr2) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :custom_attribute,
       :resource => vm_vmware,
       :name     => nil,
@@ -108,7 +108,7 @@ describe VmInfraController do
   end
 
   it 'can open the reconfigure tab' do
-    vm = FactoryGirl.create(:vm_vmware, :host => host_1x1, :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
+    vm = FactoryBot.create(:vm_vmware, :host => host_1x1, :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -155,13 +155,13 @@ describe VmInfraController do
   end
 
   it 'can open VM Compare tab' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_1x1,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
-    vm2 = FactoryGirl.create(:vm_vmware,
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
+    vm2 = FactoryBot.create(:vm_vmware,
                              :host     => host_1x1,
-                             :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '05'))
-    FactoryGirl.create(:miq_report, :filename      => 'vms.yaml',
+                             :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '05'))
+    FactoryBot.create(:miq_report, :filename      => 'vms.yaml',
                                     :template_type => 'compare',
                                     :name          => "Test Report",
                                     :rpt_type      => "Custom",
@@ -251,9 +251,9 @@ describe VmInfraController do
   end
 
   it 'can open Policies Simulation' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_1x1,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm_vmware.id}
@@ -268,11 +268,11 @@ describe VmInfraController do
   end
 
   it 'can open Edit Tags' do
-    classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
-    @tag1 = FactoryGirl.create(:classification_tag,
+    classification = FactoryBot.create(:classification, :name => "department", :description => "D    epartment")
+    @tag1 = FactoryBot.create(:classification_tag,
                                :name   => "tag1",
                                :parent => classification)
-    @tag2 = FactoryGirl.create(:classification_tag,
+    @tag2 = FactoryBot.create(:classification_tag,
                                :name   => "tag2",
                                :parent => classification)
     get :show, :params => {:id => vm_vmware.id}
@@ -287,11 +287,11 @@ describe VmInfraController do
   end
 
   it 'The VM quadicons on the tagging screen do not links' do
-    classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
-    @tag1 = FactoryGirl.create(:classification_tag,
+    classification = FactoryBot.create(:classification, :name => "department", :description => "D    epartment")
+    @tag1 = FactoryBot.create(:classification_tag,
                                :name   => "tag1",
                                :parent => classification)
-    @tag2 = FactoryGirl.create(:classification_tag,
+    @tag2 = FactoryBot.create(:classification_tag,
                                :name   => "tag2",
                                :parent => classification)
     get :show, :params => {:id => vm_vmware.id}
@@ -365,7 +365,7 @@ describe VmInfraController do
   end
 
   it 'can migrate selected items' do
-    vm_vmware_migrateable = FactoryGirl.create(:vm_vmware, :ems_id => 1, :storage_id => 1)
+    vm_vmware_migrateable = FactoryBot.create(:vm_vmware, :ems_id => 1, :storage_id => 1)
     get :show, :params => {:id => vm_vmware.id}
     expect(response).to redirect_to(:action => 'explorer')
 
@@ -378,9 +378,9 @@ describe VmInfraController do
   end
 
   it 'can Publish selected VM' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_1x1,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm_vmware.id}
@@ -405,7 +405,7 @@ describe VmInfraController do
   end
 
   context 'Mixins::Actions::VmActions::Ownership' do
-    let(:vm) { FactoryGirl.create(:vm_vmware) }
+    let(:vm) { FactoryBot.create(:vm_vmware) }
 
     it 'handles dont-change vs nil' do
       expect(VmOrTemplate).to receive(:set_ownership).with([vm.id], {:group => nil})
@@ -419,8 +419,8 @@ describe VmInfraController do
   end
 
   context 'transform VM dialog' do
-    let(:dialog)           { FactoryGirl.create(:dialog, :label => 'Transform VM', :buttons => 'submit') }
-    let!(:resource_action) { FactoryGirl.create(:resource_action, :dialog => dialog) }
+    let(:dialog)           { FactoryBot.create(:dialog, :label => 'Transform VM', :buttons => 'submit') }
+    let!(:resource_action) { FactoryBot.create(:resource_action, :dialog => dialog) }
 
     it 'can Transform selected VM' do
       get :show, :params => {:id => vm_vmware.id}
@@ -482,9 +482,9 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket <= 1 should not display the cpu_cores_per_socket dropdown' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_1x1,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => '04'))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -499,9 +499,9 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_2x2,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -516,9 +516,9 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab for a single vmware vm should display the list of disks' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_2x2,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -533,9 +533,9 @@ describe VmInfraController do
   end
 
   it 'the reconfigure tab displays the submit and cancel buttons' do
-    vm = FactoryGirl.create(:vm_vmware,
+    vm = FactoryBot.create(:vm_vmware,
                             :host     => host_2x2,
-                            :hardware => FactoryGirl.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -606,8 +606,8 @@ describe VmInfraController do
   end
 
   context 'simple searching' do
-    let(:vm1) { FactoryGirl.create(:vm_vmware, :name => 'foobar') }
-    let(:vm2) { FactoryGirl.create(:vm_vmware, :name => 'barbar') }
+    let(:vm1) { FactoryBot.create(:vm_vmware, :name => 'foobar') }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :name => 'barbar') }
 
     describe '#x_search_by_name' do
       it 'render GTL with and saves search_text in the session' do
@@ -649,8 +649,8 @@ describe VmInfraController do
   it_behaves_like "explorer controller with custom buttons"
 
   it "executes select_check? and disable_check? helper methods" do
-    admin_user = FactoryGirl.create(:user_with_group, :role => 'super_administrator')
-    wf = FactoryGirl.create(:miq_provision_workflow, :requester => admin_user)
+    admin_user = FactoryBot.create(:user_with_group, :role => 'super_administrator')
+    wf = FactoryBot.create(:miq_provision_workflow, :requester => admin_user)
 
     controller.send(:select_check?, wf)
     expect(response.status).to eq(200)

--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -1,6 +1,6 @@
 describe VmOrTemplateController do
-  let(:template_vmware) { FactoryGirl.create(:template_vmware, :name => 'template_vmware Name') }
-  let(:vm_vmware)       { FactoryGirl.create(:vm_vmware, :name => "vm_vmware Name") }
+  let(:template_vmware) { FactoryBot.create(:template_vmware, :name => 'template_vmware Name') }
+  let(:vm_vmware)       { FactoryBot.create(:vm_vmware, :name => "vm_vmware Name") }
   before { stub_user(:features => :all) }
 
   # All of the x_button is a suplement for Rails routes that is written in

--- a/spec/decorators/manageiq/providers/storage_manager_decorator_spec.rb
+++ b/spec/decorators/manageiq/providers/storage_manager_decorator_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::StorageManagerDecorator do
     subject { model.decorate.quadicon }
 
     context 'block storage' do
-      let(:model) { FactoryGirl.create(:ems_cinder) }
+      let(:model) { FactoryBot.create(:ems_cinder) }
 
       it 'includes cloud volumes and snapshots' do
         expect(subject[:top_left][:tooltip]).to include("Cloud Volume")
@@ -12,7 +12,7 @@ describe ManageIQ::Providers::StorageManagerDecorator do
     end
 
     context 'object storage' do
-      let(:model) { FactoryGirl.create(:ems_swift) }
+      let(:model) { FactoryBot.create(:ems_swift) }
 
       it 'includes cloud object store containers' do
         expect(subject[:top_left][:tooltip]).to include("Cloud Object Store Container")

--- a/spec/helpers/application_helper/buttons/ab_group_reorder_spec.rb
+++ b/spec/helpers/application_helper/buttons/ab_group_reorder_spec.rb
@@ -7,7 +7,7 @@ describe ApplicationHelper::Button::AbGroupReorder do
 
       before do
         custom_button_sets_count.times do
-          FactoryGirl.create(:custom_button_set, :set_data => {:applies_to_class => cb_class})
+          FactoryBot.create(:custom_button_set, :set_data => {:applies_to_class => cb_class})
         end
         allow(view_context).to receive(:x_node).and_return("xx-ab_#{cb_class}")
       end
@@ -27,10 +27,10 @@ describe ApplicationHelper::Button::AbGroupReorder do
     context 'when :active_tree != :ab_tree' do
       let(:view_context) { setup_view_context_with_sandbox(:active_tree => :not_ab_tree) }
       let(:cb_class) { 'ServiceTemplate' }
-      let(:service_template) { FactoryGirl.create(:service_template, :custom_button_sets => custom_button_sets) }
+      let(:service_template) { FactoryBot.create(:service_template, :custom_button_sets => custom_button_sets) }
       let(:custom_button_sets) do
         (1..custom_button_sets_count).inject([]) do |arr|
-          arr << FactoryGirl.create(:custom_button_set)
+          arr << FactoryBot.create(:custom_button_set)
         end
       end
 

--- a/spec/helpers/application_helper/buttons/availability_zone_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/availability_zone_performance_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::AvailabilityZonePerformance do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/availability_zone_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/availability_zone_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::AvailabilityZoneTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationHelper::Button::CatalogItemButton do
   let(:session) { {} }
   before do
     @view_context = setup_view_context_with_sandbox({})
-    allow(@view_context).to receive(:current_user).and_return(FactoryGirl.create(:user))
+    allow(@view_context).to receive(:current_user).and_return(FactoryBot.create(:user))
     @button = described_class.new(@view_context, {}, {}, {:child_id => "ab_button_new"})
   end
 
@@ -16,7 +16,7 @@ describe ApplicationHelper::Button::CatalogItemButton do
     it "won't be skipped" do
       EvmSpecHelper.seed_specific_product_features("catalogitem_new")
       feature = MiqProductFeature.find_all_by_identifier(["everything"])
-      allow(@view_context).to receive(:current_user).and_return(FactoryGirl.create(:user, :features => feature))
+      allow(@view_context).to receive(:current_user).and_return(FactoryBot.create(:user, :features => feature))
       expect(@button.role_allows_feature?).to be true
     end
   end

--- a/spec/helpers/application_helper/buttons/cloud_network_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_network_new_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::CloudNetworkNew do
   describe '#disabled?' do
     it "when at least one provider supports network create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::CloudNetworkNew do
 
     it "when at least one provider supports network create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationHelper::Button::CloudSubnetNew do
   describe '#disabled?' do
     it "when at least one provider supports subnet create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -26,7 +26,7 @@ describe ApplicationHelper::Button::CloudSubnetNew do
 
     it "when at least one provider supports subnet create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::CloudVolumeNew do
   describe '#disabled?' do
     it "when at least one provider supports volume create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -15,7 +15,7 @@ describe ApplicationHelper::Button::CloudVolumeNew do
 
     it "when only Amazon EBS storage manager is available, the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_amazon_ebs)
+      FactoryBot.create(:ems_amazon_ebs)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -31,7 +31,7 @@ describe ApplicationHelper::Button::CloudVolumeNew do
 
     it "when at least one provider supports volume create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil
@@ -39,7 +39,7 @@ describe ApplicationHelper::Button::CloudVolumeNew do
 
     it "when only Amazon EBS storage manager is available, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_amazon_ebs)
+      FactoryBot.create(:ems_amazon_ebs)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/cockpit_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/cockpit_console_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::CockpitConsole do
   describe '#disabled?' do
     before do
-      @record = FactoryGirl.create(:vm)
+      @record = FactoryBot.create(:vm)
       MiqRegion.seed
       EvmSpecHelper.create_guid_miq_server_zone
 
@@ -14,7 +14,7 @@ describe ApplicationHelper::Button::CockpitConsole do
 
     context 'passes checks' do
       before do
-        @server_role = FactoryGirl.create(
+        @server_role = FactoryBot.create(
           :server_role,
           :name              => 'cockpit_ws',
           :description       => 'Cockpit WS',
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::CockpitConsole do
           :external_failover => false,
           :role_scope        => 'zone'
         )
-        FactoryGirl.create(
+        FactoryBot.create(
           :assigned_server_role,
           :miq_server_id  => MiqServer.first.id,
           :server_role_id => @server_role.id,

--- a/spec/helpers/application_helper/buttons/collect_logs_spec.rb
+++ b/spec/helpers/application_helper/buttons/collect_logs_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::CollectLogs do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:file_depot) { FactoryGirl.create(:file_depot) }
-  let(:record) { FactoryGirl.create(:miq_server, :status => server_status, :log_file_depot => file_depot) }
+  let(:file_depot) { FactoryBot.create(:file_depot) }
+  let(:record) { FactoryBot.create(:miq_server, :status => server_status, :log_file_depot => file_depot) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   def tear_down
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::CollectLogs do
     context 'when server is started' do
       let(:server_status) { 'started' }
       let(:setup_log_files) do
-        log_file = FactoryGirl.create(:log_file, :resource => record, :state => log_state)
+        log_file = FactoryBot.create(:log_file, :resource => record, :state => log_state)
         log_file.save
         record.log_files << log_file
       end
@@ -43,7 +43,7 @@ describe ApplicationHelper::Button::CollectLogs do
 
         context 'and has an unfinished task' do
           let(:setup_tasks) do
-            task = FactoryGirl.create(:miq_task, :name => 'Zipped log retrieval for XXX', :miq_server_id => record.id)
+            task = FactoryBot.create(:miq_task, :name => 'Zipped log retrieval for XXX', :miq_server_id => record.id)
             task.save
           end
           it_behaves_like 'a disabled button', 'Log collection is already in progress for this Server'

--- a/spec/helpers/application_helper/buttons/condition_policy_spec.rb
+++ b/spec/helpers/application_helper/buttons/condition_policy_spec.rb
@@ -8,12 +8,12 @@ describe ApplicationHelper::Button::ConditionPolicy do
     end
 
     it "will be skipped" do
-      login_as FactoryGirl.create(:user, :features => "none")
+      login_as FactoryBot.create(:user, :features => "none")
       expect(@button.role_allows_feature?).to be false
     end
 
     it "won't be skipped", :type => :helper do
-      login_as FactoryGirl.create(:user, :features => "condition_remove")
+      login_as FactoryBot.create(:user, :features => "condition_remove")
       expect(@button.role_allows_feature?).to be true
     end
   end

--- a/spec/helpers/application_helper/buttons/condition_spec.rb
+++ b/spec/helpers/application_helper/buttons/condition_spec.rb
@@ -8,19 +8,19 @@ describe ApplicationHelper::Button::Condition do
     end
 
     it "will be skipped" do
-      login_as FactoryGirl.create(:user, :features => "none")
+      login_as FactoryBot.create(:user, :features => "none")
       expect(@button.role_allows_feature?).to be false
     end
 
     it "won't be skipped", :type => :helper do
-      login_as FactoryGirl.create(:user, :features => "condition_copy")
+      login_as FactoryBot.create(:user, :features => "condition_copy")
       expect(@button.role_allows_feature?).to be true
     end
   end
 
   describe "#disabled?" do
     before do
-      @condition = FactoryGirl.create(:condition)
+      @condition = FactoryBot.create(:condition)
       sandbox = {:active_tree => :condition_tree}
       @view_context = setup_view_context_with_sandbox(sandbox)
       @button = described_class.new(@view_context, {}, {'condition' => @condition}, {:child_id => "condition_delete"})

--- a/spec/helpers/application_helper/buttons/configured_system_provision_spec.rb
+++ b/spec/helpers/application_helper/buttons/configured_system_provision_spec.rb
@@ -5,15 +5,15 @@ describe ApplicationHelper::Button::ConfiguredSystemProvision do
   describe '#visible?' do
     context 'when record is present' do
       context 'and record cannot be provisionable' do
-        let(:record) { FactoryGirl.create(:configuration_profile_foreman) }
+        let(:record) { FactoryBot.create(:configuration_profile_foreman) }
         it { expect(subject.visible?).to be_truthy }
       end
       context 'and record is provisionable' do
-        let(:record) { FactoryGirl.create(:configured_system_foreman) }
+        let(:record) { FactoryBot.create(:configured_system_foreman) }
         it { expect(subject.visible?).to be_truthy }
       end
       context 'and record is not provisionable' do
-        let(:record) { FactoryGirl.create(:configured_system_ansible_tower) }
+        let(:record) { FactoryBot.create(:configured_system_ansible_tower) }
         it { expect(subject.visible?).to be_falsey }
       end
     end

--- a/spec/helpers/application_helper/buttons/container_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/container_timeline_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::ContainerTimeline do
-  let(:record) { FactoryGirl.create(:container) }
+  let(:record) { FactoryBot.create(:container) }
   let(:button) do
     described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record},
                         {:options => {:entity => 'Container'}})

--- a/spec/helpers/application_helper/buttons/customization_template_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_copy_spec.rb
@@ -16,7 +16,7 @@ describe ApplicationHelper::Button::CustomizationTemplateCopy do
     end
     context 'when record has system' do
       let(:x_node) { 'does-not-matter' }
-      let(:record) { FactoryGirl.create(:customization_template_cloud_init, :system => true) }
+      let(:record) { FactoryBot.create(:customization_template_cloud_init, :system => true) }
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when other node is active' do

--- a/spec/helpers/application_helper/buttons/db_delete_sepc.rb
+++ b/spec/helpers/application_helper/buttons/db_delete_sepc.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::DbDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:dashboard) { FactoryGirl.create(:miq_widget_set, :read_only => read_only) }
+  let(:dashboard) { FactoryBot.create(:miq_widget_set, :read_only => read_only) }
   let(:button) { described_class.new(view_context, {}, {'db' => dashboard}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/helpers/application_helper/buttons/db_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/db_new_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::DbNew do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:dashboard_count) { 9 }
-  let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryGirl.create(:miq_widget_set) } }
+  let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryBot.create(:miq_widget_set) } }
   let(:button) { described_class.new(view_context, {}, {'widgetsets' => widgetsets}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/helpers/application_helper/buttons/db_seq_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/db_seq_edit_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::DbSeqEdit do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:dashboard_count) { 2 }
-  let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryGirl.create(:miq_widget_set) } }
+  let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryBot.create(:miq_widget_set) } }
   let(:button) { described_class.new(view_context, {}, {'widgetsets' => widgetsets}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/helpers/application_helper/buttons/embedded_ansible_spec.rb
+++ b/spec/helpers/application_helper/buttons/embedded_ansible_spec.rb
@@ -9,7 +9,7 @@ describe ApplicationHelper::Button::EmbeddedAnsible do
 
   context 'Embedded Ansible role is turned on and provider is present' do
     before do
-      server_role = FactoryGirl.create(
+      server_role = FactoryBot.create(
         :server_role,
         :name              => "embedded_ansible",
         :description       => "Embedded Ansible",
@@ -17,7 +17,7 @@ describe ApplicationHelper::Button::EmbeddedAnsible do
         :external_failover => false,
         :role_scope        => "zone"
       )
-      FactoryGirl.create(
+      FactoryBot.create(
         :assigned_server_role,
         :miq_server_id  => MiqServer.first.id,
         :server_role_id => server_role.id,
@@ -25,7 +25,7 @@ describe ApplicationHelper::Button::EmbeddedAnsible do
         :priority       => 1
       )
       # Add embedded Ansible provider if there is none
-      FactoryGirl.create(:provider_embedded_ansible) if ManageIQ::Providers::EmbeddedAnsible::Provider.count == 0
+      FactoryBot.create(:provider_embedded_ansible) if ManageIQ::Providers::EmbeddedAnsible::Provider.count == 0
     end
     it '#disabled? returns false' do
       expect(subject.disabled?).to be false

--- a/spec/helpers/application_helper/buttons/ems_cluster_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_cluster_performance_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsClusterPerformance do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/ems_cluster_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_cluster_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsClusterTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/ems_infra_scale_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_infra_scale_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::EmsInfraScale do
-  let(:record) { FactoryGirl.create(:ems_openstack_infra) }
+  let(:record) { FactoryBot.create(:ems_openstack_infra) }
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   describe '#visible?' do
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::EmsInfraScale do
         it { expect(subject).to be_falsey }
       end
       context 'and orchestration stack is not empty' do
-        let(:record) { FactoryGirl.create(:ems_openstack_infra_with_stack) }
+        let(:record) { FactoryBot.create(:ems_openstack_infra_with_stack) }
         it { expect(subject).to be_truthy }
       end
     end

--- a/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsRefresh do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:ems_infra) }
+  let(:record) { FactoryBot.create(:ems_infra) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/ems_storage_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_storage_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsStorageTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:ext_management_system) }
+  let(:record) { FactoryBot.create(:ext_management_system) }
   let(:props) { {:options => {:feature => :timeline}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 

--- a/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/floating_ip_new_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationHelper::Button::FloatingIpNew do
   describe '#disabled?' do
     it "when at least one provider supports floating ip create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -26,7 +26,7 @@ describe ApplicationHelper::Button::FloatingIpNew do
 
     it "when at least one provider supports floating ip create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm_vmware) }
+  let(:record) { FactoryBot.create(:vm_vmware) }
   let(:feature) { :evacuate }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }

--- a/spec/helpers/application_helper/buttons/host_check_compliance_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_check_compliance_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostCheckCompliance do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/host_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_feature_button_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostFeatureButton do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:ems_openstack_infra) }
+  let(:record) { FactoryBot.create(:ems_openstack_infra) }
   let(:feature) { :standby }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
@@ -23,7 +23,7 @@ describe ApplicationHelper::Button::HostFeatureButton do
       end
     end
     context 'when record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)' do
-      let(:record) { FactoryGirl.create(:host_openstack_infra) }
+      let(:record) { FactoryBot.create(:host_openstack_infra) }
       before { allow(record).to receive(:is_available?).and_return(available) }
       context 'and feature is available' do
         let(:feature) { :stop }

--- a/spec/helpers/application_helper/buttons/host_introspect_provide_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_introspect_provide_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostIntrospectProvide do
   let(:provision_state) { 'not_manageable' }
-  let(:record) { FactoryGirl.create(:host_openstack_infra) }
+  let(:record) { FactoryBot.create(:host_openstack_infra) }
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   before { allow(record).to receive_message_chain(:hardware, :provision_state).and_return(provision_state) }
@@ -18,7 +18,7 @@ describe ApplicationHelper::Button::HostIntrospectProvide do
       end
     end
     context 'when record type is not host_openstack_infra, nor ems_openstack_infra' do
-      let(:record) { FactoryGirl.create(:host_vmware) }
+      let(:record) { FactoryBot.create(:host_vmware) }
       it { expect(subject).to be_falsey }
     end
   end

--- a/spec/helpers/application_helper/buttons/host_manageable_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_manageable_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostManageable do
   let(:provision_state) { String.new 'not_manageable' }
-  let(:record) { FactoryGirl.create(:host_openstack_infra) }
+  let(:record) { FactoryBot.create(:host_openstack_infra) }
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   before { allow(record).to receive_message_chain(:hardware, :provision_state).and_return(provision_state) }
@@ -18,7 +18,7 @@ describe ApplicationHelper::Button::HostManageable do
       end
     end
     context 'when record type is not host_openstack_infra, nor ems_openstack_infra' do
-      let(:record) { FactoryGirl.create(:host_vmware) }
+      let(:record) { FactoryBot.create(:host_vmware) }
       it { expect(subject).to be_falsey }
     end
   end

--- a/spec/helpers/application_helper/buttons/host_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_performance_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostPerformance do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/host_register_nodes_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_register_nodes_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::HostRegisterNodes do
-  let(:record) { FactoryGirl.create(:ems_openstack_infra) }
+  let(:record) { FactoryBot.create(:ems_openstack_infra) }
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   describe '#visible?' do
@@ -9,7 +9,7 @@ describe ApplicationHelper::Button::HostRegisterNodes do
       it { expect(subject).to be_truthy }
     end
     context 'when recor.class != ManageIQ::Providers::Openstack::InfraManager' do
-      let(:record) { FactoryGirl.create(:host_openstack_infra) }
+      let(:record) { FactoryBot.create(:host_openstack_infra) }
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/host_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::HostTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/instance_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_attach_spec.rb
@@ -3,18 +3,18 @@ describe ApplicationHelper::Button::InstanceAttach do
     it "when there are available volumes, then the button is enabled" do
       view_context = setup_view_context_with_sandbox({})
 
-      tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
-      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      tenant = FactoryBot.create(:cloud_tenant_openstack)
+      volume = FactoryBot.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
+      record = FactoryBot.create(:vm_openstack, :cloud_tenant => tenant)
       button = described_class.new(view_context, {}, {"record" => record}, {})
       expect(button.disabled?).to be false
     end
 
     it "when there are no available volumes then the button is disabled" do
       view_context = setup_view_context_with_sandbox({})
-      tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
-      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      tenant = FactoryBot.create(:cloud_tenant_openstack)
+      volume = FactoryBot.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
+      record = FactoryBot.create(:vm_openstack, :cloud_tenant => tenant)
       button = described_class.new(view_context, {}, {"record" => record}, {})
       expect(button.disabled?).to be true
     end
@@ -23,9 +23,9 @@ describe ApplicationHelper::Button::InstanceAttach do
   describe '#calculate_properties' do
     it "when there are no available volumes then the button has the error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
-      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      tenant = FactoryBot.create(:cloud_tenant_openstack)
+      volume = FactoryBot.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
+      record = FactoryBot.create(:vm_openstack, :cloud_tenant => tenant)
       button = described_class.new(view_context, {}, {"record" => record}, {})
       button.calculate_properties
       expect(button[:title]).to eq("There are no Cloud Volumes available to attach to this Instance.")
@@ -33,9 +33,9 @@ describe ApplicationHelper::Button::InstanceAttach do
 
     it "when there are available volumes, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
-      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      tenant = FactoryBot.create(:cloud_tenant_openstack)
+      volume = FactoryBot.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
+      record = FactoryBot.create(:vm_openstack, :cloud_tenant => tenant)
       button = described_class.new(view_context, {}, {"record" => record}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::InstanceCheckCompare do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:display) { nil }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   subject { described_class.new(view_context, {}, {'record' => record, 'display' => display}, {}) }
 
   describe '#visible?' do
@@ -9,11 +9,11 @@ describe ApplicationHelper::Button::InstanceCheckCompare do
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when record is kind of OrchestrationStack && display != instances' do
-      let(:record) { FactoryGirl.create(:orchestration_stack) }
+      let(:record) { FactoryBot.create(:orchestration_stack) }
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when record is an OrchestrationStack && display == instances' do
-      let(:record) { FactoryGirl.create(:orchestration_stack) }
+      let(:record) { FactoryBot.create(:orchestration_stack) }
       let(:display) { 'instances' }
       it { expect(subject.visible?).to be_falsey }
     end

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::InstanceReset do
   describe '#visible?' do
     context "when record is resetable" do
       before do
-        @record = FactoryGirl.create(:vm_openstack)
+        @record = FactoryBot.create(:vm_openstack)
         allow(@record).to receive(:supports_reset?).and_return(true)
       end
 
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::InstanceReset do
 
     context "when record is not resetable" do
       before do
-        @record = FactoryGirl.create(:vm_openstack)
+        @record = FactoryBot.create(:vm_openstack)
         allow(@record).to receive(:supports_reset?).and_return(false)
       end
 

--- a/spec/helpers/application_helper/buttons/instance_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_retire_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::InstanceRetire do
-  let(:record) { FactoryGirl.create(:vm, :retired => retired) }
+  let(:record) { FactoryBot.create(:vm, :retired => retired) }
   subject { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/iso_datastore_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/iso_datastore_new_spec.rb
@@ -5,7 +5,7 @@ describe ApplicationHelper::Button::IsoDatastoreNew do
   describe '#calculate_properties' do
     context 'when there is a RedHat InfraManager without iso datastores' do
       before do
-        FactoryGirl.create(:ems_redhat)
+        FactoryBot.create(:ems_redhat)
         button.calculate_properties
       end
 
@@ -14,7 +14,7 @@ describe ApplicationHelper::Button::IsoDatastoreNew do
 
     context 'when all RedHat InfraManagers have iso datastores' do
       before do
-        FactoryGirl.create(:iso_datastore, :ems_id => FactoryGirl.create(:ems_redhat).id)
+        FactoryBot.create(:iso_datastore, :ems_id => FactoryBot.create(:ems_redhat).id)
         button.calculate_properties
       end
 

--- a/spec/helpers/application_helper/buttons/miq_action_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_delete_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqActionDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/miq_action_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_edit_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqActionEdit do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqActionModify do
   let(:view_context) { setup_view_context_with_sandbox(:active_tree => tree) }
-  let(:record) { FactoryGirl.create(:miq_event_definition) }
+  let(:record) { FactoryBot.create(:miq_event_definition) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
   let(:tree) { :policy_tree }
 
@@ -21,11 +21,11 @@ describe ApplicationHelper::Button::MiqActionModify do
     before { allow(view_context).to receive(:x_node).and_return("p-#{policy.id}_ev-1") }
 
     context 'when policy is read_only' do
-      let(:policy) { FactoryGirl.create(:miq_policy_read_only) }
+      let(:policy) { FactoryBot.create(:miq_policy_read_only) }
       it { expect(subject).to be_truthy }
     end
     context 'when policy is not read-only' do
-      let(:policy) { FactoryGirl.create(:miq_policy) }
+      let(:policy) { FactoryBot.create(:miq_policy) }
       it { expect(subject).to be_falsey }
     end
   end
@@ -36,7 +36,7 @@ describe ApplicationHelper::Button::MiqActionModify do
        'This Event belongs to a read only Policy and cannot be modified',
        nil]
     end
-    let(:policy) { FactoryGirl.create(:miq_policy_read_only) }
+    let(:policy) { FactoryBot.create(:miq_policy_read_only) }
     subject { button[:title] }
 
     before { allow(view_context).to receive(:x_node).and_return("p-#{policy.id}_#{type}-1") }

--- a/spec/helpers/application_helper/buttons/miq_ae_class_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_class_copy_spec.rb
@@ -3,16 +3,16 @@ describe ApplicationHelper::Button::MiqAeClassCopy do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_class_copy'}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
-    let(:record) { FactoryGirl.create(:miq_ae_class, :of_domain, :domain => domain) }
+    let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
     context 'when there are no editable domains' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.visible?).to be_falsey }
     end
     context 'when there are editable domains' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain) }
       it { expect(subject.visible?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_default_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_default_spec.rb
@@ -1,30 +1,30 @@
 describe ApplicationHelper::Button::MiqAeDefault do
   let(:session) { {} }
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:miq_ae_class, :of_domain, :domain => domain) }
+  let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
   let(:subject) { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_class_edit'}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
     context 'when button does not copy and domains are not editable' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.visible?).to be_falsey }
     end
     context 'when button does not copy but domains are editable' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain) }
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when user has view access only' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain) }
-      before { login_as FactoryGirl.create(:user, :features => 'miq_ae_domain_view') }
+      let(:domain) { FactoryBot.create(:miq_ae_domain) }
+      before { login_as FactoryBot.create(:user, :features => 'miq_ae_domain_view') }
       it { expect(subject.skipped?).to be_truthy }
     end
   end
 
   describe '#disabled?' do
     context 'when domains are not editable and not available for copy' do
-      let(:domain) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.disabled?).to be_falsey }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_domain_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_domain_edit_spec.rb
@@ -4,7 +4,7 @@ describe ApplicationHelper::Button::MiqAeDomainEdit do
 
   describe '#visible?' do
     context 'when domain is locked' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain_disabled) }
+      let(:record) { FactoryBot.create(:miq_ae_domain_disabled) }
       it { expect(subject.visible?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_domain_lock_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_domain_lock_spec.rb
@@ -4,11 +4,11 @@ describe ApplicationHelper::Button::MiqAeDomainLock do
 
   describe '#visible?' do
     context 'when domain locked by user' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:record) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.visible?).to be_falsey }
     end
     context 'when domain lockable but edit not possible' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain) }
+      let(:record) { FactoryBot.create(:miq_ae_domain) }
       it { expect(subject.visible?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_domain_priority_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_domain_priority_edit_spec.rb
@@ -3,10 +3,10 @@ describe ApplicationHelper::Button::MiqAeDomainPriorityEdit do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_domain_priority_edit'}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#disabled?' do
-    let(:record) { FactoryGirl.create(:miq_ae_domain) }
+    let(:record) { FactoryBot.create(:miq_ae_domain) }
     before { allow(User).to receive(:current_tenant).and_return(Tenant.first) }
 
     context 'when number of visible domains < 2' do

--- a/spec/helpers/application_helper/buttons/miq_ae_domain_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_domain_spec.rb
@@ -4,11 +4,11 @@ describe ApplicationHelper::Button::MiqAeDomain do
 
   describe '#disabled?' do
     context 'when record has editable properties' do
-      let(:record) { FactoryGirl.build(:miq_ae_domain_enabled) }
+      let(:record) { FactoryBot.build(:miq_ae_domain_enabled) }
       it { expect(subject.disabled?).to be_falsey }
     end
     context 'when record has not editable properties' do
-      let(:record) { FactoryGirl.build(:miq_ae_system_domain) }
+      let(:record) { FactoryBot.build(:miq_ae_system_domain) }
       it { expect(subject.disabled?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_domain_unlock_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_domain_unlock_spec.rb
@@ -4,22 +4,22 @@ describe ApplicationHelper::Button::MiqAeDomainUnlock do
 
   describe '#visible?' do
     context 'when domain not locked by user' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain) }
+      let(:record) { FactoryBot.create(:miq_ae_domain) }
       it { expect(subject.visible?).to be_falsey }
     end
     context 'when domain locked by user' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:record) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.visible?).to be_truthy }
     end
   end
 
   describe '#disabled?' do
     context 'when record is a system domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_system_domain) }
+      let(:record) { FactoryBot.create(:miq_ae_system_domain) }
       it { expect(subject.disabled?).to be_truthy }
     end
     context 'when record is a user locked domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain_user_locked) }
+      let(:record) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.disabled?).to be_falsey }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_git_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_git_refresh_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqAeGitRefresh do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:miq_ae_git_domain) }
+  let(:record) { FactoryBot.create(:miq_ae_git_domain) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_git_refresh'}) }
 
   before { MiqRegion.seed }

--- a/spec/helpers/application_helper/buttons/miq_ae_instance_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_instance_copy_spec.rb
@@ -1,11 +1,11 @@
 describe ApplicationHelper::Button::MiqAeInstanceCopy do
   let(:session) { {} }
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:miq_ae_class, :of_domain, :domain => domain) }
-  let(:domain) { FactoryGirl.create(:miq_ae_domain_disabled) }
+  let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
+  let(:domain) { FactoryBot.create(:miq_ae_domain_disabled) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => child_id}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
     context 'when domain is locked' do
@@ -21,9 +21,9 @@ describe ApplicationHelper::Button::MiqAeInstanceCopy do
       end
       context 'and button is miq_ae_method_copy with method record' do
         let(:child_id) { 'miq_ae_method_copy' }
-        let(:klass) { FactoryGirl.create(:miq_ae_class, :of_domain, :domain => domain) }
+        let(:klass) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
         let(:record) do
-          FactoryGirl.create(:miq_ae_method, :scope => 'class', :language => 'ruby',
+          FactoryBot.create(:miq_ae_method, :scope => 'class', :language => 'ruby',
                                           :location => 'builtin', :ae_class => klass)
         end
         it { expect(subject.visible?).to be_truthy }

--- a/spec/helpers/application_helper/buttons/miq_ae_namespace_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_namespace_edit_spec.rb
@@ -3,34 +3,34 @@ describe ApplicationHelper::Button::MiqAeNamespaceEdit do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_namespace_edit'}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
     context 'when domain is unlocked' do
-      let(:record) { FactoryGirl.create(:miq_ae_domain) }
+      let(:record) { FactoryBot.create(:miq_ae_domain) }
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when record is a namespace with user domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain)) }
+      let(:record) { FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain)) }
       it { expect(subject.visible?).to be_truthy }
     end
     context 'when record is a namespace with user locked domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain_user_locked)) }
+      let(:record) { FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain_user_locked)) }
       it { expect(subject.visible?).to be_falsey }
     end
   end
 
   describe '#disabled?' do
     context 'when record is a system domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_system_domain) }
+      let(:record) { FactoryBot.create(:miq_ae_system_domain) }
       it { expect(subject.disabled?).to be_truthy }
     end
     context 'when record is a namespace domain of an editable domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain)) }
+      let(:record) { FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain)) }
       it { expect(subject.disabled?).to be_falsey }
     end
     context 'when record is a namespace domain of an uneditable domain' do
-      let(:record) { FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_system_domain)) }
+      let(:record) { FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_system_domain)) }
       it { expect(subject.disabled?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_ae_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_spec.rb
@@ -3,22 +3,22 @@ describe ApplicationHelper::Button::MiqAe do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => child_id}) }
 
-  before { login_as FactoryGirl.create(:user, :with_miq_edit_features) }
+  before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
     context 'when button does not copy' do
       let(:child_id) { 'miq_ae_domain_edit' }
-      let(:record) { FactoryGirl.build(:miq_ae_domain_enabled) }
+      let(:record) { FactoryBot.build(:miq_ae_domain_enabled) }
       it { expect(subject.visible?).to be_falsey }
     end
     context do
       let(:child_id) { 'miq_ae_class_copy' }
       context 'when editable domains not available' do
-        let(:record) { FactoryGirl.build(:miq_ae_domain_disabled) }
+        let(:record) { FactoryBot.build(:miq_ae_domain_disabled) }
         it { expect(subject.visible?).to be_falsey }
       end
       context 'when editable domains available' do
-        let(:record) { FactoryGirl.create(:miq_ae_class, :of_domain, :domain => FactoryGirl.create(:miq_ae_domain)) }
+        let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => FactoryBot.create(:miq_ae_domain)) }
         it { expect(subject.visible?).to be_truthy }
       end
     end
@@ -27,17 +27,17 @@ describe ApplicationHelper::Button::MiqAe do
   describe '#disabled?' do
     context 'when domains not editable' do
       let(:child_id) { 'miq_ae_domain_edit' }
-      let(:record) { FactoryGirl.build(:miq_ae_domain_disabled) }
+      let(:record) { FactoryBot.build(:miq_ae_domain_disabled) }
       it { expect(subject.disabled?).to be_falsey }
     end
     context 'when domains not available for copy but editable' do
       let(:child_id) { 'miq_ae_domain_copy' }
-      let(:record) { FactoryGirl.build(:miq_ae_domain_enabled) }
+      let(:record) { FactoryBot.build(:miq_ae_domain_enabled) }
       it { expect(subject.disabled?).to be_falsey }
     end
     context 'when domains are not editable and not available for copy' do
       let(:child_id) { 'miq_ae_domain_edit' }
-      let(:record) { FactoryGirl.build(:miq_ae_system_domain) }
+      let(:record) { FactoryBot.build(:miq_ae_system_domain) }
       it { expect(subject.disabled?).to be_truthy }
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_alert_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_alert_delete_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqAlertDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/miq_check_compliance_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_check_compliance_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqCheckCompliance do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:template_redhat) }
+  let(:record) { FactoryBot.create(:template_redhat) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   it_behaves_like 'a check_compliance button', 'Template'

--- a/spec/helpers/application_helper/buttons/miq_report_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_report_edit_spec.rb
@@ -11,11 +11,11 @@ describe ApplicationHelper::Button::MiqReportEdit do
       context 'and active_tab == report_info' do
         let(:tab) { 'report_info' }
         context 'and record.rpt_type == Custom' do
-          let(:record) { FactoryGirl.create(:miq_report, :rpt_type => 'Custom') }
+          let(:record) { FactoryBot.create(:miq_report, :rpt_type => 'Custom') }
           it { expect(subject.visible?).to be_truthy }
         end
         context 'and record.rpt_type != Custom' do
-          let(:record) { FactoryGirl.create(:miq_report) }
+          let(:record) { FactoryBot.create(:miq_report) }
           it { expect(subject.visible?).to be_falsey }
         end
       end

--- a/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
     end
 
     let(:view_context) { setup_view_context_with_sandbox({}) }
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:request) { "SomeRequest" }
     let(:username) { user.name }
     let(:state) { "xx" }

--- a/spec/helpers/application_helper/buttons/miq_request_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_copy_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::MiqRequestCopy do
     end
 
     let(:view_context) { setup_view_context_with_sandbox({}) }
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     %w(MiqProvisionRequest VmReconfigureRequest VmCloudReconfigureRequest
        VmMigrateRequest AutomationRequest ServiceTemplateProvisionRequest).each do |cls|
       let(:request) { "MiqProvisionRequest" }

--- a/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqRequestDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {:options => {:feature => 'miq_request_delete'}}) }
 
   describe '#disabled?' do
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::MiqRequestDelete do
       allow(record).to receive(:resource_type).and_return(resource_type)
     end
 
-    let(:current_user) { FactoryGirl.create(:user, :features => "everything") }
+    let(:current_user) { FactoryBot.create(:user, :features => "everything") }
     let(:approval_state) { 'sorryjako' }
     let(:requester_name) { {:requester_name => current_user.name} }
     let(:resource_type) { 'knedlik' }
@@ -35,12 +35,12 @@ describe ApplicationHelper::Button::MiqRequestDelete do
 
     context 'request is approved and suer is not admin' do
       let(:approval_state) { 'approved' }
-      let(:current_user) { FactoryGirl.create(:user, :role => "test") }
+      let(:current_user) { FactoryBot.create(:user, :role => "test") }
       it_behaves_like 'a disabled button', 'Approved requests cannot be deleted'
     end
 
     context 'request is approved' do
-      let(:current_user) { FactoryGirl.create(:user, :role => "test") }
+      let(:current_user) { FactoryBot.create(:user, :role => "test") }
       it_behaves_like 'a disabled button', 'Users are only allowed to delete their own requests'
     end
   end

--- a/spec/helpers/application_helper/buttons/miq_request_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_edit_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::MiqRequestEdit do
     end
 
     let(:view_context) { setup_view_context_with_sandbox({}) }
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
     let(:request) { "SomeRequest" }
     let(:username) { user.name }
     let(:state) { "xx" }

--- a/spec/helpers/application_helper/buttons/miq_template_perf_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_template_perf_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqTemplatePerf do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:template_redhat) }
+  let(:record) { FactoryBot.create(:template_redhat) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   it_behaves_like 'a performance button', 'Template'

--- a/spec/helpers/application_helper/buttons/miq_template_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_template_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::MiqTemplateTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:template_redhat) }
+  let(:record) { FactoryBot.create(:template_redhat) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   it_behaves_like 'a timeline button', :entity => 'Template'

--- a/spec/helpers/application_helper/buttons/network_router_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/network_router_new_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::NetworkRouterNew do
   describe '#disabled?' do
     it "when at least one provider supports network router create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::NetworkRouterNew do
 
     it "when at least one provider supports network router create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
@@ -13,7 +13,7 @@ describe ApplicationHelper::Button::NewCloudTenant do
 
     context 'provider available' do
       before do
-        FactoryGirl.create(:ems_openstack)
+        FactoryBot.create(:ems_openstack)
         button.calculate_properties
       end
 

--- a/spec/helpers/application_helper/buttons/new_flavor_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_flavor_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationHelper::Button::NewFlavor do
 
     context 'provider available' do
       before do
-        provider = FactoryGirl.create(:ems_openstack)
+        provider = FactoryBot.create(:ems_openstack)
         allow(provider.class::Flavor).to receive(:create).and_return(true)
         button.calculate_properties
       end

--- a/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
@@ -1,10 +1,10 @@
 describe ApplicationHelper::Button::NewHostAggregate do
-  let(:user)   { FactoryGirl.create(:user, :miq_groups => [group]) }
-  let(:group)  { FactoryGirl.create(:miq_group, :tenant => tenant, :entitlement => entitlement) }
-  let(:tenant) { FactoryGirl.create(:tenant) }
+  let(:user)   { FactoryBot.create(:user, :miq_groups => [group]) }
+  let(:group)  { FactoryBot.create(:miq_group, :tenant => tenant, :entitlement => entitlement) }
+  let(:tenant) { FactoryBot.create(:tenant) }
   let(:entitlement) { nil }
 
-  let!(:provider) { FactoryGirl.create(:ems_openstack, :tenant => tenant) }
+  let!(:provider) { FactoryBot.create(:ems_openstack, :tenant => tenant) }
 
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button)       { described_class.new(view_context, {}, {}, {}) }
@@ -25,7 +25,7 @@ describe ApplicationHelper::Button::NewHostAggregate do
     end
 
     context 'provider is not available due to RBAC rules' do
-      let(:entitlement) { FactoryGirl.create(:entitlement) }
+      let(:entitlement) { FactoryBot.create(:entitlement) }
 
       before do
         entitlement.set_managed_filters([["/managed/environment/prod"]])

--- a/spec/helpers/application_helper/buttons/orchestration_stack_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/orchestration_stack_retire_now_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::OrchestrationStackRetireNow do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:orchestration_stack, :retired => retired) }
+  let(:record) { FactoryBot.create(:orchestration_stack, :retired => retired) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
+++ b/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
@@ -2,8 +2,8 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
   describe '#disabled?' do
     context "button should not be disabled" do
       before do
-        ems = FactoryGirl.create(:ems_physical_infra)
-        @record = FactoryGirl.create(:physical_server, :ems_id => ems.id)
+        ems = FactoryBot.create(:ems_physical_infra)
+        @record = FactoryBot.create(:physical_server, :ems_id => ems.id)
       end
 
       it "does not disable the Provision button" do
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
 
     context "button should be disabled when there are no Physical Servers" do
       before do
-        FactoryGirl.create(:ems_physical_infra)
+        FactoryBot.create(:ems_physical_infra)
       end
 
       it "disable the Provision button" do
@@ -36,8 +36,8 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
 
     context "button should be disabled when there are no Physical infrastructure providers that support VM Provisioning" do
       before do
-        ems = FactoryGirl.create(:ems_physical_infra)
-        @record = FactoryGirl.create(:physical_server, :ems_id => ems.id)
+        ems = FactoryBot.create(:ems_physical_infra)
+        @record = FactoryBot.create(:physical_server, :ems_id => ems.id)
       end
 
       it "disable the Provision button" do

--- a/spec/helpers/application_helper/buttons/policy_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/policy_copy_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::PolicyCopy do
     let(:view_context) { setup_view_context_with_sandbox({}) }
 
     before do
-      @record = FactoryGirl.create(:miq_policy)
+      @record = FactoryBot.create(:miq_policy)
     end
 
     it "that supports policy_copy will not be skipped" do

--- a/spec/helpers/application_helper/buttons/policy_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/policy_delete_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::PolicyDelete do
     let(:view_context) { setup_view_context_with_sandbox({}) }
 
     before do
-      @record = FactoryGirl.create(:miq_policy)
+      @record = FactoryBot.create(:miq_policy)
     end
 
     it "that supports policy_copy will not be skipped" do

--- a/spec/helpers/application_helper/buttons/rbac_role_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_role_delete_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::RbacRoleDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:read_only) { false }
-  let(:record) { FactoryGirl.create(:miq_user_role, :read_only => read_only) }
+  let(:record) { FactoryBot.create(:miq_user_role, :read_only => read_only) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do
@@ -21,7 +21,7 @@ describe ApplicationHelper::Button::RbacRoleDelete do
         it_behaves_like 'an enabled button'
       end
       context 'when role is in use by one or more Groups' do
-        let(:setup_miq_groups) { FactoryGirl.create(:miq_group, :miq_user_role => record) }
+        let(:setup_miq_groups) { FactoryBot.create(:miq_group, :miq_user_role => record) }
         it_behaves_like 'a disabled button', 'This Role is in use by one or more Groups and can not be deleted'
       end
     end

--- a/spec/helpers/application_helper/buttons/rbac_role_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_role_edit_spec.rb
@@ -3,7 +3,7 @@ describe ApplicationHelper::Button::RbacRoleEdit do
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do
-    let(:record) { FactoryGirl.create(:miq_user_role, :read_only => read_only) }
+    let(:record) { FactoryBot.create(:miq_user_role, :read_only => read_only) }
     before { button.calculate_properties }
 
     context 'when role is writable' do

--- a/spec/helpers/application_helper/buttons/rbac_tenant_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_tenant_delete_spec.rb
@@ -1,13 +1,13 @@
 describe ApplicationHelper::Button::RbacTenantDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:tenant, :parent => tenant_parent) }
+  let(:record) { FactoryBot.create(:tenant, :parent => tenant_parent) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do
     before { button.calculate_properties }
 
     context 'when record is a child tenant' do
-      let(:tenant_parent) { FactoryGirl.create(:tenant) }
+      let(:tenant_parent) { FactoryBot.create(:tenant) }
       it_behaves_like 'an enabled button'
     end
     context 'when record is the default tenant' do

--- a/spec/helpers/application_helper/buttons/rbac_user_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_user_copy_spec.rb
@@ -6,11 +6,11 @@ describe ApplicationHelper::Button::RbacUserCopy do
     before { button.calculate_properties }
 
     context 'when user is an administrator' do
-      let(:record) { FactoryGirl.create(:user_admin) }
+      let(:record) { FactoryBot.create(:user_admin) }
       it_behaves_like 'a disabled button', 'Super Administrator can not be copied'
     end
     context 'when user is not an administrator' do
-      let(:record) { FactoryGirl.create(:user) }
+      let(:record) { FactoryBot.create(:user) }
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/helpers/application_helper/buttons/rbac_user_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_user_delete_spec.rb
@@ -6,11 +6,11 @@ describe ApplicationHelper::Button::RbacUserDelete do
     before { button.calculate_properties }
 
     context 'when user is the root administrator' do
-      let(:record) { FactoryGirl.create(:user_admin, :userid => 'admin') }
+      let(:record) { FactoryBot.create(:user_admin, :userid => 'admin') }
       it_behaves_like 'a disabled button', 'Default Administrator can not be deleted'
     end
     context 'when user is a common administrator' do
-      let(:record) { FactoryGirl.create(:user) }
+      let(:record) { FactoryBot.create(:user) }
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/helpers/application_helper/buttons/report_only_spec.rb
+++ b/spec/helpers/application_helper/buttons/report_only_spec.rb
@@ -1,8 +1,8 @@
 describe ApplicationHelper::Button::ReportOnly do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:result_detail) { FactoryGirl.create(:miq_report_result_detail, :miq_report_result_id => report_result_id) }
-  let(:record) { FactoryGirl.create(:miq_report_result, :miq_report_result_details => []) }
-  let(:report) { FactoryGirl.create(:miq_report, :miq_report_results => []) }
+  let(:result_detail) { FactoryBot.create(:miq_report_result_detail, :miq_report_result_id => report_result_id) }
+  let(:record) { FactoryBot.create(:miq_report_result, :miq_report_result_details => []) }
+  let(:report) { FactoryBot.create(:miq_report, :miq_report_results => []) }
   let(:report_result_id) { record.id }
   let(:instance_data) { {'record' => record, 'report' => report, 'report_result_id' => report_result_id} }
   let(:button) { described_class.new(view_context, {}, instance_data, {}) }

--- a/spec/helpers/application_helper/buttons/role_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_start_spec.rb
@@ -8,27 +8,27 @@ describe ApplicationHelper::Button::RoleStart do
   describe '#visible?' do
     context 'when record is assigned server role and miq server is started' do
       let(:record) do
-        FactoryGirl.create(:assigned_server_role,
-                           :miq_server => FactoryGirl.create(:miq_server))
+        FactoryBot.create(:assigned_server_role,
+                           :miq_server => FactoryBot.create(:miq_server))
       end
       before { allow(record.miq_server).to receive(:started?).and_return(true) }
       it { expect(subject.visible?).to be_truthy }
     end
 
     context 'when record is server role' do
-      let(:record) { FactoryGirl.create(:server_role, :name => 'server_role') }
+      let(:record) { FactoryBot.create(:server_role, :name => 'server_role') }
       it { expect(subject.visible?).to be_falsey }
     end
 
     context 'when record is miq server' do
-      let(:record) { FactoryGirl.create(:miq_server) }
+      let(:record) { FactoryBot.create(:miq_server) }
       it { expect(subject.visible?).to be_falsey }
     end
   end
 
   describe '#disabled?' do
     context 'when record is assigned server role' do
-      let(:record) { FactoryGirl.create(:assigned_server_role) }
+      let(:record) { FactoryBot.create(:assigned_server_role) }
       before { allow(record).to receive(:active?).and_return(true) }
       before { subject.calculate_properties }
       it { expect(subject.disabled?).to be_truthy }
@@ -37,9 +37,9 @@ describe ApplicationHelper::Button::RoleStart do
 
     context 'when record is inactive assigned server role' do
       let(:record) do
-        FactoryGirl.create(:assigned_server_role,
+        FactoryBot.create(:assigned_server_role,
                            :active     => false,
-                           :miq_server => FactoryGirl.create(:miq_server))
+                           :miq_server => FactoryBot.create(:miq_server))
       end
       before { allow(record.miq_server).to receive(:started?).and_return(false) }
       before { subject.calculate_properties }
@@ -49,10 +49,10 @@ describe ApplicationHelper::Button::RoleStart do
 
     context 'when record is inactive assigned server role' do
       let(:record) do
-        FactoryGirl.create(:assigned_server_role,
+        FactoryBot.create(:assigned_server_role,
                            :active      => false,
-                           :miq_server  => FactoryGirl.create(:miq_server),
-                           :server_role => FactoryGirl.create(:server_role,
+                           :miq_server  => FactoryBot.create(:miq_server),
+                           :server_role => FactoryBot.create(:server_role,
                                                               :name => "server_role"))
       end
       before { allow(record.server_role).to receive(:regional_role?).and_return(true) }

--- a/spec/helpers/application_helper/buttons/role_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_suspend_spec.rb
@@ -2,9 +2,9 @@ describe ApplicationHelper::Button::RoleSuspend do
   describe '#disabled?' do
     context "record has regional role" do
       before do
-        @record = FactoryGirl.create(
+        @record = FactoryBot.create(
           :assigned_server_role,
-          :server_role => FactoryGirl.create(
+          :server_role => FactoryBot.create(
             :server_role,
             :name => "terminator",
           )
@@ -24,15 +24,15 @@ describe ApplicationHelper::Button::RoleSuspend do
 
     context "record is active and max_concurrent is 1" do
       before do
-        @record = FactoryGirl.create(
+        @record = FactoryBot.create(
           :assigned_server_role,
           :active      => true,
-          :server_role => FactoryGirl.create(
+          :server_role => FactoryBot.create(
             :server_role,
             :name        => "terminator",
             :description => "cyborg"
           ),
-          :miq_server  => FactoryGirl.create(
+          :miq_server  => FactoryBot.create(
             :miq_server,
             :name => "ratman"
           )
@@ -53,15 +53,15 @@ describe ApplicationHelper::Button::RoleSuspend do
 
     context "record is inactive" do
       before do
-        @record = FactoryGirl.create(
+        @record = FactoryBot.create(
           :assigned_server_role,
           :active      => false,
-          :server_role => FactoryGirl.create(
+          :server_role => FactoryBot.create(
             :server_role,
             :name        => "terminator",
             :description => "cyborg"
           ),
-          :miq_server  => FactoryGirl.create(
+          :miq_server  => FactoryBot.create(
             :miq_server,
             :name => "ratman"
           )

--- a/spec/helpers/application_helper/buttons/security_group_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/security_group_new_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::SecurityGroupNew do
   describe '#disabled?' do
     it "when at least one provider supports security group create then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       expect(button.disabled?).to be false
     end
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::SecurityGroupNew do
 
     it "when at least one provider supports security group create, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
-      FactoryGirl.create(:ems_openstack)
+      FactoryBot.create(:ems_openstack)
       button = described_class.new(view_context, {}, {}, {})
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/helpers/application_helper/buttons/server_demote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_demote_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::ServerDemote do
   describe '#visible?' do
     context "with master supported server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role_in_master_region)
+        @record = FactoryBot.create(:assigned_server_role_in_master_region)
       end
 
       it "will not be skipped for this record" do
@@ -16,7 +16,7 @@ describe ApplicationHelper::Button::ServerDemote do
 
     context "without server role" do
       before do
-        @record = FactoryGirl.create(:server_role)
+        @record = FactoryBot.create(:server_role)
       end
 
       it "will be skipped for this record" do
@@ -32,7 +32,7 @@ describe ApplicationHelper::Button::ServerDemote do
   describe '#disabled?' do
     context "with medium prioirity server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 2)
+        @record = FactoryBot.create(:assigned_server_role_in_master_region, :priority => 2)
       end
 
       it "disables the button and returns the error message" do

--- a/spec/helpers/application_helper/buttons/server_promote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_promote_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::ServerPromote do
   describe '#disabled?' do
     context "with medium priority server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 2)
+        @record = FactoryBot.create(:assigned_server_role_in_master_region, :priority => 2)
       end
 
       it "disables the button and returns the error message" do
@@ -17,7 +17,7 @@ describe ApplicationHelper::Button::ServerPromote do
 
     context "with high priority server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 1)
+        @record = FactoryBot.create(:assigned_server_role_in_master_region, :priority => 1)
       end
 
       it "disables the button and returns the error message" do

--- a/spec/helpers/application_helper/buttons/service_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/service_retire_now_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::ServiceRetireNow do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:service, :retired => retired) }
+  let(:record) { FactoryBot.create(:service, :retired => retired) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -2,10 +2,10 @@ describe ApplicationHelper::Button::SetOwnership do
   let(:view_context) { setup_view_context_with_sandbox({}) }
 
   let(:ext_management_system) do
-    FactoryGirl.create(:ext_management_system, :tenant_mapping_enabled => tenant_mapping_enabled)
+    FactoryBot.create(:ext_management_system, :tenant_mapping_enabled => tenant_mapping_enabled)
   end
 
-  let(:record) { FactoryGirl.create(:vm, :ext_management_system => ext_management_system) }
+  let(:record) { FactoryBot.create(:vm, :ext_management_system => ext_management_system) }
 
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 

--- a/spec/helpers/application_helper/buttons/smart_state_scan.rb
+++ b/spec/helpers/application_helper/buttons/smart_state_scan.rb
@@ -7,7 +7,7 @@ describe ApplicationHelper::Button::SmartStateScan do
     context "when only SmartProxy role is set" do
       before do
         SSAButtonHelper.create_server_role(MiqServer.my_server, 'SmartProxy')
-        @record = FactoryGirl.create(:container_image)
+        @record = FactoryBot.create(:container_image)
       end
 
       it "will not be disabled" do
@@ -20,7 +20,7 @@ describe ApplicationHelper::Button::SmartStateScan do
     context "when only SmartState role is set" do
       before do
         SSAButtonHelper.create_server_role(MiqServer.my_server, 'SmartState')
-        @record = FactoryGirl.create(:container_image)
+        @record = FactoryBot.create(:container_image)
       end
 
       it "will not be disabled" do
@@ -33,7 +33,7 @@ describe ApplicationHelper::Button::SmartStateScan do
     context "when both proxy roles are set" do
       before do
         SSAButtonHelper.create_server_smart_roles
-        @record = FactoryGirl.create(:container_image)
+        @record = FactoryBot.create(:container_image)
       end
 
       it "will not be disabled" do

--- a/spec/helpers/application_helper/buttons/storage_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_delete_spec.rb
@@ -2,18 +2,18 @@ describe ApplicationHelper::Button::StorageDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:vms) { [] }
   let(:hosts) { [] }
-  let(:record) { FactoryGirl.create(:storage, :vms_and_templates => vms, :hosts => hosts) }
+  let(:record) { FactoryBot.create(:storage, :vms_and_templates => vms, :hosts => hosts) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#calculate_properties' do
     before { button.calculate_properties }
 
     context 'when with VMs' do
-      let(:vms) { [FactoryGirl.create(:vm_or_template)] }
+      let(:vms) { [FactoryBot.create(:vm_or_template)] }
       it_behaves_like 'a disabled button', 'Only Datastore without VMs and Hosts can be removed'
     end
     context 'when with Hosts' do
-      let(:hosts) { [FactoryGirl.create(:host)] }
+      let(:hosts) { [FactoryBot.create(:host)] }
       it_behaves_like 'a disabled button', 'Only Datastore without VMs and Hosts can be removed'
     end
     context 'when without VMs and Hosts' do

--- a/spec/helpers/application_helper/buttons/storage_perf_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_perf_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::StoragePerf do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:storage) }
+  let(:record) { FactoryBot.create(:storage) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   it_behaves_like 'a performance button', 'Datastore'

--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -1,10 +1,10 @@
 describe ApplicationHelper::Button::StorageScan do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:storage) }
+  let(:record) { FactoryBot.create(:storage) }
   let(:feature) { :smartstate_analysis }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
-  let(:ems)                  { FactoryGirl.create(:ems_vmware) }
+  let(:ems)                  { FactoryBot.create(:ems_vmware) }
   let(:emss)                 { [ems] }
   let(:emss_with_valid_auth) { [ems] }
 

--- a/spec/helpers/application_helper/buttons/template_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/template_refresh_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::TemplateRefresh do
   describe '#visible?' do
     context "when record is refreshable" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:ext_management_system).and_return(true)
       end
 
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::TemplateRefresh do
 
     context "when record is not refreshable but @perf_options[:typ] is 'realtime'" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         @perf_options = ApplicationController::Performance::Options.new
         @perf_options.typ = 'realtime'
         allow(@record).to receive(:ext_management_system).and_return(false)
@@ -26,7 +26,7 @@ describe ApplicationHelper::Button::TemplateRefresh do
 
     context "when record is not refreshable but @perf_options[:typ] is 'realtime'" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         @perf_options = ApplicationController::Performance::Options.new
         @perf_options.typ = 'Hourly'
         allow(@record).to receive(:ext_management_system).and_return(false)

--- a/spec/helpers/application_helper/buttons/tenant_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/tenant_add_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::TenantAdd do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:tenant) }
+  let(:record) { FactoryBot.create(:tenant) }
   let(:feature) { 'rbac_project_add' }
   let(:options) { {:feature => feature} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {:options => options}) }
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::TenantAdd do
   describe '#visible?' do
     subject { button.visible? }
     context 'when record is a project' do
-      let(:record) { FactoryGirl.create(:tenant_project) }
+      let(:record) { FactoryBot.create(:tenant_project) }
       it { expect(subject).to be_falsey }
     end
     context 'when record is not a project' do

--- a/spec/helpers/application_helper/buttons/tenant_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/tenant_edit_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::TenantEdit do
   describe '#disabled?' do
-    let(:tenant_with_cloud_tenant)    { FactoryGirl.create(:tenant_with_cloud_tenant) }
-    let(:tenant_without_cloud_tenant) { FactoryGirl.create(:tenant) }
+    let(:tenant_with_cloud_tenant)    { FactoryBot.create(:tenant_with_cloud_tenant) }
+    let(:tenant_without_cloud_tenant) { FactoryBot.create(:tenant) }
 
     before do
       @view_context = setup_view_context_with_sandbox({})

--- a/spec/helpers/application_helper/buttons/utilization_download_spec.rb
+++ b/spec/helpers/application_helper/buttons/utilization_download_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::UtilizationDownload do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:report) { FactoryGirl.create(:miq_report, :miq_report_results => []) }
+  let(:report) { FactoryBot.create(:miq_report, :miq_report_results => []) }
   let!(:button) { described_class.new(view_context, {}, {'layout' => 'miq_capacity_bottlenecks'}, {}) }
 
   context "Bottlenecks explorer" do

--- a/spec/helpers/application_helper/buttons/view_ght_spec.rb
+++ b/spec/helpers/application_helper/buttons/view_ght_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::ViewGHT do
   let(:view_context) { setup_view_context_with_sandbox(:active_tree => tree) }
   let(:ght_type) { 'tabular' }
-  let(:report) { FactoryGirl.create(:miq_report) }
+  let(:report) { FactoryBot.create(:miq_report) }
   let(:render_chart) { nil }
   let(:graph) { nil }
   subject do

--- a/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::VmInstanceTemplateScan do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm_or_template) }
+  let(:record) { FactoryBot.create(:vm_or_template) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#visible?' do
@@ -36,8 +36,8 @@ describe ApplicationHelper::Button::VmInstanceTemplateScan do
 
     context 'when smart_roles are enabled' do
       before do
-        roles = %w(smartproxy smartstate).collect { |role| FactoryGirl.create(:server_role, :name => role) }
-        FactoryGirl.create(:miq_server, :zone => MiqServer.my_server.zone, :active_roles => roles)
+        roles = %w(smartproxy smartstate).collect { |role| FactoryBot.create(:server_role, :name => role) }
+        FactoryBot.create(:miq_server, :zone => MiqServer.my_server.zone, :active_roles => roles)
         button.calculate_properties
       end
 

--- a/spec/helpers/application_helper/buttons/vm_perf_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_perf_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::VmPerf do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm_or_template) }
+  let(:record) { FactoryBot.create(:vm_or_template) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   it_behaves_like 'a performance button', 'VM'

--- a/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::VmReconfigure do
   describe '#visible?' do
     context "record is vmware vm" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
       end
 
       it_behaves_like "will not be skipped for this record"
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::VmReconfigure do
 
     context "record is vmware template" do
       before do
-        @record = FactoryGirl.create(:template_vmware)
+        @record = FactoryBot.create(:template_vmware)
       end
 
       it_behaves_like "will be skipped for this record"

--- a/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::VmRefresh do
   describe '#visible?' do
     context "when record has ext_management_system and host vmm_product is workstation" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive_messages(:host                  => double(:vmm_product => "Workstation"),
                                            :ext_management_system => true)
       end
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::VmRefresh do
 
     context "when record has no ext_management_system and host vmm_product is server" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive_messages(:host                  => double(:vmm_product => "Server"),
                                            :ext_management_system => false)
       end

--- a/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::VmRetireNow do
   describe '#visible?' do
     context "when record is retireable" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:supports_retire?).and_return(true)
       end
 
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::VmRetireNow do
 
     context "when record is not retiretable" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:supports_retire?).and_return(false)
       end
 
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::VmRetireNow do
   describe '#disabled?' do
     context "when record has an error message" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:retired).and_return(true)
       end
 
@@ -37,7 +37,7 @@ describe ApplicationHelper::Button::VmRetireNow do
   describe "#calculate_properties" do
     context "when record is retired" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:retired).and_return(true)
       end
 

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::VmRetire do
   describe '#visible?' do
     context "when record is retireable" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:supports_retire?).and_return(true)
       end
 
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::VmRetire do
 
     context "when record is not retiretable" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:supports_retire?).and_return(false)
       end
 
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::VmRetire do
   describe '#disabled?' do
     context "button should not be disabled" do
       before do
-        @record = FactoryGirl.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware)
         allow(@record).to receive(:retired).and_return(true)
       end
 

--- a/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
@@ -3,9 +3,9 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
   let(:session) { {} }
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:zone) { EvmSpecHelper.local_miq_server(:is_master => true).zone }
-  let(:ems) { FactoryGirl.create(:ems_vmware, :zone => zone, :name => 'Test EMS') }
-  let(:host) { FactoryGirl.create(:host) }
-  let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id) }
+  let(:ems) { FactoryBot.create(:ems_vmware, :zone => zone, :name => 'Test EMS') }
+  let(:host) { FactoryBot.create(:host) }
+  let(:record) { FactoryBot.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id) }
   let(:active) { true }
   let(:button) { described_class.new(view_context, {}, {'record' => record, 'active' => active}, {}) }
 
@@ -17,8 +17,8 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
     context 'when creating snapshots is available' do
       let(:current) { 1 }
       let(:record) do
-        record = FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
-        record.snapshots = [FactoryGirl.create(:snapshot,
+        record = FactoryBot.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
+        record.snapshots = [FactoryBot.create(:snapshot,
                                                :create_time       => 1.minute.ago,
                                                :vm_or_template_id => record.id,
                                                :name              => 'EvmSnapshot',
@@ -27,7 +27,7 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
         record
       end
       context 'and the selected snapshot may be active but the vm is not connected to a host' do
-        let(:record) { FactoryGirl.create(:vm_vmware) }
+        let(:record) { FactoryBot.create(:vm_vmware) }
         it_behaves_like 'a disabled button', 'The VM is not connected to a Host'
       end
       context 'and the selected snapshot is active and current' do
@@ -37,7 +37,7 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
       end
     end
     context 'when creating snapshots is not available' do
-      let(:record) { FactoryGirl.create(:vm_amazon) }
+      let(:record) { FactoryBot.create(:vm_amazon) }
       it_behaves_like 'a disabled button', 'Operation not supported'
     end
     context 'when user has permissions to create snapsnots' do

--- a/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
@@ -1,11 +1,11 @@
 describe ApplicationHelper::Button::VmSnapshotRemoveOne do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:zone) { EvmSpecHelper.local_miq_server(:is_master => true).zone }
-  let(:ems) { FactoryGirl.create(:ems_redhat, :zone => zone, :name => 'Test EMS') }
-  let(:host) { FactoryGirl.create(:host) }
+  let(:ems) { FactoryBot.create(:ems_redhat, :zone => zone, :name => 'Test EMS') }
+  let(:host) { FactoryBot.create(:host) }
   let(:record) do
-    record = FactoryGirl.create(:vm_redhat, :ems_id => ems.id, :host_id => host.id)
-    record.snapshots = [FactoryGirl.create(:snapshot,
+    record = FactoryBot.create(:vm_redhat, :ems_id => ems.id, :host_id => host.id)
+    record.snapshots = [FactoryBot.create(:snapshot,
                                            :create_time       => 1.minute.ago,
                                            :vm_or_template_id => record.id,
                                            :name              => 'EvmSnapshot',
@@ -31,8 +31,8 @@ describe ApplicationHelper::Button::VmSnapshotRemoveOne do
     end
     context 'when !record.kind_of?(ManageIQ::Providers::Redhat::InfraManager::Vm)' do
       let(:record) do
-        record = FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
-        record.snapshots = [FactoryGirl.create(:snapshot,
+        record = FactoryBot.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
+        record.snapshots = [FactoryBot.create(:snapshot,
                                                :create_time       => 1.minute.ago,
                                                :vm_or_template_id => record.id,
                                                :name              => 'EvmSnapshot',

--- a/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
@@ -1,11 +1,11 @@
 describe ApplicationHelper::Button::VmSnapshotRevert do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:zone) { EvmSpecHelper.local_miq_server(:is_master => true).zone }
-  let(:ems) { FactoryGirl.create(:ems_vmware, :zone => zone, :name => 'Test EMS') }
-  let(:host) { FactoryGirl.create(:host) }
+  let(:ems) { FactoryBot.create(:ems_vmware, :zone => zone, :name => 'Test EMS') }
+  let(:host) { FactoryBot.create(:host) }
   let(:record) do
-    record = FactoryGirl.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
-    record.snapshots = [FactoryGirl.create(:snapshot,
+    record = FactoryBot.create(:vm_vmware, :ems_id => ems.id, :host_id => host.id)
+    record.snapshots = [FactoryBot.create(:snapshot,
                                            :create_time       => 1.minute.ago,
                                            :vm_or_template_id => record.id,
                                            :name              => 'EvmSnapshot',
@@ -19,7 +19,7 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
   describe '#visible?' do
     subject { button.visible? }
     context 'when record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)' do
-      let(:record) { FactoryGirl.create(:vm_openstack) }
+      let(:record) { FactoryBot.create(:vm_openstack) }
       it { is_expected.to be_falsey }
     end
     context 'when !record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)' do
@@ -34,7 +34,7 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
       it_behaves_like 'an enabled button'
     end
     context 'when reverting to a snapshot is not available' do
-      let(:record) { FactoryGirl.create(:vm_amazon) }
+      let(:record) { FactoryBot.create(:vm_amazon) }
       it_behaves_like 'a disabled button', 'Operation not supported'
     end
   end

--- a/spec/helpers/application_helper/buttons/vm_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_timeline_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmTimeline do
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
 
   it_behaves_like 'a timeline button', :entity => 'VM'

--- a/spec/helpers/application_helper/buttons/vm_vmrc_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_vmrc_console_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::VmVmrcConsole do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm_vmware) }
+  let(:record) { FactoryBot.create(:vm_vmware) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#visible?' do

--- a/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_vnc_console_spec.rb
@@ -1,12 +1,12 @@
 describe ApplicationHelper::Button::VmVncConsole do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#visible?' do
     subject { button.visible? }
     context 'when record.vendor == vmware' do
-      let(:record) { FactoryGirl.create(:vm_vmware) }
+      let(:record) { FactoryBot.create(:vm_vmware) }
       it_behaves_like 'vm_console_visible?', 'VNC', :vm_vmware => true
     end
     context 'when record.vendor != vmware' do
@@ -19,7 +19,7 @@ describe ApplicationHelper::Button::VmVncConsole do
     end
 
     context 'vm console button is not visible' do
-      let(:record) { FactoryGirl.create(:vm_vmware, :ems_id => nil) }
+      let(:record) { FactoryBot.create(:vm_vmware, :ems_id => nil) }
       it_behaves_like 'vm_console_not_visible?'
     end
   end
@@ -30,8 +30,8 @@ describe ApplicationHelper::Button::VmVncConsole do
 
     context 'when record.vendor == vmware' do
       let(:power_state) { 'on' }
-      let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
-      let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
+      let(:host) { FactoryBot.create(:host_vmware_esx, :vmm_version => api_version) }
+      let(:record) { FactoryBot.create(:vm_vmware, :host => host) }
 
       context 'and vendor api is not supported' do
         let(:api_version) { 6.5 }

--- a/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_webmks_console_spec.rb
@@ -1,12 +1,12 @@
 describe ApplicationHelper::Button::VmWebmksConsole do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryGirl.create(:vm) }
+  let(:record) { FactoryBot.create(:vm) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#visible?' do
     subject { button.visible? }
     context 'when record.vendor == vmware' do
-      let(:record) { FactoryGirl.create(:vm_vmware) }
+      let(:record) { FactoryBot.create(:vm_vmware) }
       it_behaves_like 'vm_console_visible?', 'WebMKS', :vm_vmware => true
     end
     context 'when record.vendor != vmware' do
@@ -26,8 +26,8 @@ describe ApplicationHelper::Button::VmWebmksConsole do
     context 'when record.vendor == vmware (infra)' do
       let(:power_state) { 'on' }
       let(:api_version) { 6.5 }
-      let(:host) { FactoryGirl.create(:host_vmware_esx, :vmm_version => api_version) }
-      let(:record) { FactoryGirl.create(:vm_vmware, :host => host) }
+      let(:host) { FactoryBot.create(:host_vmware_esx, :vmm_version => api_version) }
+      let(:record) { FactoryBot.create(:vm_vmware, :host => host) }
 
       context 'and the power is on' do
         it_behaves_like 'vm_console_with_power_state_on_off',
@@ -58,8 +58,8 @@ describe ApplicationHelper::Button::VmWebmksConsole do
     context 'when record.vendor == vmware (cloud)' do
       let(:power_state) { 'on' }
       let(:api_version) { 5.5 }
-      let(:ems) { FactoryGirl.create(:ems_vmware_cloud, :api_version => api_version) }
-      let(:record) { FactoryGirl.create(:vm_vmware_cloud, :ext_management_system => ems) }
+      let(:ems) { FactoryBot.create(:ems_vmware_cloud, :api_version => api_version) }
+      let(:record) { FactoryBot.create(:vm_vmware_cloud, :ext_management_system => ems) }
 
       context 'and the power is on' do
         it_behaves_like 'vm_console_with_power_state_on_off',

--- a/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
+++ b/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
@@ -1,10 +1,10 @@
 describe ApplicationHelper::Button::WidgetGenerateContent do
   let(:view_context) { setup_view_context_with_sandbox(:wtype => wtype) }
   let(:record) do
-    rec = FactoryGirl.create(:miq_widget)
-    set = FactoryGirl.create(:miq_widget_set)
-    w_set_rel = FactoryGirl.create(:relationship_miq_widget_set_with_membership, :resource_id => set.id)
-    FactoryGirl.create(:relationship_miq_widget_with_membership, :resource_id => rec.id, :ancestry => w_set_rel.id)
+    rec = FactoryBot.create(:miq_widget)
+    set = FactoryBot.create(:miq_widget_set)
+    w_set_rel = FactoryBot.create(:relationship_miq_widget_set_with_membership, :resource_id => set.id)
+    FactoryBot.create(:relationship_miq_widget_with_membership, :resource_id => rec.id, :ancestry => w_set_rel.id)
     rec
   end
   let(:widget_running) { false }
@@ -23,7 +23,7 @@ describe ApplicationHelper::Button::WidgetGenerateContent do
 
   describe '#disabled?' do
     context 'when widget is not assigned to any dashboard' do
-      let(:record) { FactoryGirl.create(:miq_widget) }
+      let(:record) { FactoryBot.create(:miq_widget) }
       it { expect(subject.disabled?).to be_truthy }
     end
     context 'when widget is assigned to some dashboards' do

--- a/spec/helpers/application_helper/buttons/zone_collect_logs_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_collect_logs_spec.rb
@@ -1,8 +1,8 @@
 describe ApplicationHelper::Button::ZoneCollectLogs do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:file_depot) { FactoryGirl.create(:file_depot) }
-  let(:record) { FactoryGirl.create(:zone, :log_file_depot => file_depot) }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :status => server_status) }
+  let(:file_depot) { FactoryBot.create(:file_depot) }
+  let(:record) { FactoryBot.create(:zone, :log_file_depot => file_depot) }
+  let(:miq_server) { FactoryBot.create(:miq_server, :status => server_status) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   def tear_down
@@ -26,7 +26,7 @@ describe ApplicationHelper::Button::ZoneCollectLogs do
     context 'when some miq_servers are started' do
       let(:server_status) { 'started' }
       let(:setup_log_files) do
-        log_file = FactoryGirl.create(:log_file, :resource => record, :state => log_state)
+        log_file = FactoryBot.create(:log_file, :resource => record, :state => log_state)
         log_file.save
         miq_server.log_files << log_file
       end
@@ -42,7 +42,7 @@ describe ApplicationHelper::Button::ZoneCollectLogs do
 
           context 'and has an unfinished task' do
             let(:setup_tasks) do
-              task = FactoryGirl.create(:miq_task, :name => 'Zipped log retrieval for XXX', :miq_server_id => record.id)
+              task = FactoryBot.create(:miq_task, :name => 'Zipped log retrieval for XXX', :miq_server_id => record.id)
               task.save
             end
             it_behaves_like 'a disabled button',

--- a/spec/helpers/application_helper/buttons/zone_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_delete_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::ZoneDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:zone_name) { 'NotDefault' }
-  let(:selected_zone) { FactoryGirl.create(:zone, :name => zone_name) }
+  let(:selected_zone) { FactoryBot.create(:zone, :name => zone_name) }
   let(:button) { described_class.new(view_context, {}, {'selected_zone' => selected_zone}, {}) }
 
   describe '#calculate_properties' do
@@ -18,20 +18,20 @@ describe ApplicationHelper::Button::ZoneDelete do
 
     context 'when selected zone is not the default one' do
       context 'and zone has ext_management_systems' do
-        let(:set_relationships) { selected_zone.ext_management_systems << FactoryGirl.create(:ext_management_system) }
+        let(:set_relationships) { selected_zone.ext_management_systems << FactoryBot.create(:ext_management_system) }
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
 
       context 'and zone has miq_schedules' do
         let(:set_relationships) do
           EvmSpecHelper.local_guid_miq_server_zone
-          selected_zone.miq_schedules << FactoryGirl.create(:miq_schedule)
+          selected_zone.miq_schedules << FactoryBot.create(:miq_schedule)
         end
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
 
       context 'and zone has miq_servers' do
-        let(:set_relationships) { selected_zone.miq_servers << FactoryGirl.create(:miq_server) }
+        let(:set_relationships) { selected_zone.miq_servers << FactoryBot.create(:miq_server) }
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
 

--- a/spec/helpers/application_helper/title_spec.rb
+++ b/spec/helpers/application_helper/title_spec.rb
@@ -96,20 +96,20 @@ describe ApplicationHelper::Title do
 
   context "#title_for_hosts" do
     it "returns 'Hosts / Nodes' when there are both openstack & non-openstack hosts" do
-      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+      FactoryBot.create(:host_vmware_esx, :ext_management_system => FactoryBot.create(:ems_vmware))
+      FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
 
       expect(helper.title_for_hosts).to eq("Hosts / Nodes")
     end
 
     it "returns 'Hosts' when there are only non-openstack hosts" do
-      FactoryGirl.create(:host_vmware_esx, :ext_management_system => FactoryGirl.create(:ems_vmware))
+      FactoryBot.create(:host_vmware_esx, :ext_management_system => FactoryBot.create(:ems_vmware))
 
       expect(helper.title_for_hosts).to eq("Hosts")
     end
 
     it "returns 'Nodes' when there are only openstack hosts" do
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+      FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
 
       expect(helper.title_for_hosts).to eq("Nodes")
     end
@@ -117,13 +117,13 @@ describe ApplicationHelper::Title do
 
   context "#title_for_host" do
     it "returns 'Host' for non-openstack host" do
-      FactoryGirl.create(:host_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware))
+      FactoryBot.create(:host_vmware, :ext_management_system => FactoryBot.create(:ems_vmware))
 
       expect(helper.title_for_host).to eq("Host")
     end
 
     it "returns 'Node' for openstack host" do
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+      FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
 
       expect(helper.title_for_host).to eq("Node")
     end
@@ -131,27 +131,27 @@ describe ApplicationHelper::Title do
 
   context "#title_for_clusters" do
     before do
-      @ems1 = FactoryGirl.create(:ems_vmware)
-      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+      @ems1 = FactoryBot.create(:ems_vmware)
+      @ems2 = FactoryBot.create(:ems_openstack_infra)
     end
 
     it "returns 'Clusters / Deployment Roles' when there are both openstack & non-openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
 
       result = helper.title_for_clusters
       expect(result).to eq("Clusters / Deployment Roles")
     end
 
     it "returns 'Clusters' when there are only non-openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
 
       result = helper.title_for_clusters
       expect(result).to eq("Clusters")
     end
 
     it "returns 'Deployment Roles' when there are only openstack clusters" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
 
       result = helper.title_for_clusters
       expect(result).to eq("Deployment Roles")
@@ -160,19 +160,19 @@ describe ApplicationHelper::Title do
 
   context "#title_for_cluster" do
     before do
-      @ems1 = FactoryGirl.create(:ems_vmware)
-      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+      @ems1 = FactoryBot.create(:ems_vmware)
+      @ems2 = FactoryBot.create(:ems_openstack_infra)
     end
 
     it "returns 'Cluster' for non-openstack cluster" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
 
       result = helper.title_for_cluster
       expect(result).to eq("Cluster")
     end
 
     it "returns 'Deployment Role' for openstack cluster" do
-      FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+      FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
 
       result = helper.title_for_cluster
       expect(result).to eq("Deployment Role")

--- a/spec/helpers/application_helper/toolbar/ems_network_center_spec.rb
+++ b/spec/helpers/application_helper/toolbar/ems_network_center_spec.rb
@@ -6,8 +6,8 @@ describe ApplicationHelper::Toolbar::EmsNetworkCenter do
     let(:button_hash)   { ems_network_vmdb_choice[:items].detect { |b| b[:id] == 'ems_network_edit' } }
     let(:button_klass)  { button_hash[:klass] }
     let(:button)        { button_klass.new(nil, nil, {}, {}) }
-    let(:ems_nuage)     { FactoryGirl.create(:ems_nuage_network) }
-    let(:ems_openstack) { FactoryGirl.create(:ems_openstack) }
+    let(:ems_nuage)     { FactoryBot.create(:ems_nuage_network) }
+    let(:ems_openstack) { FactoryBot.create(:ems_openstack) }
 
     it 'appropriate button class' do
       expect(button_klass).to eq(ApplicationHelper::Button::EmsNetwork)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
   end
 
   describe "custom_buttons" do
-    let(:user) { FactoryGirl.create(:user, :role => "super_administrator") }
+    let(:user) { FactoryBot.create(:user, :role => "super_administrator") }
 
     shared_examples "no custom buttons" do
       it "#get_custom_buttons" do
@@ -39,9 +39,9 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       end
 
       before do
-        @button_set = FactoryGirl.create(:custom_button_set, :set_data => {:applies_to_class => applies_to_class, :button_icon => 'fa fa-cogs'})
+        @button_set = FactoryBot.create(:custom_button_set, :set_data => {:applies_to_class => applies_to_class, :button_icon => 'fa fa-cogs'})
         login_as user
-        @button1 = FactoryGirl.create(:custom_button, :applies_to_class => applies_to_class, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})
+        @button1 = FactoryBot.create(:custom_button, :applies_to_class => applies_to_class, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})
         add_button_to_set(@button_set, @button1)
       end
 
@@ -138,7 +138,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
     context "for VM" do
       let(:applies_to_class) { 'Vm' }
-      subject { FactoryGirl.create(:vm_vmware) }
+      subject { FactoryBot.create(:vm_vmware) }
 
       it_behaves_like "no custom buttons"
       it_behaves_like "with custom buttons"
@@ -146,8 +146,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
     context "for Service" do
       let(:applies_to_class) { 'ServiceTemplate' }
-      let(:service_template) { FactoryGirl.create(:service_template) }
-      subject                { FactoryGirl.create(:service, :service_template => service_template) }
+      let(:service_template) { FactoryBot.create(:service_template) }
+      subject                { FactoryBot.create(:service, :service_template => service_template) }
 
       it_behaves_like "no custom buttons"
       it_behaves_like "with custom buttons"
@@ -403,7 +403,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     end
 
     it "Enables edit and remove buttons for read-write orchestration templates" do
-      @record = FactoryGirl.create(:orchestration_template)
+      @record = FactoryBot.create(:orchestration_template)
       buttons = helper.build_toolbar('orchestration_template_center_tb').first[:items]
       edit_btn = buttons.find { |b| b[:id].end_with?("_edit") }
       remove_btn = buttons.find { |b| b[:id].end_with?("_remove") }
@@ -412,7 +412,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
     end
 
     it "Disables edit and remove buttons for read-only orchestration templates" do
-      @record = FactoryGirl.create(:orchestration_template_with_stacks)
+      @record = FactoryBot.create(:orchestration_template_with_stacks)
       buttons = helper.build_toolbar('orchestration_template_center_tb').first[:items]
       edit_btn = buttons.find { |b| b[:id].end_with?("_edit") }
       remove_btn = buttons.find { |b| b[:id].end_with?("_remove") }
@@ -434,8 +434,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       let(:toolbar_to_build) { 'generic_objects_center_tb' }
 
       before do
-        go_def = FactoryGirl.create(:generic_object_definition)
-        @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => go_def.id)
+        go_def = FactoryBot.create(:generic_object_definition)
+        @record = FactoryBot.create(:generic_object, :generic_object_definition_id => go_def.id)
         allow(Rbac).to receive(:role_allows?).and_return(true)
       end
 
@@ -467,7 +467,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       let(:toolbar_to_build) { 'generic_object_definitions_center_tb' }
 
       before do
-        @record = FactoryGirl.create(:generic_object_definition)
+        @record = FactoryBot.create(:generic_object_definition)
         allow(Rbac).to receive(:role_allows?).and_return(true)
       end
 

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -29,20 +29,20 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
 
       it "should return namespaces toolbar on domain node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
+        n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
         x_node_set("aen-#{n1.id}", :ae_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domain_center_tb")
       end
 
       it "should return namespace toolbar on namespace node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+        n1 = FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain))
         x_node_set("aen-#{n1.id}", :ae_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_namespace_center_tb")
       end
 
       it "should return tab specific toolbar on class node" do
-        n1 = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
-        c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+        n1 = FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain))
+        c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
         x_node_set("aec-#{c1.id}", :ae_tree)
 
         @sb[:active_tab] = "props"
@@ -68,7 +68,7 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
 
       it "should return storage toolbar on root node" do
-        c1 = FactoryGirl.create(:storage, :name => "foo")
+        c1 = FactoryBot.create(:storage, :name => "foo")
         x_node_set("ds-#{c1.id}", :storage_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_storage)).to eq("storage_center_tb")
       end
@@ -83,13 +83,13 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
 
       it "should return storages_center toolbar on a datastore cluster node" do
-        d1 = FactoryGirl.create(:storage_cluster, :name => "foo")
+        d1 = FactoryBot.create(:storage_cluster, :name => "foo")
         x_node_set("dsc-#{d1.id}", :storage_pod_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_storage)).to eq("storages_center_tb")
       end
 
       it "should return storage toolbar on datastore node" do
-        c1 = FactoryGirl.create(:storage, :name => "foo")
+        c1 = FactoryBot.create(:storage, :name => "foo")
         x_node_set("ds-#{c1.id}", :storage_pod_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_storage)).to eq("storage_center_tb")
       end
@@ -156,7 +156,7 @@ describe ApplicationHelper, "ToolbarChooser" do
 
   describe '#x_view_toolbar_filename' do
     before do
-      @record = FactoryGirl.create(:inventory_root_group)
+      @record = FactoryBot.create(:inventory_root_group)
     end
 
     context 'when the active tab is summary' do

--- a/spec/helpers/application_helper/views_shared_spec.rb
+++ b/spec/helpers/application_helper/views_shared_spec.rb
@@ -1,24 +1,24 @@
 describe ApplicationHelper do
   describe '#ownership_user_options' do
-    let(:child_tenant)                  { FactoryGirl.create(:tenant) }
-    let(:grand_child_tenant)            { FactoryGirl.create(:tenant, :parent => child_tenant) }
-    let(:great_grand_child_tenant)      { FactoryGirl.create(:tenant, :parent => grand_child_tenant) }
-    let(:child_role)                    { FactoryGirl.create(:miq_user_role) }
-    let(:grand_child_tenant_role)       { FactoryGirl.create(:miq_user_role) }
-    let(:great_grand_child_tenant_role) { FactoryGirl.create(:miq_user_role) }
-    let(:child_group)                   { FactoryGirl.create(:miq_group, :role => child_role, :tenant => child_tenant) }
+    let(:child_tenant)                  { FactoryBot.create(:tenant) }
+    let(:grand_child_tenant)            { FactoryBot.create(:tenant, :parent => child_tenant) }
+    let(:great_grand_child_tenant)      { FactoryBot.create(:tenant, :parent => grand_child_tenant) }
+    let(:child_role)                    { FactoryBot.create(:miq_user_role) }
+    let(:grand_child_tenant_role)       { FactoryBot.create(:miq_user_role) }
+    let(:great_grand_child_tenant_role) { FactoryBot.create(:miq_user_role) }
+    let(:child_group)                   { FactoryBot.create(:miq_group, :role => child_role, :tenant => child_tenant) }
     let(:grand_child_group) do
-      FactoryGirl.create(:miq_group, :role   => grand_child_tenant_role,
+      FactoryBot.create(:miq_group, :role   => grand_child_tenant_role,
                                      :tenant => grand_child_tenant)
     end
     let(:great_grand_child_group) do
-      FactoryGirl.create(:miq_group, :role   => great_grand_child_tenant_role,
+      FactoryBot.create(:miq_group, :role   => great_grand_child_tenant_role,
                                      :tenant => great_grand_child_tenant)
     end
-    let!(:admin_user)             { FactoryGirl.create(:user_admin) }
-    let!(:child_user)             { FactoryGirl.create(:user, :miq_groups => [child_group]) }
-    let!(:grand_child_user)       { FactoryGirl.create(:user, :miq_groups => [grand_child_group, great_grand_child_group]) }
-    let!(:great_grand_child_user) { FactoryGirl.create(:user, :miq_groups => [great_grand_child_group]) }
+    let!(:admin_user)             { FactoryBot.create(:user_admin) }
+    let!(:child_user)             { FactoryBot.create(:user, :miq_groups => [child_group]) }
+    let!(:grand_child_user)       { FactoryBot.create(:user, :miq_groups => [grand_child_group, great_grand_child_group]) }
+    let!(:great_grand_child_user) { FactoryBot.create(:user, :miq_groups => [great_grand_child_group]) }
 
     subject { helper.ownership_user_options }
     context 'admin user' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper do
   before do
-    login_as FactoryGirl.create(:user, :features => "none")
+    login_as FactoryBot.create(:user, :features => "none")
   end
 
   context "build_toolbar" do
@@ -40,7 +40,7 @@ describe ApplicationHelper do
     let(:features) { MiqProductFeature.find_all_by_identifier("everything") }
     before do
       EvmSpecHelper.seed_specific_product_features("miq_report", "service")
-      @user = login_as FactoryGirl.create(:user, :features => features)
+      @user = login_as FactoryBot.create(:user, :features => features)
     end
 
     context "permission store" do
@@ -81,7 +81,7 @@ describe ApplicationHelper do
         end
 
         it "and not entitled" do
-          login_as FactoryGirl.create(:user, :features => "service")
+          login_as FactoryBot.create(:user, :features => "service")
           expect(helper.role_allows?(:feature => "miq_report", :any => true)).to be_falsey
         end
       end
@@ -92,7 +92,7 @@ describe ApplicationHelper do
         end
 
         it "and not entitled" do
-          login_as FactoryGirl.create(:user, :features => "service")
+          login_as FactoryBot.create(:user, :features => "service")
           expect(helper.role_allows?(:feature => "miq_report")).to be_falsey
         end
       end
@@ -130,7 +130,7 @@ describe ApplicationHelper do
     subject { helper.model_to_controller(@record) }
 
     it "when with any record" do
-      @record = FactoryGirl.create(:vm_vmware)
+      @record = FactoryBot.create(:vm_vmware)
       expect(subject).to eq(@record.class.base_model.name.underscore)
     end
 
@@ -141,12 +141,12 @@ describe ApplicationHelper do
 
   describe "#object_types_for_flash_message" do
     before do
-      @record_1 = FactoryGirl.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Vm.name,       :template => false)
-      @record_2 = FactoryGirl.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Vm.name,       :template => false)
-      @record_3 = FactoryGirl.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Template.name, :template => true)
-      @record_4 = FactoryGirl.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Template.name, :template => true)
-      @record_5 = FactoryGirl.create(:vm_redhat,    :type => ManageIQ::Providers::Redhat::InfraManager::Vm.name)
-      @record_6 = FactoryGirl.create(:vm_vmware,    :type => ManageIQ::Providers::Vmware::InfraManager::Vm.name)
+      @record_1 = FactoryBot.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Vm.name,       :template => false)
+      @record_2 = FactoryBot.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Vm.name,       :template => false)
+      @record_3 = FactoryBot.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Template.name, :template => true)
+      @record_4 = FactoryBot.create(:vm_openstack, :type => ManageIQ::Providers::Openstack::CloudManager::Template.name, :template => true)
+      @record_5 = FactoryBot.create(:vm_redhat,    :type => ManageIQ::Providers::Redhat::InfraManager::Vm.name)
+      @record_6 = FactoryBot.create(:vm_vmware,    :type => ManageIQ::Providers::Vmware::InfraManager::Vm.name)
     end
 
     context "when formatting flash message for VM or Templates class" do
@@ -231,7 +231,7 @@ describe ApplicationHelper do
     end
 
     it "when record is not VmOrTemplate" do
-      @record = FactoryGirl.create(:host)
+      @record = FactoryBot.create(:host)
       expect(subject).to eq(helper.url_for_db(@record.class.base_class.to_s, @action))
     end
   end
@@ -244,7 +244,7 @@ describe ApplicationHelper do
 
     context "when with @vm" do
       before do
-        @vm = FactoryGirl.create(:vm_vmware)
+        @vm = FactoryBot.create(:vm_vmware)
       end
 
       ["Account", "User", "Group", "Patch", "GuestApplication"].each do |d|
@@ -267,7 +267,7 @@ describe ApplicationHelper do
 
     context "when with @host" do
       before do
-        @host = FactoryGirl.create(:host)
+        @host = FactoryBot.create(:host)
         @lastaction = "list"
       end
 
@@ -934,7 +934,7 @@ describe ApplicationHelper do
     end
 
     it "uses restful paths for pages" do
-      @record = FactoryGirl.create(:ems_cloud, :zone => zone)
+      @record = FactoryBot.create(:ems_cloud, :zone => zone)
       get "/ems_cloud/#{@record.id}", :params => { :display => 'images' }
 
       expect(helper.update_paging_url_parms("show", :page => 2)).to eq("/ems_cloud/#{@record.id}?display=images&page=2")
@@ -943,19 +943,19 @@ describe ApplicationHelper do
 
   context "#title_for_cluster_record" do
     before do
-      @ems1 = FactoryGirl.create(:ems_vmware)
-      @ems2 = FactoryGirl.create(:ems_openstack_infra)
+      @ems1 = FactoryBot.create(:ems_vmware)
+      @ems2 = FactoryBot.create(:ems_openstack_infra)
     end
 
     it "returns 'Cluster' for non-openstack host" do
-      cluster = FactoryGirl.create(:ems_cluster, :ems_id => @ems1.id)
+      cluster = FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
 
       result = helper.title_for_cluster_record(cluster)
       expect(result).to eq("Cluster")
     end
 
     it "returns 'Deployment Role' for openstack host" do
-      cluster = FactoryGirl.create(:ems_cluster, :ems_id => @ems2.id)
+      cluster = FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
 
       result = helper.title_for_cluster_record(cluster)
       expect(result).to eq("Deployment Role")
@@ -964,13 +964,13 @@ describe ApplicationHelper do
 
   context "#title_for_host_record" do
     it "returns 'Host' for non-openstack host" do
-      host = FactoryGirl.create(:host_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware))
+      host = FactoryBot.create(:host_vmware, :ext_management_system => FactoryBot.create(:ems_vmware))
 
       expect(helper.title_for_host_record(host)).to eq("Host")
     end
 
     it "returns 'Node' for openstack host" do
-      host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra))
+      host = FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
 
       expect(helper.title_for_host_record(host)).to eq("Node")
     end
@@ -1203,7 +1203,7 @@ describe ApplicationHelper do
       let(:args) do
         {:if         => true,
          :controller => 'availability_zone',
-         :record     => FactoryGirl.create(:availability_zone),
+         :record     => FactoryBot.create(:availability_zone),
          :action     => 'show_list',
          :display    => 'something',
          :title      => 'sometitle'}
@@ -1224,7 +1224,7 @@ describe ApplicationHelper do
       let(:args) do
         {:if         => true,
          :controller => 'availability_zone',
-         :record_id  => FactoryGirl.create(:availability_zone).id,
+         :record_id  => FactoryBot.create(:availability_zone).id,
          :action     => 'show_list',
          :display    => 'something',
          :title      => 'sometitle'}
@@ -1269,7 +1269,7 @@ describe ApplicationHelper do
     context "When record is a Container Provider" do
       it "Uses polymorphic_path for the show action" do
         stub_user(:features => :all)
-        ems = FactoryGirl.create(:ems_kubernetes)
+        ems = FactoryBot.create(:ems_kubernetes)
         ContainerProject.create(:ext_management_system => ems, :name => "Test Project")
         expect(helper.multiple_relationship_link(ems, "container_project")).to eq("<li><a title=\"Show Projects\" href=\"/ems_container/#{ems.id}?display=container_projects\">Projects (1)</a></li>")
       end

--- a/spec/helpers/catalog_helper/textual_summary_spec.rb
+++ b/spec/helpers/catalog_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe CatalogHelper::TextualSummary do
   context '#textual_tags without tags' do
     before do
-      @record = FactoryGirl.create(:orchestration_template)
+      @record = FactoryBot.create(:orchestration_template)
       session[:customer_name] = 'RspecName'
     end
     it 'returns Hash if no tags found' do
@@ -13,9 +13,9 @@ describe CatalogHelper::TextualSummary do
   end
   context '#textual_tags with tags' do
     before do
-      @record = FactoryGirl.create(:orchestration_template)
-      parent = FactoryGirl.create(:classification, :description => 'Label')
-      value = FactoryGirl.create(:classification, :description => 'Value', :parent_id => parent.id)
+      @record = FactoryBot.create(:orchestration_template)
+      parent = FactoryBot.create(:classification, :description => 'Label')
+      value = FactoryBot.create(:classification, :description => 'Value', :parent_id => parent.id)
       tag = Tag.find_by(:id => value[:tag_id])
       tag[:name] = '/managed/description/name'
       tag.save!

--- a/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe CloudTenantHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:cloud_tenant))
+    instance_variable_set(:@record, FactoryBot.create(:cloud_tenant))
     allow(@record).to receive_message_chain(:cloud_resource_quotas, :order).and_return([])
     allow(self).to receive(:textual_authentications).and_return([])
   end

--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -2,10 +2,10 @@ describe ComplianceSummaryHelper do
   include ApplicationHelper
 
   before do
-    server  = FactoryGirl.build(:miq_server, :id => 0)
-    @record = FactoryGirl.build(:vm_vmware, :miq_server => server)
-    @compliance1 = FactoryGirl.build(:compliance)
-    @compliance2 = FactoryGirl.build(:compliance)
+    server  = FactoryBot.build(:miq_server, :id => 0)
+    @record = FactoryBot.build(:vm_vmware, :miq_server => server)
+    @compliance1 = FactoryBot.build(:compliance)
+    @compliance2 = FactoryBot.build(:compliance)
     allow(self).to receive(:role_allows?).and_return(true)
   end
 

--- a/spec/helpers/configuration_job_helper/textual_summary_spec.rb
+++ b/spec/helpers/configuration_job_helper/textual_summary_spec.rb
@@ -2,11 +2,11 @@ describe ConfigurationJobHelper::TextualSummary do
   include ApplicationHelper
 
   let(:zone) { EvmSpecHelper.local_miq_server.zone }
-  let(:automation_provider) { FactoryGirl.create(:provider_ansible_tower, :name => "ansibletest", :url => "test", :zone => zone) }
+  let(:automation_provider) { FactoryBot.create(:provider_ansible_tower, :name => "ansibletest", :url => "test", :zone => zone) }
 
   it "#textual_provider" do
     manager = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider.id)
-    @record = FactoryGirl.create(:ansible_tower_job, :ext_management_system => manager)
+    @record = FactoryBot.create(:ansible_tower_job, :ext_management_system => manager)
     expect(textual_provider[:image]).to eq("svg/vendor-ansible.svg")
     expect(textual_provider[:link]).to eq("/automation_manager/explorer/at-#{manager.id}?accordion=automation_manager_providers")
   end

--- a/spec/helpers/container_summary_helper_spec.rb
+++ b/spec/helpers/container_summary_helper_spec.rb
@@ -1,12 +1,12 @@
 describe ContainerSummaryHelper do
-  let(:container_project)     { FactoryGirl.create(:container_project) }
+  let(:container_project)     { FactoryBot.create(:container_project) }
   let(:rel_hash_with_link)    { %i(label value link title) }
   let(:rel_hash_without_link) { %i(label value) }
 
   before do
     self.class.send(:include, ApplicationHelper)
 
-    @record = FactoryGirl.build(:container_group, :container_project => container_project)
+    @record = FactoryBot.build(:container_group, :container_project => container_project)
   end
 
   context ".textual_container_project" do
@@ -26,7 +26,7 @@ describe ContainerSummaryHelper do
   end
 
   context ".textual_containers" do
-    before  { 2.times { FactoryGirl.create(:container, :container_group => @record) } }
+    before  { 2.times { FactoryBot.create(:container, :container_group => @record) } }
     subject { textual_containers }
 
     it 'show link when role allows' do

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -1,33 +1,33 @@
 describe EmsCloudHelper::TextualSummary do
   context "#textual_instances and #textual_images" do
     before do
-      @record = FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.build(:zone))
+      @record = FactoryBot.create(:ems_openstack, :zone => FactoryBot.build(:zone))
       allow(self).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_cloud")
     end
 
     it "sets restful path for instances in summary for restful controllers" do
-      FactoryGirl.create(:vm_openstack, :ems_id => @record.id)
+      FactoryBot.create(:vm_openstack, :ems_id => @record.id)
 
       expect(textual_instances[:link]).to eq("/ems_cloud/#{@record.id}?display=instances")
     end
 
     it "sets restful path for images in summary for restful controllers" do
-      FactoryGirl.create(:template_cloud, :ems_id => @record.id)
+      FactoryBot.create(:template_cloud, :ems_id => @record.id)
 
       expect(textual_images[:link]).to eq("/ems_cloud/#{@record.id}?display=images")
     end
 
     it "sets correct path for security_groups on summary screen" do
-      FactoryGirl.create(:security_group, :name => "sq_1", :ext_management_system => @record.network_manager)
+      FactoryBot.create(:security_group, :name => "sq_1", :ext_management_system => @record.network_manager)
       expect(textual_security_groups[:link]).to eq("/ems_cloud/#{@record.id}?display=security_groups")
     end
   end
 
   context "#textual_groups" do
     before do
-      instance_variable_set(:@record, FactoryGirl.create(:ems_cloud))
+      instance_variable_set(:@record, FactoryBot.create(:ems_cloud))
       allow(self).to receive(:textual_authentications).and_return([])
       allow(@record).to receive(:authentication_for_summary).and_return([])
     end
@@ -54,7 +54,7 @@ describe EmsCloudHelper::TextualSummary do
   end
 
   describe '#textual_description' do
-    let(:ems) { FactoryGirl.create(:ems_cloud) }
+    let(:ems) { FactoryBot.create(:ems_cloud) }
 
     before do
       instance_variable_set(:@record, ems)

--- a/spec/helpers/ems_cluster_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cluster_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsClusterHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:ems_cluster))
+    instance_variable_set(:@record, FactoryBot.create(:ems_cluster))
     allow(@record).to receive(:ha_enabled).and_return("something")
     allow(@record).to receive(:ha_admit_control).and_return("something")
     allow(@record).to receive(:drs_enabled).and_return("something")

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -1,14 +1,14 @@
 describe EmsContainerHelper::TextualSummary do
   context "providers custom attributes" do
     before do
-      @record = FactoryGirl.build(:ems_openshift)
+      @record = FactoryBot.build(:ems_openshift)
       allow(self).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_container")
     end
 
     it "should parse custom attributes to labels and values" do
-      @record.custom_attributes << FactoryGirl.build(:custom_attribute,
+      @record.custom_attributes << FactoryBot.build(:custom_attribute,
                                                      :name  => "Example_custom_attribute",
                                                      :value => 4)
 

--- a/spec/helpers/ems_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_infra_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsInfraHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
     allow(self).to receive(:textual_authentications).and_return([])
   end
 

--- a/spec/helpers/ems_network_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_network_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsNetworkHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
     allow(self).to receive(:textual_authentications).and_return([])
   end
 

--- a/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsPhysicalInfraHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
     allow(@record).to receive(:authentication_userid_passwords).and_return([])
     allow(self).to receive(:textual_authentications).and_return([])
   end

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsStorageHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
     allow(self).to receive(:textual_authentications).and_return([])
   end
 

--- a/spec/helpers/generic_object_helper/textual_summary_spec.rb
+++ b/spec/helpers/generic_object_helper/textual_summary_spec.rb
@@ -2,8 +2,8 @@ describe GenericObjectHelper::TextualSummary do
   context "Textual Properties for GO instances" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      login_as FactoryGirl.create(:user)
-      @generic_obj_defn = FactoryGirl.create(
+      login_as FactoryBot.create(:user)
+      @generic_obj_defn = FactoryBot.create(
         :generic_object_definition,
         :name       => "test_definition",
         :properties => {
@@ -18,11 +18,11 @@ describe GenericObjectHelper::TextualSummary do
           :methods      => %w(some_method)
         }
       )
-      @generic_obj_defn_with_no_properties = FactoryGirl.create(:generic_object_definition)
+      @generic_obj_defn_with_no_properties = FactoryBot.create(:generic_object_definition)
     end
 
     it "displays the GO Attributes in the name/value format when Attributes exist" do
-      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id, :flag => true)
+      @record = FactoryBot.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id, :flag => true)
 
       expected = TextualMultilabel.new(
         "Attributes",
@@ -35,7 +35,7 @@ describe GenericObjectHelper::TextualSummary do
     end
 
     it "displays 'No Attributes defined' when Attributes do not exist" do
-      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
+      @record = FactoryBot.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
 
       expected = TextualEmpty.new('Attributes', 'No Attributes defined')
 
@@ -43,10 +43,10 @@ describe GenericObjectHelper::TextualSummary do
     end
 
     it "displays the GO Associations when Associations exist" do
-      vm1 = FactoryGirl.create(:vm_vmware)
-      vm2 = FactoryGirl.create(:vm_openstack)
-      ems = FactoryGirl.create(:ems_cloud)
-      @record = FactoryGirl.create(:generic_object,
+      vm1 = FactoryBot.create(:vm_vmware)
+      vm2 = FactoryBot.create(:vm_openstack)
+      ems = FactoryBot.create(:ems_cloud)
+      @record = FactoryBot.create(:generic_object,
                                    :generic_object_definition_id => @generic_obj_defn.id,
                                    :cp                           => [ems],
                                    :vms                          => [vm1, vm2])
@@ -57,7 +57,7 @@ describe GenericObjectHelper::TextualSummary do
     end
 
     it "displays 'No Associations defined' when do not Associations exist" do
-      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
+      @record = FactoryBot.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
 
       expected = TextualEmpty.new('Associations', 'No Associations defined')
 
@@ -65,7 +65,7 @@ describe GenericObjectHelper::TextualSummary do
     end
 
     it "displays the GO Methods when Methods exist" do
-      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
+      @record = FactoryBot.create(:generic_object, :generic_object_definition_id => @generic_obj_defn.id)
 
       expected = TextualGroup.new("Methods", %i(some_method))
 
@@ -73,7 +73,7 @@ describe GenericObjectHelper::TextualSummary do
     end
 
     it "displays 'No Methods defined' when do not Methods exist" do
-      @record = FactoryGirl.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
+      @record = FactoryBot.create(:generic_object, :generic_object_definition_id => @generic_obj_defn_with_no_properties.id)
 
       expected = TextualEmpty.new('Methods', 'No Methods defined')
 

--- a/spec/helpers/host_helper/textual_summary_spec.rb
+++ b/spec/helpers/host_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe HostHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:host_openstack_infra,
+    instance_variable_set(:@record, FactoryBot.create(:host_openstack_infra,
                                                        :type => ManageIQ::Providers::Openstack::InfraManager::Host))
     allow(self).to receive(:textual_authentications).and_return([])
     allow(::Settings).to receive_message_chain(:product, :proto).and_return("")

--- a/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
+++ b/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
@@ -1,5 +1,5 @@
 describe OrchestrationStackHelper::TextualSummary do
-  before { @record = FactoryGirl.build(:orchestration_stack) }
+  before { @record = FactoryBot.build(:orchestration_stack) }
 
   it "#textual_group_lifecycle includes retirement_date" do
     expect(textual_group_lifecycle.items).to eq(%i(retirement_date))

--- a/spec/helpers/persistent_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/persistent_volume_helper/textual_summary_spec.rb
@@ -1,10 +1,10 @@
 describe PersistentVolumeHelper::TextualSummary do
   describe ".textual_group_properties" do
     before do
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
     end
 
-    let(:ems) { FactoryGirl.create(:ems_openshift) }
+    let(:ems) { FactoryBot.create(:ems_openshift) }
     subject { textual_group_properties }
     it 'produces capacity data in the correct format' do
       @record = PersistentVolume.create(:parent => ems, :name => 'Test Volume', :capacity => {:storage => 123_456_789, :foo => 'something'})
@@ -14,10 +14,10 @@ describe PersistentVolumeHelper::TextualSummary do
 
   describe ".textual_group_capacity" do
     before do
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
     end
 
-    let(:ems) { FactoryGirl.create(:ems_openshift) }
+    let(:ems) { FactoryBot.create(:ems_openshift) }
     subject { textual_group_capacity }
     it 'produces capacity data in the correct format' do
       @record = PersistentVolume.create(:parent => ems, :name => 'Test Volume', :capacity => {:storage => 123_456_789, :foo => 'something'})
@@ -29,7 +29,7 @@ describe PersistentVolumeHelper::TextualSummary do
 
   context "#textual_groups" do
     before do
-      instance_variable_set(:@record, FactoryGirl.create(:persistent_volume))
+      instance_variable_set(:@record, FactoryBot.create(:persistent_volume))
       allow(@record).to receive(:persistent_volume_claim).and_return(true)
     end
 

--- a/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe PhysicalChassisHelper::TextualSummary do
   include ApplicationHelper
 
   let(:ems) do
-    FactoryGirl.create(:physical_infra,
+    FactoryBot.create(:physical_infra,
                        :name      => 'LXCA',
                        :hostname  => 'my.physicalinfra.com',
                        :port      => '443',
@@ -10,7 +10,7 @@ describe PhysicalChassisHelper::TextualSummary do
   end
 
   let(:asset_detail) do
-    FactoryGirl.create(:asset_detail,
+    FactoryBot.create(:asset_detail,
                        :product_name       => 'Lenovo XYZ Chassis x1000',
                        :manufacturer       => 'Lenovo',
                        :serial_number      => 'A1B2C3D4E5F6',
@@ -20,43 +20,43 @@ describe PhysicalChassisHelper::TextualSummary do
   end
 
   let(:network) do
-    FactoryGirl.build(:network, :ipaddress => '192.168.1.1')
+    FactoryBot.build(:network, :ipaddress => '192.168.1.1')
   end
 
   let(:guest_device) do
-    FactoryGirl.build(:guest_device,
+    FactoryBot.build(:guest_device,
                       :device_type => 'management',
                       :network     => network)
   end
 
   let(:hardware) do
-    FactoryGirl.build(:hardware, :guest_devices => [guest_device])
+    FactoryBot.build(:hardware, :guest_devices => [guest_device])
   end
 
   let(:computer_system) do
-    FactoryGirl.build(:computer_system, :hardware => hardware)
+    FactoryBot.build(:computer_system, :hardware => hardware)
   end
 
   let(:physical_rack) do
-    FactoryGirl.create(:physical_rack, :name => 'Rack XYZ')
+    FactoryBot.create(:physical_rack, :name => 'Rack XYZ')
   end
 
   let(:physical_servers) do
     [
-      FactoryGirl.create(:physical_server, :name => 'Physical Server I'),
-      FactoryGirl.create(:physical_server, :name => 'Physical Server J'),
-      FactoryGirl.create(:physical_server, :name => 'Physical Server K')
+      FactoryBot.create(:physical_server, :name => 'Physical Server I'),
+      FactoryBot.create(:physical_server, :name => 'Physical Server J'),
+      FactoryBot.create(:physical_server, :name => 'Physical Server K')
     ]
   end
 
   let(:physical_storages) do
     [
-      FactoryGirl.create(:physical_storage, :name => 'Physical Storage A')
+      FactoryBot.create(:physical_storage, :name => 'Physical Storage A')
     ]
   end
 
   let(:physical_chassis) do
-    FactoryGirl.create(:physical_chassis,
+    FactoryBot.create(:physical_chassis,
                        :ems_id                       => ems.id,
                        :uid_ems                      => 'NVH20GH0T4HN268902G6Y2N-G28Y8YWG',
                        :name                         => 'Chassis ABC',

--- a/spec/helpers/physical_server_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_server_helper/textual_summary_spec.rb
@@ -1,10 +1,10 @@
 describe PhysicalServerHelper::TextualSummary do
   it "#textual_ipv4" do
-    network = FactoryGirl.build(:network, :ipaddress => "192.168.1.1")
-    guest_device = FactoryGirl.build(:guest_device, :network => network)
-    hardware = FactoryGirl.build(:hardware, :guest_devices => [guest_device])
-    computer_system = FactoryGirl.build(:computer_system, :hardware => hardware)
-    @record = FactoryGirl.build(:physical_server, :computer_system => computer_system)
+    network = FactoryBot.build(:network, :ipaddress => "192.168.1.1")
+    guest_device = FactoryBot.build(:guest_device, :network => network)
+    hardware = FactoryBot.build(:hardware, :guest_devices => [guest_device])
+    computer_system = FactoryBot.build(:computer_system, :hardware => hardware)
+    @record = FactoryBot.build(:physical_server, :computer_system => computer_system)
 
     result = helper.textual_ipv4
     expect(result[:label]).to eq("IPv4 Address")

--- a/spec/helpers/physical_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_storage_helper/textual_summary_spec.rb
@@ -2,7 +2,7 @@ describe PhysicalStorageHelper::TextualSummary do
   include ApplicationHelper
 
   let(:ems) do
-    FactoryGirl.create(:physical_infra,
+    FactoryBot.create(:physical_infra,
                        :name      => 'LXCA',
                        :hostname  => 'my.physicalinfra.com',
                        :port      => '443',
@@ -10,7 +10,7 @@ describe PhysicalStorageHelper::TextualSummary do
   end
 
   let(:asset_detail) do
-    FactoryGirl.create(:asset_detail,
+    FactoryBot.create(:asset_detail,
                        :machine_type     => '6411',
                        :model            => 'S2200',
                        :contact          => 'Jonas Arioli',
@@ -25,11 +25,11 @@ describe PhysicalStorageHelper::TextualSummary do
   end
 
   let(:physical_rack) do
-    FactoryGirl.create(:physical_rack, :name => 'Rack XYZ')
+    FactoryBot.create(:physical_rack, :name => 'Rack XYZ')
   end
 
   let(:physical_storage) do
-    FactoryGirl.create(:physical_storage,
+    FactoryBot.create(:physical_storage,
                        :ems_id               => ems.id,
                        :uid_ems              => '208000C0FF2647DA',
                        :name                 => 'S2200-Test',

--- a/spec/helpers/provider_foreman_helper_spec.rb
+++ b/spec/helpers/provider_foreman_helper_spec.rb
@@ -1,6 +1,6 @@
 describe ProviderForemanHelper do
   before do
-    @record = FactoryGirl.create(:ansible_configuration_script,
+    @record = FactoryBot.create(:ansible_configuration_script,
                                  :name        => "ConfigScript1",
                                  :survey_spec => {'spec' => [{'index' => 0, 'question_description' => 'Survey',
                                                               'min' => nil, 'default' => nil, 'max' => nil,
@@ -8,7 +8,7 @@ describe ProviderForemanHelper do
                                                               'variable' => 'test', 'choices' => nil,
                                                               'type' => 'text'}]})
 
-    login_as @user = FactoryGirl.create(:user)
+    login_as @user = FactoryBot.create(:user)
   end
 
   context ".textual_configuration_script_survey" do

--- a/spec/helpers/report_helper/editor_spec.rb
+++ b/spec/helpers/report_helper/editor_spec.rb
@@ -1,9 +1,9 @@
 describe ReportHelper do
   describe '#cb_entities_by_provider_id' do
-    let(:project) { FactoryGirl.create(:container_project) }
-    let(:image) { FactoryGirl.create(:container_image) }
+    let(:project) { FactoryBot.create(:container_project) }
+    let(:image) { FactoryBot.create(:container_image) }
     let(:provider) do
-      FactoryGirl.build(:ems_container).tap do |e|
+      FactoryBot.build(:ems_container).tap do |e|
         e.container_projects = [project]
         e.container_images = [image]
         e.save!

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,6 +1,6 @@
 def create_user_with_group(user_id, group_name, role)
-  group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => group_name)
-  FactoryGirl.create(:user, :userid => user_id, :miq_groups => [group])
+  group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => group_name)
+  FactoryBot.create(:user, :userid => user_id, :miq_groups => [group])
 end
 
 def create_and_generate_report_for_user(report_name, user_id)

--- a/spec/helpers/security_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/security_group_helper/textual_summary_spec.rb
@@ -1,16 +1,16 @@
 describe SecurityGroupHelper::TextualSummary do
   describe ".textual_group_firewall" do
     before do
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
     end
 
     subject { textual_group_firewall }
     it 'returns TextualTable struct with list of of firewall rules' do
       firewall_rules = [
-        FactoryGirl.create(:firewall_rule, :name => "Foo", :display_name => "Foo", :port => 1234),
-        FactoryGirl.create(:firewall_rule, :name => "Foo", :display_name => "Foo")
+        FactoryBot.create(:firewall_rule, :name => "Foo", :display_name => "Foo", :port => 1234),
+        FactoryBot.create(:firewall_rule, :name => "Foo", :display_name => "Foo")
       ]
-      @record = FactoryGirl.create(:security_group_with_firewall_rules, :firewall_rules => firewall_rules)
+      @record = FactoryBot.create(:security_group_with_firewall_rules, :firewall_rules => firewall_rules)
       expect(subject).to be_kind_of(Struct)
     end
   end

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -1,39 +1,39 @@
 describe ServiceHelper::TextualSummary do
   describe ".textual_orchestration_stack" do
-    let(:os_cloud) { FactoryGirl.create(:orchestration_stack_cloud, :name => "cloudstack1") }
-    let(:os_infra) { FactoryGirl.create(:orchestration_stack_openstack_infra, :name => "infrastack1") }
+    let(:os_cloud) { FactoryBot.create(:orchestration_stack_cloud, :name => "cloudstack1") }
+    let(:os_infra) { FactoryBot.create(:orchestration_stack_openstack_infra, :name => "infrastack1") }
 
     before do
-      login_as FactoryGirl.create(:user)
+      login_as FactoryBot.create(:user)
     end
 
     subject { textual_orchestration_stack }
     it 'contains the link to the associated cloud stack' do
-      @record = FactoryGirl.create(:service)
+      @record = FactoryBot.create(:service)
       allow(@record).to receive(:orchestration_stack).and_return(os_cloud)
       expect(textual_orchestration_stack).to eq(os_cloud)
     end
 
     it 'contains the link to the associated infra stack' do
-      @record = FactoryGirl.create(:service)
+      @record = FactoryBot.create(:service)
       allow(@record).to receive(:orchestration_stack).and_return(os_infra)
       expect(textual_orchestration_stack).to eq(os_infra)
     end
 
     it 'contains no link for an invalid stack' do
       os_infra.id = nil
-      @record = FactoryGirl.create(:service)
+      @record = FactoryBot.create(:service)
       allow(@record).to receive(:orchestration_stack).and_return(os_infra)
       expect(textual_orchestration_stack[:link]).to be_nil
     end
   end
 
   describe ".textual_agregate_all_vms" do
-    let(:vm) { FactoryGirl.create(:vm_vmwware, :name => "vm1") }
+    let(:vm) { FactoryBot.create(:vm_vmwware, :name => "vm1") }
 
     before do
-      login_as FactoryGirl.create(:user)
-      @record = FactoryGirl.create(:service)
+      login_as FactoryBot.create(:user)
+      @record = FactoryBot.create(:service)
     end
 
     subject { textual_aggregate_all_vm_cpus }
@@ -76,9 +76,9 @@ describe ServiceHelper::TextualSummary do
   describe ".textual_cloud_credential" do
     subject { textual_cloud_credential }
     it 'displays only cloud credentials if available' do
-      @job = FactoryGirl.create(:embedded_ansible_job)
-      machine_credential = FactoryGirl.create(:embedded_ansible_machine_credential)
-      cloud_credential = FactoryGirl.create(:embedded_ansible_amazon_credential)
+      @job = FactoryBot.create(:embedded_ansible_job)
+      machine_credential = FactoryBot.create(:embedded_ansible_machine_credential)
+      cloud_credential = FactoryBot.create(:embedded_ansible_amazon_credential)
       allow(@job).to receive(:authentications).and_return([cloud_credential, machine_credential])
       allow(self).to receive(:url_for_only_path).and_return('link')
       expect(textual_cloud_credential).to eq(:label => "Cloud", :value => nil, :title => "Credential (Amazon)", :link => "link")
@@ -88,8 +88,8 @@ describe ServiceHelper::TextualSummary do
   describe ".textual_vault_credential" do
     subject { textual_vault_credential }
     it 'displays only vault credentials if available' do
-      @job = FactoryGirl.create(:embedded_ansible_job)
-      vault_credential = FactoryGirl.create(:embedded_ansible_vault_credential)
+      @job = FactoryBot.create(:embedded_ansible_job)
+      vault_credential = FactoryBot.create(:embedded_ansible_vault_credential)
       allow(@job).to receive(:authentications).and_return(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential.where(:id => vault_credential.id))
       allow(self).to receive(:url_for_only_path).and_return('link')
       expect(textual_vault_credential).to eq(:label => "Vault", :value => nil, :title => "Credential (Vault)", :link => "link")

--- a/spec/helpers/storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/storage_helper/textual_summary_spec.rb
@@ -22,7 +22,7 @@ describe StorageHelper do
   describe '#textual methods' do
     context 'for zero VMs' do
       before do
-        @record = FactoryGirl.create(:storage)
+        @record = FactoryBot.create(:storage)
       end
 
       it 'returns correct Hash' do
@@ -45,7 +45,7 @@ describe StorageHelper do
 
     context 'for any number of VMs' do
       before do
-        @record = FactoryGirl.create(:storage)
+        @record = FactoryBot.create(:storage)
         allow(self).to receive(:role_allows?).and_return(true)
         allow(self).to receive(:url_for_only_path).and_return('link')
       end

--- a/spec/helpers/textual_mixins/textual_devices_spec.rb
+++ b/spec/helpers/textual_mixins/textual_devices_spec.rb
@@ -1,5 +1,5 @@
 describe TextualMixins::TextualDevices do
-  let(:host) { FactoryGirl.create(:host, :hardware => hw) }
+  let(:host) { FactoryBot.create(:host, :hardware => hw) }
   before do
     assign(:record, host)
   end
@@ -13,7 +13,7 @@ describe TextualMixins::TextualDevices do
     end
 
     context "with a hardware" do
-      let(:hw) { FactoryGirl.create(:hardware, :cpu1x1, :ram1GB) }
+      let(:hw) { FactoryBot.create(:hardware, :cpu1x1, :ram1GB) }
       it { is_expected.not_to be_empty }
     end
   end
@@ -22,14 +22,14 @@ describe TextualMixins::TextualDevices do
     subject { helper.disks_attributes }
 
     context "without hdd hardware" do
-      let(:hw) { FactoryGirl.create(:hardware, :cpu1x1, :ram1GB) }
+      let(:hw) { FactoryBot.create(:hardware, :cpu1x1, :ram1GB) }
       it { is_expected.to be_empty }
     end
 
     context "with hdd hardware" do
       let(:hw) do
-        FactoryGirl.create(:hardware,
-                           :disks => [FactoryGirl.create(:disk,
+        FactoryBot.create(:hardware,
+                           :disks => [FactoryBot.create(:disk,
                                                          :device_type     => "disk",
                                                          :device_name     => "HD01",
                                                          :controller_type => "scsi")])
@@ -39,8 +39,8 @@ describe TextualMixins::TextualDevices do
 
     context "with hdd with no size_on_disk collected (AZURE)" do
       let(:hw) do
-        FactoryGirl.create(:hardware,
-                           :disks => [FactoryGirl.create(:disk,
+        FactoryBot.create(:hardware,
+                           :disks => [FactoryBot.create(:disk,
                                                          :device_type     => "disk",
                                                          :device_name     => "HD01",
                                                          :size            => "1072693248",
@@ -52,8 +52,8 @@ describe TextualMixins::TextualDevices do
 
     context "with hdd with size_on_disk and percent provisioned collected (AZURE)" do
       let(:hw) do
-        FactoryGirl.create(:hardware,
-                           :disks => [FactoryGirl.create(:disk,
+        FactoryBot.create(:hardware,
+                           :disks => [FactoryBot.create(:disk,
                                                          :device_type     => "disk",
                                                          :device_name     => "CLIA566D60F38FB9ECC",
                                                          :location        => "https://jdg.blob.core.windows.net/vhds/clia566d60f38fb9ecc.vhd",
@@ -80,39 +80,39 @@ describe TextualMixins::TextualDevices do
     subject { helper.network_attributes }
 
     context "without network hardware" do
-      let(:hw) { FactoryGirl.create(:hardware, :cpu1x1, :ram1GB) }
+      let(:hw) { FactoryBot.create(:hardware, :cpu1x1, :ram1GB) }
       it { is_expected.to be_empty }
     end
 
     context "with network hardware" do
       let(:hw) do
-        FactoryGirl.create(:hardware,
-                           :guest_devices => [FactoryGirl.create(:guest_device_nic)])
+        FactoryBot.create(:hardware,
+                           :guest_devices => [FactoryBot.create(:guest_device_nic)])
       end
       it { is_expected.not_to be_empty }
     end
 
     context "with model type parsed" do
-      let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :model => 'Vmxnet3')]) }
+      let(:hw) { FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic, :model => 'Vmxnet3')]) }
       it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Vmxnet3", "Default Adapter"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "without vswitch and portgroup" do
-      let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic)]) }
+      let(:hw) { FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic)]) }
       it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "with vswitch and portgroup" do
-      let(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'false') }
-      let(:lan) { FactoryGirl.create(:lan, :name => "VM NFS Network", :switch => switch) }
-      let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :lan => lan)]) }
+      let(:switch) { FactoryBot.create(:switch, :name => 'test_switch1', :shared => 'false') }
+      let(:lan) { FactoryBot.create(:lan, :name => "VM NFS Network", :switch => switch) }
+      let(:hw) { FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic, :lan => lan)]) }
       it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Switch: test_switch1)"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
 
     context "with dvswitch and dvportgroup" do
-      let(:switch) { FactoryGirl.create(:switch, :name => 'test_switch1', :shared => 'true') }
-      let(:lan) { FactoryGirl.create(:lan, :name => "VM NFS Network", :switch => switch) }
-      let(:hw) { FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :lan => lan)]) }
+      let(:switch) { FactoryBot.create(:switch, :name => 'test_switch1', :shared => 'true') }
+      let(:lan) { FactoryBot.create(:lan, :name => "VM NFS Network", :switch => switch) }
+      let(:hw) { FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic, :lan => lan)]) }
       it { is_expected.to eq([Device.new("Ethernet #{hw.ports.first.name}", [hw.ports.first.address.to_s, "Default Adapter", "Network:VM NFS Network(Distributed Switch: test_switch1)"].compact.join(', '), nil, "ff ff-network-card")]) }
     end
   end

--- a/spec/helpers/textual_mixins/textual_os_info_spec.rb
+++ b/spec/helpers/textual_mixins/textual_os_info_spec.rb
@@ -1,5 +1,5 @@
 describe TextualMixins::TextualOsInfo do
-  let(:host) { FactoryGirl.create(:host) }
+  let(:host) { FactoryBot.create(:host) }
 
   before do
     assign(:record, host)
@@ -14,8 +14,8 @@ describe TextualMixins::TextualOsInfo do
 
     context "with OS" do
       let(:host) do
-        FactoryGirl.create(:host,
-                           :operating_system => FactoryGirl.create(:operating_system,
+        FactoryBot.create(:host,
+                           :operating_system => FactoryBot.create(:operating_system,
                                                                    :product_name => "rhel-7x64"))
       end
 

--- a/spec/helpers/textual_mixins/textual_vmm_info_spec.rb
+++ b/spec/helpers/textual_mixins/textual_vmm_info_spec.rb
@@ -1,5 +1,5 @@
 describe TextualMixins::TextualVmmInfo do
-  let(:host) { FactoryGirl.create(:host, :vmm_vendor => vmm) }
+  let(:host) { FactoryBot.create(:host, :vmm_vendor => vmm) }
 
   before do
     assign(:record, host)

--- a/spec/helpers/textual_summary_helper_spec.rb
+++ b/spec/helpers/textual_summary_helper_spec.rb
@@ -8,15 +8,15 @@ describe TextualSummaryHelper do
   context "textual_link" do
     context "with a restfully-routed model" do
       it "uses the restful path to retrieve the summary screen link" do
-        ems = FactoryGirl.create(:ems_openstack)
-        ems.availability_zones << FactoryGirl.create(:availability_zone_openstack)
+        ems = FactoryBot.create(:ems_openstack)
+        ems.availability_zones << FactoryBot.create(:availability_zone_openstack)
 
         result = helper.textual_link(ems.availability_zones)
         expect(result[:link]).to eq("/ems_cloud/#{ems.id}?display=availability_zones")
       end
 
       it "uses the restful path for the base show screen" do
-        ems = FactoryGirl.create(:ems_openstack)
+        ems = FactoryBot.create(:ems_openstack)
 
         result = helper.textual_link(ems)
         expect(result[:link]).to eq("/ems_cloud/#{ems.id}")
@@ -25,15 +25,15 @@ describe TextualSummaryHelper do
 
     context "with a non-restful model" do
       it "uses the controller-action-id path to retrieve the summary screen link" do
-        ems = FactoryGirl.create(:ems_openstack_infra)
-        ems.hosts << FactoryGirl.create(:host)
+        ems = FactoryBot.create(:ems_openstack_infra)
+        ems.hosts << FactoryBot.create(:host)
 
         result = helper.textual_link(ems.hosts)
         expect(result[:link]).to eq("/ems_infra/#{ems.id}?display=hosts")
       end
 
       it "uses the controller-action-id path for the base show screen" do
-        ems = FactoryGirl.create(:ems_openstack_infra)
+        ems = FactoryBot.create(:ems_openstack_infra)
 
         result = helper.textual_link(ems)
         expect(result[:link]).to eq("/ems_infra/#{ems.id}")

--- a/spec/helpers/vm_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_cloud_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe VmCloudHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:vm))
+    instance_variable_set(:@record, FactoryBot.create(:vm))
   end
 
   include_examples "textual_group", "Properties", %i(

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -1,12 +1,12 @@
 describe VmHelper::TextualSummary do
   it "#textual_server" do
-    server  = FactoryGirl.build(:miq_server, :id => 99999)
-    @record = FactoryGirl.build(:vm_vmware, :miq_server => server)
+    server  = FactoryBot.build(:miq_server, :id => 99999)
+    @record = FactoryBot.build(:vm_vmware, :miq_server => server)
     expect(helper.textual_server).to eq("#{server.name} [#{server.id}]")
   end
 
   before do
-    instance_variable_set(:@record, FactoryGirl.create(:vm))
+    instance_variable_set(:@record, FactoryBot.create(:vm))
     allow(self).to receive(:textual_key_value_group).and_return([])
   end
 

--- a/spec/helpers/vm_helper_spec.rb
+++ b/spec/helpers/vm_helper_spec.rb
@@ -3,9 +3,9 @@
 describe VmHelper do
   describe "#last_date_processes" do
     it "supports vm with os and processes" do
-      server = FactoryGirl.build(:miq_server, :id => 99_999)
-      operating_system = FactoryGirl.build(:operating_system)
-      @record = FactoryGirl.create(:vm_vmware, :miq_server => server, :operating_system => operating_system)
+      server = FactoryBot.build(:miq_server, :id => 99_999)
+      operating_system = FactoryBot.build(:operating_system)
+      @record = FactoryBot.create(:vm_vmware, :miq_server => server, :operating_system => operating_system)
       now = Time.now.utc
       operating_system.processes.create(:updated_on => 1.day.ago)
       operating_system.processes.create(:updated_on => now)
@@ -14,7 +14,7 @@ describe VmHelper do
     end
 
     it "supports vm without an OS" do
-      @record = FactoryGirl.create(:vm_vmware)
+      @record = FactoryBot.create(:vm_vmware)
       expect(helper.last_date_processes).to be_nil
     end
   end

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -1,9 +1,9 @@
 describe ReportFormatter::TimelineMessage do
   describe '#message_html on container event' do
     row = {}
-    let(:ems) { FactoryGirl.create(:ems_redhat, :id => 42) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :id => 42) }
     let(:event) do
-      FactoryGirl.create(:ems_event,
+      FactoryBot.create(:ems_event,
                          :event_type            => 'CONTAINER_CREATED',
                          :ems_id                => 6,
                          :container_group_name  => 'hawkular-cassandra-1-wb1z6',
@@ -30,9 +30,9 @@ describe ReportFormatter::TimelineMessage do
 
   describe '#message_html on vm event' do
     row = {}
-    let(:vm) { FactoryGirl.create(:vm_redhat, :id => 42) }
+    let(:vm) { FactoryBot.create(:vm_redhat, :id => 42) }
     let(:event) do
-      FactoryGirl.create(:ems_event,
+      FactoryBot.create(:ems_event,
                          :event_type     => 'VM_CREATED',
                          :vm_or_template => vm)
     end
@@ -55,9 +55,9 @@ describe ReportFormatter::TimelineMessage do
 
   describe '#message_html on bottleneck event' do
     row = {}
-    let(:ems_cluster) { FactoryGirl.create(:ems_cluster, :id => 42, :name => 'Test Cluster') }
+    let(:ems_cluster) { FactoryBot.create(:ems_cluster, :id => 42, :name => 'Test Cluster') }
     let(:event) do
-      FactoryGirl.create(:bottleneck_event,
+      FactoryBot.create(:bottleneck_event,
                          :event_type    => 'MemoryUsage',
                          :resource_id   => 42,
                          :resource_name => ems_cluster.name,
@@ -78,9 +78,9 @@ describe ReportFormatter::TimelineMessage do
 
   describe '#message_html on policy event' do
     row = {}
-    let(:vm) { FactoryGirl.create(:vm_redhat, :id => 42, :name => 'Test VM') }
+    let(:vm) { FactoryBot.create(:vm_redhat, :id => 42, :name => 'Test VM') }
     let(:event) do
-      FactoryGirl.create(:policy_event,
+      FactoryBot.create(:policy_event,
                          :event_type   => 'vm_poweroff',
                          :target_id    => 42,
                          :target_name  => vm.name,
@@ -91,8 +91,8 @@ describe ReportFormatter::TimelineMessage do
              'target_name' => 'Test VM<br><b>VM or Template:</b>&nbsp;<a href=/vm_or_template/show/42>Test VM</a><br/><b>Assigned Profiles:</b>&nbsp;'}
 
     context 'policy profile assigned' do
-      let(:event_content) { FactoryGirl.create(:policy_event_content, :resource => policy_set) }
-      let(:policy_set) { FactoryGirl.create(:miq_policy_set) }
+      let(:event_content) { FactoryBot.create(:policy_event_content, :resource => policy_set) }
+      let(:policy_set) { FactoryBot.create(:miq_policy_set) }
 
       before { event.contents << event_content }
 
@@ -113,14 +113,14 @@ describe ReportFormatter::TimelineMessage do
   end
 
   describe '#events count for different categories' do
-    let(:ems) { FactoryGirl.create(:ems_redhat, :name => 'foobar') }
+    let(:ems) { FactoryBot.create(:ems_redhat, :name => 'foobar') }
 
     def stub_ems_event(event_type)
       EventStream.new(:event_type => event_type, :ems_id => ems.id)
     end
 
     before do
-      @report = FactoryGirl.create(:miq_report,
+      @report = FactoryBot.create(:miq_report,
                                    :db        => "EventStream",
                                    :col_order => %w(id name event_type timestamp),
                                    :headers   => %w(id name event_type timestamp),
@@ -179,14 +179,14 @@ describe ReportFormatter::TimelineMessage do
   end
 
   describe '#events count for regex categories' do
-    let(:ems) { FactoryGirl.create(:ems_redhat) }
+    let(:ems) { FactoryBot.create(:ems_redhat) }
 
     def stub_ems_event(event_type)
       EventStream.new(:event_type => event_type, :ems_id => ems.id)
     end
 
     before do
-      @report = FactoryGirl.create(
+      @report = FactoryBot.create(
         :miq_report,
         :db        => "EventStream",
         :col_order => %w(id name event_type timestamp),
@@ -265,14 +265,14 @@ describe ReportFormatter::TimelineMessage do
 end
 
 describe '#set data for headers that exist in col headers' do
-  let(:ems) { FactoryGirl.create(:ems_amazon) }
+  let(:ems) { FactoryBot.create(:ems_amazon) }
 
   def stub_ems_event(event_type)
     EventStream.create!(:event_type => event_type, :ems_id => ems.id)
   end
 
   before do
-    @report = FactoryGirl.create(:miq_report,
+    @report = FactoryBot.create(:miq_report,
                                  :db        => "EventStream",
                                  :col_order => %w(id name event_type timestamp vm_location),
                                  :headers   => %w(id name event_type timestamp vm_location),

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -17,12 +17,12 @@ describe Menu::DefaultMenu do
 
   context "infrastructure_menu_section" do
     before do
-      @ems_openstack = FactoryGirl.create(:ems_openstack_infra)
-      @ems_vmware = FactoryGirl.create(:ems_vmware)
+      @ems_openstack = FactoryBot.create(:ems_openstack_infra)
+      @ems_vmware = FactoryBot.create(:ems_vmware)
     end
 
     it "shows correct title for Hosts submenu item when openstack only records exist" do
-      FactoryGirl.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
+      FactoryBot.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Nodes", "Virtual Machines", "Resource Pools",
                 "Datastores", "PXE", "Networking", "Topology"]
@@ -30,7 +30,7 @@ describe Menu::DefaultMenu do
     end
 
     it "shows correct title for Hosts submenu item when non-openstack only records exist" do
-      FactoryGirl.create(:host_vmware, :ems_id => @ems_vmware.id)
+      FactoryBot.create(:host_vmware, :ems_id => @ems_vmware.id)
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
                 "Datastores", "PXE", "Networking", "Topology"]
@@ -38,8 +38,8 @@ describe Menu::DefaultMenu do
     end
 
     it "shows correct title for Hosts submenu item when both openstack & non-openstack only records exist" do
-      FactoryGirl.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
-      FactoryGirl.create(:host_vmware, :ems_id => @ems_vmware.id)
+      FactoryBot.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
+      FactoryBot.create(:host_vmware, :ems_id => @ems_vmware.id)
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts / Nodes", "Virtual Machines", "Resource Pools",
@@ -48,7 +48,7 @@ describe Menu::DefaultMenu do
     end
 
     it "shows correct title for Clusters submenu item when openstack only records exist" do
-      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
+      FactoryBot.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",
@@ -57,7 +57,7 @@ describe Menu::DefaultMenu do
     end
 
     it "shows correct title for Clusters submenu item when non-openstack only records exist" do
-      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
+      FactoryBot.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
@@ -66,8 +66,8 @@ describe Menu::DefaultMenu do
     end
 
     it "shows correct title for Clusters submenu item when both openstack & non-openstack only records exist" do
-      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
-      FactoryGirl.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
+      FactoryBot.create(:ems_cluster_openstack, :ems_id => @ems_openstack.id)
+      FactoryBot.create(:ems_cluster_openstack, :ems_id => @ems_vmware.id)
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters / Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -3,7 +3,7 @@ describe TreeBuilderAeClass do
 
   context "initialize" do
     before do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       login_as user
       create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
       create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
@@ -26,12 +26,12 @@ describe TreeBuilderAeClass do
 
   context "#x_get_tree_roots" do
     before do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       login_as user
       tenant1 = user.current_tenant
-      tenant2 = FactoryGirl.create(:tenant, :parent => tenant1)
-      FactoryGirl.create(:miq_ae_domain, :name => "test1", :tenant => tenant1)
-      FactoryGirl.create(:miq_ae_domain, :name => "test2", :tenant => tenant2)
+      tenant2 = FactoryBot.create(:tenant, :parent => tenant1)
+      FactoryBot.create(:miq_ae_domain, :name => "test1", :tenant => tenant1)
+      FactoryBot.create(:miq_ae_domain, :name => "test2", :tenant => tenant2)
     end
 
     it "should only return domains in a user's current tenant" do
@@ -44,11 +44,11 @@ describe TreeBuilderAeClass do
 
   context "#x_get_tree_roots" do
     before do
-      user = FactoryGirl.create(:user_with_group)
+      user = FactoryBot.create(:user_with_group)
       login_as user
       tenant1 = user.current_tenant
-      FactoryGirl.create(:miq_ae_domain, :name => "test1", :tenant => tenant1, :priority => 1)
-      FactoryGirl.create(:miq_ae_domain, :name => "test2", :tenant => tenant1, :priority => 2)
+      FactoryBot.create(:miq_ae_domain, :name => "test1", :tenant => tenant1, :priority => 1)
+      FactoryBot.create(:miq_ae_domain, :name => "test2", :tenant => tenant1, :priority => 2)
     end
 
     it "should return domains in correct order" do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -1,22 +1,22 @@
 describe TreeBuilderAlertProfileObj do
   before do
     role = MiqUserRole.find_by(:name => "EvmRole-operator")
-    group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+    group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
+    login_as FactoryBot.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end
-  let(:tag1a) { FactoryGirl.create(:classification, :name => 'tag1a') }
-  let(:tag2a) { FactoryGirl.create(:classification, :name => 'tag2a') }
-  let(:tag3a) { FactoryGirl.create(:classification, :name => 'tag3a') }
+  let(:tag1a) { FactoryBot.create(:classification, :name => 'tag1a') }
+  let(:tag2a) { FactoryBot.create(:classification, :name => 'tag2a') }
+  let(:tag3a) { FactoryBot.create(:classification, :name => 'tag3a') }
   let(:folder1a) do
-    f1 = FactoryGirl.create(:classification, :name => 'folder1a', :show => true)
+    f1 = FactoryBot.create(:classification, :name => 'folder1a', :show => true)
     f1.entries.push(tag1a)
     f1.entries.push(tag2a)
     f1.entries.push(tag3a)
     f1
   end
-  let!(:tag1b) { FactoryGirl.create(:tenant, :name => 'tag1b') }
-  let!(:tag2b) { FactoryGirl.create(:tenant, :name => 'tag2b') }
-  let!(:tag3b) { FactoryGirl.create(:tenant, :name => 'tag3b') }
+  let!(:tag1b) { FactoryBot.create(:tenant, :name => 'tag1b') }
+  let!(:tag2b) { FactoryBot.create(:tenant, :name => 'tag2b') }
+  let!(:tag3b) { FactoryBot.create(:tenant, :name => 'tag3b') }
 
   context 'classification tree' do
     subject do

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -4,7 +4,7 @@ describe TreeBuilderArchived do
     allow(archived).to receive(:count_only_or_objects_filtered) do |count_only, objects, name|
       count_only ? objects.size : objects.sort_by { |object| object[name.to_sym] }
     end
-    login_as FactoryGirl.create(:user_with_group, :role => "operator", :settings => {})
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
   end
 
   it '#x_get_tree_arch_orph_nodes' do
@@ -35,10 +35,10 @@ describe TreeBuilderArchived do
 
   it '#x_get_tree_custom_kids with Infra VMs/Templates returns VMs' do
     User.current_user.settings[:display] = {:display_vms => true}
-    vm_orph = FactoryGirl.create(:vm_infra, :storage => FactoryGirl.create(:storage))
-    template_orph = FactoryGirl.create(:template_infra, :storage => FactoryGirl.create(:storage))
-    vm_arch = FactoryGirl.create(:vm_infra)
-    template_arch = FactoryGirl.create(:template_infra)
+    vm_orph = FactoryBot.create(:vm_infra, :storage => FactoryBot.create(:storage))
+    template_orph = FactoryBot.create(:template_infra, :storage => FactoryBot.create(:storage))
+    vm_arch = FactoryBot.create(:vm_infra)
+    template_arch = FactoryBot.create(:template_infra)
     allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:orphaned) { [vm_orph, template_orph] }
     allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:archived) { [vm_arch, template_arch] }
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
@@ -65,8 +65,8 @@ describe TreeBuilderArchived do
 
   it '#x_get_tree_custom_kids with Cloud VMs returns VMs' do
     User.current_user.settings[:display] = {:display_vms => true}
-    vm_arch_cloud = FactoryGirl.create(:vm_cloud)
-    vm_orph_cloud = FactoryGirl.create(:vm_cloud, :storage => FactoryGirl.create(:storage))
+    vm_arch_cloud = FactoryBot.create(:vm_cloud)
+    vm_orph_cloud = FactoryBot.create(:vm_cloud, :storage => FactoryBot.create(:storage))
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'VmCloud')
@@ -91,8 +91,8 @@ describe TreeBuilderArchived do
 
   it '#x_get_tree_custom_kids with Cloud Templates returns Templates' do
     User.current_user.settings[:display] = {:display_vms => true}
-    template_arch_cloud = FactoryGirl.create(:template_cloud)
-    template_orph_cloud = FactoryGirl.create(:template_cloud, :storage => FactoryGirl.create(:storage))
+    template_arch_cloud = FactoryBot.create(:template_cloud)
+    template_orph_cloud = FactoryBot.create(:template_cloud, :storage => FactoryBot.create(:storage))
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'ManageIQ::Providers::CloudManager::Template')

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -1,33 +1,33 @@
 describe TreeBuilderBelongsToHac do
   before do
-    login_as FactoryGirl.create(:user_with_group, :role => "operator", :settings => {})
-    FactoryGirl.create(:ems_redhat)
-    FactoryGirl.create(:ems_google_network)
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
+    FactoryBot.create(:ems_redhat)
+    FactoryBot.create(:ems_google_network)
   end
 
   let!(:edit) { nil }
-  let!(:group) { FactoryGirl.create(:miq_group) }
+  let!(:group) { FactoryBot.create(:miq_group) }
   let!(:datacenter1) do
-    datacenter = FactoryGirl.create(:datacenter)
+    datacenter = FactoryBot.create(:datacenter)
     datacenter.with_relationship_type("ems_metadata") { datacenter.add_folder(subfolder) }
     datacenter
   end
-  let!(:datacenter2) { FactoryGirl.create(:datacenter) }
+  let!(:datacenter2) { FactoryBot.create(:datacenter) }
   let!(:rp1) do
-    rp1 = FactoryGirl.create(:resource_pool, :is_default => true)
+    rp1 = FactoryBot.create(:resource_pool, :is_default => true)
     rp1.with_relationship_type("ems_metadata") { rp1.add_child(rp2) }
     rp1
   end
-  let!(:rp2) { FactoryGirl.create(:resource_pool) }
+  let!(:rp2) { FactoryBot.create(:resource_pool) }
   let!(:cluster) do
-    cluster = FactoryGirl.create(:ems_cluster)
+    cluster = FactoryBot.create(:ems_cluster)
     allow(cluster).to receive(:resource_pools) { [rp1] }
     allow(cluster).to receive(:hosts) { [host] }
     cluster
   end
-  let!(:ems_folder) { FactoryGirl.create(:ems_folder) }
+  let!(:ems_folder) { FactoryBot.create(:ems_folder) }
   let!(:subfolder) do
-    subfolder = FactoryGirl.create(:ems_folder, :name => 'host')
+    subfolder = FactoryBot.create(:ems_folder, :name => 'host')
     subfolder.with_relationship_type("ems_metadata") { subfolder.add_child(datacenter2) }
     subfolder.with_relationship_type("ems_metadata") { subfolder.add_child(ems_folder) }
     subfolder.with_relationship_type("ems_metadata") { subfolder.add_host(host) }
@@ -35,21 +35,21 @@ describe TreeBuilderBelongsToHac do
     subfolder
   end
   let!(:subfolder_vm) do
-    subfolder_vm = FactoryGirl.create(:ems_folder, :name => 'vm')
+    subfolder_vm = FactoryBot.create(:ems_folder, :name => 'vm')
     subfolder_vm.with_relationship_type("ems_metadata") { subfolder_vm.add_child(ems_folder) }
     subfolder_vm
   end
   let!(:folder) do
-    folder = FactoryGirl.create(:ems_folder)
+    folder = FactoryBot.create(:ems_folder)
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(datacenter1) }
     folder
   end
   let!(:host) do
-    FactoryGirl.create(:host, :ems_cluster => cluster)
+    FactoryBot.create(:host, :ems_cluster => cluster)
   end
   let!(:ems_azure_network) do
-    network = FactoryGirl.create(:ems_azure_network)
+    network = FactoryBot.create(:ems_azure_network)
     network.with_relationship_type("ems_metadata") { network.add_child(folder) }
     network
   end

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -1,26 +1,26 @@
 describe TreeBuilderBelongsToVat do
   before do
-    login_as FactoryGirl.create(:user_with_group, :role => "operator", :settings => {})
-    FactoryGirl.create(:ems_redhat)
-    FactoryGirl.create(:ems_google_network)
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
+    FactoryBot.create(:ems_redhat)
+    FactoryBot.create(:ems_google_network)
   end
 
   let!(:edit) { nil }
-  let!(:group) { FactoryGirl.create(:miq_group) }
-  let!(:ems_folder) { FactoryGirl.create(:ems_folder) }
+  let!(:group) { FactoryBot.create(:miq_group) }
+  let!(:ems_folder) { FactoryBot.create(:ems_folder) }
   let!(:subfolder) do
-    subfolder = FactoryGirl.create(:ems_folder, :name => 'vm')
+    subfolder = FactoryBot.create(:ems_folder, :name => 'vm')
     subfolder.with_relationship_type("ems_metadata") { subfolder.add_child(ems_folder) }
     subfolder
   end
-  let!(:folder) { FactoryGirl.create(:ems_folder) }
+  let!(:folder) { FactoryBot.create(:ems_folder) }
   let!(:ems_azure_network) do
-    ems_azure_network = FactoryGirl.create(:ems_azure_network)
+    ems_azure_network = FactoryBot.create(:ems_azure_network)
     ems_azure_network.with_relationship_type("ems_metadata") { ems_azure_network.add_child(folder) }
     ems_azure_network
   end
   let!(:datacenter) do
-    datacenter = FactoryGirl.create(:datacenter)
+    datacenter = FactoryBot.create(:datacenter)
     datacenter.with_relationship_type("ems_metadata") { datacenter.add_folder(subfolder) }
     datacenter
   end

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -2,10 +2,10 @@ describe TreeBuilderClusters do
   context 'TreeBuilderClusters' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Clusters Group")
-      login_as FactoryGirl.create(:user, :userid => 'clusters__wilma', :miq_groups => [@group])
-      @ho_enabled = [FactoryGirl.create(:host)]
-      @ho_disabled = [FactoryGirl.create(:host)]
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Clusters Group")
+      login_as FactoryBot.create(:user, :userid => 'clusters__wilma', :miq_groups => [@group])
+      @ho_enabled = [FactoryBot.create(:host)]
+      @ho_disabled = [FactoryBot.create(:host)]
       allow(EmsCluster).to receive(:get_perf_collection_object_list).and_return(:'1'.to_i =>
                                                                                              {:id          => 1,
                                                                                               :name        => 'Name',

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -2,22 +2,22 @@ describe TreeBuilderComplianceHistory do
   context 'TreeBuilderComplianceHistory' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Compliance History Group")
-      login_as FactoryGirl.create(:user, :userid => 'comliance_history__wilma', :miq_groups => [@group])
-      compliance_detail_one = FactoryGirl.create(:compliance_detail,
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Compliance History Group")
+      login_as FactoryBot.create(:user, :userid => 'comliance_history__wilma', :miq_groups => [@group])
+      compliance_detail_one = FactoryBot.create(:compliance_detail,
                                                  :miq_policy_id  => 1234,
                                                  :condition_desc => "I am first condition")
-      compliance_detail_two = FactoryGirl.create(:compliance_detail,
+      compliance_detail_two = FactoryBot.create(:compliance_detail,
                                                  :miq_policy_id  => 1234,
                                                  :condition_desc => "I am second condition")
-      compliance_detail_negative = FactoryGirl.create(:compliance_detail,
+      compliance_detail_negative = FactoryBot.create(:compliance_detail,
                                                       :miq_policy_id     => 1111,
                                                       :miq_policy_result => false,
                                                       :condition_result  => false)
       compliance_details = [compliance_detail_one, compliance_detail_two, compliance_detail_negative]
-      empty_compliance = FactoryGirl.create(:compliance)
-      compliance = FactoryGirl.create(:compliance, :compliance_details => compliance_details)
-      root = FactoryGirl.create(:host, :compliances => [empty_compliance, compliance])
+      empty_compliance = FactoryBot.create(:compliance)
+      compliance = FactoryBot.create(:compliance, :compliance_details => compliance_details)
+      root = FactoryBot.create(:host, :compliances => [empty_compliance, compliance])
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, {}, true, root)
     end
     it 'is not lazy' do

--- a/spec/presenters/tree_builder_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_datacenter_spec.rb
@@ -2,15 +2,15 @@ describe TreeBuilderDatacenter do
   context 'TreeBuilderDatacenter Cluster root' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Datacenter Group Cluster root")
-      login_as FactoryGirl.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
-      host = FactoryGirl.create(:host)
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Datacenter Group Cluster root")
+      login_as FactoryBot.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
+      host = FactoryBot.create(:host)
 
-      vm = FactoryGirl.create(:vm)
-      cluster = FactoryGirl.create(:ems_cluster, :hosts => [host], :vms => [vm])
+      vm = FactoryBot.create(:vm)
+      cluster = FactoryBot.create(:ems_cluster, :hosts => [host], :vms => [vm])
       class << cluster
         def resource_pools
-          [FactoryGirl.create(:resource_pool)]
+          [FactoryBot.create(:resource_pool)]
         end
       end
       @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, cluster)
@@ -36,18 +36,18 @@ describe TreeBuilderDatacenter do
   context 'TreeBuilderDatacenter Resource pool root' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group,
+      @group = FactoryBot.create(:miq_group,
                                   :miq_user_role => role,
                                   :description   => "Datacenter Group Resource pool root")
-      login_as FactoryGirl.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
-      cluster = FactoryGirl.create(:resource_pool)
+      login_as FactoryBot.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
+      cluster = FactoryBot.create(:resource_pool)
       class << cluster
         def resource_pools
-          [FactoryGirl.create(:resource_pool)]
+          [FactoryBot.create(:resource_pool)]
         end
 
         def vms
-          [FactoryGirl.create(:vm)]
+          [FactoryBot.create(:vm)]
         end
       end
       @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, cluster)

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -2,10 +2,10 @@ describe TreeBuilderDatastores do
   context 'TreeBuilderDatastores' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Datastores Group")
-      login_as FactoryGirl.create(:user, :userid => 'datastores_wilma', :miq_groups => [@group])
-      @host = FactoryGirl.create(:host, :name => 'Host Name')
-      FactoryGirl.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Datastores Group")
+      login_as FactoryBot.create(:user, :userid => 'datastores_wilma', :miq_groups => [@group])
+      @host = FactoryBot.create(:host, :name => 'Host Name')
+      FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
       @datastore = [{:id => 1, :name => 'Datastore', :location => 'Location', :capture => false}]
       @datastores_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, @datastore)
     end

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -2,58 +2,58 @@ describe TreeBuilderDefaultFilters do
   context 'TreeBuilderDefaultFilters' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Default filters Group")
-      login_as FactoryGirl.create(:user, :userid => 'default_filters__wilma', :miq_groups => [@group])
-      @filters = [FactoryGirl.create(:miq_search,
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Default filters Group")
+      login_as FactoryBot.create(:user, :userid => 'default_filters__wilma', :miq_groups => [@group])
+      @filters = [FactoryBot.create(:miq_search,
                                      :name        => "default_Platform / HyperV",
                                      :description => "Platform / HyperV",
                                      :options     => nil,
                                      :db          => "Host",
                                      :search_type => "default",
                                      :search_key  => nil)]
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / UAT",
                                        :description => "Environment / UAT",
                                        :options     => nil,
                                        :db          => "MiqTemplate",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,
                                        :db          => "MiqTemplate",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,
                                        :db          => "Container",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,
                                        :db          => "ContainerGroup",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,
                                        :db          => "ContainerService",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,
                                        :db          => "Storage",
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
-      @filters.push(FactoryGirl.create(:miq_search,
+      @filters.push(FactoryBot.create(:miq_search,
                                        :name        => "default_Environment / Prod",
                                        :description => "Environment / Prod",
                                        :options     => nil,

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -1,13 +1,13 @@
 describe TreeBuilderGenealogy do
-  let(:vm_without_kid) { FactoryGirl.create(:vm) }
-  let(:kid) { FactoryGirl.create(:vm) }
+  let(:vm_without_kid) { FactoryBot.create(:vm) }
+  let(:kid) { FactoryBot.create(:vm) }
   let(:vm_with_kid) do
-    vm = FactoryGirl.create(:vm)
+    vm = FactoryBot.create(:vm)
     vm.add_child(kid)
     vm
   end
   let(:record) do
-    vm = FactoryGirl.create(:vm)
+    vm = FactoryBot.create(:vm)
     vm.add_child(vm_with_kid)
     vm.add_child(vm_without_kid)
     vm

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -1,12 +1,12 @@
 describe TreeBuilderImages do
   before do
-    @template_cloud_with_az = FactoryGirl.create(:template_cloud,
-                                                 :ext_management_system => FactoryGirl.create(:ems_google),
-                                                 :storage               => FactoryGirl.create(:storage))
+    @template_cloud_with_az = FactoryBot.create(:template_cloud,
+                                                 :ext_management_system => FactoryBot.create(:ems_google),
+                                                 :storage               => FactoryBot.create(:storage))
 
-    login_as FactoryGirl.create(:user_with_group, :role => "operator", :settings => {})
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
 
-    allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
+    allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
     @images_tree = TreeBuilderImages.new(:images, :images_tree, {}, nil)
   end

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -1,16 +1,16 @@
 describe TreeBuilderInstances do
   before do
-    @vm_cloud_with_az = FactoryGirl.create(:vm_cloud,
-                                           :ext_management_system => FactoryGirl.create(:ems_google),
-                                           :storage               => FactoryGirl.create(:storage),
-                                           :availability_zone     => FactoryGirl.create(:availability_zone_google))
-    @vm_cloud_without_az = FactoryGirl.create(:vm_cloud,
-                                              :ext_management_system => FactoryGirl.create(:ems_google),
-                                              :storage               => FactoryGirl.create(:storage),)
+    @vm_cloud_with_az = FactoryBot.create(:vm_cloud,
+                                           :ext_management_system => FactoryBot.create(:ems_google),
+                                           :storage               => FactoryBot.create(:storage),
+                                           :availability_zone     => FactoryBot.create(:availability_zone_google))
+    @vm_cloud_without_az = FactoryBot.create(:vm_cloud,
+                                              :ext_management_system => FactoryBot.create(:ems_google),
+                                              :storage               => FactoryBot.create(:storage),)
 
-    login_as FactoryGirl.create(:user_with_group, :role => "operator", :settings => {})
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
 
-    allow(MiqServer).to receive(:my_server) { FactoryGirl.create(:miq_server) }
+    allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
     @instances_tree = TreeBuilderInstances.new(:instances, :instances_tree, {}, nil)
   end

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -1,19 +1,19 @@
 describe TreeBuilderMiqActionCategory do
   before do
     role = MiqUserRole.find_by(:name => "EvmRole-operator")
-    group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+    group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
+    login_as FactoryBot.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
   end
 
-  let!(:tag1) { FactoryGirl.create(:classification, :name => 'tag1', :show => false) }
+  let!(:tag1) { FactoryBot.create(:classification, :name => 'tag1', :show => false) }
   let!(:folder1) do
-    f1 = FactoryGirl.create(:classification, :name => 'folder1', :show => true)
+    f1 = FactoryBot.create(:classification, :name => 'folder1', :show => true)
     f1.entries.push(tag1)
     f1
   end
-  let!(:tag2) { FactoryGirl.create(:classification, :name => 'tag2', :show => false) }
+  let!(:tag2) { FactoryBot.create(:classification, :name => 'tag2', :show => false) }
   let!(:folder2) do
-    f2 = FactoryGirl.create(:classification, :name => 'folder2', :show => true)
+    f2 = FactoryBot.create(:classification, :name => 'folder2', :show => true)
     f2.entries.push(tag2)
     f2
   end

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -2,15 +2,15 @@ describe TreeBuilderNetwork do
   context 'TreeBuilderNetwork' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Network Group")
-      login_as FactoryGirl.create(:user, :userid => 'network_wilma', :miq_groups => [@group])
-      vm = FactoryGirl.create(:vm)
-      hardware = FactoryGirl.create(:hardware, :vm_or_template => vm)
-      guest_device_with_vm = FactoryGirl.create(:guest_device, :hardware => hardware)
-      guest_device = FactoryGirl.create(:guest_device)
-      lan = FactoryGirl.create(:lan, :guest_devices => [guest_device_with_vm])
-      switch = FactoryGirl.create(:switch, :guest_devices => [guest_device], :lans => [lan])
-      network = FactoryGirl.create(:host, :switches => [switch])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Network Group")
+      login_as FactoryBot.create(:user, :userid => 'network_wilma', :miq_groups => [@group])
+      vm = FactoryBot.create(:vm)
+      hardware = FactoryBot.create(:hardware, :vm_or_template => vm)
+      guest_device_with_vm = FactoryBot.create(:guest_device, :hardware => hardware)
+      guest_device = FactoryBot.create(:guest_device)
+      lan = FactoryBot.create(:lan, :guest_devices => [guest_device_with_vm])
+      switch = FactoryBot.create(:switch, :guest_devices => [guest_device], :lans => [lan])
+      network = FactoryBot.create(:host, :switches => [switch])
       @network_tree = TreeBuilderNetwork.new(:network_tree, :network, {}, true, network)
     end
 

--- a/spec/presenters/tree_builder_ops_rbac_features_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_features_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderOpsRbacFeatures do
   end
 
   let(:role) do
-    FactoryGirl.create(:miq_user_role, :id => 100_000_002, :features => features)
+    FactoryBot.create(:miq_user_role, :id => 100_000_002, :features => features)
   end
 
   let(:tree) do

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -12,43 +12,43 @@ describe TreeBuilderOpsRbac do
     end
 
     it "with user with rbac_group role" do
-      login_as FactoryGirl.create(:user, :features => 'rbac_group_view')
+      login_as FactoryBot.create(:user, :features => 'rbac_group_view')
       assert_tree_nodes(["Groups"])
     end
 
     it "has :open_all set to false" do
-      login_as FactoryGirl.create(:user, :features => 'none')
+      login_as FactoryBot.create(:user, :features => 'none')
       tree = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
       expect(tree.send(:tree_init_options, :open_all)[:open_all]).to be_falsey
     end
 
     it "with user with rbac_role_view role" do
-      login_as FactoryGirl.create(:user, :features => 'rbac_role_view')
+      login_as FactoryBot.create(:user, :features => 'rbac_role_view')
       assert_tree_nodes(["Roles"])
     end
 
     it "with user with rbac_tenant role" do
-      login_as FactoryGirl.create(:user, :features => 'rbac_tenant_view')
+      login_as FactoryBot.create(:user, :features => 'rbac_tenant_view')
       assert_tree_nodes(["Tenants"])
     end
 
     it "with user with rbac_user role" do
-      login_as FactoryGirl.create(:user, :features => 'rbac_user_view')
+      login_as FactoryBot.create(:user, :features => 'rbac_user_view')
       assert_tree_nodes(["Users"])
     end
 
     it "with user with multiple rbac roles" do
-      login_as FactoryGirl.create(:user,
+      login_as FactoryBot.create(:user,
                                   :features => %w(rbac_group_view rbac_user_view rbac_role_view rbac_tenant_view))
       assert_tree_nodes(%w(Groups Users Roles Tenants))
     end
   end
 
   describe "#x_get_tree_custom_kids" do
-    let(:group) { FactoryGirl.create(:miq_group, :features => "none") }
-    let(:user) { FactoryGirl.create(:user, :miq_groups => [group, other_group]) }
-    let(:other_group) { FactoryGirl.create(:miq_group) }
-    let(:other_user) { FactoryGirl.create(:user, :miq_groups => [other_group]) }
+    let(:group) { FactoryBot.create(:miq_group, :features => "none") }
+    let(:user) { FactoryBot.create(:user, :miq_groups => [group, other_group]) }
+    let(:other_group) { FactoryBot.create(:miq_group) }
+    let(:other_user) { FactoryBot.create(:user, :miq_groups => [other_group]) }
 
     before do
       login_as user
@@ -69,10 +69,10 @@ describe TreeBuilderOpsRbac do
     end
 
     context "User with self service user" do
-      let(:self_service_role) { FactoryGirl.create(:miq_user_role, :settings => {:restrictions => {:vms => :user}}) }
-      let(:group)             { FactoryGirl.create(:miq_group, :miq_user_role => self_service_role) }
-      let(:other_group)       { FactoryGirl.create(:miq_group, :miq_user_role => self_service_role) }
-      let(:user)              { FactoryGirl.create(:user, :miq_groups => [group, other_group], :role => 'user_self_service') }
+      let(:self_service_role) { FactoryBot.create(:miq_user_role, :settings => {:restrictions => {:vms => :user}}) }
+      let(:group)             { FactoryBot.create(:miq_group, :miq_user_role => self_service_role) }
+      let(:other_group)       { FactoryBot.create(:miq_group, :miq_user_role => self_service_role) }
+      let(:user)              { FactoryBot.create(:user, :miq_groups => [group, other_group], :role => 'user_self_service') }
 
       it "is listing only current user" do
         x_get_tree_custom_kids_for_and_expect_objects("u", [user])

--- a/spec/presenters/tree_builder_policy_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_results_spec.rb
@@ -2,10 +2,10 @@ describe TreeBuilderPolicySimulationResults do
   context 'TreeBuilderPolicySimulationResults' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Policy Simulation Group")
-      login_as FactoryGirl.create(:user, :userid => 'policy_simulation_results_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Policy Simulation Group")
+      login_as FactoryBot.create(:user, :userid => 'policy_simulation_results_wilma', :miq_groups => [@group])
       @policy_options = {:out_of_scope => true, :passed => true, :failed => true}
-      @event = FactoryGirl.create(:miq_event_definition, :id => 123)
+      @event = FactoryBot.create(:miq_event_definition, :id => 123)
       @data = {:event_value => 123, :results => [{:id => 76, :name => "DevRHEL002", :result => "allow", :profiles => []},
                                                  {:id       => 69,
                                                   :name     => "DevLin002",

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -2,8 +2,8 @@ describe TreeBuilderPolicySimulation do
   context 'TreeBuilderPolicySimulation' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Policy Simulation Group")
-      login_as FactoryGirl.create(:user, :userid => 'policy_simulation_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Policy Simulation Group")
+      login_as FactoryBot.create(:user, :userid => 'policy_simulation_wilma', :miq_groups => [@group])
       @policy_options = {:out_of_scope => true, :passed => true, :failed => true}
       exp = {"FIND"   => {"checkcount" => {">=" => {"value" => "1", "field" => "<count>"}},
                           "search"     => {"INCLUDES" => {"value" => "nb", "field" => "Vm.filesystems-name"}}},
@@ -117,8 +117,8 @@ describe TreeBuilderPolicySimulation do
   context 'TreeBuilderPolicySimulation without data' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "No node Group")
-      login_as FactoryGirl.create(:user, :userid => 'no_node_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "No node Group")
+      login_as FactoryBot.create(:user, :userid => 'no_node_wilma', :miq_groups => [@group])
       @policy_options = {:out_of_scope => true, :passed => true, :failed => true}
       @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
                                                                 :policy_simulaton,

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -2,17 +2,17 @@ describe TreeBuilderProtect do
   context 'TreeBuilderProtect' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Select Policy Profiles")
-      login_as FactoryGirl.create(:user, :userid => 'policy_profile_wilma', :miq_groups => [@group])
-      policy1 = FactoryGirl.create(:miq_policy, :mode => 'compliance', :active => false)
-      set1 = FactoryGirl.create(:miq_policy_set, :description => 'first')
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Select Policy Profiles")
+      login_as FactoryBot.create(:user, :userid => 'policy_profile_wilma', :miq_groups => [@group])
+      policy1 = FactoryBot.create(:miq_policy, :mode => 'compliance', :active => false)
+      set1 = FactoryBot.create(:miq_policy_set, :description => 'first')
       set1.add_member(policy1)
       set1.save!
       allow(set1).to receive(:active).and_return(true)
       allow(set1).to receive(:members).and_return([policy1])
-      set2 = FactoryGirl.create(:miq_policy_set, :description => 'second')
+      set2 = FactoryBot.create(:miq_policy_set, :description => 'second')
       allow(set2).to receive(:active).and_return(true)
-      set3 = FactoryGirl.create(:miq_policy_set, :description => 'third')
+      set3 = FactoryBot.create(:miq_policy_set, :description => 'third')
       allow(set3).to receive(:active).and_return(false)
       @roots = [set1, set2, set3].sort_by! { |profile| profile.description.downcase }
       @kids = [policy1]

--- a/spec/presenters/tree_builder_report_dashboards_spec.rb
+++ b/spec/presenters/tree_builder_report_dashboards_spec.rb
@@ -5,12 +5,12 @@ describe TreeBuilderReportDashboards do
     login_as user
   end
 
-  let(:group)            { FactoryGirl.create(:miq_group) }
-  let(:user)             { FactoryGirl.create(:user, :miq_groups => [group]) }
-  let!(:other_group)     { FactoryGirl.create(:miq_group) }
+  let(:group)            { FactoryBot.create(:miq_group) }
+  let(:user)             { FactoryBot.create(:user, :miq_groups => [group]) }
+  let!(:other_group)     { FactoryBot.create(:miq_group) }
   let!(:miq_widget_set) do
     widget_set_params = {:name => "default", :read_only => true, :owner_id => group.id, :owner_type => "MiqGroup"}
-    FactoryGirl.create(:miq_widget_set, widget_set_params)
+    FactoryBot.create(:miq_widget_set, widget_set_params)
   end
 
   describe "#x_get_tree_g_kids" do

--- a/spec/presenters/tree_builder_report_roles_spec.rb
+++ b/spec/presenters/tree_builder_report_roles_spec.rb
@@ -2,8 +2,8 @@ describe TreeBuilderReportRoles do
   context "#x_get_tree_roots" do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Test Group")
-      login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Test Group")
+      login_as FactoryBot.create(:user, :userid => 'wilma', :miq_groups => [@group])
     end
 
     it "gets roles/group for the specified user" do

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -15,9 +15,9 @@ describe TreeBuilderReportWidgets do
   end
 
   it "#x_get_tree_custom_kids (private)" do
-    widget1 = FactoryGirl.create(:miq_widget)
-    widget2 = FactoryGirl.create(:miq_widget)
-    FactoryGirl.create(:miq_widget, :content_type => "menu")
+    widget1 = FactoryBot.create(:miq_widget)
+    widget2 = FactoryBot.create(:miq_widget)
+    FactoryBot.create(:miq_widget, :content_type => "menu")
 
     expect(subject.send(:x_get_tree_custom_kids, {:id => "-r"}, false, nil)).to match_array([widget1, widget2])
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -3,7 +3,7 @@ describe TreeBuilderRolesByServer do
     before do
       MiqRegion.seed
       @miq_server = EvmSpecHelper.local_miq_server
-      @server_role = FactoryGirl.create(
+      @server_role = FactoryBot.create(
         :server_role,
         :name              => "smartproxy",
         :description       => "SmartProxy",
@@ -12,7 +12,7 @@ describe TreeBuilderRolesByServer do
         :role_scope        => "zone"
       )
 
-      @assigned_server_role1 = FactoryGirl.create(
+      @assigned_server_role1 = FactoryBot.create(
         :assigned_server_role,
         :miq_server_id  => @miq_server.id,
         :server_role_id => @server_role.id,
@@ -20,7 +20,7 @@ describe TreeBuilderRolesByServer do
         :priority       => 1
       )
 
-      @assigned_server_role2 = FactoryGirl.create(
+      @assigned_server_role2 = FactoryBot.create(
         :assigned_server_role,
         :miq_server_id  => @miq_server.id,
         :server_role_id => @server_role.id,

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -2,14 +2,14 @@ describe TreeBuilderSections do
   context 'TreeBuilderSections' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "All sections")
-      login_as FactoryGirl.create(:user, :userid => 'all_sections_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "All sections")
+      login_as FactoryBot.create(:user, :userid => 'all_sections_wilma', :miq_groups => [@group])
       @controller_name = 'controller_name'
       @current_tenant = 'Current tenant name'
-      first_vm = FactoryGirl.create(:vm)
-      second_vm = FactoryGirl.create(:vm)
-      report = FactoryGirl.create(:miq_report_filesystem)
-      @compare = FactoryGirl.build(:miq_compare,
+      first_vm = FactoryBot.create(:vm)
+      second_vm = FactoryBot.create(:vm)
+      report = FactoryBot.create(:miq_report_filesystem)
+      @compare = FactoryBot.build(:miq_compare,
                                    :report  => report,
                                    :options => {:ids     => [first_vm, second_vm],
                                                 :include => {:hardware            => {:fetch   => false,

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -2,10 +2,10 @@ describe TreeBuilderServersByRole do
   context 'TreeBuilderServersByRole' do
     before do
       MiqRegion.seed
-      zone = FactoryGirl.create(:zone)
-      @miq_server = FactoryGirl.create(:miq_server, :zone => zone)
+      zone = FactoryBot.create(:zone)
+      @miq_server = FactoryBot.create(:miq_server, :zone => zone)
       allow(MiqServer).to receive(:my_zone).and_return(zone)
-      @server_role = FactoryGirl.create(
+      @server_role = FactoryBot.create(
         :server_role,
         :name              => "smartproxy",
         :description       => "SmartProxy",
@@ -14,7 +14,7 @@ describe TreeBuilderServersByRole do
         :role_scope        => "zone"
       )
 
-      @assigned_server_role1 = FactoryGirl.create(
+      @assigned_server_role1 = FactoryBot.create(
         :assigned_server_role,
         :miq_server_id  => @miq_server.id,
         :server_role_id => @server_role.id,
@@ -22,7 +22,7 @@ describe TreeBuilderServersByRole do
         :priority       => 1
       )
 
-      @assigned_server_role2 = FactoryGirl.create(
+      @assigned_server_role2 = FactoryBot.create(
         :assigned_server_role,
         :miq_server_id  => @miq_server.id,
         :server_role_id => @server_role.id,

--- a/spec/presenters/tree_builder_service_catalog_spec.rb
+++ b/spec/presenters/tree_builder_service_catalog_spec.rb
@@ -1,22 +1,22 @@
 describe TreeBuilderServiceCatalog do
   before do
     Tenant.seed
-    @catalog = FactoryGirl.create(:service_template_catalog, :name => "My Catalog")
+    @catalog = FactoryBot.create(:service_template_catalog, :name => "My Catalog")
 
-    FactoryGirl.create(:service_template_ansible_playbook,
+    FactoryBot.create(:service_template_ansible_playbook,
                        :name                     => "Display in Catalog",
                        :service_template_catalog => @catalog,
                        :display                  => true)
-    FactoryGirl.create(:service_template,
+    FactoryBot.create(:service_template,
                        :name                     => "Do not Display in Catalog",
                        :service_template_catalog => @catalog,
                        :display                  => false)
-    FactoryGirl.create(:service_template,
+    FactoryBot.create(:service_template,
                        :name                     => "Display in Catalog too",
                        :service_type             => 'generic_ansible_tower',
                        :service_template_catalog => @catalog,
                        :display                  => true)
-    FactoryGirl.create(:service_template_ansible_playbook,
+    FactoryBot.create(:service_template_ansible_playbook,
                        :service_type             => 'generic_ansible_playbook',
                        :name                     => "Display in Catalog Playbook",
                        :service_template_catalog => @catalog,

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -2,7 +2,7 @@ describe TreeBuilderServices do
   let(:builder) { TreeBuilderServices.new("x", "y", {}) }
 
   it "generates tree" do
-    User.current_user = FactoryGirl.create(:user)
+    User.current_user = FactoryBot.create(:user)
     allow(User).to receive(:server_timezone).and_return("UTC")
     create_deep_tree
 
@@ -41,13 +41,13 @@ describe TreeBuilderServices do
   end
 
   def create_deep_tree
-    @service      = FactoryGirl.create(:service, :display => true, :retired => false)
-    @service_c1   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
-    @service_c11  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c12  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c121 = FactoryGirl.create(:service, :service => @service_c12, :display => true, :retired => false)
-    @service_c2   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
+    @service      = FactoryBot.create(:service, :display => true, :retired => false)
+    @service_c1   = FactoryBot.create(:service, :service => @service, :display => true, :retired => false)
+    @service_c11  = FactoryBot.create(:service, :service => @service_c1, :display => true, :retired => false)
+    @service_c12  = FactoryBot.create(:service, :service => @service_c1, :display => true, :retired => false)
+    @service_c121 = FactoryBot.create(:service, :service => @service_c12, :display => true, :retired => false)
+    @service_c2   = FactoryBot.create(:service, :service => @service, :display => true, :retired => false)
     # hidden
-    @service_c3   = FactoryGirl.create(:service, :service => @service, :retired => true, :display => true)
+    @service_c3   = FactoryBot.create(:service, :service => @service, :retired => true, :display => true)
   end
 end

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -2,21 +2,21 @@ describe TreeBuilderSmartproxyAffinity do
   context 'TreeBuilderSmartproxyAffinity' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "SmartProxy Affinity Group")
-      login_as FactoryGirl.create(:user, :userid => 'smartproxy_affinity_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "SmartProxy Affinity Group")
+      login_as FactoryBot.create(:user, :userid => 'smartproxy_affinity_wilma', :miq_groups => [@group])
 
-      @selected_zone = FactoryGirl.create(:zone, :name => 'zone1')
+      @selected_zone = FactoryBot.create(:zone, :name => 'zone1')
 
-      @storage1 = FactoryGirl.create(:storage)
-      @storage2 = FactoryGirl.create(:storage)
+      @storage1 = FactoryBot.create(:storage)
+      @storage2 = FactoryBot.create(:storage)
 
-      @host1 = FactoryGirl.create(:host, :name => 'host1', :storages => [@storage1])
-      @host2 = FactoryGirl.create(:host, :name => 'host2', :storages => [@storage2])
+      @host1 = FactoryBot.create(:host, :name => 'host1', :storages => [@storage1])
+      @host2 = FactoryBot.create(:host, :name => 'host2', :storages => [@storage2])
 
-      @ems = FactoryGirl.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @selected_zone)
+      @ems = FactoryBot.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @selected_zone)
 
-      @svr1 = FactoryGirl.create(:miq_server, :name => 'svr1', :zone => @selected_zone)
-      @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @selected_zone)
+      @svr1 = FactoryBot.create(:miq_server, :name => 'svr1', :zone => @selected_zone)
+      @svr2 = FactoryBot.create(:miq_server, :name => 'svr2', :zone => @selected_zone)
 
       @svr1.vm_scan_host_affinity = [@host1]
       @svr2.vm_scan_host_affinity = [@host2]

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -2,17 +2,17 @@ describe TreeBuilderSnapshots do
   context 'TreeBuilderSnaphots' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Snapshot Group")
-      login_as FactoryGirl.create(:user, :userid => 'snapshot_wilma', :miq_groups => [@group])
-      snapshot_kid = FactoryGirl.create(:snapshot,
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Snapshot Group")
+      login_as FactoryBot.create(:user, :userid => 'snapshot_wilma', :miq_groups => [@group])
+      snapshot_kid = FactoryBot.create(:snapshot,
                                         :description => 'Snapshot Kid',
                                         :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1))
-      snapshot = FactoryGirl.create(:snapshot,
+      snapshot = FactoryBot.create(:snapshot,
                                     :description => 'Snapshot',
                                     :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1),
                                     :children    => [snapshot_kid])
       snapshot_kid.parent_id = snapshot.id
-      @record = FactoryGirl.create(:vm_infra, :snapshots => [snapshot])
+      @record = FactoryBot.create(:vm_infra, :snapshots => [snapshot])
       @s_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, :root => @record)
     end
     it 'sets root correctly' do

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -122,8 +122,8 @@ describe TreeBuilder do
     end
 
     it 'counts things in a Relation' do
-      a = FactoryGirl.create(:user_with_email)
-      FactoryGirl.create(:user_with_email)
+      a = FactoryBot.create(:user_with_email)
+      FactoryBot.create(:user_with_email)
 
       expect(builder.count_only_or_objects(true, User.none)).to eq(0)
       expect(builder.count_only_or_objects(true, User.where(:id => a.id))).to eq(1)
@@ -138,8 +138,8 @@ describe TreeBuilder do
     end
 
     it 'returns a collection when not counting' do
-      a = FactoryGirl.create(:user_with_email)
-      b = FactoryGirl.create(:user_with_email)
+      a = FactoryBot.create(:user_with_email)
+      b = FactoryBot.create(:user_with_email)
 
       expect(builder.count_only_or_objects(false, User.none)).to eq([])
       expect(builder.count_only_or_objects(false, User.where(:id => a.id))).to eq([a])
@@ -189,7 +189,7 @@ describe TreeBuilder do
 
   context "#build_node_cid" do
     it "returns correct cid for VM" do
-      vm = FactoryGirl.create(:vm)
+      vm = FactoryBot.create(:vm)
       expect(TreeBuilder.build_node_cid(vm)).to eq("v-#{vm.id}")
     end
   end
@@ -197,8 +197,8 @@ describe TreeBuilder do
   context "#hide_vms" do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "TreeBuilder")
-      login_as FactoryGirl.create(:user, :userid => 'treebuilder_wilma', :miq_groups => [@group])
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "TreeBuilder")
+      login_as FactoryBot.create(:user, :userid => 'treebuilder_wilma', :miq_groups => [@group])
     end
 
     it "hide vms if User didn't set it" do

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -2,15 +2,15 @@ describe TreeBuilderStorageAdapters do
   context 'TreeBuilderStorageAdapters' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "SA Group")
-      login_as FactoryGirl.create(:user, :userid => 'sa_wilma', :miq_groups => [@group])
-      host = FactoryGirl.create(:host)
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "SA Group")
+      login_as FactoryBot.create(:user, :userid => 'sa_wilma', :miq_groups => [@group])
+      host = FactoryBot.create(:host)
       class << host
         def hardware
-          OpenStruct.new(:storage_adapters => [FactoryGirl.create(:miq_scsi_target,
-                                                                  :miq_scsi_luns => [FactoryGirl.create(:miq_scsi_lun),
-                                                                                     FactoryGirl.create(:miq_scsi_lun),
-                                                                                     FactoryGirl.create(:miq_scsi_lun)])])
+          OpenStruct.new(:storage_adapters => [FactoryBot.create(:miq_scsi_target,
+                                                                  :miq_scsi_luns => [FactoryBot.create(:miq_scsi_lun),
+                                                                                     FactoryBot.create(:miq_scsi_lun),
+                                                                                     FactoryBot.create(:miq_scsi_lun)])])
         end
       end
       @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, {}, true, host)

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -1,17 +1,17 @@
 describe TreeBuilderTags do
   before do
     role = MiqUserRole.find_by(:name => "EvmRole-operator")
-    @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
-    login_as FactoryGirl.create(:user, :userid => 'tags_wilma', :miq_groups => [@group])
-    @tag_selected = FactoryGirl.create(:classification, :name => 'tag_selected', :show => false)
-    @folder_selected = FactoryGirl.create(:classification, :name => 'folder_selected', :show => true)
+    @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
+    login_as FactoryBot.create(:user, :userid => 'tags_wilma', :miq_groups => [@group])
+    @tag_selected = FactoryBot.create(:classification, :name => 'tag_selected', :show => false)
+    @folder_selected = FactoryBot.create(:classification, :name => 'folder_selected', :show => true)
     @folder_selected.entries.push(@tag_selected)
-    @tag_not_selected = FactoryGirl.create(:classification, :name => 'tag_not_selected', :show => false)
-    @folder_not_selected = FactoryGirl.create(:classification, :name => 'folder_not_selected', :show => true)
+    @tag_not_selected = FactoryBot.create(:classification, :name => 'tag_not_selected', :show => false)
+    @folder_not_selected = FactoryBot.create(:classification, :name => 'folder_not_selected', :show => true)
     @folder_not_selected.entries.push(@tag_not_selected)
     @filters = {"#{@folder_selected.name}-#{@tag_selected.name}" =>
                                                                     "/managed/#{@folder_selected.name}/#{@tag_selected.name}"}
-    @group = FactoryGirl.create(:miq_group)
+    @group = FactoryBot.create(:miq_group)
   end
   context 'read-only mode' do
     before do

--- a/spec/presenters/tree_builder_timelines_spec.rb
+++ b/spec/presenters/tree_builder_timelines_spec.rb
@@ -1,6 +1,6 @@
 describe TreeBuilderTimelines do
   let!(:report) do
-    FactoryGirl.create(:miq_report,
+    FactoryBot.create(:miq_report,
                        :name          => 'name',
                        :timeline      => 'something',
                        :template_type => 'report',

--- a/spec/presenters/tree_builder_vat_spec.rb
+++ b/spec/presenters/tree_builder_vat_spec.rb
@@ -2,13 +2,13 @@ describe TreeBuilderVat do
   context 'TreeBuilderVat' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Vat Group")
-      login_as FactoryGirl.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
-      cluster = FactoryGirl.create(:ems_cluster)
+      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Vat Group")
+      login_as FactoryBot.create(:user, :userid => 'datacenter_wilma', :miq_groups => [@group])
+      cluster = FactoryBot.create(:ems_cluster)
       class << cluster
         def children
-          [OpenStruct.new(:datacenters_only => [FactoryGirl.create(:datacenter)],
-                          :folders_only     => [FactoryGirl.create(:ems_folder)],
+          [OpenStruct.new(:datacenters_only => [FactoryBot.create(:datacenter)],
+                          :folders_only     => [FactoryBot.create(:ems_folder)],
                           :name             => 'Datacenters',)]
         end
 

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -1,11 +1,11 @@
 describe TreeBuilderVmsAndTemplates do
-  let(:ems) { FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone)) }
-  let(:folder) { FactoryGirl.create(:ems_folder, :ext_management_system => ems) }
-  let(:subfolder1) { FactoryGirl.create(:ems_folder) }
+  let(:ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
+  let(:folder) { FactoryBot.create(:ems_folder, :ext_management_system => ems) }
+  let(:subfolder1) { FactoryBot.create(:ems_folder) }
 
   let(:tree) do
-    subfolder2 = FactoryGirl.create(:ems_folder)
-    subfolder3 = FactoryGirl.create(:datacenter)
+    subfolder2 = FactoryBot.create(:ems_folder)
+    subfolder3 = FactoryBot.create(:datacenter)
 
     ems.with_relationship_type("ems_metadata") { ems.add_child(folder) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder1) }
@@ -25,9 +25,9 @@ describe TreeBuilderVmsAndTemplates do
   describe "#tree" do
     it "returns vms with display_vms=true" do
       EvmSpecHelper.local_miq_server
-      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => true}})
+      User.current_user = FactoryBot.create(:user, :settings => {:display => {:display_vms => true}})
       tree
-      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      vms = FactoryBot.create_list(:vm_vmware, 2, :ext_management_system => ems)
       subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
 
       tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
@@ -48,9 +48,9 @@ describe TreeBuilderVmsAndTemplates do
 
     it "returns no vms with display_vms=false" do
       EvmSpecHelper.local_miq_server
-      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => false}})
+      User.current_user = FactoryBot.create(:user, :settings => {:display => {:display_vms => false}})
       tree
-      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      vms = FactoryBot.create_list(:vm_vmware, 2, :ext_management_system => ems)
       subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
 
       tree_v = TreeBuilderVmsAndTemplates.new(ems).tree

--- a/spec/presenters/tree_node/availability_zone_spec.rb
+++ b/spec/presenters/tree_node/availability_zone_spec.rb
@@ -9,9 +9,9 @@ describe TreeNode::AvailabilityZone do
     availability_zone_openstack_null
     availability_zone_vmware
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'az-'
       include_examples 'TreeNode::Node#icon', 'pficon pficon-zone'

--- a/spec/presenters/tree_node/chargeback_rate_spec.rb
+++ b/spec/presenters/tree_node/chargeback_rate_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ChargebackRate do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:chargeback_rate) }
+  let(:object) { FactoryBot.create(:chargeback_rate) }
 
   include_examples 'TreeNode::Node#key prefix', 'cr-'
   include_examples 'TreeNode::Node#icon', 'fa fa-file-text-o'

--- a/spec/presenters/tree_node/classification_spec.rb
+++ b/spec/presenters/tree_node/classification_spec.rb
@@ -20,12 +20,12 @@ describe TreeNode::Classification do
   end
 
   context 'Classification' do
-    let(:object) { FactoryGirl.create(:classification) }
+    let(:object) { FactoryBot.create(:classification) }
     it_behaves_like 'TreeNode::Classification'
   end
 
   context 'Category' do
-    let(:object) { FactoryGirl.create(:category) }
+    let(:object) { FactoryBot.create(:category) }
     it_behaves_like 'TreeNode::Classification'
   end
 end

--- a/spec/presenters/tree_node/compliance_detail_spec.rb
+++ b/spec/presenters/tree_node/compliance_detail_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ComplianceDetail do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:compliance_detail, :miq_policy_result => result) }
+  let(:object) { FactoryBot.create(:compliance_detail, :miq_policy_result => result) }
   let(:result) { true }
 
   include_examples 'TreeNode::Node#key prefix', 'cd-'

--- a/spec/presenters/tree_node/compliance_spec.rb
+++ b/spec/presenters/tree_node/compliance_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Compliance do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:compliance, :compliant => compliant) }
+  let(:object) { FactoryBot.create(:compliance, :compliant => compliant) }
   let(:compliant) { true }
 
   include_examples 'TreeNode::Node#key prefix', 'cm-'

--- a/spec/presenters/tree_node/condition_spec.rb
+++ b/spec/presenters/tree_node/condition_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Condition do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:condition) }
+  let(:object) { FactoryBot.create(:condition) }
 
   include_examples 'TreeNode::Node#key prefix', 'co-'
   include_examples 'TreeNode::Node#icon', 'fa fa-diamond'

--- a/spec/presenters/tree_node/configuration_profile_spec.rb
+++ b/spec/presenters/tree_node/configuration_profile_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ConfigurationProfile do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:configuration_profile_foreman) }
+  let(:object) { FactoryBot.create(:configuration_profile_foreman) }
 
   include_examples 'TreeNode::Node#key prefix', 'cp-'
   include_examples 'TreeNode::Node#icon', 'fa fa-list-ul'

--- a/spec/presenters/tree_node/configuration_script_base_spec.rb
+++ b/spec/presenters/tree_node/configuration_script_base_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ConfigurationScriptBase do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:ansible_configuration_script) }
+  let(:object) { FactoryBot.create(:ansible_configuration_script) }
 
   include_examples 'TreeNode::Node#key prefix', 'cf-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-template'

--- a/spec/presenters/tree_node/configured_system_spec.rb
+++ b/spec/presenters/tree_node/configured_system_spec.rb
@@ -6,9 +6,9 @@ describe TreeNode::ConfiguredSystem do
     configured_system_foreman
     configured_system_ansible_tower
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'cs-'
       include_examples 'TreeNode::Node#icon', 'ff ff-configured-system'

--- a/spec/presenters/tree_node/container_spec.rb
+++ b/spec/presenters/tree_node/container_spec.rb
@@ -2,9 +2,9 @@ describe TreeNode::Container do
   subject { described_class.new(object, nil, {}) }
 
   %i(container kubernetes_container).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'cnt-'
       include_examples 'TreeNode::Node#icon', 'fa fa-cube'

--- a/spec/presenters/tree_node/custom_button_set_spec.rb
+++ b/spec/presenters/tree_node/custom_button_set_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::CustomButtonSet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:custom_button_set, :description => "custom button set description") }
+  let(:object) { FactoryBot.create(:custom_button_set, :description => "custom button set description") }
 
   include_examples 'TreeNode::Node#key prefix', 'cbg-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'

--- a/spec/presenters/tree_node/custom_button_spec.rb
+++ b/spec/presenters/tree_node/custom_button_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::CustomButton do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:custom_button, :applies_to_class => 'Host') }
+  let(:object) { FactoryBot.create(:custom_button, :applies_to_class => 'Host') }
 
   include_examples 'TreeNode::Node#key prefix', 'cb-'
   include_examples 'TreeNode::Node#icon', 'fa fa-file-o'

--- a/spec/presenters/tree_node/customization_template_spec.rb
+++ b/spec/presenters/tree_node/customization_template_spec.rb
@@ -7,9 +7,9 @@ describe TreeNode::CustomizationTemplate do
     customization_template_sysprep
     customization_template_cloud_init
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'ct-'
       include_examples 'TreeNode::Node#icon', 'pficon pficon-template'

--- a/spec/presenters/tree_node/dialog_field_spec.rb
+++ b/spec/presenters/tree_node/dialog_field_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::DialogField do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:dialog_field) }
+  let(:object) { FactoryBot.create(:dialog_field) }
 
   include_examples 'TreeNode::Node#key prefix', '-'
   include_examples 'TreeNode::Node#icon', 'ff ff-field'

--- a/spec/presenters/tree_node/dialog_group_spec.rb
+++ b/spec/presenters/tree_node/dialog_group_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::DialogGroup do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:dialog_group) }
+  let(:object) { FactoryBot.create(:dialog_group) }
 
   include_examples 'TreeNode::Node#key prefix', '-'
   include_examples 'TreeNode::Node#icon', 'fa fa-comments-o'

--- a/spec/presenters/tree_node/dialog_spec.rb
+++ b/spec/presenters/tree_node/dialog_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Dialog do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:dialog) }
+  let(:object) { FactoryBot.create(:dialog) }
 
   include_examples 'TreeNode::Node#key prefix', 'dg-'
   include_examples 'TreeNode::Node#icon', 'fa fa-comment-o'

--- a/spec/presenters/tree_node/dialog_tab_spec.rb
+++ b/spec/presenters/tree_node/dialog_tab_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::DialogTab do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:dialog_tab) }
+  let(:object) { FactoryBot.create(:dialog_tab) }
 
   include_examples 'TreeNode::Node#key prefix', '-'
   include_examples 'TreeNode::Node#icon', 'ff ff-tab'

--- a/spec/presenters/tree_node/ems_cluster_spec.rb
+++ b/spec/presenters/tree_node/ems_cluster_spec.rb
@@ -2,9 +2,9 @@ describe TreeNode::EmsCluster do
   subject { described_class.new(object, nil, {}) }
 
   %i(ems_cluster ems_cluster_openstack).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'c-'
       include_examples 'TreeNode::Node#icon', 'pficon pficon-cluster'

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -8,9 +8,9 @@ describe TreeNode::EmsFolder do
     inventory_group
     inventory_root_group
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'f-'
       include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
@@ -25,7 +25,7 @@ describe TreeNode::EmsFolder do
   end
 
   context 'Datacenter' do
-    let(:object) { FactoryGirl.create(:datacenter) }
+    let(:object) { FactoryBot.create(:datacenter) }
 
     include_examples 'TreeNode::Node#key prefix', 'dc-'
     include_examples 'TreeNode::Node#icon', 'fa fa-building-o'

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -2,7 +2,7 @@ describe TreeNode::ExtManagementSystem do
   subject { described_class.new(object, nil, {}) }
 
   describe 'ManageIQ::Providers::Redhat::InfraManager' do
-    let(:object) { FactoryGirl.create(:ems_redhat) }
+    let(:object) { FactoryBot.create(:ems_redhat) }
 
     context 'has no name' do
       describe '#title' do
@@ -49,11 +49,11 @@ describe TreeNode::ExtManagementSystem do
     # :ems_network                       => {},
     # :ems_storage                       => {}
   }.each do |factory, spec|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
       before(:all) { klass.constantize.skip_callback(:save, :after, :stop_event_monitor_queue_on_change) if spec[:suppress_callback] }
 
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', spec.fetch(:key_prefix, 'e-')
       include_examples 'TreeNode::Node#tooltip prefix', spec.fetch(:tip_prefix, 'Provider')

--- a/spec/presenters/tree_node/guest_device_spec.rb
+++ b/spec/presenters/tree_node/guest_device_spec.rb
@@ -1,13 +1,13 @@
 describe TreeNode::GuestDevice do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:guest_device, :controller_type => 'foo') }
+  let(:object) { FactoryBot.create(:guest_device, :controller_type => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', 'gd-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-unknown'
   include_examples 'TreeNode::Node#tooltip prefix', 'foo Storage Adapter'
 
   context 'ethernet' do
-    let(:object) { FactoryGirl.create(:guest_device_nic) }
+    let(:object) { FactoryBot.create(:guest_device_nic) }
 
     include_examples 'TreeNode::Node#key prefix', 'gd-'
     include_examples 'TreeNode::Node#icon', 'ff ff-network-card'

--- a/spec/presenters/tree_node/host_spec.rb
+++ b/spec/presenters/tree_node/host_spec.rb
@@ -9,9 +9,9 @@ describe TreeNode::Host do
     host_vmware
     host_vmware_esx
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'h-'
       include_examples 'TreeNode::Node#icon', 'pficon pficon-container-node'

--- a/spec/presenters/tree_node/iso_datastore_spec.rb
+++ b/spec/presenters/tree_node/iso_datastore_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::IsoDatastore do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:iso_datastore) }
+  let(:object) { FactoryBot.create(:iso_datastore) }
 
   include_examples 'TreeNode::Node#key prefix', 'isd-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-server'

--- a/spec/presenters/tree_node/iso_image_spec.rb
+++ b/spec/presenters/tree_node/iso_image_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::IsoImage do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:iso_image) }
+  let(:object) { FactoryBot.create(:iso_image) }
 
   include_examples 'TreeNode::Node#key prefix', 'isi-'
   include_examples 'TreeNode::Node#icon', 'ff ff-network-card'

--- a/spec/presenters/tree_node/lan_spec.rb
+++ b/spec/presenters/tree_node/lan_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Lan do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:lan) }
+  let(:object) { FactoryBot.create(:lan) }
 
   include_examples 'TreeNode::Node#key prefix', 'l-'
   include_examples 'TreeNode::Node#icon', 'ff ff-network-switch'

--- a/spec/presenters/tree_node/miq_action_spec.rb
+++ b/spec/presenters/tree_node/miq_action_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAction do
   subject { described_class.new(object, nil, :tree => :action_tree) }
-  let(:object) { FactoryGirl.create(:miq_action, :name => 'raise_automation_event', :action_type => 'default') }
+  let(:object) { FactoryBot.create(:miq_action, :name => 'raise_automation_event', :action_type => 'default') }
 
   include_examples 'TreeNode::Node#key prefix', 'a-'
   include_examples 'TreeNode::Node#text description'

--- a/spec/presenters/tree_node/miq_ae_class_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_class_spec.rb
@@ -1,8 +1,8 @@
 describe TreeNode::MiqAeClass do
   subject { described_class.new(object, nil, {}) }
   let(:object) do
-    ns = FactoryGirl.create(:miq_ae_namespace)
-    FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+    ns = FactoryBot.create(:miq_ae_namespace)
+    FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
   end
 
   include_examples 'TreeNode::Node#key prefix', 'aec-'

--- a/spec/presenters/tree_node/miq_ae_instance_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_instance_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAeInstance do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_ae_instance) }
+  let(:object) { FactoryBot.create(:miq_ae_instance) }
 
   include_examples 'TreeNode::Node#key prefix', 'aei-'
   include_examples 'TreeNode::Node#icon', 'fa fa-file-text-o'

--- a/spec/presenters/tree_node/miq_ae_method_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_method_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAeMethod do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_ae_method, :scope => :class, :language => :ruby, :location => :inline) }
+  let(:object) { FactoryBot.create(:miq_ae_method, :scope => :class, :language => :ruby, :location => :inline) }
 
   include_examples 'TreeNode::Node#key prefix', 'aem-'
   include_examples 'TreeNode::Node#icon', 'fa-ruby'

--- a/spec/presenters/tree_node/miq_ae_namespace_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_namespace_spec.rb
@@ -1,10 +1,10 @@
 describe TreeNode::MiqAeNamespace do
-  before { login_as FactoryGirl.create(:user_with_group) }
+  before { login_as FactoryBot.create(:user_with_group) }
   subject { described_class.new(object, nil, {}) }
 
   let(:object) do
-    domain = FactoryGirl.create(:miq_ae_domain)
-    FactoryGirl.create(:miq_ae_namespace, :parent => domain)
+    domain = FactoryBot.create(:miq_ae_domain)
+    FactoryBot.create(:miq_ae_namespace, :parent => domain)
   end
 
   include_examples 'TreeNode::Node#key prefix', 'aen-'
@@ -12,7 +12,7 @@ describe TreeNode::MiqAeNamespace do
   include_examples 'TreeNode::Node#tooltip prefix', 'Automate Namespace'
 
   context 'MiqAeDomain' do
-    let(:object) { FactoryGirl.create(:miq_ae_domain, :name => "test1") }
+    let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1") }
 
     describe '#title' do
       it 'returns without any suffix' do
@@ -21,7 +21,7 @@ describe TreeNode::MiqAeNamespace do
     end
 
     context 'disabled' do
-      let(:object) { FactoryGirl.create(:miq_ae_domain, :name => "test1", :enabled => false) }
+      let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1", :enabled => false) }
 
       describe '#title' do
         it 'returns disabled in the suffix' do
@@ -31,7 +31,7 @@ describe TreeNode::MiqAeNamespace do
     end
 
     context 'locked' do
-      let(:object) { FactoryGirl.create(:miq_ae_system_domain_enabled, :name => "test1") }
+      let(:object) { FactoryBot.create(:miq_ae_system_domain_enabled, :name => "test1") }
 
       describe '#title' do
         it 'returns locked in the suffix' do
@@ -41,7 +41,7 @@ describe TreeNode::MiqAeNamespace do
     end
 
     context 'locked & disabled' do
-      let(:object) { FactoryGirl.create(:miq_ae_system_domain, :name => "test1") }
+      let(:object) { FactoryBot.create(:miq_ae_system_domain, :name => "test1") }
 
       describe '#title' do
         it 'returns both locked and disabled in the suffix' do

--- a/spec/presenters/tree_node/miq_alert_set_spec.rb
+++ b/spec/presenters/tree_node/miq_alert_set_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAlertSet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_alert_set) }
+  let(:object) { FactoryBot.create(:miq_alert_set) }
 
   include_examples 'TreeNode::Node#key prefix', 'ap-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-warning-triangle-o'

--- a/spec/presenters/tree_node/miq_alert_spec.rb
+++ b/spec/presenters/tree_node/miq_alert_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAlert do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_alert) }
+  let(:object) { FactoryBot.create(:miq_alert) }
 
   include_examples 'TreeNode::Node#key prefix', 'al-'
   include_examples 'TreeNode::Node#text description'

--- a/spec/presenters/tree_node/miq_dialog_spec.rb
+++ b/spec/presenters/tree_node/miq_dialog_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqDialog do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_dialog) }
+  let(:object) { FactoryBot.create(:miq_dialog) }
 
   include_examples 'TreeNode::Node#key prefix', 'odg-'
   include_examples 'TreeNode::Node#icon', 'fa fa-comment-o'

--- a/spec/presenters/tree_node/miq_event_definition_spec.rb
+++ b/spec/presenters/tree_node/miq_event_definition_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqEventDefinition do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_event_definition) }
+  let(:object) { FactoryBot.create(:miq_event_definition) }
 
   include_examples 'TreeNode::Node#key prefix', 'ev-'
   include_examples 'TreeNode::Node#icon', 'fa fa-star'

--- a/spec/presenters/tree_node/miq_group_spec.rb
+++ b/spec/presenters/tree_node/miq_group_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqGroup do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_group) }
+  let(:object) { FactoryBot.create(:miq_group) }
 
   include_examples 'TreeNode::Node#key prefix', 'g-'
   include_examples 'TreeNode::Node#icon', 'ff ff-group'

--- a/spec/presenters/tree_node/miq_policy_set_spec.rb
+++ b/spec/presenters/tree_node/miq_policy_set_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqPolicySet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_policy_set, :name => 'Just a set') }
+  let(:object) { FactoryBot.create(:miq_policy_set, :name => 'Just a set') }
 
   include_examples 'TreeNode::Node#key prefix', 'pp-'
   include_examples 'TreeNode::Node#text description'

--- a/spec/presenters/tree_node/miq_policy_spec.rb
+++ b/spec/presenters/tree_node/miq_policy_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqPolicy do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control') }
+  let(:object) { FactoryBot.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control') }
 
   include_examples 'TreeNode::Node#key prefix', 'p-'
   include_examples 'TreeNode::Node#text description'

--- a/spec/presenters/tree_node/miq_region_spec.rb
+++ b/spec/presenters/tree_node/miq_region_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqRegion do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_region, :description => 'Elbonia') }
+  let(:object) { FactoryBot.create(:miq_region, :description => 'Elbonia') }
 
   include_examples 'TreeNode::Node#key prefix', 'mr-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-regions'

--- a/spec/presenters/tree_node/miq_report_result_spec.rb
+++ b/spec/presenters/tree_node/miq_report_result_spec.rb
@@ -1,7 +1,7 @@
 describe TreeNode::MiqReportResult do
   subject { described_class.new(object, nil, {}) }
 
-  let(:object) { FactoryGirl.create(:miq_report_result, :report => {}) }
+  let(:object) { FactoryBot.create(:miq_report_result, :report => {}) }
 
   include_examples 'TreeNode::Node#key prefix', 'rr-'
   include_examples 'TreeNode::Node#icon', 'fa fa-arrow-right'

--- a/spec/presenters/tree_node/miq_report_spec.rb
+++ b/spec/presenters/tree_node/miq_report_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqReport do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_report) }
+  let(:object) { FactoryBot.create(:miq_report) }
 
   include_examples 'TreeNode::Node#key prefix', 'rep-'
   include_examples 'TreeNode::Node#icon', 'fa fa-file-text-o'

--- a/spec/presenters/tree_node/miq_schedule_spec.rb
+++ b/spec/presenters/tree_node/miq_schedule_spec.rb
@@ -2,7 +2,7 @@ describe TreeNode::MiqSchedule do
   subject { described_class.new(object, nil, {}) }
   let(:object) do
     EvmSpecHelper.local_miq_server
-    FactoryGirl.create(:miq_schedule)
+    FactoryBot.create(:miq_schedule)
   end
 
   include_examples 'TreeNode::Node#key prefix', 'msc-'

--- a/spec/presenters/tree_node/miq_scsi_lun_spec.rb
+++ b/spec/presenters/tree_node/miq_scsi_lun_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqScsiLun do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_scsi_lun, :canonical_name => 'foo') }
+  let(:object) { FactoryBot.create(:miq_scsi_lun, :canonical_name => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', 'sl-'
   include_examples 'TreeNode::Node#icon', 'fa fa-database'

--- a/spec/presenters/tree_node/miq_scsi_target_spec.rb
+++ b/spec/presenters/tree_node/miq_scsi_target_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqScsiTarget do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_scsi_target) }
+  let(:object) { FactoryBot.create(:miq_scsi_target) }
 
   include_examples 'TreeNode::Node#key prefix', 'sg-'
   include_examples 'TreeNode::Node#icon', 'ff ff-network-card'

--- a/spec/presenters/tree_node/miq_search_spec.rb
+++ b/spec/presenters/tree_node/miq_search_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqSearch do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_search) }
+  let(:object) { FactoryBot.create(:miq_search) }
 
   include_examples 'TreeNode::Node#key prefix', 'ms-'
   include_examples 'TreeNode::Node#icon', 'fa fa-filter'

--- a/spec/presenters/tree_node/miq_server_spec.rb
+++ b/spec/presenters/tree_node/miq_server_spec.rb
@@ -1,8 +1,8 @@
 describe TreeNode::MiqServer do
   subject { described_class.new(object, nil, {}) }
   let(:object) do
-    zone = FactoryGirl.create(:zone)
-    FactoryGirl.create(:miq_server, :zone => zone)
+    zone = FactoryBot.create(:zone)
+    FactoryBot.create(:miq_server, :zone => zone)
   end
 
   include_examples 'TreeNode::Node#key prefix', 'svr-'

--- a/spec/presenters/tree_node/miq_user_role_spec.rb
+++ b/spec/presenters/tree_node/miq_user_role_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqUserRole do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_user_role) }
+  let(:object) { FactoryBot.create(:miq_user_role) }
 
   include_examples 'TreeNode::Node#key prefix', 'ur-'
   include_examples 'TreeNode::Node#icon', 'ff ff-user-role'

--- a/spec/presenters/tree_node/miq_widget_set_spec.rb
+++ b/spec/presenters/tree_node/miq_widget_set_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqWidgetSet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_widget_set, :name => 'foo') }
+  let(:object) { FactoryBot.create(:miq_widget_set, :name => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', '-'
   include_examples 'TreeNode::Node#icon', 'fa fa-tachometer'

--- a/spec/presenters/tree_node/miq_widget_spec.rb
+++ b/spec/presenters/tree_node/miq_widget_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqWidget do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:miq_widget) }
+  let(:object) { FactoryBot.create(:miq_widget) }
 
   include_examples 'TreeNode::Node#key prefix', '-'
   include_examples 'TreeNode::Node#icon', 'fa fa-file-text-o'

--- a/spec/presenters/tree_node/orchestration_template_spec.rb
+++ b/spec/presenters/tree_node/orchestration_template_spec.rb
@@ -9,7 +9,7 @@ describe TreeNode::OrchestrationTemplate do
     :orchestration_template_vmware_cloud_in_xml => %w(ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate vapp)
   }.each do |factory, config|
     context(config.first) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'ot-'
       include_examples 'TreeNode::Node#icon', "pficon pficon-template"

--- a/spec/presenters/tree_node/physical_server_spec.rb
+++ b/spec/presenters/tree_node/physical_server_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::PhysicalServer do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:physical_server) }
+  let(:object) { FactoryBot.create(:physical_server) }
 
   include_examples 'TreeNode::Node#key prefix', 'phys-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-server'

--- a/spec/presenters/tree_node/pxe_image_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_spec.rb
@@ -6,9 +6,9 @@ describe TreeNode::PxeImage do
     pxe_image_ipxe
     pxe_image_pxelinux
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'pi-'
       include_examples 'TreeNode::Node#icon', 'ff ff-network-card'

--- a/spec/presenters/tree_node/pxe_image_type_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_type_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::PxeImageType do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:pxe_image_type) }
+  let(:object) { FactoryBot.create(:pxe_image_type) }
 
   include_examples 'TreeNode::Node#key prefix', 'pit-'
   include_examples 'TreeNode::Node#icon', 'ff ff-network-card'

--- a/spec/presenters/tree_node/pxe_server_spec.rb
+++ b/spec/presenters/tree_node/pxe_server_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::PxeServer do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:pxe_server) }
+  let(:object) { FactoryBot.create(:pxe_server) }
 
   include_examples 'TreeNode::Node#key prefix', 'ps-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-server'

--- a/spec/presenters/tree_node/resource_pool_spec.rb
+++ b/spec/presenters/tree_node/resource_pool_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ResourcePool do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:resource_pool) }
+  let(:object) { FactoryBot.create(:resource_pool) }
 
   include_examples 'TreeNode::Node#key prefix', 'r-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-resource-pool'

--- a/spec/presenters/tree_node/scan_item_set_spec.rb
+++ b/spec/presenters/tree_node/scan_item_set_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ScanItemSet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:scan_item_set) }
+  let(:object) { FactoryBot.create(:scan_item_set) }
 
   include_examples 'TreeNode::Node#icon', 'fa fa-search'
 end

--- a/spec/presenters/tree_node/service_resource_spec.rb
+++ b/spec/presenters/tree_node/service_resource_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::ServiceResource do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:service_resource) }
+  let(:object) { FactoryBot.create(:service_resource) }
 
   include_examples 'TreeNode::Node#key prefix', 'sr-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-template'

--- a/spec/presenters/tree_node/service_spec.rb
+++ b/spec/presenters/tree_node/service_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Service do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:service) }
+  let(:object) { FactoryBot.create(:service) }
 
   include_examples 'TreeNode::Node#key prefix', 's-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-service'

--- a/spec/presenters/tree_node/service_template_catalog_spec.rb
+++ b/spec/presenters/tree_node/service_template_catalog_spec.rb
@@ -1,8 +1,8 @@
 describe TreeNode::ServiceTemplateCatalog do
   subject { described_class.new(object, nil, {}) }
   let(:object) do
-    tenant = FactoryGirl.create(:tenant)
-    FactoryGirl.create(:service_template_catalog, :name => 'foo', :tenant => tenant)
+    tenant = FactoryBot.create(:tenant)
+    FactoryBot.create(:service_template_catalog, :name => 'foo', :tenant => tenant)
   end
 
   include_examples 'TreeNode::Node#key prefix', 'stc-'

--- a/spec/presenters/tree_node/service_template_spec.rb
+++ b/spec/presenters/tree_node/service_template_spec.rb
@@ -1,13 +1,13 @@
 describe TreeNode::ServiceTemplate do
   subject { described_class.new(object, nil, {}) }
-  let(:tenant) { FactoryGirl.create(:tenant) }
+  let(:tenant) { FactoryBot.create(:tenant) }
   %i(
     service_template
     service_template_ansible_tower
     service_template_orchestration
   ).each do |factory|
     context(factory.to_s.camelize) do
-      let(:object) { FactoryGirl.create(factory, :name => 'foo', :tenant => tenant, :service_type => stype) }
+      let(:object) { FactoryBot.create(factory, :name => 'foo', :tenant => tenant, :service_type => stype) }
       let(:stype) { 'atomic' }
 
       include_examples 'TreeNode::Node#key prefix', 'st-'

--- a/spec/presenters/tree_node/snapshot_spec.rb
+++ b/spec/presenters/tree_node/snapshot_spec.rb
@@ -2,8 +2,8 @@ describe TreeNode::Snapshot do
   subject { described_class.new(object, nil, {}) }
   let(:object) do
     EvmSpecHelper.local_miq_server
-    vm = FactoryGirl.create(:vm_vmware)
-    FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :name => 'polaroid')
+    vm = FactoryBot.create(:vm_vmware)
+    FactoryBot.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :name => 'polaroid')
   end
 
   include_examples 'TreeNode::Node#key prefix', 'sn-'

--- a/spec/presenters/tree_node/storage_spec.rb
+++ b/spec/presenters/tree_node/storage_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Storage do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:storage) }
+  let(:object) { FactoryBot.create(:storage) }
 
   include_examples 'TreeNode::Node#key prefix', 'ds-'
   include_examples 'TreeNode::Node#icon', 'fa fa-database'

--- a/spec/presenters/tree_node/switch_spec.rb
+++ b/spec/presenters/tree_node/switch_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Switch do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:switch, :name => "light") }
+  let(:object) { FactoryBot.create(:switch, :name => "light") }
 
   include_examples 'TreeNode::Node#key prefix', 'sw-'
   include_examples 'TreeNode::Node#icon', 'ff ff-network-switch'

--- a/spec/presenters/tree_node/tenant_spec.rb
+++ b/spec/presenters/tree_node/tenant_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::Tenant do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:tenant) }
+  let(:object) { FactoryBot.create(:tenant) }
 
   include_examples 'TreeNode::Node#key prefix', 'tn-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-tenant'

--- a/spec/presenters/tree_node/user_spec.rb
+++ b/spec/presenters/tree_node/user_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::User do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:user) }
+  let(:object) { FactoryBot.create(:user) }
 
   include_examples 'TreeNode::Node#key prefix', 'u-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-user'

--- a/spec/presenters/tree_node/vm_or_template_spec.rb
+++ b/spec/presenters/tree_node/vm_or_template_spec.rb
@@ -17,9 +17,9 @@ describe TreeNode::VmOrTemplate do
     template_vmware
     template_xen
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory, :name => "template", :template => true) }
+      let(:object) { FactoryBot.create(factory, :name => "template", :template => true) }
 
       include_examples 'TreeNode::Node#key prefix', 't-'
       include_examples 'TreeNode::Node#icon', 'fa fa-archive'
@@ -48,9 +48,9 @@ describe TreeNode::VmOrTemplate do
     vm_vmware
     vm_xen
   ).each do |factory|
-    klass = FactoryGirl.factory_by_name(factory).instance_variable_get(:@class_name)
+    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
     context(klass) do
-      let(:object) { FactoryGirl.create(factory) }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'v-'
       include_examples 'TreeNode::Node#icon', 'fa fa-archive'

--- a/spec/presenters/tree_node/vmdb_index_spec.rb
+++ b/spec/presenters/tree_node/vmdb_index_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::VmdbIndex do
-  let(:object) { FactoryGirl.create(:vmdb_index, :name => 'foo') }
+  let(:object) { FactoryBot.create(:vmdb_index, :name => 'foo') }
   subject { described_class.new(object, nil, {}) }
 
   include_examples 'TreeNode::Node#key prefix', 'ti-'

--- a/spec/presenters/tree_node/vmdb_table_spec.rb
+++ b/spec/presenters/tree_node/vmdb_table_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::VmdbTable do
-  let(:object) { FactoryGirl.create(:vmdb_table_evm, :name => 'foo') }
+  let(:object) { FactoryBot.create(:vmdb_table_evm, :name => 'foo') }
   subject { described_class.new(object, nil, {}) }
 
   include_examples 'TreeNode::Node#key prefix', 'tb-'

--- a/spec/presenters/tree_node/windows_image_spec.rb
+++ b/spec/presenters/tree_node/windows_image_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::WindowsImage do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:windows_image) }
+  let(:object) { FactoryBot.create(:windows_image) }
 
   include_examples 'TreeNode::Node#key prefix', 'wi-'
   include_examples 'TreeNode::Node#image', 'svg/os-windows_generic.svg'

--- a/spec/presenters/tree_node/zone_spec.rb
+++ b/spec/presenters/tree_node/zone_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Zone do
-  let(:object) { FactoryGirl.create(:zone, :name => "foo") }
+  let(:object) { FactoryBot.create(:zone, :name => "foo") }
   subject { described_class.new(object, nil, {}) }
 
   include_examples 'TreeNode::Node#key prefix', 'z-'

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -2,7 +2,7 @@ describe TreeNode do
   # Force load all the TreeNode:: subclasses
   Dir[ManageIQ::UI::Classic::Engine.root.join('app', 'presenters', 'tree_node', '*.rb')].each { |f| require f }
 
-  # FIXME: rewrite this to FactoryGirl
+  # FIXME: rewrite this to FactoryBot
   let(:object) do
     # We need a Zone & Server for creating a MiqSchedule
     EvmSpecHelper.create_guid_miq_server_zone if klass == MiqSchedule

--- a/spec/product/reports_spec.rb
+++ b/spec/product/reports_spec.rb
@@ -6,7 +6,7 @@ describe 'YAML reports' do
 
   before do
     EvmSpecHelper.local_miq_server
-    @user = FactoryGirl.create(:user_with_group)
+    @user = FactoryBot.create(:user_with_group)
   end
 
   context "product directory" do

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,6 +1,6 @@
 describe "Login process" do
   let(:user) do
-    FactoryGirl.create(:user_with_email, :password => "smartvm", :role => "super_administrator")
+    FactoryBot.create(:user_with_email, :password => "smartvm", :role => "super_administrator")
   end
 
   before do

--- a/spec/requests/restful_redirect_spec.rb
+++ b/spec/requests/restful_redirect_spec.rb
@@ -1,5 +1,5 @@
 describe RestfulRedirectController do
-  let(:user) { FactoryGirl.create(:user_with_email, :role => 'super_administrator', :password => 'x') }
+  let(:user) { FactoryBot.create(:user_with_email, :role => 'super_administrator', :password => 'x') }
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
@@ -10,9 +10,9 @@ describe RestfulRedirectController do
   end
 
   context 'for MiqRequest' do
-    let(:ems)      { FactoryGirl.create(:ems_vmware_with_authentication) }
-    let(:template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
-    let(:req) { FactoryGirl.create(:miq_provision_request, :requester => user, :source => template) }
+    let(:ems)      { FactoryBot.create(:ems_vmware_with_authentication) }
+    let(:template) { FactoryBot.create(:template_vmware, :ext_management_system => ems) }
+    let(:req) { FactoryBot.create(:miq_provision_request, :requester => user, :source => template) }
 
     before do
       # Load just one dialog instead of calling `MiqDialog.seed`

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -1,5 +1,5 @@
 describe AnsibleTowerJobTemplateDialogService do
-  let(:template) { FactoryGirl.create(:ansible_configuration_script) }
+  let(:template) { FactoryBot.create(:ansible_configuration_script) }
 
   describe "#create_dialog" do
     it "creates a dialog from a job template" do

--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -32,7 +32,7 @@ describe AutomateImportService do
     let(:miq_ae_import) { double("MiqAeYamlImportZipfs", :import_stats => "import stats") }
     let(:removable_entry) { double(:name => "carrot/something_else/namespace.yaml") }
     let(:removable_class_entry) { double(:name => "carrot/something_else.class/class.yaml") }
-    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:user) { FactoryBot.create(:user_with_group) }
 
     before do
       User.current_user = user

--- a/spec/services/charts_layout_service_spec.rb
+++ b/spec/services/charts_layout_service_spec.rb
@@ -1,7 +1,7 @@
 describe ChartsLayoutService do
-  let(:host_openstack_infra) { FactoryGirl.create(:host_openstack_infra) }
-  let(:host_redhat) { FactoryGirl.create(:host_redhat) }
-  let(:vm_openstack) { FactoryGirl.create(:vm_openstack) }
+  let(:host_openstack_infra) { FactoryBot.create(:host_openstack_infra) }
+  let(:host_redhat) { FactoryBot.create(:host_redhat) }
+  let(:vm_openstack) { FactoryBot.create(:vm_openstack) }
   let(:host_openstack_infra_chart) do
     YAML.load(File.open(File.join(ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'ManageIQ_Providers_Openstack_InfraManager_Host') + '.yaml'))
   end
@@ -47,9 +47,9 @@ describe ChartsLayoutService do
     end
 
     it "includes Memory (MB) chart for azure instance" do
-      ems_azure = FactoryGirl.create(:ems_azure)
-      host = FactoryGirl.create(:host, :ext_management_system => ems_azure)
-      vm_azure = FactoryGirl.create(:vm_azure, :ext_management_system => ems_azure, :host => host)
+      ems_azure = FactoryBot.create(:ems_azure)
+      host = FactoryBot.create(:host, :ext_management_system => ems_azure)
+      vm_azure = FactoryBot.create(:vm_azure, :ext_management_system => ems_azure, :host => host)
       chart = ChartsLayoutService.layout(vm_azure, ApplicationController::Performance::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
       expect(chart.count { |x| x[:title] == "Memory (MB)" }).to equal 1
     end

--- a/spec/services/cloud_topology_service_spec.rb
+++ b/spec/services/cloud_topology_service_spec.rb
@@ -4,12 +4,12 @@ describe CloudTopologyService do
   describe "#build_topology" do
     subject { cloud_topology_service.build_topology }
 
-    let(:ems) { FactoryGirl.create(:ems_openstack) }
+    let(:ems) { FactoryBot.create(:ems_openstack) }
 
     before do
-      @availability_zone = FactoryGirl.create(:availability_zone_openstack, :ext_management_system => ems)
-      @cloud_tenant = FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems)
-      @vm = FactoryGirl.create(:vm_openstack, :cloud_tenant => @cloud_tenant, :ext_management_system => ems)
+      @availability_zone = FactoryBot.create(:availability_zone_openstack, :ext_management_system => ems)
+      @cloud_tenant = FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems)
+      @vm = FactoryBot.create(:vm_openstack, :cloud_tenant => @cloud_tenant, :ext_management_system => ems)
     end
 
     it "topology contains only the expected keys" do
@@ -17,7 +17,7 @@ describe CloudTopologyService do
     end
 
     it "provider has unknown status when no authentication exists" do
-      ems = FactoryGirl.create(:ems_openstack)
+      ems = FactoryBot.create(:ems_openstack)
 
       allow(cloud_topology_service)
         .to receive(:retrieve_providers)

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -1,6 +1,6 @@
 describe ContainerDashboardService do
   let(:controller) { double(:current_user => double(:get_timezone => "UTC", :id => 123)) }
-  let(:time_profile) { FactoryGirl.create(:time_profile_utc) }
+  let(:time_profile) { FactoryBot.create(:time_profile_utc) }
 
   before do
     MiqRegion.seed
@@ -9,7 +9,7 @@ describe ContainerDashboardService do
 
   context "providers" do
     it "filters containers providers with zero entity count and sorts providers by type correctly" do
-      ems = FactoryGirl.create(:ems_openshift, :hostname => "test2.com")
+      ems = FactoryBot.create(:ems_openshift, :hostname => "test2.com")
 
       providers_data = ContainerDashboardService.new(ems.id, nil).providers[0]
 
@@ -23,13 +23,13 @@ describe ContainerDashboardService do
 
   context "ems_utilization" do
     it "shows aggregated metrics from last 30 days only" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
-      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryBot.create(:ems_kubernetes, :zone => @zone)
 
       current_date = 7.days.ago.beginning_of_day.utc
       old_date = 35.days.ago
 
-      current_metric_openshift = FactoryGirl.create(
+      current_metric_openshift = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp                => current_date,
         :derived_memory_used      => 1024,
@@ -39,7 +39,7 @@ describe ContainerDashboardService do
         :time_profile             => time_profile
       )
 
-      current_metric_kubernetes = FactoryGirl.create(
+      current_metric_kubernetes = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp                => current_date,
         :derived_memory_used      => 512,
@@ -49,7 +49,7 @@ describe ContainerDashboardService do
         :time_profile             => time_profile
       )
 
-      old_metric = FactoryGirl.create(
+      old_metric = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp                => old_date,
         :derived_memory_used      => 1024,
@@ -59,7 +59,7 @@ describe ContainerDashboardService do
         :time_profile             => time_profile
       )
 
-      nil_fielded_metric = FactoryGirl.create(
+      nil_fielded_metric = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp    => old_date,
         :time_profile => time_profile
@@ -107,7 +107,7 @@ describe ContainerDashboardService do
     end
 
     it "returns hash with nil values when no metrics available" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
       node_utilization_all_providers = described_class.new(nil, controller).ems_utilization[:xy_data]
       node_utilization_single_provider = described_class.new(ems_openshift.id, controller).ems_utilization[:xy_data]
       expect(node_utilization_all_providers).to eq(:cpu => nil, :memory => nil)
@@ -117,19 +117,19 @@ describe ContainerDashboardService do
 
   context "heatmaps" do
     it "shows aggregated metrics from last 30 days only" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :name => 'openshift', :zone => @zone)
-      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :name => 'openshift', :zone => @zone)
+      ems_kubernetes = FactoryBot.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
 
-      @node1 = FactoryGirl.create(:container_node, :name => 'node1')
-      @node2 = FactoryGirl.create(:container_node, :name => 'node2')
-      @node3 = FactoryGirl.create(:container_node, :name => 'node3')
-      @node4 = FactoryGirl.create(:container_node, :name => 'node4')
+      @node1 = FactoryBot.create(:container_node, :name => 'node1')
+      @node2 = FactoryBot.create(:container_node, :name => 'node2')
+      @node3 = FactoryBot.create(:container_node, :name => 'node3')
+      @node4 = FactoryBot.create(:container_node, :name => 'node4')
       ems_openshift.container_nodes << @node1 << @node2
       ems_kubernetes.container_nodes << @node3 << @node4
 
       [ems_kubernetes, ems_openshift].each do |p|
         p.container_nodes.each do |node|
-          node.metric_rollups << FactoryGirl.create(
+          node.metric_rollups << FactoryBot.create(
             :metric_rollup_cm_hr,
             :timestamp                  => 1.hour.ago.utc,
             :cpu_usage_rate_average     => 90,
@@ -247,7 +247,7 @@ describe ContainerDashboardService do
     end
 
     it "returns hash with nil values when no metrics available" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
       heatmaps_all_providers = described_class.new(nil, controller).heatmaps
       heatmaps_single_provider = described_class.new(ems_openshift.id, controller).heatmaps
       expect(heatmaps_all_providers).to eq(:nodeCpuUsage => nil, :nodeMemoryUsage => nil, :title => "Node Utilization")
@@ -256,16 +256,16 @@ describe ContainerDashboardService do
 
     # BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1439671
     it "returns one metric per node in realtime case" do
-      ems = FactoryGirl.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
+      ems = FactoryBot.create(:ems_kubernetes, :name => 'kubernetes', :zone => @zone)
 
-      @node1 = FactoryGirl.create(:container_node, :name => 'node1')
-      @node2 = FactoryGirl.create(:container_node, :name => 'node2')
+      @node1 = FactoryBot.create(:container_node, :name => 'node1')
+      @node2 = FactoryBot.create(:container_node, :name => 'node2')
 
       ems.container_nodes << @node1 << @node2
 
       ems.container_nodes.each do |node|
         (1..10).each do |min|
-          node.metrics << FactoryGirl.create(
+          node.metrics << FactoryBot.create(
             :metric_container_node_rt,
             :timestamp                  => min.minute.ago.utc,
             :capture_interval           => 20,
@@ -321,35 +321,35 @@ describe ContainerDashboardService do
 
   context "network trends" do
     it "shows daily network trends from last 30 days only" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
-      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryBot.create(:ems_kubernetes, :zone => @zone)
 
       previous_date = 8.days.ago.beginning_of_day.utc
       current_date = 7.days.ago.beginning_of_day.utc
       old_date = 35.days.ago
 
-      previous_metric_openshift = FactoryGirl.create(
+      previous_metric_openshift = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp              => previous_date,
         :net_usage_rate_average => 2000,
         :time_profile           => time_profile
       )
 
-      current_metric_openshift = FactoryGirl.create(
+      current_metric_openshift = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp              => current_date,
         :net_usage_rate_average => 1000,
         :time_profile           => time_profile
       )
 
-      current_metric_kubernetes = FactoryGirl.create(
+      current_metric_kubernetes = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp              => current_date,
         :net_usage_rate_average => 1500,
         :time_profile           => time_profile
       )
 
-      old_metric = FactoryGirl.create(
+      old_metric = FactoryBot.create(
         :metric_rollup_cm_daily,
         :timestamp              => old_date,
         :net_usage_rate_average => 1500,
@@ -377,42 +377,42 @@ describe ContainerDashboardService do
     end
 
     it "show daily hourly network trends from last 24 hours only" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
-      ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
+      ems_kubernetes = FactoryBot.create(:ems_kubernetes, :zone => @zone)
 
       previous_date = 3.hours.ago
       current_date = 2.hours.ago
       old_date = 2.days.ago
 
-      previous_metric_openshift = FactoryGirl.create(
+      previous_metric_openshift = FactoryBot.create(
         :metric_rollup_cm_hr,
         :timestamp              => previous_date,
         :net_usage_rate_average => 2000,
         :time_profile           => time_profile
       )
 
-      current_metric_openshift = FactoryGirl.create(
+      current_metric_openshift = FactoryBot.create(
         :metric_rollup_cm_hr,
         :timestamp              => current_date,
         :net_usage_rate_average => 1000,
         :time_profile           => time_profile
       )
 
-      current_metric_kubernetes = FactoryGirl.create(
+      current_metric_kubernetes = FactoryBot.create(
         :metric_rollup_cm_hr,
         :timestamp              => current_date,
         :net_usage_rate_average => 1500,
         :time_profile           => time_profile
       )
 
-      old_metric = FactoryGirl.create(
+      old_metric = FactoryBot.create(
         :metric_rollup_cm_hr,
         :timestamp              => old_date,
         :net_usage_rate_average => 1500,
         :time_profile           => time_profile
       )
 
-      nil_fields_metric = FactoryGirl.create(
+      nil_fields_metric = FactoryBot.create(
         :metric_rollup_cm_hr,
         :timestamp    => old_date,
         :time_profile => time_profile
@@ -442,7 +442,7 @@ describe ContainerDashboardService do
     end
 
     it "returns hash with nil values when no metrics available" do
-      ems_openshift = FactoryGirl.create(:ems_openshift, :zone => @zone)
+      ems_openshift = FactoryBot.create(:ems_openshift, :zone => @zone)
       hourly_network_trends = described_class.new(nil, controller).hourly_network_metrics
       hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).hourly_network_metrics
 

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -11,10 +11,10 @@ describe ContainerTopologyService do
     let(:container) { Container.create(:name => "ruby-example", :state => 'running') }
     let(:container_condition) { ContainerCondition.create(:name => 'Ready', :status => 'True') }
     let(:container_node) { ContainerNode.create(:ext_management_system => ems_kube, :name => "127.0.0.1", :ems_ref => "905c90ba-3e00-11e5-a0d2-18037327aaeb", :container_conditions => [container_condition], :lives_on => vm_rhev) }
-    let(:ems_kube) { FactoryGirl.create(:ems_kubernetes_with_authentication_err) }
-    let(:ems_openshift) { FactoryGirl.create(:ems_openshift) }
-    let(:ems_rhev) { FactoryGirl.create(:ems_redhat) }
-    let(:vm_rhev) { FactoryGirl.create(:vm_redhat, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998", :ext_management_system => ems_rhev) }
+    let(:ems_kube) { FactoryBot.create(:ems_kubernetes_with_authentication_err) }
+    let(:ems_openshift) { FactoryBot.create(:ems_openshift) }
+    let(:ems_rhev) { FactoryBot.create(:ems_redhat) }
+    let(:vm_rhev) { FactoryBot.create(:vm_redhat, :uid_ems => "558d9a08-7b13-11e5-8546-129aa6621998", :ext_management_system => ems_rhev) }
 
     it "provider has unknown status when no authentication exists" do
       allow(container_topology_service).to receive(:retrieve_providers).with(anything, ManageIQ::Providers::ContainerManager).and_return([ems_openshift])
@@ -32,8 +32,8 @@ describe ContainerTopologyService do
 
     it "topology contains the expected structure and content" do
       # vm and host test cross provider correlation to infra provider
-      hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
-      host = FactoryGirl.create(:host_redhat,
+      hardware = FactoryBot.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
+      host = FactoryBot.create(:host_redhat,
                                 :uid_ems               => "abcd9a08-7b13-11e5-8546-129aa6621999",
                                 :ext_management_system => ems_rhev,
                                 :hardware              => hardware)
@@ -209,7 +209,7 @@ describe ContainerTopologyService do
 
   describe '#entity_status' do
     context 'entity is a container' do
-      let(:entity) { FactoryGirl.create(:container) }
+      let(:entity) { FactoryBot.create(:container) }
 
       context 'state is not defined' do
         before { allow(entity).to receive(:state).and_return(nil) }

--- a/spec/services/ems_cloud_dashboard_service_spec.rb
+++ b/spec/services/ems_cloud_dashboard_service_spec.rb
@@ -1,9 +1,9 @@
 describe EmsCloudDashboardService do
   context '#recentInstances' do
     before do
-      @ems1 = FactoryGirl.create(:ems_cloud)
-      @vm1 = FactoryGirl.create(:vm_openstack, :ext_management_system => @ems1)
-      @vm2 = FactoryGirl.create(:vm_openstack, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
+      @ems1 = FactoryBot.create(:ems_cloud)
+      @vm1 = FactoryBot.create(:vm_openstack, :ext_management_system => @ems1)
+      @vm2 = FactoryBot.create(:vm_openstack, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
     end
 
     subject { EmsCloudDashboardService.new(@ems1.id, "ems_cloud", EmsCloud) }

--- a/spec/services/ems_infra_dashboard_service_spec.rb
+++ b/spec/services/ems_infra_dashboard_service_spec.rb
@@ -1,17 +1,17 @@
 describe EmsInfraDashboardService do
   context '#recentVms' do
     before do
-      @ems1 = FactoryGirl.create(:ems_infra)
-      @vm1 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems1)
-      @vm2 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
+      @ems1 = FactoryBot.create(:ems_infra)
+      @vm1 = FactoryBot.create(:vm_infra, :ext_management_system => @ems1)
+      @vm2 = FactoryBot.create(:vm_infra, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
 
-      @host1 = FactoryGirl.create(:host, :ext_management_system => @ems1)
-      @host2 = FactoryGirl.create(:host, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
+      @host1 = FactoryBot.create(:host, :ext_management_system => @ems1)
+      @host2 = FactoryBot.create(:host, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
 
-      @ems2 = FactoryGirl.create(:ems_infra)
-      @vm3 = FactoryGirl.create(:vm_infra, :ext_management_system => @ems2)
+      @ems2 = FactoryBot.create(:ems_infra)
+      @vm3 = FactoryBot.create(:vm_infra, :ext_management_system => @ems2)
 
-      @host4 = FactoryGirl.create(:host, :ext_management_system => @ems2)
+      @host4 = FactoryBot.create(:host, :ext_management_system => @ems2)
     end
 
     subject { EmsInfraDashboardService.new(@ems1.id, "ems_infra", EmsInfra) }

--- a/spec/services/ems_physical_infra_dashboard_service_spec.rb
+++ b/spec/services/ems_physical_infra_dashboard_service_spec.rb
@@ -1,22 +1,22 @@
 describe EmsPhysicalInfraDashboardService do
   let(:physical_infra1) do
-    FactoryGirl.create(:physical_infra,
+    FactoryBot.create(:physical_infra,
                        :name     => "foo",
                        :hostname => "test1.com")
   end
 
   let(:physical_infra2) do
-    FactoryGirl.create(:physical_infra,
+    FactoryBot.create(:physical_infra,
                        :name     => "bar",
                        :hostname => "test2.com")
   end
 
   context "aggregate_status_card" do
     it "should display either a single provider or sum of all providers" do
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :name                  => "foo",
                          :ext_management_system => physical_infra1)
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :name                  => "bar",
                          :ext_management_system => physical_infra2)
 
@@ -40,19 +40,19 @@ describe EmsPhysicalInfraDashboardService do
       current_date = 29.days.ago.beginning_of_day.utc
       old_date = 31.days.ago
 
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :name                  => "foo",
                          :created_at            => current_date,
                          :ext_management_system => physical_infra1)
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :created_at            => old_date,
                          :name                  => "bar",
                          :ext_management_system => physical_infra2)
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :name                  => "foo2",
                          :created_at            => old_date,
                          :ext_management_system => physical_infra1)
-      FactoryGirl.create(:lenovo_physical_server,
+      FactoryBot.create(:lenovo_physical_server,
                          :created_at            => current_date,
                          :name                  => "bar2",
                          :ext_management_system => physical_infra2)

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -6,7 +6,7 @@ describe GitBasedDomainImportService do
                               :url          => 'http://www.example.com')
     end
     let(:user) { double("User", :userid => userid, :id => 123) }
-    let(:domain) { FactoryGirl.build(:miq_ae_git_domain, :id => 999) }
+    let(:domain) { FactoryBot.build(:miq_ae_git_domain, :id => 999) }
     let(:userid) { "fred" }
     let(:task) { double("MiqTask", :id => 123) }
     let(:ref_name) { 'the_branch_name' }

--- a/spec/services/infra_topology_service_spec.rb
+++ b/spec/services/infra_topology_service_spec.rb
@@ -4,11 +4,11 @@ describe InfraTopologyService do
   describe "#build_topology" do
     subject { infra_topology_service.build_topology }
 
-    let(:ems) { FactoryGirl.create(:ems_openstack_infra) }
+    let(:ems) { FactoryBot.create(:ems_openstack_infra) }
 
     before do
-      @cluster = FactoryGirl.create(:ems_cluster_openstack, :ext_management_system => ems)
-      @host = FactoryGirl.create(:host_openstack_infra, :ems_cluster => @cluster, :ext_management_system => ems)
+      @cluster = FactoryBot.create(:ems_cluster_openstack, :ext_management_system => ems)
+      @host = FactoryBot.create(:host_openstack_infra, :ems_cluster => @cluster, :ext_management_system => ems)
     end
 
     it "topology contains only the expected keys" do
@@ -16,7 +16,7 @@ describe InfraTopologyService do
     end
 
     it "provider has unknown status when no authentication exists" do
-      ems = FactoryGirl.create(:ems_openstack_infra)
+      ems = FactoryBot.create(:ems_openstack_infra)
 
       allow(infra_topology_service).to receive(:retrieve_providers)
         .with(anything, ManageIQ::Providers::InfraManager)

--- a/spec/services/miq_policy_import_service_spec.rb
+++ b/spec/services/miq_policy_import_service_spec.rb
@@ -2,7 +2,7 @@ describe MiqPolicyImportService do
   let(:miq_policy_import_service) { described_class.new }
   let(:import_file_upload) { double("ImportFileUpload") }
   let(:miq_queue) do
-    FactoryGirl.create(:miq_queue, :class_name => "ImportFileUpload", :instance_id => 123, :method_name => "destroy")
+    FactoryBot.create(:miq_queue, :class_name => "ImportFileUpload", :instance_id => 123, :method_name => "destroy")
   end
 
   describe "#cancel_import" do

--- a/spec/services/network_topology_service_spec.rb
+++ b/spec/services/network_topology_service_spec.rb
@@ -4,30 +4,30 @@ describe NetworkTopologyService do
   describe "#build_topology" do
     subject { network_topology_service.build_topology }
 
-    let(:ems_cloud) { FactoryGirl.create(:ems_openstack) }
+    let(:ems_cloud) { FactoryBot.create(:ems_openstack) }
     let(:ems) { ems_cloud.network_manager }
 
     before do
-      @cloud_tenant = FactoryGirl.create(:cloud_tenant_openstack)
-      @availability_zone = FactoryGirl.create(:availability_zone_openstack,
+      @cloud_tenant = FactoryBot.create(:cloud_tenant_openstack)
+      @availability_zone = FactoryBot.create(:availability_zone_openstack,
                                               :name                  => "AZ name",
                                               :ext_management_system => ems_cloud)
-      @vm = FactoryGirl.create(:vm_openstack,
+      @vm = FactoryBot.create(:vm_openstack,
                                :cloud_tenant          => @cloud_tenant,
                                :ext_management_system => ems_cloud,
                                :availability_zone     => @availability_zone)
-      @cloud_network = FactoryGirl.create(:cloud_network_openstack)
-      @public_network = FactoryGirl.create(:cloud_network_openstack)
-      @cloud_subnet = FactoryGirl.create(:cloud_subnet_openstack, :cloud_network         => @cloud_network,
+      @cloud_network = FactoryBot.create(:cloud_network_openstack)
+      @public_network = FactoryBot.create(:cloud_network_openstack)
+      @cloud_subnet = FactoryBot.create(:cloud_subnet_openstack, :cloud_network         => @cloud_network,
                                                                   :ext_management_system => ems)
-      @network_router = FactoryGirl.create(:network_router_openstack, :cloud_subnets => [@cloud_subnet],
+      @network_router = FactoryBot.create(:network_router_openstack, :cloud_subnets => [@cloud_subnet],
                                                                       :cloud_network => @public_network)
-      @floating_ip = FactoryGirl.create(:floating_ip_openstack, :vm => @vm, :cloud_network => @public_network)
-      @security_group = FactoryGirl.create(:security_group_openstack)
-      @network_port = FactoryGirl.create(:network_port_openstack, :device          => @vm,
+      @floating_ip = FactoryBot.create(:floating_ip_openstack, :vm => @vm, :cloud_network => @public_network)
+      @security_group = FactoryBot.create(:security_group_openstack)
+      @network_port = FactoryBot.create(:network_port_openstack, :device          => @vm,
                                                                   :security_groups => [@security_group],
                                                                   :floating_ip     => @floating_ip)
-      @cloud_subnet_network_port = FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => @cloud_subnet,
+      @cloud_subnet_network_port = FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => @cloud_subnet,
                                                                                   :network_port => @network_port)
     end
 
@@ -36,7 +36,7 @@ describe NetworkTopologyService do
     end
 
     it "provider has unknown status when no authentication exists" do
-      ems = FactoryGirl.create(:ems_openstack).network_manager
+      ems = FactoryBot.create(:ems_openstack).network_manager
 
       allow(network_topology_service).to receive(:retrieve_providers).with(
         anything, ManageIQ::Providers::NetworkManager

--- a/spec/services/physical_infra_topology_service_spec.rb
+++ b/spec/services/physical_infra_topology_service_spec.rb
@@ -11,33 +11,33 @@ describe PhysicalInfraTopologyService do
   #         - Server C
   #   - Server D
 
-  let(:server_a) { FactoryGirl.create(:physical_server, :name => 'Server A', :health_state => 'Error') }
-  let(:server_b) { FactoryGirl.create(:physical_server, :name => 'Server B', :health_state => 'Warning') }
-  let(:server_c) { FactoryGirl.create(:physical_server, :name => 'Server C', :health_state => 'Valid') }
-  let(:server_d) { FactoryGirl.create(:physical_server, :name => 'Server D', :health_state => 'Error') }
+  let(:server_a) { FactoryBot.create(:physical_server, :name => 'Server A', :health_state => 'Error') }
+  let(:server_b) { FactoryBot.create(:physical_server, :name => 'Server B', :health_state => 'Warning') }
+  let(:server_c) { FactoryBot.create(:physical_server, :name => 'Server C', :health_state => 'Valid') }
+  let(:server_d) { FactoryBot.create(:physical_server, :name => 'Server D', :health_state => 'Error') }
 
   let(:chassis_a) do
-    FactoryGirl.create(:physical_chassis,
+    FactoryBot.create(:physical_chassis,
                        :name             => 'Chassis A',
                        :health_state     => 'Valid',
                        :physical_servers => [server_a])
   end
 
   let(:chassis_b) do
-    FactoryGirl.create(:physical_chassis,
+    FactoryBot.create(:physical_chassis,
                        :name         => 'Chassis B',
                        :health_state => 'Error')
   end
 
   let(:chassis_c) do
-    FactoryGirl.create(:physical_chassis,
+    FactoryBot.create(:physical_chassis,
                        :name                    => 'Chassis C',
                        :health_state            => 'Valid',
                        :parent_physical_chassis => chassis_b)
   end
 
   let(:chassis_d) do
-    FactoryGirl.create(:physical_chassis,
+    FactoryBot.create(:physical_chassis,
                        :name                    => 'Chassis D',
                        :health_state            => 'Warning',
                        :parent_physical_chassis => chassis_c,
@@ -45,21 +45,21 @@ describe PhysicalInfraTopologyService do
   end
 
   let(:rack_a) do
-    FactoryGirl.create(:physical_rack,
+    FactoryBot.create(:physical_rack,
                        :name             => 'Rack A',
                        :physical_chassis => [chassis_a],
                        :physical_servers => [server_a, server_b])
   end
 
   let(:auth) do
-    FactoryGirl.create(:authentication,
+    FactoryBot.create(:authentication,
                        :userid   => 'admin',
                        :password => 'password',
                        :authtype => 'default')
   end
 
   let(:ems) do
-    ems = FactoryGirl.create(:physical_infra,
+    ems = FactoryBot.create(:physical_infra,
                              :name      => 'LXCA',
                              :hostname  => 'example.com',
                              :port      => '443',

--- a/spec/services/privilege_checker_service_spec.rb
+++ b/spec/services/privilege_checker_service_spec.rb
@@ -22,7 +22,7 @@ describe PrivilegeCheckerService do
     end
 
     context "when the user is signed in" do
-      let(:user) { FactoryGirl.create(:user) }
+      let(:user) { FactoryBot.create(:user) }
 
       context "when the session is timed out" do
         let(:last_trans_time) { 2.hours.ago }
@@ -63,7 +63,7 @@ describe PrivilegeCheckerService do
     end
 
     context "when a user exists" do
-      let(:user) { FactoryGirl.create(:user) }
+      let(:user) { FactoryBot.create(:user) }
 
       context "when the session is timed out" do
         let(:last_trans_time) { 2.hours.ago }

--- a/spec/services/topology_service_spec.rb
+++ b/spec/services/topology_service_spec.rb
@@ -43,7 +43,7 @@ describe TopologyService do
   end
 
   describe '#entity_id' do
-    let(:host) { FactoryGirl.create(:host) }
+    let(:host) { FactoryBot.create(:host) }
 
     it 'output begins with class name' do
       expect(subject.entity_id(host)).to start_with(host.class.to_s)
@@ -72,9 +72,9 @@ describe TopologyService do
   end
 
   describe '#map_to_graph' do
-    let(:provider) { FactoryGirl.create(:ext_management_system) }
-    let(:tag) { FactoryGirl.create(:tag) }
-    let(:vm) { FactoryGirl.create(:vm, :ext_management_system => provider, :tags => [tag]) }
+    let(:provider) { FactoryBot.create(:ext_management_system) }
+    let(:tag) { FactoryBot.create(:tag) }
+    let(:vm) { FactoryBot.create(:vm, :ext_management_system => provider, :tags => [tag]) }
     let(:graph) { {:vms => {:tags => nil}} }
 
     before do
@@ -134,7 +134,7 @@ describe TopologyService do
     let(:name) { subject.send(:entity_name, entity) }
 
     context 'entity is not a tag' do
-      let(:entity) { FactoryGirl.create(:vm_vmware) }
+      let(:entity) { FactoryBot.create(:vm_vmware) }
 
       it 'returns with the name of the entity' do
         expect(name).to eq(entity.name)
@@ -142,9 +142,9 @@ describe TopologyService do
     end
 
     context 'entity is a tag' do
-      let(:parent_cls) { FactoryGirl.create(:classification, :description => 'foo') }
-      let(:cls) { FactoryGirl.create(:classification, :parent => parent_cls, :description => 'bar') }
-      let(:entity) { FactoryGirl.create(:tag, :classification => cls) }
+      let(:parent_cls) { FactoryBot.create(:classification, :description => 'foo') }
+      let(:cls) { FactoryBot.create(:classification, :parent => parent_cls, :description => 'bar') }
+      let(:entity) { FactoryBot.create(:tag, :classification => cls) }
 
       it 'returns with the parent and the child classification description' do
         expect(name).to eq('foo: bar')

--- a/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
+++ b/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
@@ -1,13 +1,13 @@
 shared_examples '#download_summary_pdf' do |object|
   context 'download pdf file' do
-    let(:record) { FactoryGirl.create(object) }
+    let(:record) { FactoryBot.create(object) }
     let(:pdf_options) { controller.instance_variable_get(:@options) }
 
     before do
       allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
       allow(controller).to receive(:server_timezone).and_return('UTC')
       allow(controller).to receive(:tagdata).and_return(nil)
-      login_as FactoryGirl.create(:user_admin)
+      login_as FactoryBot.create(:user_admin)
       stub_user(:features => :all)
       get :download_summary_pdf, :params => {:id => record.id}
     end

--- a/spec/shared/controllers/shared_examples_for_nested_lists.rb
+++ b/spec/shared/controllers/shared_examples_for_nested_lists.rb
@@ -1,8 +1,8 @@
 shared_examples 'relationship table screen with GTL' do |displays, parent_factory|
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    login_as FactoryGirl.create(:user, :features => "none")
-    @parent = FactoryGirl.create(parent_factory)
+    login_as FactoryBot.create(:user, :features => "none")
+    @parent = FactoryBot.create(parent_factory)
   end
 
   render_views

--- a/spec/shared/controllers/shared_network_manager_context.rb
+++ b/spec/shared/controllers/shared_network_manager_context.rb
@@ -1,76 +1,76 @@
 shared_context :shared_network_manager_context do |t|
   before do
-    @ems_cloud      = FactoryGirl.create("ems_#{t}".to_sym,
+    @ems_cloud      = FactoryBot.create("ems_#{t}".to_sym,
                                          :name => "Cloud Manager")
     @ems            = @ems_cloud.network_manager
-    @security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+    @security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                          :ext_management_system => @ems,
                                          :name                  => 'Security Group')
-    @vm             = FactoryGirl.create("vm_#{t}".to_sym,
+    @vm             = FactoryBot.create("vm_#{t}".to_sym,
                                          :name                  => "Instance",
                                          :ext_management_system => @ems)
     if t == 'openstack'
-      @cloud_network        = FactoryGirl.create("cloud_network_private_#{t}".to_sym,
+      @cloud_network        = FactoryBot.create("cloud_network_private_#{t}".to_sym,
                                                  :name                  => "Cloud Network",
                                                  :ext_management_system => @ems)
-      @cloud_network_public = FactoryGirl.create("cloud_network_public_#{t}".to_sym,
+      @cloud_network_public = FactoryBot.create("cloud_network_public_#{t}".to_sym,
                                                  :name                  => "Cloud Network Public",
                                                  :ext_management_system => @ems)
     else
-      @cloud_network        = FactoryGirl.create("cloud_network_#{t}".to_sym,
+      @cloud_network        = FactoryBot.create("cloud_network_#{t}".to_sym,
                                                  :name                  => "Cloud Network",
                                                  :ext_management_system => @ems)
       @cloud_network_public = nil
     end
 
-    @network_router = FactoryGirl.create("network_router_#{t}".to_sym,
+    @network_router = FactoryBot.create("network_router_#{t}".to_sym,
                                          :cloud_network         => @cloud_network_public,
                                          :name                  => "Network Router",
                                          :ext_management_system => @ems)
-    @cloud_subnet   = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+    @cloud_subnet   = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                          :network_router        => @network_router,
                                          :cloud_network         => @cloud_network,
                                          :ext_management_system => @ems,
                                          :name                  => "Cloud Subnet")
-    @child_subnet   = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+    @child_subnet   = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                          :name                  => "Child Cloud Subnet",
                                          :parent_cloud_subnet   => @cloud_subnet,
                                          :ext_management_system => @ems)
-    @floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym,
+    @floating_ip    = FactoryBot.create("floating_ip_#{t}".to_sym,
                                          :address               => "192.0.2.1",
                                          :ext_management_system => @ems)
 
-    @vm.network_ports << @network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+    @vm.network_ports << @network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :name                  => "eth0",
                                                             :mac_address           => "06:04:25:40:8e:79",
                                                             :device                => @vm,
                                                             :security_groups       => [@security_group],
                                                             :floating_ip           => @floating_ip,
                                                             :ext_management_system => @ems)
-    FactoryGirl.create(:cloud_subnet_network_port,
+    FactoryBot.create(:cloud_subnet_network_port,
                        :cloud_subnet => @cloud_subnet,
                        :network_port => @network_port,
                        :address      => "10.10.0.2")
 
     if %w(amazon).include? t
-      @load_balancer              = FactoryGirl.create("load_balancer_#{t}".to_sym,
+      @load_balancer              = FactoryBot.create("load_balancer_#{t}".to_sym,
                                                        :ems_id => @ems.id,
                                                        :name   => "Load Balancer")
-      @load_balancer_2            = FactoryGirl.create("load_balancer_#{t}".to_sym)
-      @load_balancer_pool         = FactoryGirl.create("load_balancer_pool_#{t}".to_sym)
-      @load_balancer_listener     = FactoryGirl.create("load_balancer_listener_#{t}".to_sym,
+      @load_balancer_2            = FactoryBot.create("load_balancer_#{t}".to_sym)
+      @load_balancer_pool         = FactoryBot.create("load_balancer_pool_#{t}".to_sym)
+      @load_balancer_listener     = FactoryBot.create("load_balancer_listener_#{t}".to_sym,
                                                        :load_balancer => @load_balancer)
-      @load_balancer_pool_member  = FactoryGirl.create("load_balancer_pool_member_#{t}".to_sym,
+      @load_balancer_pool_member  = FactoryBot.create("load_balancer_pool_member_#{t}".to_sym,
                                                        :vm => @vm)
-      @load_balancer_health_check = FactoryGirl.create("load_balancer_health_check_#{t}".to_sym)
+      @load_balancer_health_check = FactoryBot.create("load_balancer_health_check_#{t}".to_sym)
 
-      FactoryGirl.create("load_balancer_listener_pool".to_sym,
+      FactoryBot.create("load_balancer_listener_pool".to_sym,
                          :load_balancer_pool     => @load_balancer_pool,
                          :load_balancer_listener => @load_balancer_listener)
-      FactoryGirl.create("load_balancer_pool_member_pool".to_sym,
+      FactoryBot.create("load_balancer_pool_member_pool".to_sym,
                          :load_balancer_pool        => @load_balancer_pool,
                          :load_balancer_pool_member => @load_balancer_pool_member)
-      FactoryGirl.create("load_balancer_health_check_member".to_sym,
+      FactoryBot.create("load_balancer_health_check_member".to_sym,
                          :load_balancer_health_check => @load_balancer_health_check,
                          :load_balancer_pool_member  => @load_balancer_pool_member)
     end

--- a/spec/shared/controllers/shared_storage_manager_context.rb
+++ b/spec/shared/controllers/shared_storage_manager_context.rb
@@ -1,6 +1,6 @@
 shared_context :shared_storage_manager_context do |t|
   before do
-    @ems_cloud = FactoryGirl.create("ems_#{t}".to_sym,
+    @ems_cloud = FactoryBot.create("ems_#{t}".to_sym,
                                     :name => "Test Cloud Manager")
     if t == 'openstack'
       @swift_manager    = @cinder_manager = nil

--- a/spec/shared/presenters/tree_node/server_roles.rb
+++ b/spec/shared/presenters/tree_node/server_roles.rb
@@ -2,7 +2,7 @@ shared_context 'server roles' do
   let(:miq_server) { EvmSpecHelper.local_miq_server }
 
   let(:server_role) do
-    FactoryGirl.create(:server_role,
+    FactoryBot.create(:server_role,
                        :name              => "smartproxy",
                        :description       => "SmartProxy",
                        :max_concurrent    => 1,
@@ -11,7 +11,7 @@ shared_context 'server roles' do
   end
 
   let(:assigned_server_role) do
-    FactoryGirl.create(:assigned_server_role,
+    FactoryBot.create(:assigned_server_role,
                        :miq_server_id  => miq_server.id,
                        :server_role_id => server_role.id,
                        :active         => true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ Dir[support_path.join("**/*.rb")].each { |f| require f }
 # require core_support_path.join('presenter_helper.rb')
 # require core_support_path.join('menu_helper.rb')
 # require core_support_path.join('automation_helper.rb')
-# require core_support_path.join('factory_girl_helper.rb')
+# require core_support_path.join('factory_bot_helper.rb')
 # require core_support_path.join('button_helper.rb')
 # require core_support_path.join('settings_helper.rb')
 #

--- a/spec/support/examples_group/shared_examples_for_analysis_profile_action_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_analysis_profile_action_buttons.rb
@@ -1,7 +1,7 @@
 shared_examples 'an analysis profile action button' do |action|
   describe '#calculate_properties' do
     let(:view_context) { setup_view_context_with_sandbox({}) }
-    let(:record) { FactoryGirl.create(:scan_item_set, :read_only => read_only) }
+    let(:record) { FactoryBot.create(:scan_item_set, :read_only => read_only) }
     let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
     before { button.calculate_properties }

--- a/spec/support/examples_group/shared_examples_for_performance_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_performance_buttons.rb
@@ -10,7 +10,7 @@ shared_examples_for 'a performance button' do |entity|
       it_behaves_like 'a disabled button', "No Capacity & Utilization data has been collected for this #{entity}"
     end
     context 'when performance data are available' do
-      let(:metric_rollup) { FactoryGirl.create(:metric_rollup_storage_hr) }
+      let(:metric_rollup) { FactoryBot.create(:metric_rollup_storage_hr) }
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/support/examples_group/shared_examples_for_rbac_group_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_rbac_group_buttons.rb
@@ -6,11 +6,11 @@ shared_examples 'an rbac_group_action button' do |action|
     before { button.calculate_properties }
 
     context 'record is read-only' do
-      let(:record) { FactoryGirl.create(:miq_group, :system_type) }
+      let(:record) { FactoryBot.create(:miq_group, :system_type) }
       it_behaves_like 'a disabled button', "This Group is Read Only and can not be #{action}"
     end
     context 'record is writable' do
-      let(:record) { FactoryGirl.create(:miq_group) }
+      let(:record) { FactoryBot.create(:miq_group) }
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/support/examples_group/shared_examples_for_render_report_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_render_report_buttons.rb
@@ -5,7 +5,7 @@ shared_examples_for 'a render_report button' do
   let(:records_count) { 0 }
   let(:records_total) { {:count => records_count} }
   let(:grouping) { {:_total_ => records_total} }
-  let(:report) { FactoryGirl.create(:miq_report, :extras => {:grouping => grouping}) }
+  let(:report) { FactoryBot.create(:miq_report, :extras => {:grouping => grouping}) }
   let(:button) { described_class.new(view_context, {}, {'report' => report, 'html' => html, 'render_chart' => render_chart}, {}) }
 
   describe '#calculate_properties' do

--- a/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
@@ -1,8 +1,8 @@
 shared_examples_for 'a smart state scan button' do
   let(:my_zone) { MiqServer.my_server.zone }
-  let(:server) { FactoryGirl.create(:miq_server, :zone => my_zone, :active_roles => roles) }
-  let(:smartproxy_role) { FactoryGirl.create(:server_role, :name => 'smartproxy') }
-  let(:smartscan_role) { FactoryGirl.create(:server_role, :name => 'smartstate') }
+  let(:server) { FactoryBot.create(:miq_server, :zone => my_zone, :active_roles => roles) }
+  let(:smartproxy_role) { FactoryBot.create(:server_role, :name => 'smartproxy') }
+  let(:smartscan_role) { FactoryBot.create(:server_role, :name => 'smartstate') }
 
   describe '#calculate_properties' do
     before do
@@ -28,8 +28,8 @@ shared_examples_for 'a smart state scan button' do
     context "when there is no server in the zone" do
       let(:roles) { [smartproxy_role, smartscan_role] }
       let(:active_role) { true }
-      let(:zone1) { FactoryGirl.create(:zone) }
-      let(:server) { FactoryGirl.create(:miq_server, :zone => zone1, :active_roles => roles) }
+      let(:zone1) { FactoryBot.create(:zone) }
+      let(:server) { FactoryBot.create(:miq_server, :zone => zone1, :active_roles => roles) }
       it_behaves_like 'a disabled button', "There is no server with the #{MiqServer::ServerSmartProxy::SMART_ROLES.last} role enabled"
     end
   end

--- a/spec/support/examples_group/shared_examples_for_vm_console.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_console.rb
@@ -2,8 +2,8 @@ shared_examples 'vm_console_record_types' do |supported_records|
   supported_records.each do |type, support|
     context "and record is type of #{type}" do
       let(:api_version) { 6.4 }
-      let(:ems) { FactoryGirl.create(:ems_vmware, :api_version => api_version) }
-      let(:record) { FactoryGirl.create(type, :ems_id => ems.id) }
+      let(:ems) { FactoryBot.create(:ems_vmware, :api_version => api_version) }
+      let(:record) { FactoryBot.create(type, :ems_id => ems.id) }
       it { is_expected.to eq(support) }
     end
   end

--- a/spec/support/ssa_button_helper.rb
+++ b/spec/support/ssa_button_helper.rb
@@ -2,7 +2,7 @@ module SSAButtonHelper
   extend RSpec::Mocks::ExampleMethods
 
   def self.create_server_role(server, role)
-    server_role = FactoryGirl.create(
+    server_role = FactoryBot.create(
       :server_role,
       :name              => role.downcase,
       :description       => role,
@@ -12,7 +12,7 @@ module SSAButtonHelper
     )
 
     priority = AssignedServerRole::DEFAULT_PRIORITY
-    FactoryGirl.create(
+    FactoryBot.create(
       :assigned_server_role,
       :miq_server_id  => server.id,
       :server_role_id => server_role.id,

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe "catalog/_form.html.haml" do
     set_controller_for_view_to_be_nonrestful
     @edit = {:new => {:available_dialogs => {}}}
     @sb = {:st_form_active_tab => "Basic", :trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
-    user = FactoryGirl.create(:user_with_group)
+    user = FactoryBot.create(:user_with_group)
     login_as user
     create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
     create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')

--- a/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
@@ -2,7 +2,7 @@ describe "catalog/_sandt_tree_show.html.haml" do
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful
-    bundle = FactoryGirl.create(:service_template,
+    bundle = FactoryBot.create(:service_template,
                                 :name         => 'My Bundle',
                                 :id           => 1,
                                 :service_type => "composite",

--- a/spec/views/ems_cluster/show.html.haml_spec.rb
+++ b/spec/views/ems_cluster/show.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe "ems_cluster/show.html.haml" do
-  let(:ems_cluster) { FactoryGirl.create(:ems_cluster_openstack) }
+  let(:ems_cluster) { FactoryBot.create(:ems_cluster_openstack) }
   let(:action) { 'index' }
 
   before do

--- a/spec/views/host/_form.html.haml_spec.rb
+++ b/spec/views/host/_form.html.haml_spec.rb
@@ -3,7 +3,7 @@ describe "rendering fields in host new/edit form" do
     set_controller_for_view("host")
     set_controller_for_view_to_be_nonrestful
     allow(controller).to receive(:validate_before_save?).and_return(false)
-    @host = FactoryGirl.create(:host)
+    @host = FactoryBot.create(:host)
     @edit = {:new => @host}
   end
 

--- a/spec/views/host/_show.html.haml_spec.rb
+++ b/spec/views/host/_show.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "host/show.html.haml" do
     end
   end
 
-  let(:host) { FactoryGirl.create(:host_vmware, :name => 'My Host') }
+  let(:host) { FactoryBot.create(:host_vmware, :name => 'My Host') }
   let(:action) { 'index' }
 
   before do

--- a/spec/views/layouts/_item.html.haml_spec.rb
+++ b/spec/views/layouts/_item.html.haml_spec.rb
@@ -1,8 +1,8 @@
 describe "layouts/_item.html.haml" do
   it "check if correct items are being rendered for filesystem" do
     set_controller_for_view("host")
-    fs = FactoryGirl.create(:filesystem, :contents => "contents")
-    assign(:view, FactoryGirl.create(:miq_report_filesystem))
+    fs = FactoryBot.create(:filesystem, :contents => "contents")
+    assign(:view, FactoryBot.create(:miq_report_filesystem))
     assign(:item, fs)
     assign(:lastaction, 'filesystems')
     render

--- a/spec/views/layouts/listnav/_availability_zone.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_availability_zone.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_availability_zone.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_openstack)
+    FactoryBot.create(:ems_openstack)
   end
 
   it "link to parent cloud provider uses restful path" do
-    @record = FactoryGirl.create(:availability_zone_openstack, :ext_management_system => provider, :name => 'A test')
+    @record = FactoryBot.create(:availability_zone_openstack, :ext_management_system => provider, :name => 'A test')
     render
     expect(response).to include("Show this Availability Zone&#39;s parent Cloud Provider\" href=\"/ems_cloud/#{@record.ext_management_system.id}\">")
   end

--- a/spec/views/layouts/listnav/_cloud_network.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_cloud_network.html.haml_spec.rb
@@ -11,21 +11,21 @@ describe "layouts/listnav/_cloud_network.html.haml" do
   %w(openstack google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider       = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider       = FactoryBot.create("ems_#{t}".to_sym)
+      security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                           :ext_management_system => provider.network_manager,
                                           :name                  => 'A test')
-      vm             = FactoryGirl.create("vm_#{t}".to_sym)
-      @network       = FactoryGirl.create("cloud_network_#{t}".to_sym, :ext_management_system => provider.network_manager)
-      subnet         = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+      vm             = FactoryBot.create("vm_#{t}".to_sym)
+      @network       = FactoryBot.create("cloud_network_#{t}".to_sym, :ext_management_system => provider.network_manager)
+      subnet         = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                           :cloud_network         => @network,
                                           :ext_management_system => provider.network_manager)
-      floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      floating_ip    = FactoryBot.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [security_group],
                                                             :floating_ip     => floating_ip)
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_cloud_subnet.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_cloud_subnet.html.haml_spec.rb
@@ -11,21 +11,21 @@ describe "layouts/listnav/_cloud_subnet.html.haml" do
   %w(openstack amazon azure google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider       = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider       = FactoryBot.create("ems_#{t}".to_sym)
+      security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                           :ext_management_system => provider.network_manager,
                                           :name                  => 'A test')
-      vm             = FactoryGirl.create("vm_#{t}".to_sym)
-      network        = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      @subnet        = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+      vm             = FactoryBot.create("vm_#{t}".to_sym)
+      network        = FactoryBot.create("cloud_network_#{t}".to_sym)
+      @subnet        = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                           :cloud_network         => network,
                                           :ext_management_system => provider.network_manager)
-      floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      floating_ip    = FactoryBot.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [security_group],
                                                             :floating_ip     => floating_ip)
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => @subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => @subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_cloud_tenant.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_cloud_tenant.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_cloud_tenant.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_openstack)
+    FactoryBot.create(:ems_openstack)
   end
 
   it "link to parent cloud provider uses restful path" do
-    @record = FactoryGirl.create(:cloud_tenant, :ext_management_system => provider)
+    @record = FactoryBot.create(:cloud_tenant, :ext_management_system => provider)
     render
     expect(response).to include("Show this Cloud Tenant&#39;s parent Cloud Provider\" href=\"/ems_cloud/#{@record.ext_management_system.id}\">")
   end

--- a/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_cloud.html.haml_spec.rb
@@ -9,7 +9,7 @@ describe "layouts/listnav/_ems_cloud.html.haml" do
   end
 
   it "Flavors link for Openstack cloud manager uses restful path" do
-    record = FactoryGirl.create(:ems_openstack)
+    record = FactoryBot.create(:ems_openstack)
     assign(:record, record)
     allow(record).to receive(:flavors).and_return(5)
     render
@@ -17,21 +17,21 @@ describe "layouts/listnav/_ems_cloud.html.haml" do
   end
 
   it "Flavors link for Amazon cloud manager uses restful paths" do
-    record = FactoryGirl.create(:ems_amazon)
+    record = FactoryBot.create(:ems_amazon)
     assign(:record, record)
     allow(record).to receive(:flavors).and_return(14)
     render
     expect(response).to include "ems_cloud/#{record.id}?display=flavors"
   end
   it "Availability Zones link uses restful paths" do
-    record = FactoryGirl.create(:ems_openstack)
+    record = FactoryBot.create(:ems_openstack)
     assign(:record, record)
     allow(record).to receive(:availability_zones).and_return(14)
     render
     expect(response).to include "ems_cloud/#{record.id}?display=availability_zones"
   end
   it "Cloud Tenants link uses restful paths" do
-    record = FactoryGirl.create(:ems_amazon)
+    record = FactoryBot.create(:ems_amazon)
     assign(:record, record)
     allow(record).to receive(:cloud_tenants).and_return(10)
     render

--- a/spec/views/layouts/listnav/_ems_container.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_container.html.haml_spec.rb
@@ -9,7 +9,7 @@ describe "layouts/listnav/_ems_container.html.haml" do
   end
 
   it "link to Capacity & Utilization uses restful path" do
-    @record = FactoryGirl.create(:ems_openshift)
+    @record = FactoryBot.create(:ems_openshift)
     allow(@record).to receive(:has_perf_data?).and_return(true)
     render
     expect(response)

--- a/spec/views/layouts/listnav/_ems_network.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_network.html.haml_spec.rb
@@ -11,21 +11,21 @@ describe "layouts/listnav/_ems_network.html.haml" do
   %w(openstack amazon google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      @provider      = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      @provider      = FactoryBot.create("ems_#{t}".to_sym)
+      security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                           :ext_management_system => @provider.network_manager,
                                           :name                  => 'A test')
-      vm             = FactoryGirl.create("vm_#{t}".to_sym)
-      network        = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      subnet         = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+      vm             = FactoryBot.create("vm_#{t}".to_sym)
+      network        = FactoryBot.create("cloud_network_#{t}".to_sym)
+      subnet         = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                           :cloud_network         => network,
                                           :ext_management_system => @provider.network_manager)
-      floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym, :ext_management_system => @provider.network_manager)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      floating_ip    = FactoryBot.create("floating_ip_#{t}".to_sym, :ext_management_system => @provider.network_manager)
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [security_group],
                                                             :floating_ip     => floating_ip)
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_flavor.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_flavor.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_flavor.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_openstack)
+    FactoryBot.create(:ems_openstack)
   end
 
   it "link to parent cloud provider uses restful path" do
-    @record = FactoryGirl.create(:flavor_openstack, :ext_management_system => provider, :name => "A test")
+    @record = FactoryBot.create(:flavor_openstack, :ext_management_system => provider, :name => "A test")
     render
     expect(response).to include("Show this Flavor&#39;s parent Cloud Provider\" href=\"/ems_cloud/#{@record.ext_management_system.id}\">")
   end

--- a/spec/views/layouts/listnav/_floating_ip.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_floating_ip.html.haml_spec.rb
@@ -11,19 +11,19 @@ describe "layouts/listnav/_floating_ip.html.haml" do
   %w(openstack amazon azure google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider       = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider       = FactoryBot.create("ems_#{t}".to_sym)
+      security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                           :ext_management_system => provider.network_manager,
                                           :name                  => 'A test')
-      vm             = FactoryGirl.create("vm_#{t}".to_sym)
-      network        = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      subnet         = FactoryGirl.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
-      @floating_ip   = FactoryGirl.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      vm             = FactoryBot.create("vm_#{t}".to_sym)
+      network        = FactoryBot.create("cloud_network_#{t}".to_sym)
+      subnet         = FactoryBot.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
+      @floating_ip   = FactoryBot.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [security_group],
                                                             :floating_ip     => @floating_ip)
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_host_aggregate.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_host_aggregate.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_host_aggregate.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_openstack)
+    FactoryBot.create(:ems_openstack)
   end
 
   it "link to parent cloud provider uses restful path" do
-    @record = FactoryGirl.create(:host_aggregate_openstack, :ext_management_system => provider, :name => 'A test')
+    @record = FactoryBot.create(:host_aggregate_openstack, :ext_management_system => provider, :name => 'A test')
     render
     expect(response).to include("Show this Host Aggregate&#39;s parent Cloud Provider\" href=\"/ems_cloud/#{@record.ext_management_system.id}\">")
   end

--- a/spec/views/layouts/listnav/_load_balancer.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_load_balancer.html.haml_spec.rb
@@ -11,25 +11,25 @@ describe "layouts/listnav/_load_balancer.html.haml" do
   %w(amazon).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider                   = FactoryGirl.create("ems_#{t}".to_sym)
-      @load_balancer             = FactoryGirl.create("load_balancer_#{t}".to_sym,
+      provider                   = FactoryBot.create("ems_#{t}".to_sym)
+      @load_balancer             = FactoryBot.create("load_balancer_#{t}".to_sym,
                                                       :name                  => "Load Balancer",
                                                       :ext_management_system => provider.network_manager)
-      vm                         = FactoryGirl.create("vm_#{t}".to_sym)
-      load_balancer_pool         = FactoryGirl.create("load_balancer_pool_#{t}".to_sym)
-      load_balancer_listener     = FactoryGirl.create("load_balancer_listener_#{t}".to_sym,
+      vm                         = FactoryBot.create("vm_#{t}".to_sym)
+      load_balancer_pool         = FactoryBot.create("load_balancer_pool_#{t}".to_sym)
+      load_balancer_listener     = FactoryBot.create("load_balancer_listener_#{t}".to_sym,
                                                       :load_balancer => @load_balancer)
-      load_balancer_pool_member  = FactoryGirl.create("load_balancer_pool_member_#{t}".to_sym,
+      load_balancer_pool_member  = FactoryBot.create("load_balancer_pool_member_#{t}".to_sym,
                                                       :vm => vm)
-      load_balancer_health_check = FactoryGirl.create("load_balancer_health_check_#{t}".to_sym)
+      load_balancer_health_check = FactoryBot.create("load_balancer_health_check_#{t}".to_sym)
 
-      FactoryGirl.create("load_balancer_listener_pool".to_sym,
+      FactoryBot.create("load_balancer_listener_pool".to_sym,
                          :load_balancer_pool     => load_balancer_pool,
                          :load_balancer_listener => load_balancer_listener)
-      FactoryGirl.create("load_balancer_pool_member_pool".to_sym,
+      FactoryBot.create("load_balancer_pool_member_pool".to_sym,
                          :load_balancer_pool        => load_balancer_pool,
                          :load_balancer_pool_member => load_balancer_pool_member)
-      FactoryGirl.create("load_balancer_health_check_member".to_sym,
+      FactoryBot.create("load_balancer_health_check_member".to_sym,
                          :load_balancer_health_check => load_balancer_health_check,
                          :load_balancer_pool_member  => load_balancer_pool_member)
     end

--- a/spec/views/layouts/listnav/_network_port.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_network_port.html.haml_spec.rb
@@ -11,20 +11,20 @@ describe "layouts/listnav/_network_port.html.haml" do
   %w(openstack google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider       = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider       = FactoryBot.create("ems_#{t}".to_sym)
+      security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                           :ext_management_system => provider.network_manager,
                                           :name                  => 'A test')
-      vm             = FactoryGirl.create("vm_#{t}".to_sym)
-      network        = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      subnet         = FactoryGirl.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
-      floating_ip    = FactoryGirl.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
-      vm.network_ports << @network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      vm             = FactoryBot.create("vm_#{t}".to_sym)
+      network        = FactoryBot.create("cloud_network_#{t}".to_sym)
+      subnet         = FactoryBot.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
+      floating_ip    = FactoryBot.create("floating_ip_#{t}".to_sym, :ext_management_system => provider.network_manager)
+      vm.network_ports << @network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                              :device                => vm,
                                                              :security_groups       => [security_group],
                                                              :floating_ip           => floating_ip,
                                                              :ext_management_system => provider.network_manager)
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => @network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => @network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_network_router.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_network_router.html.haml_spec.rb
@@ -11,26 +11,26 @@ describe "layouts/listnav/_network_router.html.haml" do
   %w(openstack amazon azure google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider        = FactoryGirl.create("ems_#{t}".to_sym)
-      security_group  = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider        = FactoryBot.create("ems_#{t}".to_sym)
+      security_group  = FactoryBot.create("security_group_#{t}".to_sym,
                                            :ext_management_system => provider.network_manager,
                                            :name                  => 'A test')
-      vm              = FactoryGirl.create("vm_#{t}".to_sym)
-      network         = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      subnet          = FactoryGirl.create("cloud_subnet_#{t}".to_sym,
+      vm              = FactoryBot.create("vm_#{t}".to_sym)
+      network         = FactoryBot.create("cloud_network_#{t}".to_sym)
+      subnet          = FactoryBot.create("cloud_subnet_#{t}".to_sym,
                                            :cloud_network         => network,
                                            :ext_management_system => provider.network_manager)
-      @network_router = FactoryGirl.create("network_router_#{t}".to_sym,
+      @network_router = FactoryBot.create("network_router_#{t}".to_sym,
                                            :cloud_subnets         => [subnet],
                                            :ext_management_system => provider.network_manager)
-      floating_ip     = FactoryGirl.create("floating_ip_#{t}".to_sym,
+      floating_ip     = FactoryBot.create("floating_ip_#{t}".to_sym,
                                            :ext_management_system => provider.network_manager)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [security_group],
                                                             :floating_ip     => floating_ip)
 
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/layouts/listnav/_orchestration_stack.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_orchestration_stack.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_orchestration_stack.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_amazon)
+    FactoryBot.create(:ems_amazon)
   end
 
   it "link to parent cloud provider uses restful path" do
-    @record = FactoryGirl.create(:orchestration_stack_amazon, :ext_management_system => provider, :name => 'A test')
+    @record = FactoryBot.create(:orchestration_stack_amazon, :ext_management_system => provider, :name => 'A test')
     render
     expect(response).to include("Show parent Cloud Provider for this Stack\" href=\"/ems_cloud/#{@record.ext_management_system.id}\">")
   end

--- a/spec/views/layouts/listnav/_persistent_volume.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_persistent_volume.html.haml_spec.rb
@@ -10,11 +10,11 @@ describe "layouts/listnav/_persistent_volume.html.haml" do
 
   let(:provider) do
     allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-    FactoryGirl.create(:ems_openshift)
+    FactoryBot.create(:ems_openshift)
   end
 
   it "link to parent containers provider uses restful path" do
-    @record = FactoryGirl.create(:persistent_volume, :parent => provider)
+    @record = FactoryBot.create(:persistent_volume, :parent => provider)
     render
     expect(response).to include("Show this persistent volume&#39;s parent Containers Provider\" href=\"/ems_container/#{@record.parent.id}\">")
   end

--- a/spec/views/layouts/listnav/_security_group.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_security_group.html.haml_spec.rb
@@ -11,17 +11,17 @@ describe "layouts/listnav/_security_group.html.haml" do
   %w(openstack amazon azure google).each do |t|
     before do
       allow_any_instance_of(User).to receive(:get_timezone).and_return(Time.zone)
-      provider        = FactoryGirl.create("ems_#{t}".to_sym)
-      @security_group = FactoryGirl.create("security_group_#{t}".to_sym,
+      provider        = FactoryBot.create("ems_#{t}".to_sym)
+      @security_group = FactoryBot.create("security_group_#{t}".to_sym,
                                            :ext_management_system => provider.network_manager,
                                            :name                  => 'A test')
-      vm              = FactoryGirl.create("vm_#{t}".to_sym)
-      network         = FactoryGirl.create("cloud_network_#{t}".to_sym)
-      subnet          = FactoryGirl.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
-      vm.network_ports << network_port = FactoryGirl.create("network_port_#{t}".to_sym,
+      vm              = FactoryBot.create("vm_#{t}".to_sym)
+      network         = FactoryBot.create("cloud_network_#{t}".to_sym)
+      subnet          = FactoryBot.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
+      vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
                                                             :device          => vm,
                                                             :security_groups => [@security_group])
-      FactoryGirl.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
+      FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
     end
 
     context "for #{t}" do

--- a/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "miq_ae_class/_ns_list.html.haml" do
 
     describe "Git domain" do
       before do
-        dom = FactoryGirl.create(:miq_ae_git_domain)
+        dom = FactoryBot.create(:miq_ae_git_domain)
         setup_namespace_form(dom)
       end
 
@@ -33,7 +33,7 @@ describe "miq_ae_class/_ns_list.html.haml" do
 
     describe "User domain" do
       before do
-        dom = FactoryGirl.create(:miq_ae_domain)
+        dom = FactoryBot.create(:miq_ae_domain)
         setup_namespace_form(dom)
       end
 
@@ -56,7 +56,7 @@ describe "miq_ae_class/_ns_list.html.haml" do
 
     describe "Namespace" do
       before do
-        dom = FactoryGirl.create(:miq_ae_namespace, :parent => FactoryGirl.create(:miq_ae_domain))
+        dom = FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain))
         assign(:sb, :namespace_path => 'namespace/path')
         setup_namespace_form(dom)
       end

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,6 +1,6 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
-    @alert = FactoryGirl.create(:miq_alert)
+    @alert = FactoryBot.create(:miq_alert)
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")

--- a/spec/views/miq_request/_prov_vm_grid.html.haml_spec.rb
+++ b/spec/views/miq_request/_prov_vm_grid.html.haml_spec.rb
@@ -1,11 +1,11 @@
 describe 'miq_request/_prov_vm_grid.html.haml' do
   context 'check for links' do
     before do
-      @vm_user = FactoryGirl.create(:user, :role => "vm_user")
-      @vms = [FactoryGirl.create(:vm_vmware)]
+      @vm_user = FactoryBot.create(:user, :role => "vm_user")
+      @vms = [FactoryBot.create(:vm_vmware)]
       edit = {:req_id     => "foo",
               :new        => {},
-              :wf         => FactoryGirl.create(:miq_provision_workflow, :requester => @vm_user),
+              :wf         => FactoryBot.create(:miq_provision_workflow, :requester => @vm_user),
               :vm_sortcol => 'name',
               :vm_sortdir => 'ASC',
               :vm_columns => %w(name),
@@ -23,10 +23,10 @@ describe 'miq_request/_prov_vm_grid.html.haml' do
   end
 
   context 'prints tenant name' do
-    let(:admin_user) { FactoryGirl.create(:user_with_group, :role => 'super_administrator') }
+    let(:admin_user) { FactoryBot.create(:user_with_group, :role => 'super_administrator') }
 
     before do
-      @vm = [FactoryGirl.create(:template_openstack, :tenant => Tenant.root_tenant)]
+      @vm = [FactoryBot.create(:template_openstack, :tenant => Tenant.root_tenant)]
       allow(@vm).to receive(:name).and_return('name')
       allow(@vm).to receive(:operating_system).and_return('linux')
       allow(@vm).to receive(:platform).and_return('platform')
@@ -39,7 +39,7 @@ describe 'miq_request/_prov_vm_grid.html.haml' do
 
       edit = {:req_id     => 'foo',
               :new        => {},
-              :wf         => FactoryGirl.create(:miq_provision_workflow, :requester => admin_user),
+              :wf         => FactoryBot.create(:miq_provision_workflow, :requester => admin_user),
               :vm_sortcol => 'name',
               :vm_sortdir => 'ASC',
               :vm_columns => %w(name),
@@ -51,7 +51,7 @@ describe 'miq_request/_prov_vm_grid.html.haml' do
     end
 
     it 'validates tenant name is printed out' do
-      allow(@vm).to receive(:cloud_tenant).and_return(FactoryGirl.create(:cloud_tenant, :name => 'cloud_tenant_name'))
+      allow(@vm).to receive(:cloud_tenant).and_return(FactoryBot.create(:cloud_tenant, :name => 'cloud_tenant_name'))
       login_as admin_user
       render :partial => 'miq_request/prov_vm_grid.html.haml', :locals => {:field_id => 'service__src_vm_id'},
              :params => { 'tab_id' => 'service' }

--- a/spec/views/ops/_all_tabs.html.haml_spec.rb
+++ b/spec/views/ops/_all_tabs.html.haml_spec.rb
@@ -19,7 +19,7 @@ describe "ops/_all_tabs.html.haml" do
     end
 
     it "should render tabs only for non-current server" do
-      assign(:selected_server, FactoryGirl.create(:miq_server))
+      assign(:selected_server, FactoryBot.create(:miq_server))
       assign(:sb,
              :active_tab         => "diagnostics_roles_servers",
              :active_tree        => :diagnostics_tree,
@@ -31,7 +31,7 @@ describe "ops/_all_tabs.html.haml" do
     end
 
     it "should render tabs only specific to zone node" do
-      assign(:selected_server, FactoryGirl.create(:miq_server))
+      assign(:selected_server, FactoryBot.create(:miq_server))
       assign(:sb,
              :active_tab         => "diagnostics_roles_servers",
              :active_tree        => :diagnostics_tree,

--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -41,7 +41,7 @@ describe 'ops/_label_tag_mapping_form.html.haml' do
 
   context 'edit existing mapping' do
     before do
-      @lt_map = FactoryGirl.create(:tag_mapping_with_category)
+      @lt_map = FactoryBot.create(:tag_mapping_with_category)
       @edit = {:id  => nil,
                :new => {:options    => [["<All>", nil]],
                         :entity     => nil,

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -1,17 +1,17 @@
 describe 'ops/_rbac_group_details.html.haml' do
   context 'add new group' do
     before do
-      miq_server = FactoryGirl.create(:miq_server)
+      miq_server = FactoryBot.create(:miq_server)
       edit = {:new                 => {:description => ''},
               :key                 => "settings_authentication_edit__#{miq_server.id}",
               :ldap_groups_by_user => [],
               :roles               => %w(fred wilma),
               :projects_tenants    => [["projects", %w(foo bar)]]}
       view.instance_variable_set(:@edit, edit)
-      @group = FactoryGirl.create(:miq_group, :description => 'flintstones')
+      @group = FactoryBot.create(:miq_group, :description => 'flintstones')
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
       allow(view).to receive(:session).and_return(:assigned_filters => [])
-      FactoryGirl.create(:classification, :name => 'folder_selected', :show => true)
+      FactoryBot.create(:classification, :name => 'folder_selected', :show => true)
 
       sb = {
         :trees                 => {},
@@ -26,7 +26,7 @@ describe 'ops/_rbac_group_details.html.haml' do
                                        :edit    => {},
                                        :filters => {},
                                        :group   => @group)
-      @ems_azure_network = FactoryGirl.create(:ems_azure_network)
+      @ems_azure_network = FactoryBot.create(:ems_azure_network)
       @hac_tree = TreeBuilderBelongsToHac.new(:hac_tree,
                                               :hac,
                                               sb,

--- a/spec/views/ops/_rbac_user_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_user_details.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe 'ops/_rbac_user_details.html.haml' do
   context "edit user" do
     before do
-      user = FactoryGirl.build(:user_with_group, :name => "Joe Test", :userid => "tester")
+      user = FactoryBot.build(:user_with_group, :name => "Joe Test", :userid => "tester")
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
       allow(view).to receive(:session).and_return(:assigned_filters => [])
       edit = {:new    => {:name   => user.name,

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -2,16 +2,16 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
   before do
     assign(:sb, :active_tab => "settings_cu_collection")
 
-    @host = FactoryGirl.create(:host, :name => 'Host Name')
-    FactoryGirl.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
+    @host = FactoryBot.create(:host, :name => 'Host Name')
+    FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
     @datastore = [{:id       => 1,
                    :name     => 'Datastore',
                    :location => 'Location',
                    :capture  => false}]
     @datastore_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, @datastore)
 
-    @ho_enabled = [FactoryGirl.create(:host)]
-    @ho_disabled = [FactoryGirl.create(:host)]
+    @ho_enabled = [FactoryBot.create(:host)]
+    @ho_disabled = [FactoryBot.create(:host)]
     allow(EmsCluster).to receive(:get_perf_collection_object_list).and_return(:'1'.to_i =>
                                                                                            {:id          => 1,
                                                                                             :name        => 'Name',

--- a/spec/views/ops/_settings_evm_servers_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_evm_servers_tab.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "ops/_settings_evm_servers_tab.html.haml" do
   before do
     assign(:sb, :active_tab => "settings_evm_servers")
-    @selected_zone = FactoryGirl.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
+    @selected_zone = FactoryBot.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
                                                 {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0, :ntp => {:server => ['Server 1']}})
     @servers = []
   end

--- a/spec/views/ops/_zone_form.html.haml_spec.rb
+++ b/spec/views/ops/_zone_form.html.haml_spec.rb
@@ -1,14 +1,14 @@
 describe "ops/_zone_form.html.haml" do
   before do
     assign(:sb, :active_tab => "settings_evm_servers")
-    @selected_zone = FactoryGirl.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
+    @selected_zone = FactoryBot.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
                                                 {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0, :ntp => {:server => ['Server 1']}})
     @servers = []
   end
 
   context "zone selected" do
     before do
-      @zone = FactoryGirl.create(:zone)
+      @zone = FactoryBot.create(:zone)
       @edit = {:zone_id               => nil,
                :new                   => {:name                => nil,
                                           :description         => nil,

--- a/spec/views/report/_db_widget_remove.html.haml_spec.rb
+++ b/spec/views/report/_db_widget_remove.html.haml_spec.rb
@@ -1,11 +1,11 @@
 describe "report/_db_widget_remove.html.haml" do
   before do
-    ws = FactoryGirl.create(:miq_widget_set)
+    ws = FactoryBot.create(:miq_widget_set)
     assign(:db, ws)
   end
 
   it "correctly renders patternfly classes" do
-    widget = FactoryGirl.create(:miq_widget)
+    widget = FactoryBot.create(:miq_widget)
     render :partial => "report/db_widget_remove",
            :locals  => {:widget => widget}
     expect(response).to have_selector('a.pull-right')

--- a/spec/views/report/_form_expression_buttons.html.haml_spec.rb
+++ b/spec/views/report/_form_expression_buttons.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'report/_form_filter.html.haml' do
-  let(:report) { FactoryGirl.create(:miq_report) }
+  let(:report) { FactoryBot.create(:miq_report) }
   let(:exp_table) { [["Example AFTER \"value1\"", 1]] }
   let(:expression) { {"after" => {"field" => "field_example", "value" => "value1"}, :token => 1} }
   let(:edit) { { :rpt_id => report.id, :record_filter => {:exp_table => exp_table, :expression => expression}} }

--- a/spec/views/report/_widget_form_menu.html.haml_spec.rb
+++ b/spec/views/report/_widget_form_menu.html.haml_spec.rb
@@ -1,6 +1,6 @@
 describe "report/_widget_form_menu.html.haml" do
   before do
-    w = FactoryGirl.create(:miq_widget)
+    w = FactoryBot.create(:miq_widget)
     assign(:widget, w)
     assign(:edit, :avail_shortcuts => %w(xx yy), :read_only => 0, :new => {:shortcuts => %w(id desc)})
   end

--- a/spec/views/shared/views/_ownership.html.haml_spec.rb
+++ b/spec/views/shared/views/_ownership.html.haml_spec.rb
@@ -7,12 +7,12 @@ describe "shared/views/_ownership" do
     root_tenant
     Tenant.default_tenant
   end
-  let(:user)         { FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
-  let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
-  let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
-  let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
-  let(:user_role)    { FactoryGirl.create(:miq_user_role) }
-  let(:user_group)   { FactoryGirl.create(:miq_group, :miq_user_role => user_role) }
+  let(:user)         { FactoryBot.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
+  let(:tenant)       { FactoryBot.build(:tenant, :parent => default_tenant) }
+  let(:tenant_users) { FactoryBot.create(:miq_user_role, :name => "tenant-users") }
+  let(:tenant_group) { FactoryBot.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
+  let(:user_role)    { FactoryBot.create(:miq_user_role) }
+  let(:user_group)   { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
 
   before do
     set_controller_for_view("vm_infra")
@@ -20,7 +20,7 @@ describe "shared/views/_ownership" do
   end
 
   it "the ownership group dropdown includes the no group option" do
-    vm = FactoryGirl.create(:vm_vmware, :miq_group => tenant_group)
+    vm = FactoryBot.create(:vm_vmware, :miq_group => tenant_group)
     allow(view).to receive(:ownership_user_options).and_return([user.id])
     allow(view).to receive(:settings).and_return('list')
     allow(view).to receive(:render_gtl_outer)

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -5,8 +5,8 @@ describe "shared/views/ems_common/show" do
     TestSetup.new(:ems_vmware,    EmsInfraHelper::TextualSummary),
   ].each do |setup|
     let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryGirl.create(:zone) }
-    let(:ems) { FactoryGirl.create(setup.ems_type, :hostname => '1.1.1.1', :zone => zone) }
+    let(:zone) { FactoryBot.create(:zone) }
+    let(:ems) { FactoryBot.create(setup.ems_type, :hostname => '1.1.1.1', :zone => zone) }
     let(:action) { 'index' }
 
     before do
@@ -49,7 +49,7 @@ describe "shared/views/ems_common/show" do
 
     let(:showtype) { "main" }
     let(:display) { 'cloud_volumes' }
-    let(:ems) { FactoryGirl.create(:ems_storage, :hostname => '1.1.1.1') }
+    let(:ems) { FactoryBot.create(:ems_storage, :hostname => '1.1.1.1') }
 
     it "should show render gtl for list of cloud_volumes" do
       render

--- a/spec/views/vm/_show.html.haml_spec.rb
+++ b/spec/views/vm/_show.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe "vm/show.html.haml" do
     end
   end
 
-  let(:vm) { FactoryGirl.create(:vm, :name => 'vm', :description => 'vm description') }
+  let(:vm) { FactoryBot.create(:vm, :name => 'vm', :description => 'vm description') }
   let(:action) { 'show' }
 
   before do


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/18279

The core PR updates factory_girl, so we get the new name, factory_bot.
=> Renaming all the references from `FactoryGirl` to `FactoryBot`.

(The core PR *does* provide a `FactoryGirl = FactoryBot` compatibility thingy, but we should still switch.)

---

Backporting: this PR will not be backported, but hammer and gaprindashvili will have a `FactoryBot = FactoryGirl` line so that specs using the new name can be backported safely. (https://github.com/ManageIQ/manageiq/pull/18288)
