### PR TITLE
Drop the unnecessary accords instance variable from some controllers

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -100,8 +100,6 @@ module ApplicationController::Automate
 
   # Reset or first time in
   def resolve_button_reset_or_none
-    @accords = [{:name => "resolve", :title => _("Options"), :container => "resolve_form_div"}]
-
     if params[:simulate] == "simulate"
       @resolve = session[:resolve]
       @resolve[:ae_result] = nil

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -46,7 +46,6 @@ module MiqPolicyController::Rsop
       javascript_redirect(:action => 'rsop')
     else # No params, first time in
       @breadcrumbs = []
-      @accords = [{:name => "rsop", :title => _("Options"), :container => "rsop_options_div"}]
       session[:changed] = false
       @sb[:rsop] ||= {} # Leave exising values
       rsop_put_objects_in_sb(find_filtered(ExtManagementSystem), :emss)

--- a/app/controllers/planning_controller.rb
+++ b/app/controllers/planning_controller.rb
@@ -8,7 +8,6 @@ class PlanningController < ApplicationController
 
   def index
     @explorer = true
-    @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
     self.x_active_tree = nil
     @sb[:active_tab] = "summary"
@@ -20,7 +19,6 @@ class PlanningController < ApplicationController
 
   def plan
     @explorer = true
-    @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
     self.x_active_tree = nil
     @sb[:active_tab] = "summary"
@@ -151,7 +149,6 @@ class PlanningController < ApplicationController
 
   def reset
     @explorer = true
-    @accords = [{:name => "planning", :title => _("Planning Options"), :container => "planning_options_accord"}]
 
     self.x_active_tree = nil
     @sb[:active_tab] = "summary"


### PR DESCRIPTION
There were some controllers that were setting the `@accords` instance variable for screens that not even have accordions. These are unnecessary as the only place we iterate through the `@accords` is when we're rendering left side explorer trees. Anyway, we should not set the variable explicitly as it is being generated from the `features` using `build_accordions_and_trees`.

@miq-bot assign @mzazrivec 
@miq-bot add_label cleanup, technical debt, trees, explorers, hammer/no