### PR TITLE
Add listnav to Embedded Ansible pages

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -9,6 +9,7 @@ class AnsibleCredentialController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::EmbeddedAnsibleRefreshMixin
+  include Mixins::ListnavMixin
 
   menu_section :ansible_credentials
 

--- a/app/controllers/ansible_playbook_controller.rb
+++ b/app/controllers/ansible_playbook_controller.rb
@@ -8,6 +8,7 @@ class AnsiblePlaybookController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::ListnavMixin
 
   menu_section :ansible_playbooks
 

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -9,6 +9,7 @@ class AnsibleRepositoryController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
   include Mixins::EmbeddedAnsibleRefreshMixin
+  include Mixins::ListnavMixin
 
   menu_section :ansible_repositories
 

--- a/app/controllers/mixins/listnav_mixin.rb
+++ b/app/controllers/mixins/listnav_mixin.rb
@@ -1,0 +1,11 @@
+module Mixins
+  module ListnavMixin
+    def listnav_filename
+      if params[:action] == "show_list"
+        "show_list"
+      elsif params[:action] == "show"
+        self.controller_name
+      end
+    end
+  end
+end

--- a/app/views/layouts/listnav/_ansible_credential.html.haml
+++ b/app/views/layouts/listnav/_ansible_credential.html.haml
@@ -1,0 +1,19 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = li_link(:count     => @record.number_of(:configuration_script_sources),
+                    :text      => _("Repositories"),
+                    :display   => 'repositories',
+                    :record_id => @record.id,
+                    :title     => _("Show all Playbooks"))

--- a/app/views/layouts/listnav/_ansible_playbook.html.haml
+++ b/app/views/layouts/listnav/_ansible_playbook.html.haml
@@ -1,0 +1,19 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Repository'),
+                    {:controller => "ansible_repository",
+                     :action     => 'show',
+                     :id         => @record.configuration_script_source_id},
+                    :title => _("Show Repositoty for this Playbook"))

--- a/app/views/layouts/listnav/_ansible_repository.html.haml
+++ b/app/views/layouts/listnav/_ansible_repository.html.haml
@@ -1,0 +1,25 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = li_link(:count => @record.total_payloads,
+                    :text          => _("Playbooks"),
+                    :display       => 'playbooks',
+                    :record_id     => @record.id,
+                    :title         => _("Show all Playbooks"))
+      - if @record.authentication.present?
+        %ul.nav.nav-pills.nav-stacked
+          %li
+            = link_to(_("Credential: %{name}") % {:name => @record.authentication.name},
+                      {:controller => "ansible_credential", :action => 'show', :id => @record.authentication.id},
+                      :title => _("Show Credential for this Repository"))

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -9,8 +9,9 @@ describe AnsibleCredentialController do
     subject { get :show, :params => {:id => machine_credential.id} }
     render_views
 
-    it "renders correct template" do
+    it "renders correct template and listnav" do
       is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      is_expected.to render_template(:partial => "layouts/listnav/_ansible_credential")
       is_expected.to have_http_status 200
     end
   end
@@ -19,8 +20,9 @@ describe AnsibleCredentialController do
     subject { get :show_list, :params => {} }
     render_views
 
-    it "renders correct template" do
+    it "renders correct template and listnav" do
       is_expected.to render_template(:partial => "layouts/_gtl")
+      is_expected.to render_template(:partial => "layouts/listnav/_show_list")
       is_expected.to have_http_status 200
     end
 

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -9,8 +9,9 @@ describe AnsiblePlaybookController do
     subject { get :show, :params => {:id => playbook.id} }
     render_views
 
-    it "renders correct template" do
+    it "renders correct template and listnav" do
       is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+      is_expected.to render_template(:partial => "layouts/listnav/_ansible_playbook")
       is_expected.to have_http_status 200
     end
 
@@ -24,8 +25,9 @@ describe AnsiblePlaybookController do
     subject { get :show_list }
     render_views
 
-    it "renders correct template" do
+    it "renders correct template and listnav" do
       is_expected.to render_template(:partial => "layouts/_gtl")
+      is_expected.to render_template(:partial => "layouts/listnav/_show_list")
       is_expected.to have_http_status 200
     end
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -12,8 +12,9 @@ describe AnsibleRepositoryController do
     describe "#show" do
       subject { get :show, :params => {:id => @repository.id} }
 
-      it "render specific view" do
+      it "render specific view and listnav" do
         is_expected.to render_template(:partial => "layouts/_textual_groups_generic")
+        is_expected.to render_template(:partial => "layouts/listnav/_ansible_repository")
         is_expected.to have_http_status 200
       end
     end
@@ -30,9 +31,10 @@ describe AnsibleRepositoryController do
     describe "#show_list" do
       subject { get :show_list, :params => {} }
 
-      it "render list of repositories with a toolbar" do
+      it "render list of repositories with a toolbar and listnav" do
         expect(ApplicationHelper::Toolbar::AnsibleRepositoriesCenter).to receive(:definition).and_call_original
         is_expected.to render_template(:partial => "layouts/_gtl")
+        is_expected.to render_template(:partial => "layouts/listnav/_show_list")
         is_expected.to have_http_status 200
       end
     end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1672689

Before:
![image](https://user-images.githubusercontent.com/9210860/52285751-36d7e680-2967-11e9-8bed-fd1f4a0fd468.png)
After:
![image](https://user-images.githubusercontent.com/9210860/52284257-57eb0800-2964-11e9-8db1-d16f1671b01f.png)
![image](https://user-images.githubusercontent.com/9210860/52284247-51f52700-2964-11e9-9d4e-52f3452c55be.png)
![image](https://user-images.githubusercontent.com/9210860/52284251-5588ae00-2964-11e9-8380-c706a3e57a09.png)

TODO:

- [x] move `listnav_filename` to a mixin
- [x] specs!
- [x] finish listnav for credentials

 
@miq-bot add_label bugzilla needed, wip, automation/ansible