### PR TITLE
[WIP] Add Dashboard Widget Edit Link

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -137,8 +137,8 @@ class ReportController < ApplicationController
     populate_reports_menu
     build_accordions_and_trees
 
-    self.x_active_tree = x_last_active_tree if x_last_active_tree
-    self.x_active_accord = x_last_active_accord.to_s if x_last_active_accord
+    # params or last
+    accord_tree_node_params(x_last_active_accord.to_s, x_last_active_tree)
 
     @widget_nodes ||= []
     @sb[:node_clicked] = false
@@ -181,6 +181,16 @@ class ReportController < ApplicationController
     tree_select
   end
 
+  def accord_tree_node_params(default_accord = nil, default_tree = nil)
+    accord = params[:accord] || default_accord
+    tree = params[:tree] || (params[:accord] ? "#{params[:accord]}_tree" : default_tree)
+    node = params[:id]
+
+    self.x_active_accord = accord if accord
+    self.x_active_tree = tree if tree
+    self.x_node = node if node
+  end
+
   def tree_select
     @edit = nil
     @sb[:select_node] = false
@@ -188,11 +198,10 @@ class ReportController < ApplicationController
       @flash_array = @sb[:flash_msg]
       @sb[:flash_msg] = nil
     end
+
     # set these when a link on one of the summary screen was pressed
-    self.x_active_accord = params[:accord]           if params[:accord]
-    self.x_active_tree   = "#{params[:accord]}_tree" if params[:accord]
-    self.x_active_tree   = params[:tree]             if params[:tree]
-    self.x_node = params[:id]
+    accord_tree_node_params
+
     @sb[:active_tab] = "report_info" if x_active_tree == :reports_tree && params[:action] != "reload"
     if params[:action] == "reload" && @sb[:active_tab] == "saved_reports"
       replace_right_cell(:replace_trees => %i(reports savedreports))

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -7,6 +7,11 @@ class TreeBuilderReportWidgets < TreeBuilder
     "m"  => N_('Menus')
   }.freeze
 
+  def self.widget_tree_id(widget)
+    widget_type = ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[widget.content_type]
+    "xx-#{widget_type}_-#{widget.id}"
+  end
+
   private
 
   def tree_init_options(_tree_name)

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -78,11 +78,24 @@ class WidgetPresenter
                    :title      => _("Zoom in on this chart"),
                    :name       => _("Zoom in"),
                    :href       => '/dashboard/widget_zoom?widget=' + @widget.id.to_s,
-                   :fonticon   => 'fa  fa-plus fa-fw',
+                   :fonticon   => 'fa fa-plus fa-fw',
                    :dataRemote => true,
                    :sparkleOn  => true,
                    :dataMethod => 'post')
     end
+
+    if role_allows?(:feature => "widget_edit")
+      # "xx-r_-25" is a *r*eport widget, id 25
+      id = TreeBuilderReportWidgets.widget_tree_id(@widget)
+
+      buttons.push(:id        => "w_#{@widget.id}_edit",
+                   :title     => t = _('Edit'),
+                   :name      => t,
+                   :sparkleOn => true,
+                   :fonticon  => 'pficon pficon-edit fa-fw',
+                   :href      => "/report/explorer?accord=widgets&id=#{id}")
+    end
+
     buttons.to_json
   end
 

--- a/app/views/report/_db_widget.html.haml
+++ b/app/views/report/_db_widget.html.haml
@@ -4,7 +4,7 @@
 - if @edit && @edit[:current]
   - params = {:id => "w_#{widget.id}", :title => _("Drag/drop Widget \"%{widget_title}\"") % {:widget_title => widget.title}}
 - else
-  - url = "/report/x_show/xx-#{ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[widget.content_type]}_-#{widget.id}?accord=widgets"
+  - url = "/report/x_show/#{TreeBuilderReportWidgets.widget_tree_id(widget)}?accord=widgets"
   - params = {:onclick => remote_function(:url => url), :id => widget.id, :title => _("View this Widget")}
 / .pointer{params}
 .panel.panel-default{params}

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -120,7 +120,7 @@
         - @widget_nodes.each do |w|
           - if role_allows?(:feature => "miq_report_widget_editor")
             - params = {:title => _("Click to view selected widget"),
-              :onclick => remote_function(:url => "/report/x_show/xx-#{ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[w.content_type]}_-#{w.id}?accord=widgets")}
+              :onclick => remote_function(:url => "/report/x_show/#{TreeBuilderReportWidgets.widget_tree_id(w)}?accord=widgets")}
           - else
             - params = {}
           %tr{params}


### PR DESCRIPTION
WIP because tests
And check menus and rss work too..

---

This adds an Edit button to all CI > Dashboards widgets' menus:

![edit](https://user-images.githubusercontent.com/289743/53206278-77eb1e80-3628-11e9-92c9-f2543f6ec032.png)

Clicking it goes to the CI > Reports > Dashboard Widgets detail screen, allowing the user to quickly edit, copy, delete or regenerate the widget.

---

The thing that bugs me about this is that "Edit" doesn't go directly to edit, but that's a) harder, and b) less flexible. "Details" sound vague, "Settings" sound more ..settingy.. Ideas?