### PR TITLE
Add ImportSetup listener back to import/export template.

### DIFF
--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -125,5 +125,6 @@
     });
 
     ImportSetup.listenForPostMessages(Automate.getAndRenderAutomateJson);
+    ImportSetup.listenForGitPostMessages();
     Automate.setUpAutomateImportClickHandlers();
   });


### PR DESCRIPTION
Based on https://github.com/ManageIQ/manageiq-ui-classic/pull/5180#discussion_r257185517, it turned out that the `ImportSetup.listenForGitPostMessages()` should not have been removed from template, because its not related to migrated form.

Its related to upload from file and injects new UI to this element: https://github.com/ManageIQ/manageiq-ui-classic/blob/8fd1d8edfc91f62f7218d8d5e7b3b11a903c26c6/app/views/miq_ae_tools/_import_export.html.haml#L110

Now i don't really like how it works and we should probably change it soon. But i will first have to find out what its doing.