### PR TITLE
Region Replication - refresh code mirror after load

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', '$scope', 'pglogicalReplicationFormId', 'miqService', '$q', function($http, $scope, pglogicalReplicationFormId, miqService, $q) {
+ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', '$scope', 'pglogicalReplicationFormId', 'miqService', '$q', '$timeout', function($http, $scope, pglogicalReplicationFormId, miqService, $q, $timeout) {
   var init = function() {
     $scope.pglogicalReplicationModel = {
       replication_type: 'none',
@@ -316,6 +316,10 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     $scope.afterGet = true;
     $scope.modelCopy = angular.copy( $scope.pglogicalReplicationModel );
     miqService.sparkleOff();
+
+    $timeout(function() {
+      $scope.codeMirrorRefresh = true;
+    });
   }
 
   init();

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -188,6 +188,7 @@
         = _('Excluded Tables')
       %br
         %textarea{"ui-codemirror" => "",
+                  "ui-refresh"    => "codeMirrorRefresh",
                   :name           => "exclusion_list",
                   'ng-model'      => 'pglogicalReplicationModel.exclusion_list',
                   'checkchange'   => ''}


### PR DESCRIPTION
(admin) > Configuration > CFME Region > Replication

when replication type is already set to Remote,
the code mirror component renders too soon and thus renders without data
(this does not happen when the user explicitly changes to Remote)

adding an explicit [ui-refresh](https://github.com/angular-ui/ui-codemirror#ui-refresh-directive), to trigger a refresh once the data is loaded

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656066
