### PR TITLE
Container Projects Dashboard & Alerts Overview fix

### DIFF
--- a/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
+++ b/app/assets/javascripts/controllers/alerts/alerts_overview_controller.js
@@ -10,7 +10,6 @@ angular.module('alertsCenter').controller('alertsOverviewController',
       miqSparkleOn();
 
       function setupInitialValues() {
-        document.getElementById('center_div').className += ' miq-body';
 
         setupConfig();
 

--- a/app/assets/javascripts/controllers/container_dashboard/container_project_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_project_dashboard_controller.js
@@ -2,7 +2,6 @@
 
 ManageIQ.angular.app.controller('containerProjectDashboardController', ['$scope', 'dashboardUtilsFactory', 'chartsMixin', 'dashboardService',
   function($scope, dashboardUtilsFactory, chartsMixin, dashboardService) {
-    document.getElementById('center_div').className += ' miq-body';
 
     // Obj-status cards init
     $scope.objectStatus = {

--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -1,12 +1,6 @@
 .miq-alerts-center {
-  margin: -20px;
-
-  .breadcrumb {
-    background-color: #f5f5f5;
-    border-bottom: 1px solid #d1d1d1;
-    margin: 0 -20px;
-    padding-left: 20px;
-    padding-right: 20px;
+  .toolbar-pf {
+    margin-top: -30px;
   }
 
   .init-hidden {

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -249,6 +249,11 @@ body#dashboard .blank-slate-pf {
   }
 }
 
+/// add padding below toolbar on angular dashboards
+.container-tiles-pf {
+  padding-top: 20px;
+}
+
 /// styling for object card on angular dashboards
 
 @media (min-width: $screen-md) {

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -8,7 +8,7 @@
         .row.toolbar-pf#toolbar
           .col-sm-12
             = render :partial => "layouts/angular/toolbar"
-      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" ? 'miq-sand-paper' : ''}
+      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
         .col-md-12
           = render :partial => "layouts/breadcrumbs"
         - if layout_uses_tabs?

--- a/app/views/shared/views/_show_alerts_overview.html.haml
+++ b/app/views/shared/views/_show_alerts_overview.html.haml
@@ -1,4 +1,4 @@
-.container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view.miq-alerts-center{"ng-controller" => "alertsOverviewController as vm"}
+.miq-dashboard-view.miq-alerts-center{"ng-controller" => "alertsOverviewController as vm"}
   .row.init-hidden{"ng-class" => "{'initialized': vm.loadingDone}"}
     %div{"pf-toolbar" => "", "config" => "vm.toolbarConfig"}
       %actions.group-toolbar-actions


### PR DESCRIPTION
This PR removes the unnecessary "miq-body" class from the Projects dashboard and Alerts Overview. The class created a  gray background behind the new breadcrumb.

Old
<img width="834" alt="Screen Shot 2019-03-28 at 10 20 56 AM" src="https://user-images.githubusercontent.com/1287144/55165369-af774a00-5143-11e9-92cc-d99df654b845.png">

<img width="1091" alt="Screen Shot 2019-03-28 at 1 55 12 PM" src="https://user-images.githubusercontent.com/1287144/55181022-23741b00-5161-11e9-967f-4502f39f283f.png">


New
<img width="832" alt="Screen Shot 2019-03-28 at 10 21 29 AM" src="https://user-images.githubusercontent.com/1287144/55165370-af774a00-5143-11e9-801f-d9affdb34ec4.png">

<img width="1081" alt="Screen Shot 2019-03-28 at 1 53 32 PM" src="https://user-images.githubusercontent.com/1287144/55180952-fc1d4e00-5160-11e9-9b23-e050242326eb.png">

