### PR TITLE
AR::QueryMethods uniq/distinct takes no block

### DIFF
--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -28,7 +28,7 @@ class TopologyService
       h[kind] = {:type => 'glyph', :class => klass.decorate.fonticon}
     end
 
-    @providers.uniq(&:class).each_with_object(kind_icons) do |provider, h|
+    @providers.to_a.uniq(&:class).each_with_object(kind_icons) do |provider, h|
       fileicon = provider.decorate.try(:fileicon)
 
       next if fileicon.nil?

--- a/spec/services/infra_topology_service_spec.rb
+++ b/spec/services/infra_topology_service_spec.rb
@@ -73,4 +73,21 @@ describe InfraTopologyService do
       )
     end
   end
+
+  describe '#build_icons' do
+    it "creates a hash of object types and their icon information" do
+      FactoryBot.create(:ems_vmware)
+      FactoryBot.create(:ems_openstack_infra)
+      FactoryBot.create(:ems_openstack_infra)
+
+      # entity_display_type is called once per class of ems
+      expect(infra_topology_service).to receive(:entity_display_type).exactly(2).times.and_call_original
+
+      icons = infra_topology_service.build_icons
+      expect(icons["Openstack"]).to eq(:type => "image", :icon  => "/images/svg/vendor-openstack_infra.svg")
+      expect(icons["Vmware"]).to    eq(:type => "image", :icon  => "/images/svg/vendor-vmwarews.svg")
+      expect(icons[:EmsCluster]).to eq(:type => "glyph", :class => "pficon pficon-cluster")
+      expect(icons[:Host]).to       eq(:type => "glyph", :class => "pficon pficon-container-node")
+    end
+  end
 end


### PR DESCRIPTION
This never worked.  The argument passed to uniq/distinct is used to
either add or remove the 'distinct' constraint. Fortunately, the bug just
caused it to be inefficient.

Since AR::QueryMethods uniq is deprecated in 5.0 and removed in 5.1 and we
want the Array#uniq method, we need to convert the relation to an array.