### PR TITLE
[WIP] Breadcrumbs: unify functions looking for active_accordion

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -24,12 +24,10 @@ module Mixins
         if @title && not_show_page? && @title != breadcrumbs.compact.last.try(:[], :title)
           breadcrumbs.push(:title => @title)
         end
-      else
+      elsif features?
         # Append breadcrumb from title of the accordion (eg "Policies")
-        if features?
-          accord = features.find { |f| f.accord_name == x_active_accord.to_s }
-          breadcrumbs.push(:title => accord.title, :key => "#{accord.name}_accord", :action => "accordion_select")
-        end
+        accord = features.find { |f| f.accord_name == x_active_accord.to_s }
+        breadcrumbs.push(:title => accord.title, :key => "#{accord.name}_accord", :action => "accordion_select")
 
         # Append breadcrumbs created from the tree (eg "All policies > Red Hat policies > Policy 1")
         breadcrumbs_from_tree = build_breadcrumbs_from_tree
@@ -105,12 +103,9 @@ module Mixins
     # Helper methods
 
     def build_tree
-      if features?
-        allowed_features = ApplicationController::Feature.allowed_features(features)
-        # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
-        return allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
-      end
-      []
+      allowed_features = ApplicationController::Feature.allowed_features(features)
+      # TODO: allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
+      allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
     end
 
     # Has controller features

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -26,7 +26,10 @@ module Mixins
         end
       else
         # Append breadcrumb from title of the accordion (eg "Policies")
-        breadcrumbs.push(:title => accord_title, :key => "#{accord_name}_accord", :action => "accordion_select") if features?
+        if features?
+          accord = features.find { |f| f.accord_name == x_active_accord.to_s }
+          breadcrumbs.push(:title => accord.title, :key => "#{accord.name}_accord", :action => "accordion_select")
+        end
 
         # Append breadcrumbs created from the tree (eg "All policies > Red Hat policies > Policy 1")
         breadcrumbs_from_tree = build_breadcrumbs_from_tree
@@ -108,14 +111,6 @@ module Mixins
         return allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
       end
       []
-    end
-
-    def accord_title
-      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:title)
-    end
-
-    def accord_name
-      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:name)
     end
 
     # Has controller features

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -42,7 +42,6 @@ describe Mixins::BreadcrumbsMixin do
 
   let(:mixin) { TestMixin.new }
   let(:controller_url) { 'testmixin' }
-  let(:features) { [{:title => "Active Tree", :name => :utilization_tree}] }
   let(:breadcrumbs) do
     [
       {:title => _("First Layer")},
@@ -66,36 +65,6 @@ describe Mixins::BreadcrumbsMixin do
   describe "#url" do
     it "returns url" do
       expect(mixin.url('ems', 'show', 'node')).to eq("/ems/show/node")
-    end
-  end
-
-  describe "#accord_name" do
-    context 'when features contains the tree' do
-      it "returns name" do
-        expect(mixin.accord_name).to eq(features[0][:name])
-      end
-    end
-
-    context 'when features do not contains the tree' do
-      it "returns nil" do
-        allow(mixin).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin.accord_name).to be(nil)
-      end
-    end
-  end
-
-  describe "#accord_title" do
-    context 'when features contains the tree' do
-      it "returns title" do
-        expect(mixin.accord_title).to eq(features[0][:title])
-      end
-    end
-
-    context 'when features do not contains the tree' do
-      it "returns nil" do
-        allow(mixin).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin.accord_title).to be(nil)
-      end
     end
   end
 


### PR DESCRIPTION
**Description**

- As @skateman noticed there is an unnecessary calling of two functions which look for the same accordion - there is now only one call used for looking for active accordion in the body of the main function
- `features?` is moved up one level in the condition (it reduces calls of this function)

@miq-bot add_label hammer/no, refactoring, performance
@miq-bot add_reviewer @skateman 