### PR TITLE
Highlight changes from default on all trees with checkboxes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -203,7 +203,6 @@ class TreeBuilder
       :checkboxes        => @options[:checkboxes],
       :autoload          => @options[:lazy],
       :allow_reselect    => @options[:allow_reselect],
-      :highlight_changes => @options[:highlight_changes],
       :three_checks      => @options[:three_checks],
       :post_check        => @options[:post_check],
       :onclick           => @options[:onclick],

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -40,11 +40,10 @@ class TreeBuilderBelongsToHac < TreeBuilder
                          end
 
     {
-      :full_ids          => true,
-      :checkboxes        => true,
-      :highlight_changes => !@assign_to,
-      :oncheck           => oncheck,
-      :check_url         => check_url
+      :full_ids   => true,
+      :checkboxes => true,
+      :oncheck    => oncheck,
+      :check_url  => check_url
     }
   end
 

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -11,12 +11,11 @@ class TreeBuilderClusters < TreeBuilder
 
   def tree_init_options
     {
-      :full_ids          => false,
-      :checkboxes        => true,
-      :highlight_changes => true,
-      :three_checks      => true,
-      :oncheck           => "miqOnCheckCUFilters",
-      :check_url         => "/ops/cu_collection_field_changed/"
+      :full_ids     => false,
+      :checkboxes   => true,
+      :three_checks => true,
+      :oncheck      => "miqOnCheckCUFilters",
+      :check_url    => "/ops/cu_collection_field_changed/"
     }
   end
 

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -11,11 +11,10 @@ class TreeBuilderDatastores < TreeBuilder
 
   def tree_init_options
     {
-      :full_ids          => false,
-      :checkboxes        => true,
-      :highlight_changes => true,
-      :oncheck           => "miqOnCheckCUFilters",
-      :check_url         => "/ops/cu_collection_field_changed/"
+      :full_ids   => false,
+      :checkboxes => true,
+      :oncheck    => "miqOnCheckCUFilters",
+      :check_url  => "/ops/cu_collection_field_changed/"
     }
   end
 

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -36,11 +36,10 @@ class TreeBuilderDefaultFilters < TreeBuilder
 
   def tree_init_options
     {
-      :full_ids          => true,
-      :checkboxes        => true,
-      :highlight_changes => true,
-      :check_url         => "/configuration/filters_field_changed/",
-      :oncheck           => "miqOnCheckGeneric"
+      :full_ids   => true,
+      :checkboxes => true,
+      :check_url  => "/configuration/filters_field_changed/",
+      :oncheck    => "miqOnCheckGeneric"
     }
   end
 

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -10,11 +10,10 @@ class TreeBuilderProtect < TreeBuilder
 
   def tree_init_options
     {
-      :full_ids          => false,
-      :checkboxes        => true,
-      :highlight_changes => true,
-      :oncheck           => "miqOnCheckProtect",
-      :check_url         => "/#{@data[:controller_name]}/protect/"
+      :full_ids   => false,
+      :checkboxes => true,
+      :oncheck    => "miqOnCheckProtect",
+      :check_url  => "/#{@data[:controller_name]}/protect/"
     }
   end
 

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -17,11 +17,10 @@ class TreeBuilderTags < TreeBuilder
 
   def tree_init_options
     {
-      :full_ids          => true,
-      :checkboxes        => true,
-      :highlight_changes => true,
-      :check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
-      :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters"
+      :full_ids   => true,
+      :checkboxes => true,
+      :check_url  => "/ops/rbac_group_field_changed/#{group_id}___",
+      :oncheck    => @edit.nil? ? nil : "miqOnCheckUserFilters"
     }
   end
 

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -7,7 +7,6 @@
 - oncheck                     ||= false
 - autoload                    ||= false
 - allow_reselect              ||= false
-- highlight_changes           ||= false
 - post_check                  ||= false
 - bs_tree                     ||= '{}'
 - tree_id                     ||= "tree_div"
@@ -28,7 +27,7 @@
              :controller         => controller_name,
              :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
              :select_node        => select_node,
-             :highlight_changes  => highlight_changes,
+             :highlight_changes  => checkboxes,
              :active_tree        => x_active_tree}
 
 :javascript

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -67,11 +67,10 @@ describe TreeBuilderBelongsToHac do
 
   describe '#tree_init_options' do
     it 'sets init options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
-                                                     :checkboxes        => true,
-                                                     :highlight_changes => true,
-                                                     :oncheck           => nil,
-                                                     :check_url         => "/ops/rbac_group_field_changed/new___")
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :checkboxes => true,
+                                                     :oncheck    => nil,
+                                                     :check_url  => "/ops/rbac_group_field_changed/new___")
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -38,11 +38,10 @@ describe TreeBuilderBelongsToVat do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
-                                                     :checkboxes        => true,
-                                                     :highlight_changes => true,
-                                                     :oncheck           => nil,
-                                                     :check_url         => "/ops/rbac_group_field_changed/#{group.id}___")
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :checkboxes => true,
+                                                     :oncheck    => nil,
+                                                     :check_url  => "/ops/rbac_group_field_changed/#{group.id}___")
     end
   end
 

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -20,12 +20,11 @@ describe TreeBuilderClusters do
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
       expect(root_options).to eq(
-        :full_ids          => false,
-        :checkboxes        => true,
-        :highlight_changes => true,
-        :three_checks      => true,
-        :oncheck           => "miqOnCheckCUFilters",
-        :check_url         => "/ops/cu_collection_field_changed/"
+        :full_ids     => false,
+        :checkboxes   => true,
+        :three_checks => true,
+        :oncheck      => "miqOnCheckCUFilters",
+        :check_url    => "/ops/cu_collection_field_changed/"
       )
     end
 

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -12,11 +12,10 @@ describe TreeBuilderDatastores do
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
       expect(root_options).to eq(
-        :full_ids          => false,
-        :checkboxes        => true,
-        :highlight_changes => true,
-        :check_url         => "/ops/cu_collection_field_changed/",
-        :oncheck           => "miqOnCheckCUFilters"
+        :full_ids   => false,
+        :checkboxes => true,
+        :check_url  => "/ops/cu_collection_field_changed/",
+        :oncheck    => "miqOnCheckCUFilters"
       )
     end
     it 'sets locals correctly' do

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -25,11 +25,10 @@ describe TreeBuilderProtect do
     it 'set init options correctly' do
       tree_options = @protect_tree.send(:tree_init_options)
       expect(tree_options).to eq(
-        :full_ids          => false,
-        :checkboxes        => true,
-        :highlight_changes => true,
-        :check_url         => "/name/protect/",
-        :oncheck           => "miqOnCheckProtect"
+        :full_ids   => false,
+        :checkboxes => true,
+        :check_url  => "/name/protect/",
+        :oncheck    => "miqOnCheckProtect"
       )
     end
 

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -25,18 +25,16 @@ describe TreeBuilderTags do
     it 'set init options correctly' do
       tree_options = @tags_tree.send(:tree_init_options)
       expect(tree_options).to eq(
-        :full_ids          => true,
-        :checkboxes        => true,
-        :highlight_changes => true,
-        :check_url         => "/ops/rbac_group_field_changed/#{@group.id}___",
-        :oncheck           => nil
+        :full_ids   => true,
+        :checkboxes => true,
+        :check_url  => "/ops/rbac_group_field_changed/#{@group.id}___",
+        :oncheck    => nil
       )
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/#{@group.id}___")
-      expect(locals[:highlight_changes]).to eq(true)
       expect(locals[:oncheck]).to eq(nil)
     end
     it 'set info about selected kids correctly' do
@@ -82,7 +80,6 @@ describe TreeBuilderTags do
       locals = @tags_tree.send(:set_locals_for_render)
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq("/ops/rbac_group_field_changed/new___")
-      expect(locals[:highlight_changes]).to eq(true)
       expect(locals[:oncheck]).to eq("miqOnCheckUserFilters")
     end
     it 'sets second level nodes correctly' do


### PR DESCRIPTION
Some trees with checkboxes highlighted the nodes that have been changed by the user in the current session. I think we should be consistent with this and have it for each tree or none. This would also allow us to drop a parameter from the options in `TreeBuilder` classes.

![checkbox-highlight](https://user-images.githubusercontent.com/649130/54670121-35b3e080-4af3-11e9-8877-0824c076645e.gif)

So the question is to have or not have this globally ...

@miq-bot add_label question, trees, ux/review, hammer/no
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 

cc @terezanovotna as this is UX-related