### PR TITLE
Adds loading state to flavor form

### DIFF
--- a/app/javascript/components/flavor-form/flavor-form.jsx
+++ b/app/javascript/components/flavor-form/flavor-form.jsx
@@ -11,7 +11,7 @@ class FlavorForm extends Component {
     super(props);
     this.state = {
       initialValues: { is_public: true, rxtx_factor: '1.0' },
-      schema: addSchema(),
+      isLoading: true,
     };
   }
 
@@ -23,6 +23,7 @@ class FlavorForm extends Component {
         schema: addSchema(ems_list, cloud_tenants),
         emsList: ems_list,
         cloudTenants: cloud_tenants.map(item => ({ label: item.name, value: item.id })),
+        isLoading: false,
       })), miqSparkleOff());
   }
 
@@ -72,11 +73,17 @@ class FlavorForm extends Component {
   }
 
   render() {
+    const { isLoading, initialValues, schema } = this.state;
+
+    if (isLoading) {
+      return null;
+    }
+
     return (
       <Grid fluid>
         <MiqFormRenderer
-          initialValues={this.state.initialValues}
-          schema={this.state.schema}
+          initialValues={initialValues}
+          schema={schema}
           onSubmit={this.submitValues}
           onCancel={this.cancelClicked}
           buttonsLabels={{

--- a/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
+++ b/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flavor form component should render form 1`] = `
-<div
-  className="container-fluid"
+<Grid
+  bsClass="container"
+  componentClass="div"
+  fluid={true}
 >
   <MiqFormRenderer
     buttonsLabels={
@@ -12,6 +14,7 @@ exports[`Flavor form component should render form 1`] = `
     }
     initialValues={
       Object {
+        "ems_id": 1,
         "is_public": true,
         "rxtx_factor": "1.0",
       }
@@ -26,7 +29,16 @@ exports[`Flavor form component should render form 1`] = `
             "isSearchable": true,
             "label": "Provider",
             "name": "ems_id",
-            "options": Array [],
+            "options": Array [
+              Object {
+                "label": "name1",
+                "value": 1,
+              },
+              Object {
+                "label": "name2",
+                "value": 2,
+              },
+            ],
             "validate": Array [
               Object {
                 "type": "required-validator",
@@ -185,12 +197,21 @@ exports[`Flavor form component should render form 1`] = `
             "label": "Cloud Tenant",
             "multi": true,
             "name": "cloud_tenant_refs",
-            "options": Array [],
+            "options": Array [
+              Object {
+                "label": "name3",
+                "value": undefined,
+              },
+              Object {
+                "label": "name4",
+                "value": undefined,
+              },
+            ],
             "placeholder": "Nothing selected",
           },
         ],
       }
     }
   />
-</div>
+</Grid>
 `;

--- a/app/javascript/spec/flavor-form/flavor-form.spec.js
+++ b/app/javascript/spec/flavor-form/flavor-form.spec.js
@@ -8,6 +8,7 @@ import '../helpers/mockAsyncRequest';
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import '../helpers/miqFlashLater';
+import { wrap } from 'module';
 
 jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
 
@@ -39,20 +40,34 @@ describe('Flavor form component', () => {
     submitSpyMiqSparkleOff.mockRestore();
   });
 
-  it('should render form', () => {
-    const wrapper = shallow(<FlavorForm />).dive();
-    expect(toJson(wrapper)).toMatchSnapshot();
+  it('should render form', (done) => {
+    fetchMock
+      .mock('/flavor/ems_list', emsList)
+      .mock('/flavor/cloud_tenants', cloudTenants);
+    const wrapper = shallow(<FlavorForm />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(toJson(wrapper)).toMatchSnapshot();
+      done();
+    });
   });
 
-  it('should call cancel callback ', () => {
+  it('should call cancel callback ', (done) => {
+    fetchMock
+      .mock('/flavor/ems_list', emsList)
+      .mock('/flavor/cloud_tenants', cloudTenants);
     const wrapper = mount(<FlavorForm />);
     const message = __('Add of Flavor cancelled by user.');
     const url = '/flavor/show_list';
 
-    const button = wrapper.find('button').last();
-    button.simulate('click');
-    expect(submitSpyMiqSparkleOn).toHaveBeenCalled();
-    expect(miqRedirectBack).toHaveBeenCalledWith(message, 'warn', url);
+    setImmediate(() => {
+      wrapper.update();
+      const button = wrapper.find('button').last();
+      button.simulate('click');
+      expect(submitSpyMiqSparkleOn).toHaveBeenCalled();
+      expect(miqRedirectBack).toHaveBeenCalledWith(message, 'warn', url);
+      done();
+    });
   });
 
   it('should request data after mount and set to state', (done) => {
@@ -85,12 +100,21 @@ describe('Flavor form component', () => {
     });
   });
 
-  it('should not submit values when form is not valid', () => {
+  it('should not submit values when form is not valid', (done) => {
+    fetchMock
+      .mock('/flavor/ems_list', emsList)
+      .mock('/flavor/cloud_tenants', cloudTenants);
+
     const wrapper = mount(<FlavorForm />);
     const spy = jest.spyOn(wrapper.instance(), 'submitValues');
-    const button = wrapper.find('button').first();
-    button.simulate('click');
-    expect(spy).toHaveBeenCalledTimes(0);
+
+    setImmediate(() => {
+      wrapper.update();
+      const button = wrapper.find('button').first();
+      button.simulate('click');
+      expect(spy).toHaveBeenCalledTimes(0);
+      done();
+    });
   });
 
   it('should submit values when form is valid', (done) => {
@@ -104,6 +128,7 @@ describe('Flavor form component', () => {
     const spySubmit = jest.spyOn(wrapper.instance(), 'submitValues');
 
     setImmediate(() => {
+      wrapper.update();
       wrapper.find('#ems_id').first().simulate('change', {
         target: {
           value: '1',


### PR DESCRIPTION
**Description**

`Compute` > `Clouds` > `Flavors` > `Configuration` > `Add a new Flavor`

Missing loading state causes that the first select gets an empty array instead of fetched options.

**Before**

![image](https://user-images.githubusercontent.com/32869456/56347115-e6c99b80-61c3-11e9-82b7-1026c3269b17.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/56347091-db767000-61c3-11e9-9909-de826c781adf.png)


@miq-bot add_label hammer/no, compute/cloud, react, bug
@miq-bot add_reviewer @Hyperkid123 
