### PR TITLE
set_ownership - use miq_template (not vm) for images

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -11,7 +11,7 @@ module Mixins
         def set_ownership
           assert_privileges(params[:pressed])
           # check to see if coming from show_list or drilled into vms from another CI
-          controller = if request.parameters[:controller] == "vm" || %w(all_vms vms instances images).include?(params[:display])
+          controller = if request.parameters[:controller] == "vm" || %w(all_vms vms instances).include?(params[:display])
                          "vm"
                        elsif %w(miq_templates images).include?(params[:display]) || params[:pressed].starts_with?("miq_template_")
                          "miq_template"


### PR DESCRIPTION
Right now, clicking the Set Ownership button on a nested list of images under a cloud provider redirects to `/vm/ownership`.

But image is not a vm, it's a template, so the url should be `/miq_template/ownership`.

The difference causes 2 bugs:

* ~~no form buttons are shown~~ (only in hammer, https://github.com/ManageIQ/manageiq-ui-classic/pull/5046 replaced it on master) (=> https://github.com/ManageIQ/manageiq-ui-classic/pull/5112)
* affected items shows No records found

Fixing to use miq_template.

(related to https://bugzilla.redhat.com/show_bug.cgi?id=1650507, but the BZ only talks about the form buttons)

---

1. go to Compute -> Cloud -> Providers
1. click on a provider
1. click on Images in the provider detail/overview screen (like /ems_cloud/3?display=images)
1. select an image via the checkbox
1. toolbar Configuration > Set ownership

Before:

![before](https://user-images.githubusercontent.com/289743/50351874-5fcd2500-053b-11e9-8cc0-12c5781cc920.png)


After:

![after](https://user-images.githubusercontent.com/289743/50351876-62c81580-053b-11e9-88f2-e37752a83ce4.png)
