### PR TITLE
Use correct dialog product features in MiqAeCustomizationController

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -32,14 +32,14 @@ module MiqAeCustomizationController::Dialogs
 
   # Add new dialog using the Dialog Editor
   def dialog_new_editor
-    assert_privileges("dialog_new")
+    assert_privileges("dialog_new_editor")
     @record = Dialog.new
     javascript_redirect(:controller => 'miq_ae_customization', :action => 'editor', :id => @record.id)
   end
 
   # Edit dialog using the Dialog Editor
   def dialog_edit_editor
-    assert_privileges("dialog_edit")
+    assert_privileges("dialog_edit_editor")
     @record = find_records_with_rbac(Dialog, checked_or_params)
     javascript_redirect(:controller => 'miq_ae_customization',
                         :action     => 'editor',

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -33,5 +33,44 @@ describe MiqAeCustomizationController do
         expect(controller.send(:flash_errors?)).to be_falsey
       end
     end
+
+    context "restricted user access" do
+      let(:permissions) { %w(dialog_new_editor dialog_edit_editor) }
+
+      before do
+        EvmSpecHelper.seed_specific_product_features(permissions)
+        allow(controller).to receive(:find_records_with_rbac).and_return(dialog)
+        allow(controller).to receive(:javascript_redirect)
+      end
+
+      let(:features) { MiqProductFeature.find_all_by_identifier(permissions) }
+      let(:role_with_access) { FactoryGirl.create(:miq_user_role, :miq_product_features => features) }
+      let(:tenant) { FactoryBot.create(:tenant, :parent => Tenant.root_tenant) }
+      let(:group) { FactoryBot.create(:miq_group, :tenant => tenant, :miq_user_role => role_with_access) }
+      let(:user)  { FactoryBot.create(:user, :miq_groups => [group]) }
+      let(:dialog) { FactoryBot.create(:dialog) }
+
+      it "grants permissions" do
+        User.with_user(user) do
+          expect do
+            controller.dialog_new_editor
+            controller.dialog_edit_editor
+          end.not_to raise_error
+        end
+      end
+
+      let(:role_without_access) { FactoryGirl.create(:miq_user_role, :miq_product_features => []) }
+      let(:group_without_access) { FactoryBot.create(:miq_group, :tenant => tenant, :miq_user_role => role_without_access) }
+      let(:user_without_access)  { FactoryBot.create(:user, :miq_groups => [group_without_access]) }
+
+      it "doesn't grant permissions for dialog_edit_editor" do
+        User.with_user(user_without_access) do
+          expect do
+            controller.dialog_new_editor
+            controller.dialog_edit_editor
+          end.to raise_exception(MiqException::RbacPrivilegeException)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
`dialog_new_editor` and `dialog_edit_editor` are correct permissions for service dialogs  (added https://github.com/ManageIQ/manageiq/pull/15418):

`Automation -> Automate -> Customization -> Service Dialogs`

<img width="539" alt="screenshot 2019-01-25 at 12 01 40" src="https://user-images.githubusercontent.com/14937244/51742118-1e2f1d00-2099-11e9-9774-4b2452e8fc62.png">



cc @skateman 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1297415
caused by https://github.com/ManageIQ/manageiq/pull/15418 and https://github.com/ManageIQ/manageiq/pull/17550
