### PR TITLE
Travis - force default python to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: ruby
+python: '2.7'
 rvm:
 - 2.4.5
 - 2.5.3


### PR DESCRIPTION
Travis [announced](https://changelog.travis-ci.com/upcoming-python-default-version-update-96873) a switch to python 3 as default will happen on Apr 16th, 2019.

node-gyp relies on python 2.7 ([ref](https://github.com/nodejs/node-gyp#on-unix)), without node-gyp, `yarn` can fail installing a JS dependency (`node-sass` and `fs-ext` both have a `bindings.gyp`).

=> forcing default python version to 2.7 on travis
