### PR TITLE
Add new Tagging instead of RBAC tree for groups

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -745,7 +745,7 @@ module OpsController::OpsRbac
 
   # AJAX driven routine to check for changes in ANY field on the form
   def rbac_field_changed(rec_type)
-    id = params[:id].split('__').first # Get the record id
+    id = params[:id].split('__').first || 'new' # Get the record id
     id = id unless %w[new seq].include?(id)
     return unless load_edit("rbac_#{rec_type}_edit__#{id}", "replace_cell__explorer")
 

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -928,7 +928,7 @@ module OpsController::OpsRbac
 
       assigned_tags.each_with_object([]) do |tag, arr|
         existing_tag = arr.find { |item| item[:id] == tag[:id] }
-        if item
+        if existing_tag
           existing_tag[:values].push(*tag[:values])
         else
           arr << tag

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { applyMiddleware } from 'redux'
 import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';
-import { TaggingWithButtonsConnected, taggingApp } from '@manageiq/react-ui-components/dist/tagging';
+import { TaggingWithButtonsConnected, TaggingConnected, taggingApp } from '@manageiq/react-ui-components/dist/tagging';
 import { http } from '../http_api';
 
 class TaggingWrapper extends React.Component {
@@ -21,7 +22,7 @@ class TaggingWrapper extends React.Component {
 
   render() {
     if (!this.props.isLoaded) return <Spinner loading size="lg" />;
-    const { urls } = this.props;
+    const { urls, options } = this.props;
     return (<TaggingWithButtonsConnected
       saveButton={{
         // don't replace $.post with http.post
@@ -51,6 +52,7 @@ class TaggingWrapper extends React.Component {
         description: 'Reset',
         }
       }
+      options={{...options}}
     />);
   }
 }

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { applyMiddleware } from 'redux'
 import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';
 import { TaggingWithButtonsConnected, TaggingConnected, taggingApp } from '@manageiq/react-ui-components/dist/tagging';

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -23,7 +23,7 @@ class TaggingWrapper extends React.Component {
   render() {
     if (!this.props.isLoaded) return <Spinner loading size="lg" />;
     const { urls, options } = this.props;
-    return (<TaggingWithButtonsConnected
+    return (options && options.hideButtons && <TaggingConnected options={{...options}}/> || <TaggingWithButtonsConnected
       saveButton={{
         // don't replace $.post with http.post
           onClick: (assignedTags) => {

--- a/app/javascript/miq-redux/middleware.js
+++ b/app/javascript/miq-redux/middleware.js
@@ -2,8 +2,23 @@ import thunk from 'redux-thunk';
 import { routerMiddleware } from 'connected-react-router';
 import promiseMiddleware from 'redux-promise-middleware';
 
+const taggingMiddleware = store => next => action => {
+  const { type, meta, tagCategory, tag } = action;
+  if (meta && meta.url) {
+    const params = {id: store.getState().tagging.appState.affectedItems[0], cat: tag.tagCategory.id, val: tag.tagValue.id, check: 1, tree_typ: 'tags' };
+    if (type === 'UI-COMPONENTS_TAGGING_TOGGLE_TAG_VALUE_CHANGE') {
+      $.post(meta.url, params)
+    } else if (type === 'UI-COMPONENTS_TAGGING_DELETE_ASSIGNED_TAG') {
+      $.post(meta.url, {...params, check: 0})
+    }
+  }
+  let result = next(action)
+  return result;
+}
+
 export default history => [
   routerMiddleware(history),
+  taggingMiddleware,
   thunk,
   promiseMiddleware(),
 ];

--- a/app/javascript/miq-redux/middleware.js
+++ b/app/javascript/miq-redux/middleware.js
@@ -2,7 +2,7 @@ import thunk from 'redux-thunk';
 import { routerMiddleware } from 'connected-react-router';
 import promiseMiddleware from 'redux-promise-middleware';
 
-const taggingMiddleware = store => next => action => {
+export const taggingMiddleware = store => next => action => {
   const { type, meta, tagCategory, tag } = action;
   if (meta && meta.url) {
     const params = {id: store.getState().tagging.appState.affectedItems[0], cat: tag.tagCategory.id, val: tag.tagValue.id, check: 1, tree_typ: 'tags' };

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -14,7 +14,7 @@ import ImportDatastoreViaGit from '../components/automate-import-export-form/imp
 import VmServerRelationshipForm from '../components/vm-server-relationship-form';
 import CatalogForm from '../components/catalog-form/catalog-form';
 import Breadcrumbs from '../components/breadcrumbs';
-import { taggingApp } from '@manageiq/react-ui-components/dist/tagging';
+import { taggingApp, TagView } from '@manageiq/react-ui-components/dist/tagging';
 import TaggingWrapperConnected from '../components/taggingWrapper';
 import '@manageiq/react-ui-components/dist/tagging.css';
 import RemoveCatalogItemModal from '../components/remove-catalog-item-modal.jsx';
@@ -43,4 +43,5 @@ ManageIQ.component.addReact('VmServerRelationshipForm', VmServerRelationshipForm
 ManageIQ.component.addReact('CatalogForm', CatalogForm);
 ManageIQ.component.addReact('Breadcrumbs', Breadcrumbs);
 ManageIQ.component.addReact('TaggingWrapperConnected', TaggingWrapperConnected);
+ManageIQ.component.addReact('TagView', TagView);
 ManageIQ.component.addReact('RemoveCatalogItemModal', RemoveCatalogItemModal);

--- a/app/javascript/spec/miq-redux/middleware.spec.js
+++ b/app/javascript/spec/miq-redux/middleware.spec.js
@@ -1,0 +1,55 @@
+import { taggingMiddleware } from '../../miq-redux/middleware'; //this is your middleware
+// const next = jest.fn(); // middleware needs those as parameters, usually calling next(action) at the end to proceed
+// const store = jest.fn();
+
+
+it('passes the intercepted action to next', () => {
+
+  const next = jest.fn(); // middleware needs those as parameters, usually calling next(action) at the end to proceed
+  const store = jest.fn();
+  const spy = jest.spyOn(window.$, 'post')
+  const action = { type: 'ACTION_TYPE', payload: { data: 'test' }}
+  taggingMiddleware(store)(next)(action);
+  expect(next.mock.calls).toEqual([[{'payload': { data: 'test'}, type: 'ACTION_TYPE'}]]);
+  expect(spy.mock.calls).toEqual([]);
+});
+
+
+it('calls post for UI-COMPONENTS_TAGGING_TOGGLE_TAG_VALUE_CHANGE action', () => {
+
+  const next = jest.fn(); // middleware needs those as parameters, usually calling next(action) at the end to proceed
+  const spy = jest.spyOn(window.$, 'post')
+  const store = {
+    getState: () => ({
+      tagging: {
+        appState: {
+          affectedItems: [{}]
+        }
+      }
+    })
+  };
+  const action = { type: 'UI-COMPONENTS_TAGGING_TOGGLE_TAG_VALUE_CHANGE', meta: { url: 'url/bla' }, tag: {tagCategory: {id: 1}, tagValue: { id:2 }}}
+  taggingMiddleware(store)(next)(action);
+  expect(next.mock.calls).toEqual( [[{"meta": {"url": "url/bla"}, "tag": {"tagCategory": {"id": 1}, "tagValue": {"id": 2}}, "type": "UI-COMPONENTS_TAGGING_TOGGLE_TAG_VALUE_CHANGE"}]]);
+  expect(spy).toHaveBeenCalledWith("url/bla", {"cat": 1, "check": 1, "id": {}, "tree_typ": "tags", "val": 2});
+});
+
+
+it('calls post for UI-COMPONENTS_TAGGING_DELETE_ASSIGNED_TAG action', () => {
+
+  const next = jest.fn(); // middleware needs those as parameters, usually calling next(action) at the end to proceed
+  const spy = jest.spyOn(window.$, 'post')
+  const store = {
+    getState: () => ({
+      tagging: {
+        appState: {
+          affectedItems: [{}]
+        }
+      }
+    })
+  };
+  const action = { type: 'UI-COMPONENTS_TAGGING_DELETE_ASSIGNED_TAG', meta: { url: 'url/bla' }, tag: {tagCategory: {id: 1}, tagValue: { id:2 }}};
+  taggingMiddleware(store)(next)(action);
+  expect(next.mock.calls).toEqual( [[{"meta": {"url": "url/bla"}, "tag": {"tagCategory": {"id": 1}, "tagValue": {"id": 2}}, "type": 'UI-COMPONENTS_TAGGING_DELETE_ASSIGNED_TAG'}]]);
+  expect(spy).toHaveBeenCalledWith("url/bla", {"cat": 1, "check": 0, "id": {}, "tree_typ": "tags", "val": 2});
+});

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -40,7 +40,6 @@
 -# use miqAjaxButton with observeQueue: true (waits for miq-observe inputs first)
 - observe_queue ||= false
 
-
 %div{:style => 'padding-top: 5px'}
   - if action_url && !export_button
     #buttons_on{:style => session[:changed] ? "" : "display: none;"}

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -27,4 +27,7 @@
     = _("This user is limited to items with the selected tags.")
     %br
     %br
-    = react 'TagView', { :assignedTags => @tags[:assignedTags] }
+    - if @tags[:assignedTags].blank?
+      = _('There are not tags assigned to this group.')
+    - else
+      = react 'TagView', { :assignedTags => @tags[:assignedTags] }

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -20,7 +20,7 @@
     - if @edit[:new][:use_filter_expression]
       = render(:partial => "layouts/group_filter_expression")
     - else
-      = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
+      = react 'TaggingWrapperConnected', { :tags => @tags, :urls => @button_urls }
   - elsif @use_filter_expression
     = render(:partial => "layouts/group_filter_expression")
   - else

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -27,4 +27,4 @@
     = _("This user is limited to items with the selected tags.")
     %br
     %br
-    = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
+    = react 'TagView', { :assignedTags => @tags[:assignedTags] }

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -20,7 +20,7 @@
     - if @edit[:new][:use_filter_expression]
       = render(:partial => "layouts/group_filter_expression")
     - else
-      = react 'TaggingWrapperConnected', { :tags => @tags, :urls => @button_urls }
+      = react 'TaggingWrapperConnected', { :tags => @tags, :urls => @button_urls, :options => { :hideHeaders => true, :hideButtons => true,  :url => url_for_only_path(:action => 'rbac_group_field_changed')} }
   - elsif @use_filter_expression
     = render(:partial => "layouts/group_filter_expression")
   - else
@@ -30,4 +30,4 @@
     - if @tags[:assignedTags].blank?
       = _('There are not tags assigned to this group.')
     - else
-      = react 'TagView', { :assignedTags => @tags[:assignedTags] }
+      = react 'TagView', { :assignedTags => @tags[:assignedTags], :hideHeader => true }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@data-driven-forms/pf3-component-mapper": "^1.9.9",
     "@data-driven-forms/react-form-renderer": "^1.9.9",
     "@manageiq/ui-components": "~1.2.4",
-    "@manageiq/react-ui-components": "~0.11.9",
+    "@manageiq/react-ui-components": "~0.11.14",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -306,6 +306,8 @@ describe OpsController do
   end
 
   describe "::MiqGroup" do
+    let(:classification) { FactoryBot.create(:classification, :name => "department", :description => "Department") }
+    let(:tag) { FactoryBot.create(:classification_tag, :name => "tag1", :parent => classification) }
     before do
       MiqUserRole.seed
       MiqGroup.seed
@@ -327,16 +329,17 @@ describe OpsController do
 
     it "saves the filters when use_filter_expression is false" do
       @group.entitlement = Entitlement.create!
+      allow(controller).to receive(:params).and_return({'data' => get_tags_json([tag])})
       controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,
                                                         :name                  => 'Name',
                                                         :description           => "Test",
                                                         :role                  => @role.id,
                                                         :filter_expression     => @exp.exp,
                                                         :belongsto             => {},
-                                                        :filters               => {'managed/env' => '/managed/env'}})
+                                                        :filters               => {'managed/department' => '/managed/department/tag1'}})
       controller.send(:rbac_group_set_record_vars, @group)
       expect(@group.entitlement.filter_expression).to be_nil
-      expect(@group.entitlement.get_managed_filters).to match([["/managed/env"]])
+      expect(@group.entitlement.get_managed_filters).to match([["/managed/department/tag1"]])
     end
 
     it "saves the filter_expression when use_filter_expression true" do
@@ -386,6 +389,7 @@ describe OpsController do
 
       post :tree_select, :params => { :id => 'root', :format => :js }
       expect(MiqExpression).to receive(:tag_details)
+
       post :exp_token_pressed, :params => {:id => 'new', :use_filter_expression => "true", :token => 1}
       @edit = controller.instance_variable_get(:@edit)
       expect(@edit[:filter_expression][:exp_typ]).to eq('tags')
@@ -424,7 +428,8 @@ describe OpsController do
       post :rbac_group_field_changed, :params => { :id => 'new', :use_filter_expression => "true"}
     end
 
-    it "initializes the group record and tag tree when switching tabs" do
+    it "initializes the group record when switching tabs" do
+      allow(controller).to receive(:url_for_only_path).and_return("")
       controller.instance_variable_set(:@edit,
                                        :group_id => @group.id,
                                        :new      => {:use_filter_expression => true,
@@ -433,12 +438,11 @@ describe OpsController do
                                                      :role                  => @role.id,
                                                      :filter_expression     => @exp.exp,
                                                      :belongsto             => {},
-                                                     :filters               => {'managed/env' => '/managed/env'}})
+                                                     :filters               => {'managed/department' => '/managed/department/tag1'}})
       controller.instance_variable_set(:@sb, :active_rbac_group_tab => 'rbac_customer_tags')
       controller.instance_variable_set(:@_params, :use_filter_expression => "false", :id => @group.id)
       controller.send(:rbac_group_get_form_vars)
       expect(controller.instance_variable_get(:@group).name).to eq(@group.name)
-      expect(controller.instance_variable_get(:@tags_tree)).to_not be_nil
     end
 
     context 'setting group record variables to new values' do
@@ -449,11 +453,6 @@ describe OpsController do
                                                           :filter_expression     => @exp.exp,
                                                           :belongsto             => {},
                                                           :filters               => {}})
-      end
-
-      it 'resets filter expression variable to default value' do
-        controller.send(:rbac_group_set_record_vars, @group)
-        expect(edit[:new][:filter_expression]).to eq({})
       end
     end
   end

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -329,7 +329,7 @@ describe OpsController do
 
     it "saves the filters when use_filter_expression is false" do
       @group.entitlement = Entitlement.create!
-      allow(controller).to receive(:params).and_return({'data' => get_tags_json([tag])})
+      allow(controller).to receive(:params).and_return('data' => get_tags_json([tag]))
       controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,
                                                         :name                  => 'Name',
                                                         :description           => "Test",


### PR DESCRIPTION
Add new Tagging instead of RBAC tree for groups

Links [Optional]
----------------
https://github.com/ManageIQ/react-ui-components/pull/105

Steps for Testing/QA [Optional]
-------------------------------
Go to Ops -> Account Settings -> Groups
Old:
![Screenshot from 2019-04-30 15-18-46](https://user-images.githubusercontent.com/9535558/56964434-7e7fa000-6b5b-11e9-8ab1-83179f4279ff.png)
![Screenshot from 2019-04-30 15-18-08](https://user-images.githubusercontent.com/9535558/56964471-90614300-6b5b-11e9-9f4c-10cd6a7d0830.png)
New:
![Screenshot from 2019-04-30 15-12-35](https://user-images.githubusercontent.com/9535558/56964496-948d6080-6b5b-11e9-9e39-43efdb5a5afb.png)
![Screenshot-from-2019-05-02-11-44-13](https://user-images.githubusercontent.com/9535558/57067692-fcfd4e80-6ccf-11e9-9f9b-ff3b2f38e6c1.png)


@skateman 
