### PR TITLE
Add Ansible related inputs to GOD haml

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -70,23 +70,22 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     ];
 
     miqService.sparkleOn();
-    var dataPromise;
     var optionsPromise = API.options('/api/custom_buttons')
       .then(function(response) {
         _.forEach(response.data.custom_button_types, function(name, id) {
           vm.button_types.push({id: id, name: name});
         });
-        if (vm.customButtonRecordId) {
-          vm.newRecord = false;
-          miqService.sparkleOn();
-          dataPromise = API.get('/api/custom_buttons/' + vm.customButtonRecordId + '?attributes=resource_action,uri_attributes')
-            .then(getCustomButtonFormData)
-            .catch(miqService.handleFailure);
-        } else {
-          vm.newRecord = true;
-          vm.modelCopy = angular.copy( vm.customButtonModel );
-        }
       });
+    var dataPromise;
+    if (vm.customButtonRecordId) {
+      vm.newRecord = false;
+      dataPromise = API.get('/api/custom_buttons/' + vm.customButtonRecordId + '?attributes=resource_action,uri_attributes')
+        .then(getCustomButtonFormData)
+        .catch(miqService.handleFailure);
+    } else {
+      vm.newRecord = true;
+      vm.modelCopy = angular.copy( vm.customButtonModel );
+    }
 
     var serviceDialogsPromise = API.get('/api/service_dialogs?expand=resources&attributes=label')
       .then(function(response) {
@@ -114,10 +113,10 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
         vm.templates = response.data.templates;
       });
 
-    $q.all([optionsPromise, serviceDialogsPromise, rolesPromise, instancesPromise, dataPromise, serviceTemplateAnsiblePlaybooks])
+    $q.all([optionsPromise, dataPromise, serviceDialogsPromise, rolesPromise, instancesPromise, serviceTemplateAnsiblePlaybooks])
       .then(function() {
-          vm.afterGet = true;
-          miqService.sparkleOff();
+        vm.afterGet = true;
+        miqService.sparkleOff();
       })
       .catch(miqService.handleFailure);
   };
@@ -269,28 +268,28 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
 
     vm.customButtonModel.uri_attributes = response.uri_attributes;
 
-      if (vm.customButtonModel.current_visibility === 'role') {
-        _.forEach(vm.customButtonModel.available_roles, function(role, index) {
-          if (_.includes(response.visibility.roles, role.name)) {
-            vm.customButtonModel.available_roles[index].value = true;
-          }
-        });
-      }
+    if (vm.customButtonModel.current_visibility === 'role') {
+      _.forEach(vm.customButtonModel.available_roles, function(role, index) {
+        if (_.includes(response.visibility.roles, role.name)) {
+          vm.customButtonModel.available_roles[index].value = true;
+        }
+      });
+    }
 
-      delete vm.customButtonModel.resource_action.ae_attributes.request;
-      vm.customButtonModel.noOfAttributeValueRows = assignObjectToKeyValueArrays(
-        vm.customButtonModel.resource_action.ae_attributes,
-        vm.customButtonModel.attribute_names,
-        vm.customButtonModel.attribute_values);
+    delete vm.customButtonModel.resource_action.ae_attributes.request;
+    vm.customButtonModel.noOfAttributeValueRows = assignObjectToKeyValueArrays(
+      vm.customButtonModel.resource_action.ae_attributes,
+      vm.customButtonModel.attribute_names,
+      vm.customButtonModel.attribute_values);
 
-      if(vm.customButtonModel.uri_attributes.hosts == undefined || vm.customButtonModel.uri_attributes.hosts === "localhost" || vm.customButtonModel.uri_attributes.hosts == null) {
-        vm.inventory = "localhost";
-      } else if(vm.customButtonModel.uri_attributes.hosts === "vmdb_object"){
-        vm.inventory = "vmdb_object";
-      } else {
-        vm.inventory = "manual";
-      }
-      vm.modelCopy = angular.element.extend(true, {}, vm.customButtonModel);
+    if (!vm.customButtonModel.uri_attributes.hosts || vm.customButtonModel.uri_attributes.hosts === "localhost") {
+      vm.inventory = "localhost";
+    } else if (vm.customButtonModel.uri_attributes.hosts === "vmdb_object") {
+      vm.inventory = "vmdb_object";
+    } else {
+      vm.inventory = "manual";
+    }
+    vm.modelCopy = angular.element.extend(true, {}, vm.customButtonModel);
   }
 
   function assignAllObjectsToKeyValueArrays(purge) {

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -88,38 +88,35 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
           vm.newRecord = true;
           vm.modelCopy = angular.copy( vm.customButtonModel );
         }
-      })
-      .catch(miqService.handleFailure);
+      });
 
     var serviceDialogsPromise = API.get('/api/service_dialogs?expand=resources&attributes=label')
       .then(function(response) {
         _.forEach(response.resources, function(item) {
           vm.dialogs.push({id: item.id, label: item.label});
         });
-      })
-      .catch(miqService.handleFailure);
+      });
 
     var rolesPromise = API.get('/api/roles?expand=resources&attributes=name')
       .then(function(response) {
         _.forEach(response.resources, function(item) {
           vm.customButtonModel.available_roles.push({name: item.name, value: false});
         });
-      })
-      .catch(miqService.handleFailure);
+      });
 
     var instancesPromise = $http.get('/generic_object_definition/retrieve_distinct_instances_across_domains')
       .then(function(response) {
         _.forEach(response.data.distinct_instances_across_domains, function(item) {
           vm.ae_instances.push({id: item, name: item});
         });
-      })
-      .catch(miqService.handleFailure);
+      });
 
     $q.all([optionsPromise, serviceDialogsPromise, rolesPromise, instancesPromise, dataPromise])
       .then(function() {
           vm.afterGet = true;
           miqService.sparkleOff();
-      });
+      })
+      .catch(miqService.handleFailure);;
   };
 
   vm.cancelClicked = function() {

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -206,6 +206,10 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
         return role.value === true;
       }), 'name');
     }
+    // set uri_attributes to default for non-Ansible button
+    if (vm.customButtonModel.button_type == "default") {
+      vm.customButtonModel.uri_attributes = {"request": "", service_template: null, hosts: null};
+    };
 
     vm.customButtonModel.visibility = {
       roles: vm.customButtonModel.roles.length === 0 ? ['_ALL_'] : vm.customButtonModel.roles,
@@ -219,6 +223,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       options: vm.customButtonModel.options,
       resource_action: vm.customButtonModel.resource_action,
       visibility: vm.customButtonModel.visibility,
+      uri_attributes: vm.customButtonModel.uri_attributes,
     };
   };
 

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -135,7 +135,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def service_template_ansible_playbooks
-    templates = ServiceTemplateAnsiblePlaybook.order(:name).map{ |item| {:name => item.name, :id => item.id} } || []
+    templates = ServiceTemplateAnsiblePlaybook.order(:name).map { |item| {:name => item.name, :id => item.id} } || []
     render :json => {:templates => templates}
   end
 

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -134,6 +134,11 @@ class GenericObjectDefinitionController < ApplicationController
     render :json => {:distinct_instances_across_domains => distinct_instances_across_domains}
   end
 
+  def service_template_ansible_playbooks
+    templates = ServiceTemplateAnsiblePlaybook.order(:name).map{ |item| {:name => item.name, :id => item.id} } || []
+    render :json => {:templates => templates}
+  end
+
   def add_button_in_group
     custom_button_set = CustomButtonSet.find(params[:id])
     custom_button_set.set_data[:button_order] ||= []

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -22,33 +22,33 @@
         = _("Required")
   .form-group{"ng-if"    => "vm.customButtonModel.button_type == 'ansible_playbook'",
               "ng-class" => "{'has-error': angularForm.playbook_catalog_item.$invalid}"}
-    #form_playbook_options
-      %label.control-label.col-md-2
-        = _("Playbook Catalog Item")
-      .col-md-8
-        %select{"name"                        => "playbook_catalog_item",
-                "ng-model"                    => "vm.customButtonModel.uri_attributes.service_template",
-                "ng-options"                  => "item.id as item.name for item in vm.templates",
-                "data-live-search"            => "true",
-                "selectpicker-for-select-tag" => "",
-                :required                     => true,
-                "miq-select"                  => true,}
-          %option{"value" => "", "disabled" => ""}
-            = "<#{_('Choose')}>"
-        %span.help-block{"ng-show" => "angularForm.playbook_catalog_item.$error.required"}
-          = _("Required")
+    %label.control-label.col-md-2
+      = _("Playbook Catalog Item")
+    .col-md-8
+      %select{"name"                        => "playbook_catalog_item",
+              "ng-model"                    => "vm.customButtonModel.uri_attributes.service_template",
+              "ng-options"                  => "item.id as item.name for item in vm.templates",
+              "data-live-search"            => "true",
+              "selectpicker-for-select-tag" => "",
+              :required                     => true,
+              "miq-select"                  => true,}
+        %option{"value" => "", "disabled" => ""}
+          = "<#{_('Choose')}>"
+      %span.help-block{"ng-show" => "angularForm.playbook_catalog_item.$error.required"}
+        = _("Required")
   .form-group{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
     %label.control-label.col-md-2
       = _("Inventory")
     .col-md-8
-      %input{:type => "radio", :id => "inventory_localhost", :value => "localhost", 'ng-model' => 'vm.inventory'}
+      %input{:name => "inventory", :type => "radio", :id => "inventory_localhost", :value => "localhost", 'ng-model' => 'vm.inventory'}
       = label_tag('inventory_localhost', _("Localhost"), "title" => _('Run on localhost'))
       %br
-      %input{:type => "radio", :id => "inventory_localhost", :value => "event_target", 'ng-model' =>  "vm.inventory"}
+      %input{:name => "inventory", :type => "radio", :id => "inventory_event_target", :value => "event_target", 'ng-model' =>  "vm.inventory"}
       = label_tag('inventory_event_target', _("Target Machine"), "title" => _('Run on the target of the Policy Event'))
       %br
-      %input{:type => "radio", :id => "manual", :value => "manual", 'ng-model' =>  "vm.inventory"}
-      = label_tag(_("Specific Hosts"))
+      %input{:name => "inventory",
+      :type => "radio", :id => "inventory_manual", :value => "manual", 'ng-model' =>  "vm.inventory"}
+      = label_tag('inventory_manual', _("Specific Hosts"))
       #manual_inventory_div{'ng-if' => "vm.inventory === 'manual'"}
         .form-group
           .col-md-8

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -20,44 +20,35 @@
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.button_type.$error.required"}
         = _("Required")
-  .form-group
-    #form_playbook_options{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
+  .form-group{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
+    #form_playbook_options
       %label.control-label.col-md-2
         = _("Playbook Catalog Item")
       .col-md-8
         %select{"name"                        => "playbook_catalog_item",
-               "ng-model"                    => "vm.customButtonModel.playbook",
-               "ng-options"                  => "item.id as item.label for item in vm.playbook_catalog_items",
-               "data-live-search"            => "true",
-               "selectpicker-for-select-tag" => "",
-               "miq-select"                  => true,}
+                "ng-model"                    => "vm.customButtonModel.uri_attributes.service_template",
+                "ng-options"                  => "item.id as item.name for item in vm.templates",
+                "data-live-search"            => "true",
+                "selectpicker-for-select-tag" => "",
+                "miq-select"                  => true,}
           %option{"value" => "", "disabled" => ""}
             = "<#{_('Choose')}>"
-  .form-group
+  .form-group{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
     %label.control-label.col-md-2
       = _("Inventory")
     .col-md-8
-      = radio_button_tag('inventory', "localhost", true,
-        "title"            => _('Run on localhost'),
-        )
+      %input{:type => "radio", :id => "inventory_localhost", :value => "localhost", 'ng-model' => 'vm.inventory'}
       = label_tag('inventory_localhost', _("Localhost"), "title" => _('Run on localhost'))
       %br
-      = radio_button_tag('inventory', "event_target", false,
-        "title"            => _('Run on the target of the Policy Event'),
-        )
+      %input{:type => "radio", :id => "inventory_localhost", :value => "event_target", 'ng-model' =>  "vm.inventory"}
       = label_tag('inventory_event_target', _("Target Machine"), "title" => _('Run on the target of the Policy Event'))
       %br
-      = radio_button_tag('inventory', "manual", false,
-        "title" => _('Enter a comma separated list of IP or DNS names'),
-        )
+      %input{:type => "radio", :id => "manual", :value => "manual", 'ng-model' =>  "vm.inventory"}
       = label_tag(_("Specific Hosts"))
-      #manual_inventory_div
+      #manual_inventory_div{'ng-if' => "vm.inventory === 'manual'"}
         .form-group
           .col-md-8
-            = text_field_tag("hosts",
-            nil,
-            :maxlength         => ViewHelper::MAX_DESC_LEN,
-            :class             => "form-control")
+            %input{:type => 'text', :maxlength => ViewHelper::MAX_DESC_LEN, "ng-model" => "vm.customButtonModel.uri_attributes.hosts", :class => 'form-control'}
             = _('Enter a comma separated list of IP or DNS names')
   %custom-button-group-form{"model"        => "vm.customButtonModel",
                             "angular-form" => "angularForm"}

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -20,7 +20,8 @@
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.button_type.$error.required"}
         = _("Required")
-  .form-group{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
+  .form-group{"ng-if"    => "vm.customButtonModel.button_type == 'ansible_playbook'",
+              "ng-class" => "{'has-error': angularForm.playbook_catalog_item.$invalid}"}
     #form_playbook_options
       %label.control-label.col-md-2
         = _("Playbook Catalog Item")
@@ -30,9 +31,12 @@
                 "ng-options"                  => "item.id as item.name for item in vm.templates",
                 "data-live-search"            => "true",
                 "selectpicker-for-select-tag" => "",
+                :required                     => true,
                 "miq-select"                  => true,}
           %option{"value" => "", "disabled" => ""}
             = "<#{_('Choose')}>"
+        %span.help-block{"ng-show" => "angularForm.playbook_catalog_item.$error.required"}
+          = _("Required")
   .form-group{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
     %label.control-label.col-md-2
       = _("Inventory")

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -20,6 +20,45 @@
           = "<#{_('Choose')}>"
       %span.help-block{"ng-show" => "angularForm.button_type.$error.required"}
         = _("Required")
+  .form-group
+    #form_playbook_options{"ng-if" => "vm.customButtonModel.button_type == 'ansible_playbook'"}
+      %label.control-label.col-md-2
+        = _("Playbook Catalog Item")
+      .col-md-8
+        %select{"name"                        => "playbook_catalog_item",
+               "ng-model"                    => "vm.customButtonModel.playbook",
+               "ng-options"                  => "item.id as item.label for item in vm.playbook_catalog_items",
+               "data-live-search"            => "true",
+               "selectpicker-for-select-tag" => "",
+               "miq-select"                  => true,}
+          %option{"value" => "", "disabled" => ""}
+            = "<#{_('Choose')}>"
+  .form-group
+    %label.control-label.col-md-2
+      = _("Inventory")
+    .col-md-8
+      = radio_button_tag('inventory', "localhost", true,
+        "title"            => _('Run on localhost'),
+        )
+      = label_tag('inventory_localhost', _("Localhost"), "title" => _('Run on localhost'))
+      %br
+      = radio_button_tag('inventory', "event_target", false,
+        "title"            => _('Run on the target of the Policy Event'),
+        )
+      = label_tag('inventory_event_target', _("Target Machine"), "title" => _('Run on the target of the Policy Event'))
+      %br
+      = radio_button_tag('inventory', "manual", false,
+        "title" => _('Enter a comma separated list of IP or DNS names'),
+        )
+      = label_tag(_("Specific Hosts"))
+      #manual_inventory_div
+        .form-group
+          .col-md-8
+            = text_field_tag("hosts",
+            nil,
+            :maxlength         => ViewHelper::MAX_DESC_LEN,
+            :class             => "form-control")
+            = _('Enter a comma separated list of IP or DNS names')
   %custom-button-group-form{"model"        => "vm.customButtonModel",
                             "angular-form" => "angularForm"}
   .form-group{"ng-class" => "{'has-error': angularForm.dialog.$invalid}"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1981,6 +1981,7 @@ Rails.application.routes.draw do
         edit
         new
         retrieve_distinct_instances_across_domains
+        service_template_ansible_playbooks
         show
         show_list
         tagging_edit

--- a/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
+++ b/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
@@ -17,7 +17,13 @@ describe('main-custom-button-form', function() {
         distinct_instances_across_domains: ["Automation", "Event", "GenericObject", "MiqEvent", "Request", "parse_automation_request", "parse_event_stream", "parse_provider_category"]
       }
     };
+    var serviceTemplatesResponse = {
+      data: {
+        templates: [{name: "Ansible Catalog Item", id: 0}],
+      }
+    };
     $httpBackend.whenGET('/generic_object_definition/retrieve_distinct_instances_across_domains').respond(domainsResponse);
+    $httpBackend.whenGET('/generic_object_definition/service_template_ansible_playbooks').respond(serviceTemplatesResponse);
     vm.$onInit();
     $httpBackend.flush();
   }));


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650559

Go to Automation -> Automate -> Generic Object -> create or edit a button -> select Button type to be Ansible Playbook

Depends on https://github.com/ManageIQ/manageiq/pull/18379

Before:
![image](https://user-images.githubusercontent.com/9210860/51310917-024bcb80-1a48-11e9-8196-65066f6fb5fd.png)

After:
![image](https://user-images.githubusercontent.com/9210860/51310922-05df5280-1a48-11e9-82d8-b5867e38bee7.png)

Ansible Catalog Item is required!

@miq-bot add_label wip, bug, hammer/yes, gaprindashvili/yes, generic objects, automation/
automate