### PR TITLE
Added missing unit label

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -208,6 +208,7 @@ class ContainerDashboardService < DashboardService
         :id       => m.resource.id,
         :node     => m.resource.name,
         :provider => provider_name,
+        :unit     => _("Cores"),
         :total    => m.derived_vm_numvcpus.present? ? m.derived_vm_numvcpus.round : nil,
         :percent  => m.cpu_usage_rate_average.present? ? (m.cpu_usage_rate_average / 100.0).round(CPU_USAGE_PRECISION) : nil # pf accepts fractions 90% = 0.90
       }
@@ -216,6 +217,7 @@ class ContainerDashboardService < DashboardService
         :id       => m.resource.id,
         :node     => m.resource.name,
         :provider => m.resource.ext_management_system.name,
+        :unit     => _("GB"),
         :total    => m.derived_memory_available.present? ? m.derived_memory_available.round : nil,
         :percent  => m.mem_usage_absolute_average.present? ? (m.mem_usage_absolute_average / 100.0).round(CPU_USAGE_PRECISION) : nil # pf accepts fractions 90% = 0.90
       }

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -152,6 +152,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "openshift",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           },
@@ -159,6 +160,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "openshift",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           },
@@ -166,6 +168,7 @@ describe ContainerDashboardService do
             :id       => @node3.id,
             :node     => "node3",
             :provider => "kubernetes",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           },
@@ -173,6 +176,7 @@ describe ContainerDashboardService do
             :id       => @node4.id,
             :node     => "node4",
             :provider => "kubernetes",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           }
@@ -182,6 +186,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "openshift",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           },
@@ -189,6 +194,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "openshift",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           },
@@ -196,6 +202,7 @@ describe ContainerDashboardService do
             :id       => @node3.id,
             :node     => "node3",
             :provider => "kubernetes",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           },
@@ -203,6 +210,7 @@ describe ContainerDashboardService do
             :id       => @node4.id,
             :node     => "node4",
             :provider => "kubernetes",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           }
@@ -216,6 +224,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "openshift",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           },
@@ -223,6 +232,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "openshift",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.9
           }
@@ -232,6 +242,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "openshift",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           },
@@ -239,6 +250,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "openshift",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.9
           }
@@ -287,6 +299,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "kubernetes",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.1
           },
@@ -294,6 +307,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "kubernetes",
+            :unit     => "Cores",
             :total    => 4,
             :percent  => 0.1
           }
@@ -303,6 +317,7 @@ describe ContainerDashboardService do
             :id       => @node1.id,
             :node     => "node1",
             :provider => "kubernetes",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.1
           },
@@ -310,6 +325,7 @@ describe ContainerDashboardService do
             :id       => @node2.id,
             :node     => "node2",
             :provider => "kubernetes",
+            :unit     => "GB",
             :total    => 8192,
             :percent  => 0.1
           }


### PR DESCRIPTION
Added missing unit label for Container CPU and Memory heatmap tooltips.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656877

@mzazrivec please review

before
![before1](https://user-images.githubusercontent.com/3450808/51700192-853acc00-1fdc-11e9-873c-2fa54197ef4c.png)

![before2](https://user-images.githubusercontent.com/3450808/51700195-879d2600-1fdc-11e9-8e02-598b314c419e.png)

after
![after1](https://user-images.githubusercontent.com/3450808/51700203-8bc94380-1fdc-11e9-9896-0d2189c8b0e5.png)

![after2](https://user-images.githubusercontent.com/3450808/51700211-8ec43400-1fdc-11e9-8cba-b6f887fb0a2f.png)
