### PR TITLE
Ansible Tower & Foreman edit - explicitly warn when Zone.visible.empty?

### DIFF
--- a/app/views/configuration_manager/_shared_form.html.haml
+++ b/app/views/configuration_manager/_shared_form.html.haml
@@ -26,7 +26,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}", "ng-if" => "!emsCommonModel.zone_hidden"}
       %label.col-md-2.control-label{"for" => "prov_zone"}
         = _("Zone")
-      .col-md-8
+      .col-md-8{"class" => @server_zones.empty? ? "has-error" : ""}
         - if @server_zones.length <= 1
           %input.form-control{"type"        => "text",
                               "id"          => "prov_zone",
@@ -36,6 +36,9 @@
                               "required"    => "",
                               "readonly"    => true,
                               "style"       => "color: black;"}
+          - if @server_zones.empty?
+            %span.help-block
+              = _("No visible Zones found in current region")
         - else
           = select_tag('zone',
                        options_for_select(@server_zones.sort_by { |name, _name| name }),


### PR DESCRIPTION
Automation > Ansible Tower > Explorer, Configuration > Add a New Provider

When there are no visible zones, the UI looks like this:

![](https://files.gitter.im/ManageIQ/manageiq/ui/4Nbq/Screenshot-from-2019-02-06-14-46-48.png)

The same happens with only 1 zone, but then, the input is filled out.
When multiple zones are found, there's a select instead.

To prevent confusion from a readonly "Zone" input, with nothing in it, adding an explicit message about no visible zones:

![fix](https://user-images.githubusercontent.com/289743/52366474-c05be700-2a41-11e9-9c67-b219d2a9bc77.png)
