### PR TITLE
Remove logic for request screen dialogs

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -1,0 +1,36 @@
+.form-group{:id => "field_#{field.id}_tr", :style => field.visible ? 'display:block' : 'display:none'}
+  %label.control-label.col-md-2{:title => field.description}
+    = field.label
+  .col-md-8{:title => field.description}
+    - case field.type
+    - when 'DialogFieldTextBox', 'DialogFieldTextAreaBox'
+      - if field.protected?
+        ********
+      - else
+        = h(field.value)
+
+    - when 'DialogFieldCheckBox'
+      = check_box_tag(field.name, "1", field.checked?, {:disabled => true})
+
+    - when 'DialogFieldDateControl'
+      = h(field.value)
+
+    - when 'DialogFieldDateTimeControl'
+      - date_val, time_val = field.value.split(" ")
+      - hour_val, minute_val = time_val.split(":")
+      = date_val
+      &nbsp;at&nbsp;
+      = "#{hour_val.rjust(2, '0')}:#{minute_val.rjust(2, '0')}"
+      &nbsp;
+      = session[:user_tz]
+
+    - when "DialogFieldRadioButton"
+      = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
+
+    - when "DialogFieldDropDownList"
+      = h(field.value || "<None>")
+
+    - when 'DialogFieldTagControl'
+      - value = wf.value(field.name) || '' # it returns in format Clasification::id
+      - _, classification_id = value.split('::')
+      = h(Classification.find(classification_id).description)

--- a/app/views/miq_request/_st_prov_show.html.haml
+++ b/app/views/miq_request/_st_prov_show.html.haml
@@ -4,10 +4,29 @@
   - if ra && ra.dialog
     - values = @miq_request.options[:dialog]
     - opts = {:display_view_only => true}
+    - wf = ResourceActionWorkflow.new(values, current_user, ra, opts)
     %fieldset
       %h3
         = _("Dialog Options")
       .row
         .col-md-12.col-lg-12
-          = render :partial => "shared/dialogs/dialog_provision",
-                   :locals  => {:wf => ResourceActionWorkflow.new(values, current_user, ra, opts)}
+          #dialog_tabs
+            %ul.nav.nav-tabs
+              - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+                - options = {:class => "active"} if tab_index == 0
+                = miq_tab_header(tab.id, nil, options) do
+                  = tab.label
+            .tab-content
+              - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
+                - options = {:class => "active"} if tab_index == 0
+                = miq_tab_content(tab.id, nil, options) do
+                  - tab.dialog_groups.each do |group|
+                    %div{:id => "group_#{group.id}_div"}
+                      %h3{:title => "#{group.description}"}
+                        = group.label
+                      - unless group.dialog_fields.empty?
+                        .form-horizontal
+                          - group.dialog_fields.each do |field|
+                            = render :partial => "miq_request/request_dialog_details",
+                                     :locals => {:wf => wf, :field => field}
+                      %hr


### PR DESCRIPTION
This PR simplifies the `st_prov_show.html.haml` from going into `dialog_provision.html.haml` which further down does a bunch of calculations based on the dialog and then can sometimes run automate depending on the field. All it really needs to do is display the values that the user picked during ordering.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663049

/cc @tinaafitz 
@miq-bot assign @h-kataria 
@miq-bot add_label bug, hammer/yes, gaprindashvili/yes