### PR TITLE
Display missing checkboxes for workers under Diagnostics

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -529,7 +529,7 @@ module OpsController::Diagnostics
   def pm_get_workers
     @lastaction = "pm_workers_list"
     @force_no_grid_xml = true
-    @no_checkboxes = true
+    @no_checkboxes = false
     @gtl_type = "list"
     @embedded = @pages = false
     @showlinks = true

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -57,6 +57,32 @@ end
 
 describe OpsController do
   render_views
+
+  describe '#report_data' do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      FactoryBot.create(:miq_worker, :miq_server => server)
+    end
+
+    let(:server) { FactoryBot.create(:miq_server) }
+
+    it 'returns workers with checkboxes' do
+      report_data_request(
+        :model       => 'MiqWorker',
+        :parent_id   => nil,
+        :named_scope => [['with_miq_server_id', server.id]],
+        :explorer    => true,
+        :gtl_dbname  => nil,
+        :gtl_type    => 'list'
+      )
+      results = assert_report_data_response
+      expect(results['data']['rows'].length).to eq(1)
+      expect(results['data']['rows'][0]["cells"][0]).to have_key("is_checkbox")
+      expect(results['data']['rows'][0]["cells"][0]["is_checkbox"]).to be_truthy
+    end
+  end
+
   context "#tree_select" do
     it "renders zone list for diagnostics_tree root node" do
       stub_user(:features => :all)


### PR DESCRIPTION
The server diagnostics page under settings was not displaying checkboxes, so it was not possible to restart the workers using the toolbar button. Setting the correct instance variable to true fixes the issue, specs are added to keep @martinpovolny happy.

**Before:**
![screenshot from 2019-02-06 14-27-42](https://user-images.githubusercontent.com/649130/52318996-6c3e0c00-2a1b-11e9-9bf4-b5c4f4ec544d.png)

**After:**
![screenshot from 2019-02-06 14-26-24](https://user-images.githubusercontent.com/649130/52319001-706a2980-2a1b-11e9-818d-977e678011a5.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1672758

@miq-bot assign @h-kataria 
@miq-bot add_label bug