### PR TITLE
Fix database connections page

### DIFF
--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -26,7 +26,7 @@ module OpsController::Db
         ]
       )
     elsif model == VmdbDatabaseConnection
-      @zones = Zone.visible.order(&:name).collect { |z| [z.name, z.name] }
+      @zones = Zone.visible.order(:name).collect { |z| [z.name, z.name] }
       # for now we dont need this pulldown, need to get a method that gives us a list of workers for filter pulldown
       # @workers = MiqWorker.all.sort_by(&:type).collect { |w| [w.friendly_name, w.id] }
     end


### PR DESCRIPTION
The AR method #order doesn't take a block.
This was changed in 08c83427a6

Currently this fails with:
```
[----] F, [2019-02-11T10:16:52.236114 #14890:2b28dbfe56a8] FATAL -- : Error caught: [ArgumentError] The method .order() must contain arguments.
/home/ncarboni/.gem/ruby/2.4.3/gems/activerecord-5.0.7.1/lib/active_record/relation/query_methods.rb:1214:in `check_if_method_has_arguments!'
/home/ncarboni/.gem/ruby/2.4.3/gems/activerecord-5.0.7.1/lib/active_record/relation/query_methods.rb:338:in `order'
/home/ncarboni/.gem/ruby/2.4.3/bundler/gems/manageiq-ui-classic-2e054446e056/app/controllers/ops_controller/db.rb:29:in `db_list'
/home/ncarboni/.gem/ruby/2.4.3/bundler/gems/manageiq-ui-classic-2e054446e056/app/controllers/ops_controller/db.rb:111:in `db_get_info'
/home/ncarboni/.gem/ruby/2.4.3/bundler/gems/manageiq-ui-classic-2e054446e056/app/controllers/ops_controller.rb:205:in `change_tab'
/home/ncarboni/.gem/ruby/2.4.3/gems/actionpack-5.0.7.1/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/home/ncarboni/.gem/ruby/2.4.3/gems/actionpack-5.0.7.1/lib/abstract_controller/base.rb:188:in `process_action'
```

@skateman please review.