### PR TITLE
Fix sumary screen for catalog item with deleted provider template

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2006,8 +2006,7 @@ class CatalogController < ApplicationController
 
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
-                     params[:action] == "x_show" ||
-                     (%w(accordion_select tree_select).include?(params[:action]) && @record.present? && type == 'st')
+                     params[:action] == "x_show"
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2005,8 +2005,7 @@ class CatalogController < ApplicationController
     type, _id = parse_nodetype_and_id(x_node)
 
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
-    record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
-                     params[:action] == "x_show"
+    record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && @record.present?) || params[:action] == "x_show"
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2007,7 +2007,7 @@ class CatalogController < ApplicationController
     allowed_records = %w(MiqTemplate OrchestrationTemplate Service ServiceTemplate ServiceTemplateCatalog)
     record_showing = (type && allowed_records.include?(TreeBuilder.get_model_for_prefix(type)) && !@view) ||
                      params[:action] == "x_show" ||
-                     (%w(accordion_select reload tree_select).include?(params[:action]) && @record.present? && type == 'st')
+                     (%w(accordion_select tree_select).include?(params[:action]) && @record.present? && type == 'st')
     # Clicked on right cell record, open the tree enough to show the node, if not already showing
     if params[:action] == "x_show" && x_active_tree != :stcat_tree &&
        @record && # Showing a record

--- a/app/views/catalog/explorer.html.haml
+++ b/app/views/catalog/explorer.html.haml
@@ -1,6 +1,6 @@
 -# Include the center cell divs
 - nodetypes = %w(MiqTemplate OrchestrationTemplate ServiceResource ServiceTemplate ServiceTemplateCatalog)
-- if nodetypes.include?(TreeBuilder.get_model_for_prefix(@nodetype)) && !@view
+- if nodetypes.include?(TreeBuilder.get_model_for_prefix(@nodetype)) && @record.present?
   #main_div
     - if TreeBuilder.get_model_for_prefix(@nodetype) == "MiqTemplate"
       = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
1. create a catalog item
2. delete the provider template used in the above catalog item
3. Services ➛ Catalogs ➛ Service Catalogs
4. In the tree view click on the created catalog item (also try refresh, full page reload, item edit, ...)
5. In the rendered GTL click on the created catalog item

Clicking in the GTL view would render the catalogs item summary screen correctly.
Clicking in the tree view would render just list of VMs.

This fix removes `@view` from the `record_showing` test, since it would confuse the code to render GTL instead of catalog item summary screen. 

https://bugzilla.redhat.com/show_bug.cgi?id=1652858