### PR TITLE
[HAMMER] set_ownership - use miq_template (not vm) for images

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -11,7 +11,7 @@ module Mixins
         def set_ownership
           assert_privileges(params[:pressed])
           # check to see if coming from show_list or drilled into vms from another CI
-          controller = if request.parameters[:controller] == "vm" || ["all_vms", "vms", "instances", "images"].include?(params[:display])
+          controller = if request.parameters[:controller] == "vm" || ["all_vms", "vms", "instances"].include?(params[:display])
                          "vm"
                        elsif ["miq_templates", "images"].include?(params[:display]) || params[:pressed].starts_with?("miq_template_")
                          "miq_template"


### PR DESCRIPTION
Right now, clicking the Set Ownership button on a nested list of images under a cloud provider redirects to `/vm/ownership`.

But image is not a vm, it's a template, so the url should be `/miq_template/ownership`.

The difference causes 2 bugs:

* no form buttons are shown
* affected items shows No records found

Fixing to use miq_template.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650507

---

Looks like this was a bug, because in the nearest `elsif`, we're already checking whether `params[:display]` matches `images`, so it was probably *also* in the vm list by mistake.