### PR TITLE
Display IDs of VMs,Reports,Result,... 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1328,11 +1328,16 @@ class ApplicationController < ActionController::Base
                "%#{stxt}%"
              end
 
+      id = @search_text if @search_text =~ /^\d+$/
       return (
-        if ::Settings.server.case_sensitive_name_search
-          ["#{view.db_class.table_name}.#{view.col_order.first} like ? escape '`'", stxt]
+        if id
+          ["#{view.db_class.table_name}.id = ?", id]
         else
-          ["lower(#{view.db_class.table_name}.#{view.col_order.first}) like ? escape '`'", stxt.downcase]
+          if ::Settings.server.case_sensitive_name_search
+            ["#{view.db_class.table_name}.#{view.col_order.first} like ? escape '`'", stxt]
+          else
+            ["lower(#{view.db_class.table_name}.#{view.col_order.first}) like ? escape '`'", stxt.downcase]
+          end
         end
       )
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1329,19 +1329,26 @@ class ApplicationController < ActionController::Base
              end
 
       id = @search_text if @search_text =~ /^\d+$/
-      return (
-        if id
-          ["#{view.db_class.table_name}.id = ?", id]
-        else
-          if ::Settings.server.case_sensitive_name_search
-            ["#{view.db_class.table_name}.#{view.col_order.first} like ? escape '`'", stxt]
-          else
-            ["lower(#{view.db_class.table_name}.#{view.col_order.first}) like ? escape '`'", stxt.downcase]
-          end
-        end
-      )
+      condition = [[]]
+      if id
+        add_to_search_condition(condition, "#{view.db_class.table_name}.id = ?", id)
+      end
+
+      if ::Settings.server.case_sensitive_name_search
+        add_to_search_condition(condition, "#{view.db_class.table_name}.#{view.col_order.first} like ? escape '`'", stxt)
+      else
+        add_to_search_condition(condition, "lower(#{view.db_class.table_name}.#{view.col_order.first}) like ? escape '`'", stxt.downcase)
+      end
+      condition[0] = condition[0].join(" OR ")
+      return condition.flatten
     end
     nil
+  end
+
+  def add_to_search_condition(condition, query, values)
+    condition[0] << query unless query.nil?
+    condition << values unless values.nil?
+    condition
   end
 
   def perpage_key(dbname)

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -25,11 +25,15 @@ module VmHelper::TextualSummary
     TextualGroup.new(
       _("Properties"),
       %i(
-        name region server description hostname ipaddress mac_address custom_1 container host_platform
+        id name region server description hostname ipaddress mac_address custom_1 container host_platform
         tools_status load_balancer_health_check_state osinfo devices cpu_affinity snapshots
         advanced_settings resources guid storage_profile
       )
     )
+  end
+
+  def textual_id
+    { :label => _("ID"), :value => @record.id }
   end
 
   def textual_group_lifecycle

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -13,6 +13,13 @@
   - if @edit
     = render :partial => "ldap_auth_users"
   .form-horizontal
+    - unless @edit
+      .form-group
+        %label.col-md-2.control-label
+          = _("ID")
+        .col-md-8
+          %p.form-control-static
+            = h(@group.id)
     .form-group
       %label.col-md-2.control-label
         = _("Description")

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -9,7 +9,7 @@
       .form-horizontal
         - unless @edit
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-4.control-label
               = _("ID")
             .col-md-8
               %p.form-control-static

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -8,12 +8,12 @@
         = _("Role Information")
       .form-horizontal
         - unless @edit
-           .form-group
-             %label.col-md-2.control-label
-               = _("ID")
-             .col-md-8
-               %p.form-control-static
-                 = h(@role.id)
+          .form-group
+            %label.col-md-2.control-label
+              = _("ID")
+            .col-md-8
+              %p.form-control-static
+                = h(@role.id)
         .form-group
           %label.col-md-4.control-label
             = _("Name")

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -7,6 +7,13 @@
       %h3
         = _("Role Information")
       .form-horizontal
+        - unless @edit
+           .form-group
+             %label.col-md-2.control-label
+               = _("ID")
+             .col-md-8
+               %p.form-control-static
+                 = h(@role.id)
         .form-group
           %label.col-md-4.control-label
             = _("Name")

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -13,6 +13,13 @@
   %h3
     = _("User Information")
   .form-horizontal
+    - unless @edit
+      .form-group
+        %label.col-md-2.control-label
+          = _("ID")
+        .col-md-8
+          %p.form-control-static
+            = h(@record.id
     .form-group
       %label.col-md-2.control-label
         = _("Full Name")

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -19,7 +19,7 @@
           = _("ID")
         .col-md-8
           %p.form-control-static
-            = h(@record.id
+            = h(@record.id)
     .form-group
       %label.col-md-2.control-label
         = _("Full Name")

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -3,6 +3,10 @@
   - if @sb[:miq_report_id] && @miq_report
     .form-horizontal.static
       .form-group
+        %label.control-label.col-md-2= _('ID')
+        .col-md-10
+          %p.form-control-static= @miq_report.id    
+      .form-group
         %label.control-label.col-md-2= _('Title')
         .col-md-10
           %p.form-control-static= @miq_report.title

--- a/product/views/MiqReportResult-all.yaml
+++ b/product/views/MiqReportResult-all.yaml
@@ -19,6 +19,7 @@ db: MiqReportResult
 
 # Columns to fetch from the main table
 cols:
+- id
 - created_on
 - last_run_on
 - name
@@ -35,6 +36,7 @@ include:
 
 # Order of columns (from all tables)
 col_order:
+- id
 - created_on
 - last_run_on
 - name
@@ -45,6 +47,7 @@ col_order:
 
 # Column titles, in order
 headers:
+- ID
 - Queued At
 - Run At
 - Name

--- a/product/views/MiqReportResult.yaml
+++ b/product/views/MiqReportResult.yaml
@@ -19,6 +19,7 @@ db: MiqReportResult
 
 # Columns to fetch from the main table
 cols:
+- id
 - created_on
 - last_run_on
 - report_source
@@ -34,6 +35,7 @@ include:
 
 # Order of columns (from all tables)
 col_order:
+- id
 - created_on
 - last_run_on
 - report_source
@@ -43,6 +45,7 @@ col_order:
 
 # Column titles, in order
 headers:
+- ID
 - Queued At
 - Run At
 - Source

--- a/product/views/MiqWidget.yaml
+++ b/product/views/MiqWidget.yaml
@@ -19,6 +19,7 @@ db: MiqWidget
 
 # Columns to fetch from the main table
 cols:
+- id
 - queued_at
 - last_run_on
 - title
@@ -32,6 +33,7 @@ include:
 
 # Order of columns (from all tables)
 col_order:
+- id
 - queued_at
 - last_run_on
 - title
@@ -41,6 +43,7 @@ col_order:
 
 # Column titles, in order
 headers:
+- ID
 - Queued At
 - Run At
 - Title

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -11,6 +11,7 @@ describe VmHelper::TextualSummary do
   end
 
   include_examples "textual_group", "Properties", %i(
+    id
     name
     region
     server


### PR DESCRIPTION
Description of problem
When used with Service Now Portal, CFME is communicating over API with IDs of VMs, Reports, Report results, etc. When something is needed to be troubleshooted, or checked, the user needs also to go to the API and drill for the names. This makes troubleshooting efforts difficult and slow.

Actual results
No item IDs visible in the GUI.

Expected results
Item IDs visible in the GUI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638245

Additional info
BZ targets CloudForms 4.6 so if merge PR need to be backport to 4.6 as well

@martinpovolny opened up a new PR with changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/4791 with a fix for your comment https://github.com/ManageIQ/manageiq-ui-classic/pull/4791#discussion_r236382928
Please take a look.