### PR TITLE
Container trends chart - wait for loadingDone before displaying pf-trends-chart

### DIFF
--- a/app/views/ems_container/_trends-chart.html.haml
+++ b/app/views/ems_container/_trends-chart.html.haml
@@ -5,4 +5,4 @@
         {{vm.config.headTitle}}
     .card-pf-body
       .spinner.spinner-lg.loading{"ng-if" => "!vm.loadingDone"}
-      %pf-trends-chart{'ng-if' => "vm.dataAvailable !== false", 'config' => "vm.config", 'chart-data' => "vm.data", 'show-x-axis' => "vm.custShowXAxis", 'show-y-axis' => "vm.custShowYAxis"}
+      %pf-trends-chart{'ng-if' => "vm.loadingDone && vm.dataAvailable !== false", 'config' => "vm.config", 'chart-data' => "vm.data", 'show-x-axis' => "vm.custShowXAxis", 'show-y-axis' => "vm.custShowYAxis"}


### PR DESCRIPTION
Compute > Containers > Overview or Compute > Containers > Providers > pick one, dashboard view

This fixes a 

```
    TypeError: Cannot read property 'layout' of undefined
    at trendsChartController.e.updateAll (application-d966831b…581bed47155710.js:3)
    at trendsChartController.e.$onChanges (application-d966831b…581bed47155710.js:3)
```

when the JSON endpoints are taking longer to respond. (Longer = angular manages to do the first render before any data arrives.)

The controller already has a concept of `loadingDone`, used to display a spinner.
But it was never used to prevent rendering of the `pf-trends-chart` component, which fails when config is undefined.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684226

(related to but not the same problem as in https://github.com/ManageIQ/manageiq-ui-classic/pull/5232)