### PR TITLE
add WEBPACK_VERBOSE (default off), only output some warnings when enabled

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -12,14 +12,23 @@ if (env.WEBPACK_EXCLUDE_NODE_MODULES) {
   base.exclude = /node_modules\/d3/;
 }
 
+let babelOptions = merge(babelrc, {
+  babelrc: false,
+  compact: false,
+});
+
+// set WEBPACK_VERBOSE=1 to get more warnings
+if (env.WEBPACK_VERBOSE) {
+  // don't drop any whitespace from the bundle, prevents warnings about filesize over the limit
+  delete babelOptions.compact;
+}
+
 module.exports = [
   merge(base, {
     test: /\.(mjs|js|jsx)$/,
     use: [{
       loader: 'babel-loader',
-      options: merge(babelrc, {
-        babelrc: false,
-      }),
+      options: babelOptions,
     }],
   }),
 

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -46,6 +46,30 @@ const nodeModulesNotShims = (module) => {
 };
 const notShims = (module) => (!SplitChunksPlugin.checkTest(/shims/, module));
 
+let plugins = [
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || 'development'),
+  }),
+
+  // Workaround for graphql/graphql-language-service#128
+  new webpack.ContextReplacementPlugin(
+    /graphql-language-service-interface[\\\/]dist$/,
+    /\.js$/
+  ),
+
+  new ManifestPlugin({
+    publicPath: output.publicPath,
+    writeToFileEmit: true,
+  }),
+];
+
+if (env.WEBPACK_VERBOSE) {
+  plugins.push(new DuplicatePackageCheckerPlugin({
+    verbose: true,
+    showHelp: false,
+  }));
+}
+
 module.exports = {
   entry: {
     ...Object.keys(packPaths).reduce(
@@ -74,27 +98,7 @@ module.exports = {
     rules: loaders,
   },
 
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || 'development'),
-    }),
-
-    // Workaround for graphql/graphql-language-service#128
-    new webpack.ContextReplacementPlugin(
-      /graphql-language-service-interface[\\\/]dist$/,
-      /\.js$/
-    ),
-
-    new ManifestPlugin({
-      publicPath: output.publicPath,
-      writeToFileEmit: true,
-    }),
-
-    new DuplicatePackageCheckerPlugin({
-      verbose: true,
-      showHelp: false,
-    }),
-  ],
+  plugins,
 
   optimization: {
     runtimeChunk: 'single',


### PR DESCRIPTION
This removes these kinds of warnings from webpack:

```
[BABEL] Note: The code generator has deoptimised the styling of "/home/dberger/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/manageiq-ui-classic-615df016338b/node_modules/lodash/lodash.js" as it exceeds the max of "500KB".
```

(coming from babel, when trying to [compact](https://babeljs.io/docs/en/options#compact) big files, removing means a bit larger bundle, but only by whitespace (so presumably compressible))

and
￼
```
WARNING in jquery
  Multiple versions of jquery found:
    2.2.4 ./~/jquery from ./app/javascript/packs/globals.js
    3.3.1 ./~/bootstrap-datepicker/~/jquery from ./~/bootstrap-datepicker/dist/js/bootstrap-datepicker.js
```

(coming from `DuplicatePackageCheckerPlugin` - used to get warned about duplicate deps)

Both can be re-enabled using `WEBPACK_VERBOSE=1 bin/webpack`.