### PR TITLE
Fixed check in if condition

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -174,7 +174,9 @@ module ApplicationController::Filter
               self.exp_key = nil
             else
               # for date time fields we should show After/Before etc. options
-              if exp_model != '_display_filter_' && MiqExpression::Field.parse(exp_field).plural? && ![:date, :datetime].include?(self[:val1][:type])
+              if exp_model != '_display_filter_' &&
+                 MiqExpression::Field.parse(exp_field).plural? &&
+                 !%i(date datetime).include?(MiqExpression.get_col_type(params[:chosen_field]))
                 self.exp_key = 'CONTAINS' # CONTAINS is valid only for plural tables
               else
                 self.exp_key = nil unless MiqExpression.get_col_operators(exp_field).include?(exp_key)

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -39,4 +39,32 @@ describe ApplicationController::Filter do
       ]
     end
   end
+
+  describe ReportController do
+    let(:expression) do
+      ApplicationController::Filter::Expression.new.tap do |e|
+        e.exp_model  = 'PolicyEvent'
+        e.exp_typ    = 'field'
+        e.exp_key    = 'BEFORE'
+        e.expression = {"BEFORE" => {"field" => "PolicyEvent.miq_actions-created_on", "value" => "Today"}}
+      end
+    end
+
+    context '#update_from_expression_editor' do
+      it "resets value of exp_key based upon type of field selected" do
+        edit = {:record_filter => expression}
+        edit[:new] = {:record_filter => {:test => "foo", :token => 1}}
+        session[:edit] = edit
+        controller.instance_variable_set(:@expkey, :record_filter)
+        controller.instance_variable_set(:@_params, :chosen_field => "PolicyEvent-chain_id")
+        expect(controller).to receive(:render)
+        controller.send(:exp_changed)
+        expect(expression.exp_key).to eq('=')
+        controller.instance_variable_set(:@_params, :chosen_field => "PolicyEvent.miq_actions-created_on")
+        expect(controller).to receive(:render)
+        controller.send(:exp_changed)
+        expect(expression.exp_key).to eq('IS')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previous change was still forcing exp_key to be limited to "CONTAINS" for date type fields when switching fields because value of `self[:val1][:type]` is updated after changed code block in `prefill_val_types` method. Fixed a change made in https://github.com/ManageIQ/manageiq-ui-classic/pull/3879 with a call to backend method to return the type of field based upon selected column

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1563823

before
![before1](https://user-images.githubusercontent.com/3450808/51496302-43681680-1d8d-11e9-8794-8cab75f7ae46.png)

![before2](https://user-images.githubusercontent.com/3450808/51496304-46630700-1d8d-11e9-8913-1c4d8b2bc7e4.png)

after
![after1](https://user-images.githubusercontent.com/3450808/51496265-13b90e80-1d8d-11e9-92ff-d460abe9e667.png)

![after2](https://user-images.githubusercontent.com/3450808/51496269-161b6880-1d8d-11e9-93da-3454ba235bc9.png)

@mzazrivec please review/test