### PR TITLE
Unify sorting in GOD page

### DIFF
--- a/app/views/generic_object_definition/_show_actions.html.haml
+++ b/app/views/generic_object_definition/_show_actions.html.haml
@@ -1,6 +1,6 @@
 #main_div
   = render :partial => "layouts/flash_msg"
-  - unless @record.custom_button_sets.empty?
+  - if @record.custom_button_sets.present?
     %hr
       %h3
         = _('Button Groups')
@@ -20,7 +20,7 @@
                 = obj[:name]
               %td
                 = obj[:description]
-  - unless @record.custom_buttons.empty?
+  - if @record.custom_buttons.present?
     = render :partial => 'table_button' , :locals => {:buttons =>  @record.custom_buttons.sort_by{ |button| button.name.downcase }}
 :javascript
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_actions.html.haml
+++ b/app/views/generic_object_definition/_show_actions.html.haml
@@ -13,7 +13,7 @@
             = _('Hover Text')
         %tbody
           - @record.custom_button_sets.each do |obj|
-            %tr{:title => 'hi'}
+            %tr
               %td.table-view-pf-select
                 %i{:class => obj.set_data[:button_icon], :style => obj.set_data.key?(:button_color) ? "color: #{obj.set_data[:button_color]};" : nil}
               %td

--- a/app/views/generic_object_definition/_show_actions.html.haml
+++ b/app/views/generic_object_definition/_show_actions.html.haml
@@ -21,24 +21,6 @@
               %td
                 = obj[:description]
   - unless @record.custom_buttons.empty?
-    %hr
-      %h3
-        = _('Buttons')
-      %table.table.table-bordered.table-hover.table-striped
-        %thead
-          %th.table-view-pf-select
-          %th
-            = _('Text')
-          %th
-            = _('Hover Text')
-        %tbody
-          - @record.custom_buttons.each do |obj|
-            %tr{:title => 'hi'}
-              %td.table-view-pf-select
-                %i{:class => obj.options[:button_icon], :style => obj.options.key?(:button_color) ? "color: #{obj.options[:button_color]};" : nil}
-              %td
-                = obj[:name]
-              %td
-                = obj[:description]
+    = render :partial => 'table_button' , :locals => {:buttons =>  @record.custom_buttons.sort_by{ |button| button.name.downcase }}
 :javascript
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_custom_button_group.html.haml
+++ b/app/views/generic_object_definition/_show_custom_button_group.html.haml
@@ -31,25 +31,7 @@
         %hr
           = render :partial => 'layouts/info_msg', :locals => {:message => _("No Buttons found.")}
       - else
-        %hr
-          %h3
-            = _('Buttons')
-          %table.table.table-bordered.table-hover.table-striped
-            %thead
-              %th.table-view-pf-select
-              %th
-                = _('Text')
-              %th
-                = _('Hover Text')
-            %tbody
-              - @record.custom_buttons.each do |obj|
-                %tr{:title => 'hi'}
-                  %td.table-view-pf-select
-                    %i{:class => obj.options[:button_icon], :style => obj.options.key?(:button_color) ? "color: #{obj.options[:button_color]};" : nil}
-                  %td
-                    = obj[:name]
-                  %td
-                    = obj[:description]
+        = render :partial => 'table_button', :locals => {:buttons => @record.set_data[:button_order].map{ |id| CustomButton.find_by(:id => id) }}
 
       %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
                                                                              'entity'       => _('Custom Button Group'),

--- a/app/views/generic_object_definition/_table_button.html.haml
+++ b/app/views/generic_object_definition/_table_button.html.haml
@@ -1,0 +1,19 @@
+%hr
+  %h3
+    = _('Buttons')
+  %table.table.table-bordered.table-hover.table-striped
+    %thead
+      %th.table-view-pf-select
+      %th
+        = _('Text')
+      %th
+        = _('Hover Text')
+    %tbody
+      - buttons.each do |obj|
+        %tr{:title => 'hi'}
+          %td.table-view-pf-select
+            %i{:class => obj.options[:button_icon], :style => obj.options.key?(:button_color) ? "color: #{obj.options[:button_color]};" : nil}
+          %td
+            = obj[:name]
+          %td
+            = obj[:description]

--- a/app/views/generic_object_definition/_table_button.html.haml
+++ b/app/views/generic_object_definition/_table_button.html.haml
@@ -10,7 +10,7 @@
         = _('Hover Text')
     %tbody
       - buttons.each do |obj|
-        %tr{:title => 'hi'}
+        %tr
           %td.table-view-pf-select
             %i{:class => obj.options[:button_icon], :style => obj.options.key?(:button_color) ? "color: #{obj.options[:button_color]};" : nil}
           %td


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1665031

Automate -> Automation -> Generic Object

**See that sort in tree and table is different.**

For ButtonGroup you may need to change it's `set_data[:button_order]` to see difference.

For Action add few unassigned button and last one that you add should be with name that should be at the start of the list.

Before:
<img width="1192" alt="screen shot 2019-01-10 at 11 26 21 am" src="https://user-images.githubusercontent.com/9210860/50962480-a4a90380-14ca-11e9-9340-3a413557abde.png">
<img width="1191" alt="screen shot 2019-01-10 at 11 26 13 am" src="https://user-images.githubusercontent.com/9210860/50962498-ac68a800-14ca-11e9-8a9a-4fae70f42f27.png">
After:
<img width="1197" alt="screen shot 2019-01-10 at 11 25 25 am" src="https://user-images.githubusercontent.com/9210860/50962487-a7a3f400-14ca-11e9-8da5-11b2be6d24cd.png">
<img width="1197" alt="screen shot 2019-01-10 at 11 25 35 am" src="https://user-images.githubusercontent.com/9210860/50962495-aa064e00-14ca-11e9-9cf6-2e83fc7385b5.png">

@miq-bot add_label bug, generic objects, automate/automation, hammer/yes, gaprindashvili/yes, bugzilla needed

