### PR TITLE
[WIP] Fix service catalog vm provisioning selection for RHV provider

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -28,8 +28,10 @@ module ApplicationController::MiqRequestMethods
       @record =
         if @edit[:new][:src_configured_system_ids].present?
           PhysicalServer.where(:id => @edit[:new][:src_configured_system_ids].first).first
-        elsif @edit[:new][:src_vm_id].first.present?
+        elsif @edit[:new][:src_vm_id].kind_of?(Array) && @edit[:new][:src_vm_id].first.present?
           MiqTemplate.where(:id => @edit[:new][:src_vm_id].first).first
+        elsif @edit[:new][:src_vm_id].kind_of?(Integer)
+          MiqTemplate.where(:id => @edit[:new][:src_vm_id]).first
         end
       render :update do |page|
         page << javascript_prologue


### PR DESCRIPTION
This is a regression caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/3928 and enhanced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5345. The incoming `src_vm_id` can be both an array and an integer and the second case has been dropped by these PRs.

@miq-bot add_reviewer @PanSpagetka 
@miq-bot add_reviewer @alexander-demichev 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label bug, blocker, hammer/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1702164