### PR TITLE
Clean up some unnecessarily set session variables

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -1039,7 +1039,6 @@ module ApplicationController::MiqRequestMethods
       end
     end
     @all_tags_tree = TreeBuilder.convert_bs_tree(all_tags).to_json # Add ci node array to root of tree
-    session[:tree] = "all_tags"
   end
 
   def build_template_filter

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -1040,7 +1040,6 @@ module ApplicationController::MiqRequestMethods
     end
     @all_tags_tree = TreeBuilder.convert_bs_tree(all_tags).to_json # Add ci node array to root of tree
     session[:tree] = "all_tags"
-    session[:tree_name] = "all_tags_tree"
   end
 
   def build_template_filter

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -23,7 +23,7 @@ module Mixins
 
     def show_compliance_history
       count = params[:count] ? params[:count].to_i : 10
-      update_session_for_compliance_history(count)
+      update_session_for_compliance_history
       drop_breadcrumb_for_compliance_history(count)
       @showtype = @display
     end
@@ -34,9 +34,8 @@ module Mixins
                       :url  => show_link(@record, :display => "topology"))
     end
 
-    def update_session_for_compliance_history(count)
+    def update_session_for_compliance_history
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:squash_open] = (count == 1)
     end
 
     def drop_breadcrumb_for_compliance_history(count)

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -36,7 +36,6 @@ module Mixins
 
     def update_session_for_compliance_history(count)
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)
     end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -227,7 +227,6 @@ module VmCommon
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:squash_open] = (count == 1)
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)
       if count == 1
         drop_breadcrumb(:name => @record.name + _(" (Latest Compliance Check)"),

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -227,7 +227,6 @@ module VmCommon
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
       @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
-      session[:tree_name] = "ch_tree"
       session[:squash_open] = (count == 1)
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)
       if count == 1

--- a/app/views/host/_network_tree.html.haml
+++ b/app/views/host/_network_tree.html.haml
@@ -1,9 +1,8 @@
 -# Network or Storage Adpater Tree
+%div
 - if x_active_tree == :sa_tree
-  %div
-    = render(:partial => 'shared/tree', :locals => {:tree => @sa_tree, :name => @sa_tree.name.to_s})
+  = render(:partial => 'shared/tree', :locals => {:tree => @sa_tree, :name => @sa_tree.name.to_s})
 - else
-  %div{:id => "#{session[:tree_name]}box", :style => "width: 100%"}
-    = render(:partial => 'shared/tree', :locals => {:tree => @network_tree, :name => @network_tree.name.to_s})
+  = render(:partial => 'shared/tree', :locals => {:tree => @network_tree, :name => @network_tree.name.to_s})
 
 


### PR DESCRIPTION
The following session variables are no longer used anywhere:
* `squash_open`
* `tree`
* `tree_name`

There was one single usage of the `tree_name`, but on that screen it was always set to nil, so :fire: 

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, technical debt, hammer/no