### PR TITLE
Fixing breadcrumbs issues in explorer controllers

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -165,6 +165,7 @@ module ApplicationController::Explorer
 
   # Tree node selected in explorer
   def tree_select(node_info = false)
+    @sb[:action] = nil if @sb
     @explorer = true
     @lastaction = "explorer"
     self.x_active_tree = params[:tree] if params[:tree]
@@ -250,7 +251,7 @@ module ApplicationController::Explorer
     return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}", "replace_cell__explorer")
     add_flash(_("Tag Edit was cancelled by the user"))
     get_node_info(x_node)
-    @edit = nil # clean out the saved info
+    @sb[:action] = @edit = nil # clean out the saved info
     replace_right_cell
   end
 

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -517,6 +517,7 @@ class AutomationManagerController < ApplicationController
         {:title => _("Explorer")},
       ],
       :record_title => :hostname,
+      :show_header  => true,
     }
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -86,7 +86,7 @@ class CatalogController < ApplicationController
       else
         add_flash(_("Add of new Service Catalog Item was cancelled by the user"))
       end
-      @edit = @record = nil
+      @sb[:action] = @edit = @record = nil
       @in_a_form = false
       replace_right_cell
     when "save", "add"
@@ -187,6 +187,7 @@ class CatalogController < ApplicationController
 
   # VM or Template show selected, redirect to proper controller
   def show
+    @sb[:action] = nil
     @explorer = true if request.xml_http_request? # Ajax request means in explorer
     record = ServiceTemplate.find(params[:id])
     if !@explorer
@@ -204,6 +205,7 @@ class CatalogController < ApplicationController
     @explorer = true
     @lastaction = "explorer"
     @report_deleted = params[:report_deleted] == 'true' if params[:report_deleted]
+    @sb[:action] = nil
 
     # if AJAX request, replace right cell, and return
     if request.xml_http_request?
@@ -251,6 +253,7 @@ class CatalogController < ApplicationController
 
   # ST clicked on in the explorer right cell
   def x_show
+    @sb[:action] = nil
     @explorer = true
     if x_active_tree == :stcat_tree
       if params[:rec_id]
@@ -282,7 +285,7 @@ class CatalogController < ApplicationController
       else
         add_flash(_("Add of new Catalog Bundle was cancelled by the user"))
       end
-      @edit = @record = nil
+      @sb[:action] = @edit = @record = nil
       @in_a_form = false
       replace_right_cell
     when "save", "add"
@@ -549,7 +552,7 @@ class CatalogController < ApplicationController
       else
         add_flash(_("Add of new Catalog was cancelled by the user"))
       end
-      @edit = nil
+      @sb[:action] = @edit = nil
       @in_a_form = false
       replace_right_cell
     when "save", "add"
@@ -950,7 +953,7 @@ class CatalogController < ApplicationController
     add_flash(_("Edit of Orchestration Template \"%{name}\" was cancelled by the user") %
       {:name => session[:edit][:new][:name]})
     @in_a_form = false
-    @edit = @record = nil
+    @sb[:action] = @edit = @record = nil
     replace_right_cell
   end
 
@@ -996,7 +999,7 @@ class CatalogController < ApplicationController
     add_flash(_("Copy of Orchestration Template \"%{name}\" was cancelled by the user") %
       {:name => session[:edit][:current][:name]})
     @in_a_form = false
-    @edit = @record = nil
+    @sb[:action] = @edit = @record = nil
     replace_right_cell
   end
 
@@ -1045,7 +1048,7 @@ class CatalogController < ApplicationController
   def ot_add_submit_cancel
     add_flash(_("Creation of a new Orchestration Template was cancelled by the user"))
     @in_a_form = false
-    @edit = @record = nil
+    @sb[:action] = @edit = @record = nil
     replace_right_cell
   end
 
@@ -1097,7 +1100,7 @@ class CatalogController < ApplicationController
   def service_dialog_from_ot_submit_cancel
     add_flash(_("Creation of a new Service Dialog was cancelled by the user"))
     @in_a_form = false
-    @edit = @record = nil
+    @sb[:action] = @edit = @record = nil
     replace_right_cell
   end
 
@@ -2096,6 +2099,7 @@ class CatalogController < ApplicationController
   end
 
   def show_record(id = nil)
+    @sb[:action] = nil
     @display = params[:display] || "main" unless pagination_or_gtl_request?
 
     @lastaction = "show"
@@ -2152,10 +2156,11 @@ class CatalogController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs       => [
         {:title => _("Services")},
         {:title => _("Catalogs")},
       ],
+      :hide_special_item => true,
     }
   end
 

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -122,6 +122,7 @@ class MiqAeCustomizationController < ApplicationController
 
     @lastaction = "automate_button"
     @layout = "miq_ae_customization"
+    @sb[:action] = nil
 
     render :layout => "application" unless request.xml_http_request?
   end
@@ -150,6 +151,7 @@ class MiqAeCustomizationController < ApplicationController
   # Record clicked on in the explorer right cell
   def x_show
     @explorer = true
+    @sb[:action] = nil
     klass = x_active_tree == :old_dialogs_tree ? MiqDialog : Dialog
     @record = identify_record(params[:id], klass)
     params[:id] = x_build_node_id(@record) # Get the tree node id

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -253,6 +253,7 @@ class MiqPolicyController < ApplicationController
     self.x_active_tree   = params[:tree]             if params[:tree]
     self.x_node          = params[:id]
 
+    @sb[:action] = nil
     get_node_info(x_node)
     replace_right_cell(:nodetype => @nodetype)
   end

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -7,7 +7,7 @@ module MiqPolicyController::AlertProfiles
 
   def alert_profile_edit_cancel
     return unless alert_profile_edit_load_edit
-    @edit = nil
+    @sb[:action] = @edit = nil
     if @alert_profile && @alert_profile.id.blank?
       add_flash(_("Add of new Alert Profile was cancelled by the user"))
     else
@@ -58,7 +58,7 @@ module MiqPolicyController::AlertProfiles
     add_flash(flash_key % {:name => @edit[:new][:description]})
     alert_profile_get_info(MiqAlertSet.find(alert_profile.id))
     alert_profile_sync_provider(current, mems.keys)
-    @edit = nil
+    @sb[:action] = @edit = nil
     self.x_node = @new_alert_profile_node = "xx-#{alert_profile.mode}_ap-#{alert_profile.id}"
     get_node_info(@new_alert_profile_node)
     replace_right_cell(:nodetype => "ap", :replace_trees => %i[alert_profile], :remove_form_buttons => true)

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -6,7 +6,7 @@ module MiqPolicyController::Alerts
   end
 
   def alert_edit_cancel
-    @edit = nil
+    @sb[:action] = @edit = nil
     @alert = session[:edit][:alert_id] ? MiqAlert.find(session[:edit][:alert_id]) : MiqAlert.new
     if @alert.id.blank?
       add_flash(_("Add of new Alert was cancelled by the user"))
@@ -36,7 +36,7 @@ module MiqPolicyController::Alerts
     add_flash(flash_key % {:name => @edit[:new][:description]})
     alert_get_info(MiqAlert.find(alert.id))
     alert_sync_provider(@edit[:alert_id] ? :update : :new)
-    @edit = nil
+    @sb[:action] = @edit = nil
     @nodetype = "al"
     @new_alert_node = "al-#{alert.id}"
     replace_right_cell(:nodetype => "al", :replace_trees => %i[alert_profile alert], :remove_form_buttons => true)

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -12,7 +12,7 @@ module MiqPolicyController::Conditions
       else
         add_flash(_("Add of new %{model} Condition was cancelled by the user") % {:model => ui_lookup(:model => @edit[:new][:towhat])})
       end
-      @edit = nil
+      @sb[:action] = @edit = nil
       get_node_info(x_node)
       replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
       return
@@ -60,7 +60,7 @@ module MiqPolicyController::Conditions
         else
           add_flash(_("Condition \"%{name}\" was added") % {:name => @edit[:new][:description]})
         end
-        @edit = nil
+        @sb[:action] = @edit = nil
         @nodetype = "co"
         if adding # If add
           condition_get_info(condition)

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -5,7 +5,7 @@ module MiqPolicyController::Events
     assert_privileges("event_edit")
     case params[:button]
     when "cancel"
-      @edit = nil
+      @sb[:action] = @edit = nil
       add_flash(_("Edit Event cancelled by user"))
       get_node_info(x_node)
       replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
@@ -43,7 +43,7 @@ module MiqPolicyController::Events
       add_flash(_("Actions for Policy Event \"%{events}\" were saved") % {:events => event.description})
       @nodetype = "ev"
       event_get_info(MiqEventDefinition.find(event.id))
-      @edit = nil
+      @sb[:action] = @edit = nil
       replace_right_cell(:nodetype => "ev", :replace_trees => %i[policy_profile policy], :remove_form_buttons => true)
     when "true_right", "true_left", "true_allleft", "true_up", "true_down", "true_sync", "true_async"
       handle_selection_buttons(:actions_true, :members_chosen_true, :choices_true, :choices_chosen_true)

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -5,7 +5,7 @@ module MiqPolicyController::MiqActions
     assert_privileges(params[:pressed]) if params[:pressed]
     case params[:button]
     when "cancel"
-      @edit = nil
+      @sb[:action] = @edit = nil
       @action = MiqAction.find(session[:edit][:action_id]) if session[:edit] && session[:edit][:action_id]
       if @action.present?
         add_flash(_("Edit of Action \"%{name}\" was cancelled by the user") % {:name => @action.description})
@@ -48,7 +48,7 @@ module MiqPolicyController::MiqActions
           add_flash(_("Action \"%{name}\" was added") % {:name => @edit[:new][:description]})
         end
         action_get_info(MiqAction.find(action.id))
-        @edit = nil
+        @sb[:action] = @edit = nil
         @nodetype = "a"
         @new_action_node = "a-#{action.id}"
         replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? %i[policy_profile policy action] : %i[action], :remove_form_buttons => true)

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -10,7 +10,7 @@ module MiqPolicyController::Policies
     else
       add_flash(_("Add of new Policy was cancelled by the user"))
     end
-    @edit = nil
+    @sb[:action] = @edit = nil
     get_node_info(x_node)
     replace_right_cell(:nodetype => @nodetype, :remove_form_buttons => true)
   end
@@ -69,7 +69,7 @@ module MiqPolicyController::Policies
       add_flash(_("Policy \"%{name}\" was added") % {:name => @edit[:new][:description]})
     end
     policy_get_info(MiqPolicy.find(policy.id))
-    @edit = nil
+    @sb[:action] = @edit = nil
     @nodetype = "p"
 
     case x_active_tree

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -4,7 +4,7 @@ module MiqPolicyController::PolicyProfiles
   def profile_edit
     case params[:button]
     when "cancel"
-      @edit = nil
+      @sb[:action] = @edit = nil
       @profile = MiqPolicySet.find(session[:edit][:profile_id]) if session[:edit] && session[:edit][:profile_id]
       if @profile.blank?
         add_flash(_("Add of new Policy Profile was cancelled by the user"))

--- a/app/controllers/miq_template_controller.rb
+++ b/app/controllers/miq_template_controller.rb
@@ -3,6 +3,7 @@ require "rexml/document"
 class MiqTemplateController < ApplicationController
   include VmCommon
   include Mixins::GenericListMixin
+  include Mixins::BreadcrumbsMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -9,6 +9,7 @@ module Mixins
       options = breadcrumbs_options || {}
       options[:record_info] ||= (@record || {})
       options[:record_title] ||= :name
+      options[:show_header] ||= false
       breadcrumbs = options[:breadcrumbs] || []
 
       # Different methods for controller with explorers and for non-explorers controllers
@@ -32,12 +33,14 @@ module Mixins
         breadcrumbs_from_tree = build_breadcrumbs_from_tree
         breadcrumbs.concat(breadcrumbs_from_tree)
 
-        if (options[:include_record] || breadcrumbs_from_tree.blank?) && options[:record_info].present? && options[:record_info][options[:record_title]]
+        if (options[:include_record] || breadcrumbs_from_tree.blank?) && options[:record_info].present? && options[:record_info][options[:record_title]] &&
+           !(@tagitems || @politems || @ownershipitems || @retireitems)
           # Append breadcrumb created from record_info if included or if result from tree was empty (eg filters page)
-          breadcrumbs.push(:title => options[:record_info][options[:record_title]])
+          breadcrumbs.push(:title => options[:record_info][options[:record_title]], :key => x_node_right_cell)
+          breadcrumbs.push(:title => @right_cell_text) if options[:show_header] && @right_cell_text
         else
           # Append breadcrumb from the title of right cell
-          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))
+          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems)) unless options[:hide_special_item]
           breadcrumbs.push(:title => @right_cell_text) if @sb["action"] && @right_cell_text
         end
       end
@@ -142,6 +145,11 @@ module Mixins
       {
         :breadcrumbs => [],
       }
+    end
+
+    # return correct node to right cell
+    def x_node_right_cell
+      @sb[@sb[:active_accord]].presence || x_node
     end
   end
 end

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -212,6 +212,7 @@ module Mixins
       assert_privileges("#{privilege_prefix}_add_provider")
       @provider_manager = concrete_model.new
       @server_zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :name)
+      @sb[:action] = params[:action]
       render_form
     end
 
@@ -228,6 +229,7 @@ module Mixins
         manager_id            = params[:miq_grid_checks] || params[:id] || find_checked_items[0]
         @provider_manager     = find_record(concrete_model, manager_id)
         @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
+        @sb[:action] = params[:action]
         render_form
       end
     end
@@ -373,10 +375,12 @@ module Mixins
     def render_form
       presenter = rendering_objects
       @in_a_form = true
+      @sb[:action] = params[:action]
       presenter.update(:main_div, r[:partial => 'form', :locals => {:controller => controller_name}])
       update_title(presenter)
       rebuild_toolbars(false, presenter)
       handle_bottom_cell(presenter)
+      presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new'])
 
       render :json => presenter.for_render
     end
@@ -391,6 +395,7 @@ module Mixins
       update_title(presenter)
       rebuild_toolbars(false, presenter)
       handle_bottom_cell(presenter)
+      presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new'])
 
       render :json => presenter.for_render
     end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -380,7 +380,6 @@ class ProviderForemanController < ApplicationController
   end
 
   def update_partials(record_showing, presenter)
-    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new'])
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)
@@ -404,6 +403,7 @@ class ProviderForemanController < ApplicationController
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
+    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new'])
     replace_search_box(presenter)
   end
 
@@ -519,6 +519,7 @@ class ProviderForemanController < ApplicationController
         {:title => _("Management")},
       ],
       :record_title => :hostname,
+      :show_header  => @sb[:action],
     }
   end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -539,6 +539,8 @@ class ServiceController < ApplicationController
         {:title => _("Services")},
         {:title => _("My services")},
       ],
+      :show_header => @sb[:action],
+      :record_info => @service,
     }
   end
 

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -245,11 +245,13 @@ class VmCloudController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs    => [
         {:title => _("Compute")},
         {:title => _("Cloud")},
         {:title => _("Instances")},
       ],
+      :include_record => true,
+      :show_header    => @sb[:action],
     }
   end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1411,11 +1411,6 @@ module VmCommon
     end
   end
 
-  # return correct node to right cell
-  def x_node_right_cell
-    @sb[@sb[:active_accord]].presence || x_node
-  end
-
   # set partial name and cell header for edit screens
   def set_right_cell_vars(options = {})
     name = @record.try(:name).to_s

--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -5,6 +5,7 @@ class VmController < ApplicationController
   after_action :set_session_data
   include VmCommon # common methods for vm controllers
   include VmRemote # methods for VM remote access
+  include Mixins::BreadcrumbsMixin
 
   def index
     session[:vm_type] = nil # Reset VM type if coming in from All tab

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -81,6 +81,7 @@ class VmInfraController < ApplicationController
         {:title => _("Virtual Machines")},
       ],
       :include_record => true,
+      :show_header    => @sb[:action],
     }
   end
 

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -64,6 +64,7 @@ class VmOrTemplateController < ApplicationController
         {:title => _("Workloads")},
       ],
       :include_record => true,
+      :show_header    => @sb[:action],
     }
   end
 

--- a/app/javascript/components/breadcrumbs/index.js
+++ b/app/javascript/components/breadcrumbs/index.js
@@ -16,7 +16,7 @@ class Breadcrumbs extends Component {
         if (item.key) {
           return (
             <Breadcrumb.Item
-              key={item.key}
+              key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
               onClick={() => sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, key: item.key } })}
             >
               {text}
@@ -32,7 +32,7 @@ class Breadcrumbs extends Component {
           </Breadcrumb.Item>
         );
       }
-      return <li key={index}>{text}</li>;
+      return <li key={index}>{text}</li>; // eslint-disable-line react/no-array-index-key
     });
   };
 

--- a/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
+++ b/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
@@ -75,7 +75,7 @@ exports[`Breadcrumbs component is correctly rendered 1`] = `
         </BreadcrumbItem>
         <BreadcrumbItem
           active={false}
-          key="in tree"
+          key="in tree-1"
           onClick={[Function]}
         >
           <li

--- a/spec/controllers/miq_policy_controller/conditions_spec.rb
+++ b/spec/controllers/miq_policy_controller/conditions_spec.rb
@@ -24,6 +24,7 @@ describe MiqPolicyController::Conditions do
                                                        :notes          => nil,
                                                        :expression     => {},
                                                        :applies_to_exp => {"???"=>"???"}})
+        subject.instance_variable_set(:@sb, {})
       end
 
       it 'sets new node correctly' do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5397

**Description**

* **clears** `@sb[:action]` after saving/cancelling actions (this caused that there were additional breadcrumbs on non-action pages - the mixin thought that he is still on an action page and because of that, generated a breadcrumb with header)
* adds **two additional options** for breadcrumb options:

`hide_special_item` - use on controller, which contains all nodes in the tree and uses tagging (or other policies screens). Because there is the final node (the item which is tagged by user, etc.), the breadcrumb of the item has been already generated from the tree path, so there is no need to generate the tagged item breadcrumb anymore.

`show_header` - use on controllers, which do not contain all nodes in the tree and action breadcrumbs are missing ('Edit item')

* **moves** `x_node_right_cell` to `breadcrumb_mixin` from `vm_common` because the mixin is using it for generating key for the active item (which is not generated by tree path). This allows to make the last item breadcrumb clickable.

**Summary**
- All fixes are in **explorer controllers**
- When clicking on some action (edit..), there should be a breadcrumb with header and a clickable breadcrumb leading back to the item
- After cancelling/saving the action, the header breadcrumb should disappeared and the breadcrumbs should be same as they were before the action 
- When tagging there should be only one breadcrumb with item (however, not always clickable yet)

Example:

Before

![Screenshot from 2019-04-03 11-29-04](https://user-images.githubusercontent.com/32869456/55468476-bac6eb80-5603-11e9-982f-d3a7ae78b7fb.png)

After

![Screenshot from 2019-04-03 11-24-50](https://user-images.githubusercontent.com/32869456/55468483-bef30900-5603-11e9-9dc8-9632db496768.png)