### PR TITLE
Use timeline listnav only for dashboard controller

### DIFF
--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -77,13 +77,14 @@ module ApplicationHelper
         vm_or_template
       )).include?(@layout)
         "vm"
+      elsif @layout == "timeline"
+        controller.controller_name == "dashboard" ? "timeline" : controller.controller_name
       elsif (common_layouts + %w(
         action
         condition
         miq_schedule
         policy
         scan_profile
-        timeline
       )).include?(@layout)
         @layout
       end

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -20,5 +20,26 @@ describe AvailabilityZoneController do
     end
   end
 
+  describe "#show display=timeline" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @zone = FactoryBot.create(:availability_zone)
+      login_as FactoryBot.create(:user_admin)
+    end
+
+    subject do
+      get :show, :params => {:id => @zone.id, :display => 'timeline'}
+    end
+
+    context "render listnav partial" do
+      render_views
+
+      it do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_availability_zone")
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :availability_zone
 end

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -1,3 +1,4 @@
+
 describe ContainerController do
   render_views
   before do
@@ -41,15 +42,22 @@ describe ContainerController do
       @container = FactoryBot.create(:container, :container_group => container_group, :name => "Test Container")
     end
 
-    subject { get :show, :params => { :id => @container.id } }
-
-    context "render" do
+    context "render listnav partial" do
       render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_container")
-        is_expected.to render_template('layouts/_textual_groups_generic')
+      it "correctly for summary page" do
+        get :show, :params => {:id => @container.id}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container")
+        expect(response).to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @container.id, :display => 'timeline'}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container")
       end
     end
   end

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -44,15 +44,22 @@ describe ContainerGroupController do
       login_as FactoryBot.create(:user)
     end
 
-    subject { get :show, :params => { :id => @container_group.id } }
-
-    context "render" do
+    context "render listnav partial" do
       render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_container_group")
-        is_expected.to render_template('layouts/_textual_groups_generic')
+      it "correctly for summary page" do
+        get :show, :params => {:id => @container_group.id}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_group")
+        expect(response).to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @container_group.id, :display => 'timeline'}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_group")
       end
     end
   end

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -31,15 +31,22 @@ describe ContainerNodeController do
       @node = FactoryBot.create(:container_node)
     end
 
-    subject { get :show, :params => { :id => @node.id } }
-
-    context "render" do
+    context "render listnav partial" do
       render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_container_node")
-        is_expected.to render_template('layouts/_textual_groups_generic')
+      it "correctly for summary page" do
+        get :show, :params => {:id => @node.id}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_node")
+        expect(response).to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @node.id, :display => 'timeline'}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_node")
       end
     end
   end

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -35,10 +35,16 @@ describe ContainerProjectController do
     context "render" do
       render_views
 
-      it do
+      it "correct listnav" do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_container_project")
         is_expected.to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correct listnav for timeline page" do
+        get :show, :params => { :id => @project.id, :display => 'timeline' }
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_container_project")
       end
 
       it "renders topology view" do

--- a/spec/controllers/container_replicator_controller_spec.rb
+++ b/spec/controllers/container_replicator_controller_spec.rb
@@ -34,14 +34,22 @@ describe ContainerReplicatorController do
       @replicator = FactoryBot.create(:replicator_with_assoc)
     end
 
-    subject { get :show, :params => { :id => @replicator.id } }
-
-    context "render" do
+    context "render listnav partial" do
       render_views
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_container_replicator")
+      it "correctly for summary page" do
+        get :show, :params => {:id => @replicator.id}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_replicator")
+        expect(response).to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @replicator.id, :display => 'timeline'}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_container_replicator")
       end
     end
   end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -460,7 +460,13 @@ describe EmsCloudController do
       subject { get :show, :params => { :id => @ems.id, :display => 'main' } }
       render_views
 
-      it do
+      it "correctly for summary page" do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_ems_cloud")
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @ems.id, :display => 'timeline'}
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_ems_cloud")
       end

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -68,15 +68,22 @@ describe EmsClusterController do
       login_as FactoryBot.create(:user, :features => "none")
     end
 
-    subject do
-      get :show, :params => {:id => @cluster.id}
-    end
-
-    context "render" do
+    context "render listnav partial" do
       render_views
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_ems_cluster")
+
+      it "correctly for summary page" do
+        get :show, :params => {:id => @cluster.id}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_ems_cluster")
+        expect(response).to render_template('layouts/_textual_groups_generic')
+      end
+
+      it "correctly for timeline page" do
+        get :show, :params => {:id => @cluster.id, :display => 'timeline'}
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_ems_cluster")
       end
     end
   end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -26,6 +26,12 @@ describe EmsContainerController do
         is_expected.to render_template(:partial => 'ems_container/_show_dashboard')
       end
 
+      it "listnav correctly for timeline" do
+        get :show, :params => { :id => @container.id, :display => 'timeline' }
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_ems_container")
+      end
+
       it "renders topology view" do
         get :show, :params => { :id => @container.id, :display => 'topology' }
         expect(response.status).to eq(200)

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -329,9 +329,15 @@ describe EmsInfraController do
     context "render listnav partial" do
       render_views
 
-      it do
+      it "listnav correctly for summary page" do
         is_expected.to have_http_status 200
         is_expected.not_to render_template(:partial => "layouts/listnav/_ems_infra")
+      end
+
+      it "listnav correctly for timeline" do
+        get :show, :params => { :id => @ems.id, :display => 'timeline' }
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_ems_infra")
       end
     end
 

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -347,10 +347,16 @@ describe HostController do
 
     context "render" do
       render_views
-      it "show and listnav" do
+      it "show and listnav correctly for summary page" do
         is_expected.to have_http_status 200
         is_expected.to render_template('host/show')
         is_expected.to render_template(:partial => "layouts/listnav/_host")
+      end
+
+      it "show and listnav correctly for timeline page" do
+        get :show, :params => {:id => @host.id, :display => 'timeline'}
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_host")
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670550

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/3827 so this PR **can not** reintroduce toolbar with Configuration,...

Steps to test:
- make sure Cloud Intel -> Timeline still has a timeline tree in listnav
- for Availability Zones, Containers, Container Groups, Container Nodes, Container Pods, Container Projects, Clusters/Deployment Roles, Hosts/Nodes, Cloud Providers, Infra Providers, Container Providers select one of items and go to its summary page and Monitoring -> Timelines -> see that listnav is the same as in summary page and toolbar has only Back button
- all things in listnav redirects correctly after clicking

Before:
![image](https://user-images.githubusercontent.com/9210860/52116265-06afe100-2611-11e9-85cc-a7852ed72acc.png)

After:
![image](https://user-images.githubusercontent.com/9210860/52115589-3eb62480-260f-11e9-90a7-3a4ea84fd8c0.png)

@miq-bot add_label bug, hammer/yes

Having [this issue](https://github.com/ManageIQ/manageiq-ui-classic/issues/2912) resolved would save me tons of time.
