### PR TITLE
Subscription ID is required when adding, readOnly when editing (Azure)

### DIFF
--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -106,11 +106,15 @@
                             "name"                    => "subscription",
                             "ng-model"                => "emsCommonModel.subscription",
                             "checkchange"             => "",
+                            "required"                => "",
                             "prefix"                  => "default",
+                            "ng-readonly"             => @ems.id ? true : false,
                             "is-uuid"                 => 4,
                             "reset-validation-status" => "default_auth_status"}
         %span.help-block{"ng-show" => "angularForm.subscription.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
+        %span.help-block{"ng-show" => "angularForm.subscription.$error.required"}
+          = _("Required")
 
     .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
       %label.col-md-2.control-label{"for" => "ems_api_version"}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1519359

**Description**

`Compute` > `Clouds` > `Providers` > `Edit selected` (Azure) / `Add a new Cloud Provider` 

**Expected results**
Subscription ID should be 
* required field when adding an Azure Provider 
* a read only field when edititng existing Azure provider.

**Before**
![image](https://user-images.githubusercontent.com/32869456/54691491-9e1ab600-4b23-11e9-9d6f-504ba7e221b7.png)
![image](https://user-images.githubusercontent.com/32869456/54691471-965b1180-4b23-11e9-9a43-d8cfa7fc99f8.png)

**After** 
![image](https://user-images.githubusercontent.com/32869456/54691428-83e0d800-4b23-11e9-96b5-8452b5927ca6.png)
![image](https://user-images.githubusercontent.com/32869456/54691453-8f340380-4b23-11e9-818f-db8460062073.png)


