### PR TITLE
Remove unnecessary `:onclick => false` local from TreeBuilders

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -19,9 +19,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def set_locals_for_render
     super.merge!(
-      :oncheck    => "miqOnCheckGeneric",
-      :check_url  => "/miq_policy/alert_profile_assign_changed/",
-      :onclick    => false
+      :oncheck   => "miqOnCheckGeneric",
+      :check_url => "/miq_policy/alert_profile_assign_changed/"
     )
   end
 

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -48,7 +48,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
                            [nil, "/ops/rbac_group_field_changed/#{group_id}___"]
                          end
 
-    super.merge!(:oncheck => oncheck, :check_url => check_url, :onclick => false)
+    super.merge!(:oncheck => oncheck, :check_url => check_url)
   end
 
   def root_options

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -24,8 +24,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def set_locals_for_render
-    super.merge!(:onclick   => false,
-                 :oncheck   => 'miqOnCheckGeneric',
+    super.merge!(:oncheck   => 'miqOnCheckGeneric',
                  :check_url => '/ops/smartproxy_affinity_field_changed/')
   end
 

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -32,8 +32,7 @@ class TreeBuilderTags < TreeBuilder
 
   def set_locals_for_render
     super.merge!(:check_url => "/ops/rbac_group_field_changed/#{group_id}___",
-                 :oncheck   => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                 :onclick   => false)
+                 :oncheck   => @edit.nil? ? nil : "miqOnCheckUserFilters")
   end
 
   def root_options

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -76,8 +76,7 @@ describe TreeBuilderBelongsToHac do
 
   describe '#set_locals_for_render' do
     it 'sets locals correctly' do
-      expect(subject.send(:set_locals_for_render)).to include(:onclick   => false,
-                                                              :check_url => "/ops/rbac_group_field_changed/new___",
+      expect(subject.send(:set_locals_for_render)).to include(:check_url => "/ops/rbac_group_field_changed/new___",
                                                               :oncheck   => nil)
     end
   end

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -49,7 +49,6 @@ describe TreeBuilderBelongsToVat do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
       expect(locals).to include(:check_url => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
-                                :onclick   => false,
                                 :oncheck   => edit ? "miqOnCheckUserFilters" : nil)
     end
   end

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -47,7 +47,6 @@ describe TreeBuilderSmartproxyAffinity do
       locals = @smartproxy_affinity_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq('/ops/smartproxy_affinity_field_changed/')
-      expect(locals[:onclick]).to eq(false)
       expect(locals[:oncheck]).to eq('miqOnCheckGeneric')
       expect(locals[:three_checks]).to eq(true)
     end


### PR DESCRIPTION
Since #5304, there's no default `onclick` handler for treebuilders, therefore, overriding it to `false` is totally unnecessary.

@miq-bot add_label cleanup, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 