### PR TITLE
Lock enzyme adapter version to stop failing travis.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "duplicate-package-checker-webpack-plugin": "~3.0.0",
     "enhanced-resolve": "~4.0.0",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-adapter-react-16": "~1.10.0",
     "enzyme-to-json": "^3.3.4",
     "eslint": "~5.9.0",
     "eslint-config-airbnb": "~17.1.0",


### PR DESCRIPTION
Currently travis is failing  on jest specs. Caused by: https://github.com/airbnb/enzyme/issues/2046

I've temporarily locked version of enzyme-adapter-react-16 to latest working.

example of failing job: https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/505693381