### PR TITLE
Fix failing travis - stub my_server when dealing with custom button sets

### DIFF
--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -39,6 +39,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       end
 
       before do
+        allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
         @button_set = FactoryBot.create(:custom_button_set, :set_data => {:applies_to_class => applies_to_class, :button_icon => 'fa fa-cogs'})
         login_as user
         @button1 = FactoryBot.create(:custom_button, :applies_to_class => applies_to_class, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})


### PR DESCRIPTION
Likely related to https://github.com/ManageIQ/manageiq/pull/18368

Using `Rbac.filtered` needs user's timezone, and for that, settings have to be stubbed, or MiqServer.my_server set.

Since creating a custom button set now needs Rbac.filtered, adding...

Should prevent:

```
Failures:
  1) ApplicationHelper::ToolbarBuilder custom_buttons for VM behaves like with custom buttons #get_custom_buttons
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:144
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  2) ApplicationHelper::ToolbarBuilder custom_buttons for VM behaves like with custom buttons #custom_button_selects
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:144
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  3) ApplicationHelper::ToolbarBuilder custom_buttons for VM behaves like with custom buttons #build_custom_toolbar_class
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:144
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  4) ApplicationHelper::ToolbarBuilder custom_buttons for VM behaves like with custom buttons #record_to_service_buttons
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:144
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  5) ApplicationHelper::ToolbarBuilder custom_buttons for Service behaves like with custom buttons #get_custom_buttons
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:153
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  6) ApplicationHelper::ToolbarBuilder custom_buttons for Service behaves like with custom buttons #record_to_service_buttons
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:153
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  7) ApplicationHelper::ToolbarBuilder custom_buttons for Service behaves like with custom buttons #custom_button_selects
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:153
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
  8) ApplicationHelper::ToolbarBuilder custom_buttons for Service behaves like with custom buttons #build_custom_toolbar_class
     Failure/Error: MiqServer.my_server.server_timezone
     NoMethodError:
       undefined method `server_timezone' for nil:NilClass
     Shared Example Group: "with custom buttons" called from ./spec/helpers/application_helper/toolbar_builder_spec.rb:153
     # ./spec/manageiq/app/models/mixins/timezone_mixin.rb:21:in `server_timezone'
     # ./spec/manageiq/app/models/user.rb:204:in `get_timezone'
     # ./spec/manageiq/lib/rbac/filterer.rb:206:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:132:in `search'
     # ./spec/manageiq/lib/rbac.rb:3:in `search'
     # ./spec/manageiq/lib/rbac/filterer.rb:355:in `filtered'
     # ./spec/manageiq/lib/rbac/filterer.rb:136:in `filtered'
     # ./spec/manageiq/lib/rbac.rb:11:in `filtered'
     # ./spec/manageiq/app/models/custom_button_set.rb:10:in `validate_children'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:38:in `add_button_to_set'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:45:in `block (4 levels) in <top (required)>'
```