### PR TITLE
Removes validateOnMount from DDF schemas and enables submit button

### DIFF
--- a/app/javascript/components/automate-import-export-form/datastore-via-git.schema.js
+++ b/app/javascript/components/automate-import-export-form/datastore-via-git.schema.js
@@ -5,7 +5,7 @@ const createSchema = () => ({
     name: 'git_url',
     label: __('Git URL'),
     component: componentTypes.TEXT_FIELD,
-    validateOnMount: true,
+    isRequired: true,
     validate: [{
       type: validatorTypes.REQUIRED,
     }, {

--- a/app/javascript/components/catalog-form/catalog-form.schema.js
+++ b/app/javascript/components/catalog-form/catalog-form.schema.js
@@ -29,7 +29,7 @@ function createSchema(options, catalogId) {
       label: __('Name'),
       maxLength: 40,
       autoFocus: true,
-      validateOnMount: true,
+      isRequired: true,
     }, {
       component: componentTypes.TEXT_FIELD,
       name: 'description',

--- a/app/javascript/components/cloud-tenant-form/create-form.schema.js
+++ b/app/javascript/components/cloud-tenant-form/create-form.schema.js
@@ -11,7 +11,7 @@ function createSchema(renderEmsChoices, emsChoices) {
     }],
     label: __('Tenant Name'),
     maxLength: 128,
-    validateOnMount: true,
+    isRequired: true,
   }];
   if (!renderEmsChoices) {
     fields = [{
@@ -19,7 +19,7 @@ function createSchema(renderEmsChoices, emsChoices) {
       name: 'ems_id',
       label: __('Cloud Provider/Parent Cloud Tenant'),
       placeholder: `<${__('Choose')}>`,
-      validateOnMount: true,
+      isRequired: true,
       validate: [{
         type: 'required-validator',
       }],

--- a/app/javascript/components/flavor-form/flavor-form.schema.js
+++ b/app/javascript/components/flavor-form/flavor-form.schema.js
@@ -10,7 +10,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       }],
       options: emsList.map(item => ({ label: item.name, value: item.id })),
       label: __('Provider'),
-      validateOnMount: true,
+      isRequired: true,
       isSearchable: true,
     },
     {
@@ -21,7 +21,7 @@ function addSchema(emsList = [], cloudTenants = []) {
         message: __('Required'),
       }],
       label: __('Name'),
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -44,7 +44,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       label: __('Ram size in MB'),
       dataType: 'integer',
       type: 'number',
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -66,7 +66,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       label: __('VCPUs'),
       dataType: 'integer',
       type: 'number',
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -88,7 +88,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       label: __('Disk size in GB'),
       dataType: 'integer',
       type: 'number',
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -110,7 +110,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       label: __('Swap size in MB'),
       dataType: 'integer',
       type: 'number',
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -131,7 +131,7 @@ function addSchema(emsList = [], cloudTenants = []) {
       }],
       label: __('RXTX factor'),
       type: 'number',
-      validateOnMount: true,
+      isRequired: true,
     },
     {
       component: componentTypes.SWITCH,

--- a/app/javascript/components/service-form/service-form.schema.js
+++ b/app/javascript/components/service-form/service-form.schema.js
@@ -5,7 +5,7 @@ function createSchema(maxNameLen, maxDescLen) {
       name: 'name',
       maxLength: maxNameLen,
       label: __('Name'),
-      validateOnMount: true,
+      isRequired: true,
       autoFocus: true,
       validate: [{
         type: 'required-validator',
@@ -15,7 +15,7 @@ function createSchema(maxNameLen, maxDescLen) {
       name: 'description',
       maxLength: maxDescLen,
       label: __('Description'),
-      validateOnMount: true,
+      isRequired: true,
       autoFocus: true,
       validate: [{
         type: 'required-validator',

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -18,10 +18,6 @@ const MiqFormRenderer = props => (
   <FormRender
     formFieldsMapper={formFieldsMapper}
     layoutMapper={layoutMapper}
-    disableSubmit={[
-      'pristine',
-      'invalid',
-    ]}
     {...buttonLabels}
     {...props}
   />

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -23,13 +23,13 @@ exports[`Catalog form component should render add variant form 1`] = `
               Object {
                 "autoFocus": true,
                 "component": "text-field",
+                "isRequired": true,
                 "label": "Name",
                 "maxLength": 40,
                 "name": "name",
                 "validate": Array [
                   [Function],
                 ],
-                "validateOnMount": true,
               },
               Object {
                 "component": "text-field",
@@ -113,13 +113,13 @@ exports[`Catalog form component should render edit variant form 1`] = `
               Object {
                 "autoFocus": true,
                 "component": "text-field",
+                "isRequired": true,
                 "label": "Name",
                 "maxLength": 40,
                 "name": "name",
                 "validate": Array [
                   [Function],
                 ],
-                "validateOnMount": true,
               },
               Object {
                 "component": "text-field",

--- a/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
+++ b/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
         "fields": Array [
           Object {
             "component": "select-field",
+            "isRequired": true,
             "label": "Cloud Provider/Parent Cloud Tenant",
             "name": "ems_id",
             "options": Array [
@@ -48,10 +49,10 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
                 "type": "required-validator",
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
+            "isRequired": true,
             "label": "Tenant Name",
             "maxLength": 128,
             "name": "name",
@@ -60,7 +61,6 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
                 "type": "required-validator",
               },
             ],
-            "validateOnMount": true,
           },
         ],
       }
@@ -91,6 +91,7 @@ exports[`Cloud tenant form component should render editing form variant 1`] = `
         "fields": Array [
           Object {
             "component": "text-field",
+            "isRequired": true,
             "label": "Tenant Name",
             "maxLength": 128,
             "name": "name",
@@ -99,7 +100,6 @@ exports[`Cloud tenant form component should render editing form variant 1`] = `
                 "type": "required-validator",
               },
             ],
-            "validateOnMount": true,
           },
         ],
       }

--- a/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
+++ b/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
@@ -23,6 +23,7 @@ exports[`Flavor form component should render form 1`] = `
         "fields": Array [
           Object {
             "component": "select-field",
+            "isRequired": true,
             "isSearchable": true,
             "label": "Provider",
             "name": "ems_id",
@@ -32,10 +33,10 @@ exports[`Flavor form component should render form 1`] = `
                 "type": "required-validator",
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
+            "isRequired": true,
             "label": "Name",
             "name": "name",
             "validate": Array [
@@ -44,11 +45,11 @@ exports[`Flavor form component should render form 1`] = `
                 "type": "required-validator",
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
             "dataType": "integer",
+            "isRequired": true,
             "label": "Ram size in MB",
             "name": "ram",
             "type": "number",
@@ -68,11 +69,11 @@ exports[`Flavor form component should render form 1`] = `
                 "value": 1,
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
             "dataType": "integer",
+            "isRequired": true,
             "label": "VCPUs",
             "name": "vcpus",
             "type": "number",
@@ -92,11 +93,11 @@ exports[`Flavor form component should render form 1`] = `
                 "value": 1,
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
             "dataType": "integer",
+            "isRequired": true,
             "label": "Disk size in GB",
             "name": "disk",
             "type": "number",
@@ -116,11 +117,11 @@ exports[`Flavor form component should render form 1`] = `
                 "value": 1,
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
             "dataType": "integer",
+            "isRequired": true,
             "label": "Swap size in MB",
             "name": "swap",
             "type": "number",
@@ -140,10 +141,10 @@ exports[`Flavor form component should render form 1`] = `
                 "value": 0,
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "component": "text-field",
+            "isRequired": true,
             "label": "RXTX factor",
             "name": "rxtx_factor",
             "type": "number",
@@ -163,7 +164,6 @@ exports[`Flavor form component should render form 1`] = `
                 "value": 0,
               },
             ],
-            "validateOnMount": true,
           },
           Object {
             "assignFieldProvider": true,

--- a/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
+++ b/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
@@ -74,20 +74,6 @@ describe('Vm server relationship form component', () => {
     });
   });
 
-  it('should not submit values when form is not valid', (done) => {
-    fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    const wrapper = mount(<VmServerRelationShipForm {...props} />);
-    const spy = jest.spyOn(wrapper.instance(), 'onSubmit');
-
-    setImmediate(() => {
-      wrapper.update();
-      const button = wrapper.find('button').first();
-      button.simulate('click');
-      expect(spy).toHaveBeenCalledTimes(0);
-      done();
-    });
-  });
-
   it('onSubmit parses data and post to API', (done) => {
     fetchMock.getOnce('http://localhost:3000/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
     fetchMock.postOnce('/vm_or_template/evm_relationship_update/10?button=save', {});


### PR DESCRIPTION
**Description**

- Removes `validateOnMount` from schemas (so no errors before a user do anything) and sets `isRequired` insert `*`
- Submit button is always enabled 
- Removes a test which checks if the tested form can't be submitted empty (that is not right after this changes)

**Before**

![image](https://user-images.githubusercontent.com/32869456/56298384-568f4600-6132-11e9-8745-e2cd10c84399.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/56351084-930f8000-61cc-11e9-886f-3b341e7a5fb8.png)

Submit button

![submitform](https://user-images.githubusercontent.com/32869456/56351319-22b52e80-61cd-11e9-9bef-41303d112eb5.gif)


TODO:

- [x] update tests
- [x] handle the button (?)

@Hyperkid123 @martinpovolny @terezanovotna 

~~Should the submit button be enabled and after a click show errors? Or is it OK as it is?~~

Button will be always enabled, it allows to show errors to users.