### PR TITLE
Use supports_volume_resizing? to toggle the Volume size field

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -136,7 +136,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
+    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
@@ -189,7 +189,8 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     // can be resized on the fly).
     return vm.newRecord ||
       (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs' &&
-        vm.cloudVolumeModel.volume_type !== 'standard');
+        vm.cloudVolumeModel.volume_type !== 'standard') ||
+        vm.supportsVolumeResizing;
   };
 
   vm.awsBaseSnapshotChanged = function(baseSnapshotId) {
@@ -276,6 +277,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.availabilityZoneChoices = data.parent_manager.availability_zones;
     vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
     vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
+    vm.supportsVolumeResizing = data.supports_volume_resizing;
     if (vm.supportsCinderVolumeTypes) {
       vm.volumeTypes = data.parent_manager.cloud_volume_types;
     } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {


### PR DESCRIPTION
The Openstack and Amazon providers both theoretically support resizing volumes, but currently detection of this feature is done in the UI via a conditional on the class name of the provider. This PR allows the field to be enabled via feature detection.

Depends on https://github.com/ManageIQ/manageiq/pull/18560
See also ManageIQ/manageiq-providers-openstack#448