### PR TITLE
Unify the signature of TreeBuilder#initialize to 4+1 arguments

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -157,7 +157,7 @@ module ApplicationController::Automate
     @resolve[:uri] = options[:uri]
     @resolve[:ae_result] = ws.root['ae_result']
     @resolve[:state_attributes] = ws.root['ae_result'] == 'retry' ? state_attributes(ws) : {}
-    @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, @sb, true, @results)
+    @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, @sb, true, :root => @results)
   end
 
   def state_attributes(ws)

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -47,9 +47,9 @@ module ApplicationController::Compare
                                              :all_sections_tree,
                                              @sb,
                                              true,
-                                             @compare,
-                                             controller_name,
-                                             current_tenant.name)
+                                             :data            => @compare,
+                                             :controller_name => controller_name,
+                                             :current_tenant  => current_tenant.name)
     compare_to_json(@compare)
     if params[:ppsetting] # Came in from per page setting
       replace_main_div({:partial => "layouts/compare"}, {:spinner_off => true})
@@ -369,9 +369,9 @@ module ApplicationController::Compare
       :all_sections_tree,
       @sb,
       true,
-      @compare,
-      controller_name,
-      current_tenant.name
+      :data            => @compare,
+      :controller_name => controller_name,
+      :current_tenant  => current_tenant.name
     )
     drift_to_json(@compare)
     drop_breadcrumb(:name => _("'%{name}' Drift Analysis") % {:name => @drift_obj.name},

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -179,7 +179,7 @@ module ApplicationController::PolicySupport
   def protect_build_tree
     @edit[:controller_name] = controller_name
     @edit[:pol_items] = session[:pol_items]
-    @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, @sb, true, @edit)
+    @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, @sb, true, :data => @edit)
   end
 
   # Create policy assignment audit record

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -511,7 +511,7 @@ class ConfigurationController < ApplicationController
         :set_filters => true,
         :current     => current,
       }
-      @df_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, filters)
+      @df_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, :data => filters)
       self.x_active_tree = :df_tree
     when 'ui_4'
       @edit = {

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -34,10 +34,10 @@ class HostController < ApplicationController
   def display_tree_resources
     @showtype = "config"
     title, tree = if @display == "network"
-                    @network_tree = TreeBuilderNetwork.new(:network_tree, :network, @sb, true, @record)
+                    @network_tree = TreeBuilderNetwork.new(:network_tree, :network, @sb, true, :root => @record)
                     [_("Network"), :network_tree]
                   else
-                    @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, @sb, true, @record)
+                    @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, @sb, true, :root => @record)
                     [_("Storage Adapters"), :sa_tree]
                   end
     drop_breadcrumb(:name => "#{@record.name} (#{title})",

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -8,7 +8,7 @@ module MiqPolicyController::Rsop
         miq_task = MiqTask.find(params[:task_id]) # Not first time, read the task record
         if miq_task.results_ready?
           @sb[:rsop][:results] = miq_task.task_results
-          @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, @sb[:rsop])
+          @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, :root => @sb[:rsop])
         else
           add_flash(_("Policy Simulation generation returned: %{error_message}") % {:error_message => miq_task.message}, :error)
         end
@@ -119,7 +119,7 @@ module MiqPolicyController::Rsop
       @sb[:rsop][:out_of_scope] = (params[:out_of_scope] == "1")
     end
     @sb[:rsop][:open] = false # reset the open state to select correct button in toolbar, need to replace partial to update checkboxes in form
-    @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, @sb[:rsop])
+    @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, :root => @sb[:rsop])
     rsop_button_pressed
   end
 

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -49,7 +49,7 @@ module Mixins
       @showtype = "config"
 
       cluster = @record
-      @datacenter_tree = TreeBuilderVat.new(:vat_tree, :vat, @sb, true, cluster, !!params[:vat])
+      @datacenter_tree = TreeBuilderVat.new(:vat_tree, :vat, @sb, true, :root => cluster, :vat => !!params[:vat])
       self.x_active_tree = :vat_tree
     end
 

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -143,7 +143,7 @@ module Mixins
       drop_breadcrumb(:name => _("%{name} (All VMs - Tree View)") % {:name => @record.name},
                       :url  => show_link(@record, :display => "descendant_vms", :treestate => true))
       self.x_active_tree = :datacenter_tree
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, @sb, true, @record)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, @sb, true, :root => @record)
     end
 
     def display_all_vms

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -35,7 +35,7 @@ module Mixins
     end
 
     def update_session_for_compliance_history(count)
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, @record)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
       session[:ch_tree] = @ch_tree.tree_nodes
       session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -854,9 +854,9 @@ module OpsController::Diagnostics
   # Method to build the server tree (parent is a zone or region instance)
   def build_server_tree(parent)
     @server_tree = if @sb[:diag_tree_type] == "roles"
-                     TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, parent)
+                     TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, :root => parent)
                    else
-                     TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, parent)
+                     TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, :root => parent)
                    end
     if @sb[:diag_selected_id]
       @record = @sb[:diag_selected_model].constantize.find(@sb[:diag_selected_id]) # Set the current record

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -130,7 +130,7 @@ module OpsController::Settings::CapAndU
                                               :cluster_tree,
                                               @sb,
                                               true,
-                                              @edit[:current])
+                                              :root => @edit[:current])
     end
     @edit[:current][:storages] = []
     @st_recs = {}
@@ -148,7 +148,7 @@ module OpsController::Settings::CapAndU
                                                   :datastore_tree,
                                                   @sb,
                                                   true,
-                                                  @edit[:current][:storages])
+                                                  :root => @edit[:current][:storages])
     end
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -658,7 +658,7 @@ module OpsController::Settings::Common
                                                                     :smartproxy_affinity_tree,
                                                                     @sb,
                                                                     true,
-                                                                    @selected_zone)
+                                                                    :data => @selected_zone)
     end
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -224,7 +224,7 @@ module VmCommon
         javascript_flash(:spinner_off => true)
         return
       else
-        @genealogy_tree = TreeBuilderGenealogy.new(:genealogy_tree, :genealogy, @sb, true, @record)
+        @genealogy_tree = TreeBuilderGenealogy.new(:genealogy_tree, :genealogy, @sb, true, :root => @record)
         session[:genealogy_tree_root_id] = @genealogy_tree.root_id
       end
     elsif @display == "compliance_history"

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -9,7 +9,7 @@ class TreeBuilder
     @x_tree_node_classes[type] ||= LEFT_TREE_CLASSES[type].constantize
   end
 
-  def initialize(name, type, sandbox, build = true)
+  def initialize(name, type, sandbox, build = true, **_params)
     @tree_state = TreeState.new(sandbox)
     @sb = sandbox # FIXME: some subclasses still access @sb
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,10 +1,10 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-  def initialize(name, type, sandbox, build = true, assign_to: nil, cat: nil, selected_nodes: nil)
-    @assign_to = assign_to
-    @cat = cat
-    @selected = selected_nodes
+  def initialize(name, type, sandbox, build = true, **params)
+    @assign_to = params[:assign_to]
+    @cat = params[:cat]
+    @selected = params[:selected_nodes]
     @cat_tree = @assign_to.ends_with?("-tags")
-    super(name, type, sandbox, build)
+    super(name, type, sandbox, build, **params)
   end
 
   def override(node, object, _pid, _options)

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -3,8 +3,8 @@ class TreeBuilderAutomate < TreeBuilderAeClass
     {:full_ids => false}
   end
 
-  def initialize(name, type, sandbox, build = true, controller = nil)
-    @controller = controller
+  def initialize(name, type, sandbox, build = true, **params)
+    @controller = params[:controller]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -2,8 +2,8 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
   include MiqAeClassHelper
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
-  def initialize(name, type, sandbox, build = true, root = nil)
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -18,7 +18,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     node[:checkable] = options[:checkboxes] if options.key?(:checkboxes)
   end
 
-  def initialize(name, type, sandbox, build, params)
+  def initialize(name, type, sandbox, build, **params)
     @edit = params[:edit]
     @group = params[:group]
     @selected_nodes = params[:selected_nodes]

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -1,8 +1,8 @@
 class TreeBuilderClusters < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     @data = EmsCluster.get_perf_collection_object_list
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -6,9 +6,9 @@ class TreeBuilderComplianceHistory < TreeBuilder
     node[:selectable] = false
   end
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:ch_root] = TreeBuilder.build_node_id(root) if root
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    sandbox[:ch_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
+    @root = params[:root]
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:ch_root])
       @root = model.constantize.find_by(:id => id)

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -22,9 +22,9 @@ class TreeBuilderDatacenter < TreeBuilder
     node[:tooltip].concat(suffix) unless node[:tooltip].ends_with?(suffix)
   end
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:datacenter_root] = TreeBuilder.build_node_id(root) if root
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    sandbox[:datacenter_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
+    @root = params[:root]
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:datacenter_root])
       @root = model.constantize.find_by(:id => id)

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -1,8 +1,8 @@
 class TreeBuilderDatastores < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     @data = Storage.all.each_with_object({}) { |st, h| h[st.id] = st; }
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -27,8 +27,8 @@ class TreeBuilderDefaultFilters < TreeBuilder
     end
   end
 
-  def initialize(name, type, sandbox, build = true, data = nil)
-    @data = prepare_data(data)
+  def initialize(name, type, sandbox, build = true, **params)
+    @data = prepare_data(params[:data])
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -1,6 +1,6 @@
 class TreeBuilderDiagnostics < TreeBuilder
-  def initialize(name, type, sandbox, build = true, parent = nil)
-    @root = parent
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -2,20 +2,20 @@ class TreeBuilderGenealogy < TreeBuilder
   has_kids_for VmOrTemplate, [:x_get_vm_or_template_kids]
 
   def override(node, object, _pid, _options)
-    if object == @vm
+    if object == @root
       node[:text] = _("%{item} (Selected)") % {:item => node[:text]}
       node[:highlighted] = true
       node[:expand] = true
     end
   end
 
-  def initialize(name, type, sandbox, build, vm)
-    @vm = vm
+  def initialize(name, type, sandbox, build, **params)
+    @root = params[:root]
     super(name, type, sandbox, build)
   end
 
   def root_id
-    @vm.parent.present? ? @vm.parent.id : @vm.id
+    @root.parent.present? ? @root.parent.id : @root.id
   end
 
   private
@@ -40,17 +40,17 @@ class TreeBuilderGenealogy < TreeBuilder
   end
 
   def root_options
-    if @vm.parent.present?
-      {:text    => @vm.parent.name + _(" (Parent)"),
-       :tooltip => _("VM: %{name} (Click to view)") % {:name => @vm.parent.name}}.merge(vm_icon_image(@vm.parent))
+    if @root.parent.present?
+      {:text    => @root.parent.name + _(" (Parent)"),
+       :tooltip => _("VM: %{name} (Click to view)") % {:name => @root.parent.name}}.merge(vm_icon_image(@root.parent))
     else
-      {:text    => @vm.name,
-       :tooltip => _("VM: %{name} (Click to view)") % {:name => @vm.name}}.merge(vm_icon_image(@vm))
+      {:text    => @root.name,
+       :tooltip => _("VM: %{name} (Click to view)") % {:name => @root.name}}.merge(vm_icon_image(@root))
     end
   end
 
   def x_get_tree_roots(count_only, _options)
-    kids = @vm.parent.present? ? [@vm] : @vm.children
+    kids = @root.parent.present? ? [@root] : @root.children
     count_only_or_objects(count_only, kids, :name)
   end
 

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -3,9 +3,9 @@ class TreeBuilderMenuRoles < TreeBuilder
 
   attr_reader :rpt_menu, :role_choice
 
-  def initialize(name, type, sandbox, build, role_choice:, rpt_menu: nil)
-    @rpt_menu    = rpt_menu || sandbox[:rpt_menu]
-    @role_choice = role_choice
+  def initialize(name, type, sandbox, build, **params)
+    @rpt_menu    = params[:rpt_menu] || sandbox[:rpt_menu]
+    @role_choice = params[:role_choice]
 
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -10,8 +10,8 @@ class TreeBuilderMiqActionCategory < TreeBuilder
     node
   end
 
-  def initialize(name, type, sandbox, build = true, tenant_name = nil)
-    @tenant_name = tenant_name
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     super(name, type, sandbox, build)
   end
 
@@ -29,8 +29,8 @@ class TreeBuilderMiqActionCategory < TreeBuilder
 
   def root_options
     {
-      :text    => @tenant_name,
-      :tooltip => @tenant_name,
+      :text    => @root,
+      :tooltip => @root,
       :icon    => "fa fa-tag"
     }
   end

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -6,9 +6,9 @@ class TreeBuilderNetwork < TreeBuilder
     node[:selectable] = false # if node[:image].nil? || !node[:image].include?('svg/currentstate-')
   end
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:network_root] = TreeBuilder.build_node_id(root) if root
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    sandbox[:network_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
+    @root = params[:root]
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:network_root])
       @root = model.constantize.find_by(:id => id)

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -3,9 +3,9 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   has_kids_for Menu::Item,        [:x_get_tree_item_kids]
   has_kids_for MiqProductFeature, [:x_get_tree_feature_kids]
 
-  def initialize(name, type, sandbox, build, role:, editable: false)
-    @role     = role
-    @editable = editable
+  def initialize(name, type, sandbox, build, **params)
+    @role     = params[:role]
+    @editable = params[:editable]
     @features = @role.miq_product_features.map(&:identifier)
 
     @root_counter = []

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -4,8 +4,8 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    @root = root
+  def initialize(name, type, sandbox, build = true, **params)
+    @root = params[:root]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -1,8 +1,8 @@
 class TreeBuilderProtect < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, data)
-    @data = data
+  def initialize(name, type, sandbox, build = true, **params)
+    @data = params[:data]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -3,10 +3,10 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
 
   private
 
-  def initialize(name, type, sandbox, _build = true)
+  def initialize(name, type, sandbox, build = true, **_params)
     @rpt_menu  = sandbox[:rpt_menu]
     @grp_title = sandbox[:grp_title]
-    super(name, type, sandbox, build = true)
+    super(name, type, sandbox, build)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -1,10 +1,10 @@
 class TreeBuilderSections < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build, data, controller_name, current_tenant)
-    @data = data
-    @controller_name = controller_name
-    @current_tenant = current_tenant
+  def initialize(name, type, sandbox, build, **params)
+    @data = params[:data]
+    @controller_name = params[:controller_name]
+    @current_tenant = params[:current_tenant]
     @sandbox = sandbox
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -2,8 +2,8 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
   has_kids_for MiqServer, [:x_get_server_kids]
 
-  def initialize(name, type, sandbox, build = true, data)
-    @data = data
+  def initialize(name, type, sandbox, build = true, **params)
+    @data = params[:data]
     super(name, type, sandbox, build)
   end
 

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -2,8 +2,8 @@ class TreeBuilderStorageAdapters < TreeBuilder
   has_kids_for GuestDevice, [:x_get_tree_guest_device_kids]
   has_kids_for MiqScsiTarget, [:x_get_tree_target_kids]
 
-  def initialize(name, type, sandbox, build = true, root = nil)
-    sandbox[:sa_root] = root if root
+  def initialize(name, type, sandbox, build = true, **params)
+    sandbox[:sa_root] = params[:root] if params[:root]
     @root = sandbox[:sa_root]
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -1,7 +1,7 @@
 class TreeBuilderTags < TreeBuilder
   has_kids_for Classification, [:x_get_classification_kids]
 
-  def initialize(name, type, sandbox, build, params)
+  def initialize(name, type, sandbox, build, **params)
     @edit = params[:edit]
     @filters = params[:filters]
     @group = params[:group]

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -2,11 +2,11 @@ class TreeBuilderVat < TreeBuilderDatacenter
   has_kids_for Datacenter, %i(x_get_tree_datacenter_kids type)
   has_kids_for EmsFolder, %i(x_get_tree_folder_kids type)
 
-  def initialize(name, type, sandbox, build = true, root = nil, vat = nil)
-    sandbox[:vat] = vat unless vat.nil?
+  def initialize(name, type, sandbox, build = true, **params)
+    sandbox[:vat] = params[:vat] if params[:vat]
     @vat = sandbox[:vat]
     @user_id = User.current_userid
-    super(name, type, sandbox, build, root)
+    super(name, type, sandbox, build, **params)
   end
 
   private

--- a/spec/presenters/tree_builder_automate_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_automate_simulation_results_spec.rb
@@ -2,7 +2,7 @@ describe TreeBuilderAutomateSimulationResults do
   context 'TreeBuilderAutomateSimulationResults' do
     before do
       @data = "<MiqAeWorkspace>\\n<MiqAeObject namespace='ManageIQ/SYSTEM' class='PROCESS' instance='Automation'>\\n</MiqAeObject>\\n</MiqAeWorkspace>\\n"
-      @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, {}, true, @data)
+      @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, {}, true, :root => @data)
     end
 
     it 'no root is set' do

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderClusters do
                                                                                               :ho_disabled => @ho_disabled})
       @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
       @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-      @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, @cluster)
+      @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, :root => @cluster)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderComplianceHistory do
       empty_compliance = FactoryBot.create(:compliance)
       compliance = FactoryBot.create(:compliance, :compliance_details => compliance_details)
       root = FactoryBot.create(:host, :compliances => [empty_compliance, compliance])
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, {}, true, root)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, {}, true, :root => root)
     end
     it 'is not lazy' do
       tree_options = @ch_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_datacenter_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderDatacenter do
           [FactoryBot.create(:resource_pool)]
         end
       end
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, cluster)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, :root => cluster)
     end
 
     it 'returns EmsCluster as root' do
@@ -50,7 +50,7 @@ describe TreeBuilderDatacenter do
           [FactoryBot.create(:vm)]
         end
       end
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, cluster)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, :root => cluster)
     end
 
     it 'returns ResourcePool as root' do

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -7,7 +7,7 @@ describe TreeBuilderDatastores do
       @host = FactoryBot.create(:host, :name => 'Host Name')
       FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
       @datastore = [{:id => 1, :name => 'Datastore', :location => 'Location', :capture => false}]
-      @datastores_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, @datastore)
+      @datastores_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, :root => @datastore)
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -61,7 +61,7 @@ describe TreeBuilderDefaultFilters do
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
       @sb = {:active_tree => :default_filters_tree}
-      @default_filters_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, @filters)
+      @default_filters_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, :data => @filters)
     end
 
     it 'is not lazy' do

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderGenealogy do
   end
 
   subject do
-    described_class.new(:genealogy_tree, :genealogy, {}, true, record)
+    described_class.new(:genealogy_tree, :genealogy, {}, true, :root => record)
   end
 
   describe '#tree_init_options' do

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -21,7 +21,7 @@ describe TreeBuilderMiqActionCategory do
   let!(:tree_name) { :action_tags }
 
   subject do
-    described_class.new(:action_tags_tree, :action_tags, {}, true, tenant)
+    described_class.new(:action_tags_tree, :action_tags, {}, true, :root => tenant)
   end
 
   describe '#tree_init_options' do

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderNetwork do
       lan = FactoryBot.create(:lan, :guest_devices => [guest_device_with_vm])
       switch = FactoryBot.create(:switch, :guest_devices => [guest_device], :lans => [lan])
       network = FactoryBot.create(:host, :switches => [switch])
-      @network_tree = TreeBuilderNetwork.new(:network_tree, :network, {}, true, network)
+      @network_tree = TreeBuilderNetwork.new(:network_tree, :network, {}, true, :root => network)
     end
 
     it 'returns Host as root' do

--- a/spec/presenters/tree_builder_policy_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_results_spec.rb
@@ -27,7 +27,7 @@ describe TreeBuilderPolicySimulationResults do
                                                                                                     {:id          => 9,
                                                                                                      :description => "Shutdown Virtual Machine Guest OS",
                                                                                                      :result      => "deny"}]}]}]}]}
-      @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, {}, true, @data)
+      @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, {}, true, :root => @data)
     end
 
     it 'sets root correctly' do

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderProtect do
       @edit = {:controller_name => 'name'}
       @edit[:new] = @edit[:current] = {set1[:id] => 1}
       @edit[:pol_items] = [101]
-      @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, {}, true, @edit)
+      @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, {}, true, :data => @edit)
     end
 
     it 'set init options correctly' do

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -31,7 +31,7 @@ describe TreeBuilderRolesByServer do
       parent = MiqRegion.my_region
       @sb[:selected_server_id] = parent.id
       @sb[:selected_typ] = "miq_region"
-      @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, parent)
+      @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, :root => parent)
     end
 
     it "is not lazy" do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -49,9 +49,9 @@ describe TreeBuilderSections do
                                                :all_sections_tree,
                                                {},
                                                true,
-                                               @compare,
-                                               @controller_name,
-                                               @current_tenant)
+                                               :data            => @compare,
+                                               :controller_name => @controller_name,
+                                               :current_tenant  => @current_tenant)
     end
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderServersByRole do
       parent = zone
       @sb[:selected_server_id] = parent.id
       @sb[:selected_typ] = "miq_region"
-      @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, parent)
+      @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, :root => parent)
     end
 
     it "is not lazy" do

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -30,7 +30,7 @@ describe TreeBuilderSmartproxyAffinity do
                                                                     :smartproxy_affinity_tree,
                                                                     {},
                                                                     true,
-                                                                    @selected_zone)
+                                                                    :data => @selected_zone)
     end
 
     it 'set init options correctly' do

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderStorageAdapters do
                                                                                      FactoryBot.create(:miq_scsi_lun)])])
         end
       end
-      @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, {}, true, host)
+      @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, {}, true, :root => host)
     end
 
     it 'returns Host as root' do

--- a/spec/presenters/tree_builder_vat_spec.rb
+++ b/spec/presenters/tree_builder_vat_spec.rb
@@ -16,7 +16,7 @@ describe TreeBuilderVat do
           'cluster'
         end
       end
-      @vat_tree = TreeBuilderVat.new(:vat_tree, :vat, {}, true, cluster, true)
+      @vat_tree = TreeBuilderVat.new(:vat_tree, :vat, {}, true, :root => cluster, :vat => true)
     end
 
     it 'returns EmsCluster as root' do

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
                    :name     => 'Datastore',
                    :location => 'Location',
                    :capture  => false}]
-    @datastore_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, @datastore)
+    @datastore_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, :root => @datastore)
 
     @ho_enabled = [FactoryBot.create(:host)]
     @ho_disabled = [FactoryBot.create(:host)]
@@ -20,7 +20,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
                                                                                             :ho_disabled => @ho_disabled})
     @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
     @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-    @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, @cluster)
+    @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, :root => @cluster)
   end
 
   it "Check All checkbox have unique id for Clusters trees" do


### PR DESCRIPTION
Except of the `FullTreeBuilder` and `TreeBuilderVmsAndTemplates` which are the :black_circle: :sheep: among treebuilders, I unified the `TreeBuilder#initialize` signatures to:
```ruby
initialize(name, type, sandbox, build = true, **params)
```
Where the `params` is a [double-splatted](https://medium.com/@sophiedeziel/the-double-splat-operator-83347d924ecf) hash which makes it implicitly optional. Some of the child classes were already using it, so I just changed the rest of them to do so as well.

I mostly took the parameter keywords from the old argument (or keyword argument) names. However, sometimes we just gave the `:root` param different names. On those places I replaced the random keyword/param with the `:root`.

I will probably go through the calls in the future to unify the keywords a little more, but I don't take this as a priority right now.

@miq-bot add_label refactoring, trees, hammer/no