### PR TITLE
Fix travis failure caused by ManageIQ/manageiq#18378

### DIFF
--- a/spec/services/topology_service_spec.rb
+++ b/spec/services/topology_service_spec.rb
@@ -143,8 +143,8 @@ describe TopologyService do
 
     context 'entity is a tag' do
       let(:parent_cls) { FactoryBot.create(:classification, :description => 'foo') }
-      let(:cls) { FactoryBot.create(:classification, :parent => parent_cls, :description => 'bar') }
-      let(:entity) { FactoryBot.create(:tag, :classification => cls) }
+      let(:cls) { FactoryBot.create(:classification_tag, :parent => parent_cls, :description => 'bar') }
+      let(:entity) { cls.tag }
 
       it 'returns with the parent and the child classification description' do
         expect(name).to eq('foo: bar')


### PR DESCRIPTION
Travis failure caused by https://github.com/ManageIQ/manageiq/pull/18378

@miq-bot add-label bug, test