### PR TITLE
[Failing Travis - Breadcrumbs] Fix container > role and x_active_tree in breadcrumbs

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1168,7 +1168,7 @@ class MiqPolicyController < ApplicationController
   end
 
   def build_tree
-    features.find { |f| f.tree_name == x_active_tree }.build_tree(@sb.deep_dup)
+    features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
   end
 
   menu_section :con

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -26,7 +26,7 @@ module Mixins
         end
       else
         # Append breadcrumb from title of the accordion (eg "Policies")
-        breadcrumbs.push(:title => accord_name, :key => accord_container, :action => "accordion_select") if features?
+        breadcrumbs.push(:title => accord_title, :key => "#{accord_name}_accord", :action => "accordion_select") if features?
 
         # Append breadcrumbs created from the tree (eg "All policies > Red Hat policies > Policy 1")
         breadcrumbs_from_tree = build_breadcrumbs_from_tree
@@ -105,17 +105,17 @@ module Mixins
       if features?
         allowed_features = ApplicationController::Feature.allowed_features(features)
         # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
-        return allowed_features.find { |f| f.tree_name == x_active_tree }.build_tree(@sb.deep_dup)
+        return allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
       end
       []
     end
 
-    def accord_name
-      features.find { |f| f.name == x_active_accord }.try(:title)
+    def accord_title
+      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:title)
     end
 
-    def accord_container
-      features.find { |f| f.name == x_active_accord }.try(:container)
+    def accord_name
+      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:name)
     end
 
     # Has controller features

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -16,26 +16,23 @@ describe Mixins::BreadcrumbsMixin do
     include Mixins::BreadcrumbsMixin
 
     def features
-      feature_active = ApplicationController::Feature.new
-      feature_active.name = :utilization_tree
-      feature_active.title = "Active Tree"
-      feature_active.container = "active_accord"
-
-      feature_not_active1 = ApplicationController::Feature.new
-      feature_not_active1.name = :old_dialog_tree
-      feature_not_active1.title = "Dialog Tree"
-      feature_not_active1.container = "dialog_accord"
-
-      feature_not_active2 = ApplicationController::Feature.new
-      feature_not_active2.name = :tree
-      feature_not_active2.title = "Tree"
-      feature_not_active2.container = "tree_accord"
-
       [
-        feature_active,
-        feature_not_active1,
-        feature_not_active2,
-      ]
+        {
+          :role_any => true,
+          :name     => :utilization_tree,
+          :title    => _("Active Tree")
+        },
+        {
+          :role_any => true,
+          :name     => :old_dialog_tree,
+          :title    => _("Dialog Tree")
+        },
+        {
+          :role_any => true,
+          :name     => :tree,
+          :title    => _("Tree")
+        }
+      ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
     end
 
     def build_tree
@@ -45,7 +42,7 @@ describe Mixins::BreadcrumbsMixin do
 
   let(:mixin) { TestMixin.new }
   let(:controller_url) { 'testmixin' }
-  let(:features) { [{:title => "Active Tree", :name => :utilization_tree, :container => "active_accord"}] }
+  let(:features) { [{:title => "Active Tree", :name => :utilization_tree}] }
   let(:breadcrumbs) do
     [
       {:title => _("First Layer")},
@@ -74,8 +71,8 @@ describe Mixins::BreadcrumbsMixin do
 
   describe "#accord_name" do
     context 'when features contains the tree' do
-      it "returns title" do
-        expect(mixin.accord_name).to eq(features[0][:title])
+      it "returns name" do
+        expect(mixin.accord_name).to eq(features[0][:name])
       end
     end
 
@@ -87,17 +84,17 @@ describe Mixins::BreadcrumbsMixin do
     end
   end
 
-  describe "#accord_container" do
+  describe "#accord_title" do
     context 'when features contains the tree' do
-      it "returns container" do
-        expect(mixin.accord_container).to eq(features[0][:container])
+      it "returns title" do
+        expect(mixin.accord_title).to eq(features[0][:title])
       end
     end
 
     context 'when features do not contains the tree' do
       it "returns nil" do
         allow(mixin).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin.accord_container).to be(nil)
+        expect(mixin.accord_title).to be(nil)
       end
     end
   end
@@ -158,7 +155,7 @@ describe Mixins::BreadcrumbsMixin do
       it "creates breadcrumbs" do
         expect(mixin.data_for_breadcrumbs).to eq([{:title => "First Layer"},
                                                   {:title => "Second Layer"},
-                                                  {:title => "Active Tree", :key => "active_accord", :action => "accordion_select"},
+                                                  {:title => "Active Tree", :key => "utilization_tree_accord", :action => "accordion_select"},
                                                   {:title => "All Dialogs", :key => "root"},
                                                   {:title => "Item1", :key => "xx-1"}])
       end


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq-ui-classic/pull/5369

Changes which happened during the review and merge process affected the breadcrumb mixin 