### PR TITLE
Report editor titles's tab unification

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -345,14 +345,15 @@ module ReportController::Reports::Editor
   }.freeze
 
   def build_tabs
-    @tabs = if @edit[:new][:model] == ApplicationController::TREND_MODEL
-              TAB_TITLES.slice('edit_1', 'edit_3', 'edit_7')
-            elsif Chargeback.db_is_chargeback?(@edit[:new][:model].to_s)
-              TAB_TITLES.slice('edit_1', 'edit_2', 'edit_3', 'edit_7')
-            else
-              TAB_TITLES.slice('edit_1', 'edit_8', 'edit_2', 'edit_9', 'edit_3', 'edit_4', 'edit_5', 'edit_6', 'edit_7')
-            end.transform_values! { |value| _(value) }.to_a
+    tab_indexes = if @edit[:new][:model] == ApplicationController::TREND_MODEL
+                    %w(edit_1 edit_3 edit_7)
+                  elsif Chargeback.db_is_chargeback?(@edit[:new][:model].to_s)
+                    %w(edit_1 edit_2 edit_3 edit_7)
+                  else
+                    %w(edit_1 edit_8 edit_2 edit_9 edit_3 edit_4 edit_5 edit_6 edit_7)
+                  end
 
+    @tabs = TAB_TITLES.slice(*tab_indexes).transform_values! { |value| _(value) }.to_a
     tab = @sb[:miq_tab].split("_")[1] # Get the tab number of the active tab
     @active_tab = "edit_#{tab}"
   end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1756,20 +1756,20 @@ module ReportController::Reports::Editor
         active_tab = 'edit_4'
       end
     when '6'
-      if @edit[:new][:fields].empty?
-        add_flash(_('Timeline tab is not available until at least 1 field has been selected'), :error)
-      else
-        found = false
+      error_message = _('Timeline tab is not available unless at least 1 time field has been selected')
+      empty_fields = @edit[:new][:fields].empty?
+
+      found = false
+      unless empty_fields
         @edit[:new][:fields].each do |field|
           if MiqReport.get_col_type(field[1]) == :datetime
             found = true
             break
           end
         end
-        unless found
-          add_flash(_('Timeline tab is not available unless at least 1 time field has been selected'), :error)
-        end
       end
+
+      add_flash(error_message, :error) if empty_fields || !found
     when '7'
       if @edit[:new][:model] == ApplicationController::TREND_MODEL
         unless @edit[:new][:perf_trend_col]

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -332,27 +332,26 @@ module ReportController::Reports::Editor
     @edit[:miq_exp]               = true
   end
 
+  TAB_TITLES = {
+    'edit_1' => N_('Columns'),
+    'edit_3' => N_('Filter'),
+    'edit_7' => N_('Preview'),
+    'edit_8' => N_('Consolidation'),
+    'edit_2' => N_('Formatting'),
+    'edit_9' => N_('Styling'),
+    'edit_4' => N_('Summary'),
+    'edit_5' => N_('Charts'),
+    'edit_6' => N_('Timeline'),
+  }.freeze
+
   def build_tabs
     @tabs = if @edit[:new][:model] == ApplicationController::TREND_MODEL
-              [["edit_1", _('Columns')],
-               ["edit_3", _('Filter')],
-               ["edit_7", _('Preview')]]
+              TAB_TITLES.slice('edit_1', 'edit_3', 'edit_7')
             elsif Chargeback.db_is_chargeback?(@edit[:new][:model].to_s)
-              [["edit_1", _('Columns')],
-               ["edit_2", _('Formatting')],
-               ["edit_3", _('Filter')],
-               ["edit_7", _('Preview')]]
+              TAB_TITLES.slice('edit_1', 'edit_2', 'edit_3', 'edit_7')
             else
-              [["edit_1", _('Columns')],
-               ["edit_8", _('Consolidation')],
-               ["edit_2", _('Formatting')],
-               ["edit_9", _('Styling')],
-               ["edit_3", _('Filter')],
-               ["edit_4", _('Summary')],
-               ["edit_5", _('Charts')],
-               ["edit_6", _('Timeline')],
-               ["edit_7", _('Preview')]]
-            end
+              TAB_TITLES.slice('edit_1', 'edit_8', 'edit_2', 'edit_9', 'edit_3', 'edit_4', 'edit_5', 'edit_6', 'edit_7')
+            end.transform_values! { |value| _(value) }.to_a
 
     tab = @sb[:miq_tab].split("_")[1] # Get the tab number of the active tab
     @active_tab = "edit_#{tab}"

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -333,30 +333,29 @@ module ReportController::Reports::Editor
   end
 
   def build_tabs
-    req = "edit"
     @tabs = if @edit[:new][:model] == ApplicationController::TREND_MODEL
-              [["#{req}_1", _('Columns')],
-               ["#{req}_3", _('Filter')],
-               ["#{req}_7", _('Preview')]]
+              [["edit_1", _('Columns')],
+               ["edit_3", _('Filter')],
+               ["edit_7", _('Preview')]]
             elsif Chargeback.db_is_chargeback?(@edit[:new][:model].to_s)
-              [["#{req}_1", _('Columns')],
-               ["#{req}_2", _('Formatting')],
-               ["#{req}_3", _('Filter')],
-               ["#{req}_7", _('Preview')]]
+              [["edit_1", _('Columns')],
+               ["edit_2", _('Formatting')],
+               ["edit_3", _('Filter')],
+               ["edit_7", _('Preview')]]
             else
-              [["#{req}_1", _('Columns')],
-               ["#{req}_8", _('Consolidation')],
-               ["#{req}_2", _('Formatting')],
-               ["#{req}_9", _('Styling')],
-               ["#{req}_3", _('Filter')],
-               ["#{req}_4", _('Summary')],
-               ["#{req}_5", _('Charts')],
-               ["#{req}_6", _('Timeline')],
-               ["#{req}_7", _('Preview')]]
+              [["edit_1", _('Columns')],
+               ["edit_8", _('Consolidation')],
+               ["edit_2", _('Formatting')],
+               ["edit_9", _('Styling')],
+               ["edit_3", _('Filter')],
+               ["edit_4", _('Summary')],
+               ["edit_5", _('Charts')],
+               ["edit_6", _('Timeline')],
+               ["edit_7", _('Preview')]]
             end
 
     tab = @sb[:miq_tab].split("_")[1] # Get the tab number of the active tab
-    @active_tab = "#{req}_#{tab}"
+    @active_tab = "edit_#{tab}"
   end
 
   # Get variables from edit form

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -378,7 +378,11 @@ describe ReportController do
         controller.instance_variable_set(:@_params, :tab => "new_#{tab_number}")
         controller.send(:check_tabs)
         flash_messages = assigns(:flash_array)
-        flash_str = "#{title} tab is not available until at least 1 field has been selected"
+        flash_str = if tab_number == 6
+                      "#{title} tab is not available unless at least 1 time field has been selected"
+                    else
+                      "#{title} tab is not available until at least 1 field has been selected"
+                    end
         expect(flash_messages.first[:message]).to eq(flash_str)
         expect(flash_messages.first[:level]).to eq(:error)
       end

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -342,6 +342,33 @@ describe ReportController do
     end
   end
 
+  describe "#build_tabs" do
+    before do
+      controller.instance_variable_set(:@sb, :miq_tab => "edit_1")
+    end
+
+    it "display title tabs for model #{ApplicationController::TREND_MODEL}" do
+      controller.instance_variable_set(:@edit, :new => {:model => ApplicationController::TREND_MODEL})
+
+      controller.send(:build_tabs)
+      expect(controller.instance_variable_get(:@tabs)).to eq([%w(edit_1 Columns), %w(edit_3 Filter), %w(edit_7 Preview)])
+    end
+
+    it "display title tabs for chargeback model" do
+      controller.instance_variable_set(:@edit, :new => {:model => ChargebackVm})
+
+      controller.send(:build_tabs)
+      expect(controller.instance_variable_get(:@tabs)).to eq([%w(edit_1 Columns), %w(edit_2 Formatting), %w(edit_3 Filter), %w(edit_7 Preview)])
+    end
+
+    it "display title tabs for any model" do
+      controller.instance_variable_set(:@edit, :new => {:model => Vm})
+
+      controller.send(:build_tabs)
+      expect(controller.instance_variable_get(:@tabs)).to eq([%w(edit_1 Columns), %w(edit_8 Consolidation), %w(edit_2 Formatting), %w(edit_9 Styling), %w(edit_3 Filter), %w(edit_4 Summary), %w(edit_5 Charts), %w(edit_6 Timeline), %w(edit_7 Preview)])
+    end
+  end
+
   describe '#check_tabs' do
     tabs.each_pair do |tab_title, tab_number|
       title = tab_title.to_s.titleize


### PR DESCRIPTION
there is bunch of refactoring but also I am using one error message for Time tab - when one time field is required (last commit)

this is needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/5210

@miq-bot add_label refactoring

@miq-bot assign @mzazrivec 