### PR TITLE
Display widget's title in full screen of widget result

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -491,6 +491,7 @@ class ApplicationController < ActionController::Base
     session[:rpt_task_id]      = nil    # Clear out report task id, using a saved report
 
     @report   = rr.report
+    @report_title = rr.friendly_title
     @html     = report_build_html_table(rr.report_results, rr.html_rows.join)
     @ght_type = params[:type] || (@report.graph.blank? ? 'tabular' : 'hybrid')
     @render_chart = (@ght_type == 'hybrid')

--- a/app/views/layouts/_show_report.html.haml
+++ b/app/views/layouts/_show_report.html.haml
@@ -2,6 +2,6 @@
   %h3= _("Choose a Report to view.")
 - else
   %fieldset
-    %h3= @report.title
+    %h3= @report_title
     = render :partial => "layouts/flash_msg"
     = render :partial => "shared/report_chart_and_html", :locals => {:html => @html, :chart => @render_chart, :report => @report}

--- a/app/views/layouts/report_only.html.haml
+++ b/app/views/layouts/report_only.html.haml
@@ -2,7 +2,7 @@
 %html.layout-pf.layout-pf-fixed.transitions{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
-      = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
+      = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report_title}
     = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'


### PR DESCRIPTION
backend

- [x] https://github.com/ManageIQ/manageiq/pull/18359

dashboard
<img width="1432" alt="screenshot 2019-01-14 at 22 09 42" src="https://user-images.githubusercontent.com/14937244/51141515-c8ad7180-1849-11e9-97b4-0352ce6e0615.png">

full screen

<img width="1420" alt="screenshot 2019-01-14 at 22 09 14" src="https://user-images.githubusercontent.com/14937244/51141555-e5e24000-1849-11e9-98dd-3bc67355eedd.png">



Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1650418

@miq-bot add_label pending backend, bug