### PR TITLE
AC::Parameters doesn't have each_value, use each

### DIFF
--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -176,7 +176,7 @@ class SecurityGroupController < ApplicationController
           end
         end
 
-        params["firewall_rules"].each_value do |rule|
+        params["firewall_rules"].each do |_key, rule|
           if rule["id"] && rule["id"].empty?
             create_rule(rule)
           elsif rule["deleted"]


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Method each_value is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.1/classes/ActionController/Parameters.html (called from update at /Users/joerafaniello/Code/manageiq-ui-classic/app/controllers/security_group_controller.rb:179


Extracted from: https://github.com/ManageIQ/manageiq-ui-classic/pull/5076