### PR TITLE
Use ljust to left justify and pad strings

### DIFF
--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -173,7 +173,7 @@ module ReportFormatter
           unless user_filters.blank?
             customer_name = Tenant.root_tenant.name
             user_filter = "User assigned " + customer_name + " Tag filters:"
-            t = user_filter + " " * (@line_len - 2 - user_filter.length)
+            t = user_filter.ljust(@line_len - 2)
             output << fit_to_width("|#{t}|" + CRLF)
             user_filters.each do |filters|
               tag_val = "  " + calculate_filter_names(filters)
@@ -201,7 +201,7 @@ module ReportFormatter
         unless mri.conditions.nil?
           if mri.conditions.kind_of?(Hash)
             filter_fields = "Report based filter fields:"
-            t = filter_fields + " " * (@line_len - 2 - filter_fields.length)
+            t = filter_fields.ljust(@line_len - 2)
             output << fit_to_width("|#{t}|" + CRLF)
 
             # Clean up the conditions for display
@@ -218,17 +218,17 @@ module ReportFormatter
             output << fit_to_width("|#{t}|" + CRLF)
           else
             filter_fields = "Report based filter fields:"
-            t = filter_fields + " " * (@line_len - 2 - filter_fields.length)
+            t = filter_fields.ljust(@line_len - 2)
             output << fit_to_width("|#{t}|" + CRLF)
             filter_val = mri.conditions.to_human
-            t = filter_val + " " * (@line_len - filter_val.length - 2)
+            t = filter_val.ljust(@line_len - 2)
             output << fit_to_width("|#{t}|" + CRLF)
           end
         end
 
         unless mri.display_filter.nil?
           filter_fields = "Display Filter:"
-          t = filter_fields + " " * (@line_len - 2 - filter_fields.length)
+          t = filter_fields.ljust(@line_len - 2)
           output << fit_to_width("|#{t}|" + CRLF)
           filter_val = mri.display_filter.to_human
           t = filter_val + " " * (@line_len - filter_val.length - 2)

--- a/spec/lib/report_formater/text_formatter_spec.rb
+++ b/spec/lib/report_formater/text_formatter_spec.rb
@@ -1,0 +1,78 @@
+describe ReportFormatter::ReportText do
+  include Spec::Support::ReportHelper
+
+  before do
+    allow(Charting).to receive(:backend).and_return(:text)
+    allow(Charting).to receive(:format).and_return(:text)
+  end
+
+  it "expands report width for really long filter condition" do
+    report = null_data_chart_with_complex_condition
+    Timecop.freeze do
+      result = render_report(report) { |r| r.options.ignore_table_width = true }
+
+      expected = <<~TABLE
+        +--------------------------------------------------------------------+
+        | Name | Hardware CPU Speed | Hardware Number of CPUs | Hardware RAM |
+        +--------------------------------------------------------------------+
+        | Чук  |                    | 4                       | 6 GB         |
+        | Гек  |                    |                         | 1 GB         |
+        +--------------------------------------------------------------------+
+        +--------------------------------------------------------------------+
+        |Report based filter fields:                                         |
+        |( Performance - VM : Activity Sample - Timestamp (Day/Time) IS "Last Hour" AND Performance - VM : CPU - Usage Rate for Collected Intervals (%) > 0 AND Performance - VM.VM and Instance : Type INCLUDES "Amazon" )|
+        +--------------------------------------------------------------------+
+        |                  #{described_class.format_timezone(Time.zone.now)}                   |
+        +--------------------------------------------------------------------+
+        TABLE
+      result.lines.each_with_index do |line, index|
+        expect(line.strip).to eq(expected.lines[index].strip)
+      end
+    end
+  end
+
+  it "renders basic text report" do
+    report = null_data_chart
+    Timecop.freeze do
+      result = render_report(report)
+      expected = <<~TABLE
+        +--------------------------------------------------------------------+
+        | Name | Hardware CPU Speed | Hardware Number of CPUs | Hardware RAM |
+        +--------------------------------------------------------------------+
+        | Чук  |                    | 4                       | 6 GB         |
+        | Гек  |                    |                         | 1 GB         |
+        +--------------------------------------------------------------------+
+        +--------------------------------------------------------------------+
+        |                  #{described_class.format_timezone(Time.zone.now)}                   |
+        +--------------------------------------------------------------------+
+        TABLE
+      result.lines.each_with_index do |line, index|
+        expect(line.strip).to eq(expected.lines[index].strip)
+      end
+    end
+  end
+
+  it "renders report with basic filter condition" do
+    report = null_data_chart_with_basic_condition
+    Timecop.freeze do
+      result = render_report(report)
+      expected = <<~TABLE
+        +--------------------------------------------------------------------+
+        | Name | Hardware CPU Speed | Hardware Number of CPUs | Hardware RAM |
+        +--------------------------------------------------------------------+
+        | Чук  |                    | 4                       | 6 GB         |
+        | Гек  |                    |                         | 1 GB         |
+        +--------------------------------------------------------------------+
+        +--------------------------------------------------------------------+
+        |Report based filter fields:                                         |
+        | Name INCLUDES "Amazon"                                             |
+        +--------------------------------------------------------------------+
+        |                  #{described_class.format_timezone(Time.zone.now)}                   |
+        +--------------------------------------------------------------------+
+        TABLE
+      result.lines.each_with_index do |line, index|
+        expect(line.strip).to eq(expected.lines[index].strip)
+      end
+    end
+  end
+end

--- a/spec/support/report_helper.rb
+++ b/spec/support/report_helper.rb
@@ -71,6 +71,33 @@ module Spec
         report
       end
 
+      def null_data_chart_with_basic_condition
+        exp = YAML.safe_load('--- !ruby/object:MiqExpression
+        exp:
+          INCLUDES:
+            field: Name
+            value: Amazon
+        ')
+        null_data_chart.tap { |r| r.update(:conditions => exp) }
+      end
+
+      def null_data_chart_with_complex_condition
+        exp = YAML.safe_load('--- !ruby/object:MiqExpression
+        exp:
+          and:
+          - IS:
+              field: VmPerformance-timestamp
+              value: Last Hour
+          - ">":
+              value: "0"
+              field: VmPerformance-cpu_usage_rate_average
+          - INCLUDES:
+              field: VmPerformance.vm-type
+              value: Amazon
+        ')
+        null_data_chart.tap { |r| r.update(:conditions => exp) }
+      end
+
       def numeric_chart_simple_with_long_strings
         report = MiqReport.new(
           :db          => "Host",


### PR DESCRIPTION
Text based reports ignore line widths.  Performing manual padding was
causing a "negative argument" error if a line exceeded the normal
report's line width.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1677839