### PR TITLE
Extract the catalog entrypoint selection from TreeBuilderAutomate

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -163,6 +163,11 @@ function miqOnClickAutomate(id) {
   miqJqueryRequest('/' + ManageIQ.controller + '/ae_tree_select/?id=' + encodeURIComponent(id) + '&tree=automate_tree');
 }
 
+function miqOnClickAutomateCatalog(id) {
+  miqTreeExpandNode('automate_catalog_tree', id);
+  miqJqueryRequest('/' + ManageIQ.controller + '/ae_tree_select/?id=' + encodeURIComponent(id) + '&tree=automate_catalog_tree');
+}
+
 function miqOnClickIncludeDomainPrefix() {
   miqJqueryRequest('/' + ManageIQ.controller + '/ae_tree_select_toggle?button=domain');
 }
@@ -424,6 +429,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnCheckSections',
     'miqOnCheckUserFilters',
     'miqOnClickAutomate',
+    'miqOnClickAutomateCatalog',
     'miqOnClickDiagnostics',
     'miqOnClickGeneric',
     'miqOnClickHostNet',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,7 +136,7 @@ class CatalogController < ApplicationController
     get_form_vars
     changed = (@edit[:new] != @edit[:current])
     # Build Catalog Items tree unless @edit[:ae_tree_select]
-    build_automate_tree(:catalog, :automate_tree) if params[:display] || params[:template_id] || params[:manager_id]
+    build_automate_tree(:automate_catalog) if params[:display] || params[:template_id] || params[:manager_id]
     if params[:st_prov_type] # build request screen for selected item type
       @_params[:org_controller] = "service_template"
       if ansible_playbook?
@@ -372,7 +372,7 @@ class CatalogController < ApplicationController
     default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:automate_catalog) # Build Catalog Items tree
     render :update do |page|
       page << javascript_prologue
       page.replace("basic_info_div", :partial => "form_basic_info") if params[:resource_id] || params[:display]
@@ -441,7 +441,7 @@ class CatalogController < ApplicationController
 
     # if resource has been deleted from group, rearrange groups incase group is now empty.
     rearrange_groups_array
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:automate_catalog) # Build Catalog Items tree
     changed = (@edit[:new] != @edit[:current])
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     render :update do |page|
@@ -498,8 +498,8 @@ class CatalogController < ApplicationController
   def ae_tree_select_toggle
     @edit = session[:edit]
     self.x_active_tree = :sandt_tree
-    at_tree_select_toggle(get_ae_tree_edit_key(@edit[:ae_field_typ]))
-    x_node_set(@edit[:active_id], :automate_tree) if params[:button] == 'submit'
+    at_tree_select_toggle(:automate_catalog, get_ae_tree_edit_key(@edit[:ae_field_typ]))
+    x_node_set(@edit[:active_id], :automate_catalog_tree) if params[:button] == 'submit'
     session[:edit] = @edit
   end
 
@@ -508,11 +508,11 @@ class CatalogController < ApplicationController
     @edit = session[:edit]
     @edit[:new][params[:typ]] = nil
     @edit[:new][ae_tree_key] = ''
-    # build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree unless @edit[:ae_tree_select]
+    # build_automate_tree(:automate_catalog) # Build Catalog Items tree unless @edit[:ae_tree_select]
     render :update do |page|
       page << javascript_prologue
       @changed = (@edit[:new] != @edit[:current])
-      x_node_set(@edit[:active_id], :automate_tree)
+      x_node_set(@edit[:active_id], :automate_catalog_tree)
       page << javascript_hide("ae_tree_select_div")
       page << javascript_hide("blocker_div")
       page << javascript_hide("#{ae_tree_key}_div")
@@ -520,7 +520,7 @@ class CatalogController < ApplicationController
       page << "$('##{ae_tree_key}').prop('title', '#{@edit[:new][ae_tree_key]}');"
       @edit[:ae_tree_select] = false
       page << javascript_for_miq_button_visibility(@changed)
-      page << "miqTreeActivateNodeSilently('automate_tree', 'root');"
+      page << "miqTreeActivateNodeSilently('automate_catalog_tree', 'root');"
       page << "miqSparkle(false);"
     end
     session[:edit] = @edit
@@ -1323,7 +1323,7 @@ class CatalogController < ApplicationController
                        else
                          _("Editing Service Catalog Item \"%{name}\"") % {:name => @record.name}
                        end
-    build_automate_tree(:catalog, :automate_tree) # Build Catalog Items tree
+    build_automate_tree(:automate_catalog) # Build Catalog Items tree
   end
 
   def st_set_form_vars

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1622,7 +1622,7 @@ class MiqAeClassController < ApplicationController
   def form_copy_objects_field_changed
     return unless load_edit("copy_objects__#{params[:id]}", "replace_cell__explorer")
     copy_objects_get_form_vars
-    build_automate_tree(:automate, :automate_tree)
+    build_automate_tree(:automate)
     @changed = (@edit[:new] != @edit[:current])
     @changed = @edit[:new][:override_source] if @edit[:new][:namespace].nil?
     render :update do |page|
@@ -1636,7 +1636,7 @@ class MiqAeClassController < ApplicationController
   def ae_tree_select_toggle
     @edit = session[:edit]
     self.x_active_tree = :ae_tree
-    at_tree_select_toggle(:namespace)
+    at_tree_select_toggle(:automate, :namespace)
 
     if params[:button] == 'submit'
       x_node_set(@edit[:active_id], :automate_tree)
@@ -1853,7 +1853,7 @@ class MiqAeClassController < ApplicationController
     if params[:button] == "reset"
       add_flash(_("All changes have been reset"), :warning)
     end
-    build_automate_tree(:automate, :automate_tree)
+    build_automate_tree(:automate)
     replace_right_cell
   end
 

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -38,6 +38,7 @@ module Sandbox
     alert_profile_tree
     alert_tree
     automate_tree
+    automate_catalog_tree
     automation_manager_providers_tree
     automation_manager_cs_filter_tree
     bottlenecks_tree

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -8,24 +8,12 @@ class TreeBuilderAutomate < TreeBuilder
     {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
   end
 
-  # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = if MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-                [MiqAeDomain.find_by(:id => @sb[:domain_id])] # GIT support can't use where
-              else
-                filter_ae_objects(User.current_tenant.visible_domains)
-              end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, [MiqAeDomain.find_by(:id => @sb[:domain_id])])
   end
 
   def override(node, object, _pid, _options)
-    if @type == 'catalog'
-      # Only the instance items should be clickable when selecting a catalog item entry point
-      node[:selectable] = false unless object.kind_of?(MiqAeInstance) # catalog
-    elsif object.kind_of?(MiqAeNamespace) && object.domain?
-      # Only the namespace items should be clickable when copying a class or instance
-      node[:selectable] = false
-    end
+    node[:selectable] = false if object.kind_of?(MiqAeNamespace) && object.domain?
   end
 
   def x_get_tree_class_kids(object, count_only)
@@ -33,29 +21,17 @@ class TreeBuilderAutomate < TreeBuilder
   end
 
   def x_get_tree_ns_kids(object, count_only)
-    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+    if object.respond_to?(:ae_namespaces) && object.ae_namespaces.size == 1
       open_node("aen-#{object.id}")
       open_node("aen-#{object.ae_namespaces.first.id}")
     end
 
-    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+    if object.respond_to?(:ae_classes) && object.ae_classes.size == 1
       open_node("aen-#{object.id}")
       open_node("aec-#{object.ae_classes.first.id}")
     end
 
-    objects = filter_ae_objects(object.ae_namespaces)
-    unless MiqAeClassController::MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
-      ns_classes = filter_ae_objects(object.ae_classes)
-      objects += ns_classes if ns_classes.present?
-    end
-    count_only_or_objects(count_only, objects, %i[display_name name])
-  end
-
-  def filter_ae_objects(objects)
-    return objects unless @sb[:cached_waypoint_ids]
-    klass_name = objects.first.class.name
-    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
-    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
+    count_only_or_objects(count_only, object.ae_namespaces, %i[display_name name])
   end
 
   def root_options

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -1,0 +1,37 @@
+class TreeBuilderAutomateCatalog < TreeBuilderAutomate
+  private
+
+  def tree_init_options
+    super.merge!(:onclick => "miqOnClickAutomateCatalog")
+  end
+
+  def x_get_tree_roots(count_only, _options)
+    count_only_or_objects(count_only, filter_ae_objects(User.current_tenant.visible_domains))
+  end
+
+  def override(node, object, _pid, _options)
+    # Only the instance items should be clickable when selecting a catalog item entry point
+    node[:selectable] = false unless object.kind_of?(MiqAeInstance)
+  end
+
+  def x_get_tree_ns_kids(object, count_only)
+    if object.respond_to?(:ae_namespaces) && filter_ae_objects(object.ae_namespaces).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aen-#{object.ae_namespaces.first.id}")
+    end
+
+    if object.respond_to?(:ae_classes) && filter_ae_objects(object.ae_classes).size == 1
+      open_node("aen-#{object.id}")
+      open_node("aec-#{object.ae_classes.first.id}")
+    end
+
+    count_only_or_objects(count_only, filter_ae_objects(object.ae_namespaces + object.ae_classes), %i[display_name name])
+  end
+
+  def filter_ae_objects(objects)
+    return objects unless @sb[:cached_waypoint_ids]
+    klass_name = objects.first.class.name
+    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
+  end
+end

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,4 +1,4 @@
-class TreeBuilderAutomateEntrypoint < TreeBuilderAutomate
+class TreeBuilderAutomateEntrypoint < TreeBuilderAutomateCatalog
   def override(node, object, _pid, _options)
     node.delete(:selectable)
     node[:fqname] = object.fqname if object.try(:fqname)

--- a/spec/presenters/tree_builder_automate_catalog_spec.rb
+++ b/spec/presenters/tree_builder_automate_catalog_spec.rb
@@ -1,0 +1,28 @@
+describe TreeBuilderAutomateCatalog do
+  include Spec::Support::AutomationHelper
+
+  describe "#initialize" do
+    subject { described_class.new(:automate_tree, :automate, sb) }
+
+    let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree} }
+    let(:domains) { JSON.parse(subject.tree_nodes).first['nodes'].collect { |h| h['text'] } }
+
+    before do
+      login_as FactoryBot.create(:user_with_group)
+      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
+      create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
+    end
+
+    context 'filtered with cached_waypoint_ids' do
+      before { sb[:cached_waypoint_ids] = MiqAeClass.waypoint_ids_for_state_machines }
+
+      it 'returns a tree with the filtered domain' do
+        expect(domains).to match_array ['LUIGI']
+      end
+    end
+
+    it 'returns a tree with both domains' do
+      expect(domains).to match_array %w[LUIGI MARIO]
+    end
+  end
+end

--- a/spec/presenters/tree_builder_automate_spec.rb
+++ b/spec/presenters/tree_builder_automate_spec.rb
@@ -1,26 +1,17 @@
-describe TreeBuilderAeClass do
+describe TreeBuilderAutomate do
   include Spec::Support::AutomationHelper
 
   describe "#initialize" do
-    before do
-      user = FactoryBot.create(:user_with_group)
-      login_as user
-      create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
-      create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
-      @sb = {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
-    end
+    before { login_as FactoryBot.create(:user_with_group) }
 
-    it "a tree with filter" do
-      @sb[:cached_waypoint_ids] = MiqAeClass.waypoint_ids_for_state_machines
-      tree = TreeBuilderAutomate.new(:automate_tree, "automate", @sb)
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+    subject { described_class.new(:automate_tree, :automate, sb) }
+
+    let(:ae_model) { create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C') }
+    let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree, :domain_id => ae_model.id} }
+    let(:domains) { JSON.parse(subject.tree_nodes).first['nodes'].collect { |h| h['text'] } }
+
+    it "creates a tree with the domains" do
       expect(domains).to match_array ['LUIGI']
-    end
-
-    it "a tree without filter" do
-      tree = TreeBuilderAutomate.new(:automate_tree, "automate", @sb)
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
-      expect(domains).to match_array %w(LUIGI MARIO)
     end
   end
 end


### PR DESCRIPTION
As far as I was able to determine, the `TreeBuilderAutomate` is being used in the automate explorer when you try to copy a method/instance/class to a custom destination AND for automate entrypoint selection in catalog items. The `name` of the tree is always the same, but the `type` is different based on where it is being used. However, we do a lot of checks against this type and also against other session variables that aren't shared between the two controllers.

To avoid these checks, I've extracted the `TreeBuilderAutomateCatalog` tree and removed all the aforementioned logic. The `build_automate_tree` method has been adjusted to take an extra argument that decides which tree should be built. This will allow us to get rid of the redundancy between the tree name and tree type by dropping one of them.

@miq-bot add_label refactoring, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 