### PR TITLE
Add Cancel button to policy simulation page

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -119,6 +119,12 @@ module ApplicationController::PolicySupport
     replace_main_div(:partial => "layouts/policy_sim")
   end
 
+  # Cancel policy simulation, add flash message and redirect
+  def policy_sim_cancel
+    flash_to_session(_("Edit policy simulation was cancelled by the user"))
+    redirect_to(previous_breadcrumb_url)
+  end
+
   def profile_build
     @catinfo ||= {}
     session[:assignments] = session[:protect_item].get_policies

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -48,3 +48,15 @@
     - session[:edit][:policy_sim] = @policy_sim
     = render :partial => "layouts/gtl",
              :locals  => {:view => @pol_view}
+
+- if params[:action] == 'policy_sim' && !@explorer
+  %table{:width => "100%"}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = link_to(_('Cancel'),
+                    {:action => 'policy_sim_cancel'},
+                     :class  => 'btn btn-default',
+                     :alt    => t = _('Cancel Changes'),
+                     :title  => t,
+                     :method => :post)

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -172,7 +172,7 @@
           :class   => "btn btn-default",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item   => 0)}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:action => "x_history", :item => 0)}');")
       - else
         -# export_button
         = link_to(_("Export"),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2967,6 +2967,7 @@ Rails.application.routes.draw do
         name_changed
         policy_sim
         policy_sim_add
+        policy_sim_cancel
         policy_sim_remove
         provision
         reconfigure

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -17,4 +17,24 @@ describe ApplicationController do
       controller.send(:assign_policies, Host)
     end
   end
+
+  describe '#policy_sim_cancel' do
+    before do
+      allow(controller).to receive(:flash_to_session).and_call_original
+      allow(controller).to receive(:previous_breadcrumb_url)
+      allow(controller).to receive(:redirect_to)
+    end
+
+    it 'calls redirect_to method' do
+      expect(controller).to receive(:redirect_to)
+      controller.send(:policy_sim_cancel)
+    end
+
+    it 'adds the message to flash array' do
+      flash_msg = 'Edit policy simulation was cancelled by the user'
+      expect(controller).to receive(:flash_to_session).with(flash_msg)
+      controller.send(:policy_sim_cancel)
+      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => flash_msg, :level => :success}])
+    end
+  end
 end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1659088
https://bugzilla.redhat.com/show_bug.cgi?id=1686617

**What:**
Add the missing button to the page for policy simulation of VMs/Instances which were displayed as a nested list (displayed from Relationships table of for example selected infra/cloud provider).

**Steps to reproduce:** (one of possible scenarios)
1. Go to _Compute > Infra > Providers_ and click on some provider
2. Display VMs/Templates from _Relationships_ table (or click on VMs/Templates from dashboard)
2. Choose some of the items, check their checkboxes (at least one item)
3. Choose _Policy > Policy Simulation_
=> no _Cancel_ button, not able to cancel policy simulation!

**Note:**
Cancel button is present and not missing, if we access VMs/Instances directly, thru _Compute > Infra > VMs_ or _Compute > Clouds > Instances_.

TODO:
- test this PR in more places where we can access VMs, Instances, Images - DONE
- display flash message about canceling policy sim - already fixed for non explorer screens (but it still does not appear always, probably some timing issue, but still better than before), still needs to be fixed for explorer ones (for example _Compute > Infra > VMs_ )
  - probably this should be solved by a separate PR
- specs - DONE

**Where I tested policy simulation and displaying Cancel button with this PR (and it works there):**
- _Compute > Infra > Providers >_ clicking on some provider > displaying VMs/Templates from _Relationships_ table (or clicking on VMs/Templates from dashboard)
- _Compute > Infra > Clusters / Deployment Roles >_ clicking on some cluster > displaying VMs/Templates from _Relationships_ table
- _Compute > Infra > VMs_ (works as usual)
- _Compute > Clouds > Providers_ > clicking on some provider > displaying Instances/Images from _Relationships_ table (or clicking on Instances/Images from dashboard) 
- _Compute > Clouds > Instances_ (works as usual)
- the same way for VMs, Instances, Images, Templates displayed from _Relationships_ table of _Availability zones, Host Aggregates, Tenants, Flavors, Stacks, Key Pairs, Clusters / Deployment Roles, Hosts / Nodes, Resource Pools, Datastores_

---

**Before:**
![polsim_before](https://user-images.githubusercontent.com/13417815/54365092-7d0f1c80-466e-11e9-8ffe-aaab3d5280e6.png)

**After:**
![polsim_after](https://user-images.githubusercontent.com/13417815/54376802-2280bb00-4684-11e9-8f93-43fe66aca191.png)
Displaying flash message for non explorer screens (not always):
![polsim_flash](https://user-images.githubusercontent.com/13417815/54427010-8dc89c80-4719-11e9-872d-d095ea53b1ff.png)

