### PR TITLE
BZ1650396: Add Allocation pools, Nameserver, Host Routes to Subnet UI

### DIFF
--- a/app/assets/javascripts/components/cloud_subnet/cloud-subnet-form.js
+++ b/app/assets/javascripts/components/cloud_subnet/cloud-subnet-form.js
@@ -39,7 +39,32 @@ function cloudSubnetFormController(API, miqService) {
       }).catch(miqService.handleFailure);
     } else {
       API.get('/api/cloud_subnets/' + vm.cloudSubnetFormId + '?expand=resources&attributes=ext_management_system.name,cloud_tenant.name,cloud_network.name').then(function(data) {
-        Object.assign(vm.cloudSubnetModel, _.pick(data, 'name', 'ext_management_system', 'cloud_network', 'cloud_tenant', 'network_protocol', 'cidr', 'dhcp_enabled', 'gateway'));
+        Object.assign(vm.cloudSubnetModel, _.pick(data, 'name', 'ext_management_system', 'cloud_network', 'cloud_tenant', 'network_protocol', 'cidr', 'dhcp_enabled', 'gateway', 'extra_attributes', 'dns_nameservers'));
+        vm.cloudSubnetModel.allocation_pools = "";
+        vm.cloudSubnetModel.host_routes = "";
+        if (vm.cloudSubnetModel.extra_attributes !== undefined) {
+          if (vm.cloudSubnetModel.extra_attributes.allocation_pools !== undefined) {
+            vm.cloudSubnetModel.extra_attributes.allocation_pools.forEach(function(val, i) {
+              if (i > 0) {
+                vm.cloudSubnetModel.allocation_pools += "\n";
+              }
+              vm.cloudSubnetModel.allocation_pools += val["start"] + "," + val["end"];
+            });
+          }
+          if (vm.cloudSubnetModel.extra_attributes.host_routes !== undefined) {
+            vm.cloudSubnetModel.extra_attributes.host_routes.forEach(function(val, i) {
+              if (i > 0) {
+                vm.cloudSubnetModel.host_routes += "\n";
+              }
+              vm.cloudSubnetModel.host_routes += val["destination"] + "," + val["nexthop"];
+            });
+          }
+        }
+        if (vm.cloudSubnetModel.dns_nameservers !== undefined) {
+          vm.cloudSubnetModel.dns_nameservers = vm.cloudSubnetModel.dns_nameservers.join("\n");
+        } else {
+          vm.cloudSubnetModel.dns_nameservers = "";
+        }
         vm.afterGet = true;
         vm.modelCopy = angular.copy( vm.cloudSubnetModel );
         miqService.sparkleOff();
@@ -64,7 +89,7 @@ function cloudSubnetFormController(API, miqService) {
 
   vm.saveClicked = function() {
     var url = '/cloud_subnet/update/' + vm.cloudSubnetFormId + '?button=save';
-    miqService.miqAjaxButton(url, _.pick(vm.cloudSubnetModel, 'name', 'dhcp_enabled', 'gateway'), { complete: false });
+    miqService.miqAjaxButton(url, _.pick(vm.cloudSubnetModel, 'name', 'dhcp_enabled', 'gateway', 'allocation_pools', 'host_routes', 'dns_nameservers'), { complete: false });
   };
 
   vm.resetClicked = function(angularForm) {

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module CloudSubnetHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i[name type cidr gateway network_protocol dns_nameservers_show allocation_pools host_routes ip_version]
+      %i[name type cidr gateway network_protocol dns_nameservers allocation_pools host_routes ip_version]
     )
   end
 
@@ -43,7 +43,7 @@ module CloudSubnetHelper::TextualSummary
     @record.network_protocol
   end
 
-  def textual_dns_nameservers_show
+  def textual_dns_nameservers
     @record.dns_nameservers_show
   end
 
@@ -54,7 +54,7 @@ module CloudSubnetHelper::TextualSummary
   def textual_host_routes
     if @record.host_routes
       @record.host_routes.map do |x|
-        "next_hop: #{x['next_hop']}, destination: #{x['destination']}"
+        "destination: #{x['destination']}, nexthop: #{x['nexthop']}"
       end.join(" | ")
     end
   end

--- a/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
+++ b/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
@@ -126,5 +126,29 @@
                             'required'    => ''}
         %span.help-block{'ng-show' => 'angularForm.cidr.$error.required'}
           = _('Required')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Allocation Pools')
+      .col-md-8
+        %textarea.form-control{'type'     => 'textarea',
+                               'name'     => 'allocation_pools',
+                               'ng-model' => 'vm.cloudSubnetModel.allocation_pools',
+                               'rows'     => 4}
+    .form-group
+      %label.col-md-2.control-label
+        = _('DNS Name Servers')
+      .col-md-8
+        %textarea.form-control{'type'     => 'textarea',
+                               'name'     => 'dns_nameservers',
+                               'ng-model' => 'vm.cloudSubnetModel.dns_nameservers',
+                               'rows'     => 4}
+    .form-group
+      %label.col-md-2.control-label
+        = _('Host Routes')
+      .col-md-8
+        %textarea.form-control{'type'     => 'textarea',
+                               'name'     => 'host_routes',
+                               'ng-model' => 'vm.cloudSubnetModel.host_routes',
+                               'rows'     => 4}
 
   = render :partial => 'layouts/angular/generic_form_buttons'

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -115,11 +115,14 @@ describe CloudSubnetController do
         :role        => 'ems_operations',
         :zone        => ems.my_zone,
         :args        => [{
-          :name         => 'test',
-          :ip_version   => 4,
-          :cloud_tenant => cloud_tenant,
-          :network_id   => cloud_network.ems_ref,
-          :enable_dhcp  => "true"
+          :name             => 'test',
+          :ip_version       => 4,
+          :cloud_tenant     => cloud_tenant,
+          :network_id       => cloud_network.ems_ref,
+          :enable_dhcp      => "true",
+          :allocation_pools => [{"start" => "172.10.1.10", "end" => "172.10.1.20"}],
+          :host_routes      => [{"destination" => "172.12.1.0/24", "nexthop" => "172.12.1.1"}],
+          :dns_nameservers  => ["172.11.1.1"]
         }]
       }
     end
@@ -145,7 +148,10 @@ describe CloudSubnetController do
         :id               => 'new',
         :name             => 'test',
         :network_protocol => 'ipv4',
-        :network_id       => cloud_network.ems_ref
+        :network_id       => cloud_network.ems_ref,
+        :allocation_pools => "172.10.1.10,172.10.1.20",
+        :host_routes      => "172.12.1.0/24,172.12.1.1",
+        :dns_nameservers  => "172.11.1.1"
       }
     end
   end
@@ -165,7 +171,13 @@ describe CloudSubnetController do
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => 'ems_operations',
         :zone        => ems.my_zone,
-        :args        => [{:name => 'test2', :enable_dhcp => false}]
+        :args        => [{
+          :name             => 'test2',
+          :enable_dhcp      => false,
+          :allocation_pools => [{"start" => "172.20.1.10", "end" => "172.20.1.20"}],
+          :host_routes      => [{"destination" => "172.22.1.0/24", "nexthop" => "172.22.1.1"}],
+          :dns_nameservers  => ["172.21.1.1"]
+        }]
       }
     end
 
@@ -181,10 +193,13 @@ describe CloudSubnetController do
       expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
 
       post :update, :params => {
-        :button => 'save',
-        :format => :js,
-        :id     => cloud_subnet.id,
-        :name   => 'test2'
+        :button           => 'save',
+        :format           => :js,
+        :id               => cloud_subnet.id,
+        :name             => 'test2',
+        :allocation_pools => "172.20.1.10,172.20.1.20",
+        :host_routes      => "172.22.1.0/24,172.22.1.1",
+        :dns_nameservers  => "172.21.1.1"
       }
     end
   end

--- a/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_subnet_helper/textual_summary_spec.rb
@@ -5,7 +5,7 @@ describe CloudSubnetHelper::TextualSummary do
     cidr
     gateway
     network_protocol
-    dns_nameservers_show
+    dns_nameservers
     allocation_pools
     host_routes
     ip_version

--- a/spec/javascripts/components/cloud_subnet/cloud_subnet_form_spec.js
+++ b/spec/javascripts/components/cloud_subnet/cloud_subnet_form_spec.js
@@ -80,7 +80,10 @@ describe('cloud-subnet-form', function() {
       vm.cloudSubnetModel.gateway = '172.10.1.2';
       vm.cloudSubnetModel.dhcp_enabled = '172.10.1.2';
       vm.cloudSubnetModel.random_field_from_API = "random data from API";
-      var correct_data = _.pick(vm.cloudSubnetModel, 'name', 'gateway', 'dhcp_enabled');
+      vm.cloudSubnetModel.allocation_pools = '172.10.1.10,172.10.1.20';
+      vm.cloudSubnetModel.host_routes = '172.12.1.0/24,172.12.1.1';
+      vm.cloudSubnetModel.dns_nameservers = '172.11.1.1';
+      var correct_data = _.pick(vm.cloudSubnetModel, 'name', 'gateway', 'dhcp_enabled', 'allocation_pools', 'host_routes', 'dns_nameservers');
       vm.saveClicked();
 
       expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/cloud_subnet/update/1111?button=save', correct_data, { complete: false });


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650396

Allocation pools, DNS Nameserver, Host Routes to Subnet CRUD were
included in Subnet show view, but were missing in the create
and update forms.

This commit adds those fields.

