### PR TITLE
[WIP] Keep users authenticated when using the UI, even when not sending server actions

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -286,26 +286,34 @@ function miqDimDiv(divname, status) {
   }
 }
 
+function miqInAForm() {
+  if (miqDomElementExists('ignore_form_changes'))
+    return false;
+
+  if (ManageIQ.angular.scope) {
+    return ManageIQ.angular.scope.angularForm && ManageIQ.angular.scope.angularForm.$dirty;
+  } else {
+    return ManageIQ.changes || $('#buttons_on').is(':visible');
+  }
+
+  return false;
+}
+
 // Check for changes and prompt
 function miqCheckForChanges() {
-  if (ManageIQ.angular.scope) {
-    if (ManageIQ.angular.scope.angularForm !== undefined &&
-      ManageIQ.angular.scope.angularForm.$dirty &&
-      !miqDomElementExists('ignore_form_changes')) {
-      var answer = confirm(__('Abandon changes?'));
-      if (answer) {
-        ManageIQ.angular.scope.angularForm.$setPristine(true);
-      }
-      return answer;
-    }
-  } else if (((miqDomElementExists('buttons_on') &&
-               $('#buttons_on').is(':visible')) ||
-              ManageIQ.changes !== null) &&
-             !miqDomElementExists('ignore_form_changes')) {
-    return confirm(__('Abandon changes?'));
+  var form = miqInAForm();
+  if (! form) {
+    // use default browser reaction for onclick
+    return true;
   }
-  // use default browser reaction for onclick
-  return true;
+
+  var answer = confirm(__('Abandon changes?'));
+
+  if (answer && ManageIQ.angular.scope && ManageIQ.angular.scope.angularForm) {
+    ManageIQ.angular.scope.angularForm.$setPristine(true);
+  }
+
+  return answer;
 }
 
 // Hide/show form buttons

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -48,6 +48,9 @@ if (!window.ManageIQ) {
     i18n: {
       mark_translated_strings: false,
     },
+    login: {
+      timeout: null, // session timeout in seconds
+    },
     mouse: {
       x: null, // mouse X coordinate for popup menu
       y: null, // mouse Y coordinate for popup menu

--- a/app/controllers/ui_controller.rb
+++ b/app/controllers/ui_controller.rb
@@ -1,0 +1,17 @@
+# **not** inheriting from ApplicationController
+# this controller should stick to JSON
+
+class UiController < ActionController::Base
+  if Vmdb::Application.config.action_controller.allow_forgery_protection
+    # Add CSRF protection for this controller, see ApplicationController for details
+    protect_from_forgery(:secret => SecureRandom.hex(64),
+                         :with   => :exception)
+  end
+
+  def keepalive
+    head :unauthorized unless session[:userid]
+    render :json => {
+      :timeout => ::Settings.session.timeout,
+    }
+  end
+end

--- a/app/controllers/ui_controller.rb
+++ b/app/controllers/ui_controller.rb
@@ -9,9 +9,21 @@ class UiController < ActionController::Base
   end
 
   def keepalive
+    # 401 when session timed out,
+    # 422 when invalid csrf,
+    # 200 otherwise
+
     head :unauthorized unless session[:userid]
     render :json => {
       :timeout => ::Settings.session.timeout,
     }
+  end
+
+  rescue_from StandardError, :with => :error_handler
+  def error_handler(e)
+    status = 500
+    status = 422 if ActionController::InvalidAuthenticityToken === e
+
+    render :json => {:error => e, :message => e.message}, :status => status
   end
 end

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -1,5 +1,5 @@
 /* global miqInAForm */
-import idleJs from 'idle-js';
+import IdleJs from 'idle-js';
 
 let last_ping = new Date() / 1000;
 let idle = null;
@@ -16,13 +16,11 @@ export default function miqKeepAlive() {
 
   interval = window.setInterval(maybePing, ManageIQ.login.timeout / 3 * 1000);
 
-  idle = new idleJs({
+  idle = new IdleJs({
     idle: 60000, // idle after a minute
-    // setTimeout - workaround for https://github.com/soixantecircuits/idle-js/issues/6
-    onActive: () => setTimeout(maybePing, 1000),
+    onActive: maybePing,
     onShow: maybePing,
-  });
-  idle.start();
+  }).start();
 }
 
 // ping, except when hidden, inactive, or pinged in the last timeout/3 seconds
@@ -73,7 +71,7 @@ function stop() {
   window.clearInterval(interval);
   interval = null;
 
-  // idle.stop();
+  idle.stop();
   stopped = true;
 }
 

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -1,0 +1,45 @@
+let last_ping = new Date() / 1000;
+
+export default function miqKeepAlive() {
+  if (! ManageIQ.login.timeout) {
+    console.warning('Not initializing keepalive, no session timeout info.');
+    return;
+  }
+
+  if (document.hidden === undefined) {
+    console.warning('Not initializing keepalive, Page Visibility API unsupported.');
+    return;
+  }
+
+  document.addEventListener("visibilitychange", maybePing);
+  window.setInterval(maybePing, ManageIQ.login.timeout / 2 * 1000);
+}
+
+// ping, except when hidden, or pinged in the last timeout/2 seconds
+function maybePing() {
+  const now = new Date() / 1000;
+
+  if (document.hidden) {
+    return;
+  }
+
+  if (now - last_ping < ManageIQ.login.timeout / 2) {
+    return;
+  }
+
+  ping();
+}
+
+// actually renews the cookie
+function ping() {
+  http.post('/ui/keepalive')
+    .then((response) => {
+      ManageIQ.login.timeout = response.timeout;
+      last_ping = new Date() / 1000;
+    })
+    .catch(() => {
+      window.add_flash(__("You have been logged out becuase of session timeout."), "warning");
+      // TODO only when editing
+      window.add_flash(__("Please make sure to log in in a different tab before submitting the form."), "info");
+    });
+}

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -13,7 +13,8 @@ export default function miqKeepAlive() {
 
   idle = new idleJs({
     idle: 60000, // idle after a minute
-    onActive: maybePing,
+    // setTimeout - workaround for https://github.com/soixantecircuits/idle-js/issues/6
+    onActive: () => setTimeout(maybePing, 1000),
     onShow: maybePing,
   });
   idle.start();

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -12,10 +12,11 @@ export default function miqKeepAlive() {
   }
 
   document.addEventListener("visibilitychange", maybePing);
-  window.setInterval(maybePing, ManageIQ.login.timeout / 2 * 1000);
+  window.setInterval(maybePing, ManageIQ.login.timeout / 3 * 1000);
 }
 
-// ping, except when hidden, or pinged in the last timeout/2 seconds
+// ping, except when hidden, or pinged in the last timeout/3 seconds
+// halving is not enough: if the server takes too long to respond, every other ping gets skipped
 function maybePing() {
   const now = new Date() / 1000;
 
@@ -23,7 +24,7 @@ function maybePing() {
     return;
   }
 
-  if (now - last_ping < ManageIQ.login.timeout / 2) {
+  if (now - last_ping < ManageIQ.login.timeout / 3) {
     return;
   }
 

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -1,4 +1,5 @@
 let last_ping = new Date() / 1000;
+let last_click = new Date() / 1000;
 
 export default function miqKeepAlive() {
   if (! ManageIQ.login.timeout) {
@@ -11,8 +12,14 @@ export default function miqKeepAlive() {
     return;
   }
 
-  document.addEventListener("visibilitychange", maybePing);
+  document.addEventListener('visibilitychange', maybePing);
   window.setInterval(maybePing, ManageIQ.login.timeout / 3 * 1000);
+
+  document.addEventListener('click', lastClick);
+}
+
+function lastClick() {
+  last_click = new Date() / 1000;
 }
 
 // ping, except when hidden, or pinged in the last timeout/3 seconds
@@ -25,6 +32,11 @@ function maybePing() {
   }
 
   if (now - last_ping < ManageIQ.login.timeout / 3) {
+    return;
+  }
+
+  // if the last click was closer to the last ping then to now, ignore it
+  if ((now - last_click) > ((now - last_ping) / 2)) {
     return;
   }
 

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -3,6 +3,8 @@ import idleJs from 'idle-js';
 
 let last_ping = new Date() / 1000;
 let idle = null;
+let interval = null;
+let stopped = true;
 
 export default function miqKeepAlive() {
   if (! ManageIQ.login.timeout) {
@@ -10,7 +12,9 @@ export default function miqKeepAlive() {
     return;
   }
 
-  window.setInterval(maybePing, ManageIQ.login.timeout / 3 * 1000);
+  stopped = false;
+
+  interval = window.setInterval(maybePing, ManageIQ.login.timeout / 3 * 1000);
 
   idle = new idleJs({
     idle: 60000, // idle after a minute
@@ -23,6 +27,10 @@ export default function miqKeepAlive() {
 
 // ping, except when hidden, inactive, or pinged in the last timeout/3 seconds
 function maybePing() {
+  if (stopped) {
+    return;
+  }
+
   const now = new Date() / 1000;
 
   if (! idle.visible) {
@@ -43,16 +51,31 @@ function maybePing() {
 
 // actually renews the cookie
 function ping() {
-  http.post('/ui/keepalive')
+  http.post('/ui/keepalive', {}, {
+    skipErrors: [401, 422], // logged out, invalid csrf
+  })
     .then((response) => {
       ManageIQ.login.timeout = response.timeout;
       last_ping = new Date() / 1000;
     })
     .catch(() => {
-      window.add_flash(__("You have been logged out becuase of session timeout."), "warning");
+      window.add_flash(__('You have been logged out because of session timeout.'), 'warning');
 
       if (miqInAForm()) {
-        window.add_flash(__("Please make sure to log in in a different tab before submitting the form."), "info");
+        window.add_flash(__('Please make sure to log in in a different tab before submitting the form.'), 'info');
       }
+
+      stop();
     });
 }
+
+function stop() {
+  window.clearInterval(interval);
+  interval = null;
+
+  // idle.stop();
+  stopped = true;
+}
+
+miqKeepAlive.ping = ping;
+miqKeepAlive.stop = stop;

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -25,22 +25,18 @@ function maybePing() {
   const now = new Date() / 1000;
 
   if (! idle.visible) {
-    console.log('bail: hidden');
     return;
   }
 
   if (idle.idle) {
-    console.log('bail: idle');
     return;
   }
 
   // halving the timeout is not enough: if the server takes too long to respond, every other ping gets skipped
   if (now - last_ping < ManageIQ.login.timeout / 3) {
-    console.log('bail: timeout', {timeout: ManageIQ.login.timeout, diff: now - last_ping, now, last_ping});
     return;
   }
 
-  console.log('ping');
   ping();
 }
 

--- a/app/javascript/helpers/keepalive.js
+++ b/app/javascript/helpers/keepalive.js
@@ -1,3 +1,4 @@
+/* global miqInAForm */
 import idleJs from 'idle-js';
 
 let last_ping = new Date() / 1000;
@@ -49,7 +50,9 @@ function ping() {
     })
     .catch(() => {
       window.add_flash(__("You have been logged out becuase of session timeout."), "warning");
-      // TODO only when editing
-      window.add_flash(__("Please make sure to log in in a different tab before submitting the form."), "info");
+
+      if (miqInAForm()) {
+        window.add_flash(__("Please make sure to log in in a different tab before submitting the form."), "info");
+      }
     });
 }

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -22,6 +22,8 @@ import { history } from '../miq-component/react-history.ts';
 import createReduxRoutingActions from '../miq-redux/redux-router-actions';
 import { formButtonsActionTypes, createFormButtonsActions } from '../forms/form-buttons-reducer';
 
+import miqKeepAlive from '../helpers/keepalive.js';
+
 ManageIQ.component = {
   ...newRegistry,
   reactBlueprint,
@@ -55,3 +57,6 @@ require('xml_display/XMLDisplay.css');
 
 // miqSpinner, miqSearchSpinner
 window.Spinner = Spinner;
+
+// don't log out in the middle of editing a form
+window.miqKeepAlive = miqKeepAlive;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,6 +24,7 @@
       ManageIQ.charts.provider = "#{Charting.backend}";
       ManageIQ.browser = "#{j browser_info(:name_ui)}";
       ManageIQ.controller = "#{j controller_name}";
+      ManageIQ.login.timeout = #{::Settings.session.timeout.to_json};
 
     - if ::Settings.server.asynchronous_notifications
       :javascript

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,6 +25,7 @@
       ManageIQ.browser = "#{j browser_info(:name_ui)}";
       ManageIQ.controller = "#{j controller_name}";
       ManageIQ.login.timeout = #{::Settings.session.timeout.to_json};
+      miqKeepAlive()
 
     - if ::Settings.server.asynchronous_notifications
       :javascript

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2954,6 +2954,10 @@ Rails.application.routes.draw do
       :get  => %w(index)
     },
 
+    :ui                       => {
+      :post => %w(keepalive),
+    },
+
     :vm                       => {
       :get  => %w(
         download_data

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "graphiql": "^0.11.11",
     "graphql": "~0.12.0",
     "history": "^4.7.2",
+    "idle-js": "~0.1.3",
     "jquery": "~2.2.4",
     "jquery-ui": "~1.12.1",
     "jquery-ujs": "~1.2.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "graphiql": "^0.11.11",
     "graphql": "~0.12.0",
     "history": "^4.7.2",
-    "idle-js": "~0.1.3",
+    "idle-js": "~1.1.2",
     "jquery": "~2.2.4",
     "jquery-ui": "~1.12.1",
     "jquery-ujs": "~1.2.2",


### PR DESCRIPTION
Problem:

* have short session timeout,
* use a new (angular or react) form, 
* start filling out the form, wait out the timeout, try to save
* :boom: , the user gets redirected to the login screen, losing the form data

Solution:

* detect user activity & page visibility, using https://github.com/soixantecircuits/idle-js/
* keep the session alive *if* the user is active in the UI

---

In order to do that:

* (ruby) added UiController, with CSRF handling, but nothing else from ApplicationController
  * a more conservative alternative would be to add the new endpoint to /dashboard, but this seems cleaner
  * and ApplicationController redirects on wrong session, so the method would not even get called

* (ruby) added a `/ui/keepalive` POST endpoint, which will refresh the cookie

* (js) `ManageIQ.login.timeout` now stores the session timeout in seconds

* (js) added `miqKeepAlive`:
  * gets called on full page loads (but not on the login screen),

  * uses `setInterval` to maybe ping every `timeout / 3` seconds
  * uses https://github.com/soixantecircuits/idle-js/ to maybe ping when the tab becomes visible or when the user becomes active

  * the "maybe ping" actually happens only when the UI is visible,
  * and the user has been active in the last minute,
  * and another ping has happened at least `timeout / 3` seconds ago
    * the `3` is to account for the possibility of every other request getting skipped because the server takes non-zero time to respond
    * the initial load is considered a ping too, without actually pinging

https://bugzilla.redhat.com/show_bug.cgi?id=1591022