### PR TITLE
Correct argument in TreeBuilderStoragePods#x_get_tree_custom_kids

### DIFF
--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -31,7 +31,7 @@ class TreeBuilderStoragePod < TreeBuilder
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _type)
+  def x_get_tree_custom_kids(object, count_only, _options)
     objects = EmsFolder.find_by(:id => object[:id])&.storages
     count_only_or_objects(count_only, objects || [], "name")
   end


### PR DESCRIPTION
It should be `_options` instead of `_type` and it's anyway unused.

@miq-bot assign @h-kataria 
@miq-bot add_label technical debt, trees, hammer/no