### PR TITLE
Correctly highlight <None> row when provisioning template deleted

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -855,6 +855,10 @@ module ApplicationController::MiqRequestMethods
         end
       end
       @edit[:new][:src_vm_id] = [nil, nil] unless @edit[:new][:src_vm_id]
+      # Check that the provisioning template exists
+      if @edit[:wf].request_type == 'template' && @edit[:new][:src_vm_id][0].present?
+        @edit[:new][:src_vm_id][0] = nil if MiqTemplate.exists?(@edit[:new][:src_vm_id][0])
+      end
       @edit[:new][tag_symbol_for_workflow] ||= [] # Initialize for new record
       @edit[:current] ||= {}
       @edit[:current] = copy_hash(@edit[:new])


### PR DESCRIPTION
1. Create catalog item (VMware for example), remember the selected provisioning template
2. Delete the provisioning template chosen in step 1
3. Try to edit the catalog item from step 1

Before:
![orphaned-before](https://user-images.githubusercontent.com/6648365/56731634-3deae580-675b-11e9-90ba-47aa3123f5e3.png)


After:
![orphaned-after](https://user-images.githubusercontent.com/6648365/56731642-43e0c680-675b-11e9-8eff-04589841053f.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1356086