### PR TITLE
[HAMMER] TreeBuilderServices - move allow_reselect to `set_locals_for_render`

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -7,13 +7,12 @@ class TreeBuilderServices < TreeBuilder
     {
       :leaf     => "Service",
       :add_root => false,
-      :allow_reselect => true
     }
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:autoload => true, :allow_reselect => true)
   end
 
   def root_options


### PR DESCRIPTION
before #5290, `allow_reselect` needs to live in `set_locals_for_render`, not `tree_init_options`

This fixes the hammer backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/5335 to do just that.

https://bugzilla.redhat.com/show_bug.cgi?id=1686433
