### PR TITLE
Do not inherit the TreeBuilderOpsVmdb from TreeBuilderOps

### DIFF
--- a/app/presenters/tree_builder_ops.rb
+++ b/app/presenters/tree_builder_ops.rb
@@ -5,13 +5,7 @@ class TreeBuilderOps < TreeBuilder
   private
 
   def active_node_set(_tree_nodes)
-    # FIXME: check all below
-    case @name
-    when :vmdb_tree
-      @tree_state.x_node_set("root", @name)
-    else
-      @tree_state.x_node_set("svr-#{MiqServer.my_server(true).id}", @name) unless @tree_state.x_node(@name)
-    end
+    @tree_state.x_node_set("svr-#{MiqServer.my_server(true).id}", @name) unless @tree_state.x_node(@name)
   end
 
   def x_get_tree_zone_kids(object, count_only)

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -1,4 +1,4 @@
-class TreeBuilderOpsVmdb < TreeBuilderOps
+class TreeBuilderOpsVmdb < TreeBuilder
   has_kids_for VmdbTableEvm, %i(x_get_tree_vmdb_table_kids options)
 
   private


### PR DESCRIPTION
The only common method has a condition for the `vmdb` tree, it can be moved over.

@miq-bot add_label refactoring, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 