### PR TITLE
Added automatic virtual DOM clean up.

### DIFF
--- a/app/javascript/components/breadcrumbs/index.js
+++ b/app/javascript/components/breadcrumbs/index.js
@@ -2,15 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import { unescape } from 'lodash';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 
 const parsedText = text => unescape(text).replace(/<[/]{0,1}strong>/g, '');
 
 class Breadcrumbs extends Component {
-  componentDidMount() {
-    cleanVirtualDom();
-  }
-
   renderItems = () => {
     const {
       items, controllerName,

--- a/app/javascript/components/catalog-form/catalog-form.jsx
+++ b/app/javascript/components/catalog-form/catalog-form.jsx
@@ -5,7 +5,6 @@ import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './catalog-form.schema';
 import { filterOptions, filterValues } from '../dual-list-select/helpers';
 import { API } from '../../http_api';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 
 class CatalogForm extends Component {
   constructor(props) {
@@ -13,7 +12,6 @@ class CatalogForm extends Component {
     this.state = {
       isLoaded: false,
     };
-    cleanVirtualDom();
   }
 
   componentDidMount() {

--- a/app/javascript/components/flavor-form/flavor-form.jsx
+++ b/app/javascript/components/flavor-form/flavor-form.jsx
@@ -4,7 +4,6 @@ import { sprintf } from 'sprintf-js';
 import addSchema from './flavor-form.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { http, API } from '../../http_api';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 class FlavorForm extends Component {
@@ -14,7 +13,6 @@ class FlavorForm extends Component {
       initialValues: { is_public: true, rxtx_factor: '1.0' },
       schema: addSchema(),
     };
-    cleanVirtualDom();
   }
 
   componentDidMount() {

--- a/app/javascript/components/service-form/index.jsx
+++ b/app/javascript/components/service-form/index.jsx
@@ -4,7 +4,6 @@ import { Grid } from 'patternfly-react';
 import createSchema from './service-form.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { http } from '../../http_api';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 
 class ServiceForm extends Component {
   constructor(props) {
@@ -15,7 +14,6 @@ class ServiceForm extends Component {
   }
 
   componentDidMount() {
-    cleanVirtualDom();
     miqSparkleOn();
     http.get(`/service/service_form_fields/${this.props.serviceFormId}`)
       .then(data => this.setState({ initialValues: { ...data } }, miqSparkleOff()));

--- a/app/javascript/components/set-service-ownership-form/index.jsx
+++ b/app/javascript/components/set-service-ownership-form/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Grid } from 'patternfly-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { http } from '../../http_api';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 import createSchema from './ownership-form.schema';
 
 class SetServiceOwnershipForm extends Component {
@@ -12,7 +11,6 @@ class SetServiceOwnershipForm extends Component {
   }
 
   componentDidMount() {
-    cleanVirtualDom();
     const { ownershipIds } = this.props;
     this.loadInitialData(ownershipIds);
   }

--- a/app/javascript/components/vm-server-relationship-form/index.jsx
+++ b/app/javascript/components/vm-server-relationship-form/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Grid } from 'patternfly-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { API } from '../../http_api';
-import { cleanVirtualDom } from '../../miq-component/helpers';
 import createSchema from './vm-server-relationship-form.schema';
 
 class VmServerRelationShipForm extends Component {
@@ -12,7 +11,6 @@ class VmServerRelationShipForm extends Component {
     this.state = {
       isLoading: true,
     };
-    cleanVirtualDom();
   }
 
   componentDidMount() {

--- a/app/javascript/miq-component/registry.ts
+++ b/app/javascript/miq-component/registry.ts
@@ -7,6 +7,7 @@ import {
 } from './component-typings';
 
 import { writeProxy, lockInstanceProperties } from './utils';
+import { cleanVirtualDom } from './helpers';
 
 interface ComponentDefinition {
   name: string;
@@ -58,7 +59,6 @@ export function validateInstance(
   if (Array.from(registry.get(definition)).find(existingInstance => existingInstance === instance)) {
     throw new Error('Instance already present, check your blueprint.create implementation');
   }
-
   if (getInstance(definition.name, instance.id)) {
     throw new Error(`Instance with id ${instance.id} already present`);
   }
@@ -100,6 +100,8 @@ export function newInstance(
   initialProps: ComponentProps = {},
   mountTo?: HTMLElement
 ): ManagedComponentInstance | undefined {
+  // clean all left over components
+  cleanVirtualDom();
   // validate inputs
   const definition = getDefinition(name);
   if (!definition) {


### PR DESCRIPTION
### Issues
Due to an async nature of React mounting/unmounting components from VirtualDOM, @martinpovolny has found and issue when the component was not cleared properly even if the cleanViertualDOM function was called. This caused component being unmounted after the new one was registered which caused overriding component ID and old component not cleared from virtualDOM.

This happens if the clean method is not called in constructor - in any functional component. Creating classes for every component just to call clean method is not convenient.

Also calling this function manually is not efficient.

There are several places where we could run this autimatically
- `ManageIQ.explorer.processReplaceRightCell` - there is no clear place where tu put this one. Clean method must be called after the React mounting point is removed, but the new component is not mounted yet
- `ManageIQ.explorer.processReplaceMainDiv` - same as above
- `ManageIQ.component.newInstance` - exactly what is needed. Is called after the DOM is loaded -> old mounting point is gone, is called just before new component should be created

Now is virtualDOM cleared before any component is mounted.

Also i've removed any `cleanVirtualDom` calls because its not necessary anymore.