### PR TITLE
 Add missing styling to user input filter modal

### DIFF
--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -23,19 +23,25 @@
                                    options_for_select([_("<Choose>")] + MiqExpression.get_entry_details(@edit[:qs_tokens][token][:tag]).sort_by { |desc, _name| desc.downcase },
                                                        nil),
                                    :multiple              => false,
-                                   :class                 => "widthed",
+                                   :class                 => "selectpicker",
                                    "data-miq_sparkle_on"  => true,
                                    "data-miq_sparkle_off" => true,
                                    "data-miq_observe"     => {:url => url}.to_json)
+                      :javascript
+                        miqInitSelectPicker();
+                        miqSelectPickerEvent("value_#{token}", "#{url}")
                     - else
                       - if @edit[:qs_tokens][token][:value_type] == :boolean
                         = select_tag("value_#{token}",
                                      options_for_select([[_("<Choose>"), nil],[_('False'), false], [_('True'), true]], nil),
                                      :multiple              => false,
-                                     :class                 => "widthed",
+                                     :class                 => "selectpicker",
                                      "data-miq_sparkle_on"  => true,
                                      "data-miq_sparkle_off" => true,
                                      "data-miq_observe"     => {:url => url}.to_json)
+                        :javascript
+                          miqInitSelectPicker();
+                          miqSelectPickerEvent("value_#{token}", "#{url}")
                       - else
                         = text_field_tag("value_#{token}", nil,
                                          :maxlength         => 500,
@@ -52,20 +58,26 @@
                                      options_for_select(MiqExpression::FORMAT_SUB_TYPES[@edit[:qs_tokens][token][:value_type]][:units],
                                                         nil),
                                      :multiple              => false,
-                                     :class                 => "widthed",
+                                     :class                 => "selectpicker",
                                      "data-miq_sparkle_on"  => true,
                                      "data-miq_sparkle_off" => true,
                                      "data-miq_observe"     => {:url => url}.to_json)
+                        :javascript
+                          miqInitSelectPicker();
+                          miqSelectPickerEvent("suffix_#{token}", "#{url}")
 
                   - elsif @edit[:qs_tokens][token].key?(:tag)
                     = select_tag("value_#{token}",
                                  options_for_select([_("<Choose>")] + MiqExpression.get_entry_details(@edit[:qs_tokens][token][:tag]).sort { |a, b| a.first.downcase <=> b.first.downcase },
                                                      nil),
                                  :multiple              => false,
-                                 :class                 => "widthed",
+                                 :class                 => "selectpicker",
                                  "data-miq_sparkle_on"  => true,
                                  "data-miq_sparkle_off" => true,
                                  "data-miq_observe"     => {:url => url}.to_json)
+                    :javascript
+                      miqInitSelectPicker();
+                      miqSelectPickerEvent("value_#{token}", "#{url}")
                   - elsif @edit[:qs_tokens][token].key?(:count)
                     = text_field_tag("value_#{token}", nil,
                                      :maxlength         => 500,


### PR DESCRIPTION
This PR adds the missing bootstrap select styling from the user input filter modal

https://bugzilla.redhat.com/show_bug.cgi?id=1670458

Before
<img width="911" alt="screen shot 2019-01-29 at 3 41 10 pm" src="https://user-images.githubusercontent.com/1287144/51938931-522d7980-23dc-11e9-9c03-19119423165a.png">

After
<img width="913" alt="screen shot 2019-01-29 at 3 40 39 pm" src="https://user-images.githubusercontent.com/1287144/51938941-56599700-23dc-11e9-85a2-128f7eb0f350.png">