### PR TITLE
Fix error while clicking quadicon after running policy simulation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3214,6 +3214,7 @@ Rails.application.routes.draw do
         launch_vmrc_console
         retirement_info
         reconfigure_form_fields
+        policies
         protect
         retire
         show


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1686619

**Steps to reproduce:**
1. Add some infra provider, if you don't have any
2. _Compute > Infra > Providers_
3. Choose some provider, click on it to display its dashboard or summary page
4. Click on _VMs_ in dashboard or summary page of the selected provider
5. Choose some VM(s), check the checkbox(es)
6. In the toolbar, choose _Policy > Policy Simulation_
7. Choose some policy profile
8.  Click on the quadicon of the VM
=> "The page you were looking for doesn't exist." Error!
In log:
```
[----] F, [2019-03-13T17:07:46.085981 #30030:44f7b90] FATAL -- : ActionController::RoutingError (No route matches [GET] "/vm_or_template/policies/3031")
```

**How reproducible:**
not always, try to add/remove more policy profiles or clicking on quadicon and going back more times in a 
row

 ---

Before clicking on quadicon (step 7):
![before_click](https://user-images.githubusercontent.com/13417815/55796513-74bdcc00-5aca-11e9-9c83-a446e34e8f68.png)

**Before:**
![route_before](https://user-images.githubusercontent.com/13417815/55568203-8fc1c200-56ff-11e9-988b-a23c978a578a.png)

Issue after applying the fix: (already SOLVED with help of @rvsia)
```
----] I, [2019-04-04T17:31:20.367394 #29767:2aab4dbfb684]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_center_div_with_listnav.html.haml (430.2ms)
[----] I, [2019-04-04T17:31:20.367513 #29767:2aab4dbfb684]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_content.html.haml (430.6ms)
[----] F, [2019-04-04T17:31:20.367682 #29767:2aab4dbfb684] FATAL -- : Error caught: [ActionView::Template::Error] undefined local variable or method `gtl_url' for #<VmOrTemplateController:0x007f6d33859f38>
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:49:in `build_breadcrumbs_no_explorer'
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:18:in `data_for_breadcrumbs'
/home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.0.7.2/lib/abstract_controller/helpers.rb:68:in `data_for_breadcrumbs'
/home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_breadcrumbs_new.html.haml:1:in `__home_hstastna_manageiq_manageiq_ui_classic_app_views_layouts__breadcrumbs_new_html_haml___2518175760922062310_70053873661420'
```

**After:**
![after_clicking](https://user-images.githubusercontent.com/13417815/55796425-493ae180-5aca-11e9-9d32-51b6c9b1b824.png)


**Note:**
The same problem occurs also for Cloud provider and its Instances.
This fix worked before merging big breadcrumbs PR.
