### PR TITLE
Cleaning up tree_init_options in TreeBuilders

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -208,14 +208,14 @@ module MiqPolicyController::AlertProfiles
     end
   end
 
-  def instantiate_tree(tree_class, tree_name, type, selected)
+  def instantiate_tree(tree_class, tree_name, type, selected_nodes)
     tree_class.constantize.new(tree_name,
                                type,
                                @sb,
                                true,
-                               :assign_to => @assign[:new][:assign_to],
-                               :cat       => @assign[:new][:cat],
-                               :selected  => selected)
+                               :assign_to      => @assign[:new][:assign_to],
+                               :cat            => @assign[:new][:cat],
+                               :selected_nodes => selected_nodes)
   end
 
   def alert_profile_build_edit_screen

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -899,7 +899,7 @@ module OpsController::OpsRbac
   end
 
   # this causes the correct tree to get instantiated, depending on the active tab
-  def rbac_group_right_tree(selected)
+  def rbac_group_right_tree(selected_nodes)
     case @sb[:active_rbac_group_tab]
     when 'rbac_customer_tags'
       @tags_tree = TreeBuilderTags.new(:tags_tree,
@@ -914,17 +914,17 @@ module OpsController::OpsRbac
                                               :hac,
                                               @sb,
                                               true,
-                                              :edit     => @edit,
-                                              :group    => @group,
-                                              :selected => selected)
+                                              :edit           => @edit,
+                                              :group          => @group,
+                                              :selected_nodes => selected_nodes)
     when 'rbac_vms_templates'
       @vat_tree = TreeBuilderBelongsToVat.new(:vat_tree,
                                               :vat,
                                               @sb,
                                               true,
-                                              :edit     => @edit,
-                                              :group    => @group,
-                                              :selected => selected)
+                                              :edit           => @edit,
+                                              :group          => @group,
+                                              :selected_nodes => selected_nodes)
     end
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -65,7 +65,6 @@ class TreeBuilder
   # * features - used by the RBAC features tree only
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only
-  # * selected_node - used by the snapshots tree only
   def tree_init_options
     $log.warn("MIQ(#{self.class.name}) - TreeBuilder descendants should have their own tree_init_options")
     {}

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -58,7 +58,6 @@ class TreeBuilder
   # * full_ids - whether to generate full node IDs or not
   # * leaf - class of the leaf nodes
   # * open_all - expand all expandable nodes
-  # * expand - ?? probably not used anywhere
   # * add_root - merge root_options with the first node
   # * lazy - is the tree lazily-loadable
   # * checkable_checkboxes - checkable checkboxes for the nodes

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -60,7 +60,7 @@ class TreeBuilder
   # * open_all - expand all expandable nodes
   # * add_root - merge root_options with the first node
   # * lazy - is the tree lazily-loadable
-  # * checkable_checkboxes - checkable checkboxes for the nodes
+  # * checkboxes - show checkboxes for the nodes
   # * features - used by the RBAC features tree only
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only
@@ -170,14 +170,14 @@ class TreeBuilder
   def add_to_sandbox
     @tree_state.add_tree(
       @options.reverse_merge(
-        :tree                 => @name,
-        :type                 => type,
-        :klass_name           => self.class.name,
-        :leaf                 => @options[:leaf],
-        :add_root             => true,
-        :open_nodes           => [],
-        :lazy                 => true,
-        :checkable_checkboxes => false
+        :tree       => @name,
+        :type       => type,
+        :klass_name => self.class.name,
+        :leaf       => @options[:leaf],
+        :add_root   => true,
+        :open_nodes => [],
+        :lazy       => true,
+        :checkboxes => false
       )
     )
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -54,6 +54,19 @@ class TreeBuilder
     end
   end
 
+  # The possible options are
+  # * full_ids - whether to generate full node IDs or not
+  # * leaf - class of the leaf nodes
+  # * open_all - expand all expandable nodes
+  # * expand - ?? probably not used anywhere
+  # * add_root - merge root_options with the first node
+  # * lazy - is the tree lazily-loadable
+  # * checkable_checkboxes - checkable checkboxes for the nodes
+  # * selected - key of the selected node
+  # * features - used by the RBAC features tree only
+  # * editable - used by the RBAC features tree only
+  # * node_id_prefix - used by the RBAC features tree only
+  # * selected_node - used by the snapshots tree only
   def tree_init_options(_tree_name)
     $log.warn("MIQ(#{self.class.name}) - TreeBuilder descendants should have their own tree_init_options")
     {}

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -15,7 +15,7 @@ class TreeBuilder
 
     @locals_for_render  = {}
     @name               = name.to_sym # includes _tree
-    @options            = tree_init_options(name.to_sym)
+    @options            = tree_init_options
     @tree_nodes         = {}.to_json
     # FIXME: remove @name or @tree, unify
     @type               = type.to_sym # *usually* same as @name but w/o _tree
@@ -67,7 +67,7 @@ class TreeBuilder
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only
   # * selected_node - used by the snapshots tree only
-  def tree_init_options(_tree_name)
+  def tree_init_options
     $log.warn("MIQ(#{self.class.name}) - TreeBuilder descendants should have their own tree_init_options")
     {}
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -61,7 +61,6 @@ class TreeBuilder
   # * add_root - merge root_options with the first node
   # * lazy - is the tree lazily-loadable
   # * checkable_checkboxes - checkable checkboxes for the nodes
-  # * selected - key of the selected node
   # * features - used by the RBAC features tree only
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only

--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAction < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -4,7 +4,7 @@ class TreeBuilderAeClass < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -5,7 +5,7 @@ class TreeBuilderAeClass < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "datastore"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAeCustomization < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAlert < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -3,7 +3,7 @@ class TreeBuilderAlertProfile < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -14,9 +14,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def tree_init_options
-    {
-      :expand => true
-    }
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -13,7 +13,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     node[:select] = @selected.include?(object.id)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :expand => true
     }

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,5 +1,5 @@
 class TreeBuilderAutomate < TreeBuilderAeClass
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => false}
   end
 

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAutomate < TreeBuilderAeClass
   def tree_init_options(_tree_name)
-    {:leaf => "datastore", :full_ids => false}
+    {:full_ids => false}
   end
 
   def initialize(name, type, sandbox, build = true, controller = nil)

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -10,12 +10,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
   private
 
   def tree_init_options
-    {
-      :full_ids => true,
-      :add_root => false,
-      :expand   => true,
-      :lazy     => false
-    }
+    {:full_ids => true, :add_root => false, :lazy => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -9,7 +9,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :full_ids => true,
       :add_root => false,

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -5,7 +5,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ConfigurationScript"}
+    {}
   end
 
   def set_locals_for_render
@@ -48,7 +48,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    objects = MiqSearch.where(:db => "ConfigurationScript").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -4,7 +4,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -1,7 +1,7 @@
 class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSystems
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:leaf => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem"}
   end
 

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -4,7 +4,7 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -5,7 +5,7 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ManageIQ::Providers::AnsibleTower::AutomationManager"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -8,9 +8,9 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def override(node, object, _pid, options)
     if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool, Host].any? { |klass| object.kind_of?(klass) }
       node[:select] = if @assign_to
-                        options.key?(:selected) && options[:selected].include?("ResourcePool_#{object[:id]}")
+                        @selected_nodes&.include?("ResourcePool_#{object[:id]}")
                       else
-                        options.key?(:selected) && options[:selected].include?("#{object.class.name}_#{object[:id]}")
+                        @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
                       end
     end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
@@ -21,7 +21,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def initialize(name, type, sandbox, build, params)
     @edit = params[:edit]
     @group = params[:group]
-    @selected = params[:selected]
+    @selected_nodes = params[:selected_nodes]
     @assign_to = params[:assign_to]
     # need to remove tree info
     TreeState.new(sandbox).remove_tree(name)
@@ -34,8 +34,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     {:full_ids             => true,
      :add_root             => false,
      :lazy                 => false,
-     :checkable_checkboxes => @edit.present? || @assign_to.present?,
-     :selected             => @selected}
+     :checkable_checkboxes => @edit.present? || @assign_to.present?}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -30,7 +30,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids             => true,
      :add_root             => false,
      :lazy                 => false,

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -15,7 +15,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:selectable] = false
-    node[:checkable] = options[:checkable_checkboxes] if options.key?(:checkable_checkboxes)
+    node[:checkable] = options[:checkboxes] if options.key?(:checkboxes)
   end
 
   def initialize(name, type, sandbox, build, params)
@@ -31,10 +31,10 @@ class TreeBuilderBelongsToHac < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids             => true,
-     :add_root             => false,
-     :lazy                 => false,
-     :checkable_checkboxes => @edit.present? || @assign_to.present?}
+    {:full_ids   => true,
+     :add_root   => false,
+     :lazy       => false,
+     :checkboxes => @edit.present? || @assign_to.present?}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -19,7 +19,7 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
       else
         node[:hideCheckbox] = true
       end
-      node[:select] = options.key?(:selected) && options[:selected].include?("EmsFolder_#{object[:id]}")
+      node[:select] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
     end
   end
 

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -9,7 +9,7 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
 
   def override(node, object, _pid, options)
     node[:selectable] = false
-    node[:checkable] = options[:checkable_checkboxes] if options.key?(:checkable_checkboxes)
+    node[:checkable] = options[:checkboxes] if options.key?(:checkboxes)
     if [ExtManagementSystem, EmsCluster, Datacenter].any? { |klass| object.kind_of?(klass) }
       node[:hideCheckbox] = true
     end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -6,7 +6,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true, :full_ids => true}
   end
 

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -7,7 +7,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "CustomButton", :open_all => true, :full_ids => true}
+    {:open_all => true, :full_ids => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -5,7 +5,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :leaf => 'ServiceTemplateCatalog'}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -4,7 +4,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_catalogs.rb
+++ b/app/presenters/tree_builder_catalogs.rb
@@ -2,7 +2,7 @@ class TreeBuilderCatalogs < TreeBuilderCatalogsClass
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :leaf => 'ServiceTemplateCatalog'}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_catalogs.rb
+++ b/app/presenters/tree_builder_catalogs.rb
@@ -1,7 +1,7 @@
 class TreeBuilderCatalogs < TreeBuilderCatalogsClass
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/app/presenters/tree_builder_chargeback_assignments.rb
@@ -2,7 +2,7 @@ class TreeBuilderChargebackAssignments < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:open_all => true, :full_ids => true, :leaf => "ChargebackRate"}
+    {:open_all => true, :full_ids => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/app/presenters/tree_builder_chargeback_assignments.rb
@@ -1,7 +1,7 @@
 class TreeBuilderChargebackAssignments < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true, :full_ids => true}
   end
 

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -2,7 +2,7 @@ class TreeBuilderChargebackRates < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:open_all => true, :full_ids => true, :leaf => "MiqReportResult"}
+    {:open_all => true, :full_ids => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -1,7 +1,7 @@
 class TreeBuilderChargebackRates < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true, :full_ids => true}
   end
 

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -1,7 +1,7 @@
 class TreeBuilderChargebackReports < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -2,7 +2,7 @@ class TreeBuilderChargebackReports < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :leaf => "MiqReportResult"}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -9,7 +9,7 @@ class TreeBuilderClusters < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => false,
      :add_root => false,
      :lazy     => false}

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -18,7 +18,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true,
      :add_root => false,
      :lazy     => false}

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -1,7 +1,7 @@
 class TreeBuilderCondition < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -4,7 +4,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -5,7 +5,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "ManageIQ::Providers::ConfigurationManager"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -1,7 +1,7 @@
 class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSystems
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:leaf => "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"}
   end
 

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -35,7 +35,7 @@ class TreeBuilderDatacenter < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -9,7 +9,7 @@ class TreeBuilderDatastores < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => false,
      :add_root => false,
      :lazy     => false}

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -34,7 +34,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true,
      :add_root => false,
      :lazy     => false}

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -7,10 +7,7 @@ class TreeBuilderDiagnostics < TreeBuilder
   private
 
   def tree_init_options
-    {:add_root => false,
-     :expand   => true,
-     :lazy     => false,
-     :open_all => true}
+    {:add_root => false, :lazy => false, :open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -6,7 +6,7 @@ class TreeBuilderDiagnostics < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:add_root => false,
      :expand   => true,
      :lazy     => false,

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -1,7 +1,7 @@
 class TreeBuilderEvent < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -20,7 +20,7 @@ class TreeBuilderGenealogy < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true, :lazy => false}
   end
 

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -33,7 +33,7 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
     count_only_or_objects(count_only, object[:object].custom_button_sets + object[:object].custom_buttons, :name)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:lazy => false}
   end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -3,7 +3,7 @@ class TreeBuilderImages < TreeBuilder
 
   include TreeBuilderArchived
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :leaf => "ManageIQ::Providers::CloudManager::Template"
     }

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderImagesFilter < TreeBuilderVmsFilter
-  def tree_init_options(_tree_name)
+  def tree_init_options
     super.update(:leaf => 'ManageIQ::Providers::CloudManager::Template')
   end
 

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -6,7 +6,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
 
   private
 
-  def tree_init_options(_)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -7,10 +7,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   private
 
   def tree_init_options(_)
-    {
-      :leaf     => "Switch",
-      :open_all => true,
-    }
+    {:open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -4,7 +4,7 @@ class TreeBuilderInstances < TreeBuilder
 
   include TreeBuilderArchived
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :leaf => 'VmCloud',
       :lazy => false

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
-  def tree_init_options(_tree_name)
+  def tree_init_options
     super.update(:leaf => 'ManageIQ::Providers::CloudManager::Vm')
   end
 

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -3,7 +3,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -4,7 +4,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "IsoDatastore"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -28,7 +28,7 @@ class TreeBuilderMenuRoles < TreeBuilder
     super.merge!(locals)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     { :lazy => false, :add_root => true }
   end
 

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -16,10 +16,7 @@ class TreeBuilderMiqActionCategory < TreeBuilder
   end
 
   def tree_init_options
-    {
-      :expand => true,
-      :lazy   => false
-    }
+    {:lazy => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -15,7 +15,7 @@ class TreeBuilderMiqActionCategory < TreeBuilder
     super(name, type, sandbox, build)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :expand => true,
       :lazy   => false

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -18,7 +18,7 @@ class TreeBuilderNetwork < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_ops_diagnostics.rb
+++ b/app/presenters/tree_builder_ops_diagnostics.rb
@@ -2,10 +2,7 @@ class TreeBuilderOpsDiagnostics < TreeBuilderOps
   private
 
   def tree_init_options(_tree_name)
-    {
-      :open_all => true,
-      :leaf     => "Diagnostics"
-    }
+    {:open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ops_diagnostics.rb
+++ b/app/presenters/tree_builder_ops_diagnostics.rb
@@ -1,7 +1,7 @@
 class TreeBuilderOpsDiagnostics < TreeBuilderOps
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -3,7 +3,7 @@ class TreeBuilderOpsRbac < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => false, :expand => false}
   end
 

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -4,11 +4,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :open_all => false,
-      :leaf     => "Access Control",
-      :expand   => false
-    }
+    {:open_all => false, :expand => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -4,7 +4,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => false, :expand => false}
+    {:open_all => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -69,7 +69,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
     count_only_or_objects(count_only, kids)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :lazy           => false,
       :add_root       => true,

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -1,7 +1,7 @@
 class TreeBuilderOpsSettings < TreeBuilderOps
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -2,10 +2,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   private
 
   def tree_init_options(_tree_name)
-    {
-      :open_all => true,
-      :leaf     => "Settings"
-    }
+    {:open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -4,10 +4,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
   private
 
   def tree_init_options(_tree_name)
-    {
-      :open_all => false,
-      :leaf     => "VmdbTable",
-    }
+    {:open_all => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -3,7 +3,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => false}
   end
 

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -1,7 +1,7 @@
 class TreeBuilderOrchestrationTemplates < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -2,8 +2,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true,
-     :leaf     => 'OrchestrationTemplate'}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -4,7 +4,7 @@ class TreeBuilderPolicy < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true,
      :lazy     => false}
   end

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -5,7 +5,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true,
      :lazy     => false}
   end

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -13,7 +13,7 @@ class TreeBuilderPolicySimulation < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:lazy => false, :full_ids => true}
   end
 

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -11,7 +11,7 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true, :lazy => false}
   end
 

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -8,7 +8,7 @@ class TreeBuilderProtect < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => false, :add_root => false, :lazy => false}
   end
 

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -1,7 +1,7 @@
 class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -2,7 +2,7 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "MiqDialog", :open_all => true}
+    {:open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -2,7 +2,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "CustomizationTemplate"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -1,7 +1,7 @@
 class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -1,7 +1,7 @@
 class TreeBuilderPxeImageTypes < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -2,7 +2,7 @@ class TreeBuilderPxeImageTypes < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :leaf => "PxeImageType"}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -4,7 +4,7 @@ class TreeBuilderPxeServers < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "PxeServer"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -3,7 +3,7 @@ class TreeBuilderPxeServers < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_region.rb
+++ b/app/presenters/tree_builder_region.rb
@@ -4,8 +4,7 @@ class TreeBuilderRegion < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    ent = MiqEnterprise.my_enterprise
-    {:leaf => ent.is_enterprise? ? "MiqEnterprise" : "MiqRegion", :add_root => ent.is_enterprise?}
+    {:add_root => MiqEnterprise.my_enterprise.is_enterprise?}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_region.rb
+++ b/app/presenters/tree_builder_region.rb
@@ -3,7 +3,7 @@ class TreeBuilderRegion < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:add_root => MiqEnterprise.my_enterprise.is_enterprise?}
   end
 

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -3,7 +3,7 @@ class TreeBuilderReportDashboards < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -4,10 +4,7 @@ class TreeBuilderReportDashboards < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => 'Dashboards',
-      :full_ids => true
-    }
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -2,11 +2,7 @@ class TreeBuilderReportExport < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => 'Export',
-      :full_ids => true,
-      :open_all => true
-    }
+    {:full_ids => true, :open_all => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportExport < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true, :open_all => true}
   end
 

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -9,7 +9,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
     super(name, type, sandbox, build = true)
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -10,10 +10,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => 'full_ids',
-      :full_ids => true
-    }
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportRoles < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -2,10 +2,7 @@ class TreeBuilderReportRoles < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => 'Roles',
-      :full_ids => true
-    }
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -2,10 +2,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   private
 
   def tree_init_options(_tree_name)
-    {
-      :full_ids => true,
-      :leaf     => 'MiqReportResult'
-    }
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportSchedules < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -2,10 +2,7 @@ class TreeBuilderReportSchedules < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => 'Schedules',
-      :full_ids => true
-    }
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -9,7 +9,7 @@ class TreeBuilderReportWidgets < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => 'Widgets', :full_ids => true}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -8,7 +8,7 @@ class TreeBuilderReportWidgets < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -11,7 +11,7 @@ class TreeBuilderSections < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true, :add_root => false, :lazy => false}
   end
 

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -3,7 +3,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -4,7 +4,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :leaf => 'ServiceTemplateCatalog'}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -1,5 +1,5 @@
 class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:open_all => true}
   end
 

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -4,10 +4,7 @@ class TreeBuilderServices < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {
-      :leaf     => "Service",
-      :add_root => false
-    }
+    {:add_root => false}
   end
 
   def set_locals_for_render
@@ -51,7 +48,7 @@ class TreeBuilderServices < TreeBuilder
     case object[:id]
     when 'my', 'global'
       # Get My Filters and Global Filters
-      count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
+      count_only_or_objects(count_only, x_get_search_results(object))
     when 'asrv', 'rsrv'
       retired = object[:id] != 'asrv'
       services = Rbac.filtered(Service.where(:retired => retired, :display => true))
@@ -62,21 +59,21 @@ class TreeBuilderServices < TreeBuilder
     end
   end
 
-  def x_get_search_results(object, leaf)
+  def x_get_search_results(object)
     case object[:id]
     when "global" # Global filters
-      x_get_global_filter_search_results(leaf)
+      x_get_global_filter_search_results
     when "my"     # My filters
-      x_get_my_filter_search_results(leaf)
+      x_get_my_filter_search_results
     end
   end
 
-  def x_get_global_filter_search_results(leaf)
-    MiqSearch.where(:db => leaf).visible_to_all.sort_by { |a| a.description.downcase }
+  def x_get_global_filter_search_results
+    MiqSearch.where(:db => "Service").visible_to_all.sort_by { |a| a.description.downcase }
   end
 
-  def x_get_my_filter_search_results(leaf)
-    MiqSearch.where(:db => leaf, :search_type => "user", :search_key => User.current_user.userid)
+  def x_get_my_filter_search_results
+    MiqSearch.where(:db => "Service", :search_type => "user", :search_key => User.current_user.userid)
              .sort_by { |a| a.description.downcase }
   end
 end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -3,7 +3,7 @@ class TreeBuilderServices < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:add_root => false}
   end
 

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -13,7 +13,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
     node[:selectable] = false
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => false, :add_root => false, :lazy => false}
   end
 

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -17,7 +17,7 @@ class TreeBuilderSnapshots < TreeBuilder
     end
   end
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true, :selected_node => @selected_node}
   end
 

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -5,20 +5,19 @@ class TreeBuilderSnapshots < TreeBuilder
 
   def initialize(name, type, sandbox, build = true, **params)
     @record = params[:root]
-    @selected_node = params.key?(:selected_node) ? id(params[:selected_node]) : nil
     super(name, type, sandbox, build)
   end
 
   private
 
-  def override(node, object, _pid, options)
-    if (options[:selected_node].present? && node[:key] == options[:selected_node]) || object.children.empty?
+  def override(node, object, _pid, _options)
+    if (@selected_node.present? && node[:key] == @selected_node) || object.children.empty?
       node[:highlighted] = true
     end
   end
 
   def tree_init_options
-    {:full_ids => true, :selected_node => @selected_node}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -2,7 +2,7 @@ class TreeBuilderStorage < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "Storage"}
+    {}
   end
 
   def set_locals_for_render
@@ -27,7 +27,7 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    objects = MiqSearch.where(:db => "Storage").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -1,7 +1,7 @@
 class TreeBuilderStorage < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -10,7 +10,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true}
   end
 

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -1,7 +1,7 @@
 class TreeBuilderStoragePod < TreeBuilder
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {}
   end
 

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -2,7 +2,7 @@ class TreeBuilderStoragePod < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "Storage"}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -15,7 +15,7 @@ class TreeBuilderTags < TreeBuilder
 
   private
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:full_ids => true,
      :add_root => false,
      :lazy     => false}

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
-  def tree_init_options(tree_name)
+  def tree_init_options
     super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
   end
 

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
-  def tree_init_options(_tree_name)
+  def tree_init_options
     super.update(:leaf => 'MiqTemplate')
   end
 

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -4,20 +4,10 @@ class TreeBuilderUtilization < TreeBuilderRegion
   has_kids_for EmsFolder, %i(x_get_tree_folder_kids type)
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
-    @selected_node = params[:selected_node]
-    super(name, type, sandbox, build)
-  end
-
   private
 
   def override(node, _object, _pid, _options)
     node[:selectable] = node[:key].split('-')[1].split('_')[0] != 'folder'
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:select_node => @selected_node.to_s)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -1,7 +1,7 @@
 class TreeBuilderVandt < TreeBuilder
   include TreeBuilderArchived
 
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {:leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate'}
   end
 

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderVmsFilter < TreeBuilder
-  def tree_init_options(_tree_name)
+  def tree_init_options
     {
       :open_all => true,
       :leaf     => 'ManageIQ::Providers::InfraManager::Vm'

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -1,5 +1,5 @@
 class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
-  def tree_init_options(_tree_name)
+  def tree_init_options
     super.update(:leaf => 'Vm')
   end
 

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -4,16 +4,16 @@ describe TreeBuilderAeCustomization do
   describe "#init_tree" do
     let(:expected_sandbox_values) do
       {
-        :tree                 => :dialog_import_export_tree,
-        :type                 => :dialog_import_export,
-        :klass_name           => "TreeBuilderAeCustomization",
-        :leaf                 => nil,
-        :add_root             => true,
-        :open_nodes           => [],
-        :lazy                 => true,
-        :checkable_checkboxes => false,
-        :open_all             => true,
-        :active_node          => "root"
+        :tree        => :dialog_import_export_tree,
+        :type        => :dialog_import_export,
+        :klass_name  => "TreeBuilderAeCustomization",
+        :leaf        => nil,
+        :add_root    => true,
+        :open_nodes  => [],
+        :lazy        => true,
+        :checkboxes  => false,
+        :open_all    => true,
+        :active_node => "root"
       }
     end
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -30,7 +30,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#tree_init_options' do
       it 'sets init options correctly' do
-        expect(subject.send(:tree_init_options, :alert_profile_obj)).to eq(:expand => true)
+        expect(subject.send(:tree_init_options)).to eq(:expand => true)
       end
     end
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -30,7 +30,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#tree_init_options' do
       it 'sets init options correctly' do
-        expect(subject.send(:tree_init_options)).to eq(:expand => true)
+        expect(subject.send(:tree_init_options)).to eq({})
       end
     end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -67,10 +67,10 @@ describe TreeBuilderBelongsToHac do
 
   describe '#tree_init_options' do
     it 'sets init options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
-                                                     :add_root             => false,
-                                                     :lazy                 => false,
-                                                     :checkable_checkboxes => edit.present?)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :add_root   => false,
+                                                     :lazy       => false,
+                                                     :checkboxes => edit.present?)
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -59,10 +59,10 @@ describe TreeBuilderBelongsToHac do
                         :hac_tree,
                         {:trees => {}},
                         true,
-                        :edit     => edit,
-                        :filters  => {},
-                        :group    => nil,
-                        :selected => {})
+                        :edit           => edit,
+                        :filters        => {},
+                        :group          => nil,
+                        :selected_nodes => {})
   end
 
   describe '#tree_init_options' do
@@ -70,8 +70,7 @@ describe TreeBuilderBelongsToHac do
       expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
                                                      :add_root             => false,
                                                      :lazy                 => false,
-                                                     :checkable_checkboxes => edit.present?,
-                                                     :selected             => {})
+                                                     :checkable_checkboxes => edit.present?)
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -67,11 +67,11 @@ describe TreeBuilderBelongsToHac do
 
   describe '#tree_init_options' do
     it 'sets init options correctly' do
-      expect(subject.send(:tree_init_options, :hac)).to eq(:full_ids             => true,
-                                                           :add_root             => false,
-                                                           :lazy                 => false,
-                                                           :checkable_checkboxes => edit.present?,
-                                                           :selected             => {})
+      expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
+                                                     :add_root             => false,
+                                                     :lazy                 => false,
+                                                     :checkable_checkboxes => edit.present?,
+                                                     :selected             => {})
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -41,8 +41,7 @@ describe TreeBuilderBelongsToVat do
       expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
                                                      :add_root             => false,
                                                      :lazy                 => false,
-                                                     :checkable_checkboxes => edit.present?,
-                                                     :selected             => {})
+                                                     :checkable_checkboxes => edit.present?)
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -38,11 +38,11 @@ describe TreeBuilderBelongsToVat do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options, :vat)).to eq(:full_ids             => true,
-                                                           :add_root             => false,
-                                                           :lazy                 => false,
-                                                           :checkable_checkboxes => edit.present?,
-                                                           :selected             => {})
+      expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
+                                                     :add_root             => false,
+                                                     :lazy                 => false,
+                                                     :checkable_checkboxes => edit.present?,
+                                                     :selected             => {})
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -38,10 +38,10 @@ describe TreeBuilderBelongsToVat do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids             => true,
-                                                     :add_root             => false,
-                                                     :lazy                 => false,
-                                                     :checkable_checkboxes => edit.present?)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :add_root   => false,
+                                                     :lazy       => false,
+                                                     :checkboxes => edit.present?)
     end
   end
 

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderClusters do
     end
 
     it 'sets tree to have full ids, not lazy and no root' do
-      root_options = @cluster_tree.send(:tree_init_options, nil)
+      root_options = @cluster_tree.send(:tree_init_options)
       expect(root_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
     end
 

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -21,11 +21,11 @@ describe TreeBuilderComplianceHistory do
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, {}, true, root)
     end
     it 'is not lazy' do
-      tree_options = @ch_tree.send(:tree_init_options, :ch)
+      tree_options = @ch_tree.send(:tree_init_options)
       expect(tree_options[:lazy]).to eq(false)
     end
     it 'has no root' do
-      tree_options = @ch_tree.send(:tree_init_options, :ch)
+      tree_options = @ch_tree.send(:tree_init_options)
       root = @ch_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
       expect(root).to eq({})

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -10,7 +10,7 @@ describe TreeBuilderDatastores do
       @datastores_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, @datastore)
     end
     it 'sets tree to have full ids, not lazy and no root' do
-      root_options = @datastores_tree.send(:tree_init_options, nil)
+      root_options = @datastores_tree.send(:tree_init_options)
       expect(root_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
     end
     it 'sets locals correctly' do

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -65,12 +65,12 @@ describe TreeBuilderDefaultFilters do
     end
 
     it 'is not lazy' do
-      tree_options = @default_filters_tree.send(:tree_init_options, :df)
+      tree_options = @default_filters_tree.send(:tree_init_options)
       expect(tree_options[:lazy]).to eq(false)
     end
 
     it 'has no root' do
-      tree_options = @default_filters_tree.send(:tree_init_options, :df)
+      tree_options = @default_filters_tree.send(:tree_init_options)
       root = @default_filters_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
       expect(root).to eq({})

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderGenealogy do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options, :genealogy)).to eq(:full_ids => true, :lazy => false)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids => true, :lazy => false)
     end
   end
 

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -12,7 +12,7 @@ describe TreeBuilderImages do
   end
 
   it 'sets tree to have leaf and not lazy' do
-    root_options = @images_tree.tree_init_options(nil)
+    root_options = @images_tree.tree_init_options
     expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template")
   end
 

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -16,7 +16,7 @@ describe TreeBuilderInstances do
   end
 
   it 'sets tree to have leaf and not lazy' do
-    root_options = @instances_tree.tree_init_options(nil)
+    root_options = @instances_tree.tree_init_options
 
     expect(root_options).to eq(:leaf => 'VmCloud', :lazy => false)
   end

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -26,7 +26,7 @@ describe TreeBuilderMiqActionCategory do
 
   describe '#tree_init_options' do
     it 'set init options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:expand => true, :lazy => false)
+      expect(subject.send(:tree_init_options)).to eq(:lazy => false)
     end
   end
 

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -26,7 +26,7 @@ describe TreeBuilderMiqActionCategory do
 
   describe '#tree_init_options' do
     it 'set init options correctly' do
-      expect(subject.send(:tree_init_options, tree_name)).to eq(:expand => true, :lazy => false)
+      expect(subject.send(:tree_init_options)).to eq(:expand => true, :lazy => false)
     end
   end
 

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderOpsRbac do
     it "has :open_all set to false" do
       login_as FactoryBot.create(:user, :features => 'none')
       tree = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
-      expect(tree.send(:tree_init_options, :open_all)[:open_all]).to be_falsey
+      expect(tree.send(:tree_init_options)[:open_all]).to be_falsey
     end
 
     it "with user with rbac_role_view role" do

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderPolicySimulation do
     end
 
     it 'sets tree as not lazy' do
-      tree_options = @policy_simulation_tree.send(:tree_init_options, :policy_simulation)
+      tree_options = @policy_simulation_tree.send(:tree_init_options)
       expect(tree_options[:lazy]).to eq(false)
     end
 

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -23,7 +23,7 @@ describe TreeBuilderProtect do
     end
 
     it 'set init options correctly' do
-      tree_options = @protect_tree.send(:tree_init_options, :protect)
+      tree_options = @protect_tree.send(:tree_init_options)
       expect(tree_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
     end
 

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -35,12 +35,12 @@ describe TreeBuilderRolesByServer do
     end
 
     it "is not lazy" do
-      tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
+      tree_options = @server_tree.send(:tree_init_options)
       expect(tree_options[:lazy]).to eq(false)
     end
 
     it 'has no root' do
-      tree_options = @server_tree.send(:tree_init_options, :roles_by_server)
+      tree_options = @server_tree.send(:tree_init_options)
       root = @server_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
       expect(root).to eq({})

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -54,7 +54,7 @@ describe TreeBuilderSections do
                                                @current_tenant)
     end
     it 'set init options correctly' do
-      tree_options = @sections_tree.send(:tree_init_options, :all_selections)
+      tree_options = @sections_tree.send(:tree_init_options)
       expect(tree_options).to eq(:full_ids => true, :add_root => false, :lazy => false)
     end
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -37,12 +37,12 @@ describe TreeBuilderServersByRole do
     end
 
     it "is not lazy" do
-      tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
+      tree_options = @server_tree.send(:tree_init_options)
       expect(tree_options[:lazy]).to eq(false)
     end
 
     it 'has no root' do
-      tree_options = @server_tree.send(:tree_init_options, :servers_by_role)
+      tree_options = @server_tree.send(:tree_init_options)
       root = @server_tree.send(:root_options)
       expect(tree_options[:add_root]).to eq(false)
       expect(root).to eq({})

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -34,7 +34,7 @@ describe TreeBuilderSmartproxyAffinity do
     end
 
     it 'set init options correctly' do
-      tree_options = @smartproxy_affinity_tree.send(:tree_init_options, :smartproxy_affinity)
+      tree_options = @smartproxy_affinity_tree.send(:tree_init_options)
       expect(tree_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
     end
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -23,7 +23,7 @@ describe TreeBuilderTags do
                                        :edit => edit, :filters => @filters, :group => @group)
     end
     it 'set init options correctly' do
-      tree_options = @tags_tree.send(:tree_init_options, :tags)
+      tree_options = @tags_tree.send(:tree_init_options)
       expect(tree_options).to eq(:full_ids => true, :add_root => false, :lazy => false)
     end
     it 'set locals for render correctly' do

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -31,16 +31,16 @@ describe 'ops/_rbac_group_details.html.haml' do
                                               :hac,
                                               sb,
                                               true,
-                                              :edit     => nil,
-                                              :group    => @group,
-                                              :selected => {})
+                                              :edit           => nil,
+                                              :group          => @group,
+                                              :selected_nodes => {})
       @vat_tree = TreeBuilderBelongsToVat.new(:vat_tree,
                                               :vat,
                                               sb,
                                               true,
-                                              :edit     => nil,
-                                              :group    => @group,
-                                              :selected => {})
+                                              :edit           => nil,
+                                              :group          => @group,
+                                              :selected_nodes => {})
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode ldap' do


### PR DESCRIPTION
I am going through the tree_init_options in each TreeBuilder and trying to make them less painful to understand by removing the unnecessary ones.

* `:leaf` - this is being used only in a few places to determine the class of the leaf nodes
* `:expand` - not used at all
* the argument of the method was never used
* `:selected_node` in `TreeBuilderUtilization` - never actually set
* `:selected_node` in `TreeBuilderSnapshots` - never actually set, used as an instance variable
* `:selected` in `TreeBuilderBelongsTo*` - no need to propagate, renaming to `@selected_nodes`
* `:checkable_checkboxes` - renamed to `:checkboxes`

@miq-bot add_label cleanup, refactoring, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 