### PR TITLE
Report editor - available fields - make opening faster

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1168,12 +1168,12 @@ function miqSerializeField(element, fieldName) {
   return $('#' + element + ' :input[id=' + fieldName + ']').serialize();
 }
 
-function miqInitSelectPicker() {
-  $('.selectpicker').selectpicker({
+function miqInitSelectPicker(selector, options) {
+  $(selector || '.selectpicker').selectpicker(Object.assign({
     size: 10,
     dropupAuto: false,
     noneSelectedText: __('Nothing selected'),
-  });
+  }, options || {}));
   $('.bootstrap-select > button[title]').not('.selectpicker').tooltip({container: 'none'});
 }
 

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -13,12 +13,11 @@
           "data-width"       => "850px",
           "data-live-search" => "true",
           "data-live-search-focus" => "false",
-          :class             => 'selectpicker',
           :style             => "overflow-x: scroll;",
           :id                => "available_fields",
           :title             => "&lt;#{_('Choose one or more Fields')}&gt;")
         :javascript
-          miqInitSelectPicker();
+          miqInitSelectPicker('#available_fields', {size: false});
       %td
     %tr
       %td.text-center{:style => "padding-top: 15px;"}


### PR DESCRIPTION
CI > Reports > Reports accordion, Configuration > Add a New Report; Columns tab

Right now, opening the "Available fields" select in report editor takes time:

![](http://g.recordit.co/boeSXebM3Y.gif)

It *looks* like a big chunk of that time is spent in `setSize`, which computes the size of the opened dropdown.

This PR makes it skip the computation for that one select, meaning it always opens all the options when expanded, but opens them right away.
The idea being that it's probably acceptable to do that if it saves multiple seconds when opening.

(The underlying cause is that we're talking 4000 `<option>` elements in that one select, while the data for those options is clearly hierarchical (under 350 nodes per level). This should be replaced by a tree or something similar when redesigning.)

Cc @epwinchell , @terezanovotna 