### PR TITLE
Add the information about the volumes of Cloud provider

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -17,7 +17,7 @@ module EmsCloudHelper::TextualSummary
       _("Relationships"),
       %i(
         ems_infra network_manager availability_zones host_aggregates cloud_tenants flavors
-        security_groups instances images orchestration_stacks storage_managers custom_button_events
+        security_groups instances images cloud_volumes orchestration_stacks storage_managers custom_button_events
       )
     )
   end
@@ -93,6 +93,16 @@ module EmsCloudHelper::TextualSummary
     if num.positive? && role_allows?(:feature => "miq_template_show_list")
       h[:link] = ems_cloud_path(@record.id, :display => 'images')
       h[:title] = _("Show all Images")
+    end
+    h
+  end
+
+  def textual_cloud_volumes
+    num = @record.number_of(:cloud_volumes)
+    h = {:label => _('Cloud Volumes'), :icon => "pficon pficon-volume", :value => num}
+    if num.positive? && role_allows?(:feature => "cloud_volume_show_list")
+      h[:link] = ems_cloud_path(@record.id, :display => 'cloud_volumes')
+      h[:title] = _("Show Cloud Volumes")
     end
     h
   end

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -42,6 +42,7 @@ describe EmsCloudHelper::TextualSummary do
       security_groups
       instances
       images
+      cloud_volumes
       orchestration_stacks
       storage_managers
       custom_button_events


### PR DESCRIPTION
PR adds the information about the volumes of the Cloud provider in its summary view.

https://bugzilla.redhat.com/show_bug.cgi?id=1662888

![screenshot from 2019-01-18 19-20-00](https://user-images.githubusercontent.com/26881797/51405257-2564a100-1b56-11e9-8f94-927c3305abe1.png)

@aufi 
@himdel 