### PR TITLE
Do not store JSON trees in the session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1974,10 +1974,6 @@ class ApplicationController < ActionController::Base
     end
 
     # Clearing out session objects that are no longer needed
-    session[:hac_tree] = session[:vat_tree] = nil if controller_name != "ops"
-    session[:ch_tree] = nil if !["compliance_history"].include?(params[:display])
-    session[:vm_tree] = nil unless ["vmtree_info"].include?(params[:display])
-    session[:policy_tree] = nil if params[:action] != "policies" && params[:pressed] != "vm_protect"
     session[:resolve] = session[:resolve_object] = nil unless %w[catalog miq_ae_customization miq_ae_tools].include?(request.parameters[:controller])
     session[:report_menu] = session[:report_folders] = session[:menu_roles_tree] = nil if controller_name != "report"
     if session.class != Hash

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -36,7 +36,6 @@ module Mixins
 
     def update_session_for_compliance_history(count)
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:ch_tree] = @ch_tree.tree_nodes
       session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)
     end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -227,7 +227,6 @@ module VmCommon
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:ch_tree] = @ch_tree.tree_nodes
       session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)


### PR DESCRIPTION
These session variables aren't used anywhere and the `tree_nodes` instance variable is obsolete, so removing...

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label hammer/no, cleanup, trees