### PR TITLE
Remove the unused squash_toggle method/route from TreeSupport

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2011,7 +2011,7 @@ class ApplicationController < ActionController::Base
 
     # Clearing out session objects that are no longer needed
     session[:hac_tree] = session[:vat_tree] = nil if controller_name != "ops"
-    session[:ch_tree] = nil if !["compliance_history"].include?(params[:display]) && params[:action] != "squash_toggle"
+    session[:ch_tree] = nil if !["compliance_history"].include?(params[:display])
     session[:vm_tree] = nil unless ["vmtree_info"].include?(params[:display])
     session[:policy_tree] = nil if params[:action] != "policies" && params[:pressed] != "vm_protect"
     session[:resolve] = session[:resolve_object] = nil unless %w(catalog miq_ae_customization miq_ae_tools).include?(request.parameters[:controller])

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -1,36 +1,6 @@
 module ApplicationController::TreeSupport
   extend ActiveSupport::Concern
 
-  def squash_toggle
-    @record = find_record
-    item = "h_#{@record.name}"
-    render :update do |page|
-      page << javascript_prologue
-      if session[:squash_open] == false
-        page << "$('#squash_img i').attr('class','fa fa-angle-double-up fa-lg')"
-        page << "$('#squash_img').prop('title', 'Collapse All')"
-        page << "miqTreeToggleExpand('#{j_str(session[:tree_name])}', true)"
-        session[:squash_open] = true
-      else
-        page << "$('#squash_img i').attr('class','fa fa-angle-double-down fa-lg')"
-        page << "$('#squash_img').prop('title', 'Expand All')"
-        page << "miqTreeToggleExpand('#{j_str(session[:tree_name])}', false);"
-        page << "miqTreeActivateNodeSilently('#{j_str(session[:tree_name])}', '#{item}');"
-        session[:squash_open] = false
-      end
-    end
-  end
-
-  def find_record
-    # TODO: This logic should probably be reversed - fixed list for VmOrTemplate.
-    # (Better yet, override the method only in VmOrTemplate related controllers.)
-    if %w(host container_replicator container_group container_node container_image container_project ext_management_system physical_server).include?(controller_name)
-      identify_record(params[:id], controller_name.classify)
-    else
-      identify_record(params[:id], VmOrTemplate)
-    end
-  end
-
   def tree_autoload
     @edit ||= session[:edit] # Remember any previous @edit
     render :json => tree_add_child_nodes(params[:id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -735,7 +735,6 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         protect
-        squash_toggle
       ) +
                adv_search_post +
                exp_post +
@@ -775,7 +774,6 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         protect
-        squash_toggle
         launch_cockpit
         launch_external_logging
       ) +
@@ -816,7 +814,6 @@ Rails.application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         protect
-        squash_toggle
       ) +
                adv_search_post +
                exp_post +
@@ -857,7 +854,6 @@ Rails.application.routes.draw do
         guest_applications
         openscap_rule_results
         protect
-        squash_toggle
       ) + adv_search_post + exp_post + save_post + dialog_runner_post
     },
 
@@ -1238,7 +1234,6 @@ Rails.application.routes.draw do
         tl_chooser
         update
         wait_for_task
-        squash_toggle
       ) +
                adv_search_post +
                compare_post +
@@ -1333,7 +1328,6 @@ Rails.application.routes.draw do
         x_show
         scaling
         scaledown
-        squash_toggle
         open_admin_ui
         open_admin_ui_done
       ) +
@@ -1375,7 +1369,6 @@ Rails.application.routes.draw do
         quick_search
         show
         show_list
-        squash_toggle
         tag_edit_form_field_changed
         tagging_edit
         tl_chooser
@@ -1563,7 +1556,6 @@ Rails.application.routes.draw do
         wait_for_task
         tagging_edit
         tag_edit_form_field_changed
-        squash_toggle
         launch_external_logging
       ) +
                adv_search_post +
@@ -1924,7 +1916,6 @@ Rails.application.routes.draw do
         sections_field_changed
         show
         show_list
-        squash_toggle
         tag_edit_form_field_changed
         tagging_edit
         tl_chooser
@@ -3094,7 +3085,6 @@ Rails.application.routes.draw do
         cloud_networks
         cloud_volumes
         show
-        squash_toggle
         tagging_edit
         tag_edit_form_field_changed
         tl_chooser
@@ -3191,7 +3181,6 @@ Rails.application.routes.draw do
         sort_vc_grid
         sort_template_grid
         sort_vm_grid
-        squash_toggle
         tagging_edit
         tag_edit_form_field_changed
         tl_chooser
@@ -3292,7 +3281,6 @@ Rails.application.routes.draw do
         sort_host_grid
         sort_iso_img_grid
         sort_vc_grid
-        squash_toggle
         tagging_edit
         tag_edit_form_field_changed
         tl_chooser

--- a/spec/routing/ems_cloud_routing_spec.rb
+++ b/spec/routing/ems_cloud_routing_spec.rb
@@ -32,7 +32,6 @@ describe EmsCloudController do
     show
     show_list
     protect
-    squash_toggle
     update
   ).each do |task|
     describe "##{task}" do

--- a/spec/routing/ems_container_routing_spec.rb
+++ b/spec/routing/ems_container_routing_spec.rb
@@ -10,7 +10,6 @@ describe EmsContainerController do
     show
     show_list
     protect
-    squash_toggle
     update
   ).each do |task|
     describe "##{task}" do

--- a/spec/routing/ems_infra_routing_spec.rb
+++ b/spec/routing/ems_infra_routing_spec.rb
@@ -39,7 +39,6 @@ describe EmsInfraController do
     update
     wait_for_task
     protect
-    squash_toggle
     scaling
     scaledown
     x_show

--- a/spec/routing/ems_physical_infra_routing_spec.rb
+++ b/spec/routing/ems_physical_infra_routing_spec.rb
@@ -39,7 +39,6 @@ describe EmsPhysicalInfraController do
     update
     wait_for_task
     protect
-    squash_toggle
     scaling
     scaledown
     x_show

--- a/spec/routing/host_routing_spec.rb
+++ b/spec/routing/host_routing_spec.rb
@@ -243,12 +243,6 @@ describe "routes for HostController" do
     end
   end
 
-  describe "#squash_toggle" do
-    it "routes with POST" do
-      expect(post("/host/squash_toggle")).to route_to("host#squash_toggle")
-    end
-  end
-
   describe "#timeline_data" do
     it "routes with GET" do
       expect(get("/host/timeline_data")).to route_to("host#timeline_data")

--- a/spec/routing/shared_examples/vm_common_examples.rb
+++ b/spec/routing/shared_examples/vm_common_examples.rb
@@ -269,12 +269,6 @@ shared_examples_for 'A controller that has vm_common routes' do
     end
   end
 
-  describe '#squash_toggle' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/squash_toggle")).to route_to("#{controller_name}#squash_toggle")
-    end
-  end
-
   describe '#users' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/users")).to route_to("#{controller_name}#users")

--- a/spec/routing/vm_or_template_routing_spec.rb
+++ b/spec/routing/vm_or_template_routing_spec.rb
@@ -97,7 +97,6 @@ describe VmOrTemplateController do
     sort_ds_grid
     sort_host_grid
     sort_iso_img_grid
-    squash_toggle
     tree_select
     users
     vm_pre_prov


### PR DESCRIPTION
As far as I see this method was used for the old trees that supported the expand/colleapse all on doubleclick. We no longer have this feature, so dropping the route and the methods behind it.

@miq-bot add_label cleanup, hammer/no
@miq-bot add_reviewer @mzazrivec 