### PR TITLE
Remove redundant information from the genealogy tree, refactor the code a little

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -222,7 +222,7 @@ module VmCommon
         return
       else
         @genealogy_tree = TreeBuilderGenealogy.new(:genealogy_tree, :genealogy, @sb, true, :root => @record)
-        session[:genealogy_tree_root_id] = @genealogy_tree.root_id
+        session[:genealogy_tree_root_id] = @record.parent.presence.try(:id) || @record.id
       end
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -4,7 +4,6 @@ class TreeBuilderGenealogy < TreeBuilder
   def override(node, object, _pid, _options)
     if object == @root
       node[:highlighted] = true
-      node[:expand] = true
     end
   end
 
@@ -23,6 +22,7 @@ class TreeBuilderGenealogy < TreeBuilder
     {
       :full_ids   => true,
       :checkboxes => true,
+      :open_all   => true,
       :click_url  => "/vm/genealogy_tree_selected/",
       :onclick    => "miqOnClickGeneric",
       :oncheck    => "miqOnCheckGenealogy",

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -12,10 +12,6 @@ class TreeBuilderGenealogy < TreeBuilder
     super(name, type, sandbox, build)
   end
 
-  def root_id
-    @root.parent.present? ? @root.parent.id : @root.id
-  end
-
   private
 
   def tree_init_options
@@ -36,13 +32,11 @@ class TreeBuilderGenealogy < TreeBuilder
   end
 
   def root_options
-    if @root.parent.present?
-      {:text    => @root.parent.name,
-       :tooltip => _("VM: %{name} (Click to view)") % {:name => @root.parent.name}}.merge(vm_icon_image(@root.parent))
-    else
-      {:text    => @root.name,
-       :tooltip => _("VM: %{name} (Click to view)") % {:name => @root.name}}.merge(vm_icon_image(@root))
-    end
+    object = @root.parent.presence || @root
+    {
+      :text    => object.name,
+      :tooltip => _("VM: %{name} (Click to view)") % {:name => object.name}
+    }.merge(vm_icon_image(object))
   end
 
   def x_get_tree_roots(count_only, _options)

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -3,7 +3,6 @@ class TreeBuilderGenealogy < TreeBuilder
 
   def override(node, object, _pid, _options)
     if object == @root
-      node[:text] = _("%{item} (Selected)") % {:item => node[:text]}
       node[:highlighted] = true
       node[:expand] = true
     end
@@ -38,7 +37,7 @@ class TreeBuilderGenealogy < TreeBuilder
 
   def root_options
     if @root.parent.present?
-      {:text    => @root.parent.name + _(" (Parent)"),
+      {:text    => @root.parent.name,
        :tooltip => _("VM: %{name} (Click to view)") % {:name => @root.parent.name}}.merge(vm_icon_image(@root.parent))
     else
       {:text    => @root.name,

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -1,12 +1,6 @@
 class TreeBuilderGenealogy < TreeBuilder
   has_kids_for VmOrTemplate, [:x_get_vm_or_template_kids]
 
-  def override(node, object, _pid, _options)
-    if object == @root
-      node[:highlighted] = true
-    end
-  end
-
   def initialize(name, type, sandbox, build, **params)
     @root = params[:root]
     super(name, type, sandbox, build)
@@ -14,15 +8,29 @@ class TreeBuilderGenealogy < TreeBuilder
 
   private
 
+  # The tree name is the same for any genealogy tree, so it doesn't make sense to
+  # load the selected node from the session.
+  def active_node_set(tree_nodes)
+    # Find the right node to be selected based on the @root.id
+    selected = tree_nodes.first[:nodes].find do |node|
+      self.class.extract_node_model_and_id(node[:key])[1] == @root.id.to_s
+    end
+    # If no node has been found, just select the root node
+    selected ||= tree_nodes.first
+    # Set it as the active node in the tree state
+    @tree_state.x_node_set(selected[:key], @name)
+  end
+
   def tree_init_options
     {
-      :full_ids   => true,
-      :checkboxes => true,
-      :open_all   => true,
-      :click_url  => "/vm/genealogy_tree_selected/",
-      :onclick    => "miqOnClickGeneric",
-      :oncheck    => "miqOnCheckGenealogy",
-      :check_url  => "/vm/set_checked_items/"
+      :full_ids        => true,
+      :checkboxes      => true,
+      :open_all        => true,
+      :silent_activate => true,
+      :click_url       => "/vm/genealogy_tree_selected/",
+      :onclick         => "miqOnClickGeneric",
+      :oncheck         => "miqOnCheckGenealogy",
+      :check_url       => "/vm/set_checked_items/"
     }
   end
 

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -22,6 +22,7 @@ describe TreeBuilderGenealogy do
       expect(subject.send(:tree_init_options)).to eq(
         :full_ids   => true,
         :checkboxes => true,
+        :open_all   => true,
         :click_url  => "/vm/genealogy_tree_selected/",
         :onclick    => "miqOnClickGeneric",
         :oncheck    => "miqOnCheckGenealogy",

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -20,13 +20,14 @@ describe TreeBuilderGenealogy do
   describe '#tree_init_options' do
     it 'sets tree options correctly' do
       expect(subject.send(:tree_init_options)).to eq(
-        :full_ids   => true,
-        :checkboxes => true,
-        :open_all   => true,
-        :click_url  => "/vm/genealogy_tree_selected/",
-        :onclick    => "miqOnClickGeneric",
-        :oncheck    => "miqOnCheckGenealogy",
-        :check_url  => "/vm/set_checked_items/"
+        :full_ids        => true,
+        :checkboxes      => true,
+        :open_all        => true,
+        :silent_activate => true,
+        :click_url       => "/vm/genealogy_tree_selected/",
+        :onclick         => "miqOnClickGeneric",
+        :oncheck         => "miqOnCheckGenealogy",
+        :check_url       => "/vm/set_checked_items/"
       )
     end
   end


### PR DESCRIPTION
Fixes #5401 as we discussed there with @terezanovotna, the information in the parentheses (parent/selected) is redundant and it can be removed. I also cleaned up the selected node detection and highlighting so the `override` method could be dropped completely.

**Before:**
![Screenshot from 2019-04-01 12-50-27](https://user-images.githubusercontent.com/649130/55325336-0737ed00-5485-11e9-8ef0-db9e19e85003.png)

**After:**
![Screenshot from 2019-04-01 12-52-47](https://user-images.githubusercontent.com/649130/55325343-0c953780-5485-11e9-8ed5-1481ec313b2e.png)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label trees, refactoring, ux/review, hammer/no
