### PR TITLE
bug 1614567: Allow user to select Network Port for provisioning

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -237,8 +237,8 @@
       - elsif [:instance_type, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
                :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8,
                :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
-               :retirement_warn, :cloud_network, :cloud_subnet, :floating_ip_address,
-               :resource_group, :load_balancer,
+               :retirement_warn, :cloud_network, :network_port, :cloud_subnet,
+               :floating_ip_address, :resource_group, :load_balancer,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory,
                :vm_maximum_memory, :boot_disk_size, :subnet].include?(field)
@@ -443,7 +443,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:addr_mode, :disk_format, :sysprep_identification, :schedule_type].include?(field)
+      - elsif [:addr_mode, :disk_format, :sysprep_identification, :schedule_type, :cloud_network_selection_method].include?(field)
         -# Radio Button fields
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -132,7 +132,9 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
       - if wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
-        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group]
+        - has_cloud_network = (@edit && @edit[:new] && (!@edit[:new][:cloud_network_selection_method] || @edit[:new][:cloud_network_selection_method][0] == "network")) || (@options && (!@options[:cloud_network_selection_method] || @options[:cloud_network_selection_method][0] == "network"))
+        - has_network_port = (@edit && @edit[:new] && @edit[:new][:cloud_network_selection_method] && @edit[:new][:cloud_network_selection_method][0] == "port") || (@options && @options[:cloud_network_selection_method] && @options[:cloud_network_selection_method][0] == "port")
+        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network_selection_method, has_cloud_network ? :cloud_network : nil, has_network_port ? :network_port : nil, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group].compact
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614567

Allow user to select Network Port or Cloud Network when provisioning
an OpenStack cloud instance.

This PR also relates to associated manageiq (https://github.com/ManageIQ/manageiq/pull/18303 ) and manageiq-providers-openstack (https://github.com/ManageIQ/manageiq-providers-openstack/pull/416 ) PRs,
but this PR can be pushed before the others -- it shouldn't depend on their code for the build to pass.

![bz-1614567](https://user-images.githubusercontent.com/1120000/52662842-3b564f00-2ed3-11e9-9e32-915aeb9ec04f.png)
