### PR TITLE
Adds missing breadcrumb in cloud network edit form

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -266,6 +266,7 @@ class CloudNetworkController < ApplicationController
         {:title => _("Networks")},
         {:url   => controller_url, :title => _("Cloud Networks")},
       ],
+      :record_info => @network,
     }
   end
 


### PR DESCRIPTION
Adds missing missing breadcrumb in 

`Networks` > `Networks` > `Cloud Networks` > select one which is editable > `Configuration` > `Edit`

**Before**

![image](https://user-images.githubusercontent.com/32869456/56348779-7b81c880-61c7-11e9-95ba-6d9e019d34cf.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/56348809-89374e00-61c7-11e9-90d2-fe8dbfa869e0.png)