### PR TITLE
Breadcrumbs - don't assume x_active_tree/accord are strings, convert

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -105,17 +105,17 @@ module Mixins
       if features?
         allowed_features = ApplicationController::Feature.allowed_features(features)
         # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
-        return allowed_features.find { |f| f.tree_name == x_active_tree }.build_tree(@sb.deep_dup)
+        return allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
       end
       []
     end
 
     def accord_name
-      features.find { |f| f.name == x_active_accord }.try(:title)
+      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:title)
     end
 
     def accord_container
-      features.find { |f| f.name == x_active_accord }.try(:container)
+      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:container)
     end
 
     # Has controller features


### PR DESCRIPTION
In Compute > Cloud > Instances, `x_active_tree == :vandt_tree`,
so we need to use `x_active_tree.to_s` when comparing with `feature.tree_name`

By the same token, code dealing with `x_active_accord` should also do `to_s`, and compare to `feature.accord_name`, which is explicitly `name.to_s`.

Fixes.. (when opening `/vm_cloud/explorer` or `/vm_infra/explorer`)

	[----] I, [2019-03-25T11:37:36.573987 #16131:2aab9d2ec64c]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_breadcrumbs_new.html.haml (2.6ms)
	[----] I, [2019-03-25T11:37:36.574181 #16131:2aab9d2ec64c]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_content.html.haml (11.0ms)
	[----] F, [2019-03-25T11:37:36.574393 #16131:2aab9d2ec64c] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `build_tree' for nil:NilClass
	/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:108:in `build_tree'
	/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:90:in `build_breadcrumbs_from_tree'
	/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:32:in `data_for_breadcrumbs'
	/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7.2/lib/abstract_controller/helpers.rb:68:in `data_for_breadcrumbs'
	/home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_breadcrumbs_new.html.haml:1:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_layouts__breadcrumbs_new_html_haml___3392965133297600725_69865813816580'

Cc @rvsia, comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/4468
Cc @hstastna, thanks for finding this