### PR TITLE
Fix unhandled promise catch in catalog form

### DIFF
--- a/app/javascript/components/catalog-form/catalog-form.jsx
+++ b/app/javascript/components/catalog-form/catalog-form.jsx
@@ -36,14 +36,16 @@ class CatalogForm extends Component {
             originalRightValues: rightValues,
             isLoaded: true,
           }), miqSparkleOff);
-        });
+        })
+        .catch(({ error: { message } = { message: __('Could not fetch the data') } }) => add_flash(message, 'error'), miqSparkleOff);
     } else {
       API.get('/api/service_templates?expand=resources&filter[]=service_template_catalog_id=null').then(
         ({ resources }) => this.setState({
           schema: createSchema(resources.map(({ href, name }) => ({ key: href, label: name }))),
           isLoaded: true,
         }, miqSparkleOff),
-      );
+      )
+        .catch(({ error: { message } = { message: __('Could not fetch the data') } }) => add_flash(message, 'error'), miqSparkleOff);
     }
   }
 


### PR DESCRIPTION
**Description**

Adds missing catch blocks to promises in Catalog form.

It caused error messages is tests.

**Before**
```
(node:27486) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'resources' of undefined
(node:27486) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
(node:27486) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**After**
```
```

