### PR TITLE
Clean up some sandbox variables on the Custom Buttons screen

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -10,7 +10,7 @@ module ApplicationController::Automate
         @sb[:attrs][a[0].to_sym] = a[1] if a[0].present?
       end
       @sb[:obj] = if @resolve[:new][:target_id] && @resolve[:new][:target_class]
-                    @resolve[:new][:target_class].constantize.find(@resolve[:new][:target_id])
+                    @resolve[:new][:target_class].safe_constantize.find(@resolve[:new][:target_id])
                   end
       @resolve[:button_class] = @resolve[:new][:target_class]
       @resolve[:button_number] ||= 1
@@ -54,7 +54,7 @@ module ApplicationController::Automate
     @edit[:new][:object_message] = @resolve[:new][:object_message]
     @edit[:new][:object_request] = @resolve[:new][:object_request]
     @edit[:new][:attrs]          = @resolve[:new][:attrs]
-    @edit[:new][:target_class]   = @resolve[:target_class] = Hash[*@resolve[:target_classes].flatten.reverse][@resolve[:new][:target_class]]
+    @edit[:new][:target_class]   = @resolve[:target_class] = @resolve[:new][:target_class]
     @edit[:uri] = @resolve[:uri]
     (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @resolve[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
     @changed = (@edit[:new] != @edit[:current])
@@ -85,9 +85,7 @@ module ApplicationController::Automate
       @resolve[:new][:other_name] = @edit[:new][:other_name]
     end
     if @edit[:new][:target_class]
-      @resolve[:new][:target_class] = Hash[*@resolve[:target_classes].flatten][@edit[:new][:target_class]]
-      target_class = @resolve[:target_classes].detect { |ui_name, _| @edit[:new][:target_class] == ui_name }.last
-      targets = target_class.constantize.all
+      targets = @resolve[:new][:target_class].safe_constantize.all
       @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
       @resolve[:new][:target_id] = nil
       @resolve[:new][:object_message] = @edit[:new][:object_message]

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -3,6 +3,7 @@ module ApplicationController::Buttons
 
   included do
     include Mixins::PlaybookOptions
+    include CustomButtonHelper
   end
 
   def ab_group_edit
@@ -1190,7 +1191,7 @@ module ApplicationController::Buttons
       @resolve[:new][:object_message] = @custom_button.try(:uri_message) || @resolve[:new][:object_message] || "create"
       @resolve[:target_class] = nil
       @resolve[:target_classes] = CustomButton.button_classes.each_with_object({}) do |klass, hash|
-        hash[klass] = ui_lookup(:model => klass)
+        hash[klass] = target_class_name(klass)
       end
       @resolve[:new][:attrs] ||= []
       if @resolve[:new][:attrs].empty?

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -1095,7 +1095,6 @@ module ApplicationController::Buttons
   def buttons_get_node_info(node)
     nodetype = node.split("_")
     # initializing variables to hold data for selected node
-    @sb[:obj_list] = nil
     @custom_button = nil
     @sb[:button_groups] = nil
     @sb[:buttons] = nil

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -858,7 +858,7 @@ module ApplicationController::Buttons
   def button_set_record_vars(button)
     button.name = @edit[:new][:name]
     button.description = @edit[:new][:description]
-    button.applies_to_class = x_active_tree == :ab_tree ? @sb[:target_classes][@resolve[:target_class]] : "ServiceTemplate"
+    button.applies_to_class = x_active_tree == :ab_tree ? @resolve[:target_class] : "ServiceTemplate"
     button.applies_to_id = x_active_tree == :ab_tree ? nil : @sb[:applies_to_id]
     button.userid = session[:userid]
     button.uri = @edit[:uri]
@@ -900,7 +900,7 @@ module ApplicationController::Buttons
   end
 
   def field_expression_model
-    @custom_button.applies_to_class ||= (x_active_tree == :ab_tree ? @sb[:target_classes][@resolve[:target_class]] : "ServiceTemplate")
+    @custom_button.applies_to_class ||= (x_active_tree == :ab_tree ? @resolve[:target_class] : "ServiceTemplate")
   end
 
   def button_set_expression_vars(field_expression, field_expression_table)
@@ -986,17 +986,12 @@ module ApplicationController::Buttons
     else
       build_resolve_screen
     end
-    if @sb[:target_classes].nil?
-      @sb[:target_classes] = {}
-      CustomButton.button_classes.each { |db| @sb[:target_classes][ui_lookup(:model => db)] = db }
-    end
     if x_active_tree == :sandt_tree
-      @resolve[:target_class] = @sb[:target_classes].invert["ServiceTemplate"]
-    elsif x_node.starts_with?("_xx-ab")
-      @resolve[:target_class] = @sb[:target_classes].invert[x_node.split('_')[1]]
+      @resolve[:target_class] = "ServiceTemplate"
+    elsif x_node.starts_with?("-ub-")
+      @resolve[:target_class] = x_node.sub('-ub-', '')
     else
-      sp = x_node.split('-')
-      @resolve[:target_class] = @sb[:target_classes].invert[sp[1] == "ub" ? sp[2].split('_')[0] : sp[1].split('_')[1]]
+      @resolve[:target_class] = x_node.sub(/xx-ab_([^_]+)_.*/, '\1')
     end
     @record = @edit[:custom_button] = @custom_button
     @edit[:instance_names] = Array(@resolve[:instance_names])
@@ -1169,7 +1164,7 @@ module ApplicationController::Buttons
           @sb[:user_roles].push(r.name) if @custom_button.visibility[:roles].include?(r.name)
         end
       end
-      @resolve[:new][:target_class] = @sb[:target_classes].invert["ServiceTemplate"]
+      @resolve[:new][:target_class] = "ServiceTemplate"
       dialog_id = @custom_button.resource_action.dialog_id
       @sb[:dialog_label] = dialog_id ? Dialog.find(dialog_id).label : _("No Dialog")
       @right_cell_text = _("Button \"%{name}\"") % {:name => @custom_button.name}

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -989,7 +989,7 @@ module ApplicationController::Buttons
     if x_active_tree == :sandt_tree
       @resolve[:target_class] = "ServiceTemplate"
     elsif x_node.starts_with?("-ub-")
-      @resolve[:target_class] = x_node.sub('-ub-', '')
+      @resolve[:target_class] = x_node.sub(/-ub-([^_]+)(_.*)?/, '\1')
     else
       @resolve[:target_class] = x_node.sub(/xx-ab_([^_]+)_.*/, '\1')
     end
@@ -1189,9 +1189,9 @@ module ApplicationController::Buttons
       @resolve[:new][:instance_name] = instance_name || @resolve[:new][:instance_name] || "Request"
       @resolve[:new][:object_message] = @custom_button.try(:uri_message) || @resolve[:new][:object_message] || "create"
       @resolve[:target_class] = nil
-      @resolve[:target_classes] = {}
-      CustomButton.button_classes.each { |db| @resolve[:target_classes][db] = ui_lookup(:model => db) }
-      @resolve[:target_classes] = Array(@resolve[:target_classes].invert).sort
+      @resolve[:target_classes] = CustomButton.button_classes.each_with_object({}) do |klass, hash|
+        hash[klass] = ui_lookup(:model => klass)
+      end
       @resolve[:new][:attrs] ||= []
       if @resolve[:new][:attrs].empty?
         ApplicationController::AE_MAX_RESOLUTION_FIELDS.times { @resolve[:new][:attrs].push([]) }

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -24,7 +24,7 @@ module MiqAeCustomizationController::CustomButtons
         @custom_button_entities[tc_node[0]] = "ab_#{tc_node[1]}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2 # one of the CI's node selected
-      @right_cell_text = _("%{typ} Button Groups") % {:typ => @sb[:target_classes].invert[@nodetype[2]]}
+      @right_cell_text = _("%{typ} Button Groups") % {:typ => @resolve[:target_classes].to_h.invert[@nodetype[1]]}
       @sb[:applies_to_class] = x_node.split('-').last.split('_').last
       asets = CustomButtonSet.find_all_by_class_name(@nodetype[1])
       @sb[:button_groups] = []
@@ -42,7 +42,7 @@ module MiqAeCustomizationController::CustomButtons
       end
     elsif @nodetype.length == 1 && nodeid[1] == "ub" # Unassigned buttons group selected
       @sb[:buttons] = []
-      @right_cell_text = _("%{typ} Button Group \"Unassigned Buttons\"") % {:typ => @sb[:target_classes].invert[nodeid[2]]}
+      @right_cell_text = _("%{typ} Button Group \"Unassigned Buttons\"") % {:typ => @resolve[:target_classes].to_h.invert[nodeid[2]]}
       uri = CustomButton.buttons_for(nodeid[2]).sort_by(&:name)
       if uri.present?
         uri.each do |b|
@@ -84,10 +84,9 @@ module MiqAeCustomizationController::CustomButtons
       @sb[:dialog_label] = dialog_id ? Dialog.find(dialog_id).label : ""
       @resolve[:new][:target_class] = if @nodetype[0].starts_with?("-ub-")
                                         # selected button is under unassigned folder
-                                        @sb[:target_classes].invert[@nodetype[0].split('-').last]
+                                        @nodetype[0].sub('-ub-', '')
                                       else
-                                        # selected button is under assigned folder
-                                        @sb[:target_classes].invert[@nodetype[1]]
+                                        @nodetype[1]
                                       end
       @visibility_expression_table = exp_build_table(@custom_button.visibility_expression.exp) if @custom_button.visibility_expression.kind_of?(MiqExpression)
       @enablement_expression_table = exp_build_table(@custom_button.enablement_expression.exp) if @custom_button.enablement_expression.kind_of?(MiqExpression)
@@ -96,7 +95,7 @@ module MiqAeCustomizationController::CustomButtons
       @sb[:applies_to_class] = @nodetype[1]
       @record = CustomButtonSet.find(nodeid.last)
       @right_cell_text = _("%{typ} Button Group \"%{name}\"") %
-                         {:typ  => @sb[:target_classes].invert[@nodetype[2]],
+                         {:typ  => @resolve[:target_classes].to_h.invert[@nodetype[1]],
                           :name => @record.name.split("|").first}
       @sb[:button_group] = {}
       @sb[:button_group][:text] = @sb[:button_group][:hover_text] = @sb[:button_group][:display]

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -8,21 +8,20 @@ module MiqAeCustomizationController::CustomButtons
     nodeid = node.split("-")
 
     # initializing variables to hold data for selected node
-    @sb[:obj_list] = nil
     @custom_button = nil
     @sb[:button_groups] = nil
     @sb[:buttons] = nil
 
     if @nodetype[0] == "root"
       @right_cell_text = _("All Object Types")
-      @sb[:obj_list] = {}
+      @custom_button_entities = {}
       if session[:resolve]
         @resolve = session[:resolve]
       else
         build_resolve_screen
       end
       Array(@resolve[:target_classes]).each do |tc_node|
-        @sb[:obj_list][tc_node[0]] = "ab_#{tc_node[1]}"
+        @custom_button_entities[tc_node[0]] = "ab_#{tc_node[1]}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2 # one of the CI's node selected
       @right_cell_text = _("%{typ} Button Groups") % {:typ => @sb[:target_classes].invert[@nodetype[2]]}

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -22,7 +22,7 @@ module MiqAeCustomizationController::CustomButtons
         build_resolve_screen
       end
       Array(@resolve[:target_classes]).each do |tc_node|
-        @sb[:obj_list][tc_node[0]] = "ab_#{tc_node[0]}"
+        @sb[:obj_list][tc_node[0]] = "ab_#{tc_node[1]}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2 # one of the CI's node selected
       @right_cell_text = _("%{typ} Button Groups") % {:typ => @sb[:target_classes].invert[@nodetype[2]]}

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -14,17 +14,16 @@ module MiqAeCustomizationController::CustomButtons
 
     if @nodetype[0] == "root"
       @right_cell_text = _("All Object Types")
-      @custom_button_entities = {}
       if session[:resolve]
         @resolve = session[:resolve]
       else
         build_resolve_screen
       end
-      Array(@resolve[:target_classes]).each do |tc_node|
-        @custom_button_entities[tc_node[0]] = "ab_#{tc_node[1]}"
+      @custom_button_entities = @resolve[:target_classes].each_with_object({}) do |(k, v), result|
+        result[v] = "ab_#{k}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2 # one of the CI's node selected
-      @right_cell_text = _("%{typ} Button Groups") % {:typ => @resolve[:target_classes].to_h.invert[@nodetype[1]]}
+      @right_cell_text = _("%{typ} Button Groups") % {:typ => @resolve[:target_classes][@nodetype[1]]}
       @sb[:applies_to_class] = x_node.split('-').last.split('_').last
       asets = CustomButtonSet.find_all_by_class_name(@nodetype[1])
       @sb[:button_groups] = []
@@ -42,7 +41,7 @@ module MiqAeCustomizationController::CustomButtons
       end
     elsif @nodetype.length == 1 && nodeid[1] == "ub" # Unassigned buttons group selected
       @sb[:buttons] = []
-      @right_cell_text = _("%{typ} Button Group \"Unassigned Buttons\"") % {:typ => @resolve[:target_classes].to_h.invert[nodeid[2]]}
+      @right_cell_text = _("%{typ} Button Group \"Unassigned Buttons\"") % {:typ => @resolve[:target_classes][nodeid[2]]}
       uri = CustomButton.buttons_for(nodeid[2]).sort_by(&:name)
       if uri.present?
         uri.each do |b|
@@ -95,7 +94,7 @@ module MiqAeCustomizationController::CustomButtons
       @sb[:applies_to_class] = @nodetype[1]
       @record = CustomButtonSet.find(nodeid.last)
       @right_cell_text = _("%{typ} Button Group \"%{name}\"") %
-                         {:typ  => @resolve[:target_classes].to_h.invert[@nodetype[1]],
+                         {:typ  => @resolve[:target_classes][@nodetype[1]],
                           :name => @record.name.split("|").first}
       @sb[:button_group] = {}
       @sb[:button_group][:text] = @sb[:button_group][:hover_text] = @sb[:button_group][:display]

--- a/app/helpers/custom_button_helper.rb
+++ b/app/helpers/custom_button_helper.rb
@@ -1,0 +1,14 @@
+module CustomButtonHelper
+  def target_class_name(klass)
+    case klass
+    when 'MiqGroup'
+      _('Group')
+    when 'Switch'
+      _('Virtual Infra Switch')
+    when 'User'
+      _('User')
+    else
+      ui_lookup(:model => klass)
+    end
+  end
+end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -17,7 +17,6 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(_count_only, _options)
-    @sb[:target_classes] = {}
     buttons = CustomButton.button_classes.map do |klass|
       name = case klass
              when 'MiqGroup'
@@ -29,8 +28,6 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
              else
                ui_lookup(:model => klass)
              end
-      # FIXME: This is probably a session backed caching of a small hash and it should be removed
-      @sb[:target_classes][name] = klass
 
       {
         :id   => "ab_#{klass}",

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -1,5 +1,7 @@
 class TreeBuilderButtons < TreeBuilderAeCustomization
   include CustomButtonsMixin
+  include CustomButtonHelper
+
   has_kids_for CustomButtonSet, [:x_get_tree_aset_kids]
 
   private
@@ -18,16 +20,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(_count_only, _options)
     buttons = CustomButton.button_classes.map do |klass|
-      name = case klass
-             when 'MiqGroup'
-               _('Group')
-             when 'Switch'
-               _('Virtual Infra Switch')
-             when 'User'
-               _('User')
-             else
-               ui_lookup(:model => klass)
-             end
+      name = target_class_name(klass)
 
       {
         :id   => "ab_#{klass}",

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -33,9 +33,6 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   def x_get_tree_custom_kids(object, count_only, _options)
     # build node showing any button groups or buttons under selected CatalogItem
     @resolve ||= {}
-    @resolve[:target_classes] = {}
-    CustomButton.button_classes.each { |db| @resolve[:target_classes][db] = ui_lookup(:model => db) }
-    @resolve[:target_classes] = Array(@resolve[:target_classes].invert).sort
     st = ServiceTemplate.find_by(:id => object[:id])
     items = st.custom_button_sets + st.custom_buttons
     objects = []

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -35,7 +35,6 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
     @resolve ||= {}
     @resolve[:target_classes] = {}
     CustomButton.button_classes.each { |db| @resolve[:target_classes][db] = ui_lookup(:model => db) }
-    @sb[:target_classes] = @resolve[:target_classes].invert
     @resolve[:target_classes] = Array(@resolve[:target_classes].invert).sort
     st = ServiceTemplate.find_by(:id => object[:id])
     items = st.custom_button_sets + st.custom_buttons

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -65,7 +65,7 @@
           = _("Type")
         .col-md-8
           = select_tag('target_class',
-                       options_for_select([["<None>", nil]] + resolve[:target_classes],
+                       options_for_select([["<None>", nil]] + resolve[:target_classes].invert.to_a,
                        resolve[:new][:target_class]),
                        "data-miq_sparkle_on"  => true,
                        "data-miq_sparkle_off" => true,

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -1,7 +1,7 @@
 #ab_form
   #policy_bar
     - if session[:resolve_object].present?
-      - copied_target_class = Hash[*@resolve[:target_classes].flatten].invert[session[:resolve_object][:new][:target_class]]
+      - copied_target_class = session[:resolve_object][:new][:target_class]
       - current_target_class =  @edit[:new][:target_class]
       - if copied_target_class == current_target_class
         = link_to({:action => "resolve", :button => "paste"},

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -1,5 +1,5 @@
 -# showing list of CIs
-- if @sb[:obj_list]
+- if @custom_button_entities
   = render :partial => "layouts/flash_msg"
   %table.table.table-bordered.table-hover.table-striped
     %thead
@@ -7,7 +7,7 @@
         = _('Object Types')
     %tbody
       -# CI node level
-      - @sb[:obj_list].sort.each do |obj|
+      - @custom_button_entities.sort.each do |obj|
         %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('ab_tree', 'xx-#{obj[1]}')"}
           %td
             = obj[0]

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -8,7 +8,7 @@
     %tbody
       -# CI node level
       - @sb[:obj_list].sort.each do |obj|
-        %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('ab_tree', 'xx-#{obj[1].split('_').first}_#{@sb[:target_classes][obj[0]]}')"}
+        %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('ab_tree', 'xx-#{obj[1]}')"}
           %td
             = obj[0]
 

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -6,7 +6,7 @@ describe MiqAeCustomizationController, "ApplicationController::Automate" do
       target_classes = {}
       CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
       resolve = {
-        :new            => {:target_class => "Host / Node"},
+        :new            => {:target_class => "Host"},
         :target_classes => Array(target_classes.invert).sort
       }
       session[:resolve] = resolve

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -190,7 +190,7 @@ describe ApplicationController do
                                        },
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
       expect(assigns(:edit)[:new][:display]).to eq(false)
       expect(assigns(:edit)[:new][:button_icon]).to eq('fa fa-info')
       expect(assigns(:edit)[:new][:open_url]).to eq(false)
@@ -202,7 +202,7 @@ describe ApplicationController do
                                        },
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
     end
 
     it "check button_set_form_vars sets correctly loads the filtering expressions when editing a button" do
@@ -221,7 +221,7 @@ describe ApplicationController do
                                        :trees       => {:ab_tree => {:active_node => "-ub-Vm_cb-10r51"}},
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
       expect(assigns(:edit)[:new][:display]).to eq(false)
       expect(assigns(:edit)[:new][:button_icon]).to eq('5')
       expect(assigns(:edit)[:new][:open_url]).to eq(false)
@@ -233,7 +233,7 @@ describe ApplicationController do
                                        :trees       => { :ab_tree => {:active_node => "xx-ab_Vm_cbg-10r96_cb-10r7"}},
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
     end
 
     it "check button_set_form_vars sets correct values when editing a playbook button" do
@@ -257,7 +257,7 @@ describe ApplicationController do
                                        :trees       => {:ab_tree => {:active_node => "-ub-Vm_cb-10r51"}},
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
       expect(assigns(:edit)[:new][:display]).to eq(false)
       expect(assigns(:edit)[:new][:button_icon]).to eq('fa fa-info')
       expect(assigns(:edit)[:new][:open_url]).to eq(false)
@@ -270,7 +270,7 @@ describe ApplicationController do
                                        :trees       => {:ab_tree => {:active_node => "xx-ab_Vm_cbg-10r96_cb-10r7"}},
                                        :active_tree => :ab_tree)
       controller.send(:button_set_form_vars)
-      expect(assigns(:edit)[:new][:target_class]).to eq("VM and Instance")
+      expect(assigns(:edit)[:new][:target_class]).to eq("Vm")
     end
   end
 

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -10,7 +10,7 @@ describe MiqAeCustomizationController do
         CustomButton.button_classes.each { |db| target_classes[ui_lookup(:model => db)] = db }
         controller.instance_variable_set(:@sb, :target_classes => target_classes)
         controller.send(:ab_get_node_info, "xx-ab_Host_cbg-10r95_cb-#{custom_button.id}")
-        expect(assigns(:resolve)[:new][:target_class]).to eq("Host / Node")
+        expect(assigns(:resolve)[:new][:target_class]).to eq("Host")
       end
     end
   end

--- a/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
+++ b/spec/views/shared/buttons/_ab_form.html.haml_spec.rb
@@ -2,7 +2,7 @@ describe "shared/buttons/_ab_form.html.haml" do
   before do
     set_controller_for_view("miq_ae_customization")
     assign(:sb, :active_tab => "ab_options_tab")
-    assign(:edit, :new => {:target_class => "Cloud Network"})
+    assign(:edit, :new => {:target_class => "CloudNetwork"})
     assign(:resolve, :target_classes => [
       ["Availability Zone", "AvailabilityZone"],
       ["Cloud Network", "CloudNetwork"],


### PR DESCRIPTION
Initially I just wanted to drop the `target_classes` from the Custom Buttons treebuilder, but I found the hydra and started to cut it down :snake: by :snake:. The PR will make sense if you read it commit by commit, also it will require a lot of clicking and testing...

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label refactoring, hammer/no, trees, automation/automate
