### PR TITLE
Extract the sandbox variables from the Roles/Servers TreeBuilders under Diagnostics

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -136,18 +136,20 @@ function miqOnClickSelectRbacTreeNode(id) {
 function miqTreeScrollToNode(tree, id) {
   var node = miqTreeFindNodeByKey(tree, id);
   var parentPanelBody = node.$el.parents('div.panel-body');
-  // Calculate the current node position relative to the scrollable panel
-  var nodePos = node.$el.offset().top - parentPanelBody.offset().top;
+  if (parentPanelBody.length > 0) {
+    // Calculate the current node position relative to the scrollable panel
+    var nodePos = node.$el.offset().top - parentPanelBody.offset().top;
 
-  var offset = 0; // Calculate the required scrolling offset
-  if (nodePos < 0) {
-    offset = nodePos - node.$el.height();
-  } else if (nodePos > parentPanelBody.height()) {
-    offset = nodePos + node.$el.height() - parentPanelBody.height();
-  }
+    var offset = 0; // Calculate the required scrolling offset
+    if (nodePos < 0) {
+      offset = nodePos - node.$el.height();
+    } else if (nodePos > parentPanelBody.height()) {
+      offset = nodePos + node.$el.height() - parentPanelBody.height();
+    }
 
-  if (offset != 0) { // Scroll the panel to the node's position if necessary
-    parentPanelBody.animate({scrollTop: parentPanelBody.scrollTop() + offset});
+    if (offset != 0) { // Scroll the panel to the node's position if necessary
+      parentPanelBody.animate({scrollTop: parentPanelBody.scrollTop() + offset});
+    }
   }
 }
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -858,10 +858,12 @@ module OpsController::Diagnostics
                    else
                      TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, :root => parent)
                    end
-    if @sb[:diag_selected_id]
-      @record = @sb[:diag_selected_model].constantize.find(@sb[:diag_selected_id]) # Set the current record
-      @rec_status = @record.assigned_server_roles.find_by(:active => true) ? "active" : "stopped" if @record.class == ServerRole
-    end
+
+    # Pull out the selected node from the tree state and store it in the sandbox for future use
+    prefix, @sb[:diag_selected_id] = x_node(@server_tree.name).split('-')
+    @sb[:diag_selected_model] = TreeBuilder.get_model_for_prefix(prefix)
+    @record = @sb[:diag_selected_model].constantize.find(@sb[:diag_selected_id]) # Set the current record
+    @rec_status = @record.assigned_server_roles.find_by(:active => true) ? "active" : "stopped" if @record.class == ServerRole
   end
 
   # Get information for a node

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -67,6 +67,7 @@ class TreeBuilder
   # * highlight_changes - highlight the changes in checkboxes differing from initial
   # * three_checks - hierarchically check the parent if all children are checked
   # * post_check - some kind of post-processing hierarchical checks
+  # * silent_activate - whether to activate the active_node silently or not (by default for explorers)
   def tree_init_options
     $log.warn("MIQ(#{self.class.name}) - TreeBuilder descendants should have their own tree_init_options")
     {}
@@ -193,18 +194,19 @@ class TreeBuilder
 
   def set_locals_for_render
     {
-      :tree_id           => "#{@name}box",
-      :tree_name         => @name.to_s,
-      :bs_tree           => @bs_tree,
-      :checkboxes        => @options[:checkboxes],
-      :autoload          => @options[:lazy],
-      :allow_reselect    => @options[:allow_reselect],
-      :three_checks      => @options[:three_checks],
-      :post_check        => @options[:post_check],
-      :onclick           => @options[:onclick],
-      :oncheck           => @options[:oncheck],
-      :click_url         => @options[:click_url],
-      :check_url         => @options[:check_url]
+      :tree_id         => "#{@name}box",
+      :tree_name       => @name.to_s,
+      :bs_tree         => @bs_tree,
+      :checkboxes      => @options[:checkboxes],
+      :autoload        => @options[:lazy],
+      :allow_reselect  => @options[:allow_reselect],
+      :three_checks    => @options[:three_checks],
+      :post_check      => @options[:post_check],
+      :onclick         => @options[:onclick],
+      :oncheck         => @options[:oncheck],
+      :click_url       => @options[:click_url],
+      :check_url       => @options[:check_url],
+      :silent_activate => @options[:silent_activate]
     }.compact
   end
 

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -7,7 +7,12 @@ class TreeBuilderDiagnostics < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => true, :click_url => "/ops/diagnostics_tree_select/", :onclick => "miqOnClickDiagnostics"}
+    {
+      :open_all        => true,
+      :click_url       => "/ops/diagnostics_tree_select/",
+      :onclick         => "miqOnClickDiagnostics",
+      :silent_activate => true
+    }
   end
 
   def x_build_single_node(object, pid, options)

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -7,12 +7,6 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
     x_get_tree_miq_servers
   end
 
-  def override(node, _object, _pid, _options)
-    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
-      node[:highlighted] = true
-    end
-  end
-
   def x_get_tree_miq_servers
     @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
       objects.push(server)

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -15,10 +15,6 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
 
   def x_get_tree_miq_servers
     @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
-      unless @sb[:diag_selected_id] # Set default selected record vars
-        @sb[:diag_selected_model] = server.class.to_s
-        @sb[:diag_selected_id] = server.id
-      end
       objects.push(server)
     end
   end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -19,10 +19,6 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
       next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
                   (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
       next if r.name == "database_owner"
-      unless @sb[:diag_selected_id] # Set default selected record vars
-        @sb[:diag_selected_model] = r.class.to_s
-        @sb[:diag_selected_id] = r.id
-      end
       objects.push(r)
     end
   end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -7,12 +7,6 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
     x_get_tree_server_roles
   end
 
-  def override(node, _object, _pid, _options)
-    if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
-      node[:highlighted] = true
-    end
-  end
-
   def x_get_tree_server_roles
     ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -11,6 +11,7 @@
 - bs_tree                     ||= '{}'
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
+- silent_activate             ||= @explorer && tree_name == x_active_tree.to_s
 
 - options = {:tree_id            => tree_id,
              :tree_name          => tree_name,
@@ -25,7 +26,7 @@
              :autoload           => autoload,
              :allow_reselect     => allow_reselect,
              :controller         => controller_name,
-             :silent_activate    => @explorer && tree_name == x_active_tree.to_s,
+             :silent_activate    => silent_activate,
              :select_node        => select_node,
              :highlight_changes  => checkboxes,
              :active_tree        => x_active_tree}

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -64,7 +64,7 @@ describe TreeBuilderRolesByServer do
                                   'state'          => {'expanded' => true},
                                   'selectable'     => true,
                                   'class'          => ''},],
-                'state'      => {'expanded' => true, 'selected' => true},
+                'state'      => {'expanded' => true},
                 'class'      => ''}]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -66,7 +66,7 @@ describe TreeBuilderServersByRole do
                                   'state'          => { 'expanded' => true },
                                   'selectable'     => true,
                                   'class'          => ''}],
-                'state'      => { 'expanded' => true, "selected" => true},
+                'state'      => { 'expanded' => true},
                 'class'      => '' }]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end


### PR DESCRIPTION
The `Servers by Roles` and `Roles by Servers` trees under the `Settings -> Diagnostics` screen were setting and accessing the `@sb[:diag_selected_id]` and `@sb[:diag_selected_model]` variables from the session. These variables are used to determine what should be rendered on the right side from the tree, i.e. the details of the selected node. If there was no node selected, it has been also used for highlighting the first node.

Inside the tree this can be substituted with the `:selected_node` key from the `TreeState` which already includes the first node if nothing is selected. So instead of setting these variables inside the tree, I'm retrieving the node from the tree's state after the `TreeBuilder` has done its work. To be able to still highlight the right node, I leveraged the `silent_activate` parameter from the tree's view and exposed it into the `TreeBuilder`. There is a possible error with autoscroll if the silent activate is called, so I added a safeguard in the `miqTreeScrollToNode` to prevent any DOM changes in non-left-side trees. Finally, I was able to drop the `override` methods from both trees.

This is a next step into the world of stateless trees :wink: :tada: 

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @romanblanco 

@miq-bot add_label trees, hammer/no, refactoring