### PR TITLE
Add error when clicking upload image without selecting a file

### DIFF
--- a/app/assets/javascripts/components/generic_object/custom-image.js
+++ b/app/assets/javascripts/components/generic_object/custom-image.js
@@ -21,6 +21,7 @@ function customImageController($timeout) {
   vm.$onInit = function() {
     vm.imageUploadStatus = '';
     vm.changeImage = false;
+    vm.imageMissing = false;
   };
 
   vm.$onChanges = function(changes) {
@@ -34,8 +35,11 @@ function customImageController($timeout) {
     var imageFile;
 
     if (angular.element('#generic_object_definition_image_file')[0].files.length === 0) {
+      add_flash(__("No file chosen."), 'error');
+      vm.imageMissing = true;
       return;
     }
+    vm.imageMissing = false;
 
     imageFile = angular.element('#generic_object_definition_image_file')[0].files[0];
 

--- a/app/views/static/generic_object/custom-image.html.haml
+++ b/app/views/static/generic_object/custom-image.html.haml
@@ -1,5 +1,5 @@
 .form-group{"ng-show" => "vm.newRecord || vm.changeImage || vm.pictureUrlPath === '' || vm.pictureRemove",
-            "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid}"}
+            "ng-class" => "{'has-error': vm.angularForm.generic_object_definition_image_file_status.$invalid || vm.imageMissing}"}
   %label.col-md-2.control-label{"for" => "generic_object_definition_image_file_status"}
     = _("Custom Image File")
   .col-md-4
@@ -7,6 +7,8 @@
                         "class"       => "filestyle",
                         "id"          => "generic_object_definition_image_file",
                         "name"        => "generic_object_definition_image_file"}
+      %span.help-block{"ng-show" => "vm.imageMissing"}
+        = _("Please select a file before uploading")
     %input.form-control{"type"        => "hidden",
                         "id"          => "generic_object_definition_image_file_status",
                         "ng-model"    => "vm.imageUploadStatus",


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650104

Go to Automation -> Automate -> Generic Objects -> Configuration -> Add a new Generic Object Class -> DO NOT chose a file for Custom Image -> click chosen image

**Before:**
Nothing happens
![image](https://user-images.githubusercontent.com/9210860/53231537-73a31d80-3689-11e9-99e1-1e6f107e49f5.png)

**After:**
There's error message and the input is read with a hint what's wrong (based on https://github.com/ManageIQ/manageiq-ui-classic/pull/5139#issuecomment-466010379)
![image](https://user-images.githubusercontent.com/9210860/53231543-7736a480-3689-11e9-8534-6a742183ddea.png)

@miq-bot add_label bug, hammer/yes, generic objects, automation/automate
