### PR TITLE
Fix  Edit screen backgrounds

### DIFF
--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -106,6 +106,10 @@ module ApplicationHelper::PageLayouts
     ].include?(controller.action_name)
   end
 
+  def miq_layout_center_div_no_listnav_class
+    !@in_a_form && (@lastaction == "show_dashboard" || @layout == "monitor_alerts_overview") ? 'miq-body' : ''
+  end
+
   def center_div_partial
     if layout_uses_listnav?
       "layouts/center_div_with_listnav"

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -8,7 +8,7 @@
         .row.toolbar-pf#toolbar
           .col-sm-12
             = render :partial => "layouts/angular/toolbar"
-      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
+      .row#main-content.miq-layout-center_div_no_listnav{:class => miq_layout_center_div_no_listnav_class }
         .col-md-12
         - if layout_uses_tabs?
           .col-md-12


### PR DESCRIPTION
This PR adds a method to insure that Edit screens (reached from Angular dashboards) do not use a gray background.
Issue: #5438

Old
<img width="859" alt="Screen Shot 2019-04-11 at 10 12 29 AM" src="https://user-images.githubusercontent.com/1287144/55964219-57ac0900-5c42-11e9-8f59-ee58d083dff3.png">


New
<img width="754" alt="Screen Shot 2019-04-11 at 9 56 55 AM" src="https://user-images.githubusercontent.com/1287144/55963738-63e39680-5c41-11e9-80dc-50f99462fc94.png">
