### PR TITLE
Check button's inputs before looking for records

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -587,7 +587,6 @@ module ApplicationController::Buttons
     end
     @edit[:uri] = MiqAeEngine.create_automation_object(ab_button_name, attrs, :fqclass => @edit[:new][:starting_object], :message => @edit[:new][:object_message])
     @edit[:new][:description] = @edit[:new][:description].strip == "" ? nil : @edit[:new][:description] unless @edit[:new][:description].nil?
-    button_set_record_vars(@custom_button)
 
     unless button_valid?
       @breadcrumbs = []
@@ -597,6 +596,8 @@ module ApplicationController::Buttons
       javascript_flash
       return
     end
+
+    button_set_record_vars(@custom_button)
 
     if @custom_button.save
       add_flash(_("Custom Button \"%{name}\" was saved") % {:name => @edit[:new][:description]})
@@ -845,7 +846,9 @@ module ApplicationController::Buttons
   end
 
   def validate_playbook_button(button_hash)
-    add_flash(_("An Ansible Playbook must be selected"), :error) if button_hash[:service_template_id].blank?
+    if button_hash[:service_template_id].blank? || button_hash[:service_template_id].zero?
+      add_flash(_("An Ansible Playbook must be selected"), :error)
+    end
     if button_hash[:inventory_type] == 'manual' && button_hash[:hosts].blank?
       add_flash(_("At least one host must be specified for manual mode"), :error)
     end


### PR DESCRIPTION
Solves https://github.com/ManageIQ/manageiq-ui-classic/issues/5238

Go to Automation -> Automate ->Customization -> Buttons -> try to save/add one that has type Ansible Playbook without  Playbook Catalog Item

Before:
"Nothing" happens
![image](https://user-images.githubusercontent.com/9210860/52717242-f862ad00-2fa0-11e9-83ed-3445d3e4a363.png)
with error in log
```
 : Error caught: [ActiveRecord::RecordNotFound] Couldn't find ServiceTemplate without an ID
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/relation/finder_methods.rb:456:in `find_with_ids'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/relation/finder_methods.rb:66:in `find'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/querying.rb:3:in `find'
/Users/zita/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/core.rb:151:in `find'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:946:in `button_set_playbook_record'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:890:in `button_set_record_vars'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:590:in `ab_button_save'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:486:in `button_create_update'
/Users/zita/Desktop/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/buttons.rb:190:in `button_update'
```
After:
![image](https://user-images.githubusercontent.com/9210860/52717195-d6692a80-2fa0-11e9-9268-f7ac8907d36a.png)

@miq-bot add_label bug, hammer/yes, gaprindashvili/yes, automation/automate