### PR TITLE
Fix missing title in Policy Simulation page 

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -114,6 +114,7 @@ module ApplicationController::PolicySupport
   # Remove selected policy from the simulation
   def policy_sim_remove
     @edit = session[:edit]
+    @explorer = @edit[:explorer]
     session[:policies].delete(params[:del_pol].to_i)
     policy_sim_build_screen
     replace_main_div(:partial => "layouts/policy_sim")
@@ -213,6 +214,7 @@ module ApplicationController::PolicySupport
   # Build the policy simulation screen
   def policy_sim_build_screen(records = [])
     @edit ||= {}
+    @right_cell_text = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => vm_or_instance(records.first || session[:tag_items].first))}
     @tagitems = records.presence || session[:tag_items] # Get the db records that are being tagged
     @tagitems = @tagitems.sort_by(&:name)
     @edit[:pol_items] = session[:tag_items]

--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,6 +1,8 @@
 - url = url_for_only_path(:action => 'policy_sim_add')
 #main_div
 
+  %h1
+    = @right_cell_text unless @explorer
   #flash_msg_div
     = render :partial => "layouts/flash_msg"
 

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -37,4 +37,33 @@ describe ApplicationController do
       expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => flash_msg, :level => :success}])
     end
   end
+
+  describe '#policy_sim_build_screen' do
+    before do
+      allow(controller).to receive(:session).and_return(:tag_items => [vm], :tag_db => VmOrTemplate)
+      controller.instance_variable_set(:@_params, :controller => vm_ctrl)
+    end
+
+    context 'VM policy simulation and non explorer screen' do
+      let(:controller) { VmInfraController.new }
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+      let(:vm_ctrl) { 'vm_infra' }
+
+      it 'sets right cell text' do
+        controller.send(:policy_sim_build_screen, [vm])
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Virtual Machine Policy Simulation')
+      end
+    end
+
+    context 'Instance policy simulation and non explorer screen' do
+      let(:controller) { VmCloudController.new }
+      let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
+      let(:vm_ctrl) { 'vm_cloud' }
+
+      it 'sets right cell text' do
+        controller.send(:policy_sim_build_screen, [vm])
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Instance Policy Simulation')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1688370

**What:**
Fix missing title in Policy Simulation page, for items (VMs, Instances) displayed as a nested list (non explorer).

**Steps to reproduce:**
1. Go to _Compute > Cloud/Infrastructure > Providers_
2. Choose some provider, click on it to display its dashboard or summary page
3. Click on VMs/Instances
4. Check the checkbox(es) of some VM(s)/Instance(s)
5. In the toolbar, choose _Policy > Policy Simulation_
=> there is no title in this page

---

**Before:**
![before_scenario2](https://user-images.githubusercontent.com/13417815/55091518-421ad900-50b1-11e9-950f-e67f95d95c2d.png)

**After:** (for both VMs and also Instances)
![after_scenario2](https://user-images.githubusercontent.com/13417815/55092086-3b409600-50b2-11e9-9a89-bf26a4ddd884.png)
![after2_scenario2](https://user-images.githubusercontent.com/13417815/55092095-3d0a5980-50b2-11e9-872d-df7ffc025f24.png)

---

**Note:**
I've also added missing https://github.com/ManageIQ/manageiq-ui-classic/pull/5429/commits/a17b053279f70a9e1b566a0e4d66c1bfb6aa1b7a#diff-dcf973c55609c594de2b7f1c5471d434R117
which should be set, as we are still in explorer screen. This also fixes small issue - double displaying the title in policy simulation page. See also https://github.com/ManageIQ/manageiq-ui-classic/pull/5429/commits/a17b053279f70a9e1b566a0e4d66c1bfb6aa1b7a#diff-dcf973c55609c594de2b7f1c5471d434L104
