### PR TITLE
Delete the "report_menus" instead of :report_menus when resetting

### DIFF
--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -223,7 +223,7 @@ module ReportController::Menus
       rec[:settings] ||= {}
       if @sb[:menu_default]
         # delete report_menus from settings if menu set to default
-        rec[:settings].delete(:report_menus)
+        rec[:settings].delete("report_menus")
       else
         rec[:settings]["report_menus"] ||= {}
         rec[:settings]["report_menus"] = copy_array(@edit[:new])

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -22,5 +22,23 @@ describe ReportController do
       expect(assigns(:edit)[:new]).to eq([["foo", [["bar", [report.name]]]]])
       expect(assigns(:flash_array).first[:message]).to include("default")
     end
+
+    context "report menu set to default" do
+      it "clears the report_menus from the selected group settings" do
+        controller.instance_variable_set(:@sb, :new => {}, :menu_default => true)
+        controller.instance_variable_set(:@_params, :button => "save")
+
+        expect(controller).to receive(:menu_get_form_vars)
+        expect(controller).to receive(:get_tree_data)
+        expect(controller).to receive(:replace_right_cell)
+
+        expect(MiqGroup).to receive(:find_by).and_return(user.current_group)
+        user.current_group[:settings] = { "report_menus" => 'foo' }
+
+        controller.menu_update
+
+        expect(user.current_group[:settings]["report_menus"]).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
When setting a report menu to default under `Cloud Intel -> Reports -> Edit report menus`, the wrong hash key was deleted. The group's settings is indexed by strings and not symbols, so when resetting & saving a menu nothing happened. For more details see the BZ.

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes, cloud intel/reports
@miq-bot assign @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670293