### PR TITLE
Add support for passing custom options for import_git_url

### DIFF
--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -50,14 +50,14 @@ class GitBasedDomainImportService
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end
 
-  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id)
+  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id, custom_import_options = {})
     import_options = {
       "git_url"   => git_url,
       "ref"       => ref,
       "ref_type"  => ref_type,
       "tenant_id" => tenant_id,
       "overwrite" => true
-    }
+    }.merge(custom_import_options)
 
     task_options = {
       :action => "Refresh and import git repository",

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -50,14 +50,14 @@ class GitBasedDomainImportService
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end
 
-  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id, custom_import_options = {})
+  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id, auth_args = {})
     import_options = {
       "git_url"   => git_url,
       "ref"       => ref,
       "ref_type"  => ref_type,
       "tenant_id" => tenant_id,
       "overwrite" => true
-    }.merge(custom_import_options)
+    }.merge(prepare_auth_options(auth_args))
 
     task_options = {
       :action => "Refresh and import git repository",
@@ -127,5 +127,18 @@ class GitBasedDomainImportService
 
   def self.available?
     MiqRegion.my_region.role_active?("git_owner")
+  end
+
+  private
+
+  def prepare_auth_options(auth_args)
+    auth_args.stringify_keys!
+
+    auth_options = {}
+    auth_options["password"] = ManageIQ::Password.try_encrypt(auth_args["password"]) unless auth_args["password"].nil?
+    auth_options["userid"] = auth_args["userid"] unless auth_args["userid"].nil?
+    auth_options["verify_ssl"] = auth_args["verify_ssl"] unless auth_args["verify_ssl"].nil?
+
+    auth_options
   end
 end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -161,12 +161,13 @@ describe GitBasedDomainImportService do
       allow(task).to receive(:message).and_return(nil)
     end
 
+    let(:git_branches) { [] }
+    let(:ref_name) { "the_tag_name" }
+    let(:ref_type) { "tag" }
+    let(:method_name) { 'import_git_url' }
+    let(:action) { 'Refresh and import git repository' }
+
     context "when git branches that match the given name do not exist" do
-      let(:git_branches) { [] }
-      let(:ref_name) { "the_tag_name" }
-      let(:ref_type) { "tag" }
-      let(:method_name) { 'import_git_url' }
-      let(:action) { 'Refresh and import git repository' }
       let(:import_options) do
         {
           "git_url"   => git_repo.url,
@@ -181,6 +182,25 @@ describe GitBasedDomainImportService do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
         expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321)).to eq(task.id)
+      end
+    end
+
+    context "when custom options are provided" do
+      let(:import_options) do
+        {
+          "git_url"   => git_repo.url,
+          "ref"       => ref_name,
+          "ref_type"  => ref_type,
+          "tenant_id" => 321,
+          "overwrite" => true,
+          "userid" => "bob"
+        }
+      end
+
+      it "calls 'queue_import' with the the additional custom options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321, "userid" => "bob")).to eq(task.id)
       end
     end
   end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -193,7 +193,7 @@ describe GitBasedDomainImportService do
           "ref_type"  => ref_type,
           "tenant_id" => 321,
           "overwrite" => true,
-          "userid" => "bob"
+          "userid"    => "bob"
         }
       end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600961

This PR, along with a PR [manageiq-api/571](https://github.com/ManageIQ/manageiq-api/pull/571) will provide the support to allow the
API to be used to create a Git backed automation domain.

To fully support this new feature additional options are, sometime but not always
needed. If access to the GIT repo requires authentication credentials these
credentials need to be passed to the underlying automation engine.

This PR provides support to allow for passing additional optional arguments.

I purposely do not validate the additional optional arguments here, instead relying on
the underlying automation engine code to do so. This will avoid validating them multiple
times and allow for future enhancement to the automation engine to not require additional
code changes here.

Steps for Testing/QA [Optional]
-------------------------------

See the associated manageiq-api PR for testing instructions
