### PR TITLE
Rewrite column modification to be more stable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -199,12 +199,6 @@ class ApplicationController < ActionController::Base
 
   AE_MAX_RESOLUTION_FIELDS = 5 # Maximum fields to show for automation engine resolution screens
 
-  PROV_STATES = {
-    "pending_approval" => N_("Pending Approval"),
-    "approved"         => N_("Approved"),
-    "denied"           => N_("Denied")
-  }.freeze
-
   def local_request?
     Rails.env.development? || Rails.env.test?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -900,20 +900,22 @@ class ApplicationController < ActionController::Base
 
         celltext = nil
 
-        case view.col_order[col_idx]
-        when 'approval_state'
+        if view.col_order[col_idx] == 'approval_state' && view.extras[:filename] == "MiqRequest"
           celltext = _(PROV_STATES[row[col]])
-        when 'prov_type'
+        elsif view.col_order[col_idx] == 'prov_type' && view.extras[:filename] == "ServiceTemplate"
           celltext = row[col] ? _(ServiceTemplate::CATALOG_ITEM_TYPES[row[col]]) : ''
-        when "result"
+        elsif view.col_order[col_idx] == "result" && view.extras[:filename] == "OpenscapRuleResult"
           new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
-        when "severity"
+        elsif view.col_order[col_idx] == "severity" && view.extras[:filename] == "OpenscapRuleResult"
           new_row[:cells] << {:span => severity_span_class(row[col]), :text => row[col].titleize}
-        when 'state'
+        elsif view.col_order[col_idx] == 'state' && %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
           celltext = row[col].to_s.titleize
-        when 'hardware.bitness'
+        elsif view.col_order[col_idx] == 'hardware.bitness' && %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates
+                                                                  ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates
+                                                                  ManageIQ_Providers_CloudManager_Vm ManageIQ_Providers_CloudManager_Vm-vms
+                                                                  ManageIQ_Providers_CloudManager_Template).include?(view.extras[:filename])
           celltext = row[col] ? "#{row[col]} bit" : ''
-        when 'image?'
+        elsif view.col_order[col_idx] == 'image?' && view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
           celltext = row[col] ? _("Image") : _("Snapshot")
         else
           # Use scheduled tz for formatting, if configured

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -901,8 +901,6 @@ class ApplicationController < ActionController::Base
         celltext = nil
 
         case view.col_order[col_idx]
-        when 'db'
-          celltext = Dictionary.gettext(row[col], :type => :model, :notfound => :titleize)
         when 'approval_state'
           celltext = _(PROV_STATES[row[col]])
         when 'prov_type'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1333,7 +1333,7 @@ class ApplicationController < ActionController::Base
     view =
       if options['report_name']
         path_to_report = ManageIQ::UI::Classic::Engine.root.join("product", "views", options['report_name']).to_s
-        MiqReport.new(YAML.safe_load(File.open(path_to_report), [Symbol]))
+        MiqReport.load_from_filename(path_to_report, {})
       else
         refresh_view ? get_db_view(db.gsub('::', '_'), :association => association, :view_suffix => view_suffix) : session[:view]
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -815,9 +815,6 @@ class ApplicationController < ActionController::Base
 
   # Render the view data to a Hash structure for the list view
   def view_to_hash(view, fetch_data = false)
-    # Get the time zone in effect for this view
-    tz = view.db.downcase == 'miqschedule' ? server_timezone : Time.zone
-
     root = {:head => [], :rows => []}
 
     has_checkbox = !@embedded && !@no_checkboxes
@@ -894,7 +891,7 @@ class ApplicationController < ActionController::Base
                           :image => ActionController::Base.helpers.image_path(image.to_s),
                           :icon  => icon,
                           :icon2 => icon2}.compact
-      new_row[:cells].concat(::GtlFormatter.format_cols(view, row, tz))
+      new_row[:cells].concat(::GtlFormatter.format_cols(view, row))
 
       next unless @row_button # Show a button in the last col
       new_row[:cells] << {

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -9,6 +9,12 @@ class MiqRequestController < ApplicationController
 
   helper ProvisionCustomizeHelper
 
+  PROV_STATES = {
+    "pending_approval" => N_("Pending Approval"),
+    "approved"         => N_("Approved"),
+    "denied"           => N_("Denied")
+  }.freeze
+
   def index
     @request_tab = params[:typ] if params[:typ] # set this to be used to identify which Requests subtab was clicked
     redirect_to(:action => 'show_list')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -656,15 +656,6 @@ module ApplicationHelper
       (@toolbars['history_tb'] != 'blank_view_tb' && @toolbars['history_tb'] != 'blank_view_tb' && @toolbars['view_tb'] != 'blank_view_tb')
   end
 
-  # Format a column in a report view for display on the screen
-  def format_col_for_display(view, row, col, tz = nil)
-    tz ||= ["miqschedule"].include?(view.db.downcase) ? MiqServer.my_server.server_timezone : Time.zone
-    celltext = view.format(col,
-                           row[col],
-                           :tz => tz).gsub(/\\/, '\&') # Call format, then escape any backslashes
-    celltext
-  end
-
   def check_if_button_is_implemented
     if !@flash_array && !@refresh_partial # if no button handler ran, show not implemented msg
       add_flash(_("Button not yet implemented"), :error)

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -16,8 +16,8 @@ class GtlFormatter
 
       if view.col_order[col_idx] == 'approval_state' && view.extras[:filename] == "MiqRequest"
         celltext = _(PROV_STATES[row[col]])
-      elsif view.col_order[col_idx] == 'prov_type' && view.extras[:filename] == "ServiceTemplate"
-        celltext = row[col] ? _(ServiceTemplate::CATALOG_ITEM_TYPES[row[col]]) : ''
+      elsif view.extras[:filename] == "ServiceTemplate"
+        celltext = service_template_format(view.col_order[col_idx], row[col])
       elsif view.extras[:filename] == "OpenscapRuleResult"
         celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
       elsif view.col_order[col_idx] == 'state' && %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
@@ -55,6 +55,16 @@ class GtlFormatter
       celltext = format_col_for_display(view, row, col, celltz || tz)
     end
     [celltext, span]
+  end
+
+  def self.service_template_format(key, value)
+    celltext = nil
+    if key == "prov_type"
+      celltext = value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : ''
+    else
+      celltext = format_col_for_display(view, row, col, celltz || tz)
+    end
+    celltext
   end
 
   # Format a column in a report view for display on the screen

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -1,0 +1,80 @@
+class GtlFormatter
+
+  PROV_STATES = {
+    "pending_approval" => N_("Pending Approval"),
+    "approved"         => N_("Approved"),
+    "denied"           => N_("Denied")
+  }.freeze
+
+  def self.format_cols(view, row, tz)
+    rows = []
+    view.col_order.each_with_index do |col, col_idx|
+      next if view.column_is_hidden?(col)
+
+      celltext = nil
+      span = nil
+
+      if view.col_order[col_idx] == 'approval_state' && view.extras[:filename] == "MiqRequest"
+        celltext = _(PROV_STATES[row[col]])
+      elsif view.col_order[col_idx] == 'prov_type' && view.extras[:filename] == "ServiceTemplate"
+        celltext = row[col] ? _(ServiceTemplate::CATALOG_ITEM_TYPES[row[col]]) : ''
+      elsif view.col_order[col_idx] == "result" && view.extras[:filename] == "OpenscapRuleResult"
+        span = result_span_class(row[col])
+        celltext = row[col].titleize
+      elsif view.col_order[col_idx] == "severity" && view.extras[:filename] == "OpenscapRuleResult"
+        span = severity_span_class(row[col])
+        celltext = row[col].titleize
+      elsif view.col_order[col_idx] == 'state' && %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
+        celltext = row[col].to_s.titleize
+      elsif view.col_order[col_idx] == 'hardware.bitness' && %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates
+                                                                  ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates
+                                                                  ManageIQ_Providers_CloudManager_Vm ManageIQ_Providers_CloudManager_Vm-vms
+                                                                  ManageIQ_Providers_CloudManager_Template).include?(view.extras[:filename])
+        celltext = row[col] ? "#{row[col]} bit" : ''
+      elsif view.col_order[col_idx] == 'image?' && view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
+        celltext = row[col] ? _("Image") : _("Snapshot")
+      else
+        # Use scheduled tz for formatting, if configured
+        if ['miqschedule'].include?(view.db.downcase)
+          celltz = row['run_at'][:tz] if row['run_at'] && row['run_at'][:tz]
+        end
+        celltext = format_col_for_display(view, row, col, celltz || tz)
+      end
+      item = {:text => celltext}
+      item[:span] = span if span.present?
+      rows.push(item)
+    end
+    rows
+  end
+
+  # Format a column in a report view for display on the screen
+  def self.format_col_for_display(view, row, col, tz = nil)
+    tz ||= ["miqschedule"].include?(view.db.downcase) ? MiqServer.my_server.server_timezone : Time.zone
+    celltext = view.format(col,
+                           row[col],
+                           :tz => tz).gsub(/\\/, '\&') # Call format, then escape any backslashes
+    celltext
+  end
+
+  def self.result_span_class(value)
+    case value.downcase
+    when "pass"
+      "label label-success center-block"
+    when "fail"
+      "label label-danger center-block"
+    else
+      "label label-primary center-block"
+    end
+  end
+
+  def self.severity_span_class(value)
+    case value.downcase
+    when "high"
+      "label label-danger center-block"
+    when "medium"
+      "label label-warning center-block"
+    else
+      "label label-low-severity center-block"
+    end
+  end
+end

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -1,5 +1,4 @@
 class GtlFormatter
-
   PROV_STATES = {
     "pending_approval" => N_("Pending Approval"),
     "approved"         => N_("Approved"),
@@ -13,7 +12,7 @@ class GtlFormatter
 
     view.col_order.each_with_index do |col, col_idx|
       next if view.column_is_hidden?(col)
-      
+
       @col = col
       span = nil
 
@@ -23,11 +22,11 @@ class GtlFormatter
         celltext = service_template_format(view.col_order[col_idx], row[col])
       elsif view.extras[:filename] == "OpenscapRuleResult"
         celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
-      elsif %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
+      elsif %w[AutomationRequest MiqRequest Container MiqTask MiqProvision].include?(view.extras[:filename])
         celltext = state_format(view.col_order[col_idx], row[col])
-      elsif %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm-vms
+      elsif %w[ManageIQ_Providers_CloudManager_Template-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm-vms
                ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm
-               ManageIQ_Providers_CloudManager_Template).include?(view.extras[:filename])
+               ManageIQ_Providers_CloudManager_Template].include?(view.extras[:filename])
         celltext = hardware_bitness_format(view.col_order[col_idx], row[col])
       elsif view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
         celltext = cloud_manager_template_format(view.col_order[col_idx], row[col])
@@ -43,38 +42,34 @@ class GtlFormatter
 
   def self.cloud_manager_template_format(key, value)
     if key == 'image?'
-      celltext = value ? _("Image") : _("Snapshot")
+      value ? _("Image") : _("Snapshot")
     else
-      celltext = hardware_bitness_format(key, value)
+      hardware_bitness_format(key, value)
     end
-    celltext
   end
 
   def self.hardware_bitness_format(key, value)
     if key == 'hardware.bitness'
-      celltext = value ? "#{value} bit" : ''
+      value ? "#{value} bit" : ''
     else
-      celltext = format_col_for_display(@view, @row, @col)
+      format_col_for_display(@view, @row, @col)
     end
-    celltext
   end
 
   def self.state_format(key, value)
     if key == 'state'
-      celltext = value.to_s.titleize
+      value.to_s.titleize
     else
-      celltext = format_col_for_display(@view, @row, @col)
+      format_col_for_display(@view, @row, @col)
     end
-    celltext
   end
 
   def self.miq_request_format(key, value)
     if key == 'approval_state'
-      celltext = _(PROV_STATES[value])
+      _(PROV_STATES[value])
     else
-      celltext = state_format(key, value)
+      state_format(key, value)
     end
-    celltext
   end
 
   def self.openscap_role_result_format(key, value)
@@ -93,11 +88,10 @@ class GtlFormatter
 
   def self.service_template_format(key, value)
     if key == "prov_type"
-      celltext = value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : ''
+      value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : ''
     else
-      celltext = format_col_for_display(@view, @row, @col)
+      format_col_for_display(@view, @row, @col)
     end
-    celltext
   end
 
   def self.timezone(view, row)
@@ -113,10 +107,7 @@ class GtlFormatter
 
   # Format a column in a report view for display on the screen
   def self.format_col_for_display(view, row, col)
-    celltext = view.format(col,
-                           row[col],
-                           :tz => timezone(view, row)).gsub(/\\/, '\&') # Call format, then escape any backslashes
-    celltext
+    view.format(col, row[col], :tz => timezone(view, row)).gsub(/\\/, '\&') # Call format, then escape any backslashes
   end
 
   def self.result_span_class(value)

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -22,13 +22,12 @@ class GtlFormatter
         celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
       elsif %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
         celltext = state_format(view.col_order[col_idx], row[col])
-      elsif view.col_order[col_idx] == 'hardware.bitness' && %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates
-                                                                  ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates
-                                                                  ManageIQ_Providers_CloudManager_Vm ManageIQ_Providers_CloudManager_Vm-vms
-                                                                  ManageIQ_Providers_CloudManager_Template).include?(view.extras[:filename])
-        celltext = row[col] ? "#{row[col]} bit" : ''
-      elsif view.col_order[col_idx] == 'image?' && view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
-        celltext = row[col] ? _("Image") : _("Snapshot")
+      elsif %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm-vms
+               ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm
+               ManageIQ_Providers_CloudManager_Template).include?(view.extras[:filename])
+        celltext = hardware_bitness_format(view.col_order[col_idx], row[col])
+      elsif view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
+        celltext = cloud_manager_template_format(view.col_order[col_idx], row[col])
       else
         # Use scheduled tz for formatting, if configured
         if ['miqschedule'].include?(view.db.downcase)
@@ -41,6 +40,24 @@ class GtlFormatter
       rows.push(item)
     end
     rows
+  end
+
+  def self.cloud_manager_template_format(key, value)
+    if key == 'image?'
+      celltext = value ? _("Image") : _("Snapshot")
+    else
+      celltext = hardware_bitness_format(key, value)
+    end
+    celltext
+  end
+
+  def self.hardware_bitness_format(key, value)
+    if key == 'hardware.bitness'
+      celltext = value ? "#{value} bit" : ''
+    else
+      celltext = format_col_for_display(view, row, col, celltz || tz)
+    end
+    celltext
   end
 
   def self.state_format(key, value)

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -1,10 +1,4 @@
 class GtlFormatter
-  PROV_STATES = {
-    "pending_approval" => N_("Pending Approval"),
-    "approved"         => N_("Approved"),
-    "denied"           => N_("Denied")
-  }.freeze
-
   def self.format_cols(view, row)
     cols = []
 
@@ -68,7 +62,7 @@ class GtlFormatter
   end
 
   def self.miq_request_format(value)
-    [_(PROV_STATES[value]), nil]
+    [_(MiqRequestController::PROV_STATES[value]), nil]
   end
 
   def self.service_template_format(value)

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -18,12 +18,8 @@ class GtlFormatter
         celltext = _(PROV_STATES[row[col]])
       elsif view.col_order[col_idx] == 'prov_type' && view.extras[:filename] == "ServiceTemplate"
         celltext = row[col] ? _(ServiceTemplate::CATALOG_ITEM_TYPES[row[col]]) : ''
-      elsif view.col_order[col_idx] == "result" && view.extras[:filename] == "OpenscapRuleResult"
-        span = result_span_class(row[col])
-        celltext = row[col].titleize
-      elsif view.col_order[col_idx] == "severity" && view.extras[:filename] == "OpenscapRuleResult"
-        span = severity_span_class(row[col])
-        celltext = row[col].titleize
+      elsif view.extras[:filename] == "OpenscapRuleResult"
+        celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
       elsif view.col_order[col_idx] == 'state' && %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
         celltext = row[col].to_s.titleize
       elsif view.col_order[col_idx] == 'hardware.bitness' && %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates
@@ -45,6 +41,20 @@ class GtlFormatter
       rows.push(item)
     end
     rows
+  end
+
+  def self.openscap_role_result_format(key, value)
+    celltext, span = nil
+    if key == "result"
+      span = result_span_class(value)
+      celltext = value.titleize
+    elsif key == "severity"
+      span = severity_span_class(value)
+      celltext = value.titleize
+    else
+      celltext = format_col_for_display(view, row, col, celltz || tz)
+    end
+    [celltext, span]
   end
 
   # Format a column in a report view for display on the screen

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -14,14 +14,14 @@ class GtlFormatter
       celltext = nil
       span = nil
 
-      if view.col_order[col_idx] == 'approval_state' && view.extras[:filename] == "MiqRequest"
-        celltext = _(PROV_STATES[row[col]])
+      if view.extras[:filename] == "MiqRequest"
+        celltext = miq_request_format(view.col_order[col_idx], row[col])
       elsif view.extras[:filename] == "ServiceTemplate"
         celltext = service_template_format(view.col_order[col_idx], row[col])
       elsif view.extras[:filename] == "OpenscapRuleResult"
         celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
-      elsif view.col_order[col_idx] == 'state' && %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
-        celltext = row[col].to_s.titleize
+      elsif %w(AutomationRequest MiqRequest Container MiqTask MiqProvision).include?(view.extras[:filename])
+        celltext = state_format(view.col_order[col_idx], row[col])
       elsif view.col_order[col_idx] == 'hardware.bitness' && %w(ManageIQ_Providers_CloudManager_Template-all_vms_and_templates
                                                                   ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates
                                                                   ManageIQ_Providers_CloudManager_Vm ManageIQ_Providers_CloudManager_Vm-vms
@@ -43,8 +43,26 @@ class GtlFormatter
     rows
   end
 
+  def self.state_format(key, value)
+    if key == 'state'
+      celltext = value.to_s.titleize
+    else
+      celltext = format_col_for_display(view, row, col, celltz || tz)
+    end
+    celltext
+  end
+
+  def self.miq_request_format(key, value)
+    if key == 'approval_state'
+      celltext = _(PROV_STATES[value])
+    else
+      celltext = state_format(key, value)
+    end
+    celltext
+  end
+
   def self.openscap_role_result_format(key, value)
-    celltext, span = nil
+    span = nil
     if key == "result"
       span = result_span_class(value)
       celltext = value.titleize
@@ -58,7 +76,6 @@ class GtlFormatter
   end
 
   def self.service_template_format(key, value)
-    celltext = nil
     if key == "prov_type"
       celltext = value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : ''
     else

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -6,129 +6,108 @@ class GtlFormatter
   }.freeze
 
   def self.format_cols(view, row)
-    rows = []
-    @row = row
-    @view = view
+    cols = []
+
+    state = {"state" => :state_format}
+    hardware = {"hardware.bitness" => :hardware_bitness_format}
+    special_cases = {
+      "AutomationRequest"                                              => state,
+      "Container"                                                      => state,
+      "MiqTask"                                                        => state,
+      "MiqProvision"                                                   => state,
+      "MiqRequest"                                                     => state.merge({
+        'approval_state' => :miq_request_format,
+      }),
+      "ManageIQ_Providers_CloudManager_Template-all_vms_and_templates" => hardware,
+      "ManageIQ_Providers_CloudManager_Vm-vms"                         => hardware,
+      "ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates"       => hardware,
+      "ManageIQ_Providers_CloudManager_Vm"                             => hardware,
+      "ManageIQ_Providers_CloudManager_Template"                       => hardware.merge({
+        "image?" => :cloud_manager_template_format,
+      }),
+      "MiqSchedule" => :timezone, # all fields have same specific format
+      "OpenscapRuleResult" => {
+        "result"   => :result_format,
+        "severity" => :severity_format,
+      },
+      "ServiceTemplate" => {
+        "prov_type" => :service_template_format,
+      },
+    }
 
     view.col_order.each_with_index do |col, col_idx|
       next if view.column_is_hidden?(col)
 
-      @col = col
       span = nil
 
-      if view.extras[:filename] == "MiqRequest"
-        celltext = miq_request_format(view.col_order[col_idx], row[col])
-      elsif view.extras[:filename] == "ServiceTemplate"
-        celltext = service_template_format(view.col_order[col_idx], row[col])
-      elsif view.extras[:filename] == "OpenscapRuleResult"
-        celltext, span = openscap_role_result_format(view.col_order[col_idx], row[col])
-      elsif %w[AutomationRequest MiqRequest Container MiqTask MiqProvision].include?(view.extras[:filename])
-        celltext = state_format(view.col_order[col_idx], row[col])
-      elsif %w[ManageIQ_Providers_CloudManager_Template-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm-vms
-               ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates ManageIQ_Providers_CloudManager_Vm
-               ManageIQ_Providers_CloudManager_Template].include?(view.extras[:filename])
-        celltext = hardware_bitness_format(view.col_order[col_idx], row[col])
-      elsif view.extras[:filename] == "ManageIQ_Providers_CloudManager_Template"
-        celltext = cloud_manager_template_format(view.col_order[col_idx], row[col])
+      if special_cases[view.extras[:filename]].kind_of?(Symbol)
+        celltext = send(special_cases[view.extras[:filename]], view, row, col)
+      elsif special_cases[view.extras[:filename]].kind_of?(Hash) && special_cases[view.extras[:filename]][view.col_order[col_idx]].present?
+        celltext, span = send(special_cases[view.extras[:filename]][view.col_order[col_idx]], row[col])
       else
         celltext = format_col_for_display(view, row, col)
       end
+
       item = {:text => celltext}
       item[:span] = span if span.present?
-      rows.push(item)
+      cols.push(item)
     end
-    rows
+    cols
   end
 
-  def self.cloud_manager_template_format(key, value)
-    if key == 'image?'
-      value ? _("Image") : _("Snapshot")
-    else
-      hardware_bitness_format(key, value)
-    end
+  def self.cloud_manager_template_format(value)
+    [value ? _("Image") : _("Snapshot"), nil]
   end
 
-  def self.hardware_bitness_format(key, value)
-    if key == 'hardware.bitness'
-      value ? "#{value} bit" : ''
-    else
-      format_col_for_display(@view, @row, @col)
-    end
+  def self.hardware_bitness_format(value)
+    [value ? "#{value} bit" : '', nil]
   end
 
-  def self.state_format(key, value)
-    if key == 'state'
-      value.to_s.titleize
-    else
-      format_col_for_display(@view, @row, @col)
-    end
+  def self.state_format(value)
+    [value.to_s.titleize, nil]
   end
 
-  def self.miq_request_format(key, value)
-    if key == 'approval_state'
-      _(PROV_STATES[value])
-    else
-      state_format(key, value)
-    end
+  def self.miq_request_format(value)
+    [_(PROV_STATES[value]), nil]
   end
 
-  def self.openscap_role_result_format(key, value)
-    span = nil
-    if key == "result"
-      span = result_span_class(value)
-      celltext = value.titleize
-    elsif key == "severity"
-      span = severity_span_class(value)
-      celltext = value.titleize
-    else
-      celltext = format_col_for_display(@view, @row, @col)
-    end
-    [celltext, span]
+  def self.service_template_format(value)
+    [value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : '', nil]
   end
 
-  def self.service_template_format(key, value)
-    if key == "prov_type"
-      value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : ''
-    else
-      format_col_for_display(@view, @row, @col)
-    end
-  end
-
-  def self.timezone(view, row)
-    if view.extras[:filename] == "MiqSchedule"
-      timezone = MiqServer.my_server.server_timezone
-      # Use scheduled tz for formatting, if configured
-      timezone = row['run_at'][:tz] if row['run_at'] && row['run_at'][:tz]
-    else
-      timezone = Time.zone
-    end
-    timezone
+  def self.timezone(view, row, col)
+    timezone = MiqServer.my_server.server_timezone
+    # Use scheduled tz for formatting, if configured
+    timezone = row['run_at'][:tz] if row['run_at'] && row['run_at'][:tz]
+    format_col_for_display(view, row, col, timezone)
   end
 
   # Format a column in a report view for display on the screen
-  def self.format_col_for_display(view, row, col)
-    view.format(col, row[col], :tz => timezone(view, row)).gsub(/\\/, '\&') # Call format, then escape any backslashes
+  def self.format_col_for_display(view, row, col, tz = Time.zone)
+    view.format(col, row[col], :tz => tz).gsub(/\\/, '\&') # Call format, then escape any backslashes
   end
 
-  def self.result_span_class(value)
-    case value.downcase
-    when "pass"
-      "label label-success center-block"
-    when "fail"
-      "label label-danger center-block"
-    else
-      "label label-primary center-block"
-    end
+  def self.result_format(value)
+    span = case value.downcase
+           when "pass"
+             "label label-success center-block"
+           when "fail"
+             "label label-danger center-block"
+           else
+             "label label-primary center-block"
+           end
+    [value.titleize, span]
   end
 
-  def self.severity_span_class(value)
-    case value.downcase
-    when "high"
-      "label label-danger center-block"
-    when "medium"
-      "label label-warning center-block"
-    else
-      "label label-low-severity center-block"
-    end
+  def self.severity_format(value)
+    span = case value.downcase
+           when "high"
+             "label label-danger center-block"
+           when "medium"
+             "label label-warning center-block"
+           else
+             "label label-low-severity center-block"
+           end
+    [value.titleize, span]
   end
 end


### PR DESCRIPTION
It's not enough to decide in [this switch](https://github.com/ManageIQ/manageiq-ui-classic/blob/3f609dab512cf49350cb10545d2a80ca9b343a0d/app/controllers/application_controller.rb#L989-L1012) only by column name. It will be more stable if check for "report name" is added. Based on https://github.com/ManageIQ/manageiq-ui-classic/pull/5326#discussion_r266374434

Related to https://github.com/ManageIQ/manageiq/pull/18588 (merged)

@miq-bot add_label hammer/no, technical debt, pending core, wip
