### PR TITLE
Fix usage of TreeBuilder.extract_node_model_and_id in OpcControler

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -10,7 +10,12 @@ module OpsController::OpsRbac
 
   def role_allows?(**options)
     if MiqProductFeature.my_root_tenant_identifier?(options[:feature]) && params.key?(:id)
-      _, _, id = TreeBuilder.extract_node_model_and_id(params[:id].to_s)
+      if params[:id].to_s.include?('tn')
+        _, id, _ = TreeBuilder.extract_node_model_and_id(params[:id].to_s)
+      else
+        id = params[:id].to_s
+      end
+
       options[:feature] = MiqProductFeature.tenant_identifier(options[:feature], id)
     end
 

--- a/spec/helpers/application_helper/buttons/basic_spec.rb
+++ b/spec/helpers/application_helper/buttons/basic_spec.rb
@@ -23,13 +23,13 @@ describe ApplicationHelper::Button::Basic do
     end
 
     it "doesn't displays button Manage Tenant Quota for alpha tenant without tenant product permission for alpha tenant" do
-      controller.instance_variable_set(:@_params, :id => "tn_#{tenant_alpha.id}")
+      controller.instance_variable_set(:@_params, :id => "tn-#{tenant_alpha.id}")
 
       expect(button.role_allows_feature?).to be_falsey
     end
 
     it "displays button Manage Tenant Quota from a tenant omega with tenant product permission for omega tenant" do
-      controller.instance_variable_set(:@_params, :id => "tn_#{tenant_omega.id}")
+      controller.instance_variable_set(:@_params, :id => "tn-#{tenant_omega.id}")
 
       expect(button.role_allows_feature?).to be_truthy
     end


### PR DESCRIPTION
fix displaying menu "Manage Tenant Quota" from https://github.com/ManageIQ/manageiq-ui-classic/pull/5123

`params[:id]` has format `"tn-ID"` **(not `"tn_ID"`)**

method 

`TreeBuilder.extract_node_model_and_id(params[:id].to_s)`

returns `id` in second element:

`TreeBuilder.extract_node_model_and_id("tn-33333")`
returns
`[nil,"33333", "tn"]`


 and we had case written with `'_'` in [specs](https://github.com/ManageIQ/manageiq-ui-classic/pull/5129) 


Links
-----

* https://github.com/ManageIQ/manageiq-ui-classic/pull/5129
* https://github.com/ManageIQ/manageiq-ui-classic/pull/5123
* https://bugzilla.redhat.com/show_bug.cgi?id=1468795

@miq-bot add_label bug

