### PR TITLE
Add create-react-context dependency to fix react-bootstrap-typeahead failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "classnames": "~2.2.6",
     "codemirror": "~5.19.0",
     "connected-react-router": "^4.3.0",
+    "create-react-context": "~0.2.3",
     "eonasdan-bootstrap-datetimepicker": "~4.17.47",
     "es6-shim": "~0.35.3",
     "graphiql": "^0.11.11",


### PR DESCRIPTION
react-bootstrap-typeahead 3.3.0 came out, and it requires create-react-context without depending on it, causing...

    ERROR in ./node_modules/react-bootstrap-typeahead/lib/TypeaheadContext.js
    Module not found: Error: Can't resolve 'create-react-context' in '/home/himdel/manageiq-ui-classic/node_modules/react-bootstrap-typeahead/lib'
    resolve 'create-react-context' in '/home/himdel/manageiq-ui-classic/node_modules/react-bootstrap-typeahead/lib'
      Parsed request is a module
      using description file: /home/himdel/manageiq-ui-classic/node_modules/react-bootstrap-typeahead/package.json (relative path: ./lib)
        Field 'browser' doesn't contain a valid alias configuration
    @ ./node_modules/react-bootstrap-typeahead/lib/TypeaheadContext.js 12:49-80
    @ ./node_modules/react-bootstrap-typeahead/lib/containers/menuItemContainer.js
    @ ./node_modules/react-bootstrap-typeahead/lib/index.js
    @ ./node_modules/patternfly-react/dist/esm/components/TypeAheadSelect/TypeAheadSelect.js
    @ ./node_modules/patternfly-react/dist/esm/components/TypeAheadSelect/index.js
    @ ./node_modules/patternfly-react/dist/esm/index.js
    @ ./app/javascript/provider-dialogs/modal.js
    @ ./app/javascript/packs/provider-dialogs-common.js
    error Command failed with exit code 2.

during webpack.

But since react-bootstrap-typeahead is not a direct dependency (via patternfly-react), it's easier to fix the missing package than to override the version.

Reported as https://github.com/ericgio/react-bootstrap-typeahead/issues/411