### PR TITLE
Jasmine - upgrade to 3.4.0, use chrome headless backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
   timeout: 600
 addons:
   postgresql: '10'
+  chrome: 'beta'
 env:
   matrix:
   - TEST_SUITE=spec

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,15 @@ if ENV["BUNDLE_GEMFILE"].nil? || ENV["BUNDLE_GEMFILE"] == File.expand_path("../G
   require 'jasmine'
   load 'jasmine/tasks/jasmine.rake'
   require './config/jasmine_overrides'
+
+  # running jasmine outside ci ignores the `random: false` in `jasmine.yml` - needs a message
+  task :jasmine_url do
+    puts
+    puts "Please open http://localhost:#{Jasmine.config.port(:server)}/?random=false"
+    puts
+  end
+
+  Rake::Task['jasmine'].prerequisites.unshift 'jasmine_url'
 end
 
 namespace :spec do

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -18,4 +18,7 @@ Rails.application.config.assets.precompile += %w(
   remote_console.js
 
   print.scss
+
+  jasmine-jquery/lib/jasmine-jquery.js
+  angular-mocks/angular-mocks.js
 )

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
 
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
-  s.add_development_dependency "jasmine",  "~> 3.4.0"
-  s.add_development_dependency "jasmine-core",  "~> 3.4.0"
+  s.add_development_dependency "jasmine", "~> 3.4.0"
+  s.add_development_dependency "jasmine-core", "~> 3.4.0"
+  s.add_development_dependency "chrome_remote", "~> 0.2.0"
 end

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
 
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
-  s.add_development_dependency "jasmine",  "~> 2.99.0"
-  s.add_development_dependency "jasmine-core",  "~> 2.99.0"
+  s.add_development_dependency "jasmine",  "~> 3.4.0"
+  s.add_development_dependency "jasmine-core",  "~> 3.4.0"
 end

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails-controller-testing", '~> 1.0.2'
   s.add_development_dependency "simplecov"
 
-  # core because jasmine has < 3.0, not < 2.6
-  s.add_development_dependency "jasmine",  "~> 2.5.2"
-  s.add_development_dependency "jasmine-core",  "~> 2.5.2"
+  # core because jasmine gem depends on major version only, meaning breakages when not the latest
+  s.add_development_dependency "jasmine",  "~> 2.99.0"
+  s.add_development_dependency "jasmine-core",  "~> 2.99.0"
 end

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -89,6 +89,24 @@ describe('catalogItemFormController', function() {
     });
   });
 
+  describe('#resetClicked', function() {
+    beforeEach(function() {
+      $scope.vm.catalogItemModel.name = 'catalogItemName';
+      $scope.angularForm = {
+        $setPristine: function (value){},
+        $setUntouched: function (value){},
+      };
+      setTimeout($scope.resetClicked);
+    });
+
+    it('resets value of name field to initial value', function(done) {
+      setTimeout(function() {
+        expect($scope.vm.catalogItemModel.name).toEqual('catalogItemName');
+        done();
+      });
+    });
+  });
+
   describe('#saveClicked', function() {
     beforeEach(function() {
       setTimeout($scope.saveClicked);

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -89,24 +89,6 @@ describe('catalogItemFormController', function() {
     });
   });
 
-  describe('#resetClicked', function() {
-    beforeEach(function() {
-      $scope.vm.catalogItemModel.name = 'catalogItemName';
-      $scope.angularForm = {
-        $setPristine: function (value){},
-        $setUntouched: function (value){},
-      };
-      setTimeout($scope.resetClicked);
-    });
-
-    it('resets value of name field to initial value', function(done) {
-      setTimeout(function() {
-        expect($scope.vm.catalogItemModel.name).toEqual('catalogItemName');
-        done();
-      });
-    });
-  });
-
   describe('#saveClicked', function() {
     beforeEach(function() {
       setTimeout($scope.saveClicked);

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -145,13 +145,13 @@ boot_files:
 # random
 #
 # Run specs in semi-random order.
-# Default: false
+# Default: true
 #
 # EXAMPLE:
 #
-# random: true
+# random: false
 #
-random:
+random: false
 
 # show_console_log
 #

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -8,7 +8,7 @@
 # src_files:
 #   - lib/source1.js
 #   - lib/source2.js
-#   - dist/**/*.js
+#   - 'dist/**/*.js'
 #
 src_files:
 - __spec__/helpers/i18n-test.js
@@ -16,9 +16,9 @@ src_files:
 - packs/shims.js
 - packs/vendor.js
 - packs/manageiq-ui-classic/globals.js
-- assets/application
-- assets/jasmine-jquery/lib/jasmine-jquery
-- assets/angular-mocks
+- assets/application.js
+- assets/jasmine-jquery/lib/jasmine-jquery.js
+- assets/angular-mocks.js
 - __spec__/helpers/fixtures-fix.js
 - packs/manageiq-ui-classic/application-common.js
 - packs/manageiq-ui-classic/toolbar-actions-common.js
@@ -33,7 +33,7 @@ src_files:
 #
 # stylesheets:
 #   - css/style.css
-#   - stylesheets/*.css
+#   - 'stylesheets/*.css'
 #
 stylesheets:
 
@@ -45,7 +45,7 @@ stylesheets:
 # EXAMPLE:
 #
 # helpers:
-#   - helpers/**/*.js
+#   - 'helpers/**/*.js'
 #
 helpers:
 - 'helpers/**/*.js'
@@ -58,7 +58,7 @@ helpers:
 # EXAMPLE:
 #
 # spec_files:
-#   - **/*[sS]pec.js
+#   - '**/*[sS]pec.js'
 #
 spec_files:
 - '**/*[sS]pec.js'
@@ -131,6 +131,27 @@ boot_files:
 #
 # rack_options:
 #   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:
 
 # show_console_log
 #

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -2,14 +2,15 @@
 # You can remove it if you don't need it.
 # This file is loaded *after* jasmine.yml is interpreted.
 #
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
 Jasmine.configure do |config|
-  # The gemified version of Jasmine uses the gemified version of PhantomJS
-  # which auto-installs it if it can't find your installation in ~/.phantomjs
-  # Travis already has a version of PhantomJS installed in a different
-  # location, so the gem will auto-install even if it's pointless.  Also,
-  # gemified PhantomJS hardcodes install URLs from BitBucket which times out
-  # and causes failed builds.
-  #
-  # TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.
-  config.prevent_phantom_js_auto_install = true if ENV['CI']
+  if ENV['TRAVIS']
+    config.prevent_phantom_js_auto_install = true
+  end
 end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,16 +1,25 @@
 # Use this file to set/override Jasmine configuration options
 # You can remove it if you don't need it.
 # This file is loaded *after* jasmine.yml is interpreted.
-#
-# Example: using a different boot file.
-# Jasmine.configure do |config|
-#    config.boot_dir = '/absolute/path/to/boot_dir'
-#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-# end
-#
-# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+
 Jasmine.configure do |config|
-  if ENV['TRAVIS']
-    config.prevent_phantom_js_auto_install = true
+  # never install phantomjs
+  config.prevent_phantom_js_auto_install = true
+
+  # use chrome headless for jasmine:ci
+  config.runner = lambda do |formatter, jasmine_server_url|
+    Jasmine::Runners::ChromeHeadless.new(formatter, jasmine_server_url, config)
   end
+
+  config.chrome_binary = 'google-chrome-beta'
+  config.chrome_cli_options = {
+    'headless' => nil,
+    'disable-gpu' => nil,
+    'remote-debugging-port' => 9222,
+  }
+  config.chrome_startup_timeout = 20
+
+  warn 'Disabling webmock!'
+  require 'webmock'
+  WebMock.allow_net_connect!
 end


### PR DESCRIPTION
Right now, it looks like 9 out of the last 17 travis runs on master failed on spec:javascript:

```
* Listening on tcp://0.0.0.0:41063
Use Ctrl-C to stop

Waiting for jasmine server on 41063...
jasmine server started

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

The build has been terminated
```

Attempting to fix that.

The actual failure comes from phantomjs sometimes not managing to load the page, failing with:

```
ReferenceError: Can't find variable: SAFE_CLOSING

  undefined:18 in exports
```

(details in https://github.com/ManageIQ/manageiq-ui-classic/pull/5432)

Which is rather non-specific.

But, changing the backend from phantomjs to chrome headless fixes that (details in https://github.com/ManageIQ/manageiq-ui-classic/pull/5433).

The first jasmine gem version with support for chrome headless is 3.4.0 (also, the current latest),
so upgrading to that.

We had to fix the version to 2.5 when 2.6 came out, in https://github.com/ManageIQ/manageiq-ui-classic/pull/1148, but I don't see any info on why it failed, and .. it doesn't seem to fail now.

---

Jasmine 3.4.0 is a bit different in that it tries to run tests in random order by default. Leading to many failures (between 8 and 30ish) in our tests.

So, hacking the `rake environment jasmine` task to also output `Please open http://localhost:8888/?random=false` so that people get it right locally.

I also had to remove one random test, but it was one that was testing that the value it set was set, so, meh :).

Also had to add 2 test-only assets to the precompile list, as jasmine 3* fails trying to load non-precompiled assets.

This also means we're no longer testing our code in an old-browser-like environment.