### PR TITLE
5.1 AC::Parameters isn't a hash, use what's available

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -972,7 +972,7 @@ class ApplicationController < ActionController::Base
 
       # Clickable should be false only when it's explicitly set to false
       not_clickable = if params
-                        (params.fetch_path(:additional_options, :clickable) == false)
+                        (params.dig(:additional_options, :clickable) == false)
                       else
                         false
                       end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -662,7 +662,7 @@ module ApplicationController::MiqRequestMethods
     @edit[:new][:start_min]     = params[:start_min] if params[:start_min]
     @edit[:new][:schedule_time] = Time.zone.parse("#{@edit[:new][:start_date]} #{@edit[:new][:start_hour]}:#{@edit[:new][:start_min]}")
 
-    params.each_key do |key|
+    params.each do |key, _value|
       next unless key.include?("__")
       d, f  = key.split("__") # Parse dialog and field names from the parameter key
       field = @edit[:wf].get_field(f.to_sym, d.to_sym) # Get the field hash

--- a/app/controllers/application_controller/sysprep_answer_file.rb
+++ b/app/controllers/application_controller/sysprep_answer_file.rb
@@ -5,7 +5,7 @@ class ApplicationController
       @upload_sysprep_file = true
       @edit = session[:edit]
       build_grid
-      if params.fetch_path(:upload, :file).respond_to?(:read)
+      if params.dig(:upload, :file).respond_to?(:read)
         @edit[:new][:sysprep_upload_file] = params[:upload][:file].original_filename
         begin
           @edit[:new][:sysprep_upload_text] = SysprepFile.new(params[:upload][:file]).content

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -236,7 +236,7 @@ class CloudSubnetController < ApplicationController
       options[:gateway_ip] = params[:gateway].presence
     end
     options[:ip_version] = params[:network_protocol] =~ /4/ ? 4 : 6
-    options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant][:id]) if params.fetch_path(:cloud_tenant, :id)
+    options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant][:id]) if params.dig(:cloud_tenant, :id)
     options[:network_id] = params[:network_id] if params[:network_id]
     options[:enable_dhcp] = params[:dhcp_enabled]
     # TODO: Add dns_nameservers, allocation_pools, host_routes

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -565,7 +565,7 @@ class ConfigurationController < ApplicationController
     when "ui_2" # Visual Settings tab
       @edit[:new][:display][:compare] = params[:display][:compare] if !params[:display].nil? && !params[:display][:compare].nil?
       @edit[:new][:display][:drift] = params[:display][:drift] if !params[:display].nil? && !params[:display][:drift].nil?
-      @edit[:new][:display][:display_vms] = params[:display_vms] unless params.fetch_path(:display_vms)
+      @edit[:new][:display][:display_vms] = params[:display_vms] unless params.dig(:display_vms)
     when "ui_3" # Visual Settings tab
       @edit[:new][:display][:compare] = params[:display][:compare] if !params[:display].nil? && !params[:display][:compare].nil?
       @edit[:new][:display][:drift] = params[:display][:drift] if !params[:display].nil? && !params[:display][:drift].nil?

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -840,7 +840,7 @@ class MiqAeClassController < ApplicationController
           session[:field_data][:default_value] =
             @edit[:new_field][:default_value] = ''
         end
-        params.each_key do |field|
+        params.each do |field, _value|
           next unless field.to_s.starts_with?("fields_datatype")
 
           f = field.split('fields_datatype')
@@ -938,7 +938,7 @@ class MiqAeClassController < ApplicationController
           end
         end
 
-        params.each_key do |field|
+        params.each do |field, _value|
           if field.to_s.starts_with?("cls_fields_datatype_")
             f = field.split('cls_fields_datatype_')
             def_field = "cls_fields_value_" << f[1].to_s

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -177,7 +177,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
   def upload_import_file
     redirect_options = {:action => :review_import}
 
-    upload_file = params.fetch_path(:upload, :file)
+    upload_file = params.dig(:upload, :file)
 
     if upload_file.blank?
       add_flash(_("Use the Choose file button to locate an import file"), :warning)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -344,7 +344,7 @@ class MiqPolicyController < ApplicationController
   end
 
   def upload_file_valid?
-    params.fetch_path(:upload, :file).respond_to?(:read)
+    params.dig(:upload, :file).respond_to?(:read)
   end
 
   def peca_get_all(what, get_view)
@@ -1045,7 +1045,7 @@ class MiqPolicyController < ApplicationController
     @edit[:new][subkey][:trap_id]      = params[:trap_id] if params[:trap_id]
     refresh = true if params[:snmp_version]
     if process_variables
-      params.each_key do |var|
+      params.each do |var, _value|
         vars = var.split("__")
         next unless %w(oid var_type value).include?(vars[0])
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -167,7 +167,7 @@ module MiqPolicyController::Policies
       @edit[:new][:notes] = params[:notes].presence if params[:notes]
       @edit[:new][:active] = (params[:active] == "1") if params.key?(:active)
     when "events"
-      params.each_key do |field|
+      params.each do |field, _value|
         if field.to_s.starts_with?("event_")
           event = field.to_s.split("_").last
           if params[field] == "true"

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -387,7 +387,7 @@ class NetworkRouterController < ApplicationController
         subnet = find_record_with_rbac(CloudSubnet, params[:cloud_subnet_id])
         options[:external_gateway_info][:external_fixed_ips] = [{:subnet_id => subnet.ems_ref}]
       end
-      if params.fetch_path(:extra_attributes, :external_gateway_info, :enable_snat)
+      if params.dig(:extra_attributes, :external_gateway_info, :enable_snat)
         options[:external_gateway_info][:enable_snat] = params[:extra_attributes][:external_gateway_info][:enable_snat]
       end
     end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -64,7 +64,7 @@ class ReportController < ApplicationController
 
   def upload
     @sb[:flash_msg] = []
-    if params.fetch_path(:upload, :file) && File.size(params[:upload][:file].tempfile).zero?
+    if params.dig(:upload, :file) && File.size(params[:upload][:file].tempfile).zero?
       redirect_to(:action      => 'explorer',
                   :flash_msg   => _("Import file cannot be empty"),
                   :flash_error => true)
@@ -219,7 +219,7 @@ class ReportController < ApplicationController
   end
 
   def upload_widget_import_file
-    upload_file = params.fetch_path(:upload, :file)
+    upload_file = params.dig(:upload, :file)
 
     if upload_file.blank?
       add_flash("Use the Choose file button to locate an import file", :warning)

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -176,7 +176,7 @@ class SecurityGroupController < ApplicationController
           end
         end
 
-        params["firewall_rules"].each_value do |rule|
+        params["firewall_rules"].each do |_key, rule|
           if rule["id"] && rule["id"].empty?
             create_rule(rule)
           elsif rule["deleted"]


### PR DESCRIPTION
NOTE:  Please review carefully.  The tests didn't find these so this code is not exercised in tests.  I was not able to figure out how to test some of these methods.  Let me know if there's an existing test I could change to hit these code paths.  

The ActionController#params method returns ActionController::Parameter
objects which do not respond to all hash methods.

Use dig instead of fetch_path (fetch is our extension on hash, dig is
ruby and also implemented in AC::Params).

Use each instead of each_key/each_value.

rails PR: #20868

Prior PR doing something similar for each_with_object:
https://github.com/ManageIQ/manageiq-ui-classic/pull/4935

Related to: https://github.com/ManageIQ/manageiq/pull/18076
