### PR TITLE
Make Add button respond properly on changes while adding Catalog Item

### DIFF
--- a/app/helpers/params_helper.rb
+++ b/app/helpers/params_helper.rb
@@ -3,9 +3,20 @@ module ParamsHelper
     target[key] = source[key] if source[key]
   end
 
+  def copy_param_if_present(target, source, key)
+    target[key] = source[key].presence if source[key]
+  end
+
   def copy_params_if_set(target, source, list)
     list.each do |key|
       copy_param_if_set(target, source, key)
+    end
+    target
+  end
+
+  def copy_params_if_present(target, source, list)
+    list.each do |key|
+      copy_param_if_present(target, source, key)
     end
     target
   end


### PR DESCRIPTION
**Fixes BZ:**
https://bugzilla.redhat.com/show_bug.cgi?id=1728774

**Issue:**
https://github.com/ManageIQ/manageiq-ui-classic/issues/5469

**What:**
Add button is already (always) enabled while adding a new Service Catalog Item, even when there is nothing to add, because we haven't filled in anything. This behavior is not consistent with other screens. We want _Add_ button to properly response on changes, as in other screens.

**How:**
When user fills in some form, the text for the appropriate form is stored in `@edit[:new]` where the original values are usually set to `nil`. The same values are copied to `@edit[:current]` in the beginning. If the user deletes the text from the form, the variable is set to `""` which is different to the original value, so the `changed` variable stilll 'detects' the change even when there is no change according to the original value (`nil`). So I am adding new common method `copy_params_if_present` which deals with `""` vs `nil` values.

**Note:**
This PR fixes response of _Add_ button on changes (bot adding and editing Catalog Item), except _Long Description_. This is more complicated and requires different fix (Also not sure how this should work - issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5853).

---

**Before:** (when first time in for adding new Catalog Item, _Add_ button already enabled!)
![add_issue](https://user-images.githubusercontent.com/13417815/56348844-9ce2b480-61c7-11e9-9434-8ae9c74ca6ac.png)

**After:** (when first time in for adding new Catalog Item, _Add_ button disabled, there is nothing to add)
![catitem_after](https://user-images.githubusercontent.com/13417815/61222195-8098da00-a71a-11e9-9c6a-ff78aef6834d.png)
