### PR TITLE
Fix internal server error while creating schedule with EVM Group/Tenant option

### DIFF
--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -17,10 +17,24 @@ module OpsController::Settings::AutomateSchedules
     }
   end
 
+  def name_included?(klass)
+    klass.safe_constantize.column_names.include?('name')
+  end
+
+  def columns_for_klass(klass)
+    if klass == 'Tenant'
+      [:name, :use_config_for_attributes]
+    elsif name_included?(klass)
+      [:name]
+    else
+      [:description]
+    end
+  end
+
   def fetch_target_ids
     if params[:target_class] && params[:target_class] != 'null'
-      targets = Rbac.filtered(params[:target_class]).select(:id, :name)
-      unless targets.nil?
+      targets = Rbac.filtered(params[:target_class]).select(:id, *columns_for_klass(params[:target_class]))
+      if targets.present?
         targets = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
       end
     end

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -77,6 +77,17 @@ describe OpsController do
         ops.fetch_target_ids
       end
     end
+
+    ['MiqGroup', 'User', 'Tenant'].each do |klass|
+      context "#{klass} class" do
+        it "fetches appropriate ids" do
+          ops.params = {:target_class => klass }
+          targets = klass.safe_constantize.all.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
+          expect(ops).to receive(:render).with(:json => {:target_id => '', :targets => targets})
+          ops.fetch_target_ids
+        end
+      end
+    end
   end
 
   describe "#fetch_automate_request_vars" do


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1686762

**What:**
Creating schedule with _EVM Group_ and _Tenant_ under _Automation Tasks_ was giving internal server error. This PR fixes it.
For _EVM Group_, there was only _description_ column, instead of _name_.
For _Tenant_, there was a different problem:
```
ActiveModel::MissingAttributeError: missing attribute: use_config_for_attributes
from /home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.1/lib/active_record/attribute_methods/read.rb:66:in `block in _read_attribute'
```
I've tested all other options(types) and it worked well.

**Steps to reproduce:**
1. Go to _Configuration > Settings > Schedules_
2. _Configuration > Add a new Schedule_
3. For _Action_, choose _Automation Tasks_
4. For _Type_, choose _EVM Group_ or _Tenant_
=> error:
```
[----] I, [2019-03-11T15:22:27.774154 #20026:2ad8eb99f298]  INFO -- : Started POST "/ops/fetch_target_ids/?target_class=MiqGroup" for ::1 at 2019-03-11 15:22:27 +0100
[----] I, [2019-03-11T15:22:27.837696 #20026:2ad8eb99f298]  INFO -- : Processing by OpsController#fetch_target_ids as HTML
[----] I, [2019-03-11T15:22:27.837871 #20026:2ad8eb99f298]  INFO -- :   Parameters: {"target_class"=>"MiqGroup"}
[----] F, [2019-03-11T15:22:27.860229 #20026:2ad8eb99f298] FATAL -- : Error caught: [ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column "name" does not exist
LINE 1: SELECT "miq_groups"."id", "name" FROM "miq_groups"
                                  ^
: SELECT "miq_groups"."id", "name" FROM "miq_groups"

```
or
```
[----] I, [2019-03-11T15:22:50.342920 #20026:2ad8eb99ecd0]  INFO -- : Started POST "/ops/fetch_target_ids/?target_class=Tenant" for ::1 at 2019-03-11 15:22:50 +0100
[----] I, [2019-03-11T15:22:50.388895 #20026:2ad8eb99ecd0]  INFO -- : Processing by OpsController#fetch_target_ids as HTML
[----] I, [2019-03-11T15:22:50.389079 #20026:2ad8eb99ecd0]  INFO -- :   Parameters: {"target_class"=>"Tenant"}
[----] F, [2019-03-11T15:22:50.413189 #20026:2ad8eb99ecd0] FATAL -- : Error caught: [ActiveModel::MissingAttributeError] missing attribute: use_config_for_attributes
```


---

**Before:**
Choosing _EVM Group_ option:
![evm_before](https://user-images.githubusercontent.com/13417815/54131025-cf9fcd00-4411-11e9-9c8d-91409dbc345d.png)
Choosing _Tenant_ option:
![ten_before](https://user-images.githubusercontent.com/13417815/54131027-d2022700-4411-11e9-8b17-a5be1b0ac502.png)


**After:**
Choosing _EVM Group_ option:
![evm_after](https://user-images.githubusercontent.com/13417815/54132702-fad7eb80-4414-11e9-95cc-625682227203.png)
Choosing _Tenant_ option:
![ten_after](https://user-images.githubusercontent.com/13417815/54132709-fca1af00-4414-11e9-9ca8-9f11002f9446.png)
Saving a new Schedule:
![after](https://user-images.githubusercontent.com/13417815/54132524-a9c7f780-4414-11e9-8379-92ae31d3089a.png)
