### PR TITLE
Remove the obsolete assert_type method from TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -343,10 +343,6 @@ class TreeBuilder
     count_only_or_objects(count_only, Rbac.filtered(objects, options), sort_by, &block)
   end
 
-  def assert_type(actual, expected)
-    raise "#{self.class}: expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
-  end
-
   def open_node(id)
     open_nodes = @tree_state.x_tree(@name)[:open_nodes]
     open_nodes.push(id) unless open_nodes.include?(id)

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -38,8 +38,6 @@ class TreeBuilderAlertProfile < TreeBuilder
 
   # level 2 - alert profiles
   def x_get_tree_custom_kids(parent, count_only, options)
-    assert_type(options[:type], :alert_profile)
-
     objects = MiqAlertSet.where(:mode => parent[:id].split('-'))
 
     count_only_or_objects(count_only, objects, :description)

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -51,7 +51,6 @@ class TreeBuilderCondition < TreeBuilder
 
   # level 2 - conditions
   def x_get_tree_custom_kids(parent, count_only, options)
-    assert_type(options[:type], :condition)
     towhat = parent[:id].camelize
     return super unless MiqPolicyController::UI_FOLDERS.collect(&:name).include?(towhat)
 

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -68,8 +68,6 @@ class TreeBuilderPolicy < TreeBuilder
 
   # level 2 & 3...
   def x_get_tree_custom_kids(parent, count_only, options)
-    assert_type(options[:type], :policy)
-
     # level 2 - host, vm, etc. under compliance/control
     if %w(compliance control).include?(parent[:id])
       mode = parent[:id]

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -30,7 +30,6 @@ class TreeBuilderReportDashboards < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    assert_type(options[:type], :db)
     objects = []
     if object[:id].split('-').first == "g"
       objects = Rbac.filtered(MiqGroup.non_tenant_groups)


### PR DESCRIPTION
It is an obsolete method that was being used to verify if some methods have been called in the correct TreeBuilders. If the assertion fails, it raises an exception so it's something we don't want to have...

@miq-bot assign @himdel 