### PR TITLE
Fix missing flash message for Re-check Authentication Status

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -1,3 +1,4 @@
+#flash_msg_div
 .container-fluid.container-tiles-pf.containers-dashboard
   .row.row-tile-pf
     = render :partial => "ems_container/aggregate-status-card"


### PR DESCRIPTION
**Fixes:**
 https://bugzilla.redhat.com/show_bug.cgi?id=1667980

**What:**
Fix the missing flash message (or better missing flash message div) for re-checking authentication status (and another actions) for selected Container Provider, under _Compute > Containers > Providers_.

**Steps to reproduce:**
1. Have some Openshift Provider and go to _Compute > Containers >Providers_ 
2. Choose some provider, click on it, display its details page
3. On the Dashboard view, select _Authentication > Re-check Authentication Status_
=> nothing is displayed, just error about missing flash message div, in the right upper corner

---

**Before:** (no flash message, error)
![auth_before](https://user-images.githubusercontent.com/13417815/52719852-bfc5d200-2fa6-11e9-929f-20a75410a36b.png)

**After:** (flash message appears also for another actions/operations)
![auth_after](https://user-images.githubusercontent.com/13417815/52719860-c2282c00-2fa6-11e9-8933-26833f365dce.png)
![check_after](https://user-images.githubusercontent.com/13417815/52719865-c5231c80-2fa6-11e9-815b-80f6af316f5c.png)
![refresh_after](https://user-images.githubusercontent.com/13417815/52719868-c6ece000-2fa6-11e9-938a-29407297e242.png)


