### PR TITLE
[WIP] rewrite miq_observe to not rely on document focus + element change

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1,4 +1,4 @@
-/* global add_flash dialogFieldRefresh getChartColumnDataValues getChartFormatedValue miqBrowserDetect miqExpressionPrefill miqFlashLater miqFlashSaved miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqTreeObject miqValueStylePrefill performFiltering recalculateChartYAxisLabels */
+/* global add_flash getChartColumnDataValues getChartFormatedValue miqBrowserDetect miqExpressionPrefill miqFlashLater miqFlashSaved miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqTreeObject miqValueStylePrefill performFiltering recalculateChartYAxisLabels */
 
 // MIQ specific JS functions
 
@@ -874,27 +874,6 @@ function miqBuildCalendar() {
       ManageIQ.observeDate = observeDateBackup;
     }
   });
-}
-
-function miqSendDateRequest(el) {
-  var parms = $.parseJSON(el.attr('data-miq_observe_date'));
-  var url = parms.url;
-  //  tack on the id and value to the URL
-  var urlstring = url + '?' + el.prop('id') + '=' + el.val();
-
-  var attemptAutoRefreshTrigger = function() {
-    if (parms.auto_refresh === true) {
-      dialogFieldRefresh.triggerAutoRefresh(parms);
-    }
-  };
-
-  var options = {
-    beforeSend: !!el.attr('data-miq_sparkle_on'),
-    complete: !!el.attr('data-miq_sparkle_off'),
-    done: attemptAutoRefreshTrigger,
-  };
-
-  return miqObserveRequest(urlstring, options);
 }
 
 // common function to pass ajax request to server

--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -1,4 +1,4 @@
-/* global dialogFieldRefresh miqCheckForChanges miqCheckMaxLength miqJqueryRequest miqMenuChangeRow miqObserveRequest miqSendDateRequest miqSendOneTrans miqSerializeForm miqSparkle miqSparkleOn */
+/* global miqCheckForChanges miqCheckMaxLength miqJqueryRequest miqMenuChangeRow miqSerializeForm miqSparkle miqSparkleOn miqObserveSetup */
 
 // MIQ unobtrusive javascript bindings run when document is fully loaded
 
@@ -65,121 +65,7 @@ $(document).ready(function() {
     $(this).data('params', miqSerializeForm(form_id));
   });
 
-  // Bind in the observe support. If interval is configured, use the observe_field function
-  var attemptAutoRefreshTrigger = function(parms) {
-    return function() {
-      if (parms.auto_refresh === true) {
-        dialogFieldRefresh.triggerAutoRefresh(parms);
-      }
-    };
-  };
-
-  var observeWithInterval = function(el, parms) {
-    if (el.data('isObserved')) {
-      return;
-    }
-    el.data('isObserved', true);
-
-    var interval = parms.interval;
-    var url = parms.url;
-    var submit = parms.submit;
-
-    el.observe_field(interval, function() {
-      var oneTrans = this.getAttribute('data-miq_send_one_trans'); // Grab one trans URL, if present
-      if (typeof submit !== 'undefined') {
-        // If submit element passed in
-        miqObserveRequest(url, {
-          data: miqSerializeForm(submit),
-          done: attemptAutoRefreshTrigger(parms),
-        });
-      } else if (oneTrans) {
-        miqSendOneTrans(url, {
-          observe: true,
-          done: attemptAutoRefreshTrigger(parms),
-        });
-      } else {
-        // tack on the id and value to the URL
-        var data = {};
-        data[el.attr('id')] = el.prop('value');
-
-        miqObserveRequest(url, {
-          done: attemptAutoRefreshTrigger(parms),
-          data: data,
-        });
-      }
-    });
-  };
-
-  var observeOnChange = function(el, parms) {
-    // No interval passed, use event observer
-    el.off('change');
-    el.on('change', _.debounce(function() {
-      var id = el.attr('id');
-      var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
-
-      miqObserveRequest(parms.url, {
-        no_encoding: true,
-        data: id + '=' + value,
-        beforeSend: !!el.attr('data-miq_sparkle_on'),
-        complete: !!el.attr('data-miq_sparkle_off'),
-        done: attemptAutoRefreshTrigger(parms),
-      });
-    }, 700, {leading: true, trailing: true}));
-  };
-
-  $(document).on('focus', '[data-miq_observe]', function() {
-    var el = $(this);
-    var parms = $.parseJSON(el.attr('data-miq_observe'));
-
-    if (typeof parms.interval === 'undefined') {
-      observeOnChange(el, parms);
-    } else {
-      observeWithInterval(el, parms);
-    }
-  });
-
-  // Firefox on MacOs isn't firing onfocus events for radio buttons so onchange is used instead
-  $(document).on('change', '[data-miq_observe]', function() {
-    var el = $(this);
-    var parms = $.parseJSON(el.attr('data-miq_observe'));
-    var id = el.attr('id');
-    var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
-
-    miqObserveRequest(parms.url, {
-      no_encoding: true,
-      data: id + '=' + value,
-      beforeSend: !!el.attr('data-miq_sparkle_on'),
-      complete: !!el.attr('data-miq_sparkle_off'),
-      done: attemptAutoRefreshTrigger(parms),
-    });
-  });
-
-  $(document).on('change', '[data-miq_observe_checkbox]', function(event) {
-    var el = $(this);
-    var parms = $.parseJSON(el.attr('data-miq_observe_checkbox'));
-    var url = parms.url;
-
-    var id = el.attr('id');
-    var value = encodeURIComponent(el.prop('checked') ? el.val() : 'null');
-
-    miqObserveRequest(url, {
-      no_encoding: true,
-      data: id + '=' + value,
-      beforeSend: !!el.attr('data-miq_sparkle_on'),
-      complete: !!el.attr('data-miq_sparkle_off'),
-      done: attemptAutoRefreshTrigger(parms),
-    });
-
-    event.stopPropagation();
-  });
-
-  ManageIQ.observeDate = function(el) {
-    miqSendDateRequest(el);
-  };
-
-  $(document).on('changeDate clearDate', '[data-miq_observe_date]', function() {
-    ManageIQ.observeDate($(this));
-  });
+  miqObserveSetup();
 
   // Run this last to be sure all other UJS bindings have been run in case the focus field is observed
   $('[data-miq_focus]').each(function(_index) {

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -66,7 +66,12 @@ const miqObserve = (element, params) => {
   }
 
   const id = element.attr('id');
+  const name = element.attr('name');
   const value = elementValue(element);
+
+  if (id !== name) {
+    console.warn(`miq_observe: element id and name differ: id=${id}, name=${name}, value=${value}`);
+  }
 
   return miqObserveRequest(url, {
     no_encoding: true,

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -46,20 +46,19 @@ const observeWithInterval = (element, params) => {
   });
 };
 
-function miqSendDateRequest(el) {
-  var parms = $.parseJSON(el.attr('data-miq_observe_date'));
-  var url = parms.url;
+ManageIQ.observeDate = (element) => {
+  const params = $.parseJSON(element.attr('data-miq_observe_date'));
+  let { url } = params;
+
   //  tack on the id and value to the URL
-  var urlstring = url + '?' + el.prop('id') + '=' + el.val();
+  url += '?' + element.prop('id') + '=' + element.val();
 
-  var options = {
-    beforeSend: !!el.attr('data-miq_sparkle_on'),
-    complete: !!el.attr('data-miq_sparkle_off'),
-    done: attemptAutoRefreshTrigger(parms),
-  };
-
-  return miqObserveRequest(urlstring, options);
-}
+  return miqObserveRequest(url, {
+    beforeSend: !!element.attr('data-miq_sparkle_on'),
+    complete: !!element.attr('data-miq_sparkle_off'),
+    done: attemptAutoRefreshTrigger(params),
+  });
+};
 
 export function setup() {
   var observeOnChange = function(el, parms) {
@@ -124,10 +123,6 @@ export function setup() {
 
     event.stopPropagation();
   });
-
-  ManageIQ.observeDate = function(el) {
-    miqSendDateRequest(el);
-  };
 
   $(document).on('changeDate clearDate', '[data-miq_observe_date]', function() {
     ManageIQ.observeDate($(this));

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -36,18 +36,18 @@ const observeWithInterval = (element, params) => {
       // tack on the id and value to the URL
       const data = {
         [id]: element.prop('value'),
-      }
+      };
 
       miqObserveRequest(url, {
         done: attemptAutoRefreshTrigger(params),
-        data: data,
+        data,
       });
     }
   });
 };
 
 const elementValue = (element) => {
-  if (element.prop('type') == 'checkbox' || element.attr('data-miq_observe_checkbox')) {
+  if (element.prop('type') === 'checkbox' || element.attr('data-miq_observe_checkbox')) {
     return encodeURIComponent(element.prop('checked') ? element.val() : 'null');
   }
 
@@ -75,7 +75,7 @@ const miqObserve = (element, params) => {
 
   return miqObserveRequest(url, {
     no_encoding: true,
-    data: id + '=' + value,
+    data: `${id}=${value}`,
     beforeSend: !!element.attr('data-miq_sparkle_on'),
     complete: !!element.attr('data-miq_sparkle_off'),
     done: attemptAutoRefreshTrigger(params),
@@ -89,12 +89,12 @@ const debouncedObserve = debounce(miqObserve, 700, {
 
 ManageIQ.observeDate = (element) => {
   const params = $.parseJSON(element.attr('data-miq_observe_date'));
-  let { url } = params;
+  const { url } = params;
 
-  //  tack on the id and value to the URL
-  url += '?' + element.prop('id') + '=' + element.val();
+  const id = element.prop('id');
+  const value = element.val();
 
-  return miqObserveRequest(url, {
+  return miqObserveRequest(`${url}?${id}=${value}`, {
     beforeSend: !!element.attr('data-miq_sparkle_on'),
     complete: !!element.attr('data-miq_sparkle_off'),
     done: attemptAutoRefreshTrigger(params),

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -46,6 +46,18 @@ const observeWithInterval = (element, params) => {
   });
 };
 
+const elementValue = (element) => {
+  if (element.prop('type') == 'checkbox' || element.attr('data-miq_observe_checkbox')) {
+    return encodeURIComponent(element.prop('checked') ? element.val() : 'null');
+  }
+
+  if (element.prop('multiple')) {
+    return element.val();
+  }
+
+  return encodeURIComponent(element.prop('value'));
+};
+
 const miqObserve = (element, params) => {
   const { url, interval } = params;
   if (interval) {
@@ -54,7 +66,7 @@ const miqObserve = (element, params) => {
   }
 
   const id = element.attr('id');
-  const value = element.prop('multiple') ? element.val() : encodeURIComponent(element.prop('value'));
+  const value = elementValue(element);
 
   return miqObserveRequest(url, {
     no_encoding: true,
@@ -105,20 +117,10 @@ export function setup() {
   });
 
   $(document).on('change', '[data-miq_observe_checkbox]', function(event) {
-    var el = $(this);
-    var parms = $.parseJSON(el.attr('data-miq_observe_checkbox'));
-    var url = parms.url;
+    const element = $(this);
+    const params = $.parseJSON(element.attr('data-miq_observe_checkbox'));
 
-    var id = el.attr('id');
-    var value = encodeURIComponent(el.prop('checked') ? el.val() : 'null');
-
-    miqObserveRequest(url, {
-      no_encoding: true,
-      data: id + '=' + value,
-      beforeSend: !!el.attr('data-miq_sparkle_on'),
-      complete: !!el.attr('data-miq_sparkle_off'),
-      done: attemptAutoRefreshTrigger(parms),
-    });
+    debouncedObserve(element, params);
 
     event.stopPropagation();
   });

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -99,13 +99,11 @@ ManageIQ.observeDate = (element) => {
 
 export function setup() {
   $(document).on('focus', '[data-miq_observe]', function() {
-    var el = $(this);
-    var parms = $.parseJSON(el.attr('data-miq_observe'));
+    const element = $(this);
+    const params = $.parseJSON(element.attr('data-miq_observe'));
 
-    if (typeof parms.interval === 'undefined') {
-      // replaced by miqObserve
-    } else {
-      observeWithInterval(el, parms);
+    if (params.interval) {
+      observeWithInterval(element, params);
     }
   });
 
@@ -121,11 +119,12 @@ export function setup() {
     const params = $.parseJSON(element.attr('data-miq_observe_checkbox'));
 
     debouncedObserve(element, params);
-
     event.stopPropagation();
   });
 
   $(document).on('changeDate clearDate', '[data-miq_observe_date]', function() {
-    ManageIQ.observeDate($(this));
+    const element = $(this);
+
+    ManageIQ.observeDate(element);
   });
 }

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -1,21 +1,22 @@
 /* global dialogFieldRefresh miqObserveRequest miqSerializeForm miqSendOneTrans */
 
+const attemptAutoRefreshTrigger = (params) =>
+  () => {
+    if (params.auto_refresh === true) {
+      dialogFieldRefresh.triggerAutoRefresh(params);
+    }
+  };
+
 function miqSendDateRequest(el) {
   var parms = $.parseJSON(el.attr('data-miq_observe_date'));
   var url = parms.url;
   //  tack on the id and value to the URL
   var urlstring = url + '?' + el.prop('id') + '=' + el.val();
 
-  var attemptAutoRefreshTrigger = function() {
-    if (parms.auto_refresh === true) {
-      dialogFieldRefresh.triggerAutoRefresh(parms);
-    }
-  };
-
   var options = {
     beforeSend: !!el.attr('data-miq_sparkle_on'),
     complete: !!el.attr('data-miq_sparkle_off'),
-    done: attemptAutoRefreshTrigger,
+    done: attemptAutoRefreshTrigger(parms),
   };
 
   return miqObserveRequest(urlstring, options);
@@ -24,14 +25,6 @@ function miqSendDateRequest(el) {
 export function setup() {
   // Bind in the observe support. If interval is configured, use the observe_field functi
 n
-  var attemptAutoRefreshTrigger = function(parms) {
-    return function() {
-      if (parms.auto_refresh === true) {
-        dialogFieldRefresh.triggerAutoRefresh(parms);
-      }
-    };
-  };
-
   var observeWithInterval = function(el, parms) {
     if (el.data('isObserved')) {
       return;

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -1,5 +1,7 @@
 /* global dialogFieldRefresh miqObserveRequest miqSerializeForm miqSendOneTrans */
 
+import { debounce } from 'lodash';
+
 const attemptAutoRefreshTrigger = (params) =>
   () => {
     if (params.auto_refresh === true) {
@@ -64,7 +66,7 @@ n
   var observeOnChange = function(el, parms) {
     // No interval passed, use event observer
     el.off('change');
-    el.on('change', _.debounce(function() {
+    el.on('change', debounce(function() {
       var id = el.attr('id');
       var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
 

--- a/app/javascript/miq_observe.js
+++ b/app/javascript/miq_observe.js
@@ -1,0 +1,141 @@
+/* global dialogFieldRefresh miqObserveRequest miqSerializeForm miqSendOneTrans */
+
+function miqSendDateRequest(el) {
+  var parms = $.parseJSON(el.attr('data-miq_observe_date'));
+  var url = parms.url;
+  //  tack on the id and value to the URL
+  var urlstring = url + '?' + el.prop('id') + '=' + el.val();
+
+  var attemptAutoRefreshTrigger = function() {
+    if (parms.auto_refresh === true) {
+      dialogFieldRefresh.triggerAutoRefresh(parms);
+    }
+  };
+
+  var options = {
+    beforeSend: !!el.attr('data-miq_sparkle_on'),
+    complete: !!el.attr('data-miq_sparkle_off'),
+    done: attemptAutoRefreshTrigger,
+  };
+
+  return miqObserveRequest(urlstring, options);
+}
+
+export function setup() {
+  // Bind in the observe support. If interval is configured, use the observe_field functi
+n
+  var attemptAutoRefreshTrigger = function(parms) {
+    return function() {
+      if (parms.auto_refresh === true) {
+        dialogFieldRefresh.triggerAutoRefresh(parms);
+      }
+    };
+  };
+
+  var observeWithInterval = function(el, parms) {
+    if (el.data('isObserved')) {
+      return;
+    }
+    el.data('isObserved', true);
+
+    var interval = parms.interval;
+    var url = parms.url;
+    var submit = parms.submit;
+
+    el.observe_field(interval, function() {
+      var oneTrans = this.getAttribute('data-miq_send_one_trans'); // Grab one trans URL, if present
+      if (typeof submit !== 'undefined') {
+        // If submit element passed in
+        miqObserveRequest(url, {
+          data: miqSerializeForm(submit),
+          done: attemptAutoRefreshTrigger(parms),
+        });
+      } else if (oneTrans) {
+        miqSendOneTrans(url, {
+          observe: true,
+          done: attemptAutoRefreshTrigger(parms),
+        });
+      } else {
+        // tack on the id and value to the URL
+        var data = {};
+        data[el.attr('id')] = el.prop('value');
+
+        miqObserveRequest(url, {
+          done: attemptAutoRefreshTrigger(parms),
+          data: data,
+        });
+      }
+    });
+  };
+
+  var observeOnChange = function(el, parms) {
+    // No interval passed, use event observer
+    el.off('change');
+    el.on('change', _.debounce(function() {
+      var id = el.attr('id');
+      var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
+
+      miqObserveRequest(parms.url, {
+        no_encoding: true,
+        data: id + '=' + value,
+        beforeSend: !!el.attr('data-miq_sparkle_on'),
+        complete: !!el.attr('data-miq_sparkle_off'),
+        done: attemptAutoRefreshTrigger(parms),
+      });
+    }, 700, {leading: true, trailing: true}));
+  };
+
+  $(document).on('focus', '[data-miq_observe]', function() {
+    var el = $(this);
+    var parms = $.parseJSON(el.attr('data-miq_observe'));
+
+    if (typeof parms.interval === 'undefined') {
+      observeOnChange(el, parms);
+    } else {
+      observeWithInterval(el, parms);
+    }
+  });
+
+  // Firefox on MacOs isn't firing onfocus events for radio buttons so onchange is used instead
+  $(document).on('change', '[data-miq_observe]', function() {
+    var el = $(this);
+    var parms = $.parseJSON(el.attr('data-miq_observe'));
+    var id = el.attr('id');
+    var value = el.prop('multiple') ? el.val() : encodeURIComponent(el.prop('value'));
+
+    miqObserveRequest(parms.url, {
+      no_encoding: true,
+      data: id + '=' + value,
+      beforeSend: !!el.attr('data-miq_sparkle_on'),
+      complete: !!el.attr('data-miq_sparkle_off'),
+      done: attemptAutoRefreshTrigger(parms),
+    });
+  });
+
+  $(document).on('change', '[data-miq_observe_checkbox]', function(event) {
+    var el = $(this);
+    var parms = $.parseJSON(el.attr('data-miq_observe_checkbox'));
+    var url = parms.url;
+
+    var id = el.attr('id');
+    var value = encodeURIComponent(el.prop('checked') ? el.val() : 'null');
+
+    miqObserveRequest(url, {
+      no_encoding: true,
+      data: id + '=' + value,
+      beforeSend: !!el.attr('data-miq_sparkle_on'),
+      complete: !!el.attr('data-miq_sparkle_off'),
+      done: attemptAutoRefreshTrigger(parms),
+    });
+
+    event.stopPropagation();
+  });
+
+  ManageIQ.observeDate = function(el) {
+    miqSendDateRequest(el);
+  };
+
+  $(document).on('changeDate clearDate', '[data-miq_observe_date]', function() {
+    ManageIQ.observeDate($(this));
+  });
+}

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -21,6 +21,7 @@ import { initializeStore } from '../miq-redux';
 import { history } from '../miq-component/react-history.ts';
 import createReduxRoutingActions from '../miq-redux/redux-router-actions';
 import { formButtonsActionTypes, createFormButtonsActions } from '../forms/form-buttons-reducer';
+import { setup as miqObserveSetup } from '../miq_observe.js';
 
 ManageIQ.component = {
   ...newRegistry,
@@ -55,3 +56,6 @@ require('xml_display/XMLDisplay.css');
 
 // miqSpinner, miqSearchSpinner
 window.Spinner = Spinner;
+
+// used by miq_ujs_bindings.js
+window.miqObserveSetup = miqObserveSetup;


### PR DESCRIPTION
All of our miq_observe elements are listenting on window for focus events on those elements,
and use that to either set up an observer with interval (`jquery.observe_field`) or an onchange listener on that element.

Now, observer with interval is unaffected, but for the rest, we can just listen of change events on window, without setting up specific onchange listeners.

(+ moved to es6)

Also trying to unify checkbox, radio & the rest, TODO also supposrt selects, and later fix date to generate change events properly.

Cc @ZitaNemeckova 