### PR TITLE
Allow Approver user to deny the request

### DIFF
--- a/app/helpers/application_helper/button/miq_request.rb
+++ b/app/helpers/application_helper/button/miq_request.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Button::MiqRequest < ApplicationHelper::Button::Generic
 
   def visible?
     return false if @record.resource_type == "AutomationRequest" &&
-                   !%w(miq_request_approval miq_request_deny miq_request_delete).include?(@feature)
+                    !%w(miq_request_approval miq_request_delete).include?(@feature)
     true
   end
 

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -48,7 +48,7 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       N_('Deny this Request'),
       nil,
       :klass     => ApplicationHelper::Button::MiqRequestApproval,
-      :options   => {:feature => 'miq_request_deny'},
+      :options   => {:feature => 'miq_request_approval'},
       :url       => "/stamp",
       :url_parms => "?typ=d"),
   ])

--- a/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_approval_spec.rb
@@ -14,6 +14,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
     let(:request) { "SomeRequest" }
     let(:username) { user.name }
     let(:state) { "xx" }
+
     %w(MiqProvisionRequest VmReconfigureRequest VmCloudReconfigureRequest
        VmMigrateRequest AutomationRequest ServiceTemplateProvisionRequest).each do |cls|
       context "id = miq_request_approval" do
@@ -27,22 +28,28 @@ describe ApplicationHelper::Button::MiqRequestApproval do
           button.instance_variable_set(:@showtype, "prase")
           button.instance_variable_set(:@request_tab, "service")
         end
+
         context "resource_type = AutomationRequest" do
           let(:request) { "AutomationRequest" }
+
           it "and resource_type = AutomationRequest" do
             expect(button.skipped?).to be_falsey
           end
         end
+
         context "approval_state = approved" do
           let(:state) { "approved" }
+
           it "and approval_state = approved" do
             expect(button.skipped?).to be_truthy
           end
         end
+
         it "and showtype = miq_provisions" do
           button.instance_variable_set(:@showtype, "miq_provisions")
           expect(button.skipped?).to be_truthy
         end
+
         it "and approval_state != approved and showtype != miq_provisions" do
           expect(button.skipped?).to be_falsey
         end
@@ -53,7 +60,7 @@ describe ApplicationHelper::Button::MiqRequestApproval do
           view_context,
           {},
           {'record' => @record, 'showtype' => @showtype},
-          {:options => {:feature => 'miq_request_deny'}}
+          {:options => {:feature => 'miq_request_approval'}}
         )
       end
 
@@ -68,28 +75,36 @@ describe ApplicationHelper::Button::MiqRequestApproval do
           button.instance_variable_set(:@showtype, "prase")
           button.instance_variable_set(:@request_tab, "service")
         end
+
         context "resource_type = AutomationRequest" do
           let(:request) { "AutomationRequest" }
+
           it "and resource_type = AutomationRequest" do
             expect(button.skipped?).to be_falsey
           end
         end
+
         context "approval_state = approved" do
           let(:state) { "approved" }
+
           it "and approval_state = approved" do
             expect(button.skipped?).to be_truthy
           end
         end
+
         context "approval_state = denied" do
           let(:state) { "denied" }
+
           it "and approval_state = denied" do
             expect(button.skipped?).to be_truthy
           end
         end
+
         it "and showtype = miq_provisions" do
           button.instance_variable_set(:@showtype, "miq_provisions")
           expect(button.skipped?).to be_truthy
         end
+
         it "and approval_state != approved|denied and showtype != miq_provisions" do
           expect(button.skipped?).to be_falsey
         end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1676910

**What:**
This PR fixes the problem that Approver user was not able to deny the request, only to approve it.
Of course, this makes no sense, the user should have permissions also to deny the request. 
The button for denying the request was missing in the toolbar - 

**Details:**
The problem was that `miq_request_deny` does not exist, there aren't two different features - for approving and denying the request. It is the one - `miq_request_approval`, and the two buttons for appropriate actions.
Check also https://github.com/hstastna/manageiq/blob/master/db/fixtures/miq_product_features.yml#L162,
there is `Approve and Deny` feature, not the two ones.

**How to test:**
You can try the db provided by the reporter of this bug and just click on some already created request under `Services -> Requests` and you will see that, with this PR, the button is not missing anymore. Or .. you can follow the steps in the BZ ticket and create Approver user and a VM creation request but it is not necessary.

**Before:**
![app_before](https://user-images.githubusercontent.com/13417815/53086090-b2f43180-3504-11e9-8bed-5957e7603060.png)

**After:**
![app_after](https://user-images.githubusercontent.com/13417815/53085400-13826f00-3503-11e9-9aac-490252d9ad7c.png)
