### PR TITLE
Add severity to Alerts

### DIFF
--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -32,6 +32,23 @@
             .col-md-8
               %p.form-control-static
                 = @alert.enabled ? _("Yes") : _("No")
+        .form-group
+          %label.control-label.col-md-2
+            = _("Severity")
+          - if @edit
+            .col-md-8
+              - options = [[_("<Choose>"), nil]]
+              - controller.class::SEVERITIES.each { |key, value| options.push([_(value), key]) }
+              = select_tag('miq_alert_severity',
+                options_for_select(options, @edit[:new][:severity]),
+                :class => "selectpicker")
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('miq_alert_severity', '#{url}', {beforeSend: true, complete: true})
+          - else
+            .col-md-8
+              %p.form-control-static
+                = _(controller.class::SEVERITIES[@alert.severity])
         -# Based on (model)
         .form-group
           %label.control-label.col-md-2

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -20,6 +20,9 @@ class GtlFormatter
         "image?" => :cloud_manager_template_format,
       }),
       "MiqSchedule" => :timezone, # all fields have same specific format
+      "MiqAlert"    => {
+        "severity" => :alert_severity_format,
+      },
       "OpenscapRuleResult" => {
         "result"   => :result_format,
         "severity" => :severity_format,
@@ -103,5 +106,9 @@ class GtlFormatter
              "label label-low-severity center-block"
            end
     [value.titleize, span]
+  end
+
+  def self.alert_severity_format(value)
+    [_(MiqPolicyController::Alerts::SEVERITIES[value]), nil]
   end
 end

--- a/product/views/MiqAlert.yaml
+++ b/product/views/MiqAlert.yaml
@@ -27,6 +27,7 @@ cols:
 - notify_snmp
 - notify_evm_event
 - notify_automate
+- severity
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -41,6 +42,7 @@ col_order:
 - notify_snmp
 - notify_evm_event
 - notify_automate
+- severity
 
 # Column titles, in order
 headers:
@@ -52,6 +54,7 @@ headers:
 - SNMP
 - Event on Timeline
 - Management Event Raised
+- Severity
 
 # Condition(s) string for the SQL query
 conditions:

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -136,7 +136,8 @@ describe MiqPolicyController do
           :miq_alert,
           :db         => "Host",
           :options    => {:notifications => {:email => {:to => ["fred@test.com"]}}},
-          :expression => expression
+          :expression => expression,
+          :severity   => 'info'
         )
         edit = {
           :new => {
@@ -159,6 +160,7 @@ describe MiqPolicyController do
             :name       => "New Name",
             :expression => {:eval_method => nil},
             :db         => "ContainerNode",
+            :severity   => 'info'
           }
         }
         controller.instance_variable_set(:@edit, edit)
@@ -171,7 +173,8 @@ describe MiqPolicyController do
           FactoryBot.create(:miq_alert,
                              :expression         => {:eval_method => 'nothing'},
                              :options            => {:notifications => {:delay_next_evaluation => 3600, :evm_event => {}}},
-                             :responds_to_events => '_hourly_timer_')
+                             :responds_to_events => '_hourly_timer_',
+                             :severity           => 'info')
         end
         let(:edit) { {:new => {:db => 'ContainerNode', :expression => {:eval_method => 'nothing'}}} }
 

--- a/spec/views/miq_policy/_alert_details.html.haml_spec.rb
+++ b/spec/views/miq_policy/_alert_details.html.haml_spec.rb
@@ -1,6 +1,7 @@
 describe "miq_policy/_alert_details.html.haml" do
   before do
     @alert = FactoryBot.create(:miq_alert)
+    ActionView::TestCase::TestController::SEVERITIES = MiqPolicyController::SEVERITIES
     exp = {:eval_method => 'nothing', :mode => 'internal', :options => {}}
     allow(@alert).to receive(:expression).and_return(exp)
     set_controller_for_view("miq_policy")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653427

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2280 (merged) and https://github.com/ManageIQ/manageiq-ui-classic/pull/3075 (merged)

Go to: Control -> Explorer -> Alerts

Before:
<img width="886" alt="screen shot 2017-12-15 at 12 29 10 pm" src="https://user-images.githubusercontent.com/9210860/34040358-9c906b90-e193-11e7-8755-b64e99b86151.png">
<img width="382" alt="screen shot 2017-12-15 at 12 29 20 pm" src="https://user-images.githubusercontent.com/9210860/34040357-9c795770-e193-11e7-8ddf-d8a7cb807a7f.png">
<img width="763" alt="screen shot 2017-12-15 at 12 29 36 pm" src="https://user-images.githubusercontent.com/9210860/34040356-9c60aed2-e193-11e7-93d6-495215ea915f.png">

After:
<img width="897" alt="screen shot 2017-10-03 at 4 13 19 pm" src="https://user-images.githubusercontent.com/9210860/31129780-e0164a5a-a855-11e7-8586-ca4014e781e8.png">

<img width="897" alt="screen shot 2017-10-03 at 4 13 19 pm" src="https://user-images.githubusercontent.com/9210860/54208831-eeb76100-44dc-11e9-85b2-38d6e108ed29.png">


![image](https://user-images.githubusercontent.com/9210860/54208658-9d0ed680-44dc-11e9-97ef-6e447ba6d914.png)


@miq-bot add_label hammer/no, enhancement, control