### PR TITLE
rake yarn:clobber - an easy way to remove node_modules & yarn.lock from all engines

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -126,10 +126,20 @@ if Rake::Task.task_defined?("assets:clobber")
   end
 end
 
-# yarn:install is a rails 5.1 task, webpacker:compile needs it
 namespace :yarn do
+  # yarn:install is a rails 5.1 task, webpacker:compile needs it
   task :install do
     puts 'yarn:install called, not doing anything'
+  end
+
+  # useful right after upgrading node
+  task :clobber do
+    puts 'Removing yarn.lock and node_modules in...'
+    asset_engines.each do |engine|
+      puts "  #{engine.name} (#{engine.path})"
+      FileUtils.rm_rf(engine.path.join('node_modules'))
+      FileUtils.rm_rf(engine.path.join('yarn.lock'))
+    end
   end
 end
 


### PR DESCRIPTION
Example run:

```
$ rake yarn:clobber

Removing yarn.lock and node_modules in...
  ManageIQ::GraphQL::Engine (/home/himdel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/manageiq-graphql-82fdd9385bdd)
  ManageIQ::Providers::Lenovo::Engine (/home/himdel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/manageiq-providers-lenovo-10d8f40ba15c)
  ManageIQ::Providers::Nuage::Engine (/home/himdel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/manageiq-providers-nuage-ee21a2e6e9e2)
  ManageIQ::UI::Classic::Engine (/home/himdel/manageiq-ui-classic)
  ManageIQ::V2V::Engine (/home/himdel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/manageiq-v2v-dad48b06c823)
```

Useful after upgrading node, or just generally when it breaks :).

Cc @jerryk55 