### PR TITLE
TreeBuilderInfraNetworking - remove dead code, fix style

### DIFF
--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -28,9 +28,6 @@ class TreeBuilderInfraNetworking < TreeBuilder
 
   def x_get_tree_roots(count_only, _options)
     objects = Rbac.filtered(ManageIQ::Providers::Vmware::InfraManager.order("lower(name)"))
-    objects.each do |item|
-      item[:load_children => true]
-    end
     count_only_or_objects(count_only, objects)
   end
 
@@ -53,12 +50,8 @@ class TreeBuilderInfraNetworking < TreeBuilder
   end
 
   def x_get_tree_switch_kids(object, count_only)
-    objects = count_only_or_objects(count_only,
-                                    object.lans.sort,
-                                    "name")
-    objects.each do |item|
-      item[:load_children => true]
-      item[:selectable => false]
-    end
+    count_only_or_objects(count_only,
+                          object.lans.sort,
+                          "name")
   end
 end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -22,7 +22,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   def root_options
     {
       :text    => t = _("All Distributed Switches"),
-      :tooltip => t
+      :tooltip => t,
     }
   end
 
@@ -40,12 +40,14 @@ class TreeBuilderInfraNetworking < TreeBuilder
   def x_get_tree_cluster_kids(object, count_only)
     hosts = object.hosts
     switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-    count_only_or_objects(count_only, Rbac.filtered(Switch, :named_scope => [:shareable, [:with_id, switch_ids.flatten.uniq]]))
+
+    objects = Rbac.filtered(Switch, :named_scope => [:shareable, [:with_id, switch_ids.flatten.uniq]])
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_host_kids(object, count_only)
     count_only_or_objects(count_only,
-                          Rbac.filtered(object.switches.where(:shared =>'true')).sort,
+                          Rbac.filtered(object.switches.where(:shared => 'true')).sort,
                           "name")
   end
 


### PR DESCRIPTION
Removes a bunch of `hash[:foo => 'bar']` accesses.

Those should probably have been...

```
      item[:load_children] = true
      item[:selectable] = false
```

but:
a) not seeing any difference,
b) it never worked that way in this tree
c) there is no `load_children` or `selectable` property on `Lan` instances.

Removing.

(
comes from ManageIQ/manageiq#10753
see ManageIQ/manageiq#10753 (comment)
)