### PR TITLE
Display info about unavailable fields while adding/editing report

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -131,11 +131,24 @@ module ReportController::Reports::Editor
     replace_right_cell
   end
 
+  # Get string with unavailable fields while adding/editing report
+  def unavailable_fields_for_model(model)
+    case model
+    when 'ChargebackVm'
+      _('* Caution: CPU Cores Allocated Metric, CPU Cores Used Metric are not supported for Chargeback for Vms.')
+    when 'ChargebackContainerImage'
+      _('* Caution: CPU Allocated Metric, CPU Used Metric, Disk I/O Used Metric, Fixed Storage Metric, Storage Allocated Metric, Storage Used Metric are not supported for Chargeback for Images.')
+    when 'ChargebackContainerProject'
+      _('* Caution: CPU Allocated Metric, CPU Used Metric, CPU Cores Allocated Metric, Disk I/O Used Metric, Memory Allocated Metric, Fixed Storage Metric, Storage Allocated Metric, Storage Used Metric are not supported for Chargeback for Projects.')
+    end
+  end
+
   # AJAX driven routine to check for changes in ANY field on the form
   def form_field_changed
     return unless load_edit("report_edit__#{params[:id]}", "replace_cell__explorer")
     get_form_vars
     build_edit_screen
+    @unavailable_fields = unavailable_fields_for_model(@edit[:new][:model])
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -26,6 +26,12 @@
       = render :partial => "column_lists"
     %strong
       = _('* Caution: Changing these fields will clear all selected values below them!')
+    - if @unavailable_fields
+      %br
+      %p{:style => "max-width: 850px;"}
+        %strong
+          = @unavailable_fields
+
     %hr
       %h3
         = _('Report Creation Timeout')

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -28,8 +28,8 @@ describe ReportController do
     end
   end
 
-  context "::Reports::Editor" do
-    context "#set_form_vars" do
+  describe "::Reports::Editor" do
+    describe "#set_form_vars" do
       let(:user) { stub_user(:features => :all) }
 
       let(:chargeback_report) do
@@ -109,6 +109,7 @@ describe ReportController do
 
       describe '#reportable_models' do
         subject { controller.send(:reportable_models) }
+
         it 'does not contain duplicate items' do
           duplicates = subject.group_by(&:first).select { |_, v| v.size > 1 }.map(&:first)
           expect(duplicates).to be_empty
@@ -116,7 +117,7 @@ describe ReportController do
       end
     end
 
-    context "#miq_report_edit" do
+    describe "#miq_report_edit" do
       it "should build tabs with correct tab id after reset button is pressed to prevent error when changing tabs" do
         user = stub_user(:features => :all)
         user.save!
@@ -200,7 +201,7 @@ describe ReportController do
       end
     end
 
-    describe "set_form_vars" do
+    describe "#set_form_vars" do
       let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
       let(:chargeback_report) do
         FactoryBot.create(:miq_report, :db => "ChargebackVm", :col_order => ["name"], :headers => ["Name"])
@@ -280,6 +281,43 @@ describe ReportController do
 
       it "returns {} given invalid category name" do
         expect(controller.send(:entries_hash, "no_such_name")).to eq({})
+      end
+    end
+
+    describe '#form_field_changed' do
+      before do
+        allow(controller).to receive(:build_edit_screen)
+        allow(controller).to receive(:get_form_vars)
+        allow(controller).to receive(:load_edit).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@edit, :new => {:model => model})
+      end
+
+      context 'configuring Report Columns and Chargeback for VMs' do
+        let(:model) { 'ChargebackVm' }
+
+        it 'sets string with unavailable fields while adding/editing report' do
+          controller.send(:form_field_changed)
+          expect(controller.instance_variable_get(:@unavailable_fields)).to include('CPU Cores Allocated Metric, CPU Cores Used Metric')
+        end
+      end
+
+      context 'configuring Report Columns and Chargeback for Images' do
+        let(:model) { 'ChargebackContainerImage' }
+
+        it 'sets string with unavailable fields while adding/editing report' do
+          controller.send(:form_field_changed)
+          expect(controller.instance_variable_get(:@unavailable_fields)).to include('CPU Allocated Metric, CPU Used Metric, Disk I/O Used Metric, Fixed Storage Metric, Storage Allocated Metric, Storage Used Metric')
+        end
+      end
+
+      context 'configuring Report Columns and Chargeback for Projects' do
+        let(:model) { 'ChargebackContainerProject' }
+
+        it 'sets string with unavailable fields while adding/editing report' do
+          controller.send(:form_field_changed)
+          expect(controller.instance_variable_get(:@unavailable_fields)).to include('CPU Allocated Metric, CPU Used Metric, CPU Cores Allocated Metric, Disk I/O Used Metric, Memory Allocated Metric, Fixed Storage Metric, Storage Allocated Metric, Storage Used Metric')
+        end
       end
     end
   end

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -13,7 +13,7 @@ def create_and_generate_report_for_user(report_name, user_id)
 end
 
 describe ReportHelper do
-  context '#chart_fields_options' do
+  describe '#chart_fields_options' do
     it 'should return fields with models and aggregate functions from summary when "Show Sort Breaks" is not "No"' do
       @edit = {
         :new => {


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1581817

**What:**
When choosing _Chargeback for Images/Projects/Vms_ under Configure Report Columns section while adding a new/editing an existing Report under _Cloud Intel > Reports > Reports_, some of the fields are not available. This is ok but there was a misunderstanding that those fields were missing there. This is why I am adding note about which fields are not supported to the Report editing screen.

**Steps to reproduce:**
1. Go to _Cloud Intel > Reports > Reports_ accordion
2. In toolbar, choose _Configuration > Add a new Report_ (or you can also edit an existing report)
3. Under _Configure Report Columns_, for _Base the report on_ choose one of _Chargeback for Images/Projects/Vms_
=> some of the fields are not available, for example _Cpu Cores Allocated Metric_ for _Chargeback for Fms_ (Carefully! They are not missing!)

**Before:**
Choosing _Chargeback for Images_ while adding/editing report:
![b1](https://user-images.githubusercontent.com/13417815/55402747-7cbebe80-5554-11e9-8149-f80fdcd0e6fc.png)
Choosing _Chargeback for Projects_:
![b2](https://user-images.githubusercontent.com/13417815/55402751-7e888200-5554-11e9-9059-608069efa2cc.png)
Choosing _Chargeback for Vms_:
![b3](https://user-images.githubusercontent.com/13417815/55402752-80524580-5554-11e9-89ed-c6307589dc19.png)

**After:**
Choosing _Chargeback for Images_ while adding/editing report:
![images](https://user-images.githubusercontent.com/13417815/55798226-b2bcef00-5ace-11e9-8c72-5f723a449822.png)
Choosing _Chargeback for Projects_:
![projects](https://user-images.githubusercontent.com/13417815/55798230-b781a300-5ace-11e9-8f42-57b817811885.png)
Choosing _Chargeback for Vms_:
![vms](https://user-images.githubusercontent.com/13417815/55798234-ba7c9380-5ace-11e9-8535-421867536e0f.png)
