### PR TITLE
Downgrade types/enzyme to fix Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@babel/runtime": "7.0.0-beta.42",
     "@types/cheerio": "^0.22.9",
-    "@types/enzyme": "^3.1.15",
+    "@types/enzyme": "~3.1.18",
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
     "angular-mocks": "~1.6.9",


### PR DESCRIPTION
Broken by https://www.npmjs.com/package/@types/enzyme/v/3.9.0

Issue is described here:
https://github.com/Microsoft/TypeScript/issues/15972

Fixes:
```
ERROR in [at-loader] ./node_modules/@types/enzyme/index.d.ts:367:40 
    TS2370: A rest parameter must be of an array type.
ERROR in [at-loader] ./node_modules/@types/enzyme/index.d.ts:457:60 
    TS2370: A rest parameter must be of an array type.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[Webpacker] Compilation Failed
```

@miq-bot add_label build, hammer/no