### PR TITLE
Split up tree builders for automate/catalog entrypoint selection

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,7 +136,7 @@ class CatalogController < ApplicationController
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
     # Build Catalog Items tree unless @edit[:ae_tree_select]
-    build_automate_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
+    build_automate_tree if params[:display] || params[:template_id] || params[:manager_id]
     if params[:st_prov_type] # build request screen for selected item type
       @_params[:org_controller] = "service_template"
       if ansible_playbook?
@@ -372,7 +372,7 @@ class CatalogController < ApplicationController
     default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
       page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
@@ -441,7 +441,7 @@ class CatalogController < ApplicationController
 
     # if resource has been deleted from group, rearrange groups incase group is now empty.
     rearrange_groups_array
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree # Build Catalog Items tree
     changed = (@edit[:new] != @edit[:current])
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     render :update do |page|
@@ -508,7 +508,7 @@ class CatalogController < ApplicationController
     @edit = session[:edit]
     @edit[:new][params[:typ]] = nil
     @edit[:new][ae_tree_key] = ''
-    # build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
+    # build_automate_tree # Build Catalog Items tree unless @edit[:ae_tree_select]
     render :update do |page|
       page << javascript_prologue
       @changed = (@edit[:new] != @edit[:current])
@@ -778,6 +778,11 @@ class CatalogController < ApplicationController
   end
 
   private
+
+  def build_automate_tree
+    automate_open_nodes
+    @automate_tree = TreeBuilderAutomateCatalog.new(:automate_catalog_tree, :automate_catalog, @sb)
+  end
 
   def svc_catalog_provision_finish_submit_endpoint
     role_allows?(:feature => "miq_request_show_list", :any => true) ? "/miq_request/show_list" : "/catalog/explorer"
@@ -1323,7 +1328,7 @@ class CatalogController < ApplicationController
                        else
                          _("Editing Service Catalog Item \"%{name}\"") % {:name => @record.name}
                        end
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree
   end
 
   def st_set_form_vars

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1622,7 +1622,7 @@ class MiqAeClassController < ApplicationController
   def form_copy_objects_field_changed
     return unless load_edit("copy_objects__#{params[:id]}", "replace_cell__explorer")
     copy_objects_get_form_vars
-    build_automate_tree(:automate, :automate_tree)
+    build_automate_tree
     @changed = (@edit[:new] != @edit[:current])
     @changed = @edit[:new][:override_source] if @edit[:new][:namespace].nil?
     render :update do |page|
@@ -1703,6 +1703,11 @@ class MiqAeClassController < ApplicationController
   end
 
   private
+
+  def build_automate_tree
+    automate_open_nodes
+    @automate_tree = TreeBuilderAutomate.new(:automate_tree, :automate, @sb)
+  end
 
   # Builds a regular expression that controls the selectable items in the ae_methods tree
   def embedded_method_regex(fqname)
@@ -1853,7 +1858,7 @@ class MiqAeClassController < ApplicationController
     if params[:button] == "reset"
       add_flash(_("All changes have been reset"), :warning)
     end
-    build_automate_tree(:automate, :automate_tree)
+    build_automate_tree
     replace_right_cell
   end
 

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -14,8 +14,7 @@ module AutomateTreeHelper
   private :submit_embedded_method
 
   # Build the tree for catalog item entry point selection and automate copy
-  def build_automate_tree(type, name)
-    # build the ae tree to show the tree select box for entry point
+  def automate_open_nodes
     if x_active_tree == :automate_tree && @edit && @edit[:new][:fqname]
       nodes = @edit[:new][:fqname].split("/")
       @open_nodes = []
@@ -38,12 +37,10 @@ module AutomateTreeHelper
         end
       end
     end
-
-    @automate_tree = TreeBuilderAutomate.new(name, type, @sb)
   end
 
   def at_tree_select_toggle(edit_key)
-    build_automate_tree(:automate, :automate_tree)
+    build_automate_tree
     render :update do |page|
       page << javascript_prologue
       tree_close = proc do

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -13,19 +13,14 @@ class TreeBuilderAutomate < TreeBuilder
     objects = if MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
                 [MiqAeDomain.find_by(:id => @sb[:domain_id])] # GIT support can't use where
               else
-                filter_ae_objects(User.current_tenant.visible_domains)
+                User.current_tenant.visible_domains
               end
     count_only_or_objects(count_only, objects)
   end
 
   def override(node, object, _pid, _options)
-    if @type == 'catalog'
-      # Only the instance items should be clickable when selecting a catalog item entry point
-      node[:selectable] = false unless object.kind_of?(MiqAeInstance) # catalog
-    elsif object.kind_of?(MiqAeNamespace) && object.domain?
-      # Only the namespace items should be clickable when copying a class or instance
-      node[:selectable] = false
-    end
+    # Only the namespace items should be clickable when copying a class or instance
+    node[:selectable] = false if object.kind_of?(MiqAeNamespace) && object.domain?
   end
 
   def x_get_tree_class_kids(object, count_only)
@@ -33,29 +28,22 @@ class TreeBuilderAutomate < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, count_only)
-    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+    if object.respond_to?(:ae_namespaces) && object.ae_namespaces.size == 1
       open_node("aen-#{object.id}")
       open_node("aen-#{object.ae_namespaces.first.id}")
     end
 
-    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+    if object.respond_to?(:ae_classes) && object.ae_classes.size == 1
       open_node("aen-#{object.id}")
       open_node("aec-#{object.ae_classes.first.id}")
     end
 
-    objects = filter_ae_objects(object.ae_namespaces)
+    objects = object.ae_namespaces
     unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       ns_classes = filter_ae_objects(object.ae_classes)
       objects += ns_classes if ns_classes.present?
     end
     count_only_or_objects(count_only, objects, %i(display_name name))
-  end
-
-  def filter_ae_objects(objects)
-    return objects unless @sb[:cached_waypoint_ids]
-    klass_name = objects.first.class.name
-    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
-    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
   end
 
   def root_options

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -1,0 +1,38 @@
+class TreeBuilderAutomateCatalog < TreeBuilder
+  private
+
+  def override(node, object, _pid, _options)
+    # Only the instance items should be clickable when selecting a catalog item entry point
+    node[:selectable] = false unless object.kind_of?(MiqAeInstance)
+  end
+
+  def x_get_tree_roots(count_only, _options)
+    count_only_or_objects(count_only, User.current_tenant.visible_domains)
+  end
+
+  def x_get_tree_ns_kids(object, count_only)
+    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aen-#{object.ae_namespaces.first.id}")
+    end
+
+    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aec-#{object.ae_classes.first.id}")
+    end
+
+    objects = filter_ae_objects(object.ae_namespaces)
+    unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
+      ns_classes = filter_ae_objects(object.ae_classes)
+      objects += ns_classes if ns_classes.present?
+    end
+    count_only_or_objects(count_only, objects, %i(display_name name))
+  end
+
+  def filter_ae_objects(objects)
+    return objects unless @sb[:cached_waypoint_ids]
+    klass_name = objects.first.class.name
+    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
+  end
+end


### PR DESCRIPTION
The logic is a little :spaghetti: as the `TreeBuilderAutomate` is being used for both entrypoint selection in the catalog controller and for automate copy. I'm making this a little less complex by extracting the `TreeBuilderAutomateCatalogs`. 

@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, refactoring, hammer/no