### PR TITLE
[WIP] Symlink node_modules and yarn.lock

### DIFF
--- a/config/webpack/RailsEnginesPlugin.js
+++ b/config/webpack/RailsEnginesPlugin.js
@@ -15,6 +15,7 @@ module.exports = class RailsEnginesPlugin {
   pathToEngine(path) {
     const pathLength = (path) => (path.match(/\//g) || []).length;
 
+    // FIXME: support vendor/engines/ too
     const candidates = (path, field) => Object.keys(this.engines)
       .filter((engine) => path.startsWith(this.engines[engine][field]))
       .sort((a, b) => {

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -49,11 +49,10 @@ namespace :symlink do
         next if File.symlink?(gemloc)
 
         # old one, move
-        if File.exists?(gemloc)
-          FileUtils.mv(gemloc, coreloc)
-        end
+        next unless File.exists?(gemloc)
 
-        # create the symlink
+        # move to core and symlink
+        FileUtils.mv(gemloc, coreloc)
         File.symlink(coreloc, gemloc)
       end
     end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -51,6 +51,8 @@ namespace :symlink do
         # old one, move
         next unless File.exists?(gemloc)
 
+        # FIXME: what if File.exists?(coreloc)
+
         # move to core and symlink
         FileUtils.mv(gemloc, coreloc)
         File.symlink(coreloc, gemloc)


### PR DESCRIPTION
So, we still have `node_modules` in gem dirs, and related attempts (https://github.com/ManageIQ/manageiq-ui-classic/pull/4435, https://github.com/ManageIQ/manageiq-ui-classic/pull/5196) each have problems.

At @Fryguy's suggestion, this is a simpler alternative - we keep the tools mostly happy by having symlinks in the gem dirs, and we keep the drives emptier by having the files mostly reside in `manageiq/vendor/engines/` (instead of under every copy of the gem).

The catch is: `yarn` fails miserably when `node_modules` is a symlink, and dies trying to create it.

So, presenting:

* `symlink:prepare` - creates a dir like `manageiq/vendor/engines/manageiq-ui-classic/` for each asset gem
* `symlink:link` - moves `yarn.lock` and `node_modules` to that directory, and creates symlinks from the gem dir
* `symlink:unlink` - moves the files back in the gem dir, removing the symlinks

(still TODO: a bunch of FIXMEs in the code, including fixing `pathToEngine` in `RailsEnginesPlugin`)
(and probably enable only for gems marked as `development_gem?`, to prevent issues with running `yarn` manually)
TODOTODO: make doubly sure this is not a specific version of yarn, or something like that
