### PR TITLE
Remove unnecessary cases from Custom Button tree node name generation

### DIFF
--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -20,12 +20,6 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
     @sb[:target_classes] = {}
     buttons = CustomButton.button_classes.map do |klass|
       name = case klass
-             when 'ContainerGroup'
-               _('Container Pod')
-             when 'ContainerNode'
-               _('Container Node')
-             when 'ContainerProject'
-               _('Container Project')
              when 'MiqGroup'
                _('Group')
              when 'Switch'


### PR DESCRIPTION
Calling `ui_lookup(:model => klass)` on these is giving the same result as the hardcoded strings.

@miq-bot add_label cleanup, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 