### PR TITLE
Provider edit - move message about a username near the field, fix everything

### DIFF
--- a/app/assets/javascripts/components/auth-credentials.js
+++ b/app/assets/javascripts/components/auth-credentials.js
@@ -7,6 +7,7 @@ ManageIQ.angular.app.component('authCredentials', {
     prefix: '@',
     formLabels: '<?',
     userRequired: '<?',
+    userPrivileged: '<?',
     passwordRequired: '<?',
     hideUser: '<?',
     hidePassword: '<?',

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -280,6 +280,26 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
+  $scope.useridPrivileged = function() {
+    // disabled outside the default tab
+    if ($scope.currentTab !== 'default') {
+      return false;
+    }
+
+    // disabled for container providers
+    if ($scope.emsCommonModel.ems_controller == 'ems_container') {
+      return false;
+    }
+
+    // disabled for specific types
+    var blacklist = [
+      'azure_stack',
+      'gce',
+      'kubevirt',
+    ];
+    return ! blacklist.includes($scope.emsCommonModel.emstype);
+  }
+
   $scope.hideDisabledTabs = function() {
     if ($scope.emsCommonModel.alerts_selection === 'disabled') {
       angular.element('#alerts_tab').hide();

--- a/app/views/configuration_manager/_shared_form.html.haml
+++ b/app/views/configuration_manager/_shared_form.html.haml
@@ -82,6 +82,7 @@
                       'model-copy'                     => 'vm.modelCopy',
                       'prefix'                         => '{{vm.prefix}}',
                       'user-required'                  => true,
+                      'user-privileged'                => true,
                       'password-required'              => true,
                       'enable-valid-button'            => 'vm.canValidateBasicInfo()',
                       'validate'                       => 'vm.validateClicked',
@@ -90,4 +91,3 @@
                       'new-record'                     => 'vm.newRecord',
                       'check-authentication'           => true}
     = render :partial => "layouts/angular/generic_form_buttons"
-    %span{:style => "color:black"}= _("Required. Should have privileged access, such as root or administrator.")

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -46,6 +46,8 @@
           = _("Invalid input format, please enter a GUID")
         .note{"ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
           = _("Note: Username must be in the format: name@realm")
+        .note{"ng-if" => "'#{j_str ng_model}' == 'emsCommonModel' && useridPrivileged()"}
+          = _("Should have privileged access, such as root or administrator.")
 
   %div{"ng-show" => "#{ng_show} && #{ng_show_password}"}
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_password.$error.required}"}

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -169,9 +169,6 @@
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
           %span{:style => "color:black"}
             = _("Used to authenticate as a service account against your provider.")
-        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'" && "#{ng_model}.ems_controller != 'ems_container'" && "#{ng_model}.emstype != 'kubevirt'" && "#{ng_model}.emstype != 'azure_stack'"}
-          %span{:style => "color:black"}
-            = _("Required. Should have privileged access, such as root or administrator.")
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
           %span{:style => "color:black"}
             = _("Required. Used to gather Utilization data.")

--- a/app/views/static/auth-credentials.html.haml
+++ b/app/views/static/auth-credentials.html.haml
@@ -24,6 +24,8 @@
           = _("Invalid input format, please enter a GUID")
         .note{"ng-if" => "vm.guidRegex"}
           = _("Note: Username must be in the format: name@realm")
+        .note{"ng-if" => "vm.userPrivileged"}
+          = _("Should have privileged access, such as root or administrator.")
   %div{"ng-show" => "!vm.hidePassword"}
     .form-group{"ng-class" => "{'has-error': authCredentialsForm[vm.prefix + '_password'].$error.required}"}
       %label.col-md-2.control-label{"for" => "{{vm.prefix}}_password"}


### PR DESCRIPTION
Compute > * > Providers - add/edit

Problems:

* a black "Required. \<a note\>" pops up on some provider edit screens, but not near the Username field
  * => removing Required, as the field itself can already handle it
  * => moving the rest of the message to the username notes section

* the whole condition is partly evaluated server side, and only the result gets evaluated client side
  * => restoring the conditions that were eaten by `string1 && string2 && string3` becoming `string3`

https://bugzilla.redhat.com/show_bug.cgi?id=1528984
