### PR TITLE
Clean out cache of MiqProductFeature at CUD tenant actions in UI process

### DIFF
--- a/app/assets/javascripts/components/ops/tenant-component.js
+++ b/app/assets/javascripts/components/ops/tenant-component.js
@@ -10,9 +10,9 @@ ManageIQ.angular.app.component('tenantComponent', {
   templateUrl: '/static/ops/tenant/tenant.html.haml',
 });
 
-tenantFormController.$inject = ['API', 'miqService'];
+tenantFormController.$inject = ['API', 'miqService', '$http'];
 
-function tenantFormController(API, miqService) {
+function tenantFormController(API, miqService, $http) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -67,6 +67,9 @@ function tenantFormController(API, miqService) {
     API[method](url, saveObject, {
       skipErrors: [400],  // server-side validation
     })
+      .then(function() {
+        return $http.post('/ops/invalidate_miq_product_feature_caches', {});
+      })
       .then(miqService.redirectBack.bind(vm, saveMsg, 'success', vm.redirectUrl))
       .catch(miqService.handleFailure);
   };

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -8,6 +8,11 @@ module OpsController::OpsRbac
     'Tenant'   => 'tenant'
   }.freeze
 
+  def invalidate_miq_product_feature_caches
+    MiqProductFeature.invalidate_caches
+    render :json => {}
+  end
+
   # Edit user or group tags
   def rbac_tags_edit
     case params[:button]
@@ -298,7 +303,12 @@ module OpsController::OpsRbac
       parent_id = Tenant.find(params[:id]).parent.id
       self.x_node = "tn-#{parent_id}"
     end
-    process_tenants(tenants, "destroy") unless tenants.empty?
+
+    unless tenants.empty?
+      process_tenants(tenants, "destroy")
+      MiqProductFeature.invalidate_caches
+    end
+
     get_node_info(x_node)
     replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2563,6 +2563,7 @@ Rails.application.routes.draw do
         forest_form_field_changed
         forest_select
         help_menu_form_field_changed
+        invalidate_miq_product_feature_caches
         label_tag_mapping_delete
         label_tag_mapping_edit
         label_tag_mapping_update

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -8,6 +8,13 @@ describe OpsController do
       stub_user(:features => :all)
     end
 
+    it 'confirms existence of route and action with name invalidate_miq_product_feature_caches ' do
+      EvmSpecHelper.local_miq_server
+
+      post :invalidate_miq_product_feature_caches
+      expect(response.status).to eq(200)
+    end
+
     describe "rbac_edit_tags_reset" do
       let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
       let(:another_tenant) { FactoryBot.create(:tenant) }
@@ -104,6 +111,8 @@ describe OpsController do
 
       it "deletes a tenant record successfully" do
         expect(controller).to receive(:x_active_tree_replace_cell)
+        expect(MiqProductFeature).to receive(:invalidate_caches)
+
         controller.send(:rbac_tenant_delete)
 
         expect(response.status).to eq(200)

--- a/spec/javascripts/components/ops/tenant-component_spec.js
+++ b/spec/javascripts/components/ops/tenant-component_spec.js
@@ -1,17 +1,17 @@
 describe('tenant-component', function() {
-  var $componentController, vm, miqService, API;
+  var $componentController, vm, miqService, API, $httpBackend, deferred;
 
   describe('when the vm.recordId is not defined', function () {
 
     beforeEach(module('ManageIQ'));
-    beforeEach(inject(function (_$componentController_, _API_, _miqService_, $q) {
+    beforeEach(inject(function (_$componentController_, _API_, _miqService_, $q, _$httpBackend_) {
       $componentController = _$componentController_;
       API = _API_;
       miqService = _miqService_;
-
+      $httpBackend = _$httpBackend_;
       spyOn(miqService.redirectBack, 'bind');
 
-      var deferred = $q.defer();
+      deferred = $q.defer();
       spyOn(API, 'post').and.callFake(function() {return deferred.promise;});
 
       var bindings = {redirectUrl: '/controller/go_back', divisible: true};
@@ -28,6 +28,8 @@ describe('tenant-component', function() {
     });
 
     it('adds a Tenant record', function () {
+      $httpBackend.expectPOST('/ops/invalidate_miq_product_feature_caches').respond({});
+
       vm.tenantModel.name = 'newTenant';
       vm.tenantModel.description = 'newTenant_desc';
       vm.tenantModel.ancestry = null;
@@ -43,7 +45,14 @@ describe('tenant-component', function() {
       }, {
         skipErrors: [400],
       });
+
+      deferred.resolve({});
+
       expect(miqService.redirectBack.bind).toHaveBeenCalledWith(vm, 'Tenant \"newTenant\" has been successfully added.', 'success', vm.redirectUrl);
+    });
+
+    afterEach(function () {
+      $httpBackend.verifyNoOutstandingExpectation();
     });
   });
 


### PR DESCRIPTION
CUD - create, update, delete

**Issue**
MiqProductFeature is using cache for some queries. MiqProductFeatures are tied to Tenants. Where we are adding/updating/delete tenant we need update this cache to reflect changes in UI. 
But it doesn't work when cache is cleaned out at model's callbacks because UI is different process.

**Reproducer**
https://user-images.githubusercontent.com/14937244/50166079-8c3c3380-02e6-11e9-8a53-a39dddcb9cab.gif


Thanks to the @gtanzillo's [idea](https://github.com/ManageIQ/manageiq-ui-classic/pull/5101#issuecomment-448279251 ) and @skateman's [research](https://github.com/ManageIQ/manageiq-ui-classic/pull/5101#issuecomment-448324700) we confirmed that if you clean the cache from the API(on instantiated classes), it doesn't reflects the changes in the UI probably because of different processes. We found with @himdel obviously better solution how to tie cleaning of cache to CUD of tenants. (then it was presented here https://github.com/ManageIQ/manageiq-ui-classic/pull/5101 and https://github.com/ManageIQ/manageiq-ui-classic/pull/5100)

Fix tested on appliance.



@miq-bot assign @himdel 

@miq-bot add_label bug, blocker

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1468795
https://bugzilla.redhat.com/show_bug.cgi?id=1655012