### PR TITLE
Ansible job launch confirmation message fix

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -307,7 +307,7 @@ module ApplicationController::Buttons
     ids = find_checked_items if ids == 'LIST' || ids.nil?
 
     if ids.blank?
-      render_flash(_("Error executing custom button: No item was selected."), :error)
+      render_flash(_("Error launching custom button: No item was selected."), :error)
       return
     end
 
@@ -315,7 +315,7 @@ module ApplicationController::Buttons
     obj = objs.first
 
     if objs.empty?
-      render_flash(_("Error executing custom button: No item was selected."), :error)
+      render_flash(_("Error launching custom button: No item was selected."), :error)
       return
     end
 
@@ -344,10 +344,10 @@ module ApplicationController::Buttons
       begin
         custom_buttons_invoke(button, objs)
       rescue StandardError => bang
-        add_flash(_("Error executing: \"%{task_description}\" %{error_message}") %
+        add_flash(_("Error launching: \"%{task_description}\" %{error_message}") %
           {:task_description => params[:desc], :error_message => bang.message}, :error)
       else
-        add_flash(_("\"%{task_description}\" was executed") % {:task_description => params[:desc]})
+        add_flash(_("\"%{task_description}\" was launched") % {:task_description => params[:desc]})
       end
       javascript_flash
     end


### PR DESCRIPTION
Refactor flash messages to use "launch" instead of "execute" when launching Ansible jobs. 

https://bugzilla.redhat.com/show_bug.cgi?id=1669578

Screen shot prior to fix:

![ansible job executed message prior to fix](https://user-images.githubusercontent.com/552686/52380593-4157b600-2a23-11e9-9b9b-47f33f966471.png)

Screen shot post fix:

![ansible job launched message post fix](https://user-images.githubusercontent.com/552686/52380606-50d6ff00-2a23-11e9-93bd-73fa7ab0da33.png)
