### PR TITLE
Swap ng-if with ng-show on VMRC Console in ems common.

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -312,7 +312,7 @@
                                               :basic_info_needed      => true}
       = miq_tab_content('console', 'default') do
         .form-group
-          .col-md-12.col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'vmwarews'"}
+          .col-md-12.col-md-12{"ng-show" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'vmwarews'"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1543007

There was an issue with 'linering' validation status after tab change from RHV provider to VMWare provider.

Validation was enforced on VMRC Console tab event thought its required. After input change the validation corrected it self.

I've erplaced `ng-if` with `ng-show` which will place the tab always into DOM (but hide it) ainstead of completely remove it from DOM(like ng-if does). This will initialize the tab correctly and prevents lingering  validation.

I am still not sure what was causing the error but after 3 hours of debugging this is the only thing that actually worked.