### PR TITLE
Replace MiqReport.get_col_type with parse_field_or_tag

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1750,20 +1750,9 @@ module ReportController::Reports::Editor
         active_tab = 'edit_4'
       end
     when '6'
-      error_message = _('Timeline tab is not available unless at least 1 time field has been selected')
-      empty_fields = @edit[:new][:fields].empty?
-
-      found = false
-      unless empty_fields
-        @edit[:new][:fields].each do |field|
-          if MiqExpression.parse_field_or_tag(field[1])&.datetime?
-            found = true
-            break
-          end
-        end
+      if @edit[:new][:fields].empty? || !@edit[:new][:fields].detect { |field| MiqExpression.parse_field_or_tag(field[1])&.datetime? }
+        add_flash(_('Timeline tab is not available unless at least 1 time field has been selected'), :error)
       end
-
-      add_flash(error_message, :error) if empty_fields || !found
     when '7'
       if @edit[:new][:model] == ApplicationController::TREND_MODEL
         unless @edit[:new][:perf_trend_col]

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -266,7 +266,7 @@ module ReportController::Reports::Editor
     when "6"  # Timeline
       @tl_fields = []
       @edit[:new][:fields].each do |field|
-        if MiqReport.get_col_type(field[1]) == :datetime
+        if MiqExpression.parse_field_or_tag(field[1])&.datetime?
           @tl_fields.push(field)
         end
       end
@@ -1756,7 +1756,7 @@ module ReportController::Reports::Editor
       found = false
       unless empty_fields
         @edit[:new][:fields].each do |field|
-          if MiqReport.get_col_type(field[1]) == :datetime
+          if MiqExpression.parse_field_or_tag(field[1])&.datetime?
             found = true
             break
           end

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -410,7 +410,7 @@ describe ReportController do
   describe '#check_tabs' do
     tabs.each_pair do |tab_title, tab_number|
       title = tab_title.to_s.titleize
-      it "check existence of flash message when tab is changed to #{title} without selecting fields" do
+      it "check existence of flash message when tab is changed to #{title} without selecting (time) fields" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@edit, :new => {:fields => []})
         controller.instance_variable_set(:@_params, :tab => "new_#{tab_number}")


### PR DESCRIPTION
Goal ⚽️ : remove usage of `MiqReport.get_col_type`

I did also some simplification in second commit.

