### PR TITLE
PhysicalInfraTopologyService spec - expect manager to have Valid status, not nil

### DIFF
--- a/spec/services/physical_infra_topology_service_spec.rb
+++ b/spec/services/physical_infra_topology_service_spec.rb
@@ -89,7 +89,7 @@ describe PhysicalInfraTopologyService do
           :name         => ems.name,
           :kind         => "PhysicalInfraManager",
           :miq_id       => ems.id,
-          :status       => nil,
+          :status       => 'Valid',
           :display_kind => "Lenovo",
           :model        => ems.class.name,
           :key          => "PhysicalInfraManager" + ems.id.to_s


### PR DESCRIPTION
This changed because of https://github.com/ManageIQ/manageiq/pull/18266,
just making sure the tests are green again.

Fixes red travis: (tracking issue https://github.com/ManageIQ/manageiq-ui-classic/issues/4921#issuecomment-451129620)

https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/474623058

```
  1) PhysicalInfraTopologyService#build_topology topology contains the expected structure and content
     Failure/Error:
       expect(subject[:items]).to eq(
         "PhysicalInfraManager" + ems.id.to_s  => {
           :name         => ems.name,
           :kind         => "PhysicalInfraManager",
           :miq_id       => ems.id,
           :status       => nil,
           :display_kind => "Lenovo",
           :model        => ems.class.name,
           :key          => "PhysicalInfraManager" + ems.id.to_s
         },
       expected: {"PhysicalInfraManager96000000000077"=>{:name=>"LXCA", :kind=>"PhysicalInfraManager", :miq_id=>960000...PhysicalServer", :provider=>"LXCA", :model=>"PhysicalServer", :key=>"PhysicalServer96000000000004"}}
            got: {"PhysicalInfraManager96000000000077"=>{:name=>"LXCA", :kind=>"PhysicalInfraManager", :model=>"Manage..."PhysicalRack96000000000001", :status=>"Unknown", :display_kind=>"PhysicalRack", :provider=>"LXCA"}}
```
(hidden in the diff, but expected has `:status => nil`, while actual has `:status => 'Valid'`).