### PR TITLE
Fix wrong displayed elapsed time in the service

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -331,7 +331,7 @@ module ServiceHelper::TextualSummary
   def calculate_elapsed_time(stime, ftime)
     val = (ftime - stime)
     hours = val / 3600
-    mins = val / 60
+    mins = (val / 60) % 60
     secs = val % 60
     ("%02d:%02d:%02d" % [hours, mins, secs])
   end

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -96,6 +96,14 @@ describe ServiceHelper::TextualSummary do
     end
   end
 
+  describe '.calculate_elapsed_time' do
+    subject { helper.send(:calculate_elapsed_time, Time.new(2019, 1, 1, 10, 0, 0, 0), Time.new(2019, 1, 1, 11, 5, 0, 0)) }
+
+    it 'calculates elapsed time' do
+      expect(subject).to eq("01:05:00")
+    end
+  end
+
   before do
     allow(self).to receive(:provisioning_get_job).and_return(true)
     allow(self).to receive(:retirement_get_job).and_return(true)


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1660803

**What:**
Fix wrong displayed elapsed time in the service. When running a ansible-playbook service, at the end of the run in the service entry you can see the elapsed time for provisioning.  If this time is more than 60 minutes, it shows hours, however, the minutes counter still displays a value over 60.

**Note:**
The BZ is for 5.9. but we need the same fix also in master, hammer.

**Before:**
![elapsed_before](https://user-images.githubusercontent.com/13417815/53164937-b43f6000-35d1-11e9-9dda-689eedad806d.png)

**After:**
![elapsed_after](https://user-images.githubusercontent.com/13417815/53164945-b6092380-35d1-11e9-97ac-de7793dac45f.png)
