### PR TITLE
[WIP] Fix jasmine timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ addons:
   postgresql: '10'
 env:
   matrix:
-  - TEST_SUITE=spec
   - TEST_SUITE=spec:javascript
-  - TEST_SUITE=spec:compile
-  - TEST_SUITE=spec:jest
 matrix:
   exclude:
   - rvm: 2.4.5

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -61,7 +61,16 @@ module Jasmine
           :run_details => run_details,
         }]
 
-        system("curl '#{jasmine_server_url}'")
+        IO.popen(command) do |output|
+          p [:IO, output]
+          output.each do |line|
+            p [:X, line]
+          end
+          output.each_line do |line|
+            p [:Y, line]
+          end
+        end
+
         run_bak.tap do |ret|
           p [:RUN_BAK, 'done']
         end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -61,7 +61,10 @@ module Jasmine
           :run_details => run_details,
         }]
 
-        run_bak
+        system("curl '#{jasmine_server_url}'")
+        run_bak.tap do |ret|
+          p [:RUN_BAK, 'done']
+        end
       end
     end
   end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -51,13 +51,12 @@ module Jasmine
         command = "\"#{phantom_js_path}\" \"#{phantom_script}\" \"#{jasmine_server_url}\" \"#{show_console_log}\" \"#{@phantom_config_script}\""
         run_details = { 'random' => false }
 
+        i = 0
         IO.popen(command) do |output|
           p [:IO, output]
           output.each do |line|
-            p [:X, line]
-          end
-          output.each_line do |line|
-            p [:Y, line]
+            break if i >= 100
+            p [i += 1, line]
           end
         end
 

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -35,3 +35,34 @@ module Jasmine
     puts "end wait"
   end
 end
+
+
+module Jasmine
+  module Runners
+    class PhantomJs
+      alias_method :run_bak, :run
+
+      def run
+        p [:RUN, {
+          :formatter => @formatter,
+          :jasmine_server_url => @jasmine_server_url,
+          :prevent_phantom_js_auto_install => @prevent_phantom_js_auto_install,
+          :show_console_log => @show_console_log,
+          :phantom_config_script => @phantom_config_script,
+          :show_full_stack_trace => @show_full_stack_trace,
+        }]
+
+        phantom_script = File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')
+        command = "\"#{phantom_js_path}\" \"#{phantom_script}\" \"#{jasmine_server_url}\" \"#{show_console_log}\" \"#{@phantom_config_script}\""
+        run_details = { 'random' => false }
+        p [{
+          :phantom_script => phantom_script,
+          :command => command,
+          :run_details => run_details,
+        }]
+
+        run_bak
+      end
+    end
+  end
+end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -47,6 +47,20 @@ module Jasmine
 
         system("phantomjs --version")
 
+        phantom_script = File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')
+        command = "\"#{phantom_js_path}\" \"#{phantom_script}\" \"#{jasmine_server_url}\" \"#{show_console_log}\" \"#{@phantom_config_script}\""
+        run_details = { 'random' => false }
+
+        IO.popen(command) do |output|
+          p [:IO, output]
+          output.each do |line|
+            p [:X, line]
+          end
+          output.each_line do |line|
+            p [:Y, line]
+          end
+        end
+
         run_bak.tap do |ret|
           p [:RUN_BAK, 'done']
         end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -13,3 +13,11 @@ Jasmine.configure do |config|
   # TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.
   config.prevent_phantom_js_auto_install = true if ENV['CI']
 end
+
+module Jasmine
+  def self.wait_for_listener(*args)
+    puts "Fake wait_for_listener"
+    sleep 20
+    puts "end wait"
+  end
+end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -43,33 +43,9 @@ module Jasmine
       alias_method :run_bak, :run
 
       def run
-        p [:RUN, {
-          :formatter => @formatter,
-          :jasmine_server_url => @jasmine_server_url,
-          :prevent_phantom_js_auto_install => @prevent_phantom_js_auto_install,
-          :show_console_log => @show_console_log,
-          :phantom_config_script => @phantom_config_script,
-          :show_full_stack_trace => @show_full_stack_trace,
-        }]
+        p [:RUN, jasmine_server_url]
 
-        phantom_script = File.join(File.dirname(__FILE__), 'phantom_jasmine_run.js')
-        command = "\"#{phantom_js_path}\" \"#{phantom_script}\" \"#{jasmine_server_url}\" \"#{show_console_log}\" \"#{@phantom_config_script}\""
-        run_details = { 'random' => false }
-        p [{
-          :phantom_script => phantom_script,
-          :command => command,
-          :run_details => run_details,
-        }]
-
-        IO.popen(command) do |output|
-          p [:IO, output]
-          output.each do |line|
-            p [:X, line]
-          end
-          output.each_line do |line|
-            p [:Y, line]
-          end
-        end
+        system("phantomjs --version")
 
         run_bak.tap do |ret|
           p [:RUN_BAK, 'done']

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -12,12 +12,26 @@ Jasmine.configure do |config|
   #
   # TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.
   config.prevent_phantom_js_auto_install = true if ENV['CI']
+
+  bak = config.runner
+  config.runner = lambda do |formatter, jasmine_server_url|
+    p [:RUNNER, formatter, jasmine_server_url]
+    bak.call(formatter, jasmine_server_url).tap do |ret|
+      p [:RET, ret]
+    end
+  end
 end
 
 module Jasmine
+   class << self
+     alias_method :wait_for_listener_bak, :wait_for_listener
+   end
+
   def self.wait_for_listener(*args)
-    puts "Fake wait_for_listener"
-    sleep 20
+    puts "wrap wait_for_listener"
+    self.wait_for_listener_bak(*args)
+    puts "done, wait"
+    sleep 1
     puts "end wait"
   end
 end

--- a/spec/javascripts/support/phantom_jasmine_run.js
+++ b/spec/javascripts/support/phantom_jasmine_run.js
@@ -1,0 +1,50 @@
+(function() {
+
+  if (phantom.version.major >= 2) {
+    var system = require('system');
+    var url = system.args[1];
+    var showConsoleLog = system.args[2] === 'true';
+    var configScript = system.args[3];
+  }
+  else {
+    var url = phantom.args[0];
+    var showConsoleLog = phantom.args[1] === 'true';
+    var configScript = phantom.args[2];
+  }
+
+  var page = require('webpage').create();
+  configScript = configScript.replace(/['"]{2}/,"");
+  
+  if (configScript !== '') {
+    try {
+      require(configScript).configure(page);
+    } catch(e) {
+      console.error('Failed to configure phantom');
+      console.error(e.stack);
+      phantom.exit(1);
+    }
+  }
+
+  page.onCallback = function(data) {
+    if(data.state === 'specDone') {
+      console.log('jasmine_spec_result' + JSON.stringify([].concat(data.results)));
+    } else if (data.state === 'suiteDone') {
+      console.log('jasmine_suite_result' + JSON.stringify([].concat(data.results)));
+    } else {
+      console.log('jasmine_done' + JSON.stringify(data.details));
+      phantom.exit(0);
+    }
+  };
+
+  if (showConsoleLog) {
+    page.onConsoleMessage = function(message) {
+      console.log(message);
+    };
+  }
+
+  page.open(url, function(status) {
+    if (status !== "success") {
+      phantom.exit(1);
+    }
+  });
+}).call(this);


### PR DESCRIPTION
Right now, it looks like 9 out of the last 17 travis runs on master failed on `spec:javascript`:

```
* Listening on tcp://0.0.0.0:41063
Use Ctrl-C to stop

Waiting for jasmine server on 41063...
jasmine server started

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

The build has been terminated
```

Attempting to fix that.

---

@miq-bot add_label wip

first theory, the server starts, but needs time to finish loading stuff before the first request
.. nope, long wai didn't work, still failed
.. adding *more* logging around `runner.run`
.. and curl for the same URL