### PR TITLE
Alias moment to fix moment-strftime dependency

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -125,6 +125,7 @@ module.exports = {
     alias: {
       'react': resolve(dirname(__filename), '../../node_modules', 'react'),
       'bootstrap-select': '@pf3/select',  // never use vanilla bootstrap-select
+      'moment': resolve(dirname(__filename), '../../node_modules', 'moment'), // fix moment-strftime peerDependency issue
     },
     extensions: settings.extensions,
     modules: [],


### PR DESCRIPTION
moment 2.23.0 came out yesterday,
moment-strftime does `require('moment')`,
but its package.json lists moment (^2.11) as a dependency, not peerDependency.

So, the new version gets added in `node_modules/moment-strftime/node_modules/moment`,
instead of just using the older `node_modules/moment`.

Aliasing moment so that doesn't happen.

---

Fixes (during `spec:javascript`):

```
         ManageIQ.charts.formatters .datetime Date (M/D/YYYY)
          TypeError: undefined is not a function (evaluating 'val.strftime(options.format)') in http://127.0.0.1:43021/assets/miq_formatters.self-ce4b8e42c62955443827c716d1072357a04813393bcd6af7f5a0445144012fc1.js?body=1?body=true (line 203)
          datetime@http://127.0.0.1:43021/assets/miq_formatters.self-ce4b8e42c62955443827c716d1072357a04813393bcd6af7f5a0445144012fc1.js?body=1?body=true:203:26
http://127.0.0.1:43021/__spec__/miq_formatters_spec.js:338:16
attemptSync@http://127.0.0.1:43021/__jasmine__/jasmine.js:1950:28
run@http://127.0.0.1:43021/__jasmine__/jasmine.js:1938:20
execute@http://127.0.0.1:43021/__jasmine__/jasmine.js:1923:13
queueRunnerFactory@http://127.0.0.1:43021/__jasmine__/jasmine.js:714:42
execute@http://127.0.0.1:43021/__jasmine__/jasmine.js:371:28
```

(and 25 [more like that](https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/467725972#L2692))