### PR TITLE
Show affected servers on PhysicalServerProvisionRequest details

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -805,6 +805,9 @@ module ApplicationController::MiqRequestMethods
       if (service_id = @miq_request.options[:src_ids].first) && (service = Service.find_by(:id => service_id)) && Rbac.filtered_object(service)
         @view, @pages = get_view(Vm, :parent => service, :view_suffix => 'OrchestrationStackRetireRequest')
       end
+    elsif @miq_request.resource_type == 'PhysicalServerProvisionRequest'
+      @selected_ids = @miq_request.options[:src_ids]
+      @view, @pages = get_view(PhysicalServer, :view_suffix => 'PhysicalServerProvisionRequest')
     else
       @options = @miq_request.options
       @options[:memory], @options[:mem_typ] = reconfigure_calculations(@options[:vm_memory][0]) if @options[:vm_memory]

--- a/app/views/miq_request/_physical_server_provision_show.html.haml
+++ b/app/views/miq_request/_physical_server_provision_show.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  %h3
+    = _("Affected Physical Servers")
+  - if @view
+    - @embedded = true
+    - @gtl_type = "list"
+    = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -127,6 +127,8 @@
     = render :partial => "service_retire_show"
   - elsif @miq_request.type == "AutomationRequest"
     = render :partial => "ae_prov_show"
+  - elsif @miq_request.type == "PhysicalServerProvisionRequest"
+    = render :partial => "physical_server_provision_show"
   - else
     = render :partial => "reconfigure_show"
 


### PR DESCRIPTION
Currently, PhysicalServerProvision details page was trying to fetch and display affected VMs (with given src_ids), instead PhysicalServers. With this commit we make sure it displays the correct model, see screenshot below:

![image](https://user-images.githubusercontent.com/8102426/56199131-95db6b00-603c-11e9-815c-c8a0da8ff2b9.png)

@miq-bot add_label enhancement
@miq-bot assign @mzazrivec 
(assigning @mzazrivec since he merged a very similar PR some time ago when we were fixing it for service retirement, see https://github.com/ManageIQ/manageiq-ui-classic/pull/4710)


