### PR TITLE
Fixes breadcrumb when disabling/enabling schedules

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -13,7 +13,7 @@ module Mixins
 
       # Different methods for controller with explorers and for non-explorers controllers
 
-      if @sb[:explorer].blank? && @right_cell_text.blank?
+      if !features?
         # Append breadcrumb from @record item (eg "Openstack")
         breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title]))
 
@@ -26,7 +26,7 @@ module Mixins
         end
       else
         # Append breadcrumb from title of the accordion (eg "Policies")
-        breadcrumbs.push(:title => accord_title, :key => "#{accord_name}_accord", :action => "accordion_select") if features?
+        breadcrumbs.push(:title => accord_title, :key => "#{accord_name}_accord", :action => "accordion_select") if accord_title
 
         # Append breadcrumbs created from the tree (eg "All policies > Red Hat policies > Policy 1")
         breadcrumbs_from_tree = build_breadcrumbs_from_tree
@@ -38,7 +38,7 @@ module Mixins
         else
           # Append breadcrumb from the title of right cell
           breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))
-          breadcrumbs.push(:title => @right_cell_text) if @sb["action"]
+          breadcrumbs.push(:title => @right_cell_text) if @sb["action"] && @right_cell_text
         end
       end
       breadcrumbs.compact
@@ -102,12 +102,9 @@ module Mixins
     # Helper methods
 
     def build_tree
-      if features?
-        allowed_features = ApplicationController::Feature.allowed_features(features)
-        # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
-        return allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
-      end
-      []
+      allowed_features = ApplicationController::Feature.allowed_features(features)
+      # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
+      allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
     end
 
     def accord_title

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -161,6 +161,7 @@ class OpsController < ApplicationController
   def tree_select
     session[:flash_msgs] = @flash_array = nil           # clear out any messages from previous screen i.e import tab
     @sb[:active_node] ||= {}
+    @sb[:action] = nil
     self.x_node = params[:id]
     tree_selected_model
     set_active_tab(params[:id])

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -10,9 +10,9 @@ describe Mixins::BreadcrumbsMixin do
     end
   end
 
-  # dummy for a controller using Mixin
+  # dummies for a controller using Mixin
 
-  class TestMixin < ApplicationController
+  class TestMixinExplorer < ApplicationController
     include Mixins::BreadcrumbsMixin
 
     def features
@@ -40,9 +40,14 @@ describe Mixins::BreadcrumbsMixin do
     end
   end
 
+  class TestMixin < ApplicationController
+    include Mixins::BreadcrumbsMixin
+  end
+
+  let(:mixin_explorer) { TestMixinExplorer.new }
   let(:mixin) { TestMixin.new }
   let(:controller_url) { 'testmixin' }
-  let(:features) { [{:title => "Active Tree", :name => :utilization_tree}] }
+  let(:features) { {:title => "Active Tree", :name => :utilization_tree} }
   let(:breadcrumbs) do
     [
       {:title => _("First Layer")},
@@ -51,35 +56,43 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   before do
-    allow(mixin).to receive(:controller_name).and_return("testmixin")
+    allow(mixin_explorer).to receive(:controller_name).and_return("testmixin")
+    allow(mixin_explorer).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
+                                                                        {:title => _("First Layer")},
+                                                                        {:title => _("Second Layer")},
+                                                                      ])
+    allow(mixin_explorer).to receive(:x_node).and_return("xx-1")
+    allow(mixin_explorer).to receive(:x_active_accord).and_return(:utilization_tree)
+    allow(mixin_explorer).to receive(:x_active_tree).and_return(:active_tree)
+    allow(mixin_explorer).to receive(:gtl_url).and_return("/show")
+    mixin_explorer.instance_variable_set(:@sb, {})
+
     allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
                                                                {:title => _("First Layer")},
                                                                {:title => _("Second Layer")},
                                                              ])
-    allow(mixin).to receive(:x_node).and_return("xx-1")
-    allow(mixin).to receive(:x_active_accord).and_return(:utilization_tree)
-    allow(mixin).to receive(:x_active_tree).and_return(:active_tree)
+    allow(mixin).to receive(:controller_name).and_return("testmixin")
     allow(mixin).to receive(:gtl_url).and_return("/show")
     mixin.instance_variable_set(:@sb, {})
   end
 
   describe "#url" do
     it "returns url" do
-      expect(mixin.url('ems', 'show', 'node')).to eq("/ems/show/node")
+      expect(mixin_explorer.url('ems', 'show', 'node')).to eq("/ems/show/node")
     end
   end
 
   describe "#accord_name" do
     context 'when features contains the tree' do
       it "returns name" do
-        expect(mixin.accord_name).to eq(features[0][:name])
+        expect(mixin_explorer.accord_name).to eq(features[:name])
       end
     end
 
     context 'when features do not contains the tree' do
       it "returns nil" do
-        allow(mixin).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin.accord_name).to be(nil)
+        allow(mixin_explorer).to receive(:x_active_accord).and_return(:not_tree)
+        expect(mixin_explorer.accord_name).to be(nil)
       end
     end
   end
@@ -87,24 +100,24 @@ describe Mixins::BreadcrumbsMixin do
   describe "#accord_title" do
     context 'when features contains the tree' do
       it "returns title" do
-        expect(mixin.accord_title).to eq(features[0][:title])
+        expect(mixin_explorer.accord_title).to eq(features[:title])
       end
     end
 
     context 'when features do not contains the tree' do
       it "returns nil" do
-        allow(mixin).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin.accord_title).to be(nil)
+        allow(mixin_explorer).to receive(:x_active_accord).and_return(:not_tree)
+        expect(mixin_explorer.accord_title).to be(nil)
       end
     end
   end
 
   describe "#build_breadcrumbs_from_tree" do
     it "returns breadcrumbs" do
-      expect(mixin.build_breadcrumbs_from_tree).to eq([
-                                                        {:title => "All Dialogs", :key => "root"},
-                                                        {:title => "Item1", :key => "xx-1"}
-                                                      ])
+      expect(mixin_explorer.build_breadcrumbs_from_tree).to eq([
+                                                                 {:title => "All Dialogs", :key => "root"},
+                                                                 {:title => "Item1", :key => "xx-1"}
+                                                               ])
     end
   end
 
@@ -130,34 +143,20 @@ describe Mixins::BreadcrumbsMixin do
                                                     {:title => "record_info_title", :url => "/testmixin/show/1234"}])
         end
       end
-
-      context "when show_list_title set" do
-        it "creates breadcrumbs" do
-          allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
-                                                                     {:title => _("First Layer")},
-                                                                     {:title => _("Second Layer")},
-                                                                     {:url   => controller_url, :title => _("Providers")},
-                                                                   ])
-
-          expect(mixin.data_for_breadcrumbs).to eq([{:title => "First Layer"},
-                                                    {:title => "Second Layer"},
-                                                    {:title => "Providers", :url => "testmixin"}])
-        end
-      end
     end
 
     context "when explorer controller" do
       before do
-        mixin.instance_variable_set(:@right_cell_text, "Right text")
-        mixin.instance_variable_set(:@sb, :explorer => true)
+        mixin_explorer.instance_variable_set(:@right_cell_text, "Right text")
+        mixin_explorer.instance_variable_set(:@sb, :explorer => true)
       end
 
       it "creates breadcrumbs" do
-        expect(mixin.data_for_breadcrumbs).to eq([{:title => "First Layer"},
-                                                  {:title => "Second Layer"},
-                                                  {:title => "Active Tree", :key => "utilization_tree_accord", :action => "accordion_select"},
-                                                  {:title => "All Dialogs", :key => "root"},
-                                                  {:title => "Item1", :key => "xx-1"}])
+        expect(mixin_explorer.data_for_breadcrumbs).to eq([{:title => "First Layer"},
+                                                           {:title => "Second Layer"},
+                                                           {:title => "Active Tree", :key => "utilization_tree_accord", :action => "accordion_select"},
+                                                           {:title => "All Dialogs", :key => "root"},
+                                                           {:title => "Item1", :key => "xx-1"}])
       end
     end
   end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -133,6 +133,7 @@ describe OpsController do
       let(:user) { FactoryBot.create(:user, :features => %w(zone_edit zone_new)) }
       before do
         login_as user
+        allow(controller).to receive(:data_for_breadcrumbs).and_return({})
       end
 
       it "#does not allow duplicate names when adding" do
@@ -230,6 +231,7 @@ describe OpsController do
                                        :active_tab    => 'settings_server',
                                        :active_tree   => :settings_tree)
       allow(controller).to receive(:x_node).and_return('xx-svr')
+      allow(controller).to receive(:data_for_breadcrumbs).and_return({})
       expect(controller).to receive(:x_active_tree_replace_cell)
       expect(controller).to receive(:replace_explorer_trees)
       expect(controller).to receive(:rebuild_toolbars)

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -81,6 +81,7 @@ describe PxeController do
 
     render_views
     it do
+      allow(controller).to receive(:data_for_breadcrumbs).and_return({})
       bypass_rescue
       is_expected.to have_http_status 200
     end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5375

1. Configuration ➛ Settings ➛ Schedules
2. Select a schedule from the list view
3. Configuration ➛ Enable / Disable this schedule
4. See the messed up breadcrumbs

**Description**

* replaces the breadcrumbs condition to recognize when mixin is in explorer controller (after enabling/disabling the mixin is confused and thinks it is in a not-explorer controller)
* features should always define if the controller is explorer/not-explorer
* plus clears `@sb[:action]` when `tree_select` in `ops_controller`
* plus clearing specs of removed show_list_title option
* plus checks if `@right_cell_text` and `accord_title` exist before calling them

**Before**

![bc01](https://user-images.githubusercontent.com/6648365/54987251-883e4280-4fb4-11e9-94ad-c550da96af97.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/55474452-76424c80-5611-11e9-8fca-9fc9bfb7001c.png)


@miq-bot add_label bug, hammer/no