### PR TITLE
Don't assign bool value to variable that already has it

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -101,7 +101,6 @@ class ReportController < ApplicationController
     when "saved_reports"
       redirect_to(:action => params[:tab])
     when "menueditor"
-      # redirect_to(:controller=>"configuration", :action=>"change_tab", :tab=>6)
       redirect_to(:action => "menu_edit")
     else
       redirect_to(:action => params[:tab], :id => params[:id])

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -71,7 +71,7 @@ class ReportController < ApplicationController
       return
     end
     if params[:upload] && params[:upload][:file] && params[:upload][:file].respond_to?(:read)
-      @sb[:overwrite] = !params[:overwrite].nil?
+      @sb[:overwrite] = params[:overwrite].present?
       begin
         _reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite], :userid => session[:userid])
       rescue => bang

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -12,10 +12,9 @@
              :class     => "form-horizontal",
              :multipart => true,
              :method    => :post) do
-    - overwrite = @sb[:overwrite] ? true : false
     .form-group
       .col-md-8
-        = check_box_tag("overwrite", "1", overwrite)
+        = check_box_tag("overwrite", "1", @sb[:overwrite])
         = _('Overwrite existing reports?')
     .form-group
       .col-md-4


### PR DESCRIPTION
and delete commented out code. 

Saw that some ugly code was used as reference for new one so it has to go.

**MERGE AFTER** https://github.com/ManageIQ/manageiq-ui-classic/pull/5060 to prevent backport pain.

@miq-bot add_label refactoring, hammer/no