### PR TITLE
Unify onselect with oncheck across trees with checkboxes

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -208,9 +208,13 @@ function miqOnClickHostNet(id) {
 }
 
 // OnCheck handler for the belongs to drift/compare sections tree
-function miqOnCheckSections(_tree_name, key, checked, all_checked) {
-  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(key) + '&check=' + checked;
-  miqJqueryRequest(url, {data: {all_checked: all_checked}});
+function miqOnCheckSections(node, tree_name) {
+  var selectedKeys = miqTreeObject(tree_name).getChecked().map(function(n) {
+    return n.key;
+  });
+
+  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(node.key) + '&check=' + node.state.checked;
+  miqJqueryRequest(url, {data: {all_checked: selectedKeys}});
   return true;
 }
 
@@ -297,8 +301,8 @@ function miqCheckCUAll(cb, treename) {
 }
 
 // OnCheck handler for the C&U collection trees
-function miqOnCheckCUFilters(tree_name, key, checked) {
-  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(key) + '&check=' + encodeURIComponent(checked) + '&tree_name=' + encodeURIComponent(tree_name);
+function miqOnCheckCUFilters(node, tree_name) {
+  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(node.key) + '&check=' + encodeURIComponent(node.state.checked) + '&tree_name=' + encodeURIComponent(tree_name);
   miqJqueryRequest(url);
   return true;
 }
@@ -430,10 +434,7 @@ function miqTreeOnNodeChecked(options, node) {
   if (options.oncheck) {
     miqTreeEventSafeEval(options.oncheck)(node, options.tree_name);
   } else if (options.onselect) {
-    var selectedKeys = miqTreeObject(options.tree_name).getChecked().map(function(node) {
-      return node.key;
-    });
-    miqTreeEventSafeEval(options.onselect)(options.tree_name, node.key, node.state.checked, selectedKeys);
+    miqTreeEventSafeEval(options.onselect)(node, options.tree_name);
   }
 }
 

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -433,8 +433,6 @@ function miqTreeEventSafeEval(func) {
 function miqTreeOnNodeChecked(options, node) {
   if (options.oncheck) {
     miqTreeEventSafeEval(options.oncheck)(node, options.tree_name);
-  } else if (options.onselect) {
-    miqTreeEventSafeEval(options.onselect)(node, options.tree_name);
   }
 }
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -64,7 +64,7 @@ class TreeBuilder
   # * features - used by the RBAC features tree only
   # * editable - used by the RBAC features tree only
   # * node_id_prefix - used by the RBAC features tree only
-  # * allow_reselect - fire the onselect event if a selected node is reselected
+  # * allow_reselect - fire the onclick event if a selected node is reselected
   # * highlight_changes - highlight the changes in checkboxes differing from initial
   # * three_checks - hierarchically check the parent if all children are checked
   # * post_check - some kind of post-processing hierarchical checks

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -20,7 +20,7 @@ class TreeBuilderClusters < TreeBuilder
   end
 
   def set_locals_for_render
-    super.merge!(:onselect => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
+    super.merge!(:oncheck => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -14,7 +14,7 @@ class TreeBuilderDatastores < TreeBuilder
   end
 
   def set_locals_for_render
-    super.merge!(:onselect => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
+    super.merge!(:oncheck => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
   end
 
   def root_options

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -16,7 +16,7 @@ class TreeBuilderSections < TreeBuilder
   end
 
   def set_locals_for_render
-    super.merge!(:onselect => "miqOnCheckSections", :check_url => "/#{@controller_name}/sections_field_changed/")
+    super.merge!(:oncheck => "miqOnCheckSections", :check_url => "/#{@controller_name}/sections_field_changed/")
   end
 
   def root_options

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -4,7 +4,6 @@
 - checkboxes                  ||= false
 - three_checks                ||= false
 - onclick                     ||= false
-- onselect                    ||= false
 - oncheck                     ||= false
 - autoload                    ||= false
 - allow_reselect              ||= false
@@ -23,7 +22,6 @@
              :oncheck            => oncheck,
              :click_url          => click_url,
              :check_url          => check_url,
-             :onselect           => onselect,
              :post_check         => post_check,
              :autoload           => autoload,
              :allow_reselect     => allow_reselect,

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -25,7 +25,7 @@ describe TreeBuilderClusters do
     it 'sets tree to have full ids, not lazy and no root' do
       locals = @cluster_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
-      expect(locals[:onselect]).to eq("miqOnCheckCUFilters")
+      expect(locals[:oncheck]).to eq("miqOnCheckCUFilters")
       expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
     end
 

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -16,7 +16,7 @@ describe TreeBuilderDatastores do
     it 'sets locals correctly' do
       locals = @datastores_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
-      expect(locals[:onselect]).to eq("miqOnCheckCUFilters")
+      expect(locals[:oncheck]).to eq("miqOnCheckCUFilters")
       expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
     end
     it 'sets Datastore node correctly' do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -60,7 +60,7 @@ describe TreeBuilderSections do
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)
       expect(locals[:check_url]).to eq("/#{@controller_name}/sections_field_changed/")
-      expect(locals[:onselect]).to eq("miqOnCheckSections")
+      expect(locals[:oncheck]).to eq("miqOnCheckSections")
       expect(locals[:three_checks]).to eq(true)
     end
     it 'sets roots correctly' do


### PR DESCRIPTION
We were using two different locals for handling checkboxes in trees. Some of the trees were using `oncheck` and others `onselect`. Hereby I am merging these two into `oncheck` and also unifying the method signatures for handling these events.

The affected trees are on the compare and capacity and utilization collection screens.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 
@miq-bot add_label refactoring, trees, hammer/no