### PR TITLE
[WIP] InfraNetworking - support showing Lan (port group) details

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -78,7 +78,7 @@ module ApplicationController::CiProcessing
     elsif db == "ems_cloud"
       @ems = @record = identify_record(params[:id], EmsCloud)
     elsif db == "switch"
-      @switch = @record = identify_record(params[:id], Switch)
+      @record = identify_record(params[:id], Switch)
     elsif db == "service"
       @service = @record = identify_record(params[:id], Service)
     end

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -139,6 +139,17 @@ class InfraNetworkingController < ApplicationController
     show_details(CustomButtonEvent, :association => "custom_button_events", :clickable => false)
   end
 
+  def get_record(db)
+    case db
+    when 'switch'
+      @record = identify_record(params[:id], Switch)
+    when 'lan'
+      @record = identify_record(params[:id], Lan)
+    else
+      super
+    end
+  end
+
   private
 
   def textual_group_list

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -147,14 +147,9 @@ class InfraNetworkingController < ApplicationController
   helper_method :textual_group_list
 
   def display_node(id, model)
-    if @record.nil?
-      self.x_node = "root"
-      get_node_info("root")
-    else
-      show_record(id)
-      model_string = ui_lookup(:model => (model ? model : @record.class).to_s)
-      @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => model_string}
-    end
+    show_record(id)
+    model_string = ui_lookup(:model => (model ? model : @record.class).to_s)
+    @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => model_string}
   end
 
   def features
@@ -185,6 +180,10 @@ class InfraNetworkingController < ApplicationController
       Switch
     ).include?(model)
       @record = find_record(model.constantize, id)
+      if @record.nil?
+        self.x_node = "root"
+        return get_node_info("root")
+      end
     end
 
     options = case model
@@ -217,12 +216,6 @@ class InfraNetworkingController < ApplicationController
   end
 
   def switches_list(model, ids)
-    if @record.nil?
-      self.x_node = "root"
-      get_node_info("root")
-      return
-    end
-
     options = {
       :model => "Switch",
       :named_scope => :shareable,

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -69,7 +69,7 @@ class InfraNetworkingController < ApplicationController
   end
 
   def x_show
-    @switch = @record = identify_record(params[:id], Switch)
+    @record = identify_record(params[:id], Switch)
     generic_x_show
   end
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -515,7 +515,7 @@ class InfraNetworkingController < ApplicationController
   end
 
   def display_adv_searchbox
-    !(@infra_networking_record || @in_a_form || @nodetype == 'sw')
+    !(@record || @in_a_form)
   end
 
   def breadcrumb_name(_model)

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -148,7 +148,7 @@ class InfraNetworkingController < ApplicationController
 
   def display_node(id, model)
     show_record(id)
-    model_string = ui_lookup(:model => (model ? model : @record.class).to_s)
+    model_string = ui_lookup(:model => model)
     @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => model_string}
   end
 
@@ -195,7 +195,7 @@ class InfraNetworkingController < ApplicationController
       switches_list(model, hosts_switches_list(@record.hosts))
     when "Switch",
          "Lan"
-      display_node(id, model.constantize)
+      display_node(id, model)
     when "MiqSearch"
       miq_search_node
     else

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -88,7 +88,7 @@ class InfraNetworkingController < ApplicationController
 
     return unless %w(download_pdf main).include?(@display)
     @showtype = "main"
-    @center_toolbar = 'infra_networking'
+    @center_toolbar = 'infra_networking' if @record.kind_of?(Switch)
   end
 
   def explorer

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -186,6 +186,8 @@ class InfraNetworkingController < ApplicationController
                 cluster_switches_list(id, EmsCluster)
               when "Switch"
                 dvswitch_node(id, Switch)
+              when "Lan"
+                lan_node(id, Lan)
               when "MiqSearch"
                 miq_search_node
               else
@@ -202,6 +204,11 @@ class InfraNetworkingController < ApplicationController
       x_history_add_item(:id => treenodeid, :text => @right_cell_text) # Add to history pulldown array
     end
     options
+  end
+
+  def lan_node(id, model)
+    @record = find_record(model, id) if model
+    display_node(id, model)
   end
 
   def dvswitch_node(id, model)
@@ -315,7 +322,7 @@ class InfraNetworkingController < ApplicationController
       @delete_node = params[:id] if @replace_trees # get_node_info might set this
       type, _id = parse_nodetype_and_id(x_node)
 
-      record_showing = type && ["Switch"].include?(TreeBuilder.get_model_for_prefix(type))
+      record_showing = type && %w(Switch Lan).include?(TreeBuilder.get_model_for_prefix(type))
     end
 
     # Build presenter to render the JS command for the tree update
@@ -384,7 +391,7 @@ class InfraNetworkingController < ApplicationController
 
   def dvswitch_record?(node = x_node)
     type, _id = node.split("-")
-    type && ["Switch"].include?(TreeBuilder.get_model_for_prefix(type))
+    type && TreeBuilder.get_model_for_prefix(type) == "Switch"
   end
 
   def search_text_type(node)

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -177,6 +177,16 @@ class InfraNetworkingController < ApplicationController
       id = nil
     end
 
+    if %w(
+      EmsCluster
+      ExtManagementSystem
+      Host
+      Lan
+      Switch
+    ).include?(model)
+      @record = find_record(model.constantize, id)
+    end
+
     options = case model
               when "ExtManagementSystem"
                 provider_switches_list(id, ExtManagementSystem)
@@ -207,18 +217,14 @@ class InfraNetworkingController < ApplicationController
   end
 
   def lan_node(id, model)
-    @record = find_record(model, id) if model
     display_node(id, model)
   end
 
   def dvswitch_node(id, model)
-    @record = find_record(model, id) if model
     display_node(id, model)
   end
 
   def host_switches_list(id, model)
-    @record = find_record(model, id) if model
-
     if @record.nil?
       self.x_node = "root"
       get_node_info("root")
@@ -233,8 +239,6 @@ class InfraNetworkingController < ApplicationController
   end
 
   def cluster_switches_list(id, model)
-    @record = find_record(model, id) if model
-
     if @record.nil?
       self.x_node = "root"
       get_node_info("root")
@@ -251,8 +255,6 @@ class InfraNetworkingController < ApplicationController
   end
 
   def provider_switches_list(id, model)
-    @record = find_record(model, id) if model
-
     if @record.nil?
       self.x_node = "root"
       get_node_info("root")

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -330,6 +330,7 @@ class InfraNetworkingController < ApplicationController
   def set_right_cell_vars
     @sb[:action] = params[:action]
     name = @record.try(:name).to_s
+    db = @record.class.try(:base_class).try(:display_name) # Switch, Lan, nil?
     partial = if ["details"].include?(@showtype)
                 "layouts/x_gtl"
               elsif @showtype == "item"
@@ -338,16 +339,18 @@ class InfraNetworkingController < ApplicationController
                 @showtype.to_s
               end
     if @showtype == "item"
-      header = _("%{action} \"%{item_name}\" for Switch \"%{name}\"") % {
+      header = _("%{action} \"%{item_name}\" for %{db} \"%{name}\"") % {
         :name      => name,
         :item_name => @item.name,
-        :action    => action_type(@sb[:action], 1)
+        :action    => action_type(@sb[:action], 1),
+        :db        => db,
       }
       x_history_add_item(:id => x_node, :text => header, :action => @sb[:action], :item => @item.id)
     else
-      header = _("\"%{action}\" for Switch \"%{name}\"") % {
+      header = _("\"%{action}\" for %{db} \"%{name}\"") % {
         :name   => name,
-        :action => action_type(@sb[:action], 2)
+        :action => action_type(@sb[:action], 2),
+        :db     => db,
       }
       if @display && @display != "main"
         x_history_add_item(:id => x_node, :text => header, :display => @display)

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -194,10 +194,9 @@ class InfraNetworkingController < ApplicationController
                 host_switches_list(id, Host)
               when "EmsCluster"
                 cluster_switches_list(id, EmsCluster)
-              when "Switch"
-                dvswitch_node(id, Switch)
-              when "Lan"
-                lan_node(id, Lan)
+              when "Switch",
+                   "Lan"
+                display_node(id, model.constantize)
               when "MiqSearch"
                 miq_search_node
               else
@@ -214,14 +213,6 @@ class InfraNetworkingController < ApplicationController
       x_history_add_item(:id => treenodeid, :text => @right_cell_text) # Add to history pulldown array
     end
     options
-  end
-
-  def lan_node(id, model)
-    display_node(id, model)
-  end
-
-  def dvswitch_node(id, model)
-    display_node(id, model)
   end
 
   def host_switches_list(id, model)

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -212,58 +212,58 @@ class InfraNetworkingController < ApplicationController
   end
 
   def dvswitch_node(id, model)
-    @record = @switch_record = find_record(model, id) if model
+    @record = find_record(model, id) if model
     display_node(id, model)
   end
 
   def host_switches_list(id, model)
-    @record = @host_record = find_record(model, id) if model
+    @record = find_record(model, id) if model
 
-    if @host_record.nil?
+    if @record.nil?
       self.x_node = "root"
       get_node_info("root")
     else
-      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => @host_record.switches.pluck(:id)}
+      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => @record.switches.pluck(:id)}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
-      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @host_record.name}
+      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @record.name}
     end
     options
   end
 
   def cluster_switches_list(id, model)
-    @record = @cluster_record = find_record(model, id) if model
+    @record = find_record(model, id) if model
 
-    if @cluster_record.nil?
+    if @record.nil?
       self.x_node = "root"
       get_node_info("root")
     else
-      hosts = @cluster_record.hosts
+      hosts = @record.hosts
       switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
       options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
-      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @cluster_record.name}
+      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @record.name}
     end
     options
   end
 
   def provider_switches_list(id, model)
-    @record = @provider_record = find_record(model, id) if model
+    @record = find_record(model, id) if model
 
-    if @provider_record.nil?
+    if @record.nil?
       self.x_node = "root"
       get_node_info("root")
     else
-      hosts = Host.where(:ems_id => @provider_record.id)
+      hosts = Host.where(:ems_id => @record.id)
       switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
       options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
-      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @provider_record.name}
+      @right_cell_text = _("Switches for %{model} \"%{name}\"") % {:model => model, :name => @record.name}
     end
     options
   end

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -142,7 +142,6 @@ module Mixins
 
     def hosts
       db = params[:db] || controller_name
-      db = 'switch' if db == 'infra_networking'
       return unless init_show_variables(db)
 
       @lastaction = "hosts"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -373,9 +373,12 @@ module ApplicationHelper
     else
       # need to add a check for @explorer while setting controller incase building a link for details screen to show items
       # i.e users list view screen inside explorer needs to point to vm_or_template controller
+      query_params = "?"
+      query_params += "db=#{params[:db]}&" if params[:db]
+      query_params += "#{@explorer ? "x_show" : "show"}=" # this one must go last
       return url_for_only_path(:controller => parent.kind_of?(VmOrTemplate) && !@explorer ? parent.class.base_model.to_s.underscore : request.parameters["controller"],
                                :action     => association,
-                               :id         => parent.id) + "?#{@explorer ? "x_show" : "show"}="
+                               :id         => parent.id) + query_params
     end
   end
 

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -31,6 +31,7 @@ module InfraNetworkingHelper::TextualSummary
 
   def textual_custom_button_events
     return nil unless User.current_user.super_admin_user? || User.current_user.admin?
+    return nil unless @record.respond_to?(:custom_button_events) # Lan has no custom buttons
 
     {
       :label    => _('Custom Button Events'),

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -20,7 +20,7 @@ module InfraNetworkingHelper::TextualSummary
     if num.positive? && role_allows?(:feature => "host_show_list")
       h = {:label => title_for_hosts, :icon => "pficon pficon-container-node", :value => num}
       h[:explorer] = true
-      h[:link] = url_for_only_path(:action => 'hosts', :id => @record, :db => 'switch')
+      h[:link] = url_for_only_path(:action => 'hosts', :id => @record, :db => db)
     end
     h
   end
@@ -32,9 +32,20 @@ module InfraNetworkingHelper::TextualSummary
     {
       :label    => _('Custom Button Events'),
       :value    => num = @record.number_of(:custom_button_events),
-      :link     => num.positive? ? url_for_only_path(:action => 'custom_button_events', :id => @record, :db => 'switch') : nil,
+      :link     => num.positive? ? url_for_only_path(:action => 'custom_button_events', :id => @record, :db => db) : nil,
       :icon     => CustomButtonEvent.decorate.fonticon,
       :explorer => true
     }
+  end
+
+  private
+
+  def db
+    case @record
+    when Switch
+      'switch'
+    when Lan
+      'lan'
+    end
   end
 end

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -3,10 +3,6 @@ module InfraNetworkingHelper::TextualSummary
   # Groups
   #
 
-  def textual_group_properties
-    TextualGroup.new(_('UNUSED?'), %i(switch_type))
-  end
-
   def textual_group_relationships
     TextualGroup.new(_("Relationships"), %i(hosts custom_button_events))
   end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -42,12 +42,6 @@ class TreeBuilderInfraNetworking < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_host_kids(object, count_only)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(object.switches.where(:shared => 'true')).sort,
-                          "name")
-  end
-
   def x_get_tree_switch_kids(object, count_only)
     count_only_or_objects(count_only,
                           object.lans.sort,

--- a/spec/helpers/infra_networking_helper/textual_summary_spec.rb
+++ b/spec/helpers/infra_networking_helper/textual_summary_spec.rb
@@ -1,6 +1,4 @@
 describe InfraNetworkingHelper::TextualSummary do
-  include_examples "textual_group", "UNUSED?", %i(switch_type), "properties"
-
   include_examples "textual_group", "Relationships", %i(hosts custom_button_events)
 
   include_examples "textual_group_smart_management"


### PR DESCRIPTION
until now, trying to access Lan objects under a switch would just render the "All Switches" view

updating to render a textual summary (albeit an almost empty one)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650423

---

But Lans do also have a relationship with hosts, so

* updated the Hosts list to support showing hosts under a Lan
* fixed the strings talking about hosts "for Switch"... when under a Lan
* removed search from Lan textual summary & nested hosts view

Furhtermore, to limit the scope of this fix: disabled center toolbar for Lans - no tagging for Lans for now.

