### PR TITLE
Menu Simplification: extract Configuration into the top-right bar

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -264,8 +264,7 @@ module Menu
       def settings_menu_section
         Menu::Section.new(:set, N_("Settings"), 'pficon pficon-settings', [
           Menu::Item.new('configuration', N_('My Settings'),   'my_settings',  {:feature => 'my_settings', :any => true},  '/configuration/index'),
-          Menu::Item.new('my_tasks',      N_('Tasks'),         'tasks',        {:feature => 'tasks', :any => true},        '/miq_task/index?jobs_tab=tasks'),
-          Menu::Item.new('ops',           N_('Configuration'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer')
+          Menu::Item.new('my_tasks',      N_('Tasks'),         'tasks',        {:feature => 'tasks', :any => true},        '/miq_task/index?jobs_tab=tasks')
         ], :top_right)
       end
 

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -1,4 +1,8 @@
 - if current_user
+  - if ApplicationHelper.role_allows?(:feature => 'ops_explorer', :any => true)
+    %li.dropdown
+      %a.nav-item-iconic{:href => '/ops/explorer', :title => _('Configuration')}
+        %i.fa.fa-cog
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu2", "data-toggle" => "dropdown", "aria-haspopup" => "true"}
       %span.pficon.pficon-user

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -246,22 +246,6 @@ describe DashboardController do
     end
   end
 
-  context "#main_tab redirects to correct url when maintab is pressed by user with only Tenant features" do
-    before do
-      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
-      allow(controller).to receive(:check_privileges).and_return(true)
-      EvmSpecHelper.seed_specific_product_features("rbac_tenant")
-      feature_id = MiqProductFeature.find_all_by_identifier(["rbac_tenant"])
-      login_as FactoryBot.create(:user, :features => feature_id)
-    end
-
-    it "for Configure maintab" do
-      session[:tab_url] = {}
-      post :maintab, :params => { :tab => "set" }
-      expect(response.body).to include("ops/explorer")
-    end
-  end
-
   describe "#start_url_for_user" do
     before do
       MiqShortcut.seed


### PR DESCRIPTION
**Before:**
![Screenshot from 2019-04-11 13-39-27](https://user-images.githubusercontent.com/649130/55954559-40c7df80-5c5f-11e9-8c7b-b64c4e619885.png)

**After:**
![Screenshot from 2019-04-11 12-38-26](https://user-images.githubusercontent.com/649130/55954465-0c542380-5c5f-11e9-98a7-a938521c0928.png)

According to @h-kataria the related failing specs aren't valid anymore, so deleting them :scissors: 


@miq-bot add_label enhancement, hammer/no, ux/review
@miq-bot add_reviewer @mzazrivec
@miq-bot add_reviewer @epwinchell

Maybe the size of the `fa-cog` isn't the best, @epwinchell any ideas? Also cc @terezanovotna @loicavenel...

https://bugzilla.redhat.com/show_bug.cgi?id=1678196