### PR TITLE
Remove not working stuff

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -861,7 +861,6 @@ module ApplicationController::Buttons
     button.uri = @edit[:uri]
     button[:options] = {}
     button.disabled_text = @edit[:new][:disabled_text]
-    #   button[:options][:target_attr_name] = @edit[:new][:target_attr_name]
     button.uri_path, button.uri_attributes, button.uri_message = CustomButton.parse_uri(@edit[:uri])
     button.uri_attributes["request"] = @edit[:new][:object_request]
     button.options[:button_icon] = @edit[:new][:button_icon] if @edit[:new][:button_icon].present?

--- a/app/views/static/generic_object/main_custom_button_form.html.haml
+++ b/app/views/static/generic_object/main_custom_button_form.html.haml
@@ -34,8 +34,6 @@
               "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
-      %span.help-block{"ng-show" => "angularForm.dialog_id.$error.required"}
-        = _("Required")
   .form-group{"ng-class" => "{'has-error': angularForm.display_for.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_display_for"}
       = _("Display for")
@@ -47,8 +45,6 @@
               "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
-      %span.help-block{"ng-show" => "angularForm.display_for.$error.required"}
-        = _("Required")
   .form-group{"ng-class" => "{'has-error': angularForm.submit_how.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_submit_how"}
       = _("Submit")
@@ -60,8 +56,6 @@
               "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
-      %span.help-block{"ng-show" => "angularForm.submit_how.$error.required"}
-        = _("Required")
   .form-group{"ng-class" => "{'has-error': angularForm.ae_instance.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_ae_instance"}
       = _("System/Process")
@@ -73,8 +67,6 @@
               "miq-select"                  => true,}
         %option{"value" => "", "disabled" => ""}
           = "<#{_('Choose')}>"
-      %span.help-block{"ng-show" => "angularForm.ae_instance.$error.required"}
-        = _("Required")
   .form-group{"ng-class" => "{'has-error': angularForm.ae_message.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_ae_message"}
       = _("Message")
@@ -84,8 +76,6 @@
                           "name"        => "ae_message",
                           "ng-model"    => "vm.customButtonModel.ae_message",
                           "maxlength"   => ViewHelper::MAX_NAME_LEN}
-      %span.help-block{"ng-show" => "angularForm.ae_message.$error.required"}
-        = _("Required")
   .form-group{"ng-class" => "{'has-error': angularForm.request.$invalid}"}
     %label.col-md-2.control-label{"for" => "custom_button_request"}
       = _("Request")


### PR DESCRIPTION
Just removing stuff that doesn't work because of a typo/not being complete. Saving myself some time in the future :)

Go to Automation -> Automate -> Generic Objects -> Add/Edit Custom button
 
Before/After:
Has to be same.
![image](https://user-images.githubusercontent.com/9210860/52718478-de769980-2fa3-11e9-8a69-77c4cdfd877d.png)
Only four inputs are red/required.

@miq-bot add_label technical debt, hammer/no
