### PR TITLE
sync_from_file is deprecated in favor of seed_dialog

### DIFF
--- a/spec/requests/restful_redirect_spec.rb
+++ b/spec/requests/restful_redirect_spec.rb
@@ -16,9 +16,8 @@ describe RestfulRedirectController do
 
     before do
       # Load just one dialog instead of calling `MiqDialog.seed`
-      MiqDialog.sync_from_file(
+      MiqDialog.seed_dialog(
         Rails.root.join('product', 'dialogs', 'miq_dialogs', 'miq_provision_dialogs.yaml').to_s,
-        Rails.root.join('product', 'dialogs', 'miq_dialogs')
       )
     end
 


### PR DESCRIPTION
Dialog seeding was refactored in https://github.com/ManageIQ/manageiq/pull/18366, and in doing so the simpler `seed_dialog` is put in place as an alternative to `sync_from_file`.  This PR removes the last caller of `sync_from_file`, so it can be removed from core after this is merged.

See the comment here: https://github.com/ManageIQ/manageiq/pull/18366/files#diff-4662619cda7219ae1605ab55f1e2f2bcR28