### PR TITLE
Replace x_tree[:type] with x_tree[:name] and remove type from sandbox

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -255,7 +255,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def filtering?
-    %w[automation_manager_cs_filter configuration_scripts].include?(x_tree[:type].to_s)
+    %w[automation_manager_cs_filter_tree configuration_scripts_tree].include?(x_tree[:tree].to_s)
   end
 
   def provider_node(id, model)

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -262,7 +262,7 @@ class ProviderForemanController < ApplicationController
                 end
               end
     @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present?
-    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :configuration_manager_cs_filter && @edit && @edit[:adv_search_applied]
+    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:tree] == :configuration_manager_cs_filter_tree && @edit && @edit[:adv_search_applied]
 
     if @edit && @edit.fetch_path(:adv_search_applied, :qs_exp) # If qs is active, save it in history
       x_history_add_item(:id     => x_node,

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -193,12 +193,12 @@ class StorageController < ApplicationController
     session[:edit] = @edit
     @explorer = true
 
-    if x_tree[:type] != :storage || x_node == "root"
+    if x_tree[:tree] != :storage_tree || x_node == "root"
       listnav_search_selected(0)
     else
       @nodetype, id = parse_nodetype_and_id(valid_active_node(x_node))
 
-      if x_tree[:type] == :storage && (@nodetype == "root" || @nodetype == "ms")
+      if x_tree[:tree] == :storage_tree && (@nodetype == "root" || @nodetype == "ms")
         search_id = @nodetype == "root" ? 0 : id
         listnav_search_selected(search_id) unless params.key?(:search_text) # Clear or set the adv search filter
         if @edit[:adv_search_applied] &&
@@ -478,7 +478,7 @@ class StorageController < ApplicationController
 
   def set_right_cell_text
     @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && @nodetype != 'ds'
-    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:type] == :storage && @edit && @edit[:adv_search_applied]
+    @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:tree] == :storage_tree && @edit && @edit[:adv_search_applied]
   end
 
   def textual_group_list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1149,23 +1149,25 @@ module ApplicationHelper
   end
 
   def tree_with_advanced_search?
-    %i[automation_manager_providers
-       automation_manager_cs_filter
-       configuration_manager_cs_filter
-       configuration_scripts
-       configuration_manager_providers
-       images
-       images_filter
-       instances
-       instances_filter
-       providers
-       storage
-       svcs
-       templates_filter
-       templates_images_filter
-       vandt
-       vms_filter
-       vms_instances_filter].include?(x_tree[:type])
+    %i[
+      automation_manager_providers_tree
+      automation_manager_cs_filter_tree
+      configuration_manager_cs_filter_tree
+      configuration_scripts_tree
+      configuration_manager_providers_tree
+      images_tree
+      images_filter_tree
+      instances_tree
+      instances_filter_tree
+      providers_tree
+      storage_tree
+      svcs_tree
+      templates_filter_tree
+      templates_images_filter_tree
+      vandt_tree
+      vms_filter_tree
+      vms_instances_filter_tree
+    ].include?(x_tree[:tree])
   end
 
   def fonticon_or_fileicon(item)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -167,7 +167,6 @@ class TreeBuilder
     @tree_state.add_tree(
       @options.reverse_merge(
         :tree       => @name,
-        :type       => type,
         :klass_name => self.class.name,
         :open_nodes => []
       )

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -436,7 +436,7 @@ describe StorageController do
 
       context 'using Advanced Search' do
         before do
-          allow(controller).to receive(:x_tree).and_return(:type => :storage)
+          allow(controller).to receive(:x_tree).and_return(:tree => :storage_tree)
           allow(controller).to receive(:valid_active_node).and_return('ms-1')
           controller.instance_variable_set(:@edit, :adv_search_applied => {:text => " - Filtered by \"Filter1\""})
         end

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -5,7 +5,6 @@ describe TreeBuilderAeCustomization do
     let(:expected_sandbox_values) do
       {
         :tree        => :dialog_import_export_tree,
-        :type        => :dialog_import_export,
         :klass_name  => "TreeBuilderAeCustomization",
         :open_nodes  => [],
         :open_all    => true,


### PR DESCRIPTION
I'd like to get rid of the `type` vs `name` duality in `TreeBuilder` and for that we should not reference the `type` in the sandbox at all. Since https://github.com/ManageIQ/manageiq-ui-classic/pull/5426 the `name` and `type` differs from each other in the `_tree` suffix only. Therefore, it's now possible to add the suffix to every check that works with `x_tree[:type]` and replace it with `x_tree[:name]`.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, refactoring, hammer/no