### PR TITLE
Rename WebsocketWorker to RemoteConsoleWorker

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -440,8 +440,8 @@ module OpsController::Settings::Common
       set_worker_setting(@edit[:new], MiqWebServiceWorker, :count, w[:count].to_i)
       set_worker_setting(@edit[:new], MiqWebServiceWorker, :memory_threshold, w[:memory_threshold])
 
-      w = wb[:websocket_worker]
-      set_worker_setting(@edit[:new], MiqWebsocketWorker, :count, w[:count].to_i)
+      w = wb[:remote_console_worker]
+      set_worker_setting(@edit[:new], MiqRemoteConsoleWorker, :count, w[:count].to_i)
 
       @update = MiqServer.find(@sb[:selected_server_id]).settings
     when "settings_custom_logos" # Custom Logo tab
@@ -861,8 +861,8 @@ module OpsController::Settings::Common
       w[:count] = params[:web_service_worker_count].to_i if params[:web_service_worker_count]
       w[:memory_threshold] = params[:web_service_worker_threshold].to_i if params[:web_service_worker_threshold]
 
-      w = wb[:websocket_worker]
-      w[:count] = params[:websocket_worker_count].to_i if params[:websocket_worker_count]
+      w = wb[:remote_console_worker]
+      w[:count] = params[:remote_console_worker_count].to_i if params[:remote_console_worker_count]
     when "settings_custom_logos" # Custom Logo tab
       new[:server][:custom_logo] = (params[:server_uselogo] == "true") if params[:server_uselogo]
       new[:server][:custom_login_logo] = (params[:server_useloginlogo] == "true") if params[:server_useloginlogo]
@@ -1072,8 +1072,8 @@ module OpsController::Settings::Common
     @sb[:web_service_threshold] = []
     @sb[:web_service_threshold] = copy_array(@sb[:threshold])
 
-    w = (wb[:websocket_worker] ||= {})
-    w[:count] = get_worker_setting(@edit[:current], MiqWebsocketWorker, :count) || 2
+    w = (wb[:remote_console_worker] ||= {})
+    w[:count] = get_worker_setting(@edit[:current], MiqRemoteConsoleWorker, :count) || 2
 
     @edit[:new] = copy_hash(@edit[:current])
     session[:log_depot_default_verify_status] = true

--- a/app/views/ops/_settings_workers_tab.html.haml
+++ b/app/views/ops/_settings_workers_tab.html.haml
@@ -237,15 +237,15 @@
             miqSelectPickerEvent('proxy_worker_threshold', "#{url}")
       %hr
       %h3
-        = _("Websocket Workers")
+        = _("Remote Console Workers")
       .form-horizontal
         .form-group
           %label.col-md-2.control-label
             = _("Count")
           .col-md-8
-            = select_tag('websocket_worker_count',
+            = select_tag('remote_console_worker_count',
                         options_for_select((0..9).to_a,
-                                          @edit[:new][:workers][:worker_base][:websocket_worker][:count].to_i),
+                                          @edit[:new][:workers][:worker_base][:remote_console_worker][:count].to_i),
                           :class    => "selectpicker")
           :javascript
-            miqSelectPickerEvent('websocket_worker_count', "#{url}")
+            miqSelectPickerEvent('remote_console_worker_count', "#{url}")


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq/issues/18300
Core PR: https://github.com/ManageIQ/manageiq/pull/18337
Schema: https://github.com/ManageIQ/manageiq-schema/pull/319

@miq-bot add_label hammer/no, pending core 