### PR TITLE
Clean up and move logic between the TreeBuilder classes for automate

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -612,39 +612,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Build a Catalog Items explorer tree
-  def build_ae_tree(type = :ae, name = :ae_tree)
-    # build the ae tree to show the tree select box for entry point
-    if x_active_tree == :automate_tree && @edit && @edit[:new][:fqname]
-      nodes = @edit[:new][:fqname].split("/")
-      @open_nodes = []
-      # if there are more than one nested namespaces
-      nodes.each_with_index do |_node, i|
-        if i == nodes.length - 1
-          # check if @cls is there, to make sure the class/instance still exists in Automate db
-          inst = @cls ? MiqAeInstance.find_by(:class_id => @cls.id, :name => nodes[i]) : nil
-          # show this as selected/expanded node when tree loads
-          if inst
-            @open_nodes.push("aei-#{inst.id}")
-            @active_node = "aei-#{inst.id}"
-          end
-        elsif i == nodes.length - 2
-          @cls = MiqAeClass.find_by(:namespace_id => @ns.id, :name => nodes[i])
-          @open_nodes.push("aec-#{@cls.id}") if @cls
-        else
-          @ns = MiqAeNamespace.find_by(:name => nodes[i])
-          @open_nodes.push("aen-#{@ns.id}") if @ns
-        end
-      end
-    end
-
-    if name == :ae_tree
-      TreeBuilderAeClass.new(name, type, @sb)
-    else
-      @automate_tree = TreeBuilderAutomate.new(name, type, @sb)
-    end
-  end
-
   # Build an audit object when configuration is changed in configuration and ops controllers
   def build_config_audit(new, current)
     if controller_name == "ops" && @sb[:active_tab] == "settings_server"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,7 +136,7 @@ class CatalogController < ApplicationController
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
     # Build Catalog Items tree unless @edit[:ae_tree_select]
-    build_ae_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
+    build_automate_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
     if params[:st_prov_type] # build request screen for selected item type
       @_params[:org_controller] = "service_template"
       if ansible_playbook?
@@ -372,7 +372,7 @@ class CatalogController < ApplicationController
     default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
       page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
@@ -441,7 +441,7 @@ class CatalogController < ApplicationController
 
     # if resource has been deleted from group, rearrange groups incase group is now empty.
     rearrange_groups_array
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
     changed = (@edit[:new] != @edit[:current])
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     render :update do |page|
@@ -508,7 +508,7 @@ class CatalogController < ApplicationController
     @edit = session[:edit]
     @edit[:new][params[:typ]] = nil
     @edit[:new][ae_tree_key] = ''
-    # build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
+    # build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
     render :update do |page|
       page << javascript_prologue
       @changed = (@edit[:new] != @edit[:current])
@@ -1323,7 +1323,7 @@ class CatalogController < ApplicationController
                        else
                          _("Editing Service Catalog Item \"%{name}\"") % {:name => @record.name}
                        end
-    build_ae_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
   end
 
   def st_set_form_vars

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -283,7 +283,8 @@ class MiqAeClassController < ApplicationController
       :add_nodes       => add_nodes,
     )
 
-    reload_trees_by_presenter(presenter, [build_ae_tree]) if replace_trees.present?
+    trees = build_replaced_trees(replace_trees, %i(ae))
+    reload_trees_by_presenter(presenter, trees)
 
     if @sb[:action] == "miq_ae_field_seq"
       presenter.update(:class_fields_div, r[:partial => "fields_seq_form"])

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -258,6 +258,10 @@ class MiqAeClassController < ApplicationController
     existing_node
   end
 
+  def build_ae_tree
+    TreeBuilderAeClass.new(:ae, :ae_tree, @sb)
+  end
+
   def replace_right_cell(options = {})
     @explorer = true
     replace_trees = options[:replace_trees]
@@ -1618,7 +1622,7 @@ class MiqAeClassController < ApplicationController
   def form_copy_objects_field_changed
     return unless load_edit("copy_objects__#{params[:id]}", "replace_cell__explorer")
     copy_objects_get_form_vars
-    build_ae_tree(:automate, :automate_tree)
+    build_automate_tree(:automate, :automate_tree)
     @changed = (@edit[:new] != @edit[:current])
     @changed = @edit[:new][:override_source] if @edit[:new][:namespace].nil?
     render :update do |page|
@@ -1849,7 +1853,7 @@ class MiqAeClassController < ApplicationController
     if params[:button] == "reset"
       add_flash(_("All changes have been reset"), :warning)
     end
-    build_ae_tree(:automate, :automate_tree)
+    build_automate_tree(:automate, :automate_tree)
     replace_right_cell
   end
 

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAeClass < TreeBuilder
-  has_kids_for MiqAeClass, %i(x_get_tree_class_kids type)
-  has_kids_for MiqAeNamespace, %i(x_get_tree_ns_kids type)
+  has_kids_for MiqAeClass, [:x_get_tree_class_kids]
+  has_kids_for MiqAeNamespace, [:x_get_tree_ns_kids]
 
   private
 
@@ -25,29 +25,11 @@ class TreeBuilderAeClass < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_class_kids(object, count_only, type)
-    instances = count_only_or_objects(count_only, object.ae_instances, %i(display_name name))
-    # show methods in automate explorer tree
-    if type == :ae # FIXME: is this ever false?
-      methods = count_only_or_objects(count_only, object.ae_methods, %i(display_name name))
-      instances + methods
-    else
-      instances
-    end
+  def x_get_tree_class_kids(object, count_only)
+    count_only_or_objects(count_only, object.ae_instances + object.ae_methods, %i(display_name name))
   end
 
-  def x_get_tree_ns_kids(object, count_only, type)
-    if type == :automate
-      if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
-        open_node("aen-#{object.id}")
-        open_node("aen-#{object.ae_namespaces.first.id}")
-      end
-
-      if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
-        open_node("aen-#{object.id}")
-        open_node("aec-#{object.ae_classes.first.id}")
-      end
-    end
+  def x_get_tree_ns_kids(object, count_only)
     objects = filter_ae_objects(object.ae_namespaces)
     unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = filter_ae_objects(object.ae_classes)

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -17,12 +17,7 @@ class TreeBuilderAeClass < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = if MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-                [MiqAeDomain.find_by(:id => @sb[:domain_id])] # GIT support can't use where
-              else
-                filter_ae_objects(User.current_tenant.visible_domains)
-              end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, User.current_tenant.visible_domains)
   end
 
   def x_get_tree_class_kids(object, count_only)
@@ -30,18 +25,6 @@ class TreeBuilderAeClass < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, count_only)
-    objects = filter_ae_objects(object.ae_namespaces)
-    unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      ns_classes = filter_ae_objects(object.ae_classes)
-      objects += ns_classes if ns_classes.present?
-    end
-    count_only_or_objects(count_only, objects, %i(display_name name))
-  end
-
-  def filter_ae_objects(objects)
-    return objects unless @sb[:cached_waypoint_ids]
-    klass_name = objects.first.class.name
-    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
-    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
+    count_only_or_objects(count_only, object.ae_namespaces + object.ae_classes, %i(display_name name))
   end
 end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -8,6 +8,16 @@ class TreeBuilderAutomate < TreeBuilderAeClass
     super(name, type, sandbox, build)
   end
 
+  # Get root nodes count/array for explorer tree
+  def x_get_tree_roots(count_only, _options)
+    objects = if MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
+                [MiqAeDomain.find_by(:id => @sb[:domain_id])] # GIT support can't use where
+              else
+                filter_ae_objects(User.current_tenant.visible_domains)
+              end
+    count_only_or_objects(count_only, objects)
+  end
+
   def override(node, object, _pid, _options)
     if @type == 'catalog'
       # Only the instance items should be clickable when selecting a catalog item entry point
@@ -33,7 +43,19 @@ class TreeBuilderAutomate < TreeBuilderAeClass
       open_node("aec-#{object.ae_classes.first.id}")
     end
 
-    super(object, count_only)
+    objects = filter_ae_objects(object.ae_namespaces)
+    unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
+      ns_classes = filter_ae_objects(object.ae_classes)
+      objects += ns_classes if ns_classes.present?
+    end
+    count_only_or_objects(count_only, objects, %i(display_name name))
+  end
+
+  def filter_ae_objects(objects)
+    return objects unless @sb[:cached_waypoint_ids]
+    klass_name = objects.first.class.name
+    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
   end
 
   def root_options

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -2,11 +2,6 @@ class TreeBuilderAutomate < TreeBuilder
   has_kids_for MiqAeClass, [:x_get_tree_class_kids]
   has_kids_for MiqAeNamespace, [:x_get_tree_ns_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
-    @controller = params[:controller]
-    super(name, type, sandbox, build)
-  end
-
   private
 
   def tree_init_options

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -18,6 +18,24 @@ class TreeBuilderAutomate < TreeBuilderAeClass
     end
   end
 
+  def x_get_tree_class_kids(object, count_only)
+    count_only_or_objects(count_only, object.ae_instances, %i(display_name name))
+  end
+
+  def x_get_tree_ns_kids(object, count_only)
+    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aen-#{object.ae_namespaces.first.id}")
+    end
+
+    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aec-#{object.ae_classes.first.id}")
+    end
+
+    super(object, count_only)
+  end
+
   def root_options
     {
       :text       => t = _("Datastore"),

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,11 +1,16 @@
-class TreeBuilderAutomate < TreeBuilderAeClass
-  def tree_init_options
-    {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
-  end
+class TreeBuilderAutomate < TreeBuilder
+  has_kids_for MiqAeClass, [:x_get_tree_class_kids]
+  has_kids_for MiqAeNamespace, [:x_get_tree_ns_kids]
 
   def initialize(name, type, sandbox, build = true, **params)
     @controller = params[:controller]
     super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options
+    {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
   end
 
   # Get root nodes count/array for explorer tree

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1253,7 +1253,7 @@ describe CatalogController do
 
   describe '#set_form_vars' do
     before do
-      allow(controller).to receive(:build_ae_tree)
+      allow(controller).to receive(:build_automate_tree)
       controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@record, FactoryBot.create(:service_template))
     end
@@ -1308,7 +1308,7 @@ describe CatalogController do
 
   describe '#resource_delete' do
     before do
-      allow(controller).to receive(:build_ae_tree)
+      allow(controller).to receive(:build_automate_tree)
       allow(controller).to receive(:load_edit).and_return(true)
       allow(controller).to receive(:rearrange_groups_array)
       allow(controller).to receive(:render)

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -96,7 +96,7 @@ describe MiqAeClassController do
                                        :trees       => {:ae_tree => {:active_node => node}})
       controller.instance_variable_set(:@_params, :button => "reset", :id => cls1.id)
       allow(controller).to receive(:open_parent_nodes)
-      expect(controller).to_not receive(:reload_trees_by_presenter)
+      expect(controller).to receive(:reload_trees_by_presenter).with(anything, [])
       expect(controller).to receive(:render)
       controller.send(:copy_objects)
       expect(controller.send(:flash_errors?)).not_to be_truthy

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -10,13 +10,6 @@ describe TreeBuilderAeClass do
       @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
     end
 
-    it "a tree with filter" do
-      @sb[:cached_waypoint_ids] = MiqAeClass.waypoint_ids_for_state_machines
-      tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
-      expect(domains).to match_array ['LUIGI']
-    end
-
     it "a tree without filter" do
       tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
       domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }

--- a/spec/presenters/tree_builder_automate_spec.rb
+++ b/spec/presenters/tree_builder_automate_spec.rb
@@ -1,0 +1,26 @@
+describe TreeBuilderAeClass do
+  include Spec::Support::AutomationHelper
+
+  describe "#initialize" do
+    before do
+      user = FactoryBot.create(:user_with_group)
+      login_as user
+      create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
+      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
+      @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
+    end
+
+    it "a tree with filter" do
+      @sb[:cached_waypoint_ids] = MiqAeClass.waypoint_ids_for_state_machines
+      tree = TreeBuilderAutomate.new(:automate_tree, "automate", @sb)
+      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      expect(domains).to match_array ['LUIGI']
+    end
+
+    it "a tree without filter" do
+      tree = TreeBuilderAutomate.new(:automate_tree, "automate", @sb)
+      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      expect(domains).to match_array %w(LUIGI MARIO)
+    end
+  end
+end


### PR DESCRIPTION
There are four levels of inheritance for automate trees:
* `TreeBuilderAeClass` - used on the left side on `Automate -> Explorer`
* `TreeBuilderAutomate` - used for catalog entrypoing selection and copying stuff in the automate explorer
* `TreeBuilderAutomateEntrypoint` - used in `TreeController` for entrypoint selection in the dialog editor
* `TreeBuilderAutomateInlineMethod` - used in `TreeController` for embedded methods selection

The rebuilding of `TreeBuilderAeClass` was called inconsistently compared to the other controllers, so I leveraged the `build_replaced_trees` helper method. The `build_ae_tree` was calling both the `TreeBuilderAeClass` and `TreeBuilderAutomate`, so I extracted the `build_automate_tree` from it. I also found some logic in the `TreeBuilderAeClass` that has been used in the `TreeBuilderAutomate` only, so I moved that into the child class. After discussing with @mkanoor I realized that the `filter_ae_objects` method is used by the catalog entry point selection only. The decision logic `@sb[:action]` only makes sense when selecting the destination of a copy in the automate. Therefore, it was safe to break the inheritance between the `TreeBuilderAeClass` and the `TreeBuilderAutomate` by moving most of the logic into the latter one.

There is still a lot of :spaghetti: code in the area, but I'll keep working on it in future PRs.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label trees, automation/automate, refactoring, hammer/no