### PR TITLE
Remove @babel/runtime dependency workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "xml_display": "~0.1.1"
   },
   "devDependencies": {
-    "@babel/runtime": "7.0.0-beta.42",
     "@types/cheerio": "^0.22.9",
     "@types/enzyme": "3.1.17",
     "@types/jasmine": "^2.8.6",


### PR DESCRIPTION
This reverts 8e7b987 (https://github.com/ManageIQ/manageiq-ui-classic/pull/4495),
because now the old version of `@babel/runtime` is causing an issue with react-transition-group 2.7.0 (not 2.6.1):

    ERROR in ./node_modules/react-bootstrap/node_modules/react-transition-group/esm/Transition.js
    Module not found: Error: Can't resolve '@babel/runtime/helpers/esm/inheritsLoose' in '/Users/gpiatigorski/dev/manageiq/plugins/manageiq-ui-classic/node_modules/react-bootstrap/node_modules/react-transition-group/esm'

A current version of `@babel/runtime` works, and doesn't break `react-bootstrap` (0.32.4) anymore,
and we still don't depend on it directly, so removing the dependency.
