### PR TITLE
Add Enable/Disable button to Schedule summary page

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -241,7 +241,15 @@ module OpsController::Settings::Schedules
     add_flash(msg, :info, true) unless flash_errors?
     schedule_build_list
     settings_get_info("st")
-    replace_right_cell(:nodetype => "root")
+    if x_node == "xx-msc"
+      replace_right_cell(:nodetype => "root")
+    else
+      @selected_schedule = @record = schedules.first
+      if @selected_schedule.filter.kind_of?(MiqExpression)
+        @exp_table = exp_build_table(@selected_schedule.filter.exp)
+      end
+      replace_right_cell(:nodetype => x_node)
+    end
   end
 
   def schedule_enable

--- a/app/helpers/application_helper/toolbar/miq_report_schedule_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_schedule_center.rb
@@ -18,6 +18,18 @@ class ApplicationHelper::Toolbar::MiqReportScheduleCenter < ApplicationHelper::T
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed!")),
+        button(
+          :miq_report_schedule_enable,
+          'fa fa-check fa-lg',
+          t = N_('Enable this Schedule'),
+          t
+        ),
+        button(
+          :miq_report_schedule_disable,
+          'fa fa-ban fa-lg',
+          t = N_('Disable this Schedule'),
+          t
+        ),
         separator,
         button(
           :miq_report_schedule_run_now,

--- a/app/helpers/application_helper/toolbar/miq_schedule_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_schedule_center.rb
@@ -18,6 +18,18 @@ class ApplicationHelper::Toolbar::MiqScheduleCenter < ApplicationHelper::Toolbar
           t,
           :url_parms => "&refresh=y",
           :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed!")),
+        button(
+          :schedule_enable,
+          'fa fa-check fa-lg',
+          t = N_('Enable this Schedule'),
+          t
+        ),
+        button(
+          :schedule_disable,
+          'fa fa-ban fa-lg',
+          t = N_('Disable this Schedule'),
+          t
+        ),
         separator,
         button(
           :schedule_run_now,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559335

Go to:
- Configuration -> Settings -> Schedules -> click on one -> Configuration -> Enable/Disable this Schedule
- Cloud Intel -> Reports -> Schedules -> click on one -> Configuration -> Enable/Disable this Schedule

Before:

After:
![image](https://user-images.githubusercontent.com/9210860/54438322-bf039580-4736-11e9-84ee-421e9a9dcb10.png)


@miq-bot add_label wip, bug