### PR TITLE
Container dashboard utilization metrics - fix hourly metrics

### DIFF
--- a/app/assets/javascripts/components/pf_charts/line-chart.component.js
+++ b/app/assets/javascripts/components/pf_charts/line-chart.component.js
@@ -18,6 +18,10 @@ function lineChartController(pfUtils) {
   var prevChartData;
 
   vm.updateAll = function() {
+    if (! vm.config || ! vm.chartData) {
+      return;
+    }
+
     // Need to deep watch changes in chart data
     prevChartData = angular.copy(vm.chartData);
     vm.loadingDone = false;

--- a/app/assets/javascripts/controllers/ems_container_dashboard/utilization_trend_chart_controller.js
+++ b/app/assets/javascripts/controllers/ems_container_dashboard/utilization_trend_chart_controller.js
@@ -67,9 +67,9 @@ angular.module( 'patternfly.charts' ).controller('utilizationTrendChartContainer
             },
           };
         } else {
-          if (allData.interval_name !== 'daily') {
-            vm.cpuUsageSparklineConfig.tooltipFn = chartsMixin.hourlyTimeTooltip;
-            vm.memoryUsageSparklineConfig.tooltipFn = chartsMixin.hourlyTimeTooltip;
+          var sparkline = Object.assign({}, chartsMixin.chartConfig[key + 'UsageSparklineConfig']);
+          if (allData.interval_name !== 'daily') { // hourly or realtime
+            sparkline.tooltipFn = chartsMixin.hourlyTimeTooltip;
           }
 
           metricsDataStruct.data[key] = {
@@ -80,7 +80,7 @@ angular.module( 'patternfly.charts' ).controller('utilizationTrendChartContainer
               'units': chartsMixin.chartConfig[key + 'UsageConfig'].units,
             },
             'donutConfig': chartsMixin.chartConfig[key + 'UsageDonutConfig'],
-            'sparklineConfig': chartsMixin.chartConfig[key + 'UsageSparklineConfig'],
+            'sparklineConfig': sparkline,
           };
         }
       }

--- a/app/assets/javascripts/controllers/ems_container_dashboard/utilization_trend_chart_controller.js
+++ b/app/assets/javascripts/controllers/ems_container_dashboard/utilization_trend_chart_controller.js
@@ -58,11 +58,12 @@ angular.module( 'patternfly.charts' ).controller('utilizationTrendChartContainer
     if (data) {
       var keys = Object.keys(data);
       for (var i in keys) {
-        if (data[keys[i]] === null) {
-          metricsDataStruct.data[keys[i]] = {
+        var key = keys[i];  // 'cpu' || 'memory'
+        if (data[key] === null) {
+          metricsDataStruct.data[key] = {
             'data': {dataAvailable: false},
             'config': {
-              'title': chartsMixin.chartConfig[keys[i] + 'UsageConfig'].title,
+              'title': chartsMixin.chartConfig[key + 'UsageConfig'].title,
             },
           };
         } else {
@@ -70,15 +71,16 @@ angular.module( 'patternfly.charts' ).controller('utilizationTrendChartContainer
             vm.cpuUsageSparklineConfig.tooltipFn = chartsMixin.hourlyTimeTooltip;
             vm.memoryUsageSparklineConfig.tooltipFn = chartsMixin.hourlyTimeTooltip;
           }
-          metricsDataStruct.data[keys[i]] = {
-            'data': chartsMixin.processData(data[keys[i]], 'dates', chartsMixin.chartConfig[keys[i] + 'UsageConfig'].units),
-            'id': keys[i] + 'UsageConfig_' + providerId,
+
+          metricsDataStruct.data[key] = {
+            'data': chartsMixin.processData(data[key], 'dates', chartsMixin.chartConfig[key + 'UsageConfig'].units),
+            'id': key + 'UsageConfig_' + providerId,
             'config': {
-              'title': chartsMixin.chartConfig[keys[i] + 'UsageConfig'].title,
-              'units': chartsMixin.chartConfig[keys[i] + 'UsageConfig'].units,
+              'title': chartsMixin.chartConfig[key + 'UsageConfig'].title,
+              'units': chartsMixin.chartConfig[key + 'UsageConfig'].units,
             },
-            'donutConfig': chartsMixin.chartConfig[keys[i] + 'UsageDonutConfig'],
-            'sparklineConfig': chartsMixin.chartConfig[keys[i] + 'UsageSparklineConfig'],
+            'donutConfig': chartsMixin.chartConfig[key + 'UsageDonutConfig'],
+            'sparklineConfig': chartsMixin.chartConfig[key + 'UsageSparklineConfig'],
           };
         }
       }

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -251,11 +251,13 @@ class ContainerDashboardService < DashboardService
       end
     end
 
-    {
-      :dataAvailable => true,
-      :interval_name => "hourly",
-      :xy_data       => trend_data(hourly_image_metrics)
-    }
+    if hourly_image_metrics.size > 1
+      {
+        :dataAvailable => true,
+        :interval_name => "hourly",
+        :xy_data       => trend_data(hourly_image_metrics)
+      }
+    end
   end
 
   def daily_image_metrics


### PR DESCRIPTION
Compute > Containers > Providers > pick a provider, dashboard view

![good](https://user-images.githubusercontent.com/289743/52480714-67589400-2ba4-11e9-93fb-6b11a3ab8a4a.png)

---

When there **is** daily utilization data, there is no bug.

When no daily data is available, we get console errors:

```
TypeError: Cannot set property 'tooltipFn' of undefined
in app/assets/javascripts/controllers/ems_container_dashboard/utilization_trend_chart_controller.js:70

TypeError: Cannot read property 'layout' of undefined
in app/assets/javascripts/components/pf_charts/trends-chart.component.js:27
```

When no *hourly* data is available, the fallback to realtime or empty (`... || realtime_utilization || empty_utilization_trend_data`) would never get called, because `hourly_utilization` always returned data.

---

=> made sure hourly returns no data when empty, allowing the realtime fallback
=> fix the JS error by setting the `tooltipFn` on the right `metricsDataStruct` object.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667986