### PR TITLE
Clean up the build_ae_tree method used in automate/catalogs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -614,7 +614,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Build a tree for automate copy or catalog entrypoint selection
-  def build_ae_tree(type, name)
+  def build_ae_tree(selectable)
     # build the ae tree to show the tree select box for entry point
     if x_active_tree == :automate_tree && @edit && @edit[:new][:fqname]
       nodes = @edit[:new][:fqname].split("/")
@@ -639,7 +639,7 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    @automate_tree = TreeBuilderAutomate.new(name, type, @sb)
+    @automate_tree = TreeBuilderAutomate.new(:automate_tree, :automate, @sb, :selectable => selectable)
   end
 
   # Build an audit object when configuration is changed in configuration and ops controllers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -613,8 +613,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Build a Catalog Items explorer tree
-  def build_ae_tree(type = :ae, name = :ae_tree)
+  # Build a tree for automate copy or catalog entrypoint selection
+  def build_ae_tree(type, name)
     # build the ae tree to show the tree select box for entry point
     if x_active_tree == :automate_tree && @edit && @edit[:new][:fqname]
       nodes = @edit[:new][:fqname].split("/")
@@ -639,11 +639,7 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    if name == :ae_tree
-      TreeBuilderAeClass.new(name, type, @sb)
-    else
-      @automate_tree = TreeBuilderAutomate.new(name, type, @sb)
-    end
+    @automate_tree = TreeBuilderAutomate.new(name, type, @sb)
   end
 
   # Build an audit object when configuration is changed in configuration and ops controllers

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -135,7 +135,7 @@ class CatalogController < ApplicationController
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
     # Build Catalog Items tree unless @edit[:ae_tree_select]
-    build_ae_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
+    build_ae_tree(MiqAeInstance) if params[:display] || params[:template_id] || params[:manager_id]
     if params[:st_prov_type] # build request screen for selected item type
       @_params[:org_controller] = "service_template"
       if ansible_playbook?
@@ -371,7 +371,7 @@ class CatalogController < ApplicationController
     default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_ae_tree(MiqAeInstance) # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
       page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
@@ -440,7 +440,7 @@ class CatalogController < ApplicationController
 
     # if resource has been deleted from group, rearrange groups incase group is now empty.
     rearrange_groups_array
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_ae_tree(MiqAeInstance) # Build Catalog Items tree
     changed = (@edit[:new] != @edit[:current])
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     render :update do |page|
@@ -507,7 +507,7 @@ class CatalogController < ApplicationController
     @edit = session[:edit]
     @edit[:new][params[:typ]] = nil
     @edit[:new][ae_tree_key] = ''
-    # build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
+    # build_ae_tree(MiqAeInstance) # Build Catalog Items tree unless @edit[:ae_tree_select]
     render :update do |page|
       page << javascript_prologue
       @changed = (@edit[:new] != @edit[:current])
@@ -1316,7 +1316,7 @@ class CatalogController < ApplicationController
                        else
                          _("Editing Service Catalog Item \"%{name}\"") % {:name => @record.name}
                        end
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_ae_tree(MiqAeInstance) # Build Catalog Items tree
   end
 
   def st_set_form_vars

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -282,7 +282,8 @@ class MiqAeClassController < ApplicationController
       :add_nodes       => add_nodes,
     )
 
-    reload_trees_by_presenter(presenter, [build_ae_tree]) if replace_trees.present?
+    # Rebuild the left-side explorer tree if it needs replacing
+    reload_trees_by_presenter(presenter, [TreeBuilderAeClass.new(:ae, :ae_tree, @sb)]) if replace_trees.present?
 
     if @sb[:action] == "miq_ae_field_seq"
       presenter.update(:class_fields_div, r[:partial => "fields_seq_form"])

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1615,7 +1615,7 @@ class MiqAeClassController < ApplicationController
   def form_copy_objects_field_changed
     return unless load_edit("copy_objects__#{params[:id]}", "replace_cell__explorer")
     copy_objects_get_form_vars
-    build_ae_tree(:automate, :automate_tree)
+    build_ae_tree(MiqAeNamespace)
     @changed = (@edit[:new] != @edit[:current])
     @changed = @edit[:new][:override_source] if @edit[:new][:namespace].nil?
     render :update do |page|
@@ -1843,7 +1843,7 @@ class MiqAeClassController < ApplicationController
     if params[:button] == "reset"
       add_flash(_("All changes have been reset"), :warning)
     end
-    build_ae_tree(:automate, :automate_tree)
+    build_ae_tree(MiqAeNamespace)
     replace_right_cell
   end
 

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -14,7 +14,7 @@ module AutomateTreeHelper
   private :submit_embedded_method
 
   def at_tree_select_toggle(edit_key)
-    build_ae_tree(:automate, :automate_tree)
+    build_ae_tree(MiqAeNamespace)
     render :update do |page|
       page << javascript_prologue
       tree_close = proc do

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAeClass < TreeBuilder
-  has_kids_for MiqAeClass, %i(x_get_tree_class_kids type)
-  has_kids_for MiqAeNamespace, %i(x_get_tree_ns_kids type)
+  has_kids_for MiqAeClass, [:x_get_tree_class_kids]
+  has_kids_for MiqAeNamespace, [:x_get_tree_ns_kids]
 
   private
 
@@ -30,29 +30,14 @@ class TreeBuilderAeClass < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_class_kids(object, count_only, type)
+  def x_get_tree_class_kids(object, count_only)
     instances = count_only_or_objects(count_only, object.ae_instances, %i(display_name name))
     # show methods in automate explorer tree
-    if type == :ae # FIXME: is this ever false?
-      methods = count_only_or_objects(count_only, object.ae_methods, %i(display_name name))
-      instances + methods
-    else
-      instances
-    end
+    methods = count_only_or_objects(count_only, object.ae_methods, %i(display_name name))
+    instances + methods
   end
 
-  def x_get_tree_ns_kids(object, count_only, type)
-    if type == :automate
-      if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
-        open_node("aen-#{object.id}")
-        open_node("aen-#{object.ae_namespaces.first.id}")
-      end
-
-      if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
-        open_node("aen-#{object.id}")
-        open_node("aec-#{object.ae_classes.first.id}")
-      end
-    end
+  def x_get_tree_ns_kids(object, count_only)
     objects = filter_ae_objects(object.ae_namespaces)
     unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = filter_ae_objects(object.ae_classes)

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -5,16 +5,16 @@ class TreeBuilderAutomate < TreeBuilderAeClass
 
   def initialize(name, type, sandbox, build = true, **params)
     @controller = params[:controller]
+    @selectable = params[:selectable]
     super(name, type, sandbox, build)
   end
 
   def override(node, object, _pid, _options)
-    if @type == 'catalog'
+    if @selectable
       # Only the instance items should be clickable when selecting a catalog item entry point
-      node[:selectable] = false unless object.kind_of?(MiqAeInstance) # catalog
-    elsif object.kind_of?(MiqAeNamespace) && object.domain?
+      node[:selectable] = false unless object.kind_of?(@selectable)
       # Only the namespace items should be clickable when copying a class or instance
-      node[:selectable] = false
+      node[:selectable] = false if @selectable == MiqAeNamespace && !object.domain?
     end
   end
 

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -4,7 +4,6 @@ class TreeBuilderAutomate < TreeBuilderAeClass
   end
 
   def initialize(name, type, sandbox, build = true, **params)
-    @controller = params[:controller]
     @selectable = params[:selectable]
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -33,4 +33,22 @@ class TreeBuilderAutomate < TreeBuilderAeClass
                   :base_id      => "root",
                   :highlighting => true)
   end
+
+  def x_get_tree_class_kids(object, count_only)
+    count_only_or_objects(count_only, object.ae_instances, %i(display_name name))
+  end
+
+  def x_get_tree_ns_kids(object, count_only)
+    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aen-#{object.ae_namespaces.first.id}")
+    end
+
+    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aec-#{object.ae_classes.first.id}")
+    end
+
+    super(object, count_only)
+  end
 end


### PR DESCRIPTION
This method was being used for creating a non-explorer tree for:
* automate entrypoint selection in service catalog items
* copying instances or classes under the automate explorer
* ~~building the left-side tree for reloading after adding/editing/deleting something in automate~~

After crossing out the 3rd point (as it was a total nonsense) I wanted to stop using the tree type to distinguish between what nodes are selectable. For that purrpose I added a new param for the `TreeBuilderAutomate` to set the selectable node type. So from now on this is being used as a parameter in `build_ae_tree` which makes way more sense...

Also removed a rogue instance variable :scissors: :toilet: :fire: 

@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @martinpovolny
@miq-bot add_label refactoring, trees, hammer/no