### PR TITLE
Fixed condition to use correct feature id

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -3,7 +3,7 @@ module ApplicationController::Tags
 
   # Edit user, group or tenant tags
   def tagging_edit(db = nil, assert = true)
-    assert_privileges("#{@display ? @display.singularize : controller_for_common_methods}_tag") if assert
+    assert_privileges("#{@display && @display != "main" ? @display.singularize : controller_for_common_methods}_tag") if assert
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
 
     @tagging = session[:tag_db] = params[:db] ? params[:db] : db if params[:db] || db

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -114,15 +114,32 @@ describe ApplicationController do
 
   describe EmsInfraController do
     before do
-      login_as FactoryBot.create(:user, :features => %w(storage_tag))
+      login_as FactoryBot.create(:user, :features => %w(storage_tag ems_infra_tag))
       controller.instance_variable_set(:@_params, params)
-      controller.instance_variable_set(:@display, "storages")
     end
 
-    context 'check for correct feature id when tagging selected storage thru Provider relationship' do
+    context 'check for correct feature id when tagging selected storage thru Provider relationship and directly from summary screen' do
       let(:params) { {:db => "Storage", :id => "1"} }
-      it 'sets @tagging properly' do
+      let(:controller_name) { Storage }
+      it 'sets @tagging properly and passes in correct feature to assert_privileges' do
+        controller.instance_variable_set(:@display, "storages")
         allow(controller).to receive(:tagging_edit_tags_reset)
+        expect(controller).to receive(:assert_privileges).with("storage_tag")
+        controller.send(:tagging_edit, "storage", true)
+        expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+
+      it 'checks proper feature id when trying to go to tagging directly from a summary screen' do
+        controller.instance_variable_set(:@display, "main")
+        allow(controller).to receive(:tagging_edit_tags_reset)
+        expect(controller).to receive(:assert_privileges).with("ems_infra_tag")
+        controller.send(:tagging_edit)
+        expect(controller.instance_variable_get(:@tagging)).not_to be_nil
+      end
+
+      it 'checks proper feature id when trying to go to tagging from list view and @dsiplay is not set' do
+        allow(controller).to receive(:tagging_edit_tags_reset)
+        expect(controller).to receive(:assert_privileges).with("ems_infra_tag")
         controller.send(:tagging_edit)
         expect(controller.instance_variable_get(:@tagging)).not_to be_nil
       end


### PR DESCRIPTION
Fixed condition to use correct feature id when goign to tagging from summary screen directly. https://github.com/ManageIQ/manageiq-ui-classic/pull/4843 did not cover all scenarios.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684472

@hstastna can you please test/review.