### PR TITLE
miqSetToolbarCount - fix setting toolbar counts

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -403,16 +403,19 @@ function miqUpdateButtons(obj, button_div) {
   miqSetButtons(count, button_div);
 }
 
+function miqSetToolbarCount(count) {
+  sendDataWithRx({
+    eventType: 'updateToolbarCount',
+    countSelected: count,
+  });
+}
+
 // Set the buttons in a div based on the count of checked items passed in
 function miqSetButtons(count, button_div) {
   if (button_div.match('_tb$') && count === 0) {
     // FIXME: this should be happening regardless of `count === 0`
     // ..but that needs more refactoring around miqUpdateAllCheckboxes, miqUpdateButtons, etc.
-    sendDataWithRx({
-      eventType: 'updateToolbarCount',
-      countSelected: count,
-    });
-
+    miqSetToolbarCount(count);
     return;
   }
 

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -1,4 +1,4 @@
-/* global DoNav miqClearTreeState miqDomElementExists miqJqueryRequest miqSetButtons miqSparkle */
+/* global DoNav miqClearTreeState miqDomElementExists miqJqueryRequest miqSetToolbarCount miqSparkle */
 
 function miqTreeObject(tree) {
   var obj;
@@ -232,7 +232,7 @@ function miqOnCheckGenealogy(node, treename) {
     return encodeURIComponent(item.key);
   });
   // Activate toolbar items according to the selection
-  miqSetButtons(selectedKeys.length, 'center_tb');
+  miqSetToolbarCount(selectedKeys.length);
   // Inform the backend about the checkbox changes
   miqJqueryRequest(ManageIQ.tree.checkUrl + '?all_checked=' + selectedKeys, {beforeSend: true, complete: true});
 }
@@ -250,7 +250,7 @@ function miqCheckAll(cb, treename) {
     return encodeURIComponent(item.key);
   });
   // Activate toolbar items according to the selection
-  miqSetButtons(selectedKeys.length, 'center_tb');
+  miqSetToolbarCount(selectedKeys.length);
   // Inform the backend about the checkbox changes
   miqJqueryRequest(ManageIQ.tree.checkUrl + '?check_all=' + encodeURIComponent(cb.checked) + '&all_checked=' + selectedKeys);
 }


### PR DESCRIPTION
Compute > Infrastructure > VMs
pick a VM with a parent/child (`vm.add_parent(other_vm); vm.save!`)
click Genealogy in textual summary
check 2 checkboxes
the compare toolbar button should work now

miqSetButtons is not only called for toolbars, but also fake toolbars,
so, we can't always update the toolbar count when nonzero.

But for specific cases we can - so splitting the functionality into miqSetToolbarCount,
which will always set the count for toolbars.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694712
Fixes #64 
