### PR TITLE
Permanently hide the VMs where it was possible to optionally display them

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -193,8 +193,7 @@ class ApplicationController < ActionController::Base
       :taskbartext   => true,             # Show button text on taskbar
       :vmcompare     => "Compressed",     # Start VM compare and drift in compressed mode
       :hostcompare   => "Compressed",     # Start Host compare in compressed mode
-      :timezone      => nil,              # This will be set when the user logs in
-      :display_vms   => false # don't display vms by default
+      :timezone      => nil               # This will be set when the user logs in
     },
   }.freeze
 

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -110,7 +110,6 @@ class ConfigurationController < ApplicationController
     # ui2 form
     return unless load_edit("config_edit__ui2", "configuration")
     @edit[:new][:views][VIEW_RESOURCES[params[:resource]]] = params[:view] # Capture the new view setting
-    @edit[:new][:display][:display_vms] = params[:display_vms] == 'true' if params.key?(:display_vms)
     session[:changed] = (@edit[:new] != @edit[:current])
     @changed = session[:changed]
     render :update do |page|
@@ -473,8 +472,6 @@ class ConfigurationController < ApplicationController
         value.merge!(user_settings[key]) unless user_settings[key].nil?
       end
     end
-    # Override nil settings since we only expect 2 settings: true/false later on
-    settings[:display][:display_vms] = false if settings[:display][:display_vms].nil?
     settings
   end
 
@@ -566,7 +563,6 @@ class ConfigurationController < ApplicationController
     when "ui_2" # Visual Settings tab
       @edit[:new][:display][:compare] = params[:display][:compare] if !params[:display].nil? && !params[:display][:compare].nil?
       @edit[:new][:display][:drift] = params[:display][:drift] if !params[:display].nil? && !params[:display][:drift].nil?
-      @edit[:new][:display][:display_vms] = params[:display_vms] unless params.fetch_path(:display_vms)
     when "ui_3" # Visual Settings tab
       @edit[:new][:display][:compare] = params[:display][:compare] if !params[:display].nil? && !params[:display][:compare].nil?
       @edit[:new][:display][:drift] = params[:display][:drift] if !params[:display].nil? && !params[:display][:drift].nil?

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -78,7 +78,7 @@ module VmCommon
 
   # to reload currently displayed summary screen in explorer
   def reload
-    @_params[:id] = if hide_vms && x_node.split('-')[1] != params[:id] && params[:id].present?
+    @_params[:id] = if x_node.split('-')[1] != params[:id] && params[:id].present?
                       'v-' + params[:id]
                     else
                       x_node
@@ -107,10 +107,6 @@ module VmCommon
   alias_method :instance_timeline, :show_timeline
   alias_method :vm_timeline, :show_timeline
   alias_method :miq_template_timeline, :show_timeline
-
-  def hide_vms
-    !User.current_user.settings.fetch_path(:display, :display_vms) # default value is false
-  end
 
   def x_show
     @vm = @record = identify_record(params[:id], VmOrTemplate)
@@ -911,7 +907,7 @@ module VmCommon
       javascript_flash(:spinner_off => true, :activate_node => {:tree => x_active_tree.to_s, :node => x_node})
     end
 
-    self.x_node = (@record.present? && hide_vms ? parent_folder_id(@record) : params[:id])
+    self.x_node = (@record.present? ? parent_folder_id(@record) : params[:id])
     replace_right_cell
   end
 
@@ -971,11 +967,11 @@ module VmCommon
     add_nodes
   end
 
-  # if node is VM or Template and hide_vms is true - select parent node in explorer tree but show info of Vm/Template
+  # if node is VM or Template is true - select parent node in explorer tree but show info of Vm/Template
   def resolve_node_info(id)
     nodetype, id = id.split("-")
 
-    if hide_vms && (nodetype == 'v' || nodetype == 't')
+    if nodetype == 'v' || nodetype == 't'
       @vm = VmOrTemplate.find(id)
       self.x_node = parent_folder_id(@vm)
     else
@@ -989,7 +985,7 @@ module VmCommon
   def get_node_info(treenodeid, show_list = true)
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
-    @nodetype, id = if (treenodeid.split('-')[0] == 'v' || treenodeid.split('-')[0] == 't') && hide_vms
+    @nodetype, id = if treenodeid.split('-')[0] == 'v' || treenodeid.split('-')[0] == 't'
                       @sb[@sb[:active_accord]] = treenodeid
                       parse_nodetype_and_id(treenodeid)
                     else
@@ -1132,7 +1128,7 @@ module VmCommon
     end
 
     if !@in_a_form && !@sb[:action]
-      id = @record.present? && hide_vms ? TreeBuilder.build_node_cid(@record) : x_node
+      id = @record.present? ? TreeBuilder.build_node_cid(@record) : x_node
       id = @sb[@sb[:active_accord]] if @sb[@sb[:active_accord]].present? && params[:action] != 'tree_select'
       get_node_info(id)
       type, _id = parse_nodetype_and_id(id)

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -80,7 +80,7 @@ class VmInfraController < ApplicationController
         {:title => _("Infrastructure")},
         {:title => _("Virtual Machines")},
       ],
-      :include_record => (!@settings[:display][:display_vms]),
+      :include_record => true,
     }
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -98,10 +98,6 @@ class TreeBuilder
     "#{prefix}-#{id}"
   end
 
-  def self.hide_vms
-    !User.current_user.settings.fetch_path(:display, :display_vms) # default value is false
-  end
-
   # return this nodes model and record id
   def self.extract_node_model_and_id(node_id)
     prefix, record_id = node_id.split("_").last.split('-')

--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -1,10 +1,4 @@
 module TreeBuilderArchived
-  def x_get_tree_custom_kids(object, count_only, options)
-    klass = options[:leaf].safe_constantize
-    objects = []
-    count_only_or_objects_filtered(count_only, objects, "name")
-  end
-
   def x_get_tree_arch_orph_nodes(model_name)
     archived = QuadiconHelper.machine_state('archived').values_at(:fonticon, :background)
     orphaned = QuadiconHelper.machine_state('orphaned').values_at(:fonticon, :background)

--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -1,14 +1,7 @@
 module TreeBuilderArchived
   def x_get_tree_custom_kids(object, count_only, options)
     klass = options[:leaf].safe_constantize
-    objects = if TreeBuilder.hide_vms
-                [] # hidden all VMs
-              else
-                case object[:id]
-                when "orph" then  klass.orphaned
-                when "arch" then  klass.archived
-                end
-              end
+    objects = []
     count_only_or_objects_filtered(count_only, objects, "name")
   end
 

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -7,7 +7,7 @@ class TreeBuilderImages < TreeBuilder
     {
       :leaf           => "ManageIQ::Providers::CloudManager::Template",
       :lazy           => true,
-      :allow_reselect => TreeBuilder.hide_vms
+      :allow_reselect => true
     }
   end
 
@@ -24,6 +24,6 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def x_get_tree_ems_kids(object, count_only)
-    count_only_or_objects_filtered(count_only, TreeBuilder.hide_vms ? [] : object.miq_templates, "name")
+    count_only_or_objects_filtered(count_only, [], "name")
   end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -1,6 +1,4 @@
 class TreeBuilderImages < TreeBuilder
-  has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
-
   include TreeBuilderArchived
 
   def tree_init_options
@@ -21,9 +19,5 @@ class TreeBuilderImages < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => TemplateCloud) +
       count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Images"))
-  end
-
-  def x_get_tree_ems_kids(object, count_only)
-    count_only_or_objects_filtered(count_only, [], "name")
   end
 end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -5,7 +5,7 @@ class TreeBuilderInstances < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {:leaf => 'VmCloud', :allow_reselect => TreeBuilder.hide_vms}
+    {:leaf => 'VmCloud', :allow_reselect => true}
   end
 
   def root_options
@@ -22,15 +22,11 @@ class TreeBuilderInstances < TreeBuilder
 
   def x_get_tree_ems_kids(object, count_only)
     count_only_or_objects_filtered(count_only, object.availability_zones, "name") +
-      count_only_or_objects_filtered(count_only,
-                                     TreeBuilder.hide_vms ? [] : object.vms.where(:availability_zone_id => nil),
-                                     "name")
+      count_only_or_objects_filtered(count_only, [], "name")
   end
 
   # Get AvailabilityZone children count/array
   def x_get_tree_az_kids(object, count_only)
-    count_only_or_objects_filtered(count_only,
-                                   TreeBuilder.hide_vms ? [] : object.vms.with_ems,
-                                   "name")
+    count_only_or_objects_filtered(count_only, [], "name")
   end
 end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -1,5 +1,4 @@
 class TreeBuilderInstances < TreeBuilder
-  has_kids_for AvailabilityZone, [:x_get_tree_az_kids]
   has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
 
   include TreeBuilderArchived
@@ -21,12 +20,6 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def x_get_tree_ems_kids(object, count_only)
-    count_only_or_objects_filtered(count_only, object.availability_zones, "name") +
-      count_only_or_objects_filtered(count_only, [], "name")
-  end
-
-  # Get AvailabilityZone children count/array
-  def x_get_tree_az_kids(object, count_only)
-    count_only_or_objects_filtered(count_only, [], "name")
+    count_only_or_objects_filtered(count_only, object.availability_zones, "name")
   end
 end

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -5,7 +5,7 @@ class TreeBuilderVandt < TreeBuilder
     {
       :leaf           => 'ManageIQ::Providers::InfraManager::VmOrTemplate',
       :lazy           => true,
-      :allow_reselect => TreeBuilder.hide_vms
+      :allow_reselect => true
     }
   end
 

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -15,7 +15,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     #   so taking them from the relationship records can cut down on the huge
     #   VM query.
 
-    tree = root.subtree_arranged(TreeBuilder.hide_vms ? {:except_type => "VmOrTemplate"} : {})
+    tree = root.subtree_arranged(:except_type => "VmOrTemplate")
 
     prune_rbac(tree)
     prune_non_vandt_folders(tree)
@@ -51,18 +51,13 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
   end
 
   def prune_rbac(tree)
-    if TreeBuilder.hide_vms
-      allowed_vms = Rbac.filtered(@root_ems.vms) # this is a sub-query
-      vm_relations = Relationship.where(:resource     => allowed_vms,
-                                        :relationship => "ems_metadata")
-                                 .select(:ancestry).distinct # bigger sub-query
-                                 .map(&:parent_id)
-      allowed_folder_ids = Relationship.where(:id => vm_relations).pluck(:resource_id)
-      prune_folders_via_folders(tree, allowed_folder_ids)
-    else
-      allowed_vm_ids = Set.new(Rbac.filtered(@root_ems.vms).pluck(:id))
-      prune_folders_via_vms(tree, allowed_vm_ids)
-    end
+    allowed_vms = Rbac.filtered(@root_ems.vms) # this is a sub-query
+    vm_relations = Relationship.where(:resource     => allowed_vms,
+                                      :relationship => "ems_metadata")
+                               .select(:ancestry).distinct # bigger sub-query
+                               .map(&:parent_id)
+    allowed_folder_ids = Relationship.where(:id => vm_relations).pluck(:resource_id)
+    prune_folders_via_folders(tree, allowed_folder_ids)
   end
 
   def prune_folders_via_vms(tree, allowed_vm_ids)

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -62,21 +62,6 @@
                   = label
                 .col-md-8
                   %ul.list-inline= render_view_buttons(resource, @edit[:new][:views][resource])
-        %fieldset
-          %h3
-            = _('VM Visibility')
-          .form-group
-            %label.col-md-3.control-label
-              = _("Show VMs in Explorer tree.")
-            .col-md-6
-              = check_box_tag("display_vms",
-                               '1',
-                               @edit[:new][:display][:display_vms],
-                               :data => {:on_text => _('Yes'), :off_text => _('No')})
-              .note
-                = _("Warning: Enabling this option may cause performance issues in large environments (i.e. thousands of VMs)")
-              :javascript
-                miqInitBootstrapSwitch("display_vms", "#{url}")
       .col-md-12.col-lg-6
         - if has_any_role?(%w(ems_cloud_show_list availability_zone_show_list host_aggregate_show_list cloud_tenant_show_list flavor_show_list instances_accord instances_filter_accord images_filter_accord orchestration_stack_show_list cloud_volume_show_list cloud_volume_snapshot_show_list cloud_object_store_container_show_list))
           %fieldset

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -55,20 +55,12 @@ describe VmOrTemplateController do
     end
 
     it 'sets params[:id] to hidden vm if its summary is displayed' do
-      User.current_user.settings[:display] = {:display_vms => false}
       allow(controller).to receive(:x_node).and_return('f-' + @folder.id.to_s)
       controller.instance_variable_set(:@_params, :id => @vm.id.to_s)
       controller.reload
       expect(controller.params[:id]).to eq("v-#{@vm.id}")
     end
 
-    it 'sets params[:id] to x_node if vms are displayed in a tree' do
-      User.current_user.settings[:display] = {:display_vms => true}
-      allow(controller).to receive(:x_node).and_return('f-' + @folder.id.to_s)
-      controller.instance_variable_set(:@_params, :id => @folder.id.to_s)
-      controller.reload
-      expect(controller.params[:id]).to eq(controller.x_node)
-    end
   end
 
   context "#show" do
@@ -293,17 +285,7 @@ describe VmOrTemplateController do
     end
 
     it 'when VM hidden select parent in tree but show VMs info' do
-      User.current_user.settings[:display] = {:display_vms => false}
-
       allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(controller.parent_folder_id(@vm_arch)) }
-      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
-      vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
-    end
-
-    it 'when VM shown select it in tree and show its info' do
-      User.current_user.settings[:display] = {:display_vms => true}
-
-      allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
       allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
       vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
     end

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -22,7 +22,6 @@ describe TreeBuilderArchived do
   end
 
   it '#x_get_tree_custom_kids with hidden Infra VMs returns empty Array' do
-    User.current_user.settings[:display] = {:display_vms => false}
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
@@ -31,28 +30,9 @@ describe TreeBuilderArchived do
                                                  :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
     expect(nodes_orph).to eq([])
     expect(nodes_arch).to eq([])
-  end
-
-  it '#x_get_tree_custom_kids with Infra VMs/Templates returns VMs' do
-    User.current_user.settings[:display] = {:display_vms => true}
-    vm_orph = FactoryBot.create(:vm_infra, :storage => FactoryBot.create(:storage))
-    template_orph = FactoryBot.create(:template_infra, :storage => FactoryBot.create(:storage))
-    vm_arch = FactoryBot.create(:vm_infra)
-    template_arch = FactoryBot.create(:template_infra)
-    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:orphaned) { [vm_orph, template_orph] }
-    allow(ManageIQ::Providers::InfraManager::VmOrTemplate).to receive(:archived) { [vm_arch, template_arch] }
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
-    expect(nodes_orph).to eq([vm_orph, template_orph].sort_by { |object| object[:name] })
-    expect(nodes_arch).to eq([vm_arch, template_arch].sort_by { |object| object[:name] })
   end
 
   it '#x_get_tree_custom_kids with hidden Cloud VMs returns empty Array' do
-    User.current_user.settings[:display] = {:display_vms => false}
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'VmCloud')
@@ -63,22 +43,7 @@ describe TreeBuilderArchived do
     expect(nodes_arch).to eq([])
   end
 
-  it '#x_get_tree_custom_kids with Cloud VMs returns VMs' do
-    User.current_user.settings[:display] = {:display_vms => true}
-    vm_arch_cloud = FactoryBot.create(:vm_cloud)
-    vm_orph_cloud = FactoryBot.create(:vm_cloud, :storage => FactoryBot.create(:storage))
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'VmCloud')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'VmCloud')
-    expect(nodes_orph).to eq([vm_orph_cloud])
-    expect(nodes_arch).to eq([vm_arch_cloud])
-  end
-
   it '#x_get_tree_custom_kids with hidden Cloud Templates returns empty Array' do
-    User.current_user.settings[:display] = {:display_vms => false}
     nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
                                                  false,
                                                  :leaf => 'ManageIQ::Providers::CloudManager::Template')
@@ -87,19 +52,5 @@ describe TreeBuilderArchived do
                                                  :leaf => 'ManageIQ::Providers::InfraManager::Template')
     expect(nodes_orph).to eq([])
     expect(nodes_arch).to eq([])
-  end
-
-  it '#x_get_tree_custom_kids with Cloud Templates returns Templates' do
-    User.current_user.settings[:display] = {:display_vms => true}
-    template_arch_cloud = FactoryBot.create(:template_cloud)
-    template_orph_cloud = FactoryBot.create(:template_cloud, :storage => FactoryBot.create(:storage))
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::CloudManager::Template')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::CloudManager::Template')
-    expect(nodes_orph).to eq([template_orph_cloud])
-    expect(nodes_arch).to eq([template_arch_cloud])
   end
 end

--- a/spec/presenters/tree_builder_archived_spec.rb
+++ b/spec/presenters/tree_builder_archived_spec.rb
@@ -20,37 +20,4 @@ describe TreeBuilderArchived do
                           :icon_background => "#336699",
                           :tip             => "Orphaned VMs/Templates"}])
   end
-
-  it '#x_get_tree_custom_kids with hidden Infra VMs returns empty Array' do
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::InfraManager::VmOrTemplate')
-    expect(nodes_orph).to eq([])
-    expect(nodes_arch).to eq([])
-  end
-
-  it '#x_get_tree_custom_kids with hidden Cloud VMs returns empty Array' do
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'VmCloud')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'VmCloud')
-    expect(nodes_orph).to eq([])
-    expect(nodes_arch).to eq([])
-  end
-
-  it '#x_get_tree_custom_kids with hidden Cloud Templates returns empty Array' do
-    nodes_orph = archived.x_get_tree_custom_kids({:id => 'orph'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::CloudManager::Template')
-    nodes_arch = archived.x_get_tree_custom_kids({:id => 'arch'},
-                                                 false,
-                                                 :leaf => 'ManageIQ::Providers::InfraManager::Template')
-    expect(nodes_orph).to eq([])
-    expect(nodes_arch).to eq([])
-  end
 end

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -47,17 +47,8 @@ describe TreeBuilderImages do
   end
 
   it 'sets Templates nodes to empty Array if VMs/Templates are hidden' do
-    User.current_user.settings[:display] = {:display_vms => false}
-
     provider = @images_tree.x_get_tree_roots(false, nil)[0]
     template = @images_tree.x_get_tree_ems_kids(provider, false)
     expect(template).to eq([])
-  end
-
-  it 'sets Templates nodes correctly if VMs/Templates are shown' do
-    User.current_user.settings[:display] = {:display_vms => true}
-    provider = @images_tree.x_get_tree_roots(false, nil)[0]
-    template = @images_tree.x_get_tree_ems_kids(provider, false)
-    expect(template).to eq([@template_cloud_with_az])
   end
 end

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -45,10 +45,4 @@ describe TreeBuilderImages do
                               :icon_background => "#336699",
                               :tip             => "Orphaned Images"}])
   end
-
-  it 'sets Templates nodes to empty Array if VMs/Templates are hidden' do
-    provider = @images_tree.x_get_tree_roots(false, nil)[0]
-    template = @images_tree.x_get_tree_ems_kids(provider, false)
-    expect(template).to eq([])
-  end
 end

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -52,8 +52,6 @@ describe TreeBuilderInstances do
   end
 
   it 'sets availability zones correctly if vms are hidden' do
-    User.current_user.settings[:display] = {:display_vms => false}
-
     provider_with_az = @instances_tree.x_get_tree_roots(false, nil)[0] # provider with vm that has availability zone
     provider_without_az = @instances_tree.x_get_tree_roots(false, nil)[1] # provider with vm that doesn't have availability zone
     allow(provider_with_az).to receive(:availability_zones) { [@vm_cloud_with_az.availability_zone] }
@@ -62,18 +60,5 @@ describe TreeBuilderInstances do
 
     expect(az).to eq(provider_with_az.availability_zones)
     expect(vm_without_az).to eq([])
-  end
-
-  it 'sets availability zones correctly if vms are shown' do
-    User.current_user.settings[:display] = {:display_vms => true}
-
-    provider_with_az = @instances_tree.x_get_tree_roots(false, nil)[0] # provider with vm that has availability zone
-    provider_without_az = @instances_tree.x_get_tree_roots(false, nil)[1] # provider with vm that doesn't have availability zone
-    allow(provider_with_az).to receive(:availability_zones) { [@vm_cloud_with_az.availability_zone] }
-    az = @instances_tree.x_get_tree_ems_kids(provider_with_az, false)
-    vm_without_az = @instances_tree.x_get_tree_ems_kids(provider_without_az, false)
-
-    expect(az).to eq([@vm_cloud_with_az.availability_zone])
-    expect(vm_without_az).to eq([@vm_cloud_without_az])
   end
 end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -193,26 +193,4 @@ describe TreeBuilder do
       expect(TreeBuilder.build_node_cid(vm)).to eq("v-#{vm.id}")
     end
   end
-
-  context "#hide_vms" do
-    before do
-      role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "TreeBuilder")
-      login_as FactoryBot.create(:user, :userid => 'treebuilder_wilma', :miq_groups => [@group])
-    end
-
-    it "hide vms if User didn't set it" do
-      expect(TreeBuilder.hide_vms).to eq(true)
-    end
-
-    it "show vms if User had set it so" do
-      User.current_user.settings[:display] = {:display_vms => true}
-      expect(TreeBuilder.hide_vms).to eq(false)
-    end
-
-    it "hide vms if User had set it so" do
-      User.current_user.settings[:display] = {:display_vms => false}
-      expect(TreeBuilder.hide_vms).to eq(true)
-    end
-  end
 end

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -23,32 +23,8 @@ describe TreeBuilderVmsAndTemplates do
   end
 
   describe "#tree" do
-    it "returns vms with display_vms=true" do
-      EvmSpecHelper.local_miq_server
-      User.current_user = FactoryBot.create(:user, :settings => {:display => {:display_vms => true}})
-      tree
-      vms = FactoryBot.create_list(:vm_vmware, 2, :ext_management_system => ems)
-      subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
-
-      tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
-      expect(tree_v[:text]).to eq(ems.name)
-      expect(tree_v[:nodes].size).to eq(1)
-
-      folders_v = tree_v[:nodes].first
-      expect(folders_v[:text]).to match folder.name
-      expect(folders_v[:nodes].size).to eq(1)
-
-      subfolders_v = folders_v[:nodes].detect { |f| f[:text] == subfolder1.name }
-      expect(subfolders_v).to be_present
-      expect(subfolders_v[:nodes].size).to eq(2)
-
-      ems_vs = subfolders_v[:nodes]
-      expect(ems_vs.map { |e| e[:text] }).to match_array(vms.map(&:name))
-    end
-
     it "returns no vms with display_vms=false" do
       EvmSpecHelper.local_miq_server
-      User.current_user = FactoryBot.create(:user, :settings => {:display => {:display_vms => false}})
       tree
       vms = FactoryBot.create_list(:vm_vmware, 2, :ext_management_system => ems)
       subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }


### PR DESCRIPTION
@ZitaNemeckova introduced a feature a few years ago to increase the performance of some trees by hiding the VM nodes. This optional feature could be still turned off under `My settings`, so it's optionally still possible to cause performance problems. As I've discussed with @lavenel and @dmetzger57 I am proposing to make this setting permanent, not exposing the setting to the user.

This would allow us to delete a lof of logic and so making our codebase a little bit simpler.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label cleanup, trees, hammer/no