### PR TITLE
Send button_order via API

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-group-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-group-form.js
@@ -75,6 +75,7 @@ function mainCustomButtonGroupFormController(API, miqService) {
     vm.customButtonGroupModel.set_data = {
       button_icon: vm.customButtonGroupModel.button_icon,
       button_color: vm.customButtonGroupModel.button_color,
+      button_order: vm.customButtonGroupModel.button_order,
       display: vm.customButtonGroupModel.display,
       applies_to_class: 'GenericObjectDefinition',
       applies_to_id: parseInt(vm.genericObjectDefnRecordId, 10),
@@ -103,6 +104,7 @@ function mainCustomButtonGroupFormController(API, miqService) {
 
     vm.customButtonGroupModel.button_icon = response.set_data.button_icon;
     vm.customButtonGroupModel.button_color = response.set_data.button_color;
+    vm.customButtonGroupModel.button_order = response.set_data.button_order;
     vm.customButtonGroupModel.display = response.set_data.display;
     vm.customButtonGroupModel.group_index = response.set_data.group_index;
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534539

Automation -> Automate -> Generic Object -> select a button group with button(s) in tree-> Edit it -> Save -> see what happens to the tree after saving the group

Make sure that button group has buttons in the tree before editing. Once ordering is lost during editing it's lost for good.

Before:
<img width="697" alt="screen shot 2019-01-09 at 1 49 22 pm" src="https://user-images.githubusercontent.com/9210860/50900406-5ede3380-1415-11e9-8376-d47f30aba0fa.png">

After:
<img width="738" alt="screen shot 2019-01-09 at 1 58 38 pm" src="https://user-images.githubusercontent.com/9210860/50900825-9b5e5f00-1416-11e9-891f-5bd6f38849a5.png">


@miq-bot add_label bug, hammer/yes, gaprindashvili/yes, automation/automate, generic objects