### PR TITLE
Automate Datastore Schema Edit reset click message

### DIFF
--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/flash_msg"
 #column_lists
   .col-md-7.col-sm-10.col-xs-10
     = _('Class Schema Sequencing:')


### PR DESCRIPTION
Automate Explorer datastore schema edit reset button click fixed to display only one confirmation message.

https://bugzilla.redhat.com/show_bug.cgi?id=1525835

Screen shot prior to code fix, double confirmation messages displayed:

![datastore schema edit reset prior to code fix](https://user-images.githubusercontent.com/552686/52596215-a2590280-2e04-11e9-8d49-4123496e7640.png)

Screen shot post code fix, single message:

![datastore schema edit reset post code fix](https://user-images.githubusercontent.com/552686/52596240-b0a71e80-2e04-11e9-85ef-c76ad86b6e7d.png)


