### PR TITLE
Adjust accordion height calculation hack to the new breadcrumbs

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1474,7 +1474,7 @@ function miqWidgetToolbarClick(_e) {
 }
 
 function miqInitAccordions() {
-  var height = $('#left_div').height() - $('#toolbar').outerHeight();
+  var height = $('#left_div').height() - $('#toolbar').outerHeight() - $('#breadcrumbs').outerHeight();
   var panel = $('#left_div .panel-heading').outerHeight();
   var count = $('#accordion:visible > .panel .panel-body').length;
   $('#accordion:visible > .panel .panel-body').each(function(_k, v) {


### PR DESCRIPTION
We missed this when the new breadcrumbs were merged...

**Before:**
![Screenshot from 2019-03-27 09-54-37](https://user-images.githubusercontent.com/649130/55062769-eb90a900-5076-11e9-9d87-e69f453b0c1b.png)

**After:**
![Screenshot from 2019-03-27 09-53-04](https://user-images.githubusercontent.com/649130/55062807-fd724c00-5076-11e9-99e8-20eb07c4d4ee.png)

@miq-bot add_reviewer @rvsia 
@miq-bot add_reviewer @himdel 
@miq-bot add_label bug
