### PR TITLE
Drop the click_url from TreeBuilder locals for miqOnClickHostNet

### DIFF
--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -23,8 +23,7 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
+    super.merge!(:onclick => "miqOnClickHostNet")
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -15,8 +15,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
   end
 
   def set_locals_for_render
-    locals = super
-    locals.merge!(:click_url => "/vm/show/", :onclick => "miqOnClickHostNet")
+    super.merge!(:onclick => "miqOnClickHostNet")
   end
 
   def root_options


### PR DESCRIPTION
The `miqOnClickHostNet` function doesn't use the `click_url` local at all, so it is totally unnecessary to set it.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, trees, hammer/no