### PR TITLE
Dialog Editor - rework tree params, *don't* pre-initialize the tree

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -5,12 +5,11 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
   vm.saveDialogDetails = saveDialogDetails;
   vm.dismissChanges = dismissChanges;
 
-  // treeSelector related
-  vm.lazyLoad = DialogEditorHttp.treeSelectorLazyLoadData;
-  vm.node = {};
-  DialogEditorHttp.treeSelectorLoadData().then(function(data) {
-    vm.treeSelectorData = data;
-  });
+  // options for tree selector
+  vm.treeOptions = {
+    load: DialogEditorHttp.treeSelectorLoadData,
+    lazyLoad: DialogEditorHttp.treeSelectorLazyLoadData,
+  };
 
   function requestDialogId() {
     return JSON.parse(dialogIdAction).id;

--- a/app/assets/javascripts/services/dialog_editor_http_service.js
+++ b/app/assets/javascripts/services/dialog_editor_http_service.js
@@ -12,8 +12,9 @@ ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http
     });
   };
 
-  this.treeSelectorLoadData = function() {
-    return $http.get('/tree/automate_entrypoint').then(function(response) {
+  this.treeSelectorLoadData = function(fqdn) {
+    var url = '/tree/automate_entrypoint' + (fqdn ? '?fqdn=' + encodeURIComponent(fqdn) : '');
+    return $http.get(url).then(function(response) {
       return response.data;
     });
   };

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -17,7 +17,7 @@
             %textarea#description{"ng-model" => "vm.dialog.content[0].description",
               :title => _("Dialog's description")}
               {{ vm.dialog.content[0].description }}
-    %dialog-editor{'tree-selector-data' => 'vm.treeSelectorData', 'tree-selector-lazy-load' => 'vm.lazyLoad'}
+    %dialog-editor{'tree-options' => vm.treeOptions}
     .pull-right
       %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
                               "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) || vm.saveButtonDisabled",

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -17,7 +17,7 @@
             %textarea#description{"ng-model" => "vm.dialog.content[0].description",
               :title => _("Dialog's description")}
               {{ vm.dialog.content[0].description }}
-    %dialog-editor{'tree-options' => vm.treeOptions}
+    %dialog-editor{'tree-options' => 'vm.treeOptions'}
     .pull-right
       %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
                               "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) || vm.saveButtonDisabled",


### PR DESCRIPTION
Automation > Automate > Customization, add/edit a dialog

https://bugzilla.redhat.com/show_bug.cgi?id=1553846

When editing dynamic field details in the dialog editor, the tree gets loaded before any field data is available, so it can't expand the active node, because it doesn't know it.

This, along with https://github.com/ManageIQ/ui-components/pull/369 makes it possible to delay the tree initialization until the tree gets displayed.

Depends on https://github.com/ManageIQ/ui-components/pull/369 and will need (a @skateman PR adding `?fqdn` support to `/tree/automate_entrypoint`) for the preselection to work.

(Feel free to merge https://github.com/ManageIQ/manageiq-ui-classic/pull/5267 + https://github.com/ManageIQ/ui-components/pull/369 together, the endpoint PR can be separate.)

Cc @skateman 