### PR TITLE
Properly handle non-existent hash key

### DIFF
--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -191,7 +191,7 @@ class PxeController < ApplicationController
     presenter[:right_cell_text] = right_cell_text || @right_cell_text
 
     if !@view || @in_a_form ||
-       (@pages && (@items_per_page == ONE_MILLION || @pages[:items].zero?))
+       (@pages && (@items_per_page == ONE_MILLION || @pages[:items]&.zero?))
       if @in_a_form
         presenter.hide(:toolbar)
         # in case it was hidden for summary screen, and incase there were no records on show_list


### PR DESCRIPTION
Commit 635e85fa3a1cd2bc9ceeb8e7ca943d325aabb3e1 replaced @pages[:item] == 0 with @pages[:item].zero? on line 194 as suggested by Rubocop, but unfortunately those two snippets are not functionally equal if the @pages does not have an :items key.

This commit just ensures that the missing key scenario is properly handled.

@miq-bot assign @mzazrivec 