### PR TITLE
Fixed regression on schedules screen due to bad towhat refactoring

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -39,9 +39,9 @@ module ReportController::Schedules
     @sortdir = session[:schedule_sortdir].nil? ? "ASC" : session[:schedule_sortdir]
 
     if super_admin_user? # Super admins see all user's schedules
-      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_resource_type, "MiqReport"]]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"]]) # Get the records (into a view) and the paginator
     else
-      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_resource_type, "MiqReport"], [:with_userid, session[:userid]]]) # Get the records (into a view) and the paginator
+      @view, @pages = get_view(MiqSchedule, :named_scope => [[:with_towhat, "MiqReport"], [:with_userid, session[:userid]]]) # Get the records (into a view) and the paginator
     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number


### PR DESCRIPTION
Sorry, my cut-n-paste was probably bad when I was renaming the deprecated `towhat` stuff. This is a partial revert that fixes the issue.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5131

@miq-bot add_reviewer @epwinchell 
@miq-bot assign @mzazrivec 
@miq-bot add_label bug, hammer/no