### PR TITLE
Fix the access to child services from parents under My Services

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -73,6 +73,11 @@ function miqOnClickMenuRoles(id) {
   });
 }
 
+function miqTreeSelect(key) {
+  var url = '/' + ManageIQ.controller + '/tree_select/?id=' + encodeURIComponent(key.split('__')[0]);
+  miqJqueryRequest(url, {beforeSend: true});
+}
+
 // Activate and focus on a node within a tree given the node's key
 function miqTreeActivateNode(tree, key) {
   miqSparkle(true);

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -27,7 +27,7 @@
               %table.table.table-striped.table-bordered.table-hover
                 %tbody
                   - child_services.sort_by { |o| o.name.downcase }.each do |s|
-                    %tr{:onclick => "miqTreeActivateNode('svcs_tree', 's-#{s.id}');", :title => _("View this Service")}
+                    %tr{:onclick => "miqTreeSelect('s-#{s.id}');", :title => _("View this Service")}
                       %td.table-view-pf-select
                         %i.pficon.pficon-service
                       %td


### PR DESCRIPTION
When I hid the services in #5335 we didn't count with the fact that services might be nested into each other. Unfortunately, the child service access is only doable through the `tree_select` route and it has been accessed by `miqTreeActivateNode`. Without the node actually being in the tree, this function did nothing and so the child services weren't accessible.

![Screenshot from 2019-03-27 13-37-40](https://user-images.githubusercontent.com/649130/55076410-9ca63c00-5095-11e9-94f4-8f764efdc08e.png)

I'm proposing a workaround to call the `tree_select` directly from the `miqTreeSelect` function. This is not a permanent solution, these areas where we access items exclusively through `tree_select` should be refactored.

Navigating back to the parent service in hammer can be done using the toolbar's back button, in upstream we should also update the breadcrumb generation logic to contain the hierarchy. 

![Screenshot from 2019-03-27 13-40-25](https://user-images.githubusercontent.com/649130/55076511-e858e580-5095-11e9-8193-9638ea63e83c.png)

@miq-bot add_label bug, trees, services, hammer/yes
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1693264