### PR TITLE
Fix summary tab in bottlenecks

### DIFF
--- a/app/controllers/bottlenecks_controller.rb
+++ b/app/controllers/bottlenecks_controller.rb
@@ -24,7 +24,7 @@ class BottlenecksController < ApplicationController
 
     # build timeline data when coming back to Summary tab for bottlenecks
     displaying_timeline = @sb[:active_tab] == "summary"
-    get_node_info(x_node) if displaying_timeline
+    get_node_info(x_node, "n") if displaying_timeline
 
     render :update do |page|
       page << javascript_prologue


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670628

Steps to reproduce:
Go to Optimize -> Bottlenecks -> check `Show Host Events` -> see how many events you have -> switch to `Report` tab -> switch back to `Summary` tab -> see that you have less events than before but `Show Host Events` is checked

In my case there's **76** events with `Host Events`


Before:
![image](https://user-images.githubusercontent.com/9210860/52418051-88aa7900-2aed-11e9-89fa-e3ea4b810921.png)

After:
![image](https://user-images.githubusercontent.com/9210860/52418043-847e5b80-2aed-11e9-9452-4846f77514ee.png)


@miq-bot add_label bug, hammer/yes,