### PR TITLE
Fix add new action

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -305,7 +305,7 @@ module MiqPolicyController::MiqActions
 
   # Build the alert choice hash for evaluate_alerts action_type
   def action_build_alert_choices
-    @edit[:choices] = MiqAlert.all.reduce({}) { |h, a| h[a.description] = a.guid } # Build the hash of alert choices
+    @edit[:choices] = MiqAlert.all.reduce({}) { |h, a| h[a.description] = a.guid; h } # Build the hash of alert choices
     @edit[:new][:alerts] = {} # Clear out the alerts hash
   end
 

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -305,7 +305,7 @@ module MiqPolicyController::MiqActions
 
   # Build the alert choice hash for evaluate_alerts action_type
   def action_build_alert_choices
-    @edit[:choices] = MiqAlert.all.reduce({}) { |h, a| h[a.description] = a.guid; h } # Build the hash of alert choices
+    @edit[:choices] = MiqAlert.all.each_with_object({}) { |h, a| h[a.description] = a.guid } # Build the hash of alert choices
     @edit[:new][:alerts] = {} # Clear out the alerts hash
   end
 


### PR DESCRIPTION
When you navigate `Control -> Explorer -> Actions -> Configuration -> Add a new action` you get following error:
```
[----] F, [2019-02-27T14:40:55.173928 #11193:2ae5cbf9b8e4] FATAL -- : Error caught: [IndexError] string not matched
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:308:in `[]='
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:308:in `block in action_build_alert_choices'
/home/rknaur/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/relation/delegation.rb:38:in `each'
/home/rknaur/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/relation/delegation.rb:38:in `each'
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:308:in `reduce'
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:308:in `action_build_alert_choices'
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:275:in `action_build_edit_screen'
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:20:in `action_edit'
/home/rknaur/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:203:in `generic_x_button'
/home/rknaur/manageiq-ui-classic/app/controllers/miq_policy_controller.rb:117:in `x_button'

```

This PR should fix the error.

Steps for Testing/QA [Optional]
-------------------------------
Navigate Control -> Explorer -> Actions -> Configuration -> Add a new action

@mzazrivec please review
