### PR TITLE
[WIP] Jasmine - use headless chrome instead of phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ addons:
   postgresql: '10'
 env:
   matrix:
-  - TEST_SUITE=spec
   - TEST_SUITE=spec:javascript
-  - TEST_SUITE=spec:compile
-  - TEST_SUITE=spec:jest
 matrix:
   exclude:
   - rvm: 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   timeout: 600
 addons:
   postgresql: '10'
+  chrome: 'beta'
 env:
   matrix:
   - TEST_SUITE=spec:javascript

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |s|
   # core because jasmine has < 3.0, not < 2.6
   s.add_development_dependency "jasmine",  "~> 2.5.2"
   s.add_development_dependency "jasmine-core",  "~> 2.5.2"
+
+  s.add_development_dependency "chrome_remote",  "~> 0.2.0"
 end

--- a/spec/javascripts/support/chromeheadless_boot.js
+++ b/spec/javascripts/support/chromeheadless_boot.js
@@ -1,0 +1,15 @@
+function ChromeHeadlessReporter() {
+  this.jasmineDone = function(details) {
+    console.log('jasmine_done', JSON.stringify(details));
+  };
+
+  this.specDone = function(results) {
+    console.log('jasmine_spec_result', JSON.stringify([].concat(results)));
+  };
+
+  this.suiteDone = function(results) {
+    console.log('jasmine_suite_result',JSON.stringify([].concat(results)));
+  };
+}
+
+jasmine.getEnv().addReporter(new ChromeHeadlessReporter());

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -28,6 +28,9 @@ Jasmine.configure do |config|
     'remote-debugging-port' => 9222,
   }
   config.chrome_startup_timeout = 20
+
+  require 'webmock'
+  WebMock.allow_net_connect!
 end
 
 require "socket"

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -2,14 +2,139 @@
 # You can remove it if you don't need it.
 # This file is loaded *after* jasmine.yml is interpreted.
 #
+
+module Jasmine
+  class Configuration
+    attr_accessor :chrome_binary
+    attr_accessor :chrome_cli_options
+    attr_accessor :chrome_startup_timeout
+  end
+end
+
 Jasmine.configure do |config|
-  # The gemified version of Jasmine uses the gemified version of PhantomJS
-  # which auto-installs it if it can't find your installation in ~/.phantomjs
-  # Travis already has a version of PhantomJS installed in a different
-  # location, so the gem will auto-install even if it's pointless.  Also,
-  # gemified PhantomJS hardcodes install URLs from BitBucket which times out
-  # and causes failed builds.
-  #
-  # TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.
-  config.prevent_phantom_js_auto_install = true if ENV['CI']
+  # don't install phantom, we're using chrome headless
+  config.prevent_phantom_js_auto_install = true
+
+  config.runner = lambda do |formatter, jasmine_server_url|
+    Jasmine::Runners::ChromeHeadless.new(formatter,
+                                         jasmine_server_url,
+                                         config)
+  end
+
+  config.chrome_binary = 'google-chrome-beta'
+  config.chrome_cli_options = {
+    'headless' => nil,
+    'disable-gpu' => nil,
+    'remote-debugging-port' => 9222,
+  }
+  config.chrome_startup_timeout = 20
+end
+
+require "socket"
+module Jasmine
+  module Runners
+    class ChromeHeadless
+      def initialize(formatter, jasmine_server_url, config)
+        @formatter = formatter
+        @jasmine_server_url = jasmine_server_url
+        @config = config
+        @show_console_log = @config.show_console_log
+        @show_full_stack_trace = @config.show_full_stack_trace
+        @cli_options = @config.chrome_cli_options || {}
+      end
+
+      def run
+        chrome_server = IO.popen("\"#{chrome_binary}\" #{cli_options_string}")
+        wait_for_chrome_to_start_debug_socket
+
+        begin
+          require "chrome_remote"
+        rescue LoadError => e
+          raise 'Add "chrome_remote" you your Gemfile. To use chromeheadless we require this gem.'
+        end
+
+        chrome = ChromeRemote.client
+        chrome.send_cmd "Runtime.enable"
+        chrome.send_cmd "Page.navigate", url: jasmine_server_url
+        result_recived = false
+        run_details = { 'random' => false }
+        chrome.on "Runtime.consoleAPICalled" do |params|
+          if params["type"] == "log"
+            if params["args"][0] && params["args"][0]["value"] == "jasmine_spec_result"
+              results = JSON.parse(params["args"][1]["value"], :max_nesting => false)
+                            .map { |r| Result.new(r.merge!("show_full_stack_trace" => @show_full_stack_trace)) }
+              formatter.format(results)
+            elsif params["args"][0] && params["args"][0]["value"] == "jasmine_suite_result"
+              results = JSON.parse(params["args"][1]["value"], :max_nesting => false)
+                            .map { |r| Result.new(r.merge!("show_full_stack_trace" => @show_full_stack_trace)) }
+              failures = results.select(&:failed?)
+              if failures.any?
+                formatter.format(failures)
+              end
+            elsif params["args"][0] && params["args"][0]["value"] == "jasmine_done"
+              result_recived = true
+              run_details = JSON.parse(params["args"][1]["value"], :max_nesting => false)
+            elsif show_console_log
+              puts params["args"].map { |e| e["value"] }.join(' ')
+            end
+          end
+        end
+
+        chrome.listen_until {|msg| result_recived }
+        formatter.done(run_details)
+        chrome.send_cmd "Browser.close"
+        Process.kill("INT", chrome_server.pid)
+      end
+
+      def chrome_binary
+        config.chrome_binary || find_chrome_binary
+      end
+
+      def find_chrome_binary
+        path = [
+          "/usr/bin/google-chrome",
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        ].detect { |path|
+          File.file?(path)
+        }
+        raise "No Chrome binary found" if path.nil?
+        path
+      end
+
+      def cli_options_string
+        @cli_options.
+            map {|(k, v)| if v then "--#{k}=#{v}" else "--#{k}" end }.
+            join(' ')
+      end
+
+      def wait_for_chrome_to_start_debug_socket
+        time = Time.now
+        while Time.now - time < config.chrome_startup_timeout
+          begin;
+            conn = TCPSocket.new('localhost', 9222);
+          rescue SocketError;
+            sleep 0.1
+            next
+          rescue Errno::ECONNREFUSED;
+            sleep 0.1
+            next
+          rescue Errno::EADDRNOTAVAIL;
+            sleep 0.1
+            next
+          else;
+            conn.close;
+            return
+          end
+        end
+        raise "Chrome did't seam to start the webSocketDebugger at port: 9222, timeout #{config.chrome_startup_timeout}sec"
+      end
+
+      def boot_js
+        File.expand_path('chromeheadless_boot.js', File.dirname(__FILE__))
+      end
+
+      private
+      attr_reader :formatter, :jasmine_server_url, :show_console_log, :config
+    end
+  end
 end


### PR DESCRIPTION
During experiments with https://github.com/ManageIQ/manageiq-ui-classic/pull/5432, I noticed newer versions of jasmine support chrome headless: https://github.com/jasmine/jasmine-gem/tree/master/lib/jasmine/runners

But newer versions also break our tests, so trying to just pull the chrome runner.

This should prevent `spec:javascript` failing on the obscure `ReferenceError: Can't find variable: SAFE_CLOSING` and hanging forever.

@miq-bot add_label wip