### PR TITLE
Fix room display in physical infra summary views

### DIFF
--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module PhysicalServerHelper::TextualSummary
   def textual_group_asset_details
     TextualGroup.new(
       _("Asset Details"),
-      %i(support_contact description location room_id rack_name lowest_rack_unit)
+      %i[support_contact description location room rack_name lowest_rack_unit]
     )
   end
 
@@ -180,8 +180,8 @@ module PhysicalServerHelper::TextualSummary
     {:label => _("Location"), :value => @record.asset_detail['location']}
   end
 
-  def textual_room_id
-    {:label => _("Room"), :value => @record.asset_detail['room_id']}
+  def textual_room
+    {:label => _("Room"), :value => @record.asset_detail['room']}
   end
 
   def textual_rack_name

--- a/app/helpers/physical_storage_helper/textual_summary.rb
+++ b/app/helpers/physical_storage_helper/textual_summary.rb
@@ -16,7 +16,7 @@ module PhysicalStorageHelper::TextualSummary
   def textual_group_asset_details
     TextualGroup.new(
       _("Asset Details"),
-      %i(machine_type model contact location room_id rack_name lowest_rack_unit)
+      %i[machine_type model contact location room rack_name lowest_rack_unit]
     )
   end
 
@@ -86,8 +86,8 @@ module PhysicalStorageHelper::TextualSummary
     {:label => _("Location"), :value => @record.asset_detail["location"]}
   end
 
-  def textual_room_id
-    {:label => _("Room ID"), :value => @record.asset_detail["room_id"]}
+  def textual_room
+    {:label => _("Room"), :value => @record.asset_detail["room"]}
   end
 
   def textual_rack_name

--- a/spec/helpers/physical_server_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_server_helper/textual_summary_spec.rb
@@ -61,7 +61,7 @@ describe PhysicalServerHelper::TextualSummary do
     support_contact
     description
     location
-    room_id
+    room
     rack_name
     lowest_rack_unit
   ), "asset_details"

--- a/spec/helpers/physical_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_storage_helper/textual_summary_spec.rb
@@ -108,7 +108,7 @@ describe PhysicalStorageHelper::TextualSummary do
         :model,
         :contact,
         :location,
-        :room_id,
+        :room,
         :rack_name,
         :lowest_rack_unit
       )
@@ -246,11 +246,11 @@ describe PhysicalStorageHelper::TextualSummary do
     end
   end
 
-  describe '.textual_room_id' do
-    subject { textual_room_id }
+  describe '.textual_room' do
+    subject { textual_room }
 
-    it 'show the storage Room ID' do
-      expect(subject).to eq(:label => 'Room ID', :value => nil)
+    it 'show the storage Room' do
+      expect(subject).to eq(:label => 'Room', :value => 'Room')
     end
   end
 


### PR DESCRIPTION
Code responsible for retrieving the room data used the invalid room_id key. This commit changes the key and associated display fields accordingly.