### PR TITLE
Put back the missing TreeBuilderUtilization#get_tree_custom_kids

### DIFF
--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -58,6 +58,25 @@ class TreeBuilderUtilization < TreeBuilder
     end
   end
 
+  def x_get_tree_custom_kids(object, count_only, _options)
+    nodes = object[:id].split('_')
+    id = nodes.last.split('-').last
+    if object_ems?(nodes, object)
+      rec = MiqRegion.find_by(:id => id)
+      objects = rbac_filtered_sorted_objects(rec.ems_infras, "name")
+      count_only_or_objects(count_only, objects)
+    elsif object_ds?(nodes, object)
+      rec = MiqRegion.find_by(:id => id)
+      objects = rbac_filtered_sorted_objects(rec.storages, "name")
+      count_only_or_objects(count_only, objects)
+    elsif object_cluster?(nodes, object)
+      rec = ExtManagementSystem.find_by(:id => id)
+      objects = rbac_filtered_sorted_objects(rec.ems_clusters, "name") +
+                rbac_filtered_sorted_objects(rec.non_clustered_hosts, "name")
+      count_only_or_objects(count_only, objects)
+    end
+  end
+
   def object_ems?(nodes, object)
     (nodes.length > 1 && nodes[1] == "e") ||
       (object[:full_id] && object[:full_id].split('_')[1] == "e")


### PR DESCRIPTION
This method was accidentally deleted when the `TreeBuilderRegion` and `TreeBuilderUtilization` classes have been joined. Without this method, there is no way to access the utilization data of a single provider as the folders don't contain any data.

**Before:**
![Screenshot from 2019-04-01 21-04-37](https://user-images.githubusercontent.com/649130/55352710-c8745800-54c1-11e9-9c13-e1a9f09d55f2.png)

**After:**
![Screenshot from 2019-04-01 21-03-24](https://user-images.githubusercontent.com/649130/55352634-a24eb800-54c1-11e9-86fe-234c3909a93c.png)

@miq-bot add_reviewer @h-kataria 
@miq-bot add_label bug, trees, hammer/no