### PR TITLE
Fix highlighting the condition in accordion after creating it

### DIFF
--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -66,7 +66,7 @@ module MiqPolicyController::Conditions
           condition_get_info(condition)
           case x_active_tree
           when :condition_tree
-            @new_condition_node = "xx-#{condition.towhat.downcase}_co-#{condition.id}"
+            @new_condition_node = "xx-#{condition.towhat.camelize(:lower)}_co-#{condition.id}"
             replace_right_cell(:nodetype => "co", :replace_trees => %i(condition), :remove_form_buttons => true)
           when :policy_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -345,4 +345,24 @@ describe MiqPolicyController do
       end
     end
   end
+
+  context 'removing conditions' do
+    let(:condition) { FactoryBot.create(:condition) }
+    let(:policy) { FactoryBot.create(:miq_policy, :name => "test_policy", :conditions => [condition]) }
+
+    before do
+      login_as FactoryBot.create(:user, :features => 'condition_remove')
+      controller.instance_variable_set(:@_params, :policy_id => policy.id, :id => condition.id)
+      controller.instance_variable_set(:@sb, {})
+      allow(controller).to receive(:x_node).and_return("pp_pp-1r36_p-#{policy.id}_co-#{condition.id}")
+    end
+
+    it 'removes condition successfully' do
+      expect(controller).to receive(:replace_right_cell)
+      controller.send(:condition_remove)
+      policy.reload
+      expect(assigns(:flash_array).first[:message]).to include("has been removed from Policy")
+      expect(policy.conditions).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1683697

**What:**
Fix highlighting condition in accordion right after creating it: the newly created condition was not highlighted in accordion as expected, instead of that, _All Conditions_ node was highlighted. Everything else regarding adding new conditions seems to work.

**Steps to reproduce:**
1. Navigate to _Control > Explorer_, then _Conditions > Replicator Conditions_ ,or any other conditions
2. Create a new condition: choose _Configuration > Add a New Container Replicator Condition_ or any other type of condition (depends on step 1)
3. Fill in required fields (description and expression), values are not important
4. Click on _Add_ button
=>  _All Conditions_ node highlighted instead of newly created condition

TODO: _(done)_
- specs - DONE
- test all other types/classes of conditions if it works - DONE, works
- check this also in `:policy_tree`, `:policy_profile_tree` - there is similar code for setting a new node - DONE, works

**Details:**
`@new_condition_node` was set incorrectly (see https://github.com/ManageIQ/manageiq-ui-classic/pull/5302/files#diff-4b771fc8b6101d357855d3d10d79ba8aL69), while adding a new condition, it was set for example to
`"xx-containerreplicator..."` instead of
`"xx-containerReplicator..."`

---

**Before:**
![replic_before](https://user-images.githubusercontent.com/13417815/53742271-8f33d280-3e98-11e9-92ec-185c2fbc506b.png)

**After:**
![replic_after](https://user-images.githubusercontent.com/13417815/53742276-90fd9600-3e98-11e9-9856-8f6122e11b68.png)
