### PR TITLE
Drop unnecessary optional argument from TreeBuilderAutomateInlineMethod

### DIFF
--- a/app/presenters/tree_builder_automate_inline_method.rb
+++ b/app/presenters/tree_builder_automate_inline_method.rb
@@ -1,5 +1,5 @@
 class TreeBuilderAutomateInlineMethod < TreeBuilderAutomateEntrypoint
-  def x_get_tree_class_kids(object, count_only, _type)
+  def x_get_tree_class_kids(object, count_only)
     count_only_or_objects(count_only, object.ae_methods.where(:location => 'inline'), %i[display_name name])
   end
 end


### PR DESCRIPTION
This argument is not necessary and causes and exception as the `has_kids_for` definition doesn't emit the type.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label bug, trees, cleanup, hammer/no