### PR TITLE
Make LDAP Users searchable

### DIFF
--- a/app/views/ops/_ldap_auth_users.html.haml
+++ b/app/views/ops/_ldap_auth_users.html.haml
@@ -7,7 +7,10 @@
         .col-md-8
           - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
           - options = options_for_select(["<Choose>"] + @edit[:ldap_groups_by_user].uniq.sort, @edit[:selected_ldap_groups_by_user])
-          - attributes = {"data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :class    => "selectpicker"}
+          - attributes = {"data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :class                 => "selectpicker",
+                          "data-live-search"     => "true",}
           = select_tag('ldap_groups_user', options, attributes)                                                  |
         :javascript
           miqInitSelectPicker();


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594497

Go to Configuration -> Settings -> select current Server and set it like picture below
![image](https://user-images.githubusercontent.com/9210860/51751921-63ae1300-20b6-11e9-941b-9ef94fbb7c00.png)
Go to Configuration -> Access Control -> Groups -> Configuration -> Add a new Group -> Check the "Look up External Authentication Groups" checkbox -> **if you have it set** just fill `LDAP Group Lookup` and Retrive **else** use following diff to mock data and then just fill `LDAP Group Lookup` and Retrive
```diff
diff --git a/app/controllers/ops_controller/ops_rbac.rb b/app/controllers/ops_controller/ops_rbac.rb
index 757f757..3e47784 100644
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -497,7 +497,7 @@ module OpsController::OpsRbac
                                                                        @edit[:new][:user_pwd])
                                     end
     rescue => bang
-      @edit[:ldap_groups_by_user] = []
+      @edit[:ldap_groups_by_user] = ["pepa", "pepik", "pepicek", "pepek", "pepkovic"]
       add_flash(_("Error during 'LDAP Group Look Up': %{message}") % {:message => bang.message}, :error)
       render :update do |page|
         page << javascript_prologue
```
**Before:**
![image](https://user-images.githubusercontent.com/9210860/51752208-2e55f500-20b7-11e9-8786-35050a29e1aa.png)

**After:**
![image](https://user-images.githubusercontent.com/9210860/51751821-26e21c00-20b6-11e9-87ca-0f06c391114e.png)

