### PR TITLE
Add All Custom Button Events page to Cloud Network

### DIFF
--- a/app/views/cloud_network/show.html.haml
+++ b/app/views/cloud_network/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances", "network_routers", "cloud_subnets", "floating_ips"].include?(@display) && @showtype != "compare"
+  - if ["instances", "network_routers", "cloud_subnets", "floating_ips", "custom_button_events"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render :partial => "layouts/textual_groups_generic"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1680525

Steps to reproduce:

1. Create Custom button Group on "Cloud Network" object type.
2. Create on simple custom button under group (no dialog)
3. Navigate to cloud network entity... [Networks-> Network]
4. Go to Summary page of any Cloud Network
5. Execute custom button 1+ times...
6. Refresh browser
7. Relationship table will show you custom button event counts 
8. Now navigate to event page by clicking on custom button events
9. You will not see any events

Before:
![image](https://user-images.githubusercontent.com/9210860/53416542-03bbcc80-39d4-11e9-9ed4-cab7c7f47017.png)

After:
![image](https://user-images.githubusercontent.com/9210860/53416604-22ba5e80-39d4-11e9-8044-f5eac0acc53c.png)

@miq-bot add_label gaprindashvili/yes, hammer/yes, networks, bug