### PR TITLE
Fix missed argument change for compliance history tree

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -229,7 +229,7 @@ module VmCommon
       end
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, @record)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
       session[:ch_tree] = @ch_tree.tree_nodes
       session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)


### PR DESCRIPTION
Missed the initialization call of this tree in #5309, fixing.

@miq-bot assign @h-kataria 
https://bugzilla.redhat.com/show_bug.cgi?id=1692537