### PR TITLE
Remove sandbox variables from the trees on the diagnostics screens

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -853,8 +853,6 @@ module OpsController::Diagnostics
 
   # Method to build the server tree (parent is a zone or region instance)
   def build_server_tree(parent)
-    @sb[:parent_name] = parent.name
-    @sb[:parent_kls] = parent.class.name
     @server_tree = if @sb[:diag_tree_type] == "roles"
                      TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, parent)
                    else

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -21,8 +21,8 @@ class TreeBuilderDiagnostics < TreeBuilder
   end
 
   def x_build_single_node(object, pid, options)
-    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
-    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
+    options[:parent_kls]  = @root.class.name
+    options[:parent_name] = @root.name
     super(object, pid, options)
   end
 

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -55,9 +55,9 @@ describe TreeBuilderServersByRole do
 
     it 'returns Servers by Roles' do
       nodes = [{'key'        => "role-#{@server_role.id}",
-                'tooltip'    => "Role: SmartProxy (stopped)",
+                'tooltip'    => "Role: SmartProxy (active)",
                 "icon"       => "ff ff-user-role",
-                'text'       => "Role: SmartProxy (stopped)",
+                'text'       => "Role: SmartProxy (active)",
                 'selectable' => true,
                 'nodes'      => [{'key'            => "asr-#{@assigned_server_role1.id}",
                                   'icon'           => 'pficon pficon-asleep',


### PR DESCRIPTION
These two variables are accessible through a parameter, so no need for them. The test was invalid, as the sandbox variables haven't been set properly so it was adjusted.

@miq-bot add_label cleanup, trees
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @ZitaNemeckova 