### PR TITLE
Add back paging options

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -63,6 +63,8 @@
         {id: 'per_page_20', text: 20, value: 20, hidden: false, enabled: true},
         {id: 'per_page_50', text: 50, value: 50, hidden: false, enabled: true},
         {id: 'per_page_100', text: 100, value: 100, hidden: false, enabled: true},
+        {id: 'per_page_200', text: 200, value: 200, hidden: false, enabled: true},
+        {id: 'per_page_500', text: 500, value: 500, hidden: false, enabled: true},
         {id: 'per_page_1000', text: 1000, value: 1000, hidden: false, enabled: true},
       ],
     };


### PR DESCRIPTION
This PR adds back the options for 200, 500 in "Items per page"

https://bugzilla.redhat.com/show_bug.cgi?id=1515952

<img width="755" alt="screen shot 2019-02-07 at 2 17 48 pm" src="https://user-images.githubusercontent.com/1287144/52436891-7cb9b980-2ae3-11e9-8d50-c1085ea068dd.png">
