### PR TITLE
Fix creating a group after validation message 'already exists'

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1200,7 +1200,7 @@ module OpsController::OpsRbac
       @edit[:new][:filters].clear
     else
       exp_remove_tokens(@edit[:new][:filter_expression])
-      @edit[:new][:filter_expression] = nil
+      @edit[:new][:filter_expression] = {}
     end
 
     rbac_group_set_filters(group) # Go set the filters for the group


### PR DESCRIPTION
**Fixes issue:**
https://github.com/ManageIQ/manageiq-ui-classic/issues/5140

**What:**
Fix creating a group (_Configuration > Access Control > Groups_) for the second time, after a validation message like '...already exists' appears.

**Steps to reproduce:**
1. Go to _Configuration > Access Control > Groups_ accordion
2. _Configuration > Add a new Group_ and create a group
3. Try to create another group with the same name as from step 2
=> error flash message occurs
4. Follow the message and change the name of the new group, press _Add_ button
=> nothing happens in the UI + error in log:
```
[----] I, [2019-03-19T17:28:55.994747 #11522:2ad94de6c2f0]  INFO -- : Started POST "/ops/rbac_group_edit?button=add" for ::1 at 2019-03-19 17:28:55 +0100
[----] I, [2019-03-19T17:28:56.033217 #11522:2ad94de6c2f0]  INFO -- : Processing by OpsController#rbac_group_edit as JS
[----] I, [2019-03-19T17:28:56.033346 #11522:2ad94de6c2f0]  INFO -- :   Parameters: {"button"=>"add"}
[----] F, [2019-03-19T17:28:56.045202 #11522:2ad94de6c2f0] FATAL -- : Error caught: [NoMethodError] undefined method `empty?' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:1377:in `rbac_group_validate?'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:674:in `rbac_edit_save_or_add'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/ops_controller/ops_rbac.rb:92:in `rbac_group_edit'
```

**TODO:**
- specs
- open a BZ ticket

**Note:**
This issue is also present in `hammer` branch.

**Details:**
In `rbac_group_set_record_vars` method, in https://github.com/ManageIQ/manageiq-ui-classic/pull/5354/files#diff-8078c760e06b820719715450b2a112e0L1203, `@edit[:new][:filter_expression]` was set to `nil`, so then in `rbac_group_validate?` method, in https://github.com/ManageIQ/manageiq-ui-classic/pull/5354/files#diff-8078c760e06b820719715450b2a112e0L1377 a problem occurred, because `empty?` does not work with `nil`, obviously. Also setting `@edit[:new][:filter_expression]` to `nil` is in conflict with what is in https://github.com/ManageIQ/manageiq-ui-classic/pull/5354/files#diff-8078c760e06b820719715450b2a112e0L1111 where we set it to `{}`.

---

Step 3 from steps to reproduce:
![step3](https://user-images.githubusercontent.com/13417815/54623558-0b6b1000-4a6c-11e9-9fcf-cd2e6a1369d8.png)

**Before:** (nothing happens after clicking on _Add_ button, _test2_ group is not saved properly)
![test_before](https://user-images.githubusercontent.com/13417815/54623851-9f3cdc00-4a6c-11e9-9fc9-e848c4e017eb.png)

**After:**(_test2_ group saved without any problems, flash message appears)
![test_after](https://user-images.githubusercontent.com/13417815/54623536-fbebc700-4a6b-11e9-9a59-32327169f9bb.png)
