### PR TITLE
Move the conditional node-to-model into the treebuilder subclasses

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -27,14 +27,11 @@ class TreeBuilder
   def node_by_tree_id(id)
     model, rec_id, prefix = self.class.extract_node_model_and_id(id)
 
-    if model == "Hash"
+    case model
+    when 'Hash' # create a fake hash node
       {:type => prefix, :id => rec_id, :full_id => id}
-    elsif model.nil? && %i[sandt svccat stcat].include?(@type)
-      # Creating empty record to show items under unassigned catalog node
-      ServiceTemplateCatalog.new
-    elsif model.nil? && [:configuration_manager_providers_tree].include?(@name)
-      # Creating empty record to show items under unassigned catalog node
-      ConfigurationProfile.new
+    when nil # no model, probably super() called from a redefinition
+      nil
     else
       model.constantize.find(rec_id)
     end

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -4,6 +4,11 @@ class TreeBuilderCatalogsClass < TreeBuilder
 
   private
 
+  def node_by_tree_id(id)
+    # Creating empty record to show items under unassigned catalogs
+    super(id) || ServiceTemplateCatalog.new
+  end
+
   def x_get_tree_roots(count_only, _options)
     count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
   end

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -27,6 +27,11 @@ class TreeBuilderConfigurationManager < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
+  def node_by_tree_id(id)
+    # Creating empty record to show items under unassigned profiles group
+    super(id) || ConfigurationProfile.new
+  end
+
   def x_get_tree_cmf_kids(object, count_only)
     assigned_configuration_profile_objs =
       count_only_or_objects_filtered(count_only,


### PR DESCRIPTION
When lazy-loading the tree, there is necessary to have an object for `x_get_child_nodes` which will allow us to expand its children. However, the unassigned groups aren't real objects in the DB and in catalog/foreman trees they're added via a hack. I'm moving this hack from the main tree builder to the subclasses and so dropping some extra conditions.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, refactoring, hammer/no