### PR TITLE
Showing default value for date/time picker in service dialog preview

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -33,14 +33,14 @@
                       - when "DialogFieldCheckBox"
                         = check_box_tag(field_id, "1", field.default_value == 't', :disabled => true)
                       - when "DialogFieldDateControl", "DialogFieldDateTimeControl"
+                        - time = field.default_value.present? ? Time.zone.parse(field.default_value) : Time.zone.now
                         - if field.show_past_dates
                           :javascript
                             ManageIQ.calendar.calDateFrom = undefined;
                         - else
                           :javascript
                             ManageIQ.calendar.calDateFrom = new Date("#{Time.zone.now.strftime("%Y, %m, %d")}");
-                        - t = Time.zone.now + 1.day
-                        - date_val = field.value ? field.value.split(" ") : ["#{t.month}/#{t.day}/#{t.year}"]
+                        - date_val = ["#{time.month}/#{time.day}/#{time.year}"]
                         = datepicker_input_tag("miq_date_1", h(date_val[0]),
                           :class    => "css1",
                           :readonly => "true",
@@ -49,9 +49,9 @@
                           &nbsp;
                           = _('at')
                           &nbsp;
-                          = select_tag("start_hour", options_for_select(Array.new(24) { |i| i }, 0))
+                          = select_tag("start_hour", options_for_select(Array.new(24) { |i| i }, time.hour))
                           \:
-                          = select_tag("start_min", options_for_select(Array.new(12)  { |i| i * 5 }, 0))
+                          = select_tag("start_min", options_for_select(Array.new(12)  { |i| i * 5 }, time.min))
 
                       - when "DialogFieldTextAreaBox"
                         = text_area_tag(field.id, field.sample_text, :size => "50x6", :disabled => true)


### PR DESCRIPTION
Displays correct date&time if there is a default value set.
If no default time is set, current date will be displayed.

![Screencast from 2019-04-02 08-35-25](https://user-images.githubusercontent.com/1187051/55388203-613ac000-5522-11e9-8102-741529571931.gif)


Links
----------------

* https://github.com/ManageIQ/ui-components/pull/373
* https://bugzilla.redhat.com/show_bug.cgi?id=1686077
