### PR TITLE
Remove references to MiqPassword

### DIFF
--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -126,14 +126,14 @@ module Mixins
       end
 
       def get_task_args(ems)
-        user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
+        user, password = params[:default_userid], ManageIQ::Password.encrypt(params[:default_password])
         case ems.to_s
         when 'ManageIQ::Providers::Openstack::CloudManager', 'ManageIQ::Providers::Openstack::InfraManager'
           case params[:cred_type]
           when 'default'
             [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
           when 'amqp'
-            [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
+            [ManageIQ::Password.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
           end
         when 'ManageIQ::Providers::Amazon::CloudManager'
           uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))
@@ -144,12 +144,12 @@ module Mixins
         when 'ManageIQ::Providers::Vmware::CloudManager'
           case params[:cred_type]
           when 'amqp'
-            [params[:amqp_hostname], params[:amqp_api_port], params[:amqp_userid], MiqPassword.encrypt(params[:amqp_password]), params[:api_version], true]
+            [params[:amqp_hostname], params[:amqp_api_port], params[:amqp_userid], ManageIQ::Password.encrypt(params[:amqp_password]), params[:api_version], true]
           when 'default'
             [params[:default_hostname], params[:default_api_port], user, password, params[:api_version], true]
           end
         when 'ManageIQ::Providers::Google::CloudManager'
-          [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
+          [params[:project], ManageIQ::Password.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
         when 'ManageIQ::Providers::Microsoft::InfraManager'
           connect_opts = {
             :hostname          => params[:default_hostname],
@@ -162,7 +162,7 @@ module Mixins
 
           [ems.build_connect_params(connect_opts), true]
         when 'ManageIQ::Providers::Redhat::InfraManager'
-          metrics_user, metrics_password = params[:metrics_userid], MiqPassword.encrypt(params[:metrics_password])
+          metrics_user, metrics_password = params[:metrics_userid], ManageIQ::Password.encrypt(params[:metrics_password])
           [{
             :username         => user,
             :password         => password,
@@ -187,7 +187,7 @@ module Mixins
         when 'ManageIQ::Providers::Vmware::InfraManager'
           case params[:cred_type]
           when 'console'
-            [{:pass => MiqPassword.encrypt(params[:console_password]), :user => params[:console_userid], :ip => params[:default_hostname], :use_broker => false}]
+            [{:pass => ManageIQ::Password.encrypt(params[:console_password]), :user => params[:console_userid], :ip => params[:default_hostname], :use_broker => false}]
           when 'default'
             [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}]
           end

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -121,14 +121,14 @@ module Mixins
     end
 
     def get_task_args(ems)
-      user, password = params[:default_userid], MiqPassword.encrypt(params[:default_password])
+      user, password = params[:default_userid], ManageIQ::Password.encrypt(params[:default_password])
       case ems.to_s
       when 'ManageIQ::Providers::Openstack::CloudManager', 'ManageIQ::Providers::Openstack::InfraManager'
         case params[:cred_type]
         when 'default'
           [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
         when 'amqp'
-          [MiqPassword.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
+          [ManageIQ::Password.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
         end
       when 'ManageIQ::Providers::Amazon::CloudManager'
         uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))
@@ -139,12 +139,12 @@ module Mixins
       when 'ManageIQ::Providers::Vmware::CloudManager'
         case params[:cred_type]
         when 'amqp'
-          [params[:amqp_hostname], params[:amqp_api_port], params[:amqp_userid], MiqPassword.encrypt(params[:amqp_password]), params[:api_version], true]
+          [params[:amqp_hostname], params[:amqp_api_port], params[:amqp_userid], ManageIQ::Password.encrypt(params[:amqp_password]), params[:api_version], true]
         when 'default'
           [params[:default_hostname], params[:default_api_port], user, password, params[:api_version], true]
         end
       when 'ManageIQ::Providers::Google::CloudManager'
-        [params[:project], MiqPassword.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
+        [params[:project], ManageIQ::Password.encrypt(params[:service_account]), {:service => "compute"}, ems.http_proxy_uri, true]
       when 'ManageIQ::Providers::Microsoft::InfraManager'
         connect_opts = {
           :hostname          => params[:default_hostname],
@@ -157,7 +157,7 @@ module Mixins
 
         [ems.build_connect_params(connect_opts), true]
       when 'ManageIQ::Providers::Redhat::InfraManager'
-        metrics_user, metrics_password = params[:metrics_userid], MiqPassword.encrypt(params[:metrics_password])
+        metrics_user, metrics_password = params[:metrics_userid], ManageIQ::Password.encrypt(params[:metrics_password])
         [{
           :username         => user,
           :password         => password,
@@ -182,7 +182,7 @@ module Mixins
       when 'ManageIQ::Providers::Vmware::InfraManager'
         case params[:cred_type]
         when 'console'
-          [{:pass => MiqPassword.encrypt(params[:console_password]), :user => params[:console_userid], :ip => params[:default_hostname], :use_broker => false}]
+          [{:pass => ManageIQ::Password.encrypt(params[:console_password]), :user => params[:console_userid], :ip => params[:default_hostname], :use_broker => false}]
         when 'default'
           [{:pass => password, :user => user, :ip => params[:default_hostname], :use_broker => false}]
         end

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -285,7 +285,7 @@ module OpsController::Settings::Common
   end
 
   def set_subscription_attributes(subscription, params)
-    params['password'] = MiqPassword.encrypt(params['password'])
+    params['password'] = ManageIQ::Password.encrypt(params['password'])
     params_for_connection_validation(params).each do |k, v|
       subscription.send("#{k}=".to_sym, v)
     end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -340,7 +340,7 @@ describe EmsCloudController do
         let(:compute_service) { {:service => "compute"} }
 
         it "queues the correct number of arguments" do
-          expected_validate_args = [project, MiqPassword.encrypt(service_account), compute_service, nil, true]
+          expected_validate_args = [project, ManageIQ::Password.encrypt(service_account), compute_service, nil, true]
           expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
           controller.send(:create_ems_button_validate)
         end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -234,8 +234,8 @@ describe OpsController do
           controller.send(:pglogical_save_subscriptions)
           queue_item = MiqQueue.find_by(:method_name => "save_global_region")
           queued_password = queue_item.args[0][0].password
-          expect(MiqPassword.encrypted?(queued_password)).to be(true)
-          expect(MiqPassword.decrypt(queued_password)).to eq(password)
+          expect(ManageIQ::Password.encrypted?(queued_password)).to be(true)
+          expect(ManageIQ::Password.decrypt(queued_password)).to eq(password)
         end
       end
 
@@ -278,7 +278,7 @@ describe OpsController do
       context 'get advanced config settings' do
         it 'for selected server' do
           miq_server = FactoryBot.create(:miq_server)
-          enc_pass = MiqPassword.encrypt('pa$$word')
+          enc_pass = ManageIQ::Password.encrypt('pa$$word')
           Vmdb::Settings.save!(
             miq_server,
             :http_proxy => {
@@ -303,7 +303,7 @@ describe OpsController do
 
         it 'for selected zone' do
           zone = FactoryBot.create(:zone)
-          enc_pass = MiqPassword.encrypt('pa$$word')
+          enc_pass = ManageIQ::Password.encrypt('pa$$word')
           Vmdb::Settings.save!(
             zone,
             :http_proxy => {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ Dir[support_path.join("**/*.rb")].each { |f| require f }
 Dir[Rails.root.join('spec', 'shared', '**', '*.rb')].each { |f| require f }
 
 Dir[ManageIQ::UI::Classic::Engine.root.join('spec/shared/**/*.rb')].each { |f| require f }
-Dir[ManageIQ::Gems::Pending.root.join("spec/support/custom_matchers/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.fixture_path = Rails.root.join("spec/fixtures")


### PR DESCRIPTION
@himdel @jrafanie Please review.  This gets us one step closer to removing MiqPassword from manageiq-gems-pending