### PR TITLE
Drop the unnecessary type argument inject from TreeBuilderDatacenter

### DIFF
--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -1,7 +1,7 @@
 class TreeBuilderDatacenter < TreeBuilder
   has_kids_for Host, [:x_get_tree_host_kids]
-  has_kids_for Datacenter, %i(x_get_tree_datacenter_kids type)
-  has_kids_for EmsFolder, %i(x_get_tree_folder_kids type)
+  has_kids_for Datacenter, %i(x_get_tree_datacenter_kids)
+  has_kids_for EmsFolder, %i(x_get_tree_folder_kids)
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
@@ -63,11 +63,11 @@ class TreeBuilderDatacenter < TreeBuilder
     end
   end
 
-  def x_get_tree_datacenter_kids(parent, count_only = false, _type)
+  def x_get_tree_datacenter_kids(parent, count_only = false)
     count_only_or_many_objects(count_only, parent.folders, parent.clusters, "name")
   end
 
-  def x_get_tree_folder_kids(parent, count_only, _type)
+  def x_get_tree_folder_kids(parent, count_only)
     objects = count_only ? 0 : []
 
     if parent.name == "Datacenters"


### PR DESCRIPTION
This argument is not used at all, therefore no need of it :scissors: :fire: :toilet: 

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, hammer/no, trees