### PR TITLE
Dashboard (under Reports) - fix broken accordion_select; use @dashboard, not @db

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -198,9 +198,8 @@ class DashboardController < ApplicationController
   end
 
   def show
-    @layout    = "dashboard"
-    @dashboard = true
-    @display = "dashboard"
+    @layout     = "dashboard"
+    @display    = "dashboard"
     @lastaction = "show"
 
     records = current_group.ordered_widget_sets

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -677,7 +677,7 @@ class ReportController < ApplicationController
           @right_cell_text = if @edit[:new][:dashboard_order]
                                _("Editing Dashboard sequence for \"%{name}\"") % {:name => @sb[:group_desc]}
                              else
-                               @db.id ? _("Editing Dashboard \"%{name}\"") % {:name => @db.name} : _("Adding a new dashboard")
+                               @dashboard.id ? _("Editing Dashboard \"%{name}\"") % {:name => @dashboard.name} : _("Adding a new dashboard")
                              end
           # URL to be used in miqDropComplete method
           presenter[:miq_widget_dd_url] = "report/db_widget_dd_done"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -485,7 +485,7 @@ module ApplicationHelper
       :changed          => @changed,
       :condition        => @condition,
       :condition_policy => @condition_policy,
-      :db               => @db,
+      :dashboard        => @dashboard,
       :display          => @display,
       :edit             => @edit,
       :explorer         => @explorer,

--- a/app/helpers/application_helper/button/dashboard_delete.rb
+++ b/app/helpers/application_helper/button/dashboard_delete.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::DashboardDelete < ApplicationHelper::Button::Basic
   def disabled?
-    @error_message = _('Default Dashboard cannot be deleted') if @db.read_only
+    @error_message = _('Default Dashboard cannot be deleted') if @dashboard.read_only
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/dashboard_delete.rb
+++ b/app/helpers/application_helper/button/dashboard_delete.rb
@@ -1,4 +1,6 @@
 class ApplicationHelper::Button::DashboardDelete < ApplicationHelper::Button::Basic
+  needs :@dashboard
+
   def disabled?
     @error_message = _('Default Dashboard cannot be deleted') if @dashboard.read_only
     @error_message.present?

--- a/app/helpers/application_helper/button/dashboard_delete.rb
+++ b/app/helpers/application_helper/button/dashboard_delete.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::DbDelete < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::DashboardDelete < ApplicationHelper::Button::Basic
   def disabled?
     @error_message = _('Default Dashboard cannot be deleted') if @db.read_only
     @error_message.present?

--- a/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::MiqWidgetSetCenter < ApplicationHelper::Toolba
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Dashboard and ALL of its components will be permanently removed!"),
-          :klass     => ApplicationHelper::Button::DbDelete),
+          :klass     => ApplicationHelper::Button::DashboardDelete),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -319,7 +319,7 @@ class ApplicationHelper::ToolbarChooser
   def center_toolbar_filename_report
     if x_active_tree == :db_tree
       node = x_node
-      if %w(node xx-g).include?(node)
+      if %w(root xx-g).include?(node)
         return nil
       elsif node.split('-').length == 3
         return "miq_widget_sets_center_tb"

--- a/app/views/report/_db_form.html.haml
+++ b/app/views/report/_db_form.html.haml
@@ -1,4 +1,4 @@
-- url = url_for_only_path(:action => 'db_form_field_changed', :id => (@db.id || 'new'))
+- url = url_for_only_path(:action => 'db_form_field_changed', :id => (@dashboard.id || 'new'))
 #form_div
   = render :partial => "layouts/flash_msg"
   - read_only = @edit && @edit[:db_id] && @edit[:db_id] ? true : false

--- a/app/views/report/_db_list.html.haml
+++ b/app/views/report/_db_list.html.haml
@@ -53,7 +53,7 @@
                 = "#{h(ws.description)} (#{h(ws.name)})"
   - elsif ((@sb[:nodes].length == 4 && @sb[:nodes][1] == "g_g") || (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")) && !@in_a_form
     = render :partial => "layouts/flash_msg"
-    = render :partial => "db_show", :locals => {:widget => @db}
+    = render :partial => "db_show", :locals => {:widget => @dashboard}
   - elsif @in_a_form
     - if @edit[:new][:dashboard_order]
       = render :partial => "db_seq_form"

--- a/app/views/report/_db_widget_remove.html.haml
+++ b/app/views/report/_db_widget_remove.html.haml
@@ -1,7 +1,7 @@
 -#
   Parameters:
     widget      MiqWidget object
-= link_to({:controller => "report", :action => "db_widget_remove", :id => @db.id || 'new', :widget => widget.id},
+= link_to({:controller => "report", :action => "db_widget_remove", :id => @dashboard.id || 'new', :widget => widget.id},
   "data-miq_sparkle_on" => true,
   :remote               => true,
   "data-method"         => :post,

--- a/app/views/report/_db_widgets.html.haml
+++ b/app/views/report/_db_widgets.html.haml
@@ -3,7 +3,7 @@
   %h3
     = _('Sample Dashboard')
   - if @in_a_form
-    - combo_url = "/report/db_form_field_changed/#{@db.id || 'new'}"
+    - combo_url = "/report/db_form_field_changed/#{@dashboard.id || 'new'}"
     #form-group
       = select_tag('widget',
           options_for_select(@widgets_options, @edit[:new][:widget].to_s),

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -37,7 +37,7 @@ describe ReportController do
       end
 
       it 'establishes relations between MiqWidgetSet and MiqWidgets thru Relationship table' do
-        controller.instance_variable_set(:@db, miq_widget_set)
+        controller.instance_variable_set(:@dashboard, miq_widget_set)
 
         controller.send(:db_save_members)
 

--- a/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::DashboardDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:dashboard) { FactoryBot.create(:miq_widget_set, :read_only => read_only) }
-  let(:button) { described_class.new(view_context, {}, {'db' => dashboard}, {}) }
+  let(:button) { described_class.new(view_context, {}, {:dashboard => dashboard}, {}) }
 
   describe '#calculate_properties' do
     before { button.calculate_properties }
@@ -10,9 +10,21 @@ describe ApplicationHelper::Button::DashboardDelete do
       let(:read_only) { true }
       it_behaves_like 'a disabled button', 'Default Dashboard cannot be deleted'
     end
+
     context 'when dashboard is writable' do
       let(:read_only) { false }
       it_behaves_like 'an enabled button'
+    end
+  end
+
+  describe '#skipped?' do
+    context 'when dashboard is nil' do
+      let(:dashboard) { nil }
+      subject { button }
+
+      it "button is hidden" do
+        expect(subject.skipped?).to be_truthy
+      end
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
@@ -1,4 +1,4 @@
-describe ApplicationHelper::Button::DbDelete do
+describe ApplicationHelper::Button::DashboardDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:dashboard) { FactoryBot.create(:miq_widget_set, :read_only => read_only) }
   let(:button) { described_class.new(view_context, {}, {'db' => dashboard}, {}) }

--- a/spec/views/report/_db_widget_remove.html.haml_spec.rb
+++ b/spec/views/report/_db_widget_remove.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "report/_db_widget_remove.html.haml" do
   before do
     ws = FactoryBot.create(:miq_widget_set)
-    assign(:db, ws)
+    assign(:dashboard, ws)
   end
 
   it "correctly renders patternfly classes" do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5153

Go to CI > Reports > accordion Schedules
switch to accordion Dashboards (without going through schedules, I can't reproduce it consistently),
click on a dashboard

At some point, the right side will start rendering nonsense - for example "Choose a Schedule to view from the menus on the left." (even when we're in the dashboard accordion), and there will be an exception:

```
 FATAL -- : Error caught: [NoMethodError] undefined method `read_only' for nil:NilClass
```
(or possibly `Error caught: [NoMethodError] undefined method ``first' for nil:NilClass` but I can't reproduce that one)

That's caused by the toolbar button depending on `@db` being set to a specific dashboard instance, whcih is not true when the tree root is selected. And since the exception happens during accordion select, the UI thinks the accordion changed, but Rails still thinks it's on the old accordion after that.


So.. fixing by adding `needs :@dashboard` to the toolbar button, which should prevent it from throwing.

The rest of the PR is about making sure that `@db` doesn't get used for 2 entirely different things: we're primarily using `@db` to mean the GTL data model, and under Reports controller it meant two different things. Now, we use `@dashboard` instead, which was previously only assigned to, never used.

Cc @lpichler .. can you check this really fixes all the problems in https://github.com/ManageIQ/manageiq-ui-classic/issues/5153 for you please? :)