### PR TITLE
Operate with open_nodes through options instead of TreeState

### DIFF
--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -1,5 +1,5 @@
 class TreeBuilderIsoDatastores < TreeBuilder
-  has_kids_for IsoDatastore, [:x_get_tree_iso_datastore_kids]
+  has_kids_for IsoDatastore, %i(x_get_tree_iso_datastore_kids options)
 
   private
 
@@ -24,15 +24,15 @@ class TreeBuilderIsoDatastores < TreeBuilder
     count_only_or_objects(count_only, IsoDatastore.all, "name")
   end
 
-  def x_get_tree_iso_datastore_kids(object, count_only)
+  def x_get_tree_iso_datastore_kids(object, count_only, options)
     iso_images = object.iso_images
     if count_only
-      @tree_state.x_tree(@name)[:open_nodes].push("xx-isd_xx-#{object.id}")
+      options[:open_nodes].push("xx-isd_xx-#{object.id}")
       iso_images.size
     else
       objects = []
       unless iso_images.empty?
-        @tree_state.x_tree(@name)[:open_nodes].push("isd_xx-#{object.id}")
+        options[:open_nodes].push("isd_xx-#{object.id}")
         objects.push(
           :id   => "isd_xx-#{object.id}",
           :text => _("ISO Images"),

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -1,5 +1,5 @@
 class TreeBuilderOpsVmdb < TreeBuilderOps
-  has_kids_for VmdbTableEvm, [:x_get_tree_vmdb_table_kids]
+  has_kids_for VmdbTableEvm, %i(x_get_tree_vmdb_table_kids options)
 
   private
 
@@ -33,12 +33,12 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
     count_only_or_objects(count_only, vmdb_indexes, "name")
   end
 
-  def x_get_tree_vmdb_table_kids(object, count_only)
+  def x_get_tree_vmdb_table_kids(object, count_only, options)
     if count_only
       1 # each table has any index
     else
       # load this node expanded on autoload
-      @tree_state.x_tree(@name)[:open_nodes].push("xx-#{object.id}") unless @tree_state.x_tree(@name)[:open_nodes].include?("xx-#{object.id}")
+      options[:open_nodes].push("xx-#{object.id}") unless options[:open_nodes].include?("xx-#{object.id}")
       [
         {
           :id            => object.id.to_s,

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -1,5 +1,5 @@
 class TreeBuilderPxeServers < TreeBuilder
-  has_kids_for PxeServer, [:x_get_tree_pxe_server_kids]
+  has_kids_for PxeServer, %i(x_get_tree_pxe_server_kids options)
 
   private
 
@@ -24,25 +24,24 @@ class TreeBuilderPxeServers < TreeBuilder
     count_only_or_objects(count_only, PxeServer.all, "name")
   end
 
-  def x_get_tree_pxe_server_kids(object, count_only)
+  def x_get_tree_pxe_server_kids(object, count_only, options)
     pxe_images = object.pxe_images
     win_images = object.windows_images
-    open_nodes = @tree_state.x_tree(@name)[:open_nodes]
     if count_only
-      open_nodes.push("xx-pxe_xx-#{object.id}") unless open_nodes.include?("xx-pxe_xx-#{object.id}")
-      open_nodes.push("xx-win_xx-#{object.id}") unless open_nodes.include?("xx-win_xx-#{object.id}")
+      options[:open_nodes].push("xx-pxe_xx-#{object.id}") unless options[:open_nodes].include?("xx-pxe_xx-#{object.id}")
+      options[:open_nodes].push("xx-win_xx-#{object.id}") unless options[:open_nodes].include?("xx-win_xx-#{object.id}")
       pxe_images.size + win_images.size
     else
       objects = []
       unless pxe_images.empty?
-        open_nodes.push("pxe_xx-#{object.id}") unless open_nodes.include?("pxe_xx-#{object.id}")
+        options[:open_nodes].push("pxe_xx-#{object.id}") unless options[:open_nodes].include?("pxe_xx-#{object.id}")
         objects.push(:id   => "pxe_xx-#{object.id}",
                      :text => _("PXE Images"),
                      :icon => "pficon pficon-folder-close",
                      :tip  => _("PXE Images"))
       end
       unless win_images.empty?
-        open_nodes.push("win_xx-#{object.id}") unless open_nodes.include?("win_xx-#{object.id}")
+        options[:open_nodes].push("win_xx-#{object.id}") unless options[:open_nodes].include?("win_xx-#{object.id}")
         objects.push(:id   => "win_xx-#{object.id}",
                      :text => _("Windows Images"),
                      :icon => "pficon pficon-folder-close",

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -29,8 +29,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   def x_get_tree_roots(count_only, options)
     return @rpt_menu.size if count_only
     @rpt_menu.each_with_index.each_with_object({}) do |(r, node_id), a|
-      # load next level of folders when building the tree
-      @tree_state.x_tree(options[:tree])[:open_nodes].push("xx-#{node_id}")
+      options[:open_nodes].push("xx-#{node_id}")
 
       root_node = folder_hash(node_id.to_s, r[0], @grp_title == r[0])
       child_nodes = @rpt_menu[node_id][1].each_with_index.each.map do |child_r, child_id|


### PR DESCRIPTION
It's nicer if we don't touch the `@tree_state` instance variable from the classes inherited from `TreeBuilder`, as they are already available through `options`. Just have to pass the param to each `get_kids` method that operates with `open_nodes`.

@miq-bot add_label refactoring, trees, hammer/no
@miq-bot assign @martinpovolny 