### PR TITLE
Add scopes for filtering Archived/Orphaned VMs based on RBAC

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1029,7 +1029,7 @@ module VmCommon
       options[:named_scope] << :not_orphaned unless role_allows?(:feature => 'vm_show_list_orphaned')
       options[:named_scope] << :not_archived unless role_allows?(:feature => 'vm_show_list_archived')
       if model == "ManageIQ::Providers::CloudManager::Template"
-        options[:named_scope] << [:without_volume_templates]
+        options[:named_scope] << :without_volume_templates
       end
       if x_node == "root"
         if x_active_tree == :vandt_tree

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1078,6 +1078,8 @@ module VmCommon
         options[:parent] = rec
         options[:named_scope] ||= []
         options[:named_scope] << :with_ems
+        options[:named_scope] << :not_archived unless role_allows?(:feature => vm_show_list_archived)
+        options[:named_scope] << :not_orphaned unless role_allows?(:feature => vm_show_list_orphaned)
         process_show_list(options) if show_list
         model_name = @nodetype == "d" ? _("Datacenter") : ui_lookup(:model => rec.class.base_class.to_s)
         @right_cell_text = _("%{object_types} under %{datastore_or_provider} \"%{provider_or_datastore_name}\"") % {

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1028,6 +1028,7 @@ module VmCommon
       options[:named_scope] ||= []
       options[:named_scope] << :not_orphaned unless role_allows?(:feature => 'vm_show_list_orphaned')
       options[:named_scope] << :not_archived unless role_allows?(:feature => 'vm_show_list_archived')
+      options[:named_scope] << :not_retired unless role_allows?(:feature => 'vm_show_list_retired')
       if model == "ManageIQ::Providers::CloudManager::Template"
         options[:named_scope] << :without_volume_templates
       end

--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -1,11 +1,14 @@
 module TreeBuilderArchived
+  include ApplicationHelper
+
   def x_get_tree_arch_orph_nodes(model_name)
     archived = QuadiconHelper.machine_state('archived').values_at(:fonticon, :background)
     orphaned = QuadiconHelper.machine_state('orphaned').values_at(:fonticon, :background)
-
-    [
-      {:id => "arch", :text => _("<Archived>"), :icon => archived[0], :icon_background => archived[1], :tip => _("Archived %{model}") % {:model => model_name}},
-      {:id => "orph", :text => _("<Orphaned>"), :icon => orphaned[0], :icon_background => orphaned[1], :tip => _("Orphaned %{model}") % {:model => model_name}}
-    ]
+    nodes = []
+    arch_node = {:id => "arch", :text => _("<Archived>"), :icon => archived[0], :icon_background => archived[1], :tip => _("Archived %{model}") % {:model => model_name}}
+    orph_node = {:id => "orph", :text => _("<Orphaned>"), :icon => orphaned[0], :icon_background => orphaned[1], :tip => _("Orphaned %{model}") % {:model => model_name}}
+    nodes << arch_node if role_allows?(:feature => 'vm_show_list_archived')
+    nodes << orph_node if role_allows?(:feature => 'vm_show_list_orphaned')
+    nodes
   end
 end

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -8,6 +8,7 @@ describe TreeBuilderArchived do
   end
 
   it '#x_get_tree_arch_orph_nodes' do
+    allow(archived).to receive(:role_allows?).and_return(true)
     nodes = archived.x_get_tree_arch_orph_nodes('VMs/Templates')
     expect(nodes).to eq([{:id              => "arch",
                           :text            => "<Archived>",

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -32,6 +32,7 @@ describe TreeBuilderImages do
   end
 
   it 'sets providers nodes correctly' do
+    allow(@images_tree).to receive(:role_allows?).and_return(true)
     providers = @images_tree.x_get_tree_roots(false, nil)
     expect(providers).to eq([@template_cloud_with_az.ext_management_system,
                              {:id              => "arch",

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -35,6 +35,7 @@ describe TreeBuilderInstances do
   end
 
   it 'sets providers nodes correctly' do
+    allow(@instances_tree).to receive(:role_allows?).and_return(true)
     providers = @instances_tree.x_get_tree_roots(false, nil)
 
     expect(providers).to eq([@vm_cloud_with_az.ext_management_system,


### PR DESCRIPTION
Add scopes for filtering Archived/Orphaned VMs based on RBAC. All VMs & Templates should display Orphaned and Archived only if user has right to display it.

https://github.com/ManageIQ/manageiq/pull/18546 Add RBAC features and named_scopes definitions .


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1545942
https://github.com/ManageIQ/manageiq/pull/18546


Steps for Testing/QA [Optional]
-------------------------------
Go to Configuration -> Access Control -> Have the `user` in the `group` with `role` which has unchecked Access rules for all VMs -> View -> (List archived/Orphaned)
Compute -> Infrastructure -> Virtual Machines -> All VM &  Templates
