### PR TITLE
Do not modify the tree type on catalog entrypoint lazy load

### DIFF
--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -11,9 +11,6 @@ module ApplicationController::TreeSupport
     tree_type = tree_name.to_s.sub(/_tree$/, '').to_sym
     tree_klass = x_tree(tree_name)[:klass_name]
 
-    # FIXME after euwe: build_ae_tree
-    tree_type = :catalog if controller_name == 'catalog' && tree_type == :automate
-
     nodes = TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
                                              :klass_name => tree_klass,
                                              :name       => tree_name,


### PR DESCRIPTION
This line is no longer necessary since there are two separate trees for catalog entrypoint selection and automate copying.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, hammer/no, cleanup