### PR TITLE
Use @types/enzyme v3.1.17 to prevent error TS2314

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@babel/runtime": "7.0.0-beta.42",
     "@types/cheerio": "^0.22.9",
-    "@types/enzyme": "~3.1.18",
+    "@types/enzyme": "3.1.17",
     "@types/jasmine": "^2.8.6",
     "@types/jest": "^22.1.3",
     "angular-mocks": "~1.6.9",


### PR DESCRIPTION
Downgrade from `3.1.18` to `3.1.17`.

Fixes error:

`TS2314: Generic type 'ReactElement<P>' requires 1 type argument(s).`

Related issue:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33048

@miq-bot add_label hammer/no, test

@himdel ping