### PR TITLE
[GAPRINDASHVILI] [WIP] Change datastores to data_stores

### DIFF
--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -297,7 +297,7 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Storage, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "storage", "datastores", "/storage/explorer"
+                       "storage", "data_stores", "/storage/explorer"
     end
 
     context "when the object is a Template" do


### PR DESCRIPTION
Fix for change from https://github.com/ManageIQ/manageiq-ui-classic/pull/3893

Failure:
```
 1) DialogLocalService#determine_dialog_locals_for_custom_button when the object is a Storage returns a hash with the proper parameters
     Failure/Error:
       expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action, display_options))
         .to eq(
           :resource_action_id     => 321,
           :target_id              => 123,
           :target_type            => target_type,
           :dialog_id              => 654,
           :force_old_dialog_use   => false,
           :api_submit_endpoint    => "/api/#{collection_name}/123",
           :api_action             => "custom-button-name",
           :finish_submit_endpoint => finish_endpoint,
       expected: {:resource_action_id=>321, :target_id=>123, :target_type=>"storage", :dialog_id=>654, :force_old_dial...inish_submit_endpoint=>"/storage/explorer", :cancel_endpoint=>"/storage/explorer", :open_url=>false}
            got: {:force_old_dialog_use=>false, :resource_action_id=>321, :target_id=>123, :target_type=>"storage", :d...inish_submit_endpoint=>"/storage/explorer", :cancel_endpoint=>"/storage/explorer", :open_url=>false}
       (compared using ==)
       Diff:
       @@ -1,5 +1,5 @@
        :api_action => "custom-button-name",
       -:api_submit_endpoint => "/api/datastores/123",
       +:api_submit_endpoint => "/api/data_stores/123",
        :cancel_endpoint => "/storage/explorer",
        :dialog_id => 654,
        :finish_submit_endpoint => "/storage/explorer",
     Shared Example Group: "DialogLocalService#determine_dialog_locals_for_custom_button return value" called from ./spec/services/dialog_local_service_spec.rb:299
     # ./spec/services/dialog_local_service_spec.rb:50:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:73:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:35:in `clear_caches'
     # ./spec/spec_helper.rb:73:in `block (2 levels) in <top (required)>'
```
@miq-bot add_label wip