### PR TITLE
Do not hide the spinner before the custom button simulate redirect

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1413,6 +1413,8 @@ function miqToolbarOnClick(_e) {
     'download_choice__render_report_csv',
     'download_choice__render_report_pdf',
     'download_choice__render_report_txt',
+    'custom_button_vmdb_choice__ab_button_simulate',
+    'catalogitem_button_vmdb_choice__ab_button_simulate',
   ], button.attr('name')) || button.attr('name').match(/_console$/);
 
   var options = {


### PR DESCRIPTION
On a button's summary page under `Automate -> Customization -> Buttons`, there's a `Simulate` option in the `Configuration` toolbar dropdown. If clicked, a spinner shows up and immediately gets hidden. However, the page redirect might happen with a delay, that might suggest the user that nothing happened. By adding an exception into the toolbar request handling code, the spinner keeps spinning until the redirect actually happens.

@miq-bot assign @himdel 
@miq-bot add_label bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535215