### PR TITLE
Add Status Attribute to Cloud Volume Detail screen

### DIFF
--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -5,7 +5,7 @@ module CloudVolumeHelper::TextualSummary
   include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i(name size bootable description))
+    TextualGroup.new(_("Properties"), %i(name size bootable description status))
   end
 
   def textual_group_relationships
@@ -24,6 +24,10 @@ module CloudVolumeHelper::TextualSummary
 
   def textual_bootable
     @record.bootable.to_s
+  end
+
+  def textual_status
+    @record.status.to_s
   end
 
   def textual_parent_ems_cloud

--- a/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
@@ -10,5 +10,5 @@ describe CloudVolumeHelper::TextualSummary do
     attachments
     custom_button_events
   )
-  include_examples "textual_group", "Properties", %i(name size bootable description)
+  include_examples "textual_group", "Properties", %i(name size bootable description status)
 end


### PR DESCRIPTION
In list View there is displayed `Status` column for Cloud Volumes, but for the detail view of single Cloud Volume, there is no such thing.


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1650294

Steps for Testing/QA [Optional]
-------------------------------
Navigate to Storage => Block Storage => Volumes => <Select some Volume>

