### PR TITLE
styling fix for vm edit screen

### DIFF
--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -43,10 +43,10 @@
       .col-md-8
         = select_tag("chosen_parent",
                       options_for_select(parent_choices_with_no_parent_choice, @edit[:new][:parent]),
-                      :multiple => false,
-                      "data-miq_sparkle_on" => true,
+                      :multiple              => false,
+                      "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
-                      :class    => "selectpicker")
+                      :class                 => "form-control selectpicker")
     :javascript
        miqInitSelectPicker();
        miqSelectPickerEvent("chosen_parent", "#{url}")


### PR DESCRIPTION
Add missing form-control on vm parent dropdown

Before
![screen shot 2019-03-06 at 11 11 36 am](https://user-images.githubusercontent.com/1287144/53895764-b6a5af00-4000-11e9-9187-111300936185.png)

After
![screen shot 2019-03-06 at 11 10 29 am](https://user-images.githubusercontent.com/1287144/53895765-b6a5af00-4000-11e9-84e3-fe77e10a876b.png)
