### PR TITLE
Fix breadcrumbs on request page

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -89,6 +89,7 @@ class MiqRequestController < ApplicationController
     identify_request
     return if record_no_longer_exists?(@miq_request)
     @display = params[:display] || "main" unless pagination_or_gtl_request?
+    @gtl_url = "/show"
 
     if @display == "main"
       prov_set_show_vars
@@ -538,19 +539,21 @@ class MiqRequestController < ApplicationController
   end
 
   def breadcrumbs_options
-    if params[:typ] == "ae"
+    if @layout == "miq_request_ae" || @record&.type == "AutomationRequest"
       {
-        :breadcrumbs => [
+        :breadcrumbs  => [
           {:title => _("Automation")},
-          {:title => _("Automate")},
+          {:title => _("Automate"), :url => controller_url},
         ],
+        :record_title => :description,
       }
-    elsif params[:typ] == "service"
+    else
       {
-        :breadcrumbs => [
+        :breadcrumbs  => [
           {:title => _("Services")},
-          {:title => _("Requests")},
+          {:title => _("Requests"), :url => controller_url},
         ],
+        :record_title => :description,
       }
     end
   end

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -49,7 +49,7 @@ module Mixins
 
     def build_breadcrumbs_no_explorer(record_info, record_title)
       if record_info[record_title]
-        breadcrumb_url = url(controller_url, gtl_url, record_info[:id])
+        breadcrumb_url = url(controller_url, @gtl_url || gtl_url, record_info[:id])
         {:url => breadcrumb_url, :title => record_info[record_title]}
       end
     end

--- a/app/javascript/components/breadcrumbs/index.js
+++ b/app/javascript/components/breadcrumbs/index.js
@@ -40,12 +40,13 @@ class Breadcrumbs extends Component {
     const {
       items, title, controllerName, ...rest
     } = this.props;
+
     return (
       <Breadcrumb style={{ marginBottom: 0 }} {...rest}>
         {items && this.renderItems()}
         <Breadcrumb.Item active>
           <strong>
-            {items ? parsedText(items[items.length - 1].title) : parsedText(title)}
+            {items && items.length > 0 ? parsedText(items[items.length - 1].title) : parsedText(title)}
           </strong>
         </Breadcrumb.Item>
       </Breadcrumb>


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5490

**Steps to reproduce**

go to `/miq_request/show/[id]`

- Miq_report_controller is used at two places in MiQ so there is a (probably) wrong condition how to get know which place it is (it is asking for params)
- That means on Request page it doesn't know where the page is (so menu breadcrumbs are missing)
- The React component gets an empty array and tries to render a title of the last item in the empty array... and it fails. :ghost:

**Before**

![image](https://user-images.githubusercontent.com/32869456/56753353-abfad100-678a-11e9-866c-7c3141c2e2c8.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/56753367-b321df00-678a-11e9-961a-d6a130380c24.png)

TO-DO

- [x] See how it is behaves on requests selected from `automation` > `automate` > `requests`

@miq-bot add_label bug