### PR TITLE
Fix CatalogItem tree_select()

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2007,7 +2007,7 @@ class CatalogController < ApplicationController
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
                      params[:action] == "x_show" ||
-                     (%w(accordion_select tree_select).include?(params[:action]) && @record.present? && type == 'st')
+                     (%w(accordion_select reload tree_select).include?(params[:action]) && @record.present? && type == 'st')
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record


### PR DESCRIPTION
This is virtually the same problem as https://github.com/ManageIQ/manageiq-ui-classic/pull/5030/files This PR makes the fix work for `reload` as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1652858