### PR TITLE
prov_vm_grid: fix first row length

### DIFF
--- a/app/views/miq_request/_prov_vm_grid.html.haml
+++ b/app/views/miq_request/_prov_vm_grid.html.haml
@@ -24,15 +24,7 @@
           %tr{:class => cls, :onclick => "miqAjax('/miq_request/prov_field_changed/?#{field_id}=__VM__NONE__&id=#{id}');"}
             %td
               = "<#{_('None')}>"
-            %td
-            %td
-            %td
-            %td
-            %td
-            %td
-            %td
-            %td
-            - if @edit[:vm_headers].key? 'cloud_tenant'
+            - (@edit[:vm_headers].length - 1).times do
               %td
 
         - @vms.each do |row|


### PR DESCRIPTION
We can derive number of table columns from `@edit[:vm_headers]`: it will work for various catalog item types.

Before:
![tab-before](https://user-images.githubusercontent.com/6648365/56674190-df215f80-66b9-11e9-9120-e0b8fc02e3cf.png)


After:
![tab-after](https://user-images.githubusercontent.com/6648365/56674207-e47eaa00-66b9-11e9-80fc-6b47667e91a6.png)
