### PR TITLE
Drop always true condition from TreeBuilderUtilization

### DIFF
--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -109,12 +109,6 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   def x_get_tree_cluster_kids(object, count_only)
-    objects = rbac_filtered_sorted_objects(object.hosts, "name")
-    # FIXME: is the condition below ever false?
-    unless %i(bottlenecks utilization).include?(@type)
-      objects += rbac_filtered_sorted_objects(object.resource_pools, "name")
-      objects += rbac_filtered_sorted_objects(object.vms, "name")
-    end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, rbac_filtered_sorted_objects(object.hosts, "name"))
   end
 end


### PR DESCRIPTION
The tree always has one of these types, so no need for the test.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, trees, hammer/no