### PR TITLE
Schedules spec - fix sporadic failure

### DIFF
--- a/spec/controllers/report_controller/schedules_spec.rb
+++ b/spec/controllers/report_controller/schedules_spec.rb
@@ -13,7 +13,6 @@ describe ReportController do
       FactoryBot.create(:miq_schedule, :name => "tester2")
 
       allow(controller).to receive(:assert_privileges)
-      allow(controller).to receive(:checked_or_params).and_return(MiqSchedule.all.ids)
       allow(controller).to receive(:replace_right_cell).and_return(true)
 
       timer = ReportHelper::Timer.new('hourly', 1, 1, 1, 1, Time.now.utc, '00', '00')
@@ -27,8 +26,8 @@ describe ReportController do
     end
 
     it "reset rbac testing" do
+      controller.instance_variable_set(:@_params, :button => "reset", :id => schedule.id)
       controller.send(:schedule_edit)
-      controller.instance_variable_set(:@_params, :button => "reset")
       expected_id = controller.instance_variable_get(:@schedule).id
       expect(expected_id).to eq(schedule.id)
     end


### PR DESCRIPTION
Fixes:

    Failures:
     1) ReportController#schedule_edit reset rbac testing
        Failure/Error: expect(expected_id).to eq(schedule.id)
          expected: 66000000000038
               got: 66000000000039
          (compared using ==)
        # ./spec/controllers/report_controller/schedules_spec.rb:33:in `block (3 levels) in <top (required)>'

this is happening because resetting a form means calling `checked_or_params` to get the id of the schedule being editted, but the function was mocked to always give all the schedules.

So the sporadic failure was happening when the right schedule was second in the list, instead of first :).

Cc @CZJanRichter (only if you're still interested :) )
`hammer/yes` because this came in https://github.com/ManageIQ/manageiq-ui-classic/pull/3884