### PR TITLE
Drop the default onclick handler from TreeBuilder as it's not used

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -73,13 +73,6 @@ function miqOnClickMenuRoles(id) {
   });
 }
 
-// OnClick handler to run tree_select server method
-function miqOnClickSelectTreeNode(id) {
-  var rec_id = id.split('__');
-  var url = '/' + ManageIQ.controller + '/tree_select/?id=' + encodeURIComponent(rec_id[0]);
-  miqJqueryRequest(url, {beforeSend: true});
-}
-
 // Activate and focus on a node within a tree given the node's key
 function miqTreeActivateNode(tree, key) {
   miqSparkle(true);
@@ -411,7 +404,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickDiagnostics',
     'miqOnClickGeneric',
     'miqOnClickHostNet',
-    'miqOnClickSelectTreeNode',
     'miqOnClickSnapshots',
     'miqOnClickUtilization',
   ];

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -200,7 +200,6 @@ class TreeBuilder
       :tree_id    => "#{@name}box",
       :tree_name  => @name.to_s,
       :bs_tree    => @bs_tree,
-      :onclick    => "miqOnClickSelectTreeNode",
       :checkboxes => false
     }
   end


### PR DESCRIPTION
I went through all the `TreeBuilder` classes and the `miqOnClickSelectTreeNode` was used only by left-side trees on explorer screens. Since we angularized all of those, this function is no longer used anywhere. All the other trees have a custom onclick function, or non-clickable nodes.