### PR TITLE
Added promise debounce library (with updated typescript) and async validation in Catalog form

### DIFF
--- a/app/javascript/components/catalog-form/catalog-form.schema.js
+++ b/app/javascript/components/catalog-form/catalog-form.schema.js
@@ -1,4 +1,19 @@
-import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import debouncePromise from '../../helpers/promise-debounce';
+import { API } from '../../http_api';
+
+export const asyncValidator = value => API.get(`/api/service_catalogs?expand=resources&filter[]=name=${value}`)
+  .then((json) => {
+    if (json.resources.length > 0) {
+      return __('Name has already been taken');
+    }
+    if (value === '' || value === undefined) {
+      return __("Name can't be blank");
+    }
+    return undefined;
+  });
+
+const asyncValidatorDebounced = debouncePromise(asyncValidator);
 
 function createSchema(options) {
   const fields = [{
@@ -7,10 +22,9 @@ function createSchema(options) {
     fields: [{
       component: componentTypes.TEXT_FIELD,
       name: 'name',
-      validate: [{
-        type: validatorTypes.REQUIRED,
-        message: __("Name can't be blank"),
-      }],
+      validate: [
+        asyncValidatorDebounced,
+      ],
       label: __('Name'),
       maxLength: 40,
       autoFocus: true,

--- a/app/javascript/helpers/promise-debounce.js
+++ b/app/javascript/helpers/promise-debounce.js
@@ -1,0 +1,7 @@
+import AwesomeDebouncePromise from 'awesome-debounce-promise';
+
+export default (asyncFunction, debounceTime = 250, options = undefined) => AwesomeDebouncePromise(
+  asyncFunction,
+  debounceTime,
+  options,
+);

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -27,10 +27,7 @@ exports[`Catalog form component should render add variant form 1`] = `
                 "maxLength": 40,
                 "name": "name",
                 "validate": Array [
-                  Object {
-                    "message": "Name can't be blank",
-                    "type": "required-validator",
-                  },
+                  [Function],
                 ],
                 "validateOnMount": true,
               },
@@ -120,10 +117,7 @@ exports[`Catalog form component should render edit variant form 1`] = `
                 "maxLength": 40,
                 "name": "name",
                 "validate": Array [
-                  Object {
-                    "message": "Name can't be blank",
-                    "type": "required-validator",
-                  },
+                  [Function],
                 ],
                 "validateOnMount": true,
               },

--- a/app/javascript/spec/catalog-form/validator.spec.js
+++ b/app/javascript/spec/catalog-form/validator.spec.js
@@ -1,0 +1,35 @@
+import fetchMock from 'fetch-mock';
+import { asyncValidator } from '../../components/catalog-form/catalog-form.schema';
+
+describe('catalog form - promise validator', () => {
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('returns error message when name is taken', () => {
+    fetchMock.getOnce('/api/service_catalogs?expand=resources&filter[]=name=a1', {
+      resources: [
+        { name: 'a1' },
+      ],
+    });
+
+    return asyncValidator('a1').then(data => expect(data).toEqual(__('Name has already been taken')));
+  });
+
+  it('returns error message when name is undefined', () => {
+    fetchMock.getOnce('/api/service_catalogs?expand=resources&filter[]=name=undefined', {
+      resources: [],
+    });
+
+    return asyncValidator(undefined).then(data => expect(data).toEqual(__("Name can't be blank")));
+  });
+
+  it('returns nothing when passes', () => {
+    fetchMock.getOnce('/api/service_catalogs?expand=resources&filter[]=name=a1', {
+      resources: [],
+    });
+
+    return asyncValidator('a1').then(data => expect(data).toEqual(undefined));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
     "ts-jest": "~22.4.3",
-    "typescript": "~2.8.1",
+    "typescript": "~3.3.3333",
     "webpack": "~4.12.0",
     "webpack-cli": "~3.0.7",
     "webpack-dev-server": "~3.1.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "^0.4.3",
-    "@data-driven-forms/react-form-renderer": "^1.7.0",
+    "@data-driven-forms/react-form-renderer": "^1.8.0",
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.2.2",
     "@pf3/select": "~1.12.6",
@@ -39,6 +39,7 @@
     "angular-ui-sortable": "~0.16.1",
     "angular.validators": "~4.4.3",
     "array-includes": "~3.0.3",
+    "awesome-debounce-promise": "^2.1.0",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-switch": "~3.3.4",
     "classnames": "~2.2.6",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@data-driven-forms/pf3-component-mapper": "^0.4.3",
-    "@data-driven-forms/react-form-renderer": "^1.8.0",
+    "@data-driven-forms/pf3-component-mapper": "^0.4.5",
+    "@data-driven-forms/react-form-renderer": "^1.9.3",
     "@manageiq/react-ui-components": "~0.10.8",
     "@manageiq/ui-components": "~1.2.2",
     "@pf3/select": "~1.12.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
       "app/javascript/typings"
     ],
     "allowJs": true,
-    "jsx": "react"
+    "jsx": "react",
+    "allowSyntheticDefaultImports": true,
   },
   "exclude": [
     "**/*.spec.ts",


### PR DESCRIPTION
### Description

* Adds [library](https://github.com/slorber/awesome-debounce-promise) for debouncing promises
* Adds 'proof of concept' validation to Catalog form `Services > Catalogs > Catalogs > Configuration > New/Edit` (it controlls if name is available)
* Updates data-driven-form renderer to suppor function validators
* **Updates Typescript to latest and allowed synthetic default export** (to support the library)

**Before**
![validationbefore](https://user-images.githubusercontent.com/32869456/53481017-a3cd3080-3a7c-11e9-99f7-9d911e49c10a.gif)


**After**
![validationafter](https://user-images.githubusercontent.com/32869456/53481013-9fa11300-3a7c-11e9-8fd3-0405ab3d0e66.gif)

@terezanovotna 