### PR TITLE
 Fixed wrong keyword for selected nodes in TreeBuilderAlertProfileObj

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,8 +1,8 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, selected: nil)
+  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, selected_nodes: nil)
     @assign_to = assign_to
     @cat = cat
-    @selected = selected
+    @selected = selected_nodes
     @cat_tree = @assign_to.ends_with?("-tags")
     super(name, type, sandbox, build)
   end
@@ -10,7 +10,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   def override(node, object, _pid, _options)
     node[:text] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
-    node[:select] = @selected.include?(object.id)
+    node[:select] = @selected.try(:include?, object.id)
   end
 
   def tree_init_options

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -23,9 +23,9 @@ describe TreeBuilderAlertProfileObj do
       described_class.new(:alert_profile_obj_tree, :alert_profile_obj,
                           {},
                           true,
-                          :assign_to => 'storage-tags',
-                          :cat       => folder1a.id,
-                          :selected  => [tag1a.id, tag2a.id])
+                          :assign_to      => 'storage-tags',
+                          :cat            => folder1a.id,
+                          :selected_nodes => [tag1a.id, tag2a.id])
     end
 
     describe '#tree_init_options' do
@@ -97,9 +97,9 @@ describe TreeBuilderAlertProfileObj do
                           :alert_profile_obj,
                           {},
                           true,
-                          :assign_to => 'tenant',
-                          :cat       => nil,
-                          :selected  => [tag1b.id])
+                          :assign_to      => 'tenant',
+                          :cat            => nil,
+                          :selected_nodes => [tag1b.id])
     end
 
     describe '#x_get_tree_roots' do


### PR DESCRIPTION
When editing alert profile assignments, the tree building params were a little off. You can open the screen for reproducing under `Control -> Explorer -> Alert Profiles`, select a profile click as below:
![screenshot from 2019-03-01 14-28-39](https://user-images.githubusercontent.com/649130/53641145-5bee0b00-3c2e-11e9-9380-94a2d2a3694e.png)

There's an unknown keyword error in master, here I'm fixing it - specs included.
 
@miq-bot assign @mzazrivec 
@miq-bot add_label bug, hammer/no, trees

cc @ZitaNemeckova 