### PR TITLE
Hide services from the Services tree as its redundant and slow

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -4,7 +4,7 @@ class TreeBuilderServices < TreeBuilder
   private
 
   def tree_init_options
-    {:add_root => false, :lazy => true}
+    {:add_root => false, :lazy => true, :allow_reselect => true}
   end
 
   def root_options
@@ -40,18 +40,8 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    case object[:id]
-    when 'my', 'global'
-      # Get My Filters and Global Filters
-      count_only_or_objects(count_only, x_get_search_results(object))
-    when 'asrv', 'rsrv'
-      retired = object[:id] != 'asrv'
-      services = Rbac.filtered(Service.where(:retired => retired, :display => true))
-      return sevices.size if count_only
-
-      MiqPreloader.preload(services.to_a, :picture)
-      Service.arrange_nodes(services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
-    end
+    # Get My Filters and Global Filters
+    count_only_or_objects(count_only, x_get_search_results(object)) if %w(my global).include?(object[:id])
   end
 
   def x_get_search_results(object)

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -13,21 +13,6 @@ describe TreeBuilderServices do
       a_hash_including(:id => 'global'),
       a_hash_including(:id => 'my')
     ]
-
-    active_nodes = kid_nodes(root_nodes[0])
-    retired_nodes = kid_nodes(root_nodes[1])
-    expect(active_nodes).to eq(
-      @service => {
-        @service_c1 => {
-          @service_c11 => {},
-          @service_c12 => {
-            @service_c121 => {}
-          }
-        },
-        @service_c2 => {}
-      }
-    )
-    expect(retired_nodes).to eq(@service_c3 => {})
   end
 
   private


### PR DESCRIPTION
The `Services - My Services` screen can be super slow if having too many services. The left side tree always displays all the services, but the right side GTL has pagination and search. So the nodes on the left side can cause a performance problem and they are also redundant.

I'm doing basically the same thing as we did with the VMs and Templates, but not making it optional. The reason for this is my plan to replace this and other "flat" trees with similar redundancy with a listnav. Having listnavs instead of trees is way easier to maintain or rewrite if we want to get rid of the explorers.

If @kbrock says so, this PR replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/5328
I already talked with @terezanovotna about the listnavs, and she said OK, but adding the UX review label. This PR can be considered as a (backportable) first step in this change.

**Before:**
![Screenshot from 2019-03-13 12-11-02](https://user-images.githubusercontent.com/649130/54277338-de13f300-458f-11e9-8472-ca6a7a58b555.png)

**After:**
![Screenshot from 2019-03-13 12-10-13](https://user-images.githubusercontent.com/649130/54277343-e2d8a700-458f-11e9-910f-456181829821.png)

@miq-bot add_label ux/review, trees, services, bug
@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @martinpovolny 