### PR TITLE
Move common parts of CBA and CBR trees into TreeBuilderChargeback

### DIFF
--- a/app/presenters/tree_builder_chargeback.rb
+++ b/app/presenters/tree_builder_chargeback.rb
@@ -6,27 +6,17 @@ class TreeBuilderChargeback < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, options)
-    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
-    case options[:type]
-    when :cb_assignments, :cb_rates
-      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
+  def x_get_tree_roots(count_only, _options)
+    rate_types = ChargebackRate::VALID_CB_RATE_TYPES
+    return rate_types.length if count_only
 
-      if count_only
-        rate_types.length
-      else
-        objects = []
-        rate_types.sort.each do |rtype|
-          img = rtype.downcase == "compute" ? "pficon pficon-cpu" : "fa fa-hdd-o"
-          objects.push(
-            :id   => rtype,
-            :text => rtype,
-            :icon => img,
-            :tip  => rtype
-          )
-        end
-        objects
-      end
+    rate_types.map do |type|
+      {
+        :id   => type,
+        :text => type,
+        :icon => type.downcase == "compute" ? "pficon pficon-cpu" : "fa fa-hdd-o",
+        :tip  => type
+      }
     end
   end
 end

--- a/app/presenters/tree_builder_chargeback.rb
+++ b/app/presenters/tree_builder_chargeback.rb
@@ -1,0 +1,32 @@
+class TreeBuilderChargeback < TreeBuilder
+  private
+
+  def tree_init_options
+    {:open_all => true, :full_ids => true}
+  end
+
+  # Get root nodes count/array for explorer tree
+  def x_get_tree_roots(count_only, options)
+    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
+    case options[:type]
+    when :cb_assignments, :cb_rates
+      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
+
+      if count_only
+        rate_types.length
+      else
+        objects = []
+        rate_types.sort.each do |rtype|
+          img = rtype.downcase == "compute" ? "pficon pficon-cpu" : "fa fa-hdd-o"
+          objects.push(
+            :id   => rtype,
+            :text => rtype,
+            :icon => img,
+            :tip  => rtype
+          )
+        end
+        objects
+      end
+    end
+  end
+end

--- a/app/presenters/tree_builder_chargeback_assignments.rb
+++ b/app/presenters/tree_builder_chargeback_assignments.rb
@@ -1,39 +1,10 @@
-class TreeBuilderChargebackAssignments < TreeBuilder
+class TreeBuilderChargebackAssignments < TreeBuilderChargeback
   private
-
-  def tree_init_options
-    {:open_all => true, :full_ids => true}
-  end
 
   def root_options
     {
       :text    => t = _("Assignments"),
       :tooltip => t
     }
-  end
-
-  # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, options)
-    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
-    case options[:type]
-    when :cb_assignments, :cb_rates
-      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
-
-      if count_only
-        rate_types.length
-      else
-        objects = []
-        rate_types.sort.each do |rtype|
-          img = rtype.downcase == "compute" ? "pficon pficon-cpu" : "fa fa-hdd-o"
-          objects.push(
-            :id   => rtype,
-            :text => rtype,
-            :icon => img,
-            :tip  => rtype
-          )
-        end
-        objects
-      end
-    end
   end
 end

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -1,40 +1,11 @@
-class TreeBuilderChargebackRates < TreeBuilder
+class TreeBuilderChargebackRates < TreeBuilderChargeback
   private
-
-  def tree_init_options
-    {:open_all => true, :full_ids => true}
-  end
 
   def root_options
     {
       :text    => t = _("Rates"),
       :tooltip => t
     }
-  end
-
-  # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, options)
-    # TODO: Common code in CharbackRate & ChargebackAssignments, need to move into module
-    case options[:type]
-    when :cb_assignments, :cb_rates
-      rate_types = ChargebackRate::VALID_CB_RATE_TYPES
-
-      if count_only
-        rate_types.length
-      else
-        objects = []
-        rate_types.sort.each do |rtype|
-          img = rtype.downcase == "compute" ? "pficon pficon-cpu" : "fa fa-hdd-o"
-          objects.push(
-            :id   => rtype,
-            :text => rtype,
-            :icon => img,
-            :tip  => rtype
-          )
-        end
-        objects
-      end
-    end
   end
 
   # Handle custom tree nodes (object is a Hash)


### PR DESCRIPTION
Moving the common parts of the `TreeBuilderChargebackAssignments` and `TreeBuilderChargebackRates` into a common `TreeBuilderChargeback` and keeping the changes only. I also looked into the `x_get_tree_roots` method and cleaned it up a little, so it no longer depends on the tree type.

@miq-bot add_label refactoring, trees, hammer/no
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel  
@miq-bot add_reviewer @mzazrivec 