### PR TITLE
Do not reset entrypoints when editing an existing catalog bundle

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1281,7 +1281,8 @@ class CatalogController < ApplicationController
     @edit[:new] = {}
     @edit[:current] = {}
     set_form_vars
-    default_entry_point("generic", "composite")
+    # Set the default entry points if the record not yet in the DB
+    default_entry_point("generic", "composite") if @record.id.nil?
     @edit[:new][:service_type] = "composite"
     @edit[:new][:rsc_groups] = []
     @edit[:new][:selected_resources] = []

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -760,15 +760,26 @@ describe CatalogController do
     end
 
     describe "#st_set_form_vars" do
-      before do
-        bundle = FactoryBot.create(:service_template)
-        controller.instance_variable_set(:@record, bundle)
+      before { controller.instance_variable_set(:@record, bundle) }
+
+      context 'already existing catalog bundle' do
+        let(:bundle) { FactoryBot.create(:service_template) }
+
+        it "loads entry points for Catalog Bundle from the DB" do
+          controller.send(:st_set_form_vars)
+          expect(assigns(:edit)[:new][:fqname]).to eq("")
+          expect(assigns(:edit)[:new][:retire_fqname]).to eq("")
+        end
       end
 
-      it "sets default entry points for Catalog Bundle" do
-        controller.send(:st_set_form_vars)
-        expect(assigns(:edit)[:new][:fqname]).to include("CatalogBundleInitialization")
-        expect(assigns(:edit)[:new][:retire_fqname]).to include("Default")
+      context 'newly created catalog bundle' do
+        let(:bundle) { FactoryBot.build(:service_template) }
+
+        it "sets default entry points for Catalog Bundle" do
+          controller.send(:st_set_form_vars)
+          expect(assigns(:edit)[:new][:fqname]).to include("CatalogBundleInitialization")
+          expect(assigns(:edit)[:new][:retire_fqname]).to include("Default")
+        end
       end
     end
 


### PR DESCRIPTION
When editing an existing catalog bundle, the entry points in the form are being set to the default. This was caused by a missing condition to test if the catalog bundle object is an unsaved one without an ID or an already existing that doesn't need the default entrypoints.

@miq-bot add_label bug, hammer/yes, services
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698431