### PR TITLE
Drop always true conditional on TreeBuilderUtilization

### DIFF
--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -31,12 +31,7 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   def x_get_tree_region_kids(object, count_only)
-    emstype = if %i(bottlenecks utilization).include?(@type)
-                object.ems_infras
-              else
-                object.ext_management_systems
-              end
-    emses = Rbac.filtered(emstype)
+    emses = Rbac.filtered(object.ems_infras)
     storages = Rbac.filtered(object.storages)
     if count_only
       emses.count + storages.count


### PR DESCRIPTION
The `@type` here will be always `bottlenecks` or `utilization`, therefore, the conditional is always `true`. 

@miq-bot add_label cleanup, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 