### PR TITLE
Fixed display of default memory threshold correctly on new appliance

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1017,9 +1017,8 @@ module OpsController::Settings::Common
     qwb[:ems_metrics_collector_worker] ||= {}
     qwb[:ems_metrics_collector_worker][:defaults] ||= {}
     w = qwb[:ems_metrics_collector_worker][:defaults]
-    raw = get_worker_setting(@edit[:current], MiqEmsMetricsCollectorWorker)
-    w[:count] = raw[:defaults][:count] || 2
-    w[:memory_threshold] = raw[:defaults][:memory_threshold] || 400.megabytes
+    w[:count] = get_worker_setting(@edit[:current], MiqEmsMetricsCollectorWorker, :defaults, :count) || 2
+    w[:memory_threshold] = get_worker_setting(@edit[:current], MiqEmsMetricsCollectorWorker, :defaults, :memory_threshold) || 400.megabytes
     @sb[:ems_metrics_collector_threshold] = []
     @sb[:ems_metrics_collector_threshold] = copy_array(@sb[:threshold])
 
@@ -1034,6 +1033,7 @@ module OpsController::Settings::Common
     w[:memory_threshold] = get_worker_setting(@edit[:current], MiqSmartProxyWorker, :memory_threshold) || 400.megabytes
     @sb[:smart_proxy_threshold] = []
     @sb[:smart_proxy_threshold] = copy_array(@sb[:threshold])
+    (1.gigabytes..2.9.gigabytes).step(0.1.gigabyte) { |x| @sb[:smart_proxy_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
 
     qwb[:ems_refresh_worker] ||= {}
     qwb[:ems_refresh_worker][:defaults] ||= {}
@@ -1042,23 +1042,23 @@ module OpsController::Settings::Common
     @sb[:ems_refresh_threshold] = []
     (200.megabytes...550.megabytes).step(50.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
     (600.megabytes..900.megabytes).step(100.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x] }
+    (1.gigabytes..2.9.gigabytes).step(0.1.gigabyte) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
+    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:ems_refresh_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
 
     wb = @edit[:current][:workers][:worker_base]
     w = (wb[:event_catcher] ||= {})
     w[:memory_threshold] = get_worker_setting(@edit[:current], MiqEventCatcher, :memory_threshold) || 1.gigabytes
     @sb[:event_catcher_threshold] = []
     (500.megabytes...1000.megabytes).step(100.megabytes) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x] }
+    (1.gigabytes..2.9.gigabytes).step(0.1.gigabyte) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
+    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:event_catcher_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
 
     w = (wb[:vim_broker_worker] ||= {})
     w[:memory_threshold] = get_worker_setting(@edit[:current], MiqVimBrokerWorker, :memory_threshold) || 1.gigabytes
     @sb[:vim_broker_threshold] = []
     (500.megabytes..900.megabytes).step(100.megabytes) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (1.gigabytes..2.9.gigabytes).step(1.gigabyte / 10) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
-    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x] }
+    (1.gigabytes..2.9.gigabytes).step(0.1.gigabyte) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
+    (3.gigabytes..10.gigabytes).step(512.megabytes) { |x| @sb[:vim_broker_threshold] << [number_to_human_size(x, :significant => false), x.to_i] }
 
     w = (wb[:ui_worker] ||= {})
     w[:count] = get_worker_setting(@edit[:current], MiqUiWorker, :count) || 2

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -450,6 +450,7 @@ describe OpsController do
     end
 
     describe '#settings_set_form_vars_workers' do
+      include ActionView::Helpers::NumberHelper
       context "set worker settings for selected server" do
         before do
           @miq_server = FactoryBot.create(:miq_server)
@@ -482,6 +483,13 @@ describe OpsController do
           ui_worker_count = controller.send(:get_worker_setting, assigns(:edit)[:current], MiqUiWorker, :count)
           expect(ui_worker_threshold).to eq(600.megabytes)
           expect(ui_worker_count).to eq(2)
+        end
+
+        it "gets worker setting and makes sure it exists in threshold array so correct value can be selected in drop down" do
+          controller.send(:settings_set_form_vars_workers)
+          proxy_worker_threshold = controller.send(:get_worker_setting, assigns(:edit)[:current], MiqSmartProxyWorker, :memory_threshold)
+          proxy_worker_threshold_human_size = number_to_human_size(proxy_worker_threshold, :significant => false)
+          expect(assigns(:sb)[:smart_proxy_threshold]).to include([proxy_worker_threshold_human_size, proxy_worker_threshold])
         end
       end
     end


### PR DESCRIPTION
Memory Threshold value of C & U Data Collectors, Refresh, VM Analysis Collectors workers on fresh appliance was not showing correctly.
- Changed range calculation in the .step that sets the values for the drop down, to fix the issue where in rails the default config value of 2.gigabytes is converted to 2147483648 but the calculations in the .step method was generating that as 2147483644 causing the values to not match and not display the right one selected in the drop down.
- Fixed the fetching of worker setting for MiqEmsMetricsCollectorWorker worker to be the same format as other workers.
- Added additional value in VM Analysis Collectors drop down, because default for that in config is set to 2.gigabytes and drop down did not have that value present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658373

@hstastna please test/review, yet another fix to worker memory settings, this PR fixes selection of default memory settings on a fresh appliance.

before
![before](https://user-images.githubusercontent.com/3450808/55170858-adb28400-514d-11e9-908b-0a54016a8bb7.png)

![before2](https://user-images.githubusercontent.com/3450808/55170864-b014de00-514d-11e9-8922-2032c7fd180a.png)

after
![after](https://user-images.githubusercontent.com/3450808/55170874-b5722880-514d-11e9-8403-4639e2b27f7b.png)

![after2](https://user-images.githubusercontent.com/3450808/55170884-bb680980-514d-11e9-8c00-654b5616eec6.png)


