### PR TITLE
Fix missing Edit screen titles

### DIFF
--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -84,7 +84,7 @@ module ApplicationHelper::PageLayouts
 
     showtype = case @showtype
                when 'dashboard'
-                 !@lastaction.to_s.ends_with?("_dashboard")
+                 @in_a_form ? true : !@lastaction.to_s.ends_with?("_dashboard")
                when 'topology'
                  false
                else


### PR DESCRIPTION
This PR corrects a problem where Edit screens accessed from dashboards (as opposed to summary screens) do not display a title.

Issue: #5438

Old
<img width="1010" alt="Screen Shot 2019-04-10 at 3 03 37 PM" src="https://user-images.githubusercontent.com/1287144/55906287-e74dab00-5ba1-11e9-827b-64beb25dcc56.png">

New
<img width="973" alt="Screen Shot 2019-04-10 at 2 07 32 PM" src="https://user-images.githubusercontent.com/1287144/55906049-5b3b8380-5ba1-11e9-91da-488c7625984d.png">

