### PR TITLE
Fix title issues in Policy Simulation page

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -95,6 +95,8 @@ module ApplicationController::PolicySupport
         @refresh_partial = "layouts/policy_sim"
         replace_right_cell
       end
+    else
+      set_right_cell_text
     end
   end
 
@@ -135,6 +137,11 @@ module ApplicationController::PolicySupport
   end
 
   private ############################
+
+  # Set title of the policy simulation page, for non explorer screens
+  def set_right_cell_text
+    @right_cell_text = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => vm_or_instance)}
+  end
 
   # Assign policies to selected records of db
   def assign_policies(db)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -928,6 +928,14 @@ module VmCommon
     {'"no parent"' => -1}.merge(parent_choices(@record.id))
   end
 
+  # Return vm_cloud or vm_infra based on selected record
+  def vm_or_instance
+    if @record || @tagitems
+      record_model = model_for_vm(@record || @tagitems.first)
+      controller_for_vm(record_model)
+    end
+  end
+
   private
 
   # Check for parent nodes missing from vandt tree and return them if any
@@ -1531,7 +1539,7 @@ module VmCommon
       action = nil
     when "policy_sim"
       action = nil
-      header = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => table)}
+      header = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => vm_or_instance)}
       partial = params[:action] == "policies" ? "vm_common/policies" : "layouts/policy_sim"
     when "protect"
       partial = "layouts/protect"

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,5 +1,8 @@
 - url = url_for_only_path(:action => 'policy_sim_add')
 #main_div
+  - if @right_cell_text && !@explorer
+    %h1
+      = URI.unescape(@right_cell_text)
 
   #flash_msg_div
     = render :partial => "layouts/flash_msg"

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -37,4 +37,42 @@ describe ApplicationController do
       expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => flash_msg, :level => :success}])
     end
   end
+
+  describe '#policy_sim' do
+    context 'VM policy simulation and non explorer screen' do
+      let(:ctrl) { VmInfraController.new }
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+
+      before do
+        session = instance_double('VmInfraController', :session    => {:tag_items => [vm], :tag_db => VmOrTemplate},
+                                                       :parameters => {:controller => 'vm_infra'})
+        allow(ctrl).to receive(:drop_breadcrumb).and_return(true)
+        allow(session).to receive(:xml_http_request?).and_return(false)
+        ctrl.instance_variable_set(:@_request, session)
+      end
+
+      it 'sets right cell text' do
+        ctrl.send(:policy_sim)
+        expect(ctrl.instance_variable_get(:@right_cell_text)).to eq('Virtual Machine Policy Simulation')
+      end
+    end
+
+    context 'Instance policy simulation and non explorer screen' do
+      let(:ctrl) { VmCloudController.new }
+      let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
+
+      before do
+        session = instance_double('VmCloudController', :session    => {:tag_items => [vm], :tag_db => VmOrTemplate},
+                                                       :parameters => {:controller => 'vm_cloud'})
+        allow(ctrl).to receive(:drop_breadcrumb).and_return(true)
+        allow(session).to receive(:xml_http_request?).and_return(false)
+        ctrl.instance_variable_set(:@_request, session)
+      end
+
+      it 'sets right cell text' do
+        ctrl.send(:policy_sim)
+        expect(ctrl.instance_variable_get(:@right_cell_text)).to eq('Instance Policy Simulation')
+      end
+    end
+  end
 end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -1,5 +1,5 @@
 describe VmOrTemplateController do
-  context "#snap_pressed" do
+  describe "#snap_pressed" do
     before do
       stub_user(:features => :all)
       @vm = FactoryBot.create(:vm_vmware)
@@ -46,7 +46,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#reload ' do
+  describe '#reload' do
     before do
       login_as FactoryBot.create(:user_with_group, :role => "operator")
       allow(controller).to receive(:tree_select).and_return(nil)
@@ -63,7 +63,7 @@ describe VmOrTemplateController do
 
   end
 
-  context "#show" do
+  describe "#show" do
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
@@ -179,7 +179,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#replace_right_cell' do
+  describe '#replace_right_cell' do
     it 'should display form button on Migrate request screen' do
       vm = FactoryBot.create(:vm_infra)
       allow(controller).to receive(:params).and_return(:action => 'vm_migrate')
@@ -202,9 +202,25 @@ describe VmOrTemplateController do
       controller.send(:replace_right_cell, :action => 'migrate', :presenter => presenter)
       expect(presenter[:update_partials]).to have_key(:form_buttons_div)
     end
+
+    context 'Instance policy simulation' do
+      let(:vm_openstack) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
+
+      before do
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@record, vm_openstack)
+        controller.instance_variable_set(:@sb, :action => 'policy_sim')
+        request.parameters[:controller] = 'vm_or_template'
+      end
+
+      it 'sets right cell text for policy simulation page' do
+        controller.send(:replace_right_cell)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Instance Policy Simulation')
+      end
+    end
   end
 
-  context '#parent_folder_id' do
+  describe '#parent_folder_id' do
     it 'returns id of orphaned folder for orphaned VM/Template' do
       vm_orph = FactoryBot.create(:vm_infra, :storage => FactoryBot.create(:storage))
       template_orph = FactoryBot.create(:template_infra, :storage => FactoryBot.create(:storage))
@@ -273,7 +289,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context "#resolve_node_info" do
+  describe "#resolve_node_info" do
     let(:vm_common) do
       Class.new do
         extend VmCommon
@@ -291,7 +307,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#evm_relationship_get_form_vars' do
+  describe '#evm_relationship_get_form_vars' do
     before do
       @vm = FactoryBot.create(:vm_vmware)
       edit = {:vm_id => @vm.id, :new => {:server => nil}}


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1688359
https://bugzilla.redhat.com/show_bug.cgi?id=1688370

**What:**
Fix changing the title in Cloud Instance Policy Simulation page, after clicking on any quadicon (explorer screens).
Fix missing title in Policy Simulation page, for items (VMs, Instances) displayed as a nested list (non explorer).

**Steps to reproduce:**
Scenario 1:
1. Go to _Compute > Clouds > Instances_
2. Select some instance(s), check the checkbox(es)
3. In the toolbar, choose _Policy > Policy Simulation_
4. Select some Policy Profile from the drop down
=> check the title of the page (_Instance Policy Simulation_)
5. Click on a quadicon of the instance
=> the title has been changed! (_Virtual Machine Policy Simulation_)
6. Click on the _Back_ button
=> the title remains wrong, different to the title in step 4 !

_Notes:_
- for VMs, the title does not change
- sometimes it may lead to error, when clicking on quadicon (step 5), but that's another issue (missing route or.. wrong controller name), not related to the changes in this PR; there is a bunch of other bugs, issues, related to policy simulation

...

Scenario 2:
1. Go to _Compute > Cloud/Infrastructure > Providers_
2. Choose some provider, click on it to display its dashboard or summary page
3. Click on VMs/Instances
4. Check the checkbox(es) of some VM(s)/Instance(s)
5. In the toolbar, choose _Policy > Policy Simulation_
=> there is no title in this page

---

**Before:**
Scenario 1:
![before_scenario1](https://user-images.githubusercontent.com/13417815/55091286-da648e00-50b0-11e9-87e2-ea63a514990f.png)
Scenario 2:
![before_scenario2](https://user-images.githubusercontent.com/13417815/55091518-421ad900-50b1-11e9-950f-e67f95d95c2d.png)

**After:**
Scenario 1:
![after_scenario1](https://user-images.githubusercontent.com/13417815/55091326-ec463100-50b0-11e9-81b1-1c5a33ba016b.png)
Scenario 2 (for both VMs and also Instances):
![after_scenario2](https://user-images.githubusercontent.com/13417815/55092086-3b409600-50b2-11e9-9a89-bf26a4ddd884.png)
![after2_scenario2](https://user-images.githubusercontent.com/13417815/55092095-3d0a5980-50b2-11e9-872d-df7ffc025f24.png)
