### PR TITLE
Dialog import - add an error message for DialogImportValidator::InvalidDialogVersionError

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -53,6 +53,8 @@ class MiqAeCustomizationController < ApplicationController
         add_flash(_("Error during upload: the following dialog fields to be imported contain circular association references: %{error}") % {:error => $ERROR_INFO}, :error)
       rescue DialogImportValidator::InvalidDialogFieldTypeError
         add_flash(_("Error during upload: one of the DialogField types is not supported"), :error)
+      rescue DialogImportValidator::InvalidDialogVersionError
+        add_flash(_("Error during upload: the version of exported dialog is not supported in this release"), :error)
       end
     end
     get_node_info


### PR DESCRIPTION
happens when importing a dialog exported in a newer version of manageiq... introduced in https://github.com/ManageIQ/manageiq/pull/18645.

(Doesn't really depend on https://github.com/ManageIQ/manageiq/pull/18645, just doesn't do anything without it.)

Related to
https://bugzilla.redhat.com/show_bug.cgi?id=1684575
https://bugzilla.redhat.com/show_bug.cgi?id=1684567