### PR TITLE
Move and eliminate some params in redefinitions of TreeBuilders#set_locals_for_render

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -558,10 +558,10 @@ function miqInitTree(options, tree) {
       miqTreeOnNodeChecked(options, node);
     },
     onNodeExpanded: function(event, node) {
-      miqTreeState(options.cookie_id, node.key, true);
+      miqTreeState(options.tree_name, node.key, true);
     },
     onNodeCollapsed: function(event, node) {
-      miqTreeState(options.cookie_id, node.key, false);
+      miqTreeState(options.tree_name, node.key, false);
     },
     lazyLoad: function(node, display) {
       if (options.autoload) {
@@ -587,7 +587,7 @@ function miqInitTree(options, tree) {
 
   // Tree state persistence correction after the tree is completely loaded
   miqTreeObject(options.tree_name).getNodes().forEach(function(node) {
-    if (miqTreeState(options.cookie_id, node.key) === !node.state.expanded) {
+    if (miqTreeState(options.tree_name, node.key) === !node.state.expanded) {
       miqTreeObject(options.tree_name).toggleNodeExpanded(node);
     }
   });

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -38,7 +38,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def build_tree
-    @tree = TreeBuilderGenericObjectDefinition.new(:generic_object_definitions_tree, :generic_object_definitions_tree, @sb)
+    @tree = TreeBuilderGenericObjectDefinition.new(:generic_object_definitions_tree, :generic_object_definitions, @sb)
   end
 
   def button

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1202,7 +1202,7 @@ module VmCommon
         locals[:submit_button]   = @sb[:action] != 'miq_request_new' # need submit button on the screen
         locals[:continue_button] = @sb[:action] == 'miq_request_new' # need continue button on the screen
         update_buttons(locals) if @edit && @edit[:buttons].present?
-        presenter[:clear_tree_cookies] = "prov_trees"
+        presenter[:clear_tree_cookies] = "all_tags_tree"
       end
 
       if ['snapshot_add'].include?(@sb[:action])

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -201,7 +201,8 @@ class TreeBuilder
       :checkboxes        => @options[:checkboxes],
       :autoload          => @options[:lazy],
       :allow_reselect    => @options[:allow_reselect],
-      :highlight_changes => @options[:highlight_changes]
+      :highlight_changes => @options[:highlight_changes],
+      :three_checks      => @options[:three_checks]
     }
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -195,12 +195,13 @@ class TreeBuilder
 
   def set_locals_for_render
     {
-      :tree_id        => "#{@name}box",
-      :tree_name      => @name.to_s,
-      :bs_tree        => @bs_tree,
-      :checkboxes     => @options[:checkboxes],
-      :autoload       => @options[:lazy],
-      :allow_reselect => @options[:allow_reselect]
+      :tree_id           => "#{@name}box",
+      :tree_name         => @name.to_s,
+      :bs_tree           => @bs_tree,
+      :checkboxes        => @options[:checkboxes],
+      :autoload          => @options[:lazy],
+      :allow_reselect    => @options[:allow_reselect],
+      :highlight_changes => @options[:highlight_changes]
     }
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -196,11 +196,12 @@ class TreeBuilder
 
   def set_locals_for_render
     {
-      :tree_id    => "#{@name}box",
-      :tree_name  => @name.to_s,
-      :bs_tree    => @bs_tree,
-      :checkboxes => false,
-      :autoload   => @options[:lazy]
+      :tree_id        => "#{@name}box",
+      :tree_name      => @name.to_s,
+      :bs_tree        => @bs_tree,
+      :checkboxes     => false,
+      :autoload       => @options[:lazy],
+      :allow_reselect => @options[:allow_reselect]
     }
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -202,7 +202,8 @@ class TreeBuilder
       :autoload          => @options[:lazy],
       :allow_reselect    => @options[:allow_reselect],
       :highlight_changes => @options[:highlight_changes],
-      :three_checks      => @options[:three_checks]
+      :three_checks      => @options[:three_checks],
+      :post_check        => @options[:post_check]
     }
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -176,7 +176,6 @@ class TreeBuilder
         :leaf       => @options[:leaf],
         :add_root   => true,
         :open_nodes => [],
-        :lazy       => true,
         :checkboxes => false
       )
     )
@@ -200,7 +199,8 @@ class TreeBuilder
       :tree_id    => "#{@name}box",
       :tree_name  => @name.to_s,
       :bs_tree    => @bs_tree,
-      :checkboxes => false
+      :checkboxes => false,
+      :autoload   => @options[:lazy]
     }
   end
 
@@ -275,10 +275,7 @@ class TreeBuilder
                     !!options[:open_all]                                               ||
                     node[:expand]                                                      ||
                     @tree_state.x_tree(@name)[:active_node] == node[:key]
-    if ancestry_kids ||
-       load_children ||
-       node[:expand] ||
-       @options[:lazy] == false
+    if ancestry_kids || load_children || node[:expand] || !@options[:lazy]
 
       kids = (ancestry_kids || x_get_tree_objects(object, options, false, parents)).map do |o|
         x_build_node(o, node[:key], options)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -175,8 +175,7 @@ class TreeBuilder
         :klass_name => self.class.name,
         :leaf       => @options[:leaf],
         :add_root   => true,
-        :open_nodes => [],
-        :checkboxes => false
+        :open_nodes => []
       )
     )
   end
@@ -199,7 +198,7 @@ class TreeBuilder
       :tree_id        => "#{@name}box",
       :tree_name      => @name.to_s,
       :bs_tree        => @bs_tree,
-      :checkboxes     => false,
+      :checkboxes     => @options[:checkboxes],
       :autoload       => @options[:lazy],
       :allow_reselect => @options[:allow_reselect]
     }

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -64,6 +64,10 @@ class TreeBuilder
   # * features - used by the RBAC features tree only
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only
+  # * allow_reselect - fire the onselect event if a selected node is reselected
+  # * highlight_changes - highlight the changes in checkboxes differing from initial
+  # * three_checks - hierarchically check the parent if all children are checked
+  # * post_check - some kind of post-processing hierarchical checks
   def tree_init_options
     $log.warn("MIQ(#{self.class.name}) - TreeBuilder descendants should have their own tree_init_options")
     {}

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -5,12 +5,7 @@ class TreeBuilderAeClass < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -2,7 +2,7 @@ class TreeBuilderAeCustomization < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true, :lazy => true}
+    {:open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -2,12 +2,7 @@ class TreeBuilderAeCustomization < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:open_all => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -4,12 +4,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def alert_profile_kinds

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -21,7 +21,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     super.merge!(
       :oncheck    => "miqOnCheckGeneric",
       :check_url  => "/miq_policy/alert_profile_assign_changed/",
-      :selectable => false,
       :onclick    => false
     )
   end

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -14,14 +14,13 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def tree_init_options
-    {}
+    {:checkboxes => true}
   end
 
   def set_locals_for_render
     super.merge!(
       :oncheck    => "miqOnCheckGeneric",
       :check_url  => "/miq_policy/alert_profile_assign_changed/",
-      :checkboxes => true,
       :selectable => false,
       :onclick    => false
     )

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -27,10 +27,6 @@ class TreeBuilderAutomate < TreeBuilderAeClass
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:onclick      => "miqOnClickAutomate",
-                  :exp_tree     => false,
-                  :base_id      => "root",
-                  :highlighting => true)
+    super.merge!(:onclick => "miqOnClickAutomate")
   end
 end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAutomate < TreeBuilderAeClass
   def tree_init_options
-    {:full_ids => false}
+    {:full_ids => false, :lazy => true}
   end
 
   def initialize(name, type, sandbox, build = true, controller = nil)
@@ -30,7 +30,6 @@ class TreeBuilderAutomate < TreeBuilderAeClass
     locals = super
     locals.merge!(:onclick      => "miqOnClickAutomate",
                   :exp_tree     => false,
-                  :autoload     => true,
                   :base_id      => "root",
                   :highlighting => true)
   end

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -10,12 +10,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false, :lazy => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => false)
+    {:full_ids => true, :add_root => false}
   end
 
   def root_options

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -5,12 +5,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -5,12 +5,7 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -31,14 +31,15 @@ class TreeBuilderBelongsToHac < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids   => true,
-     :add_root   => false,
-     :checkboxes => true}
+    {
+      :full_ids          => true,
+      :add_root          => false,
+      :checkboxes        => true,
+      :highlight_changes => !@assign_to
+    }
   end
 
   def set_locals_for_render
-    locals = super
-
     oncheck, check_url = if @assign_to
                            ["miqOnCheckGeneric", "/miq_policy/alert_profile_assign_changed/"]
                          elsif @edit
@@ -47,10 +48,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
                            [nil, "/ops/rbac_group_field_changed/#{group_id}___"]
                          end
 
-    locals.merge!(:oncheck           => oncheck,
-                  :check_url         => check_url,
-                  :highlight_changes => @assign_to ? false : true,
-                  :onclick           => false)
+    super.merge!(:oncheck => oncheck, :check_url => check_url, :onclick => false)
   end
 
   def root_options

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -15,7 +15,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:selectable] = false
-    node[:checkable] = options[:checkboxes] if options.key?(:checkboxes)
+    node[:checkable] = @edit.present? || @assign_to.present?
   end
 
   def initialize(name, type, sandbox, build, params)
@@ -33,7 +33,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def tree_init_options
     {:full_ids   => true,
      :add_root   => false,
-     :checkboxes => @edit.present? || @assign_to.present?}
+     :checkboxes => true}
   end
 
   def set_locals_for_render
@@ -50,7 +50,6 @@ class TreeBuilderBelongsToHac < TreeBuilder
     locals.merge!(:oncheck           => oncheck,
                   :check_url         => check_url,
                   :highlight_changes => @assign_to ? false : true,
-                  :checkboxes        => true,
                   :onclick           => false)
   end
 

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -33,7 +33,6 @@ class TreeBuilderBelongsToHac < TreeBuilder
   def tree_init_options
     {:full_ids   => true,
      :add_root   => false,
-     :lazy       => false,
      :checkboxes => @edit.present? || @assign_to.present?}
   end
 

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -9,7 +9,7 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
 
   def override(node, object, _pid, options)
     node[:selectable] = false
-    node[:checkable] = options[:checkboxes] if options.key?(:checkboxes)
+    node[:checkable] = @edit.present? || @assign_to.present?
     if [ExtManagementSystem, EmsCluster, Datacenter].any? { |klass| object.kind_of?(klass) }
       node[:hideCheckbox] = true
     end

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -5,12 +5,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => 'true')
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_catalogs.rb
+++ b/app/presenters/tree_builder_catalogs.rb
@@ -2,12 +2,7 @@ class TreeBuilderCatalogs < TreeBuilderCatalogsClass
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => 'true')
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -2,12 +2,7 @@ class TreeBuilderChargebackReports < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -10,13 +10,17 @@ class TreeBuilderClusters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true}
+    {
+      :full_ids          => false,
+      :add_root          => false,
+      :checkboxes        => true,
+      :highlight_changes => true,
+      :three_checks      => true
+    }
   end
 
   def set_locals_for_render
-    super.merge!(:onselect     => "miqOnCheckCUFilters",
-                 :three_checks => true,
-                 :check_url    => "/ops/cu_collection_field_changed/")
+    super.merge!(:onselect => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -10,15 +10,13 @@ class TreeBuilderClusters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true}
+    {:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:onselect          => "miqOnCheckCUFilters",
-                  :highlight_changes => true,
-                  :three_checks      => true,
-                  :check_url         => "/ops/cu_collection_field_changed/")
+    super.merge!(:onselect     => "miqOnCheckCUFilters",
+                 :three_checks => true,
+                 :check_url    => "/ops/cu_collection_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -11,8 +11,7 @@ class TreeBuilderClusters < TreeBuilder
 
   def tree_init_options
     {:full_ids => false,
-     :add_root => false,
-     :lazy     => false}
+     :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -10,14 +10,12 @@ class TreeBuilderClusters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false,
-     :add_root => false}
+    {:full_ids => false, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:checkboxes        => true,
-                  :onselect          => "miqOnCheckCUFilters",
+    locals.merge!(:onselect          => "miqOnCheckCUFilters",
                   :highlight_changes => true,
                   :three_checks      => true,
                   :check_url         => "/ops/cu_collection_field_changed/")

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -20,8 +20,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
 
   def tree_init_options
     {:full_ids => true,
-     :add_root => false,
-     :lazy     => false}
+     :add_root => false}
   end
 
   def root_options

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -2,12 +2,7 @@ class TreeBuilderCondition < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   # level 0 - root

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -5,12 +5,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -3,9 +3,13 @@ class TreeBuilderConfiguredSystems < TreeBuilder
 
   private
 
+  def tree_init_options
+    {:lazy => true}
+  end
+
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :allow_reselect => true)
+    locals.merge!(:allow_reselect => true)
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -4,12 +4,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   private
 
   def tree_init_options
-    {:lazy => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:allow_reselect => true)
+    {:lazy => true, :allow_reselect => true}
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -40,8 +40,7 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:url => '/vm/show/', :onclick => 'miqOnClickHostNet')
+    super.merge!(:onclick => 'miqOnClickHostNet')
   end
 
   def root_options

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -36,12 +36,12 @@ class TreeBuilderDatacenter < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
+    {:full_ids => true, :lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :url => '/vm/show/', :onclick => 'miqOnClickHostNet')
+    locals.merge!(:url => '/vm/show/', :onclick => 'miqOnClickHostNet')
   end
 
   def root_options

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -10,14 +10,11 @@ class TreeBuilderDatastores < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true}
+    {:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:onselect          => "miqOnCheckCUFilters",
-                  :highlight_changes => true,
-                  :check_url         => "/ops/cu_collection_field_changed/")
+    super.merge!(:onselect => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -11,8 +11,7 @@ class TreeBuilderDatastores < TreeBuilder
 
   def tree_init_options
     {:full_ids => false,
-     :add_root => false,
-     :lazy     => false}
+     :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -10,14 +10,12 @@ class TreeBuilderDatastores < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false,
-     :add_root => false}
+    {:full_ids => false, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:checkboxes        => true,
-                  :onselect          => "miqOnCheckCUFilters",
+    locals.merge!(:onselect          => "miqOnCheckCUFilters",
                   :highlight_changes => true,
                   :check_url         => "/ops/cu_collection_field_changed/")
   end

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -35,14 +35,11 @@ class TreeBuilderDefaultFilters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false, :checkboxes => true}
+    {:full_ids => true, :add_root => false, :checkboxes => true, :highlight_changes => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:check_url         => "/configuration/filters_field_changed/",
-                  :oncheck           => "miqOnCheckGeneric",
-                  :highlight_changes => true)
+    super.merge!(:check_url => "/configuration/filters_field_changed/", :oncheck => "miqOnCheckGeneric")
   end
 
   def root_options

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -36,8 +36,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
 
   def tree_init_options
     {:full_ids => true,
-     :add_root => false,
-     :lazy     => false}
+     :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -35,15 +35,13 @@ class TreeBuilderDefaultFilters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true,
-     :add_root => false}
+    {:full_ids => true, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
     locals.merge!(:check_url         => "/configuration/filters_field_changed/",
                   :oncheck           => "miqOnCheckGeneric",
-                  :checkboxes        => true,
                   :highlight_changes => true)
   end
 

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -7,13 +7,12 @@ class TreeBuilderDiagnostics < TreeBuilder
   private
 
   def tree_init_options
-    {:add_root => false, :lazy => false, :open_all => true}
+    {:add_root => false, :open_all => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload  => false,
-                  :click_url => "/ops/diagnostics_tree_select/",
+    locals.merge!(:click_url => "/ops/diagnostics_tree_select/",
                   :onclick   => "miqOnClickDiagnostics")
   end
 

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -21,14 +21,13 @@ class TreeBuilderGenealogy < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
+    {:full_ids => true, :checkboxes => true}
   end
 
   def set_locals_for_render
     super.merge!(
       :click_url  => "/vm/genealogy_tree_selected/",
       :onclick    => "miqOnClickGeneric",
-      :checkboxes => true,
       :oncheck    => "miqOnCheckGenealogy",
       :check_url  => "/vm/set_checked_items/"
     )

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -21,7 +21,7 @@ class TreeBuilderGenealogy < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => false}
+    {:full_ids => true}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -13,12 +13,6 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
     }
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id   => "generic_object_definitions_treebox",
-                  :tree_name => "generic_object_definitions_tree")
-  end
-
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects(count_only, GenericObjectDefinition.all, :name)
   end

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -34,6 +34,6 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
   end
 
   def tree_init_options
-    {:lazy => false}
+    {}
   end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -5,13 +5,10 @@ class TreeBuilderImages < TreeBuilder
 
   def tree_init_options
     {
-      :leaf => "ManageIQ::Providers::CloudManager::Template",
-      :lazy => true
+      :leaf           => "ManageIQ::Providers::CloudManager::Template",
+      :lazy           => true,
+      :allow_reselect => TreeBuilder.hide_vms
     }
-  end
-
-  def set_locals_for_render
-    super.merge!(:allow_reselect => TreeBuilder.hide_vms)
   end
 
   def root_options

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -5,7 +5,8 @@ class TreeBuilderImages < TreeBuilder
 
   def tree_init_options
     {
-      :leaf => "ManageIQ::Providers::CloudManager::Template"
+      :leaf => "ManageIQ::Providers::CloudManager::Template",
+      :lazy => true
     }
   end
 
@@ -14,7 +15,6 @@ class TreeBuilderImages < TreeBuilder
     locals.merge!(
       :tree_id        => "images_treebox",
       :tree_name      => "images_tree",
-      :autoload       => true,
       :allow_reselect => TreeBuilder.hide_vms
     )
   end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -11,12 +11,7 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(
-      :tree_id        => "images_treebox",
-      :tree_name      => "images_tree",
-      :allow_reselect => TreeBuilder.hide_vms
-    )
+    super.merge!(:allow_reselect => TreeBuilder.hide_vms)
   end
 
   def root_options

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -3,12 +3,6 @@ class TreeBuilderImagesFilter < TreeBuilderVmsFilter
     super.update(:leaf => 'ManageIQ::Providers::CloudManager::Template')
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id   => "images_filter_treebox",
-                  :tree_name => "images_filter_tree")
-  end
-
   def root_options
     {
       :text    => _("All Images"),

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -6,8 +6,7 @@ class TreeBuilderImagesFilter < TreeBuilderVmsFilter
   def set_locals_for_render
     locals = super
     locals.merge!(:tree_id   => "images_filter_treebox",
-                  :tree_name => "images_filter_tree",
-                  :autoload  => false)
+                  :tree_name => "images_filter_tree")
   end
 
   def root_options

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -7,7 +7,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true, :lazy => true}
+    {:open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -7,13 +7,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals[:autoload] = true
-    locals
+    {:open_all => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -9,12 +9,7 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(
-      :tree_id        => "instances_treebox",
-      :tree_name      => "instances_tree",
-      :allow_reselect => TreeBuilder.hide_vms
-    )
+    super.merge!(:allow_reselect => TreeBuilder.hide_vms)
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -5,10 +5,7 @@ class TreeBuilderInstances < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {
-      :leaf => 'VmCloud',
-      :lazy => false
-    }
+    {:leaf => 'VmCloud'}
   end
 
   def set_locals_for_render
@@ -16,7 +13,6 @@ class TreeBuilderInstances < TreeBuilder
     locals.merge!(
       :tree_id        => "instances_treebox",
       :tree_name      => "instances_tree",
-      :autoload       => true,
       :allow_reselect => TreeBuilder.hide_vms
     )
   end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -5,11 +5,7 @@ class TreeBuilderInstances < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {:leaf => 'VmCloud'}
-  end
-
-  def set_locals_for_render
-    super.merge!(:allow_reselect => TreeBuilder.hide_vms)
+    {:leaf => 'VmCloud', :allow_reselect => TreeBuilder.hide_vms}
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -3,12 +3,6 @@ class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
     super.update(:leaf => 'ManageIQ::Providers::CloudManager::Vm')
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id   => "instances_filter_treebox",
-                  :tree_name => "instances_filter_tree")
-  end
-
   def root_options
     {
       :text    => _("All Instances"),

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -6,8 +6,7 @@ class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
   def set_locals_for_render
     locals = super
     locals.merge!(:tree_id   => "instances_filter_treebox",
-                  :tree_name => "instances_filter_tree",
-                  :autoload  => false)
+                  :tree_name => "instances_filter_tree")
   end
 
   def root_options

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -4,12 +4,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -29,7 +29,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   end
 
   def tree_init_options
-    { :lazy => false, :add_root => true }
+    {:add_root => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -16,7 +16,7 @@ class TreeBuilderMiqActionCategory < TreeBuilder
   end
 
   def tree_init_options
-    {:lazy => false}
+    {}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -19,12 +19,12 @@ class TreeBuilderNetwork < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
+    {:full_ids => true, :lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
+    locals.merge!(:click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_diagnostics.rb
+++ b/app/presenters/tree_builder_ops_diagnostics.rb
@@ -2,12 +2,7 @@ class TreeBuilderOpsDiagnostics < TreeBuilderOps
   private
 
   def tree_init_options
-    {:open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:open_all => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_diagnostics.rb
+++ b/app/presenters/tree_builder_ops_diagnostics.rb
@@ -2,7 +2,7 @@ class TreeBuilderOpsDiagnostics < TreeBuilderOps
   private
 
   def tree_init_options
-    {:open_all => true, :lazy => true}
+    {:open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -4,12 +4,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:open_all => false, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -19,14 +19,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   private
 
   def set_locals_for_render
-    locals = {
-      :check_url    => "/ops/rbac_role_field_changed/",
-      :onclick      => nil,
-      :post_check   => true
-    }
-
+    locals = {:check_url => "/ops/rbac_role_field_changed/", :onclick => nil}
     locals[:oncheck] = "miqOnCheckGeneric" if @editable
-
     super.merge!(locals)
   end
 
@@ -75,7 +69,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :editable       => @editable,
       :node_id_prefix => node_id_prefix,
       :checkboxes     => true,
-      :three_checks   => true
+      :three_checks   => true,
+      :post_check     => true
     }
   end
 

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -20,7 +20,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def set_locals_for_render
     locals = {
-      :three_checks => true,
       :check_url    => "/ops/rbac_role_field_changed/",
       :onclick      => nil,
       :post_check   => true
@@ -75,7 +74,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :features       => @features,
       :editable       => @editable,
       :node_id_prefix => node_id_prefix,
-      :checkboxes     => true
+      :checkboxes     => true,
+      :three_checks   => true
     }
   end
 

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -20,7 +20,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def set_locals_for_render
     locals = {
-      :checkboxes   => true,
       :three_checks => true,
       :check_url    => "/ops/rbac_role_field_changed/",
       :onclick      => nil,
@@ -75,7 +74,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :role           => @role,
       :features       => @features,
       :editable       => @editable,
-      :node_id_prefix => node_id_prefix
+      :node_id_prefix => node_id_prefix,
+      :checkboxes     => true
     }
   end
 

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -71,7 +71,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def tree_init_options
     {
-      :lazy           => false,
       :add_root       => true,
       :role           => @role,
       :features       => @features,

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -2,7 +2,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   private
 
   def tree_init_options
-    {:open_all => true, :lazy => true}
+    {:open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -2,12 +2,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   private
 
   def tree_init_options
-    {:open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:open_all => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -4,12 +4,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
   private
 
   def tree_init_options
-    {:open_all => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:open_all => false, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -2,12 +2,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => 'true')
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -5,13 +5,7 @@ class TreeBuilderPolicy < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true,
-     :lazy     => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true}
   end
 
   def compliance_control_kids(mode)

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -6,13 +6,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true,
-     :lazy     => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true}
   end
 
   # level 0 - root

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -14,12 +14,12 @@ class TreeBuilderPolicySimulation < TreeBuilder
   private
 
   def tree_init_options
-    {:lazy => false, :full_ids => true}
+    {:full_ids => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :cookie_prefix => 'edit_')
+    locals.merge!(:cookie_prefix => 'edit_')
   end
 
   def root_options

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -17,11 +17,6 @@ class TreeBuilderPolicySimulation < TreeBuilder
     {:full_ids => true}
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:cookie_prefix => 'edit_')
-  end
-
   def root_options
     {
       :text       => ViewHelper.content_tag(:strong, @root_name),

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -12,12 +12,7 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -9,14 +9,11 @@ class TreeBuilderProtect < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true}
+    {:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:oncheck           => "miqOnCheckProtect",
-                  :highlight_changes => true,
-                  :check_url         => "/#{@data[:controller_name]}/protect/")
+    super.merge!(:oncheck => "miqOnCheckProtect", :check_url => "/#{@data[:controller_name]}/protect/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -9,13 +9,12 @@ class TreeBuilderProtect < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false}
+    {:full_ids => false, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:checkboxes        => true,
-                  :oncheck           => "miqOnCheckProtect",
+    locals.merge!(:oncheck           => "miqOnCheckProtect",
                   :highlight_changes => true,
                   :check_url         => "/#{@data[:controller_name]}/protect/")
   end

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -9,7 +9,7 @@ class TreeBuilderProtect < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :lazy => false}
+    {:full_ids => false, :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -2,12 +2,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -2,12 +2,7 @@ class TreeBuilderPxeImageTypes < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -4,12 +4,7 @@ class TreeBuilderPxeServers < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_region.rb
+++ b/app/presenters/tree_builder_region.rb
@@ -4,12 +4,7 @@ class TreeBuilderRegion < TreeBuilder
   private
 
   def tree_init_options
-    {:add_root => MiqEnterprise.my_enterprise.is_enterprise?}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:add_root => MiqEnterprise.my_enterprise.is_enterprise?, :lazy => true}
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -4,12 +4,7 @@ class TreeBuilderReportDashboards < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -2,7 +2,7 @@ class TreeBuilderReportExport < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :open_all => true, :lazy => true}
+    {:full_ids => true, :open_all => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -2,12 +2,7 @@ class TreeBuilderReportExport < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :open_all => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -10,12 +10,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -2,12 +2,7 @@ class TreeBuilderReportRoles < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -2,12 +2,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -2,12 +2,7 @@ class TreeBuilderReportSchedules < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -9,11 +9,7 @@ class TreeBuilderReportWidgets < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -12,14 +12,11 @@ class TreeBuilderSections < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false, :checkboxes => true}
+    {:full_ids => true, :add_root => false, :checkboxes => true, :three_checks => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:three_checks => true,
-                  :onselect     => "miqOnCheckSections",
-                  :check_url    => "/#{@controller_name}/sections_field_changed/")
+    super.merge!(:onselect => "miqOnCheckSections", :check_url => "/#{@controller_name}/sections_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -12,7 +12,7 @@ class TreeBuilderSections < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false, :lazy => false}
+    {:full_ids => true, :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -12,13 +12,12 @@ class TreeBuilderSections < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false}
+    {:full_ids => true, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:checkboxes   => true,
-                  :three_checks => true,
+    locals.merge!(:three_checks => true,
                   :onselect     => "miqOnCheckSections",
                   :check_url    => "/#{@controller_name}/sections_field_changed/")
   end

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -4,12 +4,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
   private
 
   def tree_init_options
-    {:full_ids => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -4,12 +4,7 @@ class TreeBuilderServices < TreeBuilder
   private
 
   def tree_init_options
-    {:add_root => false}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:add_root => false, :lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -14,13 +14,12 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => false, :add_root => false}
+    {:full_ids => false, :add_root => false, :checkboxes => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:checkboxes   => true,
-                  :onclick      => false,
+    locals.merge!(:onclick      => false,
                   :three_checks => true,
                   :post_check   => true,
                   :oncheck      => 'miqOnCheckGeneric',

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -14,16 +14,14 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true}
+    {:full_ids => false, :add_root => false, :checkboxes => true, :three_checks => true}
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:onclick      => false,
-                  :three_checks => true,
-                  :post_check   => true,
-                  :oncheck      => 'miqOnCheckGeneric',
-                  :check_url    => '/ops/smartproxy_affinity_field_changed/')
+    super.merge!(:onclick    => false,
+                 :post_check => true,
+                 :oncheck    => 'miqOnCheckGeneric',
+                 :check_url  => '/ops/smartproxy_affinity_field_changed/')
   end
 
   def root_options

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -14,7 +14,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :lazy => false}
+    {:full_ids => false, :add_root => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -14,14 +14,19 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => false, :add_root => false, :checkboxes => true, :three_checks => true}
+    {
+      :full_ids     => false,
+      :add_root     => false,
+      :checkboxes   => true,
+      :three_checks => true,
+      :post_check   => true
+    }
   end
 
   def set_locals_for_render
-    super.merge!(:onclick    => false,
-                 :post_check => true,
-                 :oncheck    => 'miqOnCheckGeneric',
-                 :check_url  => '/ops/smartproxy_affinity_field_changed/')
+    super.merge!(:onclick   => false,
+                 :oncheck   => 'miqOnCheckGeneric',
+                 :check_url => '/ops/smartproxy_affinity_field_changed/')
   end
 
   def root_options

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -17,12 +17,12 @@ class TreeBuilderSnapshots < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => true}
+    {:full_ids => true, :lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :onclick => 'miqOnClickSnapshots',)
+    locals.merge!(:onclick => 'miqOnClickSnapshots',)
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -2,12 +2,12 @@ class TreeBuilderStorage < TreeBuilder
   private
 
   def tree_init_options
-    {}
+    {:lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :allow_reselect => true)
+    locals.merge!(:allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -2,12 +2,7 @@ class TreeBuilderStorage < TreeBuilder
   private
 
   def tree_init_options
-    {:lazy => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:allow_reselect => true)
+    {:lazy => true, :allow_reselect => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -11,12 +11,12 @@ class TreeBuilderStorageAdapters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true}
+    {:full_ids => true, :lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true, :click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
+    locals.merge!(:click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -2,12 +2,7 @@ class TreeBuilderStoragePod < TreeBuilder
   private
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload => true)
+    {:lazy => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -35,7 +35,6 @@ class TreeBuilderTags < TreeBuilder
     locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :highlight_changes => true,
-                  :selectable        => false,
                   :onclick           => false)
   end
 

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -16,7 +16,7 @@ class TreeBuilderTags < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :add_root => false, :checkboxes => true}
+    {:full_ids => true, :add_root => false, :checkboxes => true, :highlight_changes => true}
   end
 
   def contain_selected_kid(category)
@@ -31,11 +31,9 @@ class TreeBuilderTags < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
-                  :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                  :highlight_changes => true,
-                  :onclick           => false)
+    super.merge!(:check_url => "/ops/rbac_group_field_changed/#{group_id}___",
+                 :oncheck   => @edit.nil? ? nil : "miqOnCheckUserFilters",
+                 :onclick   => false)
   end
 
   def root_options

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -17,8 +17,7 @@ class TreeBuilderTags < TreeBuilder
 
   def tree_init_options
     {:full_ids => true,
-     :add_root => false,
-     :lazy     => false}
+     :add_root => false}
   end
 
   def contain_selected_kid(category)

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -16,8 +16,7 @@ class TreeBuilderTags < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true,
-     :add_root => false}
+    {:full_ids => true, :add_root => false, :checkboxes => true}
   end
 
   def contain_selected_kid(category)
@@ -35,7 +34,6 @@ class TreeBuilderTags < TreeBuilder
     locals = super
     locals.merge!(:check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                  :checkboxes        => true,
                   :highlight_changes => true,
                   :selectable        => false,
                   :onclick           => false)

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -3,14 +3,6 @@ class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
     super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(
-      :tree_id   => "templates_filter_treebox",
-      :tree_name => "templates_filter_tree",
-    )
-  end
-
   def root_options
     {
       :text    => _("All Templates"),

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -8,7 +8,6 @@ class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
     locals.merge!(
       :tree_id   => "templates_filter_treebox",
       :tree_name => "templates_filter_tree",
-      :autoload  => false
     )
   end
 

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -4,10 +4,7 @@ class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id        => "templates_images_filter_treebox",
-                  :tree_name      => "templates_images_filter_tree",
-                  :allow_reselect => true)
+    super.merge!(:allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -3,10 +3,6 @@ class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
     super.update(:leaf => 'MiqTemplate')
   end
 
-  def set_locals_for_render
-    super.merge!(:allow_reselect => true)
-  end
-
   def root_options
     {
       :text    => _("All Templates & Images"),

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -2,12 +2,11 @@ class TreeBuilderVandt < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {:leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate', :lazy => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:allow_reselect => TreeBuilder.hide_vms)
+    {
+      :leaf           => 'ManageIQ::Providers::InfraManager::VmOrTemplate',
+      :lazy           => true,
+      :allow_reselect => TreeBuilder.hide_vms
+    }
   end
 
   def root_options

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -2,13 +2,12 @@ class TreeBuilderVandt < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {:leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate'}
+    {:leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate', :lazy => true}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload       => true,
-                  :allow_reselect => TreeBuilder.hide_vms)
+    locals.merge!(:allow_reselect => TreeBuilder.hide_vms)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -7,8 +7,7 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id => "vms_filter_treebox", :tree_name => "vms_filter_tree", :allow_reselect => true)
+    super.merge!(:allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,13 +1,10 @@
 class TreeBuilderVmsFilter < TreeBuilder
   def tree_init_options
     {
-      :open_all => true,
-      :leaf     => 'ManageIQ::Providers::InfraManager::Vm'
+      :open_all       => true,
+      :leaf           => 'ManageIQ::Providers::InfraManager::Vm',
+      :allow_reselect => true
     }
-  end
-
-  def set_locals_for_render
-    super.merge!(:allow_reselect => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -3,12 +3,6 @@ class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
     super.update(:leaf => 'Vm')
   end
 
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:tree_id   => "vms_instances_filter_treebox",
-                  :tree_name => "vms_instances_filter_tree")
-  end
-
   def root_options
     {
       :text    => _("All VMs & Instances"),

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -1,5 +1,4 @@
 - click_url                   ||= false
-- cookie_prefix               ||= ""
 - check_url                   ||= false
 - select_node                 ||= false
 - checkboxes                  ||= false
@@ -18,7 +17,6 @@
 - options = {:tree_id            => tree_id,
              :tree_name          => tree_name,
              :group_changed      => session[:group_changed],
-             :cookie_id          => "#{cookie_prefix}#{tree_name}",
              :checkboxes         => checkboxes,
              :hierarchical_check => three_checks,
              :onclick            => onclick,

--- a/app/views/miq_request/_prov_edit.html.haml
+++ b/app/views/miq_request/_prov_edit.html.haml
@@ -5,4 +5,4 @@
   = render :partial => 'miq_request/prov_form_buttons'
   = _("Note: Fields marked with * are required.")
 :javascript
-  miqDeleteTreeCookies('prov_trees')
+  miqDeleteTreeCookies('all_tags_tree')

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -304,8 +304,7 @@
                                :bs_tree       => @all_tags_tree,
                                :oncheck       => "miqOnCheckProvTags",
                                :check_url     => "/miq_request/prov_field_changed/#{check}",
-                               :checkboxes    => true,
-                               :cookie_prefix => "prov_trees"})
+                               :checkboxes    => true})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -10,7 +10,6 @@ describe TreeBuilderAeCustomization do
         :leaf        => nil,
         :add_root    => true,
         :open_nodes  => [],
-        :checkboxes  => false,
         :open_all    => true,
         :active_node => "root"
       }

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -10,7 +10,6 @@ describe TreeBuilderAeCustomization do
         :leaf        => nil,
         :add_root    => true,
         :open_nodes  => [],
-        :lazy        => true,
         :checkboxes  => false,
         :open_all    => true,
         :active_node => "root"

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -30,7 +30,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#tree_init_options' do
       it 'sets init options correctly' do
-        expect(subject.send(:tree_init_options)).to eq({})
+        expect(subject.send(:tree_init_options)).to eq(:checkboxes => true)
       end
     end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -69,7 +69,6 @@ describe TreeBuilderBelongsToHac do
     it 'sets init options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
                                                      :add_root   => false,
-                                                     :lazy       => false,
                                                      :checkboxes => edit.present?)
     end
   end

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -67,18 +67,18 @@ describe TreeBuilderBelongsToHac do
 
   describe '#tree_init_options' do
     it 'sets init options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
-                                                     :add_root   => false,
-                                                     :checkboxes => true)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
+                                                     :add_root          => false,
+                                                     :checkboxes        => true,
+                                                     :highlight_changes => true)
     end
   end
 
   describe '#set_locals_for_render' do
     it 'sets locals correctly' do
-      expect(subject.send(:set_locals_for_render)).to include(:onclick           => false,
-                                                              :check_url         => "/ops/rbac_group_field_changed/new___",
-                                                              :oncheck           => nil,
-                                                              :highlight_changes => true)
+      expect(subject.send(:set_locals_for_render)).to include(:onclick   => false,
+                                                              :check_url => "/ops/rbac_group_field_changed/new___",
+                                                              :oncheck   => nil)
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -69,14 +69,13 @@ describe TreeBuilderBelongsToHac do
     it 'sets init options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
                                                      :add_root   => false,
-                                                     :checkboxes => edit.present?)
+                                                     :checkboxes => true)
     end
   end
 
   describe '#set_locals_for_render' do
     it 'sets locals correctly' do
       expect(subject.send(:set_locals_for_render)).to include(:onclick           => false,
-                                                              :checkboxes        => true,
                                                               :check_url         => "/ops/rbac_group_field_changed/new___",
                                                               :oncheck           => nil,
                                                               :highlight_changes => true)

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -40,7 +40,6 @@ describe TreeBuilderBelongsToVat do
     it 'sets tree options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
                                                      :add_root   => false,
-                                                     :lazy       => false,
                                                      :checkboxes => edit.present?)
     end
   end

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -38,19 +38,19 @@ describe TreeBuilderBelongsToVat do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
-                                                     :add_root   => false,
-                                                     :checkboxes => true)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
+                                                     :add_root          => false,
+                                                     :checkboxes        => true,
+                                                     :highlight_changes => true)
     end
   end
 
   describe '#set_locals_for_render' do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
-                                :onclick           => false,
-                                :oncheck           => edit ? "miqOnCheckUserFilters" : nil,
-                                :highlight_changes => true)
+      expect(locals).to include(:check_url => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
+                                :onclick   => false,
+                                :oncheck   => edit ? "miqOnCheckUserFilters" : nil)
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -40,15 +40,14 @@ describe TreeBuilderBelongsToVat do
     it 'sets tree options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
                                                      :add_root   => false,
-                                                     :checkboxes => edit.present?)
+                                                     :checkboxes => true)
     end
   end
 
   describe '#set_locals_for_render' do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:checkboxes        => true,
-                                :check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
+      expect(locals).to include(:check_url         => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
                                 :onclick           => false,
                                 :oncheck           => edit ? "miqOnCheckUserFilters" : nil,
                                 :highlight_changes => true)

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderClusters do
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
+      expect(root_options).to eq(:full_ids => false, :add_root => false)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderClusters do
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false)
+      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderClusters do
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
+      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderClusters do
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true)
+      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true, :three_checks => true)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -22,7 +22,7 @@ describe TreeBuilderComplianceHistory do
     end
     it 'is not lazy' do
       tree_options = @ch_tree.send(:tree_init_options)
-      expect(tree_options[:lazy]).to eq(false)
+      expect(tree_options[:lazy]).not_to be_truthy
     end
     it 'has no root' do
       tree_options = @ch_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderDatastores do
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
+      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true)
     end
     it 'sets locals correctly' do
       locals = @datastores_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderDatastores do
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false)
+      expect(root_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
     end
     it 'sets locals correctly' do
       locals = @datastores_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderDatastores do
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
+      expect(root_options).to eq(:full_ids => false, :add_root => false)
     end
     it 'sets locals correctly' do
       locals = @datastores_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -66,7 +66,7 @@ describe TreeBuilderDefaultFilters do
 
     it 'is not lazy' do
       tree_options = @default_filters_tree.send(:tree_init_options)
-      expect(tree_options[:lazy]).to eq(false)
+      expect(tree_options[:lazy]).not_to be_truthy
     end
 
     it 'has no root' do

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderGenealogy do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids => true)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids => true, :checkboxes => true)
     end
   end
 
@@ -27,7 +27,6 @@ describe TreeBuilderGenealogy do
     it 'sets locals for render correctly' do
       expect(subject.send(:set_locals_for_render)).to include(:click_url  => "/vm/genealogy_tree_selected/",
                                                               :onclick    => "miqOnClickGeneric",
-                                                              :checkboxes => true,
                                                               :oncheck    => "miqOnCheckGenealogy",
                                                               :check_url  => "/vm/set_checked_items/")
     end

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderGenealogy do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids => true, :lazy => false)
+      expect(subject.send(:tree_init_options)).to eq(:full_ids => true)
     end
   end
 

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -8,7 +8,7 @@ describe TreeBuilderImages do
 
     allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
-    @images_tree = TreeBuilderImages.new(:images, :images_tree, {}, nil)
+    @images_tree = TreeBuilderImages.new(:images_tree, :images, {}, nil)
   end
 
   it 'sets tree to have leaf and not lazy' do

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -13,11 +13,11 @@ describe TreeBuilderImages do
 
   it 'sets tree to have leaf and not lazy' do
     root_options = @images_tree.tree_init_options
-    expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template", :lazy => true)
+    expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template", :lazy => true, :allow_reselect => true)
   end
 
   it 'sets tree to have full ids, not lazy and no root' do
-    locals = @images_tree.set_locals_for_render
+    locals = @images_tree.send(:set_locals_for_render)
     expect(locals[:tree_id]).to eq("images_treebox")
     expect(locals[:tree_name]).to eq("images_tree")
     expect(locals[:autoload]).to eq(true)

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderImages do
 
   it 'sets tree to have leaf and not lazy' do
     root_options = @images_tree.tree_init_options
-    expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template")
+    expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template", :lazy => true)
   end
 
   it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -12,7 +12,7 @@ describe TreeBuilderInstances do
 
     allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
-    @instances_tree = TreeBuilderInstances.new(:instances, :instances_tree, {}, nil)
+    @instances_tree = TreeBuilderInstances.new(:instances_tree, :instances, {}, nil)
   end
 
   it 'sets tree to have leaf and not lazy' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderInstances do
   it 'sets tree to have leaf and not lazy' do
     root_options = @instances_tree.tree_init_options
 
-    expect(root_options).to eq(:leaf => 'VmCloud', :lazy => false)
+    expect(root_options).to eq(:leaf => 'VmCloud')
   end
 
   it 'sets tree to have full ids, not lazy and no root' do
@@ -26,7 +26,6 @@ describe TreeBuilderInstances do
 
     expect(locals[:tree_id]).to eq("instances_treebox")
     expect(locals[:tree_name]).to eq("instances_tree")
-    expect(locals[:autoload]).to eq(true)
   end
 
   it 'sets root correctly' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -18,11 +18,11 @@ describe TreeBuilderInstances do
   it 'sets tree to have leaf and not lazy' do
     root_options = @instances_tree.tree_init_options
 
-    expect(root_options).to eq(:leaf => 'VmCloud')
+    expect(root_options).to eq(:leaf => 'VmCloud', :allow_reselect => true)
   end
 
   it 'sets tree to have full ids, not lazy and no root' do
-    locals = @instances_tree.set_locals_for_render
+    locals = @instances_tree.send(:set_locals_for_render)
 
     expect(locals[:tree_id]).to eq("instances_treebox")
     expect(locals[:tree_name]).to eq("instances_tree")

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -26,7 +26,7 @@ describe TreeBuilderMiqActionCategory do
 
   describe '#tree_init_options' do
     it 'set init options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:lazy => false)
+      expect(subject.send(:tree_init_options)[:lazy]).not_to be_truthy
     end
   end
 

--- a/spec/presenters/tree_builder_policy_profile_spec.rb
+++ b/spec/presenters/tree_builder_policy_profile_spec.rb
@@ -3,7 +3,7 @@ describe TreeBuilderPolicyProfile do
     it "is explicitly not lazy" do
       tree = TreeBuilderPolicyProfile.new(:policy_profile_tree, :policy_profile, {}, true)
       options = tree.instance_variable_get(:@options)
-      expect(options[:lazy]).to eq(false)
+      expect(options[:lazy]).not_to be_truthy
     end
   end
 end

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -41,7 +41,7 @@ describe TreeBuilderPolicySimulation do
 
     it 'sets tree as not lazy' do
       tree_options = @policy_simulation_tree.send(:tree_init_options)
-      expect(tree_options[:lazy]).to eq(false)
+      expect(tree_options[:lazy]).not_to be_truthy
     end
 
     it 'sets root correctly' do

--- a/spec/presenters/tree_builder_policy_spec.rb
+++ b/spec/presenters/tree_builder_policy_spec.rb
@@ -3,7 +3,7 @@ describe TreeBuilderPolicy do
     it "is explicitly not lazy" do
       tree = TreeBuilderPolicy.new(:policy_tree, :policy, {}, true)
       options = tree.instance_variable_get(:@options)
-      expect(options[:lazy]).to eq(false)
+      expect(options[:lazy]).not_to be_truthy
     end
   end
 end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderProtect do
 
     it 'set init options correctly' do
       tree_options = @protect_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false)
     end
 
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderProtect do
 
     it 'set init options correctly' do
       tree_options = @protect_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :highlight_changes => true)
     end
 
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderProtect do
 
     it 'set init options correctly' do
       tree_options = @protect_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
     end
 
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -36,7 +36,7 @@ describe TreeBuilderRolesByServer do
 
     it "is not lazy" do
       tree_options = @server_tree.send(:tree_init_options)
-      expect(tree_options[:lazy]).to eq(false)
+      expect(tree_options[:lazy]).not_to be_truthy
     end
 
     it 'has no root' do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -55,11 +55,10 @@ describe TreeBuilderSections do
     end
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true)
     end
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)
-      expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq("/#{@controller_name}/sections_field_changed/")
       expect(locals[:onselect]).to eq("miqOnCheckSections")
       expect(locals[:three_checks]).to eq(true)

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -55,7 +55,7 @@ describe TreeBuilderSections do
     end
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false, :lazy => false)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false)
     end
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -55,7 +55,7 @@ describe TreeBuilderSections do
     end
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true, :three_checks => true)
     end
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -38,7 +38,7 @@ describe TreeBuilderServersByRole do
 
     it "is not lazy" do
       tree_options = @server_tree.send(:tree_init_options)
-      expect(tree_options[:lazy]).to eq(false)
+      expect(tree_options[:lazy]).not_to be_truthy
     end
 
     it 'has no root' do

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -35,7 +35,7 @@ describe TreeBuilderSmartproxyAffinity do
 
     it 'set init options correctly' do
       tree_options = @smartproxy_affinity_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :three_checks => true)
     end
     it 'set locals for render correctly' do
       locals = @smartproxy_affinity_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -35,7 +35,13 @@ describe TreeBuilderSmartproxyAffinity do
 
     it 'set init options correctly' do
       tree_options = @smartproxy_affinity_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true, :three_checks => true)
+      expect(tree_options).to eq(
+        :full_ids     => false,
+        :add_root     => false,
+        :checkboxes   => true,
+        :three_checks => true,
+        :post_check   => true
+      )
     end
     it 'set locals for render correctly' do
       locals = @smartproxy_affinity_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -35,7 +35,7 @@ describe TreeBuilderSmartproxyAffinity do
 
     it 'set init options correctly' do
       tree_options = @smartproxy_affinity_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false)
     end
     it 'set locals for render correctly' do
       locals = @smartproxy_affinity_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -35,7 +35,7 @@ describe TreeBuilderSmartproxyAffinity do
 
     it 'set init options correctly' do
       tree_options = @smartproxy_affinity_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :add_root => false)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false, :checkboxes => true)
     end
     it 'set locals for render correctly' do
       locals = @smartproxy_affinity_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderTags do
     end
     it 'set init options correctly' do
       tree_options = @tags_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true, :highlight_changes => true)
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -32,7 +32,6 @@ describe TreeBuilderTags do
       expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/#{@group.id}___")
       expect(locals[:highlight_changes]).to eq(true)
       expect(locals[:oncheck]).to eq(nil)
-      expect(locals[:selectable]).to eq(false)
     end
     it 'set info about selected kids correctly' do
       expect(@tags_tree.send(:contain_selected_kid, @folder_selected)).to eq(true)
@@ -80,7 +79,6 @@ describe TreeBuilderTags do
       expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/new___")
       expect(locals[:highlight_changes]).to eq(true)
       expect(locals[:oncheck]).to eq("miqOnCheckUserFilters")
-      expect(locals[:selectable]).to eq(false)
     end
     it 'sets second level nodes correctly' do
       selected_kid = @tags_tree.send(:x_get_classification_kids, @folder_selected, false)

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderTags do
     end
     it 'set init options correctly' do
       tree_options = @tags_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false, :checkboxes => true)
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderTags do
     end
     it 'set init options correctly' do
       tree_options = @tags_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :add_root => false, :lazy => false)
+      expect(tree_options).to eq(:full_ids => true, :add_root => false)
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)


### PR DESCRIPTION
I'm moving/eliminating some parameters from the `TreeBuilder#set_locals_for_render` redefinitions into the `tree_init_options` methods. The goal is to have just a single place to define the settings for all the trees instead of two.

* Merging `autoload` with `lazy` which is being used to enable/disable lazy loading
* Droped the `lazy` parameter when `open_all` is set as it doesn't make sense to use the two together
* The `tree_name` and `tree_id` redefinitions are not necessary, all can be generated
* Moved the `allow_reselect` parameter and also removed its unnecessary redefinitions
* Merged the `checkboxes` parameter that is being used for displaying checkboxes
* Removed `exp_tree`, `highlighting`, `selectable`, `base_id` and `url` as they were never used
* Moved `highlight_changes` that turns on highlighting unsaved changes in checkboxes
* Moved `three_checks` and `post_check` that are responsible for hierarchical checkboxes
* Removed the `cookie_prefix` as it was used in a single place and it was useless

The stuff that remains in the aforementioned redefinitions is related to mouse handling (onclick, onselect, oncheck) and as they are more tangled into the JavaScript codebase, I'd like to address them in a separate PR. The downside of this PR is that the `tree_init_options` is being merged into the tree's state which is being stored in the session. However, I'm also working on a PR that will eliminate this merge and only store the necessary stuff in the state object.

As I'm deleting 2 lines from the `_tree.html.haml` file, hakiri is getting triggered by a possibly false-positive error. I'm not sure about how to eliminate or fix this, so I might need some help.