### PR TITLE
Fix missing paging in provisioning template selection

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -177,7 +177,6 @@ module ApplicationController::MiqRequestMethods
     end
     session[:changed] = false # Turn off the submit button
     @edit[:explorer] = true if @explorer
-    @in_a_form = true
   end
 
   def get_template_kls


### PR DESCRIPTION
Compute -> clouds -> providers -> select cloud_provider(Openstack/Amazon) -> instances -> lifecycle -> provision instances
(or go to `/miq_request/pre_prov?template_klass=cloud` directly)

there is a GTL with a list of templates,
but thanks to `@in_a_form = true` (and `center_div_no_listnav` checking both `layout_uses_paging? && !@in_a_form`),
that means no paging toolbar.

That was correct when this was not using the GTL component but no longer, removing.

(The screen was converted to use GTL in https://github.com/ManageIQ/manageiq-ui-classic/pull/4509, adding hammer/yes.)

Cc @PanSpagetka 
Cc @Pratik1Awchat

(A workaround for this is running `$('#paging_div').show(); miqInitMainContent()` in the browser console on that screen.)