### PR TITLE
Allow `blob:` type in img-src CSP for WebMKS remote consoles

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -43,7 +43,7 @@ module VmRemote
   end
 
   def launch_html5_console
-    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: 'self'))
+    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin], :img_src => %w(data: blob: 'self'))
     %i(secret url proto).each { |p| params.require(p) }
 
     proto = j(params[:proto]).sub(/\-.*$/, '') # -suffix should be omitted from the protocol name


### PR DESCRIPTION
Somehow the CSP implementation in MS Edge forbids images coming from WebMKS remote consoles due policy violation. By adding the `blob:` to the `img-src` this works as in other browsers.

@miq-bot add_label providers/console, bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1668437