### PR TITLE
Drop unused methods from TreeBuilderUtilization

### DIFF
--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -1,8 +1,6 @@
 class TreeBuilderUtilization < TreeBuilder
   has_kids_for MiqRegion, [:x_get_tree_region_kids]
   has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
-  has_kids_for Datacenter, %i(x_get_tree_datacenter_kids type)
-  has_kids_for EmsFolder, %i(x_get_tree_folder_kids type)
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
   private
@@ -94,58 +92,6 @@ class TreeBuilderUtilization < TreeBuilder
         :tip  => _("Cluster / Deployment Role (Click to open)")
       }
     ]
-  end
-
-  def x_get_tree_datacenter_kids(object, count_only, type)
-    objects =
-      case type
-      when :vandt then x_get_tree_vandt_datacenter_kids(object)
-      when :handc then x_get_tree_handc_datacenter_kids(object)
-      end
-    count_only_or_objects(count_only, objects)
-  end
-
-  def x_get_tree_vandt_datacenter_kids(object)
-    # Count clusters directly in this folder
-    objects = rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => VmOrTemplate)
-    object.folders.each do |f|
-      if f.name == "vm"                 # Count vm folder children
-        objects += rbac_filtered_sorted_objects(f.folders, "name", :match_via_descendants => VmOrTemplate)
-        objects += rbac_filtered_sorted_objects(f.vms_and_templates, "name")
-      elsif f.name == "host"            # Don't count host folder children
-      else                              # add in other folders
-        f = Rbac.filtered_object(f, :match_via_descendants => VmOrTemplate)
-        objects << f if f
-      end
-    end
-  end
-
-  def x_get_tree_handc_datacenter_kids(object)
-    objects = rbac_filtered_sorted_objects(object.clusters, "name")
-    object.folders.each do |f|
-      if f.name == "vm"                 # Don't add vm folder children
-      elsif f.name == "host"            # Add host folder children
-        objects += rbac_filtered_sorted_objects(f.folders, "name")
-        objects += rbac_filtered_sorted_objects(f.clusters, "name")
-        objects += rbac_filtered_sorted_objects(f.hosts, "name")
-      else                              # add in other folders
-        f = Rbac.filtered_object(f)
-        objects << f if f
-      end
-    end
-  end
-
-  def x_get_tree_folder_kids(object, count_only, type)
-    objects = []
-    case type
-    when :vandt, :handc, :storage_pod
-      objects =  rbac_filtered_sorted_objects(object.folders_only, "name", :match_via_descendants => VmOrTemplate)
-      objects += rbac_filtered_sorted_objects(object.datacenters_only, "name", :match_via_descendants => VmOrTemplate)
-      objects += rbac_filtered_sorted_objects(object.clusters, "name", :match_via_descendants => VmOrTemplate)
-      objects += rbac_filtered_sorted_objects(object.hosts, "name", :match_via_descendants => VmOrTemplate)
-      objects += rbac_filtered_sorted_objects(object.vms_and_templates, "name")
-    end
-    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cluster_kids(object, count_only)


### PR DESCRIPTION
These methods were not used as there are no children of these classes. Also the tests against `type` would always be `false`. 

@miq-bot add_reviewer @h-kataria 
@miq-bot add_label cleanup, hammer/no, trees