### PR TITLE
Fix displaying selected dashboard while clicking on its tab

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -205,9 +205,9 @@ class DashboardController < ApplicationController
     records = current_group.ordered_widget_sets
 
     @tabs = []
-    active_tab_id = (params[:tab] || @sb[:active_db_id]).try(:to_s)
+    active_tab_id = (params['uib-tab'] || @sb[:active_db_id]).try(:to_s)
     active_tab = active_tab_id && records.detect { |r| r.id.to_s == active_tab_id } || records.first
-    # load first one on intial load, or load tab from params[:tab] changed,
+    # load first one on intial load, or load tab from params['uib-tab'] changed,
     # or when coming back from another screen load active tab from sandbox
     if active_tab
       @active_tab = active_tab.id.to_s

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,12 +1,8 @@
 describe DashboardController do
   context "POST authenticate" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+    before { EvmSpecHelper.create_guid_miq_server_zone }
 
-    let(:user_with_role) do
-      FactoryBot.create(:user, :role => "random")
-    end
+    let(:user_with_role) { FactoryBot.create(:user, :role => "random") }
 
     it "has secure headers" do
       get :index
@@ -93,9 +89,7 @@ describe DashboardController do
   end
 
   context "SAML and OIDC support" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+    before { EvmSpecHelper.create_guid_miq_server_zone }
 
     %i(saml oidc).each do |protocol|
       it "#{protocol.upcase} login should redirect to the protected page" do
@@ -137,10 +131,8 @@ describe DashboardController do
 
   # would like to test these controller by calling authenticate
   # need to ensure all cases are handled before deleting these
-  context "#validate_user" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+  describe "#validate_user" do
+    before { EvmSpecHelper.create_guid_miq_server_zone }
 
     it "returns flash message when user's group is missing" do
       user = FactoryBot.create(:user)
@@ -190,7 +182,7 @@ describe DashboardController do
     it "dashboard show" do
       # create dashboard for a group
       ws = FactoryBot.create(:miq_widget_set, :name     => "default",
-                                               :set_data => {:last_group_db_updated => Time.now.utc,
+                                              :set_data => {:last_group_db_updated => Time.now.utc,
                               :col1 => [1], :col2 => [], :col3 => []})
 
       ur = FactoryBot.create(:miq_user_role)
@@ -202,8 +194,8 @@ describe DashboardController do
       login_as user
       # create a user's dashboard using group dashboard name.
       FactoryBot.create(:miq_widget_set,
-                         :name     => "#{user.userid}|#{group.id}|#{ws.name}",
-                         :set_data => {:last_group_db_updated => Time.now.utc, :col1 => [1], :col2 => [], :col3 => []})
+                        :name     => "#{user.userid}|#{group.id}|#{ws.name}",
+                        :set_data => {:last_group_db_updated => Time.now.utc, :col1 => [1], :col2 => [], :col3 => []})
       controller.show
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
@@ -214,10 +206,10 @@ describe DashboardController do
       user = FactoryBot.create(:user, :miq_groups => [group])
       wi = FactoryBot.create(:miq_widget)
       ws = FactoryBot.create(:miq_widget_set, :name     => "default",
-                                               :set_data => {:last_group_db_updated => Time.now.utc,
+                                              :set_data => {:last_group_db_updated => Time.now.utc,
                                                              :col1 => [], :col2 => [], :col3 => []},
-                                               :userid   => user.userid,
-                                               :group_id => group.id)
+                                              :userid   => user.userid,
+                                              :group_id => group.id)
       session[:sandboxes] = {"dashboard" => {:active_db  => ws.name,
                                              :dashboards => {ws.name => {:col1 => [], :col2 => [], :col3 => []}}}}
       login_as user
@@ -270,7 +262,7 @@ describe DashboardController do
     end
   end
 
-  context "#start_url_for_user" do
+  describe "#start_url_for_user" do
     before do
       MiqShortcut.seed
       allow(controller).to receive(:check_privileges).and_return(true)
@@ -339,11 +331,12 @@ describe DashboardController do
     end
   end
 
-  context "#maintab" do
+  describe "#maintab" do
     before do
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
       allow(controller).to receive(:check_privileges).and_return(true)
     end
+
     it "redirects a restful link correctly" do
       ems_cloud_amz = FactoryBot.create(:ems_amazon)
       breadcrumbs = [{:name => "Name", :url => "/controller/action"}]
@@ -355,7 +348,7 @@ describe DashboardController do
     end
   end
 
-  context "#session_reset" do
+  describe "#session_reset" do
     it "verify certain keys are restored after session is cleared" do
       user_TZO           = '5'
       browser_info       = {:name => 'firefox', :version => '32'}
@@ -372,15 +365,13 @@ describe DashboardController do
     end
   end
 
-  describe "building tabs" do
+  context "building tabs" do
     let(:group) do
       role = FactoryBot.create(:miq_user_role)
       FactoryBot.create(:miq_group, :miq_user_role => role)
     end
 
-    let(:user) do
-      FactoryBot.create(:user, :miq_groups => [group])
-    end
+    let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
 
     let(:wset) do
       FactoryBot.create(
@@ -453,9 +444,9 @@ describe DashboardController do
   end
 
   describe 'private #load_dialog_definition' do
-    let (:klass) { 'Foobar' }
-    let (:name) { 'existing_dialog' }
-    let (:dialog_path) { Pathname.new("/dialogs/#{name}.json") }
+    let(:klass) { 'Foobar' }
+    let(:name) { 'existing_dialog' }
+    let(:dialog_path) { Pathname.new("/dialogs/#{name}.json") }
 
     before do
       plug = double('Plugin')
@@ -507,6 +498,40 @@ describe DashboardController do
       request.headers['X-Remote-User'] = 'foo@bar'
       controller.send(:authenticate_external_user)
       expect(assigns(:user_name)).to eq('foo')
+    end
+  end
+
+  describe '#show' do
+    context 'changing tabs' do
+      let(:group) { FactoryBot.create(:miq_group) }
+      let(:user) { FactoryBot.create(:user_admin, :current_group => group, :miq_groups => [group]) }
+      let(:ws1) do
+        FactoryBot.create(:miq_widget_set,
+                          :name     => 'A',
+                          :owner_id => group.id,
+                          :set_data => {:col1 => [], :col2 => [], :col3 => []})
+      end
+      let(:ws2) do
+        FactoryBot.create(:miq_widget_set,
+                          :name     => 'B',
+                          :owner_id => group.id,
+                          :set_data => {:col1 => [], :col2 => [], :col3 => []})
+      end
+
+      before do
+        login_as user
+        controller.instance_variable_set(:@_params, 'uib-tab' => ws2.id.to_s)
+        controller.instance_variable_set(:@sb, {})
+        controller.instance_variable_set(:@current_user, user)
+        group.update_attributes(:settings => { :dashboard_order => [ws1.id.to_s, ws2.id.to_s] })
+      end
+
+      it 'sets id of selected tab properly' do
+        controller.send(:show)
+        expect(controller.instance_variable_get(:@sb)[:active_db]).to eq(ws2.name)
+        expect(controller.instance_variable_get(:@sb)[:active_db_id]).to eq(ws2.id)
+        expect(controller.instance_variable_get(:@active_tab)).to eq(ws2.id.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
**Fixes:**
 https://bugzilla.redhat.com/show_bug.cgi?id=1666712

**What:**
Fix displaying the dashboard, in _Cloud Intel > Dashboards_.

**Steps to reproduce:**
1. Create at least 2 dashboards in the _EvmGroup-super_administrator_ group:
    go to _Cloud Intel > Reports > Dashboards_ accordion,
    click on the _EvmGroup-super_administrator_ group,
    then _Configuration > Add a new Dashboard_
2. Go to _Cloud Intel > Dashboard_ and you should see dashboards from step 1
3. Click on another tab/Choose some another dashboard
=> nothing happens, the original dashboard remains displayed, the other one not, no errors in log

---

**Before:** (after clicking on another tab _New_dashboard2_, nothing happens, we still see _New_dashboard_)
![dash_before](https://user-images.githubusercontent.com/13417815/51680896-52480680-1fe3-11e9-8e09-3754f939e055.png)

**After:** (after clicking on another tab _New_dashboard2_, the dashboard is shown)
![dash_after](https://user-images.githubusercontent.com/13417815/51680898-54aa6080-1fe3-11e9-98f1-9b00d90cc427.png)

**Note:**
I fixed the problem the similar way as it is in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/configuration_controller.rb#L70 where we also use `params['uib-tab']`, not `params[:tab]`, while changing tabs.
Tested also with more dashboards, not just two, also with some other groups, not just super admin group, and it works.