### PR TITLE
Fix changing title after clicking quadicon in Instance Policy sim page

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -920,6 +920,14 @@ module VmCommon
     {'"no parent"' => -1}.merge(parent_choices(@record.id))
   end
 
+  # Return vm_cloud or vm_infra based on selected record
+  def vm_or_instance(record)
+    if record
+      record_model = model_for_vm(record)
+      controller_for_vm(record_model)
+    end
+  end
+
   private
 
   # Check for parent nodes missing from vandt tree and return them if any
@@ -1523,7 +1531,7 @@ module VmCommon
       action = nil
     when "policy_sim"
       action = nil
-      header = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => table)}
+      header = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => vm_or_instance(@record))}
       partial = params[:action] == "policies" ? "vm_common/policies" : "layouts/policy_sim"
     when "protect"
       partial = "layouts/protect"

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -1,5 +1,5 @@
 describe VmOrTemplateController do
-  context "#snap_pressed" do
+  describe "#snap_pressed" do
     before do
       stub_user(:features => :all)
       @vm = FactoryBot.create(:vm_vmware)
@@ -46,7 +46,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#reload ' do
+  describe '#reload ' do
     before do
       login_as FactoryBot.create(:user_with_group, :role => "operator")
       allow(controller).to receive(:tree_select).and_return(nil)
@@ -63,7 +63,7 @@ describe VmOrTemplateController do
 
   end
 
-  context "#show" do
+  describe "#show" do
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
@@ -179,7 +179,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#replace_right_cell' do
+  describe '#replace_right_cell' do
     it 'should display form button on Migrate request screen' do
       vm = FactoryBot.create(:vm_infra)
       allow(controller).to receive(:params).and_return(:action => 'vm_migrate')
@@ -202,9 +202,25 @@ describe VmOrTemplateController do
       controller.send(:replace_right_cell, :action => 'migrate', :presenter => presenter)
       expect(presenter[:update_partials]).to have_key(:form_buttons_div)
     end
+
+    context 'Instance policy simulation' do
+      let(:vm_openstack) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
+
+      before do
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@record, vm_openstack)
+        controller.instance_variable_set(:@sb, :action => 'policy_sim')
+        request.parameters[:controller] = 'vm_or_template'
+      end
+
+      it 'sets right cell text for policy simulation page' do
+        controller.send(:replace_right_cell)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Instance Policy Simulation')
+      end
+    end
   end
 
-  context '#parent_folder_id' do
+  describe '#parent_folder_id' do
     it 'returns id of orphaned folder for orphaned VM/Template' do
       vm_orph = FactoryBot.create(:vm_infra, :storage => FactoryBot.create(:storage))
       template_orph = FactoryBot.create(:template_infra, :storage => FactoryBot.create(:storage))
@@ -273,7 +289,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context "#resolve_node_info" do
+  describe "#resolve_node_info" do
     let(:vm_common) do
       Class.new do
         extend VmCommon
@@ -291,7 +307,7 @@ describe VmOrTemplateController do
     end
   end
 
-  context '#evm_relationship_get_form_vars' do
+  describe '#evm_relationship_get_form_vars' do
     before do
       @vm = FactoryBot.create(:vm_vmware)
       edit = {:vm_id => @vm.id, :new => {:server => nil}}


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1688359

**What:**
Fix changing the title in Cloud Instance Policy Simulation page, after clicking on any quadicon (explorer screens).

**Steps to reproduce:**
1. Go to _Compute > Clouds > Instances_
2. Select some instance(s), check the checkbox(es)
3. In the toolbar, choose _Policy > Policy Simulation_
4. Select some Policy Profile from the drop down
=> check the title of the page (_Instance Policy Simulation_)
5. Click on a quadicon of the instance
=> the title has been changed! (_Virtual Machine Policy Simulation_)
6. Click on the _Back_ button
=> the title remains wrong, different to the title in step 4 !

_Notes:_
- for VMs, the title does not change
- sometimes it may lead to error, when clicking on quadicon (step 5), but that's another issue (missing route or.. wrong controller name?) and related to policy simulation of items displayed as a nested list, not related to the changes in this PR; there is a bunch of other bugs, issues, related to policy simulation

---

**Before:**
![before_scenario1](https://user-images.githubusercontent.com/13417815/55091286-da648e00-50b0-11e9-87e2-ea63a514990f.png)

**After:**
![after_scenario1](https://user-images.githubusercontent.com/13417815/55091326-ec463100-50b0-11e9-81b1-1c5a33ba016b.png)
