### PR TITLE
Allow to print (export to PDF) the right size recommendations of a VM

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1182,6 +1182,8 @@ module VmCommon
       c_tb = build_toolbar("drifts_center_tb") # Use vm or template tb
     elsif @sb[:action] == 'snapshot_info'
       c_tb = build_toolbar("x_vm_snapshot_center_tb")
+    elsif @sb[:action] == 'right_size'
+      v_tb = build_toolbar("right_size_view_tb")
     elsif @sb[:action] == 'vmtree_info'
       c_tb = build_toolbar("x_vm_vmtree_center_tb")
     end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -535,6 +535,21 @@ module VmCommon
     end
   end
 
+  def right_size_print
+    @record = find_record_with_rbac(Vm, params[:id])
+    @display = "download_pdf"
+    disable_client_cache
+
+    @options = {
+      :page_layout => "portrait",
+      :page_size   => "us-letter",
+      :title       => "\"#{@record.name}\"".html_safe,
+      :quadicon    => false
+    }
+
+    render :template => 'vm_common/_right_size', :layout => '/layouts/print'
+  end
+
   def evm_relationship
     @record = find_record_with_rbac(VmOrTemplate, params[:id]) # Set the VM object
     @edit = {}

--- a/app/helpers/application_helper/toolbar/right_size_view.rb
+++ b/app/helpers/application_helper/toolbar/right_size_view.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Toolbar::RightSizeView < ApplicationHelper::Toolbar::Basic
+  button_group('right_size_view', [
+    button(
+      :right_size_print,
+      'pficon pficon-print fa-lg',
+      N_('Print or export'),
+      nil,
+      :klass => ApplicationHelper::Button::Basic,
+      :url   => "/right_size_print",
+      :popup => true
+    ),
+  ])
+end

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -213,7 +213,7 @@
     - arr = [Vm.cpu_recommendation_minimum, MiqReport.new.format_mbytes_to_human_size(Vm.mem_recommendation_minimum)]
     = _("* Recommendations are subject to minimum of CPU: %{cpu} and Memory: %{memory}.") % {:cpu => arr[0], :memory => arr[1]}
 
-  - unless @explorer
+  - unless @explorer || @display = "download_pdf"
     #buttons_on{:style => "float: right"}
       = button_tag((t = _('Back')),
         :class   => 'btn btn-default',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3029,6 +3029,7 @@ Rails.application.routes.draw do
         perf_chart_chooser
         protect
         retire
+        right_size_print
         show
         tagging_edit
         resize
@@ -3136,6 +3137,7 @@ Rails.application.routes.draw do
         filesystem_download
         retirement_info
         reconfigure_form_fields
+        right_size_print
         launch_html5_console
         launch_vmrc_console
         perf_chart_chooser


### PR DESCRIPTION
Right size recommendations can be accessed from a VM's summary screen under the `Configuration` dropdown in the toolbar.

![screenshot from 2019-02-19 08-53-33](https://user-images.githubusercontent.com/649130/52998552-dd21f280-3423-11e9-8d0b-5c0b67e60350.png)

I created a new toolbar on this page with the print button and a new route that displays the printing dialog. However, it is a little weird to have the button completely on the left side of the toolbar. I don't feel it as consistent, but as far as I see, it is always aligned to the left, but on other pages there are multiple buttons pushing it more to the right.

![screenshot from 2019-02-19 08-49-25](https://user-images.githubusercontent.com/649130/52998785-6d603780-3424-11e9-8ce1-ebb90862d784.png)

The printing follows the same logic as on summary screens, a new window with the printing dialog opened. If you close the printing dialog, the window will close with it so you can get back to the previous page.

@miq-bot add_label enhancement

https://bugzilla.redhat.com/show_bug.cgi?id=1430159
