### PR TITLE
[WIP] Clear cashe of MiqProductFeature to store MiqUserRole

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1333,6 +1333,8 @@ module OpsController::OpsRbac
   end
 
   def populate_role_features(role)
+    MiqProductFeature.invalidate_caches
+
     role.miq_product_features =
       MiqProductFeature.find_all_by_identifier(rbac_compact_features(@edit[:new][:features]))
   end


### PR DESCRIPTION
Method [rbac_compact_features](https://github.com/ManageIQ/manageiq-ui-classic/blob/4c6de42dead904bff331cbb4719729288fa79aed/app/controllers/ops_controller/ops_rbac.rb#L1246) [called here](https://github.com/ManageIQ/manageiq-ui-classic/blob/4c6de42dead904bff331cbb4719729288fa79aed/app/controllers/ops_controller/ops_rbac.rb#L1335) is using cashe of feaures
(MiqProductFeature#feature_cache)

It needs to be cleared out when newly added tenant product features
are added.
even when it is cleared[ after tenant creation.](https://github.com/ManageIQ/manageiq/blob/cd56be0ac055bd5e6a1adfc3ff4847e737bf6f05/app/models/tenant.rb#L301)

This is working locally in development mode and I am not sure why it is happening in product mode.
Anyway this PR is fixing this bug.

cc @gtanzillo @skateman 

### Reproducer:
![2rxub5inkr](https://user-images.githubusercontent.com/14937244/50166079-8c3c3380-02e6-11e9-8a53-a39dddcb9cab.gif)



Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1468795

@miq-bot add_label bug, blocker