### PR TITLE
Fixes segmentation_id and physical_network required (in Cloud Network form)

### DIFF
--- a/app/assets/javascripts/components/cloud_network/cloud-network-form.js
+++ b/app/assets/javascripts/components/cloud_network/cloud-network-form.js
@@ -28,6 +28,8 @@ function cloudNetworkFormController(API, miqService) {
     vm.ems = [];
     vm.network_types_for_segmentation = /vlan|vxlan|gre/;
     vm.network_types_for_physical_network = /vlan|flat/;
+    vm.is_subscription_id_required = /gre|vlan/;
+    vm.is_physical_network_required = /flat|vlan/;
     vm.formId = vm.cloudNetworkFormId;
     vm.model = 'cloudNetworkModel';
     ManageIQ.angular.scope = vm;

--- a/app/views/static/cloud_network/cloud-network-form.html.haml
+++ b/app/views/static/cloud_network/cloud-network-form.html.haml
@@ -67,7 +67,8 @@
                 'ng-options'                  => "type as key for (key, type) in vm.providers_network_types",
                 "miq-select"                  => true,
                 "selectpicker-for-select-tag" => ""}
-    .form-group{'ng-if' => "vm.network_types_for_physical_network.test(vm.cloudNetworkModel.provider_network_type)"}
+    .form-group{'ng-if'    => "vm.network_types_for_physical_network.test(vm.cloudNetworkModel.provider_network_type)",
+                'ng-class' => "{'has-error': angularForm.provider_physical_network.$invalid}"}
       %label.control-label.col-md-2
         = _('Physical Network')
       .col-md-8
@@ -75,8 +76,12 @@
                             'name'         => "provider_physical_network",
                             'ng-disabled'  => "!vm.newRecord",
                             'ng-model'     => "vm.cloudNetworkModel.provider_physical_network",
+                            'ng-required'  => "vm.is_physical_network_required.test(vm.cloudNetworkModel.provider_network_type)",
                             'maxlength'    => 128}
-    .form-group{'ng-if' => "vm.network_types_for_segmentation.test(vm.cloudNetworkModel.provider_network_type)"}
+        %span.help-block{"ng-show" => "angularForm.provider_physical_network.$error.required"}
+          = _("Required")
+    .form-group{'ng-if'    => "vm.network_types_for_segmentation.test(vm.cloudNetworkModel.provider_network_type)",
+                'ng-class' => "{'has-error': angularForm.provider_segmentation_id.$invalid}"}
       %label.control-label.col-md-2
         = _('Segmentation ID')
       .col-md-8
@@ -84,7 +89,10 @@
                             'name'         => "provider_segmentation_id",
                             'ng-disabled'  => "!vm.newRecord",
                             'ng-model'     => "vm.cloudNetworkModel.provider_segmentation_id",
+                            'ng-required'  => "vm.is_subscription_id_required.test(vm.cloudNetworkModel.provider_network_type)",
                             'maxlength'    => 128}
+        %span.help-block{"ng-show" => "angularForm.provider_segmentation_id.$error.required"}
+          = _("Required")
   %h3
     = _('Network Information')
   .form-horizontal


### PR DESCRIPTION
Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1649280

 `Networks > Networks > Configuration > Add a new Cloud Network` 

### Description

| type  | physical_network | segmentation_id    |
|-------|------------------|--------------------|
| flat  | required         |                    |
| gre   |                  | required (GRE ID)  |
| vlan  | required         | required (VLAN ID) |
| vxlan |                  |                    |

As you can see in the table, some fields should be required, but they are not.

FLAT -> segmentation_id not needed
GRE -> segmentation_id is GRE ID
VLAN -> segmentation_id is VLAN ID
VXLAN -> segmentation_id not needed

Physical network:
It isn't required for VXLAN and GRE
But VLAN and Flat do require it. In which case the value is provided by a logical name (mapping to a real physical network)

**Before**
![image](https://user-images.githubusercontent.com/32869456/54758505-95da7d80-4bec-11e9-8b55-cc3c67be09bc.png)

**After**
![image](https://user-images.githubusercontent.com/32869456/54758446-7a6f7280-4bec-11e9-8197-fe25667eb080.png)