### PR TITLE
Fix error during jasmine

### DIFF
--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -20,7 +20,6 @@ src_files:
 - assets/jasmine-jquery/lib/jasmine-jquery
 - assets/angular-mocks
 - __spec__/helpers/fixtures-fix.js
-- __spec__/helpers/toolbar.js
 - packs/manageiq-ui-classic/application-common.js
 - packs/manageiq-ui-classic/toolbar-actions-common.js
 - packs/manageiq-ui-classic/provisioning-actions-common.js


### PR DESCRIPTION
the helper was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5203 but I left a reference to it in jasmine config

fixes

    GET http://localhost:8888/__spec__/helpers/toolbar.js net::ERR_ABORTED 404 (Not Found)
