### PR TITLE
Converts server relationship form to DDR

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -564,16 +564,6 @@ module VmCommon
     @edit[:new][:server] = @record.miq_server ? @record.miq_server.id.to_s : nil # Set to first category, if not already set
   end
 
-  def evm_relationship_field_changed
-    return unless load_edit("evm_relationship_edit__new")
-    evm_relationship_get_form_vars
-    changed = (@edit[:new] != @edit[:current])
-    render :update do |page|
-      page << javascript_prologue
-      page << javascript_for_miq_button_visibility(changed)
-    end
-  end
-
   def evm_relationship_get_form_vars
     @record = VmOrTemplate.find_by(:id => @edit[:vm_id])
     @edit[:new][:server] = params[:server_id] == "" ? nil : params[:server_id] if params[:server_id]
@@ -593,9 +583,6 @@ module VmCommon
         javascript_redirect(:action => 'show', :id => @record.id)
       end
     when "save"
-      svr = @edit[:new][:server] && @edit[:new][:server] != "" ? MiqServer.find(@edit[:new][:server]) : nil
-      @record.miq_server = svr
-      @record.save
       add_flash(_("Management Engine Relationship saved"))
       if @edit[:explorer]
         @sb[:action] = nil
@@ -603,17 +590,6 @@ module VmCommon
       else
         flash_to_session
         javascript_redirect(:action => 'show', :id => @record.id)
-      end
-    when "reset"
-      @in_a_form = true
-      if @edit[:explorer]
-        @explorer = true
-        evm_relationship
-        add_flash(_("All changes have been reset"), :warning)
-        replace_right_cell
-      else
-        flash_to_session(_("All changes have been reset"), :warning)
-        javascript_redirect(:action => 'evm_relationship', :id => @record.id, :escape => true)
       end
     end
   end
@@ -1302,6 +1278,9 @@ module VmCommon
         presenter.update(:form_buttons_div, '') if action == "retire" || hide_x_edit_buttons(action)
 
         presenter.remove_paging.show(:form_buttons_div)
+
+        # evm_relationship_update uses React form and buttons
+        presenter.hide(:form_buttons_div) if action == "evm_relationship_update"
       end
       presenter.show(:paging_div)
     else

--- a/app/javascript/components/vm-server-relationship-form/index.jsx
+++ b/app/javascript/components/vm-server-relationship-form/index.jsx
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'patternfly-react';
+import MiqFormRenderer from '../../forms/data-driven-form';
+import { API } from '../../http_api';
+import { cleanVirtualDom } from '../../miq-component/helpers';
+import createSchema from './vm-server-relationship-form.schema';
+
+class VmServerRelationShipForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: true,
+    };
+    cleanVirtualDom();
+  }
+
+  componentDidMount() {
+    const { serverId } = this.props;
+    API.get('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc')
+      .then(({ resources }) => {
+        const assignedServer = resources.find(({ id }) => id === serverId);
+        const serverHref = assignedServer ? assignedServer.href : undefined;
+        this.setState({
+          isLoading: false,
+          schema: createSchema([
+            { label: `<${__('Not a Server')}>` },
+            ...resources.map(({ href, name, id }) => ({ value: href, label: `${name} (${id})` })),
+          ]),
+          initialValues: {
+            serverId: serverHref,
+          },
+        });
+      });
+  }
+
+  onSubmit = (values) => {
+    const { vmId } = this.props;
+    const submitUrl = `/vm_or_template/evm_relationship_update/${vmId}?button=save`;
+    return API.post(`/api/vms/${vmId}`, {
+      action: 'set_miq_server',
+      resource: {
+        miq_server: { href: values.serverId || undefined },
+      },
+    })
+      .then(() => miqAjaxButton(submitUrl));
+  }
+
+  render() {
+    const { vmId } = this.props;
+    const { initialValues, isLoading, schema } = this.state;
+    const cancelUrl = `/vm_or_template/evm_relationship_update/${vmId}?button=cancel`;
+
+    if (isLoading) { return null; }
+
+    return (
+      <Grid fluid>
+        <MiqFormRenderer
+          initialValues={initialValues}
+          schema={schema}
+          onSubmit={this.onSubmit}
+          onReset={() => add_flash(__('All changes have been reset'), 'warn')}
+          onCancel={() => miqAjaxButton(cancelUrl)}
+          canReset
+          buttonsLabels={{
+            submitLabel: __('Save'),
+          }}
+        />
+      </Grid>
+    );
+  }
+}
+
+VmServerRelationShipForm.propTypes = {
+  vmId: PropTypes.string.isRequired,
+  serverId: PropTypes.string,
+};
+
+VmServerRelationShipForm.defaultProps = {
+  serverId: undefined,
+};
+
+export default VmServerRelationShipForm;

--- a/app/javascript/components/vm-server-relationship-form/vm-server-relationship-form.schema.js
+++ b/app/javascript/components/vm-server-relationship-form/vm-server-relationship-form.schema.js
@@ -1,0 +1,14 @@
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+
+const createSchema = (options = []) => ({
+  fields: [{
+    component: componentTypes.SELECT,
+    name: 'serverId',
+    id: 'serverId',
+    label: __('Select Server:'),
+    placeholder: `<${__('Not a Server')}>`,
+    options,
+  }],
+});
+
+export default createSchema;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -10,6 +10,7 @@ import CloudTenantForm from '../components/cloud-tenant-form/cloud-tenant-form';
 import ServiceForm from '../components/service-form';
 import SetServiceOwnershipForm from '../components/set-service-ownership-form';
 import FlavorForm from '../components/flavor-form/flavor-form';
+import VmServerRelationshipForm from '../components/vm-server-relationship-form';
 
 /**
 * Add component definitions to this file.
@@ -30,3 +31,4 @@ ManageIQ.component.addReact('CloudTenantForm', CloudTenantForm);
 ManageIQ.component.addReact('ServiceForm', ServiceForm);
 ManageIQ.component.addReact('SetServiceOwnershipForm', SetServiceOwnershipForm);
 ManageIQ.component.addReact('FlavorForm', FlavorForm);
+ManageIQ.component.addReact('VmServerRelationshipForm', VmServerRelationshipForm);

--- a/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
+++ b/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import fetchMock from 'fetch-mock';
+import VmServerRelationShipForm from '../../components/vm-server-relationship-form';
+import '../helpers/miqAjaxButton';
+
+describe('Vm server relationship form component', () => {
+  const miqAjaxButtonSpy = jest.spyOn(window, 'miqAjaxButton');
+  const servers = {
+    resources: [
+      { href: 'http://localhost:3000/api/servers/7', id: '7', name: 'miq-5.9.0.21-TE4' },
+      { href: 'http://localhost:3000/api/servers/13', id: '13', name: 'miq-5.9.0.21-TE7' },
+      { href: 'http://localhost:3000/api/servers/1', id: '1', name: 'miq-5.9.0.21-TE1' },
+      { href: 'http://localhost:3000/api/servers/12', id: '12', name: 'miq-5.9.0.21-TE11' },
+      { href: 'http://localhost:3000/api/servers/4', id: '4', name: 'miq-5.9.0.21-TE3' },
+      { href: 'http://localhost:3000/api/servers/10', id: '10', name: 'miq-5.9.0.21-TE10' },
+      { href: 'http://localhost:3000/api/servers/14', id: '14', name: 'miq-5.9.0.21-TE13' },
+      { href: 'http://localhost:3000/api/servers/11', id: '11', name: 'miq-5.9.0.21-TE12' },
+      { href: 'http://localhost:3000/api/servers/8', id: '8', name: 'miq-5.9.0.21-TE8' },
+      { href: 'http://localhost:3000/api/servers/2', id: '2', name: 'miq-5.9.0.21-TE2' },
+      { href: 'http://localhost:3000/api/servers/6', id: '6', name: 'miq-5.9.0.21-TE5' },
+      { href: 'http://localhost:3000/api/servers/16', id: '16', name: 'EVM' },
+    ],
+  };
+
+  const props = {
+    vmId: '10',
+  };
+
+  afterEach(() => {
+    fetchMock.reset();
+    miqAjaxButtonSpy.mockReset();
+  });
+
+  it('should call cancel callback ', (done) => {
+    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
+    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+
+    setImmediate(() => {
+      wrapper.update();
+      wrapper.find('button').last().simulate('click');
+      expect(miqAjaxButtonSpy).toHaveBeenCalledWith('/vm_or_template/evm_relationship_update/10?button=cancel');
+      done();
+    });
+  });
+
+  it('should request data after mount and set to state (no serverId)', (done) => {
+    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
+    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+
+    expect(fetchMock.called('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc')).toBe(true);
+
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.state().initialValues).toEqual({
+        serverId: undefined,
+      });
+      done();
+    });
+  });
+
+  it('should request data after mount and set to state (with serverId)', (done) => {
+    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
+    const wrapper = mount(<VmServerRelationShipForm {...props} serverId="13" />);
+
+    expect(fetchMock.called('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc')).toBe(true);
+
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.state().initialValues).toEqual({
+        serverId: 'http://localhost:3000/api/servers/13',
+      });
+      done();
+    });
+  });
+
+  it('should not submit values when form is not valid', (done) => {
+    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
+    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+    const spy = jest.spyOn(wrapper.instance(), 'onSubmit');
+
+    setImmediate(() => {
+      wrapper.update();
+      const button = wrapper.find('button').first();
+      button.simulate('click');
+      expect(spy).toHaveBeenCalledTimes(0);
+      done();
+    });
+  });
+
+  it('onSubmit parses data and post to API', (done) => {
+    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
+    fetchMock.postOnce('/vm_or_template/evm_relationship_update/10?button=save', {});
+    fetchMock.postOnce('/api/vms/10', {});
+
+    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+    const values = {
+      serverId: 'http://localhost:3000/api/servers/16',
+    };
+    wrapper.instance().onSubmit(values).then(() => {
+      expect(miqAjaxButtonSpy).toHaveBeenCalledWith('/vm_or_template/evm_relationship_update/10?button=save');
+      expect(fetchMock.called('/api/vms/10',
+        {
+          action: 'set_miq_server',
+          resource: {
+            miq_server: {
+              href: values.serverId,
+            },
+          },
+        })).toBe(true);
+      done();
+    });
+  });
+});

--- a/app/views/vm_common/_evm_relationship.html.haml
+++ b/app/views/vm_common/_evm_relationship.html.haml
@@ -3,20 +3,5 @@
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Servers')
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _('Select Server:')
-      .col-md-8
-        = select_tag("server_id",
-                      options_for_select([["<#{_('Not a Server')}>", ""]] + @servers.sort, @edit[:new][:server]),
-                      "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
-                      :class    => "selectpicker",
-                      "data-miq_observe" => {:url => url}.to_json)
-      :javascript
-        miqInitSelectPicker();
-        miqSelectPickerEvent("server_id", "#{url}")
-      %td{:width => '100'}
-  - unless @edit[:explorer]
-    = render(:partial => '/layouts/edit_form_buttons',
-      :locals => {:action_url => 'evm_relationship_update', :ajax_buttons => true})
+  .col-md-12
+    = react('VmServerRelationshipForm', { :vmId => @edit[:vm_id].to_s, :serverId => @edit[:new][:server].to_s})

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@data-driven-forms/pf3-component-mapper": "^0.2.6",
-    "@data-driven-forms/react-form-renderer": "^1.4.4",
+    "@data-driven-forms/pf3-component-mapper": "^0.4.3",
+    "@data-driven-forms/react-form-renderer": "^1.7.0",
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.2.1",
     "@pf3/select": "~1.12.6",


### PR DESCRIPTION
### Description

- Converted `Services > Workloads > Select One and go to his show page > Configuration > Edit Management Engine Relationship` form to DDR

### Before

![screenshot from 2019-02-08 12-24-51](https://user-images.githubusercontent.com/32869456/52475695-9408ad80-2b9c-11e9-9046-4a20e844e569.png)

### After

![screenshot from 2019-02-13 11-09-59](https://user-images.githubusercontent.com/32869456/52704101-1c61c680-2f80-11e9-92f2-f877abdd9175.png)

(The length of the select field was discussed with @terezanovotna and it will be changed in PF3-mapper library.) 

### Checklist
- [x] Form schema
- [x] Submit action
- [x] Tests