### PR TITLE
Don't throw exception when template is not found in Provisioning

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -25,11 +25,12 @@ module ApplicationController::MiqRequestMethods
       refresh_divs = prov_get_form_vars # Get changed option, returns true if divs need refreshing
       build_grid if refresh_divs
       changed = (@edit[:new] != @edit[:current])
-      @record = if @edit[:new][:src_configured_system_ids].present?
-                  PhysicalServer.find(@edit[:new][:src_configured_system_ids].first)
-                elsif @edit[:new][:src_vm_id].first.present?
-                  MiqTemplate.find(@edit[:new][:src_vm_id].first)
-                end
+      @record =
+        if @edit[:new][:src_configured_system_ids].present?
+          PhysicalServer.where(:id => @edit[:new][:src_configured_system_ids].first).first
+        elsif @edit[:new][:src_vm_id].first.present?
+          MiqTemplate.where(:id => @edit[:new][:src_vm_id].first).first
+        end
       render :update do |page|
         page << javascript_prologue
         # Going thru all dialogs to see if model has set any of the dialog display to hide/ignore


### PR DESCRIPTION
In #3928 was added tooltip for Volume tab in provision form. However, this sometimes causes problems when Template is not found and breaks the form. Because Provision form is used for multiple usecases (Provision, Clone, Publish,...?) and it is not clear when it could fail I think safest solution is just wrap it in try-catch block. I am not very satisfied with this, but it fixes the issue and it doesn't add to much complexity.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1687946

Related PRs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/3928
https://github.com/ManageIQ/manageiq-ui-classic/pull/4511


Steps for Testing/QA [Optional]
-------------------------------
Try to Provision, Clone, Publish VM

ping @skateman 