### PR TITLE
Update travis excludes for new ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ env:
   - TEST_SUITE=spec:jest
 matrix:
   exclude:
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     env: TEST_SUITE=spec:javascript
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     env: TEST_SUITE=spec:compile
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh


### PR DESCRIPTION
missed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5104,

we explicitly exclude all non-ruby jobs on the newer ruby version
(no point in running javascript specs twice)

so, updating the excluded ruby version to match the new one we're using

(Drops the number of travis jobs from 8 back to 5.)