### PR TITLE
Action Details screen styling fix

### DIFF
--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -20,7 +20,8 @@
                   "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
                 = javascript_tag(javascript_focus('description'))
               - else
-                = h(@action.description)
+                %p.form-control-static
+                  = h(@action.description)
         .form-group
           %label.col-md-2.control-label
             = _('Action Type')
@@ -33,7 +34,8 @@
                 miqInitSelectPicker();
                 miqSelectPickerEvent('miq_action_type', '#{url}', {beforeSend: true, complete: true})
             - else
-              = h(@action.action_type == "default" ? _('Default') : _(MiqAction::TYPES[@action.action_type]))
+              %p.form-control-static
+                = h(@action.action_type == "default" ? _('Default') : _(MiqAction::TYPES[@action.action_type]))
       %hr
       - if @edit
         = render :partial => "action_options"


### PR DESCRIPTION
Add missing "form-control-static" class to Action Details screen

Old
![Screen Shot 2019-04-01 at 11 42 51 AM](https://user-images.githubusercontent.com/1287144/55344906-a60c1b80-547c-11e9-91b3-3864ec092914.png)

New
![Screen Shot 2019-04-01 at 12 47 30 PM](https://user-images.githubusercontent.com/1287144/55344905-a60c1b80-547c-11e9-9161-802897c7a9fb.png)