### PR TITLE
Don't display too many tree nodes

### DIFF
--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -6,14 +6,18 @@
       = miq_accordion_panel(accord[:title], selected == accord, accord[:container]) do
         -# Set the first tree to be rendered if there is a mismatch with the name/type
         - tree = @trees.find(-> { @trees.first }) { |t| t.type == accord[:name].to_sym  }
-        %miq-tree-view{:name       => tree.name,
-                       :data       => "vm.data['#{tree.name}']",
-                       :reselect   => tree.locals_for_render[:allow_reselect],
-                       "ng-init"   => "vm.initData('#{tree.name}', #{tree.locals_for_render[:bs_tree]}, '#{tree.locals_for_render[:select_node]}')",
-                       'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
-                       'selected'  => "vm.selectedNodes['#{tree.name}']",
-                       'persist'   => 'key',
-                       'lazy-load' => "(vm.lazyLoad(node, '#{tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}
+        - if tree.locals_for_render[:bs_tree].length > 200_000
+          = "Treeview not available for #{tree.locals_for_render[:bs_tree].length} nodes"
+        - else
+          %miq-tree-view{:name       => tree.name,
+                         :data       => "vm.data['#{tree.name}']",
+                         :reselect   => tree.locals_for_render[:allow_reselect],
+                         "ng-init"   => "vm.initData('#{tree.name}', #{tree.locals_for_render[:bs_tree]}, '#{tree.locals_for_render[:select_node]}')",
+                         'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
+                         'selected'  => "vm.selectedNodes['#{tree.name}']",
+                         'persist'   => 'key',
+                         'lazy-load' => "(vm.lazyLoad(node, '#{tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}
+
   :javascript
     miq_bootstrap('#accordion', 'ManageIQ.treeView');
     $('#accordion').on('show.bs.collapse', miqAccordSelect);


### PR DESCRIPTION
When the number of nodes in the tree view gets significantly large, windows chrome will not be able to display the page.

https://bugzilla.redhat.com/show_bug.cgi?id=1686433

This is not an optimal solution. The number of nodes of 20,000 is arbitrary and functionality is lost by hiding the tree. On the other hand, it allows the page to work.

We need to work with the UX team to 

Thanks @skateman for helping me narrow down this solution

before

spinner waiting - until apache times out.

after
<img width="542" alt="CFME: Services 2019-03-12-whc75" src="https://user-images.githubusercontent.com/1930/54211027-f49a4b80-44b6-11e9-9f77-dd8f4c4e19f5.png">
