### PR TITLE
Advanced Search Save: don't create unnecessary flash message

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -45,7 +45,7 @@ module ApplicationController::AdvancedSearch
 
   def adv_search_button_saveid
     if @edit[:new_search_name].nil? || @edit[:new_search_name] == ""
-      add_flash(_("Search Name is required"), :error)
+      add_flash(_("Search Name is required"), :error) if params[:button] == 'saveit'
       false
     else
       s = @edit[@expkey].build_search(@edit[:new_search_name], @edit[:search_type], session[:userid])


### PR DESCRIPTION
1. Advanced search
2. Commit search expression
3. Hit `Save` button
4. Watch `log/evm.log`

Before:
```
ERROR -- : MIQ(vm_infra_controller-adv_search_button): Search Name is required
```

After: no unnecessary error log

https://bugzilla.redhat.com/show_bug.cgi?id=1670472