### PR TITLE
Fixed display of worker memory threshold settings

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -989,12 +989,12 @@ module OpsController::Settings::Common
       @sb[:threshold] << [number_to_human_size(x, :significant => false), x]
     end
     (600.megabytes...1000.megabytes).step(100.megabytes) do |x|
-      # adding values in 100 MB increments from 600 to 1gb, dividing in two statements else it p     uts 1000MB instead of 1GB in pulldown
+      # adding values in 100 MB increments from 600 to 1gb, dividing in two statements else it puts 1000MB instead of 1GB in pulldown
       @sb[:threshold] << [number_to_human_size(x, :significant => false), x]
     end
     (1.gigabytes...1.5.gigabytes).step(100.megabytes) do |x|
       # adding values in 100 MB increments from 1gb to 1.5 gb
-      @sb[:threshold] << [number_to_human_size(x, :significant => false), x]
+      @sb[:threshold] << [number_to_human_size(x, :significant => false), x.to_i]
     end
 
     cwb = @edit[:current][:workers][:worker_base] ||= {}
@@ -1082,7 +1082,7 @@ module OpsController::Settings::Common
 
   private def get_worker_setting(config, klass, *setting)
     settings = klass.worker_settings(:config => config, :raw => true)
-    setting.empty? ? settings : settings.fetch_path(setting)
+    setting.empty? ? settings : settings.fetch_path(setting).to_i_with_method
   end
 
   def settings_set_form_vars_logos

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -438,5 +438,42 @@ describe OpsController do
         end
       end
     end
+
+    describe '#settings_set_form_vars_workers' do
+      context "set worker settings for selected server" do
+        before do
+          @miq_server = FactoryBot.create(:miq_server)
+          controller.instance_variable_set(:@sb,
+                                           :selected_server_id => @miq_server.id)
+        end
+
+        it "gets worker setting in same format as in sandbox threshold array so correct value is selected in drop down" do
+          controller.send(:settings_set_form_vars_workers)
+          ui_worker_threshold = controller.send(:get_worker_setting, assigns(:edit)[:current], MiqUiWorker, :memory_threshold)
+          Hash[*assigns(:sb)[:threshold].flatten].each_value do |v|
+            expect(v.class).to eq(ui_worker_threshold.class)
+          end
+        end
+
+        it "converts '600.megabytes' string correctly to bytes" do
+          Vmdb::Settings.save!(
+            @miq_server,
+            :workers => {
+              :worker_base => {
+                :ui_worker => {
+                  :memory_threshold => "600.megabytes",
+                  :count            => 2
+                }
+              }
+            }
+          )
+          controller.send(:settings_set_form_vars_workers)
+          ui_worker_threshold = controller.send(:get_worker_setting, assigns(:edit)[:current], MiqUiWorker, :memory_threshold)
+          ui_worker_count = controller.send(:get_worker_setting, assigns(:edit)[:current], MiqUiWorker, :count)
+          expect(ui_worker_threshold).to eq(600.megabytes)
+          expect(ui_worker_count).to eq(2)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixed couple of scenarios
- Worker memory threshold of 1 GB or above was not reflected on Workers tab because https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/settings/common.rb#L997 value of variable `x` needs to be converted to integer value from a float so value can be selected correctly in the drop down.
- If a value in yaml config file is set to as 600.megabytes, it is being returned as a string, so need to evaluate/convert the value so it can be correctly selected in the drop down.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656873
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658373

before
![before](https://user-images.githubusercontent.com/3450808/51644670-ff1c7800-1f3e-11e9-9e21-7aa962268d3b.png)

after
![after](https://user-images.githubusercontent.com/3450808/51644517-6a197f00-1f3e-11e9-9f45-30db2b4062d3.png)

@mzazrivec please review/test, in order to recreate, change Advanced config YAML and enter follwoing in there

```
    :generic_worker:
        :count: 2
        :memory_threshold: 1073741824
      :priority_worker:
        :memory_threshold: 600.megabytes
```
Let me know if you need help recreating.