### PR TITLE
Allow the user to upload a custom favicon image in Custom Logos

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -7,6 +7,7 @@ module OpsController::Settings::Common
   @@logo_file = File.join(logo_dir, "custom_logo.png")
   @@login_logo_file = File.join(logo_dir, "custom_login_logo.png")
   @@login_brand_file = File.join(logo_dir, "custom_brand.png")
+  @@favicon_file = File.join(logo_dir, "custom_favicon.ico")
 
   # AJAX driven routine to check for changes in ANY field on the form
   def settings_form_field_changed
@@ -867,6 +868,7 @@ module OpsController::Settings::Common
     when "settings_custom_logos" # Custom Logo tab
       new[:server][:custom_logo] = (params[:server_uselogo] == "true") if params[:server_uselogo]
       new[:server][:custom_login_logo] = (params[:server_useloginlogo] == "true") if params[:server_useloginlogo]
+      new[:server][:custom_favicon] = (params[:server_usefavicon] == "true") if params[:server_usefavicon]
       new[:server][:custom_brand] = (params[:server_usebrand] == "true") if params[:server_usebrand]
       new[:server][:use_custom_login_text] = (params[:server_uselogintext] == "true") if params[:server_uselogintext]
       if params[:login_text]
@@ -1100,6 +1102,9 @@ module OpsController::Settings::Common
     if @edit[:current][:server][:custom_brand].nil?
       @edit[:current][:server][:custom_brand] = false # Set default custom_brand flag
     end
+    if @edit[:current][:server][:custom_favicon].nil?
+      @edit[:current][:server][:custom_favicon] = false # Set default custom_favicon flag
+    end
 
     if @edit[:current][:server][:use_custom_login_text].nil?
       @edit[:current][:server][:use_custom_login_text] = false # Set default custom_login_text flag
@@ -1107,6 +1112,7 @@ module OpsController::Settings::Common
     @logo_file = @@logo_file
     @login_logo_file = @@login_logo_file
     @login_brand_file = @@login_brand_file
+    @favicon_file = @@favicon_file
     @in_a_form = true
   end
 

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -3,29 +3,35 @@ module OpsController::Settings::Upload
 
   def upload_logo
     logo_file = File.join(logo_dir, "custom_logo.png")
-    upload_logos(logo_file, params[:upload], _('Custom logo image'))
+    upload_logos(logo_file, params[:upload], _('Custom logo image'), "png")
   end
 
   def upload_login_logo
     login_logo_file = File.join(logo_dir, "custom_login_logo.png")
-    upload_logos(login_logo_file, params[:login], _('Custom login image'))
+    upload_logos(login_logo_file, params[:login], _('Custom login image'), "png")
   end
 
   def upload_login_brand
     login_logo_file = File.join(logo_dir, "custom_brand.png")
-    upload_logos(login_logo_file, params[:brand], _('Custom brand'))
+    upload_logos(login_logo_file, params[:brand], _('Custom brand'), "png")
   end
 
-  def upload_logos(file, field, text)
+  def upload_favicon
+    logo_file = File.join(logo_dir, "custom_favicon.ico")
+    upload_logos(logo_file, params[:favicon], _('Custom favicon'), "ico")
+  end
+
+
+  def upload_logos(file, field, text, type)
     if field && field[:logo] && field[:logo].respond_to?(:read)
-      if field[:logo].original_filename.split(".").last.downcase != "png"
-        add_flash("%{image} must be a .png file" % {:image => text}, :error)
+      if field[:logo].original_filename.split(".").last.downcase != type
+        add_flash("%{image} must be a .#{type} file" % {:image => text}, :error)
       else
         File.open(file, "wb") { |f| f.write(field[:logo].read) }
         add_flash(_("%{image} \"%{name}\" uploaded") % {:image => text, :name => field[:logo].original_filename})
       end
     else
-      add_flash(_("Use the Choose file button to locate .png image file"), :error)
+      add_flash(_("Use the Choose file button to locate .#{type} image file"), :error)
     end
     flash_to_session
     redirect_to(:action => 'explorer')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1428,4 +1428,8 @@ module ApplicationHelper
   def unique_html_id(prefix = 'unknown')
     "#{prefix}-#{rand(36**8).to_s(36)}"
   end
+
+  def miq_favicon_link_tag
+    Settings.server.custom_favicon ? favicon_link_tag('/upload/custom_favicon.ico') : favicon_link_tag
+  end
 end

--- a/app/views/dashboard/oidc_login.html.haml
+++ b/app/views/dashboard/oidc_login.html.haml
@@ -1,6 +1,6 @@
 %html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'
 

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -1,6 +1,6 @@
 %html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     = javascript_include_tag 'application'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,7 @@
     %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
     %meta{"http-equiv" => "X-UA-Compatible", :content => "IE=edge"}
 
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     = render :partial => "stylesheets/template50"

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -3,7 +3,7 @@
   %head
     %title
       = h productized_title(_("Login"))
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     = javascript_dependencies

--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %title= @options[:title]
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'print', :media => 'all'
     -# Mock the gettext calls in javascript
     :javascript

--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -3,7 +3,7 @@
   %head
     %title
       = _('%{product_name} HTML5 Remote Console') % {:product_name => Vmdb::Appliance.PRODUCT_NAME}
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     -# Load the required JS based on the console type

--- a/app/views/layouts/report_only.html.haml
+++ b/app/views/layouts/report_only.html.haml
@@ -3,7 +3,7 @@
   %head
     %title
       = "%{product}: %{title}" % {:product => Vmdb::Appliance.PRODUCT_NAME, :title => @report.title}
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
     = javascript_dependencies

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -90,6 +90,33 @@
         .col-md-8
           = check_box_tag("server_usebrand", true, @edit[:new][:server][:custom_brand], :data => {:on_text => _('Yes'), :off_text => _('No')})
   %hr
+  %h3=_("Custom Favicon")
+  - if File.exist?(@favicon_file)
+    = image_tag("/upload/custom_favicon.ico?#{rand(99_999_999)}")
+    %br/
+    %br/
+  - else
+    = render :partial => 'layouts/info_msg', :locals => {:message => _("No custom favicon has been uploaded yet.")}
+  = form_tag({:action    => "upload_favicon"},
+             :class     => "form-horizontal",
+             :multipart => true,
+             :method    => :post) do
+    .form-group
+      .col-md-4
+        = render :partial => "shared/file_chooser", :locals => {:object_name => "favicon", :method => "logo"}
+      .col-md-6
+        = submit_tag(_("Upload"), :class => "btn btn-default")
+        = _("* Requirements: File-type - ICO;")
+
+  - if File.exist?(@favicon_file)
+    %br/
+    %form.form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _("Use Custom Favicon")
+        .col-md-8
+          = check_box_tag("server_usefavicon", true, @edit[:new][:server][:custom_favicon], :data => {:on_text => _('Yes'), :off_text => _('No')})
+  %hr
   %h3
     = _("Custom Login Panel Text (")
     %span#text_count= @edit[:new][:notes] ? @edit[:new][:notes].length : 0
@@ -114,3 +141,4 @@
         miqInitBootstrapSwitch('server_uselogo', "#{url}");
         miqInitBootstrapSwitch('server_useloginlogo', "#{url}");
         miqInitBootstrapSwitch('server_usebrand', "#{url}");
+        miqInitBootstrapSwitch('server_usefavicon', "#{url}");

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -1,7 +1,7 @@
 = render :partial => 'layouts/doctype'
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
-    = favicon_link_tag
+    = miq_favicon_link_tag
     = javascript_include_tag 'jquery/dist/jquery.js'
     :javascript
       // INITIALIZE

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2620,6 +2620,7 @@ Rails.application.routes.draw do
         upload_login_brand
         upload_login_logo
         upload_logo
+        upload_favicon
         validate_replcation_worker
         wait_for_task
         x_button


### PR DESCRIPTION
I created a wrapper around the `favicon_link_tag` helper to be able to set a custom favicon if the related configuration parameter is set to true. The icon upload code is awfully copy-pasted and I'm willing to fix it in a follow-up PR as this one might be backported.

https://bugzilla.redhat.com/show_bug.cgi?id=1578076

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label graphics