### PR TITLE
bin/webpack* - run yarn scripts without extra --

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -24,7 +24,7 @@ newenv  = {
   "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
   "NODE_OPTIONS" => "--max_old_space_size=4096"
 }
-cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ["yarn", "run", "webpack", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -37,7 +37,7 @@ newenv = {
   "NODE_OPTIONS" => "--max_old_space_size=4096"
 }.freeze
 
-cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ["yarn", "run", "webpack-dev-server", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline


### PR DESCRIPTION
Prevents yarn from complaining:

```diff
 $ bin/webpack
 yarn run v1.13.0
-warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
 $ /home/himdel/manageiq-ui-classic/node_modules/.bin/webpack --config /home/himdel/manageiq-ui-classic/config/webpack/development.js
 ...
```

at the cost of losing pre-yarn-1.0.0 compatibility.

Cc @djberg96 