### PR TITLE
Bug 1650484: Update misleading form label for new Cloud Tenant form

### DIFF
--- a/app/javascript/components/cloud-tenant-form/create-form-schema.js
+++ b/app/javascript/components/cloud-tenant-form/create-form-schema.js
@@ -17,7 +17,7 @@ function createSchema(renderEmsChoices, emsChoices) {
     fields = [{
       component: 'select-field',
       name: 'ems_id',
-      label: __('Cloud Provider'),
+      label: __('Cloud Provider/Parent Cloud Tenant'),
       placeholder: `<${__('Choose')}>`,
       validateOnMount: true,
       validate: [{

--- a/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
+++ b/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
         "fields": Array [
           Object {
             "component": "select-field",
-            "label": "Cloud Provider",
+            "label": "Cloud Provider/Parent Cloud Tenant",
             "name": "ems_id",
             "options": Array [
               Object {


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650484

The prior version of this labeled the field "Cloud Provider", but the
actual field content includes both cloud providers and cloud tenants
within the provider, to support hierarchical cloud tenants.

This commit updates the field label to be more accurate.

