### PR TITLE
Automate import service fix.

### DIFF
--- a/app/services/automate_import_service.rb
+++ b/app/services/automate_import_service.rb
@@ -23,7 +23,7 @@ class AutomateImportService
       }
       ae_import = MiqAeImport.new(domain_name_to_import_from, import_options)
 
-      namespace_list = namespace_or_class_list.select do |namespace_or_class|
+      namespace_list = namespace_or_class_list.reject do |namespace_or_class|
         namespace_or_class.match(/\.class/)
       end
 


### PR DESCRIPTION
Description
-------------------------------
Fixing the broken datastore import inside the automate import service from #4912. 

**before:** Domain was imported without selected namespaces.
**after:**  Domain is imported with all selected namespaces.