### PR TITLE
Fix error when clicking on created Catalog Item in the list

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1860,7 +1860,7 @@ class CatalogController < ApplicationController
       parents = [:id => template_to_node_name(record)]
     else
       # Check for parent nodes missing from vandt tree and return them if any
-      parent_rec = ServiceTemplateCatalog.find(record.service_template_catalog_id)
+      parent_rec = ServiceTemplateCatalog.find_by(:id => record.service_template_catalog_id) # nil is a valid value
       parents = if parent_rec.nil?
                   [parent_rec, :id => "-Unassigned"]
                 else


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1702343

**What:**
This simple PR fixes issue about displaying Catalog Item's info (also Catalog Bundle's), when clicking on the Catalog Item from the list. In our case, `nil` is a valid value so we prefer using `find_by_id` instead of using `find`.

**Steps to reproduce:**
1. Go to _Services > Catalogs > Catalog Items_ accordion
2. _Configuration > Add a New Catalog Item_, choose some _Catalog Item type_
3. Fill in the required info and click on _Add_ button
4. After successful saving the Catalog Item, click on the same Catalog Item in the list,
  in _All Service Catalog Items screen_, to view its details
=> clicking on a newly created Catalog Item in the list throws an error, nothing happens in the UI, Catalog Item's summary screen is not displayed.
```
[----] F, [2019-04-23T15:52:30.005889 #23768:2ac1b3113290] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find ServiceTemplateCatalog with 'id'= /home/hstastna/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/core.rb:173:in `find' /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:1897:in `open_parent_nodes' /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:1947:in `replace_right_cell' /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:177:in `tree_select' /home/hstastna/manageiq/manageiq-ui-classic/app/controllers/catalog_controller.rb:278:in `x_show'
```

**Note:**
I need this BZ to be fixed for https://github.com/ManageIQ/manageiq-ui-classic/pull/5445,
otherwise it will not be possible to display Catalog Item info (with selected Tenants in the tree I am adding there) properly from the list.

---

Clicking on the Catalog Item from the list:
![clicking](https://user-images.githubusercontent.com/13417815/56599618-38748a80-65f7-11e9-8d6c-b7587729332f.png)

**Before:**
After Clicking on created Catalog Item, nothing happens:
![before_catitem](https://user-images.githubusercontent.com/13417815/56599822-ae78f180-65f7-11e9-8f8b-6a1e65a9c0cd.png)

**After:**
Displaying created Catalog Item's info:
![after_catitem](https://user-images.githubusercontent.com/13417815/56599566-1a0e8f00-65f7-11e9-9e2c-b99493c5074b.png)
Displaying Catalog Bundle's info:
![after2_catbundle](https://user-images.githubusercontent.com/13417815/56599572-1d097f80-65f7-11e9-9af1-e44459cc3875.png)
