### PR TITLE
Hide CloudVolumeTypes for non-OpenStack storage providers

### DIFF
--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -11,11 +11,12 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"),
-                     %i[
+    relationships = %i[
                        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
-                       cloud_object_store_containers cloud_volume_types custom_button_events
-                     ])
+                       cloud_object_store_containers custom_button_events
+      ]
+    relationships.push(:cloud_volume_types) if @record.type.include?("ManageIQ::Providers::StorageManager::CinderManager")
+    TextualGroup.new(_("Relationships"), relationships)
   end
 
   def textual_group_status

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -1,22 +1,40 @@
 describe EmsStorageHelper::TextualSummary do
-  before do
-    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
-    allow(self).to receive(:textual_authentications).and_return([])
+  describe "for EmsInfra" do
+    before do
+      instance_variable_set(:@record, FactoryBot.create(:ems_infra))
+      allow(self).to receive(:textual_authentications).and_return([])
+    end
+
+    include_examples "textual_group", "Properties", %i[provider_region hostname ipaddress type port guid]
+
+    include_examples "textual_group", "Relationships", %i[
+      parent_ems_cloud
+      cloud_volumes
+      cloud_volume_snapshots
+      cloud_volume_backups
+      cloud_object_store_containers
+      custom_button_events
+    ]
+
+    include_examples "textual_group", "Status", %i[refresh_status refresh_date]
+
+    include_examples "textual_group_smart_management", %i[zone]
   end
 
-  include_examples "textual_group", "Properties", %i(provider_region hostname ipaddress type port guid)
+  describe "for OpenStack Cinder Manager" do
+    before do
+      instance_variable_set(:@record, FactoryBot.create(:ems_cinder))
+      allow(self).to receive(:textual_authentications).and_return([])
+    end
 
-  include_examples "textual_group", "Relationships", %i(
-    parent_ems_cloud
-    cloud_volumes
-    cloud_volume_snapshots
-    cloud_volume_backups
-    cloud_object_store_containers
-    cloud_volume_types
-    custom_button_events
-  )
-
-  include_examples "textual_group", "Status", %i(refresh_status refresh_date)
-
-  include_examples "textual_group_smart_management", %i(zone)
+    include_examples "textual_group", "Relationships", %i[
+      parent_ems_cloud
+      cloud_volumes
+      cloud_volume_snapshots
+      cloud_volume_backups
+      cloud_object_store_containers
+      custom_button_events
+      cloud_volume_types
+    ]
+  end
 end


### PR DESCRIPTION
Remove Cloud Volume Types from summary page of non-OpenStack storage providers
 or OpenStack Swift Provider
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650082

Storage -> Block Storage -> Managers -> click on non-Openstack storage provider or OpenStack Swift Provider
Before there's Cloud Volume Types in Relationships (last line):
![image](https://user-images.githubusercontent.com/9210860/56198164-ab4f9580-603a-11e9-8afb-44ee8321a458.png)
After there's no Cloud Volume Types in Relationships:
![image](https://user-images.githubusercontent.com/9210860/56198522-637d3e00-603b-11e9-8c15-3a0782d18f00.png)

For OpenStack Cinder Manager:
Before/After:
![image](https://user-images.githubusercontent.com/9210860/56211035-5706de80-6057-11e9-9abe-568a4686be55.png)

If you have no `CloudVolumeType` for OpenStack. Do this in console:
```
ems_id = ManageIQ::Providers::StorageManager::CinderManager.first.id
cvt = CloudVolumeType.create(:name => "name", :description => "description", :ems_id => ems_id)
cvt.save!
```

@miq-bot add_label wip, bug, hammer/yes, storage