### PR TITLE
Add Memory for Amazon Availability Zones

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -852,7 +852,6 @@ module ApplicationController::Performance
                   end
 
     chart_layout = perf_get_chart_layout(layout_name, @perf_options[:model])
-    perf_filter_charts(chart_layout, rpt)
 
     if @perf_options[:index]
       chart_index = @perf_options[:index].to_i
@@ -1273,7 +1272,6 @@ module ApplicationController::Performance
     case perf_options[:typ]
     when "Hourly"
       chart_layout = perf_get_chart_layout("hourly_perf_charts", model_title)
-      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         perf_remove_chart_cols(chart)
@@ -1303,7 +1301,6 @@ module ApplicationController::Performance
       end
     when "realtime"
       chart_layout = perf_get_chart_layout("realtime_perf_charts", model_title)
-      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         perf_remove_chart_cols(chart)
@@ -1332,7 +1329,6 @@ module ApplicationController::Performance
       end
     when "Daily"
       chart_layout = perf_get_chart_layout("daily_perf_charts", model_title)
-      perf_filter_charts(chart_layout, rpt)
       if perf_options[:index]
         chart = chart_layout[perf_options[:index].to_i]
         if chart
@@ -1546,21 +1542,6 @@ module ApplicationController::Performance
       end
     end
     new_rpt
-  end
-
-  # Deletes memory chart from chart_layout, if it is a chart for Amazon Availability Zone
-  # rpt.where_clause[0] should be query string
-  # rpt.where_clause[1] should be model name string
-  # rpt.where_clause[2] should be id
-  def perf_filter_charts(chart_layout, rpt)
-    return unless rpt&.where_clause
-    model = rpt.where_clause.dig(1).constantize
-    id = rpt.where_clause.dig(2)
-    return unless model && id
-    if model == AvailabilityZone &&
-       model.find(id).type == "ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone"
-      chart_layout.reject! { |chart| chart[:title].include?("Memory") }
-    end
   end
 
   def process_chart_trends(chart, rpt, options)


### PR DESCRIPTION
Add Memory Chart for Amazon Availability Zones which was removed by https://github.com/ManageIQ/manageiq-ui-classic/pull/3836


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1677406



