### PR TITLE
[GAPRINDASHVILI] Fix editing tags from container provider page

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -67,7 +67,7 @@ module ApplicationController::Tags
 
   # Get the string with proper feature name for asserting privileges
   def feature_name
-    is_nested_list = @display && @display != 'main'
+    is_nested_list = @display && %w(main dashboard).exclude?(@display) # if @display is set but not to default display values
     display_or_controller = is_nested_list ? @display.singularize : controller_for_common_methods
     "#{display_or_controller}_tag"
   end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1665284

**What:**
This PR fixes error while editing tags from Container provider details' page. It was not possible to edit tags. Tagging from the list of container providers worked well, but just because `@display` variable was set to `"main"` (here https://github.com/ManageIQ/manageiq-ui-classic/blob/gaprindashvili/app/controllers/mixins/generic_show_mixin.rb#L110) and `feature_name` method was already prepared for this (https://github.com/ManageIQ/manageiq-ui-classic/blob/gaprindashvili/app/controllers/application_controller/tags.rb#L70). See the changes.

**Steps to reproduce:**
1. Go to _Compute > Containers > Providers_
2. Add some provider if there is no one
3. Click on the provider in the list, display its details page
4. Choose _Policy > Edit Tags_
=> error!

---

**Before:**
![tag_before](https://user-images.githubusercontent.com/13417815/51049038-fe91f200-15cc-11e9-809f-3a39bf5b9ed0.png)

**After:**
![tag_after](https://user-images.githubusercontent.com/13417815/51048143-8296aa80-15ca-11e9-8979-bef6f79c4969.png)
Canceling editing tags:
![tag_cancel](https://user-images.githubusercontent.com/13417815/51048155-862a3180-15ca-11e9-81a1-06836418f294.png)

**Note:**
This PR also fixes tagging issue with Infra provider.

**Note 2:**
In this PR, I am just adding another value `default` for a condition while checking `@display` variable,
as it was missing there. See also `default_display` method https://github.com/ManageIQ/manageiq-ui-classic/blob/gaprindashvili/app/controllers/mixins/generic_show_mixin.rb#L106.
The problem was that `@display` was set to `dashboard` (while accessing Container provider details' page) so then the `feature_name` returned `dashboard_tag` instead of `ems_container_tag` in `tagging_edit` method https://github.com/ManageIQ/manageiq-ui-classic/pull/5154/files#diff-32a1920bfa43ecfb0853173babda0f8aR6, and that caused the issue.
