### PR TITLE
Move event handling settings from locals to options in TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -205,8 +205,12 @@ class TreeBuilder
       :allow_reselect    => @options[:allow_reselect],
       :highlight_changes => @options[:highlight_changes],
       :three_checks      => @options[:three_checks],
-      :post_check        => @options[:post_check]
-    }
+      :post_check        => @options[:post_check],
+      :onclick           => @options[:onclick],
+      :oncheck           => @options[:oncheck],
+      :click_url         => @options[:click_url],
+      :check_url         => @options[:check_url]
+    }.compact
   end
 
   # Build an explorer tree, from scratch

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -14,14 +14,11 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def tree_init_options
-    {:checkboxes => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(
-      :oncheck   => "miqOnCheckGeneric",
-      :check_url => "/miq_policy/alert_profile_assign_changed/"
-    )
+    {
+      :checkboxes => true,
+      :oncheck    => "miqOnCheckGeneric",
+      :check_url  => "/miq_policy/alert_profile_assign_changed/"
+    }
   end
 
   def root_options

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAutomate < TreeBuilderAeClass
   def tree_init_options
-    {:full_ids => false, :lazy => true}
+    {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
   end
 
   def initialize(name, type, sandbox, build = true, **params)
@@ -24,9 +24,5 @@ class TreeBuilderAutomate < TreeBuilderAeClass
       :tooltip    => t,
       :selectable => false
     }
-  end
-
-  def set_locals_for_render
-    super.merge!(:onclick => "miqOnClickAutomate")
   end
 end

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -31,14 +31,6 @@ class TreeBuilderBelongsToHac < TreeBuilder
   private
 
   def tree_init_options
-    {
-      :full_ids          => true,
-      :checkboxes        => true,
-      :highlight_changes => !@assign_to
-    }
-  end
-
-  def set_locals_for_render
     oncheck, check_url = if @assign_to
                            ["miqOnCheckGeneric", "/miq_policy/alert_profile_assign_changed/"]
                          elsif @edit
@@ -47,7 +39,13 @@ class TreeBuilderBelongsToHac < TreeBuilder
                            [nil, "/ops/rbac_group_field_changed/#{group_id}___"]
                          end
 
-    super.merge!(:oncheck => oncheck, :check_url => check_url)
+    {
+      :full_ids          => true,
+      :checkboxes        => true,
+      :highlight_changes => !@assign_to,
+      :oncheck           => oncheck,
+      :check_url         => check_url
+    }
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -14,12 +14,10 @@ class TreeBuilderClusters < TreeBuilder
       :full_ids          => false,
       :checkboxes        => true,
       :highlight_changes => true,
-      :three_checks      => true
+      :three_checks      => true,
+      :oncheck           => "miqOnCheckCUFilters",
+      :check_url         => "/ops/cu_collection_field_changed/"
     }
-  end
-
-  def set_locals_for_render
-    super.merge!(:oncheck => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
   end
 
   def non_cluster_selected

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -36,11 +36,7 @@ class TreeBuilderDatacenter < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:onclick => 'miqOnClickHostNet')
+    {:full_ids => true, :lazy => true, :onclick => 'miqOnClickHostNet'}
   end
 
   def root_options

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -10,11 +10,13 @@ class TreeBuilderDatastores < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :checkboxes => true, :highlight_changes => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:oncheck => "miqOnCheckCUFilters", :check_url => "/ops/cu_collection_field_changed/")
+    {
+      :full_ids          => false,
+      :checkboxes        => true,
+      :highlight_changes => true,
+      :oncheck           => "miqOnCheckCUFilters",
+      :check_url         => "/ops/cu_collection_field_changed/"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -35,11 +35,13 @@ class TreeBuilderDefaultFilters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :checkboxes => true, :highlight_changes => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:check_url => "/configuration/filters_field_changed/", :oncheck => "miqOnCheckGeneric")
+    {
+      :full_ids          => true,
+      :checkboxes        => true,
+      :highlight_changes => true,
+      :check_url         => "/configuration/filters_field_changed/",
+      :oncheck           => "miqOnCheckGeneric"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -7,13 +7,7 @@ class TreeBuilderDiagnostics < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:click_url => "/ops/diagnostics_tree_select/",
-                  :onclick   => "miqOnClickDiagnostics")
+    {:open_all => true, :click_url => "/ops/diagnostics_tree_select/", :onclick => "miqOnClickDiagnostics"}
   end
 
   def x_build_single_node(object, pid, options)

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -21,16 +21,14 @@ class TreeBuilderGenealogy < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :checkboxes => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(
+    {
+      :full_ids   => true,
+      :checkboxes => true,
       :click_url  => "/vm/genealogy_tree_selected/",
       :onclick    => "miqOnClickGeneric",
       :oncheck    => "miqOnCheckGenealogy",
       :check_url  => "/vm/set_checked_items/"
-    )
+    }
   end
 
   def vm_icon_image(vm)

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -19,17 +19,8 @@ class TreeBuilderMenuRoles < TreeBuilder
 
   private
 
-  def set_locals_for_render
-    locals = {
-      :click_url => "/report/menu_editor/",
-      :onclick   => "miqOnClickMenuRoles"
-    }
-
-    super.merge!(locals)
-  end
-
   def tree_init_options
-    {}
+    {:click_url => "/report/menu_editor/", :onclick => "miqOnClickMenuRoles"}
   end
 
   def root_options

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -16,15 +16,10 @@ class TreeBuilderMiqActionCategory < TreeBuilder
   end
 
   def tree_init_options
-    {}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(
+    {
       :click_url => "/miq_policy/action_tag_pressed/",
       :onclick   => "miqOnClickGeneric"
-    )
+    }
   end
 
   def root_options

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -19,11 +19,7 @@ class TreeBuilderNetwork < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:onclick => "miqOnClickHostNet")
+    {:full_ids => true, :lazy => true, :onclick => "miqOnClickHostNet"}
   end
 
   def root_options

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -18,12 +18,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   private
 
-  def set_locals_for_render
-    locals = {:check_url => "/ops/rbac_role_field_changed/", :onclick => nil}
-    locals[:oncheck] = "miqOnCheckGeneric" if @editable
-    super.merge!(locals)
-  end
-
   def x_get_tree_roots(count_only = false, _options)
     top_nodes = Menu::Manager.map do |section|
       next if section.id == :cons && !Settings.product.consumption
@@ -69,7 +63,9 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :node_id_prefix => node_id_prefix,
       :checkboxes     => true,
       :three_checks   => true,
-      :post_check     => true
+      :post_check     => true,
+      :check_url      => "/ops/rbac_role_field_changed/",
+      :oncheck        => @editable ? "miqOnCheckGeneric" : false
     }
   end
 

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -9,11 +9,13 @@ class TreeBuilderProtect < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => false, :checkboxes => true, :highlight_changes => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:oncheck => "miqOnCheckProtect", :check_url => "/#{@data[:controller_name]}/protect/")
+    {
+      :full_ids          => false,
+      :checkboxes        => true,
+      :highlight_changes => true,
+      :oncheck           => "miqOnCheckProtect",
+      :check_url         => "/#{@data[:controller_name]}/protect/"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -12,11 +12,13 @@ class TreeBuilderSections < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :checkboxes => true, :three_checks => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:oncheck => "miqOnCheckSections", :check_url => "/#{@controller_name}/sections_field_changed/")
+    {
+      :full_ids     => true,
+      :checkboxes   => true,
+      :three_checks => true,
+      :oncheck      => "miqOnCheckSections",
+      :check_url    => "/#{@controller_name}/sections_field_changed/"
+    }
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -18,13 +18,10 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
       :full_ids     => false,
       :checkboxes   => true,
       :three_checks => true,
-      :post_check   => true
+      :post_check   => true,
+      :oncheck      => 'miqOnCheckGeneric',
+      :check_url    => '/ops/smartproxy_affinity_field_changed/'
     }
-  end
-
-  def set_locals_for_render
-    super.merge!(:oncheck   => 'miqOnCheckGeneric',
-                 :check_url => '/ops/smartproxy_affinity_field_changed/')
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -17,12 +17,7 @@ class TreeBuilderSnapshots < TreeBuilder
   end
 
   def tree_init_options
-    {:full_ids => true, :lazy => true}
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:onclick => 'miqOnClickSnapshots',)
+    {:full_ids => true, :lazy => true, :onclick => 'miqOnClickSnapshots'}
   end
 
   def root_options

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -11,11 +11,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true}
-  end
-
-  def set_locals_for_render
-    super.merge!(:onclick => "miqOnClickHostNet")
+    {:full_ids => true, :lazy => true, :onclick => "miqOnClickHostNet"}
   end
 
   def root_options

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -16,7 +16,13 @@ class TreeBuilderTags < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :checkboxes => true, :highlight_changes => true}
+    {
+      :full_ids          => true,
+      :checkboxes        => true,
+      :highlight_changes => true,
+      :check_url         => "/ops/rbac_group_field_changed/#{group_id}___",
+      :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters"
+    }
   end
 
   def contain_selected_kid(category)
@@ -28,11 +34,6 @@ class TreeBuilderTags < TreeBuilder
     return false unless @edit || @filters
     path = "#{category.name}-#{entry.name}"
     (@edit&.fetch_path(:new, :filters, path)) || (@filters&.key?(path))
-  end
-
-  def set_locals_for_render
-    super.merge!(:check_url => "/ops/rbac_group_field_changed/#{group_id}___",
-                 :oncheck   => @edit.nil? ? nil : "miqOnCheckUserFilters")
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -30,7 +30,11 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#tree_init_options' do
       it 'sets init options correctly' do
-        expect(subject.send(:tree_init_options)).to eq(:checkboxes => true)
+        expect(subject.send(:tree_init_options)).to eq(
+          :checkboxes => true,
+          :oncheck    => "miqOnCheckGeneric",
+          :check_url  => "/miq_policy/alert_profile_assign_changed/"
+        )
       end
     end
 

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -69,14 +69,15 @@ describe TreeBuilderBelongsToHac do
     it 'sets init options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
                                                      :checkboxes        => true,
-                                                     :highlight_changes => true)
+                                                     :highlight_changes => true,
+                                                     :oncheck           => nil,
+                                                     :check_url         => "/ops/rbac_group_field_changed/new___")
     end
   end
 
   describe '#set_locals_for_render' do
     it 'sets locals correctly' do
-      expect(subject.send(:set_locals_for_render)).to include(:check_url => "/ops/rbac_group_field_changed/new___",
-                                                              :oncheck   => nil)
+      expect(subject.send(:set_locals_for_render)).to include(:check_url => "/ops/rbac_group_field_changed/new___")
     end
   end
 

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -40,15 +40,16 @@ describe TreeBuilderBelongsToVat do
     it 'sets tree options correctly' do
       expect(subject.send(:tree_init_options)).to eq(:full_ids          => true,
                                                      :checkboxes        => true,
-                                                     :highlight_changes => true)
+                                                     :highlight_changes => true,
+                                                     :oncheck           => nil,
+                                                     :check_url         => "/ops/rbac_group_field_changed/#{group.id}___")
     end
   end
 
   describe '#set_locals_for_render' do
     it 'set locals for render correctly' do
       locals = subject.send(:set_locals_for_render)
-      expect(locals).to include(:check_url => "/ops/rbac_group_field_changed/#{group.id || "new"}___",
-                                :oncheck   => edit ? "miqOnCheckUserFilters" : nil)
+      expect(locals).to include(:check_url => "/ops/rbac_group_field_changed/#{group.id || "new"}___")
     end
   end
 

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -19,7 +19,14 @@ describe TreeBuilderClusters do
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @cluster_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :checkboxes => true, :highlight_changes => true, :three_checks => true)
+      expect(root_options).to eq(
+        :full_ids          => false,
+        :checkboxes        => true,
+        :highlight_changes => true,
+        :three_checks      => true,
+        :oncheck           => "miqOnCheckCUFilters",
+        :check_url         => "/ops/cu_collection_field_changed/"
+      )
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -11,7 +11,13 @@ describe TreeBuilderDatastores do
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
-      expect(root_options).to eq(:full_ids => false, :checkboxes => true, :highlight_changes => true)
+      expect(root_options).to eq(
+        :full_ids          => false,
+        :checkboxes        => true,
+        :highlight_changes => true,
+        :check_url         => "/ops/cu_collection_field_changed/",
+        :oncheck           => "miqOnCheckCUFilters"
+      )
     end
     it 'sets locals correctly' do
       locals = @datastores_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -19,16 +19,23 @@ describe TreeBuilderGenealogy do
 
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
-      expect(subject.send(:tree_init_options)).to eq(:full_ids => true, :checkboxes => true)
+      expect(subject.send(:tree_init_options)).to eq(
+        :full_ids   => true,
+        :checkboxes => true,
+        :click_url  => "/vm/genealogy_tree_selected/",
+        :onclick    => "miqOnClickGeneric",
+        :oncheck    => "miqOnCheckGenealogy",
+        :check_url  => "/vm/set_checked_items/"
+      )
     end
   end
 
   describe '#set_locals_for_render' do
     it 'sets locals for render correctly' do
-      expect(subject.send(:set_locals_for_render)).to include(:click_url  => "/vm/genealogy_tree_selected/",
-                                                              :onclick    => "miqOnClickGeneric",
-                                                              :oncheck    => "miqOnCheckGenealogy",
-                                                              :check_url  => "/vm/set_checked_items/")
+      expect(subject.send(:set_locals_for_render)).to include(:click_url => "/vm/genealogy_tree_selected/",
+                                                              :onclick   => "miqOnClickGeneric",
+                                                              :oncheck   => "miqOnCheckGenealogy",
+                                                              :check_url => "/vm/set_checked_items/")
     end
   end
 

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -24,7 +24,13 @@ describe TreeBuilderProtect do
 
     it 'set init options correctly' do
       tree_options = @protect_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => false, :checkboxes => true, :highlight_changes => true)
+      expect(tree_options).to eq(
+        :full_ids          => false,
+        :checkboxes        => true,
+        :highlight_changes => true,
+        :check_url         => "/name/protect/",
+        :oncheck           => "miqOnCheckProtect"
+      )
     end
 
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -55,7 +55,13 @@ describe TreeBuilderSections do
     end
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :checkboxes => true, :three_checks => true)
+      expect(tree_options).to eq(
+        :full_ids     => true,
+        :checkboxes   => true,
+        :three_checks => true,
+        :oncheck      => "miqOnCheckSections",
+        :check_url    => "/controller_name/sections_field_changed/"
+      )
     end
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -39,7 +39,9 @@ describe TreeBuilderSmartproxyAffinity do
         :full_ids     => false,
         :checkboxes   => true,
         :three_checks => true,
-        :post_check   => true
+        :post_check   => true,
+        :check_url    => "/ops/smartproxy_affinity_field_changed/",
+        :oncheck      => "miqOnCheckGeneric"
       )
     end
     it 'set locals for render correctly' do

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -24,7 +24,13 @@ describe TreeBuilderTags do
     end
     it 'set init options correctly' do
       tree_options = @tags_tree.send(:tree_init_options)
-      expect(tree_options).to eq(:full_ids => true, :checkboxes => true, :highlight_changes => true)
+      expect(tree_options).to eq(
+        :full_ids          => true,
+        :checkboxes        => true,
+        :highlight_changes => true,
+        :check_url         => "/ops/rbac_group_field_changed/#{@group.id}___",
+        :oncheck           => nil
+      )
     end
     it 'set locals for render correctly' do
       locals = @tags_tree.send(:set_locals_for_render)


### PR DESCRIPTION
This last move makes the `set_locals_for_render` redefinitions empty, so removing them completely.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label trees, hammer/no, refactoring