### PR TITLE
Fix preselect node in servers by roles tree under diagnostics

### DIFF
--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -7,6 +7,12 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
     x_get_tree_server_roles
   end
 
+  def override(node, _object, _pid, _options)
+    if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
+      node[:highlighted] = true
+    end
+  end
+
   def x_get_tree_server_roles
     ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -66,7 +66,7 @@ describe TreeBuilderServersByRole do
                                   'state'          => { 'expanded' => true },
                                   'selectable'     => true,
                                   'class'          => ''}],
-                'state'      => { 'expanded' => true },
+                'state'      => { 'expanded' => true, "selected" => true},
                 'class'      => '' }]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end


### PR DESCRIPTION
This is as inconsistent behavior, there should be a preselected node with its details shown on the right side. The right side data was all there, however, the appropriate node was not highlighted. Now when you navigate to the page, it should preselect the node. 

![Screenshot from 2019-03-27 10-58-12](https://user-images.githubusercontent.com/649130/55067021-3dd5c800-507f-11e9-9abc-ef44ec99c5ba.png)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label bug, trees