### PR TITLE
Fix enabling Power operations for a template

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -636,10 +636,7 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_untestable_actions = %w(
-      reboot_guest stop start check_compliance_queue destroy
-      refresh_ems vm_miq_request_new suspend reset shutdown_guest
-    )
+    vm_infra_untestable_actions = %w(check_compliance_queue destroy refresh_ems vm_miq_request_new)
     ems_cluster_untestable_actions = %w(scan)
     if controller == "vm_infra"
       return vm_infra_untestable_actions.exclude?(action)

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -34,7 +34,7 @@ describe ApplicationController do
     end
   end
 
-  describe "action_to_feature" do
+  describe "#action_to_feature" do
     let(:record) { FactoryBot.create(:vm_redhat) }
 
     context 'the UI action is also a queryable feature' do
@@ -681,7 +681,7 @@ describe ApplicationController do
     end
   end
 
-  context "#discover" do
+  describe "#discover" do
     it "checks that keys in @to remain set if there is an error after submit is pressed" do
       from_first = "1"
       from_second = "1"
@@ -720,7 +720,7 @@ describe ApplicationController do
     end
   end
 
-  context "#process_elements" do
+  describe "#process_elements" do
     it "shows passed in display name in flash message" do
       pxe = FactoryBot.create(:pxe_server)
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue', 'Refresh Relationships')
@@ -735,7 +735,7 @@ describe ApplicationController do
     end
   end
 
-  context "#identify_record" do
+  describe "#identify_record" do
     it "Verify flash error message when passed in ID no longer exists in database" do
       record = controller.send(:identify_record, "1", ExtManagementSystem)
       expect(record).to be_nil
@@ -749,7 +749,7 @@ describe ApplicationController do
     end
   end
 
-  context "#get_record" do
+  describe "#get_record" do
     it "use passed in db to set class for identify_record call" do
       host = FactoryBot.create(:host)
       controller.instance_variable_set(:@_params, :id => host.id)
@@ -800,7 +800,7 @@ describe HostController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryBot.create(:zone) }
 
-  context "#show_association" do
+  describe "#show_association" do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
@@ -846,7 +846,7 @@ describe HostController do
     end
   end
 
-  context "#process_objects" do
+  describe "#process_objects" do
     it "returns array of object ids " do
       vm1 = FactoryBot.create(:vm_vmware)
       vm2 = FactoryBot.create(:vm_vmware)
@@ -858,7 +858,7 @@ describe HostController do
     end
   end
 
-  context "#process_hosts" do
+  describe "#process_hosts" do
     before do
       @host1 = FactoryBot.create(:host)
       @host2 = FactoryBot.create(:host)
@@ -881,7 +881,7 @@ describe HostController do
     end
   end
 
-  context "#generic_button_operation" do
+  describe "#generic_button_operation" do
     before do
       allow(subject).to receive(:vm_button_action).and_return(subject.method(:process_objects))
       allow(controller).to receive(:render)
@@ -916,7 +916,7 @@ describe HostController do
 end
 
 describe ServiceController do
-  context "#vm_button_operation" do
+  describe "#vm_button_operation" do
     let(:user) { FactoryBot.create(:user_admin) }
 
     before do
@@ -947,7 +947,7 @@ describe ServiceController do
 end
 
 describe MiqTemplateController do
-  context "#vm_button_operation" do
+  describe "#vm_button_operation" do
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       allow(MiqServer).to receive(:my_zone).and_return("default")
@@ -973,7 +973,7 @@ describe MiqTemplateController do
 end
 
 describe VmOrTemplateController do
-  context "#vm_button_operation" do
+  describe "#vm_button_operation" do
     let(:user) { FactoryBot.create(:user_admin) }
 
     before do
@@ -1029,7 +1029,7 @@ describe VmOrTemplateController do
 end
 
 describe OrchestrationStackController do
-  context "#orchestration_stack_delete" do
+  describe "#orchestration_stack_delete" do
     let(:orchestration_stack) { FactoryBot.create(:orchestration_stack_cloud) }
     let(:orchestration_stack_deleted) { FactoryBot.create(:orchestration_stack_cloud) }
 
@@ -1078,6 +1078,22 @@ describe EmsCloudController do
         expect(controller).to receive(:delete_flavors).and_call_original
         expect_any_instance_of(Flavor).to receive(:delete_flavor_queue)
         post :button, :params => {:pressed => 'flavor_delete', :miq_grid_checks => flavor.id}
+      end
+    end
+  end
+end
+
+describe VmInfraController do
+  describe '#testable_action' do
+    before do
+      controller.instance_variable_set(:@_params, :controller => 'vm_infra')
+    end
+
+    context 'power operations and vm infra controller' do
+      %w(reboot_guest reset shutdown_guest start stop suspend).each do |op|
+        it "returns true for #{op} operation on a VM" do
+          expect(controller.send(:testable_action, op)).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1634713
https://bugzilla.redhat.com/show_bug.cgi?id=1655477

**What:**
This PR fixes the problem about the Power operations which were enabled for a template. And Power operations don't make sense for a template. They should be enabled only for VMs.

**Steps to reproduce:**
1. Go to _Compute > Infrastructure > VMs > VMs & Templates_ accordion > _All VMs & Templates_
2. Select some template (not VM!) by checking its checkbox
3. In the toolbar, choose _Power > Power On_ or any other Power action
=> flash message about the start (for example) which was initiated successfully appears and it shouldn't

---

**Before:**
![start_before](https://user-images.githubusercontent.com/13417815/50769287-cc5a5a80-1283-11e9-9b56-7f5c728f8bb3.png)

**After:**
![start_after](https://user-images.githubusercontent.com/13417815/50769299-d11f0e80-1283-11e9-9d6d-f5078cfa8e3f.png)

**Note:**
I've removed appropriate power actions from untestable actions array in `testable_action` method which did not make sense to be there. Now the power actions should work properly for VMs and Templates. I've tested power operations for VMs and everything works as usually. And for Templates, the right flash message appears.