### PR TITLE
[Performance] Remove compliance from VmOrTemplate includes

### DIFF
--- a/product/views/VmOrTemplate.yaml
+++ b/product/views/VmOrTemplate.yaml
@@ -44,7 +44,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}


### PR DESCRIPTION
Over time, the `compliances` table will get quiet large, and when paired with the rest of the tables in this report, you end up getting a query executed that looks like this:

```SQL
SELECT "vms"."id" AS t0_r0, ..., "vms"."memory_hot_add_increment" AS t0_r75,
       "hosts"."id" AS t1_r0, ..., "hosts"."physical_server_id" AS t1_r36,
       "storages"."id" AS t2_r0, ..., "storages"."storage_domain_type" AS t2_r18,
       "ext_management_systems"."id" AS t3_r0, ..., "ext_management_systems"."tenant_mapping_enabled" AS t3_r23,
       "snapshots"."id" AS t4_r0, ..., "snapshots"."ems_ref" AS t4_r16,
       "compliances"."id" AS t5_r0, ..., "compliances"."event_type" AS t5_r6,
       "operating_systems"."id" AS t6_r0, ..., "operating_systems"."kernel_version" AS t6_r25,
       "hardwares"."id" AS t7_r0, ..., "hardwares"."provision_state" AS t7_r34,
       "tags"."id" AS t8_r0, "tags"."name" AS t8_r1
FROM "vms"
LEFT OUTER JOIN "hosts" ON "hosts"."id" = "vms"."host_id"
LEFT OUTER JOIN "storages" ON "storages"."id" = "vms"."storage_id"
LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "vms"."ems_id"
LEFT OUTER JOIN "snapshots" ON "snapshots"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "compliances" ON "compliances"."resource_id" = "vms"."id" AND "compliances"."resource_type" = $1
LEFT OUTER JOIN "operating_systems" ON "operating_systems"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "hardwares" ON "hardwares"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "taggings" ON "taggings"."taggable_id" = "vms"."id" AND "taggings"."taggable_type" = $2
LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id"
WHERE "vms"."type" IN (...)
  AND "vms"."template" = $3
  AND (lower(vms.name) like '%win2k%' escape '`')
  AND "vms"."id" IN (...)
ORDER BY LOWER("vms"."name") ASC
```


This ends up creating 243 columns per record, and the number of rows returned has been observed to be over 80k with just 20 VMs being targeted in the `"vms"."id" IN (...)` portion of the query.

Since some fixes have been made to avoid the N+1 that results from doing this:

- https://github.com/ManageIQ/manageiq/pull/17473
- https://github.com/ManageIQ/manageiq/pull/17474
- https://github.com/ManageIQ/manageiq/pull/17475

It is much better to do use those facilities.  Even with the N+1, it is much better making extra round trips than the gigs of data that would be returned as a result.

Metrics
-------

The following is output from running the QA steps below:

### Before

```
Started POST "/vm_infra/report_data" for 127.0.0.1 at 2019-02-28 21:39:28 -0600
Processing by VmInfraController#report_data as HTML
  Parameters: {"page"=>"1", "ppsetting"=>"20"}
Completed 200 OK in 9710ms (Views: 6.3ms | ActiveRecord: 2060.3ms | Rows: 70656)


Started POST "/vm_infra/report_data" for 127.0.0.1 at 2019-02-28 21:39:38 -0600
Processing by VmInfraController#report_data as HTML
  Parameters: {"page"=>"2", "ppsetting"=>"20"}
Completed 200 OK in 36920ms (Views: 6.2ms | ActiveRecord: 7886.1ms | Rows: 250654)
```



### After

```
Started POST "/vm_infra/report_data" for 127.0.0.1 at 2019-02-28 21:37:45 -0600
Processing by VmInfraController#report_data as HTML
  Parameters: {"page"=>"1", "ppsetting"=>"20"}
Completed 200 OK in 1865ms (Views: 6.3ms | ActiveRecord: 108.1ms | Rows: 4056)


Started POST "/vm_infra/report_data" for 127.0.0.1 at 2019-02-28 21:37:47 -0600
Processing by VmInfraController#report_data as HTML
  Parameters: {"page"=>"2", "ppsetting"=>"20"}
Completed 200 OK in 631ms (Views: 7.5ms | ActiveRecord: 113.8ms | Rows: 4054)
```

The "Rows" and the total request time is the important data to make note of.


Links
-----

* Will address https://bugzilla.redhat.com/show_bug.cgi?id=1648412
* Similar PR for `Host.yaml`:  https://github.com/ManageIQ/manageiq-ui-classic/pull/3989
* Previous and relevant PRs:
  - https://github.com/ManageIQ/manageiq/pull/17473
  - https://github.com/ManageIQ/manageiq/pull/17474
  - https://github.com/ManageIQ/manageiq/pull/17475


Steps for Testing/QA
--------------------

~~Will put a script together for some replication data and a script to help see the before and after.~~

**Update**:  Instructions for replication and benchmarking this change can be found in the following gist:

https://gist.github.com/NickLaMuro/f36576f9fa73c2bcc0d1ef7b7d0adafb

Left example run data in the _**Metrics**_ section above.