### PR TITLE
Make hakiri stop complaining about the controller param in trees

### DIFF
--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -27,7 +27,7 @@
              :post_check         => post_check,
              :autoload           => autoload,
              :allow_reselect     => allow_reselect,
-             :controller         => j(request.parameters[:controller]),
+             :controller         => controller_name,
              :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
              :select_node        => select_node,
              :highlight_changes  => highlight_changes,


### PR DESCRIPTION
As we discussed it here: https://github.com/ManageIQ/manageiq-ui-classic/pull/5290#issuecomment-469290530 (merge this only after that's in)
@miq-bot assign @himdel 