### PR TITLE
Menu Simplification: Drop the Optimize section

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -243,13 +243,6 @@ module Menu
         ].compact)
       end
 
-      def optimize_menu_section
-        Menu::Section.new(:opt, N_("Optimize"), 'pficon pficon-optimize', [
-          Menu::Item.new('miq_capacity_planning',    N_('Planning'),    'planning',    {:feature => 'planning'},    '/planning'),
-          Menu::Item.new('miq_capacity_bottlenecks', N_('Bottlenecks'), 'bottlenecks', {:feature => 'bottlenecks'}, '/bottlenecks')
-        ])
-      end
-
       def alerts_menu_section
         Menu::Section.new(:monitor_alerts, N_("Alerts"), 'fa fa-bullhorn-o fa-2x', [
                             Menu::Item.new('monitor_alerts_overview', N_('Overview'), 'monitor_alerts_overview', {:feature => 'monitor_alerts_overview', :any => true}, '/alerts_overview/show'),
@@ -298,7 +291,7 @@ module Menu
       def default_menu
         [cloud_inteligence_menu_section, services_menu_section, compute_menu_section, configuration_menu_section,
          network_menu_section, storage_menu_section, control_menu_section, automation_menu_section,
-         optimize_menu_section, monitor_menu_section, settings_menu_section, graphql_menu_section, help_menu_section].compact
+         monitor_menu_section, settings_menu_section, graphql_menu_section, help_menu_section].compact
       end
 
       private

--- a/spec/presenters/tree_builder_ops_rbac_features_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_features_spec.rb
@@ -38,7 +38,7 @@ describe TreeBuilderOpsRbacFeatures do
       expect(bs_tree).not_to be_nil
     end
 
-    %w(aut compute con conf net opt set sto svc vi).each do |i|
+    %w(aut compute con conf net set sto svc vi).each do |i|
       it "includes #{i}" do
         expect(main_keys).to include("100000002___tab_#{i}")
       end


### PR DESCRIPTION
As `Utilization` [went](https://github.com/ManageIQ/manageiq-ui-classic/pull/5448) into the `Cloud Intel` and the remaining two items under `Optimize` will also [go away](https://github.com/ManageIQ/manageiq-ui-classic/pull/5430), I am dropping the menu section completely. Sorry @GregP for the caused merge conflicts, we got these colliding RFEs, but it's just deletion, so probably easy to rebase.

**Before:**
![Screenshot from 2019-04-24 16-46-07](https://user-images.githubusercontent.com/649130/56668832-80a3b380-66b0-11e9-9fe1-2640e6877ea6.png)
**After:**
![Screenshot from 2019-04-24 16-45-50](https://user-images.githubusercontent.com/649130/56668831-80a3b380-66b0-11e9-978a-e8a686dbc246.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label ux/review, hammer/no

https://bugzilla.redhat.com/show_bug.cgi?id=1678196