### PR TITLE
Services use turbo button

### DIFF
--- a/product/views/Service.yaml
+++ b/product/views/Service.yaml
@@ -17,6 +17,9 @@ name: Service
 # Main DB table report is based on
 db: Service
 
+db_options:
+  :use_sql_view: true
+
 # Columns to fetch from the main table
 cols:
 - name


### PR DESCRIPTION
This will use an inline view for the services page.

This cuts back on the amount of virtual attribute work the database
performs.

We are slowly rolling this out to reduce testing efforts / introducing
regressions

This depends upon https://github.com/ManageIQ/manageiq/pull/18543
but it can be merged before that PR, as it will be a NOP

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1686433

For one customer in particular, these 2 PRs speeds up the `/services/report_data` a bit:

|         ms |     bytes |   objects |query |    qry ms |     rows |`comments`
|        ---:|       ---:|       ---:|  ---:|       ---:|      ---:| ---
|  445,306.4 | 1,694,049 |    10,177 |    6 | 445,251.6 |       25 |`before-7-attributes`
|    1,252.4 | 1,754,293 |    10,984 |    6 |   1,197.6 |       25 |`after-7-attributes`


@miq-bot tag performance hammer/yes, bug