### PR TITLE
[WIP] Force requester_type to be UI

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -71,6 +71,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     } else {
       apiData = vm.dialogData;
     }
+    apiData.requester_type = 'ui';
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]})
       .then(function(response) {
         if (vm.openUrl === 'true') {

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
@@ -133,7 +133,7 @@ describe('dialogUserController', function() {
 
         setTimeout(function() {
           expect(API.post).toHaveBeenCalledWith('generic_objects/explorer', {
-            parameters: {field1: 'field1'}, action: 'custom_action'}, {skipErrors: [400]});
+            parameters: {field1: 'field1'}, requester_type: 'ui', action: 'custom_action'}, {skipErrors: [400]});
           done();
         });
       });
@@ -167,7 +167,7 @@ describe('dialogUserController', function() {
 
         setTimeout(function() {
           expect(API.post).toHaveBeenCalledWith('service/explorer', {
-            resource: {field1: 'field1'}, action: 'reconfigure'}, {skipErrors: [400]});
+            resource: {field1: 'field1'}, requester_type: 'ui', action: 'reconfigure'}, {skipErrors: [400]});
           done();
         });
       });
@@ -193,6 +193,7 @@ describe('dialogUserController', function() {
         setTimeout(function() {
           expect(API.post).toHaveBeenCalledWith('submit endpoint', {
             action: 'order',
+            requester_type: 'ui',
             field1: 'field1'
           }, {skipErrors: [400]});
           done();


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1659602, an issue with default dialog values not populated when API auth type is auth token because the mechanism we had in place for determining the requester type in https://github.com/ManageIQ/manageiq-api/commit/f2f024a2ccabefcfbd833aa8df9b04757ab3d109 apparently wasn't bulletproof enough...

## related to 
https://github.com/ManageIQ/manageiq-api/pull/528