### PR TITLE
Fix the label of Custom Button Events for infra providers

### DIFF
--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -187,7 +187,7 @@ module EmsInfraHelper::TextualSummary
     return nil unless User.current_user.super_admin_user? || User.current_user.admin?
 
     {
-      :title => _('Custom Button Events'),
+      :label => _('Custom Button Events'),
       :value => num = @record.number_of(:custom_button_events),
       :link  => num.positive? ? ems_infra_path(:id => @record, :display => 'custom_button_events') : nil,
       :icon  => CustomButtonEvent.decorate.fonticon,


### PR DESCRIPTION
If label is not set on a textual, it will be generated from the record class. For the details, see the BZ.

@miq-bot assign @mzazrivec 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1668691