### PR TITLE
Menu Simplification: move Configuration Management into Compute

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -515,12 +515,12 @@ class ProviderForemanController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs  => [
-        {:title => _("Configuration")},
-        {:title => _("Management")},
+        {:title => _("Compute")},
+        {:title => _("Configuration Management")},
       ],
       :record_title => :hostname,
     }
   end
 
-  menu_section :conf
+  menu_section :compute
 end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -17,14 +17,9 @@ module Menu
           clouds_menu_section,
           infrastructure_menu_section,
           physical_infrastructure_menu_section,
-          container_menu_section
+          container_menu_section,
+          Menu::Item.new('provider_foreman', N_('Configuration Management'), 'provider_foreman_explorer', {:feature => 'provider_foreman_explorer', :any => true}, '/provider_foreman/explorer'),
         ].compact)
-      end
-
-      def configuration_menu_section
-        Menu::Section.new(:conf, N_("Configuration"), 'fa fa-cog', [
-          Menu::Item.new('provider_foreman',  N_('Management'), 'provider_foreman_explorer', {:feature => 'provider_foreman_explorer', :any => true}, '/provider_foreman/explorer'),
-        ])
       end
 
       def cloud_inteligence_menu_section
@@ -297,7 +292,7 @@ module Menu
       end
 
       def default_menu
-        [cloud_inteligence_menu_section, services_menu_section, compute_menu_section, configuration_menu_section,
+        [cloud_inteligence_menu_section, services_menu_section, compute_menu_section,
          network_menu_section, storage_menu_section, control_menu_section, automation_menu_section,
          optimize_menu_section, monitor_menu_section, settings_menu_section, graphql_menu_section, help_menu_section].compact
       end


### PR DESCRIPTION
![Screenshot from 2019-04-11 11-55-26](https://user-images.githubusercontent.com/649130/55948398-ba0c0600-5c50-11e9-841b-587f61167dcb.png)

As the `Migration` menu comes from the V2V plugin, it will be always the last item. IMO it's a little weird to have the non-expandable `Configuration Management` as not the last menu item. However, until we can't influence the menu ordering from plugins, we can just move the item up, but not down in the ordering.

@miq-bot add_label enhancement, hammer/no, ux/review, 
@miq-bot add_reviewer @mzazrivec
@miq-bot add_reviewer @epwinchell

/cc @terezanovotna, @Loicavenel

https://bugzilla.redhat.com/show_bug.cgi?id=1678196