### PR TITLE
Don't show x_edit_buttons for tagging screen

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -256,8 +256,6 @@ module ApplicationController::Tags
   def update_tagging_partials(presenter)
     presenter.update(:main_div, r[:partial => 'layouts/tagging',
                                   :locals  => locals_for_tagging])
-    presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons',
-                                          :locals  => locals_for_tagging])
   end
 
   def button_url(controller, id, type)


### PR DESCRIPTION

There were present two form buttons groups, one from Tagging component, second from `x_edit_buttons.html.haml`

This PR deletes the second one.

Links [Optional]
----------------
#5419


Steps for Testing/QA [Optional]
-------------------------------
Screenshot from 2019-04-02 14-44-54

Go to Compute > Infrastructure > Datastore > Select One > Edit Tags

Go to Service > Catalogs > Catalogs item > Select One > Edit Tags

Configuration > Management > Providers
