### PR TITLE
Webpack - add watchOptions to ignore vim swapfiles

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -142,4 +142,8 @@ module.exports = {
     // only read loaders from ui-classic
     modules: [moduleDir],
   },
+
+  watchOptions: {
+    ignored: ['**/.*.sw[po]'],
+  },
 };


### PR DESCRIPTION
Opening a file in vim will not trigger a rebuild when using `webpack --watch`.

(And in ui-components: https://github.com/ManageIQ/ui-components/pull/370/)
