### PR TITLE
Stop spinner after rednering flash message

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1100,7 +1100,7 @@ class MiqAeClassController < ApplicationController
       ae_ns.save!
     rescue => bang
       add_flash(_("Error during 'save': %{message}") % {:message => bang.message}, :error)
-      javascript_flash
+      javascript_flash(:spinner_off => true)
     else
       add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => @edit[:typ]), :name => get_record_display_name(ae_ns)})
       AuditEvent.success(build_saved_audit_hash_angular(old_namespace_attributes, ae_ns, false))


### PR DESCRIPTION
Stop spinner after rendering flash message when editing a namespace/domain. Similar fix was made to fix the issue when adding a namespace/domain in https://github.com/ManageIQ/manageiq-ui-classic/pull/4990

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650071

before:
![before](https://user-images.githubusercontent.com/3450808/50607436-2d0a2180-0e97-11e9-96b6-eff709c36c98.png)

after:
![after](https://user-images.githubusercontent.com/3450808/50607445-34c9c600-0e97-11e9-942d-0b270285dde9.png)

