### PR TITLE
Dont show gtl checkbox when display list from chart click

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -316,6 +316,7 @@ module ApplicationController::Performance
                           :menu_click    => params[:menu_click],
                           :sb_controller => request.parameters["controller"],
                           :bc            => bc,
+                          :no_checkboxes => true,
                           :escape        => false)
       return [true, nil]
     end

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -116,7 +116,8 @@ class HostController < ApplicationController
   # Show the main Host list view overriding method from Mixins::GenericListMixin
   def show_list
     session[:host_items] = nil
-    process_show_list
+    options = {:no_checkboxes => ActiveRecord::Type::Boolean.new.cast(params[:no_checkboxes])}
+    process_show_list(options)
   end
 
   def start

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -14,6 +14,7 @@ class VmController < ApplicationController
   def show_list
     options = {:association => session[:vm_type]}
     options[:model] = "ManageIQ::Providers::CloudManager::Vm" if params['sb_controller'] == 'availability_zone'
+    options[:no_checkboxes] = ActiveRecord::Type::Boolean.new.cast(params[:no_checkboxes])
     process_show_list(options)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1288,7 +1288,7 @@ module ApplicationHelper
     @report_data_additional_options.with_menu_click(params[:menu_click]) if params[:menu_click]
     @report_data_additional_options.with_sb_controller(params[:sb_controller]) if params[:sb_controller]
     @report_data_additional_options.with_model(curr_model) if curr_model
-    @report_data_additional_options.with_no_checkboxes(@no_checkboxes) if @no_checkboxes
+    @report_data_additional_options.with_no_checkboxes(@no_checkboxes || options[:no_checkboxes])
     # FIXME: we would like to freeze here, but the @gtl_type is calculated no sooner than in view templates.
     # So until that if fixed we cannot freeze.
     # @report_data_additional_options.freeze


### PR DESCRIPTION
Don't show `Check All` checkbox when navigating to VM list from chart

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1647230

Steps for Testing/QA [Optional]
-------------------------------
1.Manage an infra provider.Enable C&U for the provider.
2.Navigate to the summary page of a host.Click Monitoring, click Utilization.
3.Drill into any of the charts(memory, cpu etc), by clicking on a data point.
4.Select 'Display' menu, click 'VMs that were running'

