### PR TITLE
Select the latest snapshot using x_node and with silent_activate

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -195,8 +195,9 @@ module VmCommon
       session[:snap_selected] = nil if Snapshot.find_by(:id => session[:snap_selected]).nil?
       @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
-      @active = if @snapshot_tree.selected_node
-                  snap_selected = Snapshot.find(@snapshot_tree.selected_node.split('-').last)
+      selected_snapshot_node = x_node(@snapshot_tree.name)
+      @active = if selected_snapshot_node && selected_snapshot_node != 'root'
+                  snap_selected = Snapshot.find(selected_snapshot_node.split('-').last)
                   session[:snap_selected] = snap_selected.id
                   snap_selected.current?
                 else

--- a/app/views/vm_common/_snapshots_tree.html.haml
+++ b/app/views/vm_common/_snapshots_tree.html.haml
@@ -3,5 +3,3 @@
     %fieldset
       %h3= _('Available Snapshots')
       = render(:partial => 'shared/tree', :locals => {:tree => @snapshot_tree, :name => @snapshot_tree.name})
-    :javascript
-      miqTreeActivateNodeSilently("#{j_str @snapshot_tree.name}", "#{j_str @snapshot_tree.selected_node}");

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -2,37 +2,47 @@ describe TreeBuilderSnapshots do
   context 'TreeBuilderSnaphots' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Snapshot Group")
-      login_as FactoryBot.create(:user, :userid => 'snapshot_wilma', :miq_groups => [@group])
-      snapshot_kid = FactoryBot.create(:snapshot,
-                                        :description => 'Snapshot Kid',
-                                        :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1))
-      snapshot = FactoryBot.create(:snapshot,
-                                    :description => 'Snapshot',
-                                    :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1),
-                                    :children    => [snapshot_kid])
-      snapshot_kid.parent_id = snapshot.id
-      @record = FactoryBot.create(:vm_infra, :snapshots => [snapshot])
-      @s_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, :root => @record)
+      group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Snapshot Group")
+      login_as FactoryBot.create(:user, :userid => 'snapshot_wilma', :miq_groups => [group])
+
+      s1.children.push(s2)
+      s2.parent_id = s1.id
     end
+
+    let(:vm) { FactoryBot.create(:vm_infra, :snapshots => [s1]) }
+
+    let(:s1) do
+      FactoryBot.create(:snapshot, :description => 'Snapshot',
+                                   :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1))
+    end
+
+    let(:s2) do
+      FactoryBot.create(:snapshot, :description => 'Snapshot Kid',
+                                   :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1))
+    end
+
+    let(:tree) { TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, :root => vm) }
+
     it 'sets root correctly' do
-      root = @s_tree.send(:root_options)
+      root = tree.send(:root_options)
       expect(root).to eq(
-        :text       => @record.name,
-        :tooltip    => @record.name,
+        :text       => vm.name,
+        :tooltip    => vm.name,
         :icon       => 'pficon pficon-virtual-machine',
         :selectable => false
       )
     end
+
     it 'returns Snapshot as kids of root' do
-      snapshot_nodes = @s_tree.send(:x_get_tree_roots, false)
+      snapshot_nodes = tree.send(:x_get_tree_roots, false)
       snapshot_nodes.each do |snapshot_node|
         expect(snapshot_node).to be_a_kind_of(Snapshot)
       end
     end
+
     it 'returns Snapshot as kids of Snapshot' do
-      snapshot_parent = @s_tree.send(:x_get_tree_roots, false).first
-      snapshot_nodes = @s_tree.send(:x_get_tree_snapshot_kids, snapshot_parent, false)
+      snapshot_parent = tree.send(:x_get_tree_roots, false).first
+      snapshot_nodes = tree.send(:x_get_tree_snapshot_kids, snapshot_parent, false)
       snapshot_nodes.each do |snapshot_node|
         expect(snapshot_node).to be_a_kind_of(Snapshot)
       end

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -47,5 +47,10 @@ describe TreeBuilderSnapshots do
         expect(snapshot_node).to be_a_kind_of(Snapshot)
       end
     end
+
+    it 'selects the last node in the tree' do
+      sandbox = tree.instance_variable_get(:@sb)
+      expect(sandbox[:trees][:snapshot_tree][:active_node].split('-').last).to eq(s2.id.to_s)
+    end
   end
 end


### PR DESCRIPTION
Removing some :spaghetti: from the `TreeBuilderSnapshots` around the highlighted last node. The logic responsible for selecting the node has been moved into the redefinition of `active_node_set`. Instead of the instance variable, the tree state is ~~ab~~used to store the active node. This allows us to use the `silent_activate` parameter and to drop some javascript too.

@miq-bot add_label trees, refactoring, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 