### PR TITLE
Fix catalog item tree select

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2007,7 +2007,7 @@ class CatalogController < ApplicationController
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
                      params[:action] == "x_show" ||
-                     (%w(accordion_select reload tree_select).include?(params[:action]) && @record.present? && type == 'st')
+                     (%w(accordion_select button_create group_create servicetemplate_edit reload tree_select).include?(params[:action]) && @record.present? && type == 'st')
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record

--- a/app/views/catalog/explorer.html.haml
+++ b/app/views/catalog/explorer.html.haml
@@ -1,6 +1,6 @@
 -# Include the center cell divs
 - nodetypes = %w(MiqTemplate OrchestrationTemplate ServiceResource ServiceTemplate ServiceTemplateCatalog)
-- if nodetypes.include?(TreeBuilder.get_model_for_prefix(@nodetype)) && !@view
+- if nodetypes.include?(TreeBuilder.get_model_for_prefix(@nodetype)) && (!@view || @record.present?)
   #main_div
     - if TreeBuilder.get_model_for_prefix(@nodetype) == "MiqTemplate"
       = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
This is virtually the same problem as https://github.com/ManageIQ/manageiq-ui-classic/pull/5030

This PR makes the summary screen work after full page reload and after item edit, button & button group addition.

https://bugzilla.redhat.com/show_bug.cgi?id=1652858