### PR TITLE
Fix: error loading configuration screen when key/value settings exists on top level

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1150,9 +1150,7 @@ module OpsController::Settings::Common
     end
     if %w(settings_server settings_authentication settings_custom_logos).include?(@sb[:active_tab]) &&
        x_node.split("-").first != "z"
-      @edit[:current].each_key do |category|
-        @edit[:new][category] = copy_hash(@edit[:current][category])
-      end
+      @edit[:new] = @edit[:current].deep_clone
       if @sb[:active_tab] == "settings_server"
         session[:selected_roles] = @edit[:new][:server][:role].split(",") if !@edit[:new][:server].nil? && !@edit[:new][:server][:role].nil?
         server_roles = MiqServer.licensed_roles # Get the roles this server is licensed for


### PR DESCRIPTION
Issue: 
When settings value added on root level (without category) attempt to execute `copy_hash(hashin)` will raise  ` [NoMethodError] undefined method 'deep_clone'...`

Example:
execute `curl --user admin:smartvm -i -X PATCH -d '{"some_key": false}' http://<host>/api/servers/3/settings` will add `:some_key: false` settings on the top level

BEFORE:
![Screen Shot 2019-04-04 at 9 25 02 AM](https://user-images.githubusercontent.com/6556758/55559153-a0e8df80-56bb-11e9-97f3-d6177cae253b.png)


AFTER:
![Screen Shot 2019-04-04 at 9 19 05 AM](https://user-images.githubusercontent.com/6556758/55559178-afcf9200-56bb-11e9-98dc-51cdb2f5b190.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1695566

@miq-bot add-label bug

