### PR TITLE
Remove the leaf option from TreeBuilders, replace it with @root_class

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -56,7 +56,6 @@ class TreeBuilder
 
   # The possible options are
   # * full_ids - whether to generate full node IDs or not
-  # * leaf - class of the leaf nodes
   # * open_all - expand all expandable nodes
   # * lazy - is the tree lazily-loadable
   # * checkboxes - show checkboxes for the nodes
@@ -173,7 +172,6 @@ class TreeBuilder
         :tree       => @name,
         :type       => type,
         :klass_name => self.class.name,
-        :leaf       => @options[:leaf],
         :open_nodes => []
       )
     )
@@ -213,7 +211,6 @@ class TreeBuilder
   # Build an explorer tree, from scratch
   # Options:
   # :type                   # Type of tree, i.e. :handc, :vandt, :filtered, etc
-  # :leaf                   # Model name of leaf nodes, i.e. "Vm"
   # :open_nodes             # Tree node ids of currently open nodes
   # :full_ids               # stack parent id on top of each node id
   # :lazy                   # set if tree is lazy

--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -1,9 +1,10 @@
 class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSystems
-  private
-
-  def tree_init_options
-    {:leaf => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem"}
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
+    super(*args)
   end
+
+  private
 
   def root_options
     {

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -1,9 +1,10 @@
 class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSystems
-  private
-
-  def tree_init_options
-    {:leaf => "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"}
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+    super(*args)
   end
+
+  private
 
   def root_options
     {

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -7,25 +7,25 @@ class TreeBuilderConfiguredSystems < TreeBuilder
     {:lazy => true, :allow_reselect => true}
   end
 
-  def x_get_tree_custom_kids(object, count_only, options)
-    count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
+  def x_get_tree_custom_kids(object, count_only, _options)
+    count_only_or_objects(count_only, x_get_search_results(object))
   end
 
-  def x_get_search_results(object, leaf)
+  def x_get_search_results(object)
     case object[:id]
     when "global" # Global filters
-      x_get_global_filter_search_results(leaf)
+      x_get_global_filter_search_results
     when "my"     # My filters
-      x_get_my_filter_search_results(leaf)
+      x_get_my_filter_search_results
     end
   end
 
-  def x_get_global_filter_search_results(leaf)
-    MiqSearch.where(:db => leaf).visible_to_all.sort_by { |a| a.description.downcase }
+  def x_get_global_filter_search_results
+    MiqSearch.where(:db => @root_class).visible_to_all.sort_by { |a| a.description.downcase }
   end
 
-  def x_get_my_filter_search_results(leaf)
-    MiqSearch.where(:db => leaf, :search_type => "user", :search_key => User.current_user.userid)
+  def x_get_my_filter_search_results
+    MiqSearch.where(:db => @root_class, :search_type => "user", :search_key => User.current_user.userid)
              .sort_by { |a| a.description.downcase }
   end
 

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -3,7 +3,6 @@ class TreeBuilderImages < TreeBuilder
 
   def tree_init_options
     {
-      :leaf           => "ManageIQ::Providers::CloudManager::Template",
       :lazy           => true,
       :allow_reselect => true
     }

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -1,6 +1,7 @@
 class TreeBuilderImagesFilter < TreeBuilderVmsFilter
-  def tree_init_options
-    super.update(:leaf => 'ManageIQ::Providers::CloudManager::Template')
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::CloudManager::Template
+    super(*args)
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -4,7 +4,7 @@ class TreeBuilderInstances < TreeBuilder
   include TreeBuilderArchived
 
   def tree_init_options
-    {:leaf => 'VmCloud', :allow_reselect => true}
+    {:allow_reselect => true}
   end
 
   def root_options

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -1,6 +1,7 @@
 class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
-  def tree_init_options
-    super.update(:leaf => 'ManageIQ::Providers::CloudManager::Vm')
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::CloudManager::Vm
+    super(*args)
   end
 
   def root_options

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -1,6 +1,7 @@
 class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
-  def tree_init_options
-    super.update(:leaf => 'ManageIQ::Providers::InfraManager::Template')
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::InfraManager::Template
+    super(*args)
   end
 
   def root_options

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,6 +1,7 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
-  def tree_init_options
-    super.update(:leaf => 'MiqTemplate')
+  def initialize(*args)
+    @root_class = MiqTemplate
+    super(*args)
   end
 
   def root_options

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -3,7 +3,6 @@ class TreeBuilderVandt < TreeBuilder
 
   def tree_init_options
     {
-      :leaf           => 'ManageIQ::Providers::InfraManager::VmOrTemplate',
       :lazy           => true,
       :allow_reselect => true
     }

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,8 +1,12 @@
 class TreeBuilderVmsFilter < TreeBuilder
+  def initialize(*args)
+    @root_class = ManageIQ::Providers::InfraManager::Vm
+    super(*args)
+  end
+
   def tree_init_options
     {
       :open_all       => true,
-      :leaf           => 'ManageIQ::Providers::InfraManager::Vm',
       :allow_reselect => true
     }
   end
@@ -23,8 +27,8 @@ class TreeBuilderVmsFilter < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, options)
-    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+  def x_get_tree_custom_kids(object, count_only, _options)
+    objects = MiqSearch.where(:db => @root_class).filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -1,6 +1,7 @@
 class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
-  def tree_init_options
-    super.update(:leaf => 'Vm')
+  def initialize(*args)
+    @root_class = Vm
+    super(*args)
   end
 
   def root_options

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -7,7 +7,6 @@ describe TreeBuilderAeCustomization do
         :tree        => :dialog_import_export_tree,
         :type        => :dialog_import_export,
         :klass_name  => "TreeBuilderAeCustomization",
-        :leaf        => nil,
         :open_nodes  => [],
         :open_all    => true,
         :active_node => "root"

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderImages do
 
   it 'sets tree to have leaf and not lazy' do
     root_options = @images_tree.tree_init_options
-    expect(root_options).to eq(:leaf => "ManageIQ::Providers::CloudManager::Template", :lazy => true, :allow_reselect => true)
+    expect(root_options).to eq(:lazy => true, :allow_reselect => true)
   end
 
   it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderInstances do
   it 'sets tree to have leaf and not lazy' do
     root_options = @instances_tree.tree_init_options
 
-    expect(root_options).to eq(:leaf => 'VmCloud', :allow_reselect => true)
+    expect(root_options).to eq(:allow_reselect => true)
   end
 
   it 'sets tree to have full ids, not lazy and no root' do


### PR DESCRIPTION
It is totally unnecessary to make the `:leaf` option wander through the `TreeState` and back to the `TreeBuilder`, moving it into the `@root_class` instance variable.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, refactoring, hammer/no