### PR TITLE
Catalog trees: move the unassigned node add into the ServiceCatalogs

### DIFF
--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -52,4 +52,11 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
     objects = count > 0 ? [{:id => object.id.to_s, :text => 'Actions', :icon => 'pficon pficon-folder-close', :tip => 'Actions'}] : []
     count_only_or_objects(count_only, objects)
   end
+
+  def x_get_tree_roots(count_only, _options)
+    return super + 1 if count_only
+
+    # FIXME: adding gettext here would break the tree_select for languages other than English
+    super.unshift(ServiceTemplateCatalog.new(:name => 'Unassigned', :description => 'Unassigned Catalogs'))
+  end
 end

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -4,20 +4,7 @@ class TreeBuilderCatalogsClass < TreeBuilder
 
   private
 
-  def x_get_tree_roots(count_only, options)
-    objects = count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
-    case options[:type]
-    when :stcat
-      objects
-    when :sandt
-      if count_only
-        objects + 1
-      else
-        objects.unshift(ServiceTemplateCatalog.new(
-                          :name        => 'Unassigned',
-                          :description => 'Unassigned Catalogs'
-        ))
-      end
-    end
+  def x_get_tree_roots(count_only, _options)
+    count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
   end
 end


### PR DESCRIPTION
It's better to use super + 1 at the only place where it is being used.

@miq-bot add_label refactoring, trees, hammer/no
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @mzazrivec 