### PR TITLE
Display missing flash messages for tagging in Container Provider Dashboard

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -1,4 +1,4 @@
-#flash_msg_div
+= render :partial => "layouts/flash_msg"
 .container-fluid.container-tiles-pf.containers-dashboard
   .row.row-tile-pf
     = render :partial => "ems_container/aggregate-status-card"

--- a/app/views/ems_container/show_dashboard.html.haml
+++ b/app/views/ems_container/show_dashboard.html.haml
@@ -1,1 +1,2 @@
-= render :partial => "show_dashboard"
+#main_div
+  = render :partial => "show_dashboard"


### PR DESCRIPTION
**Fixes BZ:**
https://bugzilla.redhat.com/show_bug.cgi?id=1667178

**What:**
This PR fixes/enables displaying missing flash messages for tagging in Container Provider Dashboard view.

**Steps to reproduce:**
1. Add an Openshift provider, if you don't have any
2. Navigate to _Compute > Containers > Providers_ and select some Openshift provider
3. Choose _Policy -> Edit Tags_
4. Add a tag and click on _Save_ or _Cancel_ button
=> no flash message on the dashboard!

**Additional info:**
No need to set and save any tag (step 4), you can just click on _Cancel_ button.
Flash message about canceling tagging should be displayed, and it was not displayed.
For Infra and Cloud providers, this works well.

---

**Before:** (canceling or editing tags - no flash message being displayed)
![before_tag](https://user-images.githubusercontent.com/13417815/56575316-b3bd4880-65c5-11e9-89fd-fe67d4472d76.png)

**After:**
Adding/editing tags for the provider:
![after1_tags](https://user-images.githubusercontent.com/13417815/56575325-b881fc80-65c5-11e9-841b-78b4bdd4d784.png)
Canceling editing tags:
![after2_cancel](https://user-images.githubusercontent.com/13417815/56575336-bc158380-65c5-11e9-9492-cc6cffc70935.png)

