### PR TITLE
Show breadcrumbs when redirected from another controller

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -19,6 +19,11 @@ class EmsCloudController < ApplicationController
     @table_name ||= "ems_cloud"
   end
 
+  def show
+    @breadcrumbs = [{:name => "Cloud Providers", :url => "/ems_cloud/show_list"}]
+    super
+  end
+
   def ems_path(*args)
     ems_cloud_path(*args)
   end

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -20,7 +20,7 @@ class EmsCloudController < ApplicationController
   end
 
   def show
-    @breadcrumbs = [{:name => "Cloud Providers", :url => "/ems_cloud/show_list"}]
+    @breadcrumbs = [{:name => _('Cloud Providers'), :url => '/ems_cloud/show_list'}]
     super
   end
 

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -31,6 +31,11 @@ class EmsContainerController < ApplicationController
     process_show_list(:gtl_dbname => 'emscontainer')
   end
 
+  def show
+    @breadcrumbs = [{:name => "Containers Providers", :url => "/ems_container/show_list"}]
+    super
+  end
+
   def ems_path(*args)
     ems_container_path(*args)
   end

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -32,7 +32,7 @@ class EmsContainerController < ApplicationController
   end
 
   def show
-    @breadcrumbs = [{:name => "Containers Providers", :url => "/ems_container/show_list"}]
+    @breadcrumbs = [{:name => _('Containers Providers'), :url => '/ems_container/show_list'}]
     super
   end
 

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -19,7 +19,7 @@ class EmsInfraController < ApplicationController
   end
 
   def show
-    @breadcrumbs =  [{:name => "Infrastructure Providers", :url => "/ems_infra/show_list"}]
+    @breadcrumbs =  [{:name => _('Infrastructure Providers'), :url => '/ems_infra/show_list'}]
     super
   end
 

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -18,6 +18,11 @@ class EmsInfraController < ApplicationController
     @table_name ||= "ems_infra"
   end
 
+  def show
+    @breadcrumbs =  [{:name => "Infrastructure Providers", :url => "/ems_infra/show_list"}]
+    super
+  end
+
   def ems_path(*args)
     ems_infra_path(*args)
   end

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -342,7 +342,8 @@ describe EmsInfraController do
       get :show, :params => {:id => @ems.id, :display => 'storages'}
       expect(response.status).to eq(200)
       expect(response).to render_template('shared/views/ems_common/show')
-      expect(assigns(:breadcrumbs)).to eq([{:name => "#{@ems.name} (All Datastores)", :url => "/ems_infra/#{@ems.id}?display=storages"}])
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Infrastructure Providers", :url => "/ems_infra/show_list"},
+                                           {:name => "#{@ems.name} (All Datastores)", :url => "/ems_infra/#{@ems.id}?display=storages"}])
 
       # display needs to be saved to session for GTL pagination and such
       expect(session[:ems_infra_display]).to eq('storages')
@@ -357,7 +358,8 @@ describe EmsInfraController do
       post :button, :params => {:id => @ems.id, :display => 'storages', :miq_grid_checks => datastore.id, :pressed => "storage_tag", :format => :js}
       expect(response.status).to eq(200)
       _breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
-      expect(assigns(:breadcrumbs)).to eq([{:name => "#{@ems.name} (All Datastores)",
+      expect(assigns(:breadcrumbs)).to eq([{:name => "Infrastructure Providers", :url => "/ems_infra/show_list"},
+                                           {:name => "#{@ems.name} (All Datastores)",
                                             :url  => "/ems_infra/#{@ems.id}?display=storages"},
                                            {:name => "Tag Assignment", :url => "//tagging_edit"}])
     end
@@ -400,7 +402,8 @@ describe EmsInfraController do
         ems = FactoryBot.create(:ems_vmware)
         get :show, :params => { :id => ems.id }
         breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
-        expect(breadcrumbs).to eq([{:name => "#{ems.name} (Dashboard)", :url => "/ems_infra/#{ems.id}"}])
+        expect(breadcrumbs).to eq([{:name => "Infrastructure Providers", :url => "/ems_infra/show_list"},
+                                   {:name => "#{ems.name} (Dashboard)", :url => "/ems_infra/#{ems.id}"}])
       end
     end
   end


### PR DESCRIPTION
When redirect from another (e.g. Alert) controller provider dashboards have no breadcrumbs. In `GenericShowMixin`  `show_dashboard` method is dropping breadcrumb, but only for the showed record (one concrete Provider, like Amazon or Openshift instance). Not the upper level of hierarchy (Cloud/Container provider). So there are no breadcrumbs showed. 

This PR adds the base of breadcrumbs fro providers.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1655114

Steps for Testing/QA [Optional]
-------------------------------
1. Configure an appliance with a provider (e.g. infra)
2. Setup an alert to fire against that provider
3. Navigate to Monitor->Alerts->All Alerts
4. Click on the providers name in the list-view of the provider
