### PR TITLE
Adds dual list react component

### DIFF
--- a/app/javascript/components/dual-list-select/helpers.jsx
+++ b/app/javascript/components/dual-list-select/helpers.jsx
@@ -1,0 +1,22 @@
+export const isEmpty = (obj) => {
+  if (obj === '') { return true; }
+  return (Object.getOwnPropertyNames(obj).length === 0);
+};
+
+/** *********** HELPERS FOR FORMS *********** */
+/* returns left values of dual list select */
+export const leftValues = (options, value) => Object.keys(options).filter(key => !value[key]).reduce((acc, curr) => ({
+  ...acc,
+  [curr]: options[curr],
+}), {});
+
+/* returns left submitted keys of dual list select */
+export const leftSubmittedKeys = (originalOptions, value) => Object.keys(originalOptions).filter(e => !value[e]);
+
+/* returns new left keys (added to left) of dual list select */
+export const addedLeftKeys = (originalOptions, value, originalLeftValues) => (
+  leftSubmittedKeys(originalOptions, value).filter(e => !originalLeftValues[e])
+);
+
+/* return new right keys (added to right) of dual list select */
+export const addedRightKeys = (value, originalRightValues) => Object.keys(value).filter(e => !originalRightValues[e]);

--- a/app/javascript/components/dual-list-select/index.jsx
+++ b/app/javascript/components/dual-list-select/index.jsx
@@ -1,0 +1,165 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Icon } from 'patternfly-react';
+import List from './list';
+import { isEmpty, leftValues as getLeftValues } from './helpers';
+
+class DualListSelect extends Component {
+  constructor(props) {
+    super(props);
+    this.leftList = React.createRef();
+    this.rightList = React.createRef();
+  }
+
+  moveLeft = (rightValues) => {
+    const { input: { onChange } } = this.props;
+    const selectedItems = Array.prototype.map.call(this.rightList.current.selectedOptions, ({ value }) => value);
+    const reducedItems = Object.keys(rightValues).filter(key => !selectedItems.includes(key)).reduce(
+      (acc, curr) => ({
+        ...acc,
+        [curr]: rightValues[curr],
+      }), {},
+    );
+
+    onChange({
+      ...reducedItems,
+    });
+  };
+
+  moveRight = () => {
+    const { input: { onChange, value }, options } = this.props;
+    const selectedItems = Array.prototype.map.call(this.leftList.current.selectedOptions, ({ value }) => value)
+      .reduce((acc, curr) => ({
+        ...acc,
+        [curr]: options[curr],
+      }), {});
+
+    onChange({
+      ...value,
+      ...selectedItems,
+    });
+  };
+
+  moveAllRight = (leftValues) => {
+    const { input: { onChange, value } } = this.props;
+
+    onChange({
+      ...value,
+      ...leftValues,
+    });
+  };
+
+  moveAllLeft = () => {
+    const { input: { onChange } } = this.props;
+
+    onChange({});
+  };
+
+  render() {
+    const {
+      input: { value = {} },
+      options,
+      leftId,
+      rightId,
+      leftTitle,
+      rightTitle,
+      size,
+      allToRight,
+      allToLeft,
+      moveLeftTitle,
+      moveRightTitle,
+      moveAllLeftTitle,
+      moveAllRightTitle,
+    } = this.props;
+    const leftValues = getLeftValues(options, value);
+    const rightValues = value;
+
+    return (
+      <div>
+        <div className="col-md-5">
+          {leftTitle}
+          <List size={size} ref={this.leftList} id={leftId} values={leftValues} />
+        </div>
+        <div className="col-md-1" style={{ padding: 10 }}>
+          <div className="spacer" />
+          <div className="spacer" />
+          <Button disabled={isEmpty(leftValues)} className="btn-block" onClick={this.moveRight} title={moveRightTitle}>
+            <Icon type="fa" name="angle-right" size="lg" />
+          </Button>
+          { allToRight
+          && (
+          <Button disabled={isEmpty(leftValues)} className="btn-block" onClick={() => this.moveAllRight(leftValues)} title={moveAllRightTitle}>
+            <Icon type="fa" name="angle-double-right" size="lg" />
+          </Button>
+          ) }
+          { allToLeft
+          && (
+          <Button disabled={isEmpty(rightValues)} className="btn-block" onClick={this.moveAllLeft} title={moveAllLeftTitle}>
+            <Icon type="fa" name="angle-double-left" size="lg" />
+          </Button>
+          ) }
+          <Button disabled={isEmpty(rightValues)} className="btn-block" onClick={() => this.moveLeft(rightValues)} title={moveLeftTitle}>
+            <Icon type="fa" name="angle-left" size="lg" />
+          </Button>
+        </div>
+        <div className="col-md-5">
+          {rightTitle}
+          <List size={size} ref={this.rightList} id={rightId} values={rightValues} />
+        </div>
+      </div>);
+  }
+}
+
+DualListSelect.propTypes = {
+  /* ID of the left select */
+  leftId: PropTypes.string,
+  /* ID of the right select */
+  rightId: PropTypes.string,
+  /* Title above left select */
+  leftTitle: PropTypes.string,
+  /* Title above right select */
+  rightTitle: PropTypes.string,
+  /* Size of select */
+  size: PropTypes.number,
+  /* Should show button "move all to right" */
+  allToRight: PropTypes.bool,
+  /* Should show button "move all to left" */
+  allToLeft: PropTypes.bool,
+  /* Title of move left button */
+  moveLeftTitle: PropTypes.string,
+  /* Title of move right button */
+  moveRightTitle: PropTypes.string,
+  /* Title of move all right button */
+  moveAllRightTitle: PropTypes.string,
+  /* Title of move all left button */
+  moveAllLeftTitle: PropTypes.string,
+  /* Values in right select { value: "Text", value1: "Text1", ... } */
+  options: PropTypes.shape({
+    [PropTypes.string]: PropTypes.string,
+  }),
+};
+
+DualListSelect.defaultProps = {
+  leftId: undefined,
+  rightId: undefined,
+  leftTitle: undefined,
+  rightTitle: undefined,
+  size: 15,
+  allToRight: true,
+  allToLeft: false,
+  moveLeftTitle: __('Move selected to left'),
+  moveRightTitle: __('Move selected to right'),
+  moveAllRightTitle: __('Move all to right'),
+  moveAllLeftTitle: __('Move all to left'),
+  options: {},
+};
+
+const WrappedDualList = ({ FieldProvider, name, ...rest }) => (
+  <FieldProvider
+    name={name}
+    {...rest}
+    component={props => <DualListSelect {...props} />}
+  />
+);
+
+export default WrappedDualList;

--- a/app/javascript/components/dual-list-select/list.jsx
+++ b/app/javascript/components/dual-list-select/list.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const List = React.forwardRef(({ id, values = {}, ...rest }, ref) => (
+  <select
+    ref={ref}
+    id={id}
+    name={`${id}[]`}
+    multiple
+    className="form-control"
+    style={{ overflowX: 'scroll' }}
+    {...rest}
+  >
+    { Object.entries(values).sort((a, b) => a[1].localeCompare(b[1])).map(([key, text]) => <option key={key} value={key}>{text}</option>)}
+  </select>
+));
+
+export default List;

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import FormRender, { Validators } from '@data-driven-forms/react-form-renderer';
-import { formFieldsMapper, layoutMapper } from '@data-driven-forms/pf3-component-mapper';
+import { layoutMapper } from '@data-driven-forms/pf3-component-mapper';
+import formFieldsMapper from './mappers/formsFieldsMapper';
 
 Validators.messages = {
   ...Validators.messages,

--- a/app/javascript/forms/mappers/formsFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formsFieldsMapper.jsx
@@ -1,0 +1,9 @@
+import { formFieldsMapper } from '@data-driven-forms/pf3-component-mapper';
+import DualListSelect from '../../components/dual-list-select';
+
+const fieldsMapper = {
+  ...formFieldsMapper,
+  'dual-list-select': DualListSelect,
+};
+
+export default fieldsMapper;

--- a/app/javascript/spec/dual-list-select/__snapshots__/dual-list-select.spec.js.snap
+++ b/app/javascript/spec/dual-list-select/__snapshots__/dual-list-select.spec.js.snap
@@ -1,0 +1,273 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dual list component is correctly rendered 1`] = `
+<WrappedDualList
+  FieldProvider={[Function]}
+  input={
+    Object {
+      "onChange": [MockFunction],
+      "value": Object {
+        "key3": "text3",
+      },
+    }
+  }
+  options={
+    Object {
+      "key1": "text1",
+      "key2": "text2",
+      "key3": "text3",
+      "key4": "text4",
+    }
+  }
+>
+  <Component
+    component={[Function]}
+    input={
+      Object {
+        "onChange": [MockFunction],
+        "value": Object {
+          "key3": "text3",
+        },
+      }
+    }
+    options={
+      Object {
+        "key1": "text1",
+        "key2": "text2",
+        "key3": "text3",
+        "key4": "text4",
+      }
+    }
+  >
+    <div>
+      <DualListSelect
+        allToLeft={false}
+        allToRight={true}
+        input={
+          Object {
+            "onChange": [MockFunction],
+            "value": Object {
+              "key3": "text3",
+            },
+          }
+        }
+        meta={
+          Object {
+            "error": false,
+            "touched": false,
+          }
+        }
+        moveAllLeftTitle="Move all to left"
+        moveAllRightTitle="Move all to right"
+        moveLeftTitle="Move selected to left"
+        moveRightTitle="Move selected to right"
+        options={
+          Object {
+            "key1": "text1",
+            "key2": "text2",
+            "key3": "text3",
+            "key4": "text4",
+          }
+        }
+        size={15}
+      >
+        <div>
+          <div
+            className="col-md-5"
+          >
+            <ForwardRef
+              size={15}
+              values={
+                Object {
+                  "key1": "text1",
+                  "key2": "text2",
+                  "key4": "text4",
+                }
+              }
+            >
+              <select
+                className="form-control"
+                multiple={true}
+                name="undefined[]"
+                size={15}
+                style={
+                  Object {
+                    "overflowX": "scroll",
+                  }
+                }
+              >
+                <option
+                  key="key1"
+                  value="key1"
+                >
+                  text1
+                </option>
+                <option
+                  key="key2"
+                  value="key2"
+                >
+                  text2
+                </option>
+                <option
+                  key="key4"
+                  value="key4"
+                >
+                  text4
+                </option>
+              </select>
+            </ForwardRef>
+          </div>
+          <div
+            className="col-md-1"
+            style={
+              Object {
+                "padding": 10,
+              }
+            }
+          >
+            <div
+              className="spacer"
+            />
+            <div
+              className="spacer"
+            />
+            <Button
+              active={false}
+              block={false}
+              bsClass="btn"
+              bsStyle="default"
+              className="btn-block"
+              disabled={false}
+              onClick={[Function]}
+              title="Move selected to right"
+            >
+              <button
+                className="btn-block btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                title="Move selected to right"
+                type="button"
+              >
+                <Icon
+                  name="angle-right"
+                  size="lg"
+                  type="fa"
+                >
+                  <FontAwesome
+                    name="angle-right"
+                    size="lg"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-angle-right fa-lg"
+                    />
+                  </FontAwesome>
+                </Icon>
+              </button>
+            </Button>
+            <Button
+              active={false}
+              block={false}
+              bsClass="btn"
+              bsStyle="default"
+              className="btn-block"
+              disabled={false}
+              onClick={[Function]}
+              title="Move all to right"
+            >
+              <button
+                className="btn-block btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                title="Move all to right"
+                type="button"
+              >
+                <Icon
+                  name="angle-double-right"
+                  size="lg"
+                  type="fa"
+                >
+                  <FontAwesome
+                    name="angle-double-right"
+                    size="lg"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-angle-double-right fa-lg"
+                    />
+                  </FontAwesome>
+                </Icon>
+              </button>
+            </Button>
+            <Button
+              active={false}
+              block={false}
+              bsClass="btn"
+              bsStyle="default"
+              className="btn-block"
+              disabled={false}
+              onClick={[Function]}
+              title="Move selected to left"
+            >
+              <button
+                className="btn-block btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                title="Move selected to left"
+                type="button"
+              >
+                <Icon
+                  name="angle-left"
+                  size="lg"
+                  type="fa"
+                >
+                  <FontAwesome
+                    name="angle-left"
+                    size="lg"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="fa fa-angle-left fa-lg"
+                    />
+                  </FontAwesome>
+                </Icon>
+              </button>
+            </Button>
+          </div>
+          <div
+            className="col-md-5"
+          >
+            <ForwardRef
+              size={15}
+              values={
+                Object {
+                  "key3": "text3",
+                }
+              }
+            >
+              <select
+                className="form-control"
+                multiple={true}
+                name="undefined[]"
+                size={15}
+                style={
+                  Object {
+                    "overflowX": "scroll",
+                  }
+                }
+              >
+                <option
+                  key="key3"
+                  value="key3"
+                >
+                  text3
+                </option>
+              </select>
+            </ForwardRef>
+          </div>
+        </div>
+      </DualListSelect>
+    </div>
+  </Component>
+</WrappedDualList>
+`;

--- a/app/javascript/spec/dual-list-select/dual-list-select.spec.js
+++ b/app/javascript/spec/dual-list-select/dual-list-select.spec.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import DualList from '../../components/dual-list-select';
+import List from '../../components/dual-list-select/list';
+import { FieldProviderComponent as FieldProvider } from '../helpers/fieldProvider';
+
+describe('Dual list component', () => {
+  const onChangeSpy = jest.fn();
+
+  const props = {
+    options: {
+      key1: 'text1',
+      key2: 'text2',
+      key3: 'text3',
+      key4: 'text4',
+    },
+    input: {
+      value: { key3: 'text3' },
+      onChange: onChangeSpy,
+    },
+  };
+
+  afterEach(() => {
+    onChangeSpy.mockReset();
+  });
+
+  it('is correctly rendered', () => {
+    const wrapper = mount(<DualList FieldProvider={FieldProvider} {...props} />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('is correctly moves items to right', () => {
+    const wrapper = mount(<DualList FieldProvider={FieldProvider} {...props} />);
+    const leftSelect = wrapper.find(List).first().find('select').getDOMNode();
+    const button = wrapper.find('button').first(); // find toRight button
+
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    leftSelect.selectedIndex = 0; // 'select' first option
+    button.simulate('click');
+
+    expect(onChangeSpy).toHaveBeenCalledWith({ key1: 'text1', key3: 'text3' });
+  });
+
+  it('is correctly moves items to left', () => {
+    const wrapper = mount(<DualList FieldProvider={FieldProvider} {...props} />);
+    const rightSelect = wrapper.find(List).last().find('select').getDOMNode();
+    const button = wrapper.find('button').last(); // find toLeft button
+
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    rightSelect.selectedIndex = 0; // 'select' first option
+    button.simulate('click');
+
+    expect(onChangeSpy).toHaveBeenCalledWith({});
+  });
+
+  it('is correctly moves all items to right', () => {
+    const wrapper = mount(<DualList FieldProvider={FieldProvider} {...props} />);
+    const button = wrapper.find('button').at(1); // find allToRight button
+
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    button.simulate('click');
+
+    expect(onChangeSpy).toHaveBeenCalledWith({
+      key1: 'text1',
+      key2: 'text2',
+      key3: 'text3',
+      key4: 'text4',
+    });
+  });
+
+  it('is correctly moves all items to left', () => {
+    const wrapper = mount(<DualList allToLeft FieldProvider={FieldProvider} {...props} />);
+    const button = wrapper.find('button').at(2); // find allToLeft button
+
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    button.simulate('click');
+
+    expect(onChangeSpy).toHaveBeenCalledWith({});
+  });
+});

--- a/app/javascript/spec/dual-list-select/helpers.spec.js
+++ b/app/javascript/spec/dual-list-select/helpers.spec.js
@@ -1,0 +1,73 @@
+import {
+  isEmpty,
+  leftValues,
+  leftSubmittedKeys,
+  addedLeftKeys,
+  addedRightKeys,
+} from '../../components/dual-list-select/helpers';
+
+describe('Dual list select helpers', () => {
+  describe('isEmpty', () => {
+    it('should return true if object is empty ', () => {
+      expect(isEmpty({})).toEqual(true);
+    });
+
+    it('should return false if object is not empty ', () => {
+      expect(isEmpty({ foo: 'bar' })).toEqual(false);
+    });
+
+    it('should return true if object is empty string', () => {
+      expect(isEmpty('')).toEqual(true);
+    });
+
+    it('should return false if object is not empty string', () => {
+      expect(isEmpty('bar')).toEqual(false);
+    });
+  });
+
+  describe('form helpers', () => {
+    let options;
+    let value;
+
+    beforeEach(() => {
+      options = {
+        key1: 'text1',
+        key2: 'text2',
+        key3: 'text3',
+        key4: 'text4',
+      };
+      value = { key3: 'text3' };
+    });
+
+    describe('leftValues', () => {
+      it('returns all left values (all options in the left list)', () => {
+        expect(leftValues(options, value)).toEqual({
+          key1: 'text1',
+          key2: 'text2',
+          key4: 'text4',
+        });
+      });
+    });
+
+    describe('leftSubmittedKeys', () => {
+      it('returns keys of left submitted values', () => {
+        expect(leftSubmittedKeys(options, value)).toEqual(['key1', 'key2', 'key4']);
+      });
+    });
+
+    describe('addedLeftKeys', () => {
+      it('returns only added keys to left list', () => {
+        const originalLeftValues = leftValues(options, value);
+        value = { };
+        expect(addedLeftKeys(options, value, originalLeftValues)).toEqual(['key3']);
+      });
+    });
+
+    describe('addedRightKeys', () => {
+      it('returns only added keys to right list', () => {
+        const newValue = { key3: 'text3', key4: 'text4' };
+        expect(addedRightKeys(newValue, value)).toEqual(['key4']);
+      });
+    });
+  });
+});

--- a/app/javascript/spec/helpers/fieldProvider.js
+++ b/app/javascript/spec/helpers/fieldProvider.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const FieldProviderComponent = ({ component, ...props }) => (
+  <div>{ component({ input: { name: 'Foo', onChange: jest.fn() }, meta: { error: false, touched: false }, ...props }) }</div>
+);


### PR DESCRIPTION
**What**

**A React component** which will take place in all **react data-driven forms**, where dual list select is used.

(eg.: Services/Catalogs/Catalogs/Add a new catalog, Workloads/VM/Edit, etc.)

**Before**

![image](https://user-images.githubusercontent.com/32869456/50644231-872ae580-0f70-11e9-8532-297a303bb548.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/50644247-927e1100-0f70-11e9-9d3d-0e23cf48271b.png)

Customization: 
- Move all to right/left buttons
- Titles of buttons
- Headers of lists
- IDs, etc.

**Checklist**
- [X] Support for using custom components in DDF (data-driven-forms)
- [X] Dual list select component (moving items, sorting)
- [X] Helpers for the component
- [X] Test for the helpers
- [x] Tests for the component
- [x] Sending right values after submit
- [x] Clean up proptypes validations


### Documentation

(Should be added to guides? And I think we should create some kind of guide for converting old forms to data-driven format.)

**Props**

| Props  | Type | Default |  Decription |
| ------------- | ------------- | ------------- | ------------- |
| leftId  | string  | undefined  | ID passed to left select  |
| rightId  | string  | undefined  | ID passed to right select  |
| leftTitle  | string  | undefined  | Title above left select  |
| rightTitle  | string  | undefined  | Title above right select  |
| rightTitle  | string  | undefined  | Title above right select  |
| size  | number  | 15  | Size of the selects (in lines)  |
| allToRight  | bool  | true  | Should show moveAllToRight button  |
| allToLeft | bool  | false  | Should show moveAllToLeft button  |
| moveLeftTitle  | string  | __('Move selected to left')  | Title of moveToLeft button |
| moveRightTitle  | string  | __('Move selected to right')  | Title of moveToRight button |
| moveAllRightTitle  | string  | __('Move all to right')  | Title of moveAllToRight button |
| moveAllLeftTitle  | string  | __('Move all to left')  | Title of moveAllToLeft button |
| options  | object  | { }  | All options of the select |
| input: { value }  | object  | { }  | Selected options **(subset of options)** |

**Options/Value format**

`{ key: 'Text', key1: 'Text2, ... }`

The component will split values from options to left/right select lists according to value. (All values in value are going to right, others to left)

**How to use it in Data-driven form schema (example)**

```javascript
{   
    component: 'dual-list-select',
    name: 'duallist',
    assignFieldProvider: true, // always set
    options: {
      key1: 'Text1', key2: 'Text2', ...
    },
    rightId: 'child_vms',
    leftId: 'available_vms',
    rightTitle: __('Child VMs:'),
    leftTitle: __('Availables VMs'),
    moveLeftTitle: __('Move selected VMs to left'),
    moveRightTitle: __('Move selected VMs to right'),
    moveAllRightTitle: __('Move all VMs to right'),
}
```

**How to use it in Data-driven form**

By default, the value contains all options from the right side select. However, if you need left values or just added values (probably in most cases), you can use helpers in `/dual-list-select/helpers` to extract needed information:

1. In constructor/componentDidMount/elsewhere (where you fetch data) save these values into state:
 -  `originalLeftValues: leftValues(options, value)`       // this helper extracts left values from options
 -  `originalOptions: options`
 -  `originalRightValues: value`

2. In your submit method (values => (...)) you can use helper methods:

-  **`leftSubmittedKeys(originalOptions, values.duallist)`** to get all keys on left
-  **`addedLeftKeys(originalOptions, values.duallist, originalLeftValues)`** to get keys of added left values
-  **`addedRightKeys(values.duallist, originalRightValues)`** to get keys of added right values

3. Then you can send values to endpoints!
