### PR TITLE
Remove unused variable from infra networking controller

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -535,7 +535,7 @@ class InfraNetworkingController < ApplicationController
   end
 
   def display_adv_searchbox
-    !(@infra_networking_record || @in_a_form || @nodetype == 'sw')
+    !(@record || @in_a_form)
   end
 
   def breadcrumb_name(_model)

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -15,9 +15,7 @@ describe InfraNetworkingController do
   describe 'render_views' do
     render_views
 
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
+    before { EvmSpecHelper.create_guid_miq_server_zone }
 
     describe '#explorer' do
       before do
@@ -104,6 +102,26 @@ describe InfraNetworkingController do
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
       expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#rebuild_toolbars' do
+    let(:presenter) { instance_double("ExplorerPresenter") }
+
+    before do
+      allow(ExplorerPresenter).to receive(:new).and_return(presenter)
+      allow(presenter).to receive(:hide)
+      allow(presenter).to receive(:reload_toolbars)
+      allow(presenter).to receive(:set_visibility)
+      allow(presenter).to receive(:[]=)
+      controller.instance_variable_set(:@nodetype, 'sw')
+      controller.instance_variable_set(:@record, switch)
+      controller.instance_variable_set(:@sb, {})
+    end
+
+    it 'does not display Search in Switch summary screen' do
+      expect(controller).to receive(:display_adv_searchbox).and_return(false)
+      controller.send(:rebuild_toolbars, true, presenter)
     end
   end
 end


### PR DESCRIPTION
**Related BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1428584
**Related PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3838

**What:**
Remove the unused `@infra_networking_record` variable and use `@record` instead to update solution for removing _Search_ from Switch summary page (under _Compute > Infra > Networking > Switches_ accordion.)
