### PR TITLE
Fix Expression Builder to load page display only once per dropdown pick

### DIFF
--- a/app/views/layouts/exp_atom/_edit_tag.html.haml
+++ b/app/views/layouts/exp_atom/_edit_tag.html.haml
@@ -42,8 +42,7 @@
       :multiple              => false,
       :class                 => 'selectpicker',
       "data-miq_sparkle_on"  => true,
-      "data-miq_sparkle_off" => true,
-      "data-miq_observe"     => {:url => url}.to_json)
+      "data-miq_sparkle_off" => true)
 
 :javascript
   miqInitSelectPicker();


### PR DESCRIPTION
Ensure that Bootstrap SelectPicker is only invoked once when selecting from dropdowns.

NOTE: this fixes 2 similar BZ tickets, listed below.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1664852

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1664886


Screen shots post code fix:

![conditions add new count condition post code fix](https://user-images.githubusercontent.com/552686/52749655-b20c4e80-2f9e-11e9-9398-453a45122198.png)

![conditions add new host condition post code fix](https://user-images.githubusercontent.com/552686/52749669-b89ac600-2f9e-11e9-9833-c5459d650452.png)




