### PR TITLE
Fix 'Tried to load angular more than once'

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -130,6 +130,7 @@ module.exports = {
       'react': resolve(dirname(__filename), '../../node_modules', 'react'),
       'bootstrap-select': '@pf3/select',  // never use vanilla bootstrap-select
       'moment': resolve(dirname(__filename), '../../node_modules', 'moment'), // fix moment-strftime peerDependency issue
+      'angular': resolve(dirname(__filename), '../../node_modules', 'angular'),  // fix for "Tried to load angular more than once"
     },
     extensions: settings.extensions,
     modules: [],


### PR DESCRIPTION
comes from packages using `dependencies` and getting their own copy of angular to load,

the change forces the topmost angular for all packages,
thus angular loads only once

Cc @kbrock 