### PR TITLE
Rename and refactor miqOnCheckMenuRoles in miq_tree.js

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -65,15 +65,12 @@ function miqRemoveNodeChildren(treename, key) {
   }
 }
 
-function miqOnCheckMenuRoles(id) {
-  var nid = id.split('__');
-  if (nid[0] !== 'r') {
-    var url = ManageIQ.tree.clickUrl + '?node_id=' + encodeURIComponent(id) + '&node_clicked=1';
-    miqJqueryRequest(url, {beforeSend: true,
-      complete: true,
-      no_encoding: true,
-    });
-  }
+function miqOnClickMenuRoles(id) {
+  var url = ManageIQ.tree.clickUrl + '?node_id=' + encodeURIComponent(id) + '&node_clicked=1';
+  miqJqueryRequest(url, {beforeSend: true,
+    complete: true,
+    no_encoding: true,
+  });
 }
 
 // OnClick handler to run tree_select server method
@@ -405,7 +402,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnCheckCUFilters',
     'miqOnCheckGenealogy',
     'miqOnCheckGeneric',
-    'miqOnCheckMenuRoles',
+    'miqOnClickMenuRoles',
     'miqOnCheckProtect',
     'miqOnCheckProvTags',
     'miqOnCheckSections',

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -22,7 +22,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   def set_locals_for_render
     locals = {
       :click_url => "/report/menu_editor/",
-      :onclick   => "miqOnCheckMenuRoles"
+      :onclick   => "miqOnClickMenuRoles"
     }
 
     super.merge!(locals)

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -96,8 +96,8 @@ describe TreeBuilderMenuRoles do
       expect(subject[:click_url]).to eq "/report/menu_editor/"
     end
 
-    it 'uses miqOnCheckMenuRoles to handle clicks' do
-      expect(subject[:onclick]).to eq "miqOnCheckMenuRoles"
+    it 'uses miqOnClickMenuRoles to handle clicks' do
+      expect(subject[:onclick]).to eq "miqOnClickMenuRoles"
     end
   end
 end


### PR DESCRIPTION
The report menu editor's onclick handler is being called `miqOnCheckMenuRoles` which is weird, so renaming it to `miqOnClickMenuRoles`. Also the test for the node's ID prefix is unnecessary as the reports in the nodes aren't clickable, so it's not possible to trigger an onclick event from them anyway.

![screenshot from 2019-03-04 15-04-47](https://user-images.githubusercontent.com/649130/53738370-4f1c2200-3e8f-11e9-98ab-fb7d7bf2cb6b.png)

@miq-bot add_label trees, refactoring, hammer/no
@miq-bot add_reviewer @brumik
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @mzazrivec 