### PR TITLE
Add safeguard for VMs without ext_management_system

### DIFF
--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -70,7 +70,7 @@ class NetworkTopologyService < TopologyService
     data[:status]       = entity_status(entity)
     data[:display_kind] = entity_display_type(entity)
 
-    if entity.kind_of?(Host) || entity.kind_of?(Vm)
+    if (entity.kind_of?(Host) || entity.kind_of?(Vm)) && entity.try(:ems_id)
       data[:provider] = entity.ext_management_system.name
     end
 


### PR DESCRIPTION
If VM doesn't have ExtManagemntSystem UI blows up, so I have added safeguard for that. However I am not sure if it should be possible to get into such state.


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1684649

Steps for Testing/QA [Optional]
-------------------------------
Have a VM that doesn't  belong to ExtManagemntSystem
Go to Network -> Topology
