### PR TITLE
Added hostname fallback fields for openstack amqp events.

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -10,6 +10,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       hostname: '',
       default_hostname: '',
       amqp_hostname: '',
+      amqp_fallback_hostname1: '',
+      amqp_fallback_hostname2: '',
       provider_options: {},
       metrics_hostname: '',
       metrics_selection: '',
@@ -617,6 +619,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
       $scope.postValidationModel.amqp = {
         amqp_hostname:             $scope.emsCommonModel.amqp_hostname,
+        amqp_fallback_hostname1:             $scope.emsCommonModel.amqp_fallback_hostname1,
+        amqp_fallback_hostname2:             $scope.emsCommonModel.amqp_fallback_hostname2,
         amqp_api_port:             $scope.emsCommonModel.amqp_api_port,
         amqp_security_protocol:    $scope.emsCommonModel.amqp_security_protocol,
         amqp_userid:               $scope.emsCommonModel.amqp_userid,
@@ -719,6 +723,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.event_stream_selection === 'none') {
       if ($scope.postValidationModel !== undefined) {
         $scope.emsCommonModel.amqp_hostname = $scope.postValidationModel.amqp.amqp_hostname;
+        $scope.emsCommonModel.amqp_fallback_hostname1 = $scope.postValidationModel.amqp.amqp_fallback_hostname1;
+        $scope.emsCommonModel.amqp_fallback_hostname2 = $scope.postValidationModel.amqp.amqp_fallback_hostname2;
         $scope.emsCommonModel.amqp_api_port = $scope.postValidationModel.amqp.amqp_api_port;
         $scope.emsCommonModel.amqp_security_protocol = $scope.postValidationModel.amqp.amqp_security_protocol;
         $scope.emsCommonModel.amqp_userid = $scope.postValidationModel.amqp.amqp_userid;

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -116,6 +116,73 @@
                   :xs              => 'true',
                   :primary         => 'true'}
 
+%div{"ng-if" => defined?(hostname_hide) ? false : true}
+  %div{"ng-if" => "currentTab === 'amqp' && #{ng_model}.emstype === 'openstack' && #{ng_model}.event_stream_selection === 'amqp'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_fallback_hostname1.$invalid}"}
+      %label.col-md-2.control-label{"for" => "#{prefix}_fallback_hostname1"}
+        = _('Fallback Hostname 1')
+      .col-md-4
+        %input.form-control{"type"                    => "text",
+                            "id"                      => "#{prefix}_fallback_hostname1",
+                            "name"                    => "#{prefix}_fallback_hostname1",
+                            "ng-model"                => "#{ng_model}.#{prefix}_fallback_hostname1",
+                            "ng-readonly"             => ng_readonly_hostname,
+                            "maxlength"               => ViewHelper::MAX_NAME_LEN.to_s,
+                            "ng-trim"                 => false,
+                            "placeholder"             => _("Hostname or IPV4 or IPV6 address"),
+                            "detect-spaces"           => "",
+                            "hostname-validation"     => "",
+                            "checkchange"             => "",
+                            "prefix"                  => prefix.to_s,
+                            "reset-validation-status" => "#{prefix}_auth_status"}
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname1.$error.detectedSpaces"}
+          = _("Spaces are prohibited")
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname1.$error.hostnameValidation"}
+          = _("Wrong hostname format")
+
+      - detect = "detectClicked({target: '.detect_button'})"
+      %span
+        %miq-button.detect_button{"ng-if" => detection ? 'true' : 'false',
+                    :name            => _("Detect"),
+                    "on-click"       => detect,
+                    :enabled         => "isDetectionEnabled()",
+                    "disabled-title" => _("Required information missing"),
+                    "enabled-title"  => _("Detect Endpoint"),
+                    :xs              => 'true',
+                    :primary         => 'true'}
+    .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_fallback_hostname2.$invalid}"}
+      %label.col-md-2.control-label{"for" => "#{prefix}_fallback_hostname2"}
+        = _('Fallback Hostname 2')
+      .col-md-4
+        %input.form-control{"type"                    => "text",
+                            "id"                      => "#{prefix}_fallback_hostname2",
+                            "name"                    => "#{prefix}_fallback_hostname2",
+                            "ng-model"                => "#{ng_model}.#{prefix}_fallback_hostname2",
+                            "ng-readonly"             => ng_readonly_hostname,
+                            "maxlength"               => ViewHelper::MAX_NAME_LEN.to_s,
+                            "ng-trim"                 => false,
+                            "placeholder"             => _("Hostname or IPV4 or IPV6 address"),
+                            "detect-spaces"           => "",
+                            "hostname-validation"     => "",
+                            "checkchange"             => "",
+                            "prefix"                  => prefix.to_s,
+                            "reset-validation-status" => "#{prefix}_auth_status"}
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname2.$error.detectedSpaces"}
+          = _("Spaces are prohibited")
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_fallback_hostname2.$error.hostnameValidation"}
+          = _("Wrong hostname format")
+
+      - detect = "detectClicked({target: '.detect_button'})"
+      %span
+        %miq-button.detect_button{"ng-if" => detection ? 'true' : 'false',
+                    :name            => _("Detect"),
+                    "on-click"       => detect,
+                    :enabled         => "isDetectionEnabled()",
+                    "disabled-title" => _("Required information missing"),
+                    "enabled-title"  => _("Detect Endpoint"),
+                    :xs              => 'true',
+                    :primary         => 'true'}
+
 %div{"ng-if" => (defined?(hostname_hide) ? false : true) && (defined?(fallback_hostnames) ? fallback_hostnames : false)}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_fallback_hostname1.$invalid}"}
     %label.col-md-2.control-label{"for" => "#{prefix}_fallback_hostname1"}


### PR DESCRIPTION
Solves: https://bugzilla.redhat.com/show_bug.cgi?id=1595558

Adds two new fallback text fields for hostname.
![screenshot-localhost-3000-2019 02 25-16-02-28](https://user-images.githubusercontent.com/22619452/53346187-d1986500-3916-11e9-8147-e14f9dd085c5.png)


@h-kataria @alexander-demichev  do you know what labels should be assigned to these fields? Field names in model have been assigned based on this: https://github.com/ManageIQ/manageiq-providers-openstack/pull/394/files#diff-6f9b687ce51fd31aa102fa9305ef2501R148

@himdel @martinpovolny I would like to go and start converting this form into react data driven forms. Even though this was a small and relatively "safe" change i am afraid it introduces another technical debt and further diminishes maintainability. Your thoughts?