### PR TITLE
Do not show Refresh button on Monitoring page

### DIFF
--- a/app/helpers/application_helper/button/summary_reload.rb
+++ b/app/helpers/application_helper/button/summary_reload.rb
@@ -1,12 +1,16 @@
 class ApplicationHelper::Button::SummaryReload < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def visible?
-    @explorer && ((@record && proper_layout? && proper_showtype?) || @lastaction == 'show_list')
+    @explorer && !monitoring_page? && ((@record && proper_layout? && proper_showtype?) || @lastaction == 'show_list')
   end
 
   private
 
   def proper_layout?
     @layout != 'miq_policy_rsop'
+  end
+
+  def monitoring_page?
+    @lastaction == "show_timeline" || @sb[:action] == "chargeback" || @showtype == "performance"
   end
 
   def proper_showtype?

--- a/spec/helpers/application_helper/buttons/summary_reload_spec.rb
+++ b/spec/helpers/application_helper/buttons/summary_reload_spec.rb
@@ -4,10 +4,11 @@ describe ApplicationHelper::Button::SummaryReload do
   let(:layout) { 'not_miq_policy_rsop' }
   let(:showtype) { true }
   let(:lastaction) { nil }
+  let(:sb) { {} }
   let(:button) do
     described_class.new(setup_view_context_with_sandbox({}), {},
                         {'record' => record, 'explorer' => explorer, 'layout' => layout,
-                         'showtype' => showtype, 'lastaction' => lastaction}, {})
+                         'showtype' => showtype, 'lastaction' => lastaction, 'sb' => sb}, {})
   end
 
   shared_examples 'lastaction_examples' do
@@ -40,6 +41,24 @@ describe ApplicationHelper::Button::SummaryReload do
         context 'when layout == miq_policy_rsop' do
           let(:layout) { 'miq_policy_rsop' }
           include_examples 'lastaction_examples'
+        end
+        context "when at timeline page" do
+          let(:lastaction) { "show_timeline" }
+          it "returns false" do
+            expect(subject).to be_falsey
+          end
+        end
+        context "when at utilization page" do
+          let(:showtype) { "performance" }
+          it "returns false" do
+            expect(subject).to be_falsey
+          end
+        end
+        context "when at chargeback page" do
+          let(:sb) { {:action => "chargeback"} }
+          it "returns false" do
+            expect(subject).to be_falsey
+          end
         end
       end
       context 'when record not set' do


### PR DESCRIPTION
Compute -> Infrastructure -> VMs -> go to summary page of one -> Monitoring -> Utilization/Timelines/Chargeback

Compute -> Clouds -> Instances -> go to summary page of one -> Monitoring -> Utilization/Timelines/Chargeback

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547081

**Before:**
![image](https://user-images.githubusercontent.com/9210860/53098339-b34ff500-3523-11e9-8d8a-e678f6a5be1e.png)
After clicking Refresh button
![image](https://user-images.githubusercontent.com/9210860/53098350-b64ae580-3523-11e9-9bed-fe455ea0580f.png)

**After:**
No Refresh button and no weird redirect
![image](https://user-images.githubusercontent.com/9210860/53098158-59e7c600-3523-11e9-8977-c75ea9892342.png)

@miq-bot add_label bug, hammer/yes, gaprindashvili/yes, toolbars