### PR TITLE
Reset data on form when user re-selects Assign To value

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -828,6 +828,11 @@ class ChargebackController < ApplicationController
     @edit[:new][:cblabel_key] = nil if params[:cbshow_typ]
     @edit[:new][:cblabel_key] = params[:cblabel_key].to_s if params[:cblabel_key]
 
+    # if Assign To has been changed back to previously saved value, reset all data on screen
+    if params[:cbshow_typ] && params[:cbshow_typ] == @edit[:current][:cbshow_typ]
+      cb_assign_set_form_vars
+    end
+
     if @edit[:new][:cbshow_typ].ends_with?("-tags")
       get_categories_all
       get_tags_all

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -779,6 +779,24 @@ describe ChargebackController do
     end
 
     context 'changing Assigned To, for assignments' do
+      before do
+        allow(controller).to receive(:x_node).and_return("xx-Storage")
+        @edit_new = assigns(:edit)[:new]
+      end
+
+      it 'sets/resets data based upon Assign To selection' do
+        post :cb_assign_field_changed, :params => {:cbshow_typ => 'storage'}
+
+        expect(@edit_new[:cbtag_cat]).to be(nil)
+        expect(@edit_new[:cblabel_key]).to be(nil)
+
+        post :cb_assign_field_changed, :params => {:cbshow_typ => 'storage-tags'}
+        expect(@edit_new[:cbtag_cat]).to eq(assigns(:edit)[:current][:cbtag_cat])
+        expect(@edit_new[:cblabel_key]).to eq(assigns(:edit)[:current][:cblabel_key])
+      end
+    end
+
+    context 'changing Assigned To, for assignments' do
       it 'hides buttons as no change has been made' do
         post :cb_assign_field_changed, :params => {:cbshow_typ => 'storage'}
         expect(response.body).to include("miqButtons('hide');")


### PR DESCRIPTION
Reset data on form when user re-selects Assign To value back to previously saved value

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1689218

@lpichler please review/test

