### PR TITLE
Fixes value of validate_id in host form

### DIFF
--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -16,7 +16,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       ws_password: '',
       ipmi_userid: '',
       ipmi_password: '',
-      validate_id: '',
+      validate_id: null,
     };
 
     $scope.modelCopy = angular.copy( $scope.hostModel );
@@ -46,7 +46,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       $scope.hostModel.ws_password = '';
       $scope.hostModel.ipmi_userid = '';
       $scope.hostModel.ipmi_password = '';
-      $scope.hostModel.validate_id = '';
+      $scope.hostModel.validate_id = null;
       $scope.afterGet = true;
     } else if (hostFormId.split(',').length === 1) {
       miqService.sparkleOn();

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -571,7 +571,7 @@
           = _("Select Host to validate against")
         .col-md-10
           = select_tag('validate_id',
-                       options_for_select([["<#{_('Choose')}>", '']] + @selected_hosts.invert.sort, disabled: ["<#{_('Choose')}>", nil]),
+                       options_for_select([["<#{_('Choose')}>", nil]] + @selected_hosts.invert.sort, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.validate_id",
                        "checkchange"                 => "",
                        "selectpicker-for-select-tag" => "")

--- a/spec/javascripts/controllers/host/host_form_controller_spec.js
+++ b/spec/javascripts/controllers/host/host_form_controller_spec.js
@@ -65,6 +65,10 @@ describe('hostFormController', function() {
         it('sets the IPMI Address to blank', function() {
           expect($scope.hostModel.ipmi_address).toEqual('');
         });
+
+        it('sets the validate id to null', function() {
+          expect($scope.hostModel.validate_id).toEqual(null);
+        });
       });
 
       describe('when the hostFormId is an Id', function() {
@@ -77,7 +81,8 @@ describe('hostFormController', function() {
           default_userid: 'abc',
           remote_userid: 'xyz',
           ws_userid: 'aaa',
-          ipmi_userid: 'zzz'
+          ipmi_userid: 'zzz',
+          validate_id: '1',
         };
         describe('when the filter type is all', function() {
           beforeEach(inject(function(_$controller_) {
@@ -126,6 +131,10 @@ describe('hostFormController', function() {
 
           it('sets the ipmi password to the placeholder value if a ipmi user exists', function() {
             expect($scope.hostModel.ipmi_password).toEqual(miqService.storedPasswordPlaceholder);
+          });
+
+          it('sets the validate id to the value returned from the http request', function() {
+            expect($scope.hostModel.validate_id).toEqual('1');
           });
         });
       });


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1634794

**Description of problem:**
When 2 or more hosts are selected and edited, Alert 'Abandon changes' is displayed even when no changes are made by the user.

**Steps to Reproduce:**
1. Have CFME appliance with added provider with some hosts
2. Go to Compute -> Infrastructure -> Hosts
3. Select 2 or more hosts and click Configuration -> Edit selected items 
4. Leave the page without making any changes

**Actual results:**
Alert asking whether to abandon changes is displayed

**Expected results:**
If no changes are made, no 'Abandon changes' alert should be displayed


### Solution

* validation_id was **nil** in template and **blank** in controller
* => changed to null everywhere
* it caused dirty state on the form (because the model and the copy was different)

**Before** (immediately after loading of the form)

![screenshot from 2019-02-28 12-36-37](https://user-images.githubusercontent.com/32869456/53563822-80c27f80-3b55-11e9-8584-a1dfcbe49798.png)


**After** (notice form buttons)

![screenshot from 2019-02-28 12-36-15](https://user-images.githubusercontent.com/32869456/53563815-7b653500-3b55-11e9-8816-9a527de80c16.png)
