### PR TITLE
[WIP] jasmine: expose config as json endpoint

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -47,6 +47,16 @@ class WebpackPack
   end
 end
 
+class JasmineConfig
+  def initialize(file)
+    @config = YAML.load_file(file)
+  end
+
+  def call(env)
+    [200, {"Content-Type" => "application/json"}, [@config.to_json]]
+  end
+end
+
 Jasmine.configure do |config|
   # never install phantomjs
   config.prevent_phantom_js_auto_install = true
@@ -73,4 +83,7 @@ Jasmine.configure do |config|
 
   # serve weback-compiled packs from public/packs/ on /packs/
   config.add_rack_path('/packs', -> { WebpackPack.new })
+
+  # serve config as json
+  config.add_rack_path('/jasmine.yml.json', -> { JasmineConfig.new(File.join(__dir__, 'jasmine.yml')) })
 end


### PR DESCRIPTION
(Built on top of https://github.com/ManageIQ/manageiq-ui-classic/pull/5458, first commit)

Exposes `jasmine.yml` config to the test environment as a JSON GET endpoint.

Because right now, we have to run jasmine with `?random=false` in the url because the JS can't read the config.

TODO: the jasmine index html/js changes
(also, maybe this won't be necessary on our side, depends on https://github.com/jasmine/jasmine-gem/issues/307)
