### PR TITLE
Remove the second (type) argument from TreeBuilder classes

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -192,7 +192,7 @@ module ApplicationController::AdvancedSearch
     elsif @edit[:in_explorer] || %w[storage_tree configuration_scripts_tree svcs_tree].include?(x_active_tree.to_s)
       tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
       builder = TreeBuilder.class_for_type(tree_type)
-      tree = builder.new(x_active_tree, tree_type, @sb)
+      tree = builder.new(x_active_tree, @sb)
       if tree_for_building_accordions?
         @explorer = true
         build_accordions_and_trees

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -155,7 +155,7 @@ module ApplicationController::Automate
     @resolve[:uri] = options[:uri]
     @resolve[:ae_result] = ws.root['ae_result']
     @resolve[:state_attributes] = ws.root['ae_result'] == 'retry' ? state_attributes(ws) : {}
-    @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, @sb, true, :root => @results)
+    @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, @sb, true, :root => @results)
   end
 
   def state_attributes(ws)

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -43,8 +43,7 @@ module ApplicationController::Compare
       @items_per_page = params[:ppsetting].to_i # Set the new per page value
     end
     @compare = create_compare_view
-    @sections_tree = TreeBuilderSections.new(:all_sections,
-                                             :all_sections_tree,
+    @sections_tree = TreeBuilderSections.new(:all_sections_tree,
                                              @sb,
                                              true,
                                              :data            => @compare,
@@ -365,7 +364,6 @@ module ApplicationController::Compare
     @lastaction = "drift"
     @compare = create_drift_view
     @sections_tree = TreeBuilderSections.new(
-      :all_sections,
       :all_sections_tree,
       @sb,
       true,

--- a/app/controllers/application_controller/feature.rb
+++ b/app/controllers/application_controller/feature.rb
@@ -23,7 +23,7 @@ class ApplicationController
     def build_tree(sandbox)
       builder = TreeBuilder.class_for_type(name)
       raise _("No TreeBuilder found for feature '%{name}'") % {:name => name} unless builder
-      builder.new(tree_name.to_sym, name, sandbox)
+      builder.new(tree_name.to_sym, sandbox)
     end
 
     def self.allowed_features(features)

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -176,7 +176,7 @@ module ApplicationController::PolicySupport
   def protect_build_tree
     @edit[:controller_name] = controller_name
     @edit[:pol_items] = session[:pol_items]
-    @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, @sb, true, :data => @edit)
+    @protect_tree = TreeBuilderProtect.new(:protect_tree, @sb, true, :data => @edit)
   end
 
   # Create policy assignment audit record

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -8,13 +8,11 @@ module ApplicationController::TreeSupport
 
   def tree_add_child_nodes(id)
     tree_name = (params[:tree] || x_active_tree).to_sym
-    tree_type = tree_name.to_s.sub(/_tree$/, '').to_sym
     tree_klass = x_tree(tree_name)[:klass_name]
 
     nodes = TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
                                              :klass_name => tree_klass,
                                              :name       => tree_name,
-                                             :type       => tree_type,
                                              :id         => id)
     TreeBuilder.convert_bs_tree(nodes)
   end

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -349,15 +349,15 @@ class AutomationManagerController < ApplicationController
   end
 
   def build_automation_manager_providers_tree(_type)
-    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, @sb)
+    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, @sb)
   end
 
   def build_automation_manager_cs_filter(_type)
-    TreeBuilderAutomationManagerConfiguredSystems.new(:automation_manager_cs_filter_tree, :automation_manager_cs_filter, @sb)
+    TreeBuilderAutomationManagerConfiguredSystems.new(:automation_manager_cs_filter_tree, @sb)
   end
 
   def build_configuration_scripts_tree(_type)
-    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, @sb)
+    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, @sb)
   end
 
   def rebuild_trees(replace_trees)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2081,22 +2081,22 @@ class CatalogController < ApplicationController
 
   # Build a Catalog Items explorer tree
   def build_sandt_tree
-    TreeBuilderCatalogItems.new('sandt_tree', 'sandt', @sb)
+    TreeBuilderCatalogItems.new('sandt_tree', @sb)
   end
 
   # Build a Services explorer tree
   def build_svccat_tree
-    TreeBuilderServiceCatalog.new('svccat_tree', 'svccat', @sb)
+    TreeBuilderServiceCatalog.new('svccat_tree', @sb)
   end
 
   # Build a Catalogs explorer tree
   def build_stcat_tree
-    TreeBuilderCatalogs.new('stcat_tree', 'stcat', @sb)
+    TreeBuilderCatalogs.new('stcat_tree', @sb)
   end
 
   # Build a Orchestration Templates explorer tree
   def build_ot_tree
-    TreeBuilderOrchestrationTemplates.new('ot_tree', 'ot', @sb)
+    TreeBuilderOrchestrationTemplates.new('ot_tree', @sb)
   end
 
   def show_record(id = nil)

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -331,7 +331,7 @@ class ChargebackController < ApplicationController
 
   # Build a Chargeback Reports explorer tree
   def cb_rpts_build_tree
-    TreeBuilderChargebackReports.new("cb_reports_tree", "cb_reports", @sb)
+    TreeBuilderChargebackReports.new("cb_reports_tree", @sb)
   end
 
   def cb_rpts_show_saved_report
@@ -481,12 +481,12 @@ class ChargebackController < ApplicationController
   end
 
   def cb_rates_build_tree
-    TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", @sb)
+    TreeBuilderChargebackRates.new("cb_rates_tree", @sb)
   end
 
   # Build a Catalog Items explorer tree
   def cb_assignments_build_tree
-    TreeBuilderChargebackAssignments.new("cb_assignments_tree", "cb_assignments", @sb)
+    TreeBuilderChargebackAssignments.new("cb_assignments_tree", @sb)
   end
 
   # Common Schedule button handler routines

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -509,7 +509,7 @@ class ConfigurationController < ApplicationController
         :set_filters => true,
         :current     => current,
       }
-      @df_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, :data => filters)
+      @df_tree = TreeBuilderDefaultFilters.new(:df_tree, @sb, true, :data => filters)
       self.x_active_tree = :df_tree
     when 'ui_4'
       @edit = {

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -39,7 +39,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def build_tree
-    @tree = TreeBuilderGenericObjectDefinition.new(:generic_object_definitions_tree, :generic_object_definitions, @sb)
+    @tree = TreeBuilderGenericObjectDefinition.new(:generic_object_definitions_tree, @sb)
   end
 
   def button

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -35,10 +35,10 @@ class HostController < ApplicationController
   def display_tree_resources
     @showtype = "config"
     title, tree = if @display == "network"
-                    @network_tree = TreeBuilderNetwork.new(:network_tree, :network, @sb, true, :root => @record)
+                    @network_tree = TreeBuilderNetwork.new(:network_tree, @sb, true, :root => @record)
                     [_("Network"), :network_tree]
                   else
-                    @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, @sb, true, :root => @record)
+                    @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, @sb, true, :root => @record)
                     [_("Storage Adapters"), :sa_tree]
                   end
     drop_breadcrumb(:name => "#{@record.name} (#{title})",

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -259,7 +259,7 @@ class MiqAeClassController < ApplicationController
   end
 
   def build_ae_tree
-    TreeBuilderAeClass.new(:ae, :ae_tree, @sb)
+    TreeBuilderAeClass.new(:ae, @sb)
   end
 
   def replace_right_cell(options = {})

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -416,15 +416,15 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def build_old_dialogs_tree
-    TreeBuilderProvisioningDialogs.new("old_dialogs_tree", "old_dialogs", @sb)
+    TreeBuilderProvisioningDialogs.new("old_dialogs_tree", @sb)
   end
 
   def build_dialogs_tree
-    TreeBuilderServiceDialogs.new("dialogs_tree", "dialogs", @sb)
+    TreeBuilderServiceDialogs.new("dialogs_tree", @sb)
   end
 
   def build_ab_tree
-    TreeBuilderButtons.new("ab_tree", "ab", @sb)
+    TreeBuilderButtons.new("ab_tree", @sb)
   end
 
   def group_button_add_save(typ)

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -310,7 +310,7 @@ module MiqPolicyController::MiqActions
   end
 
   def action_build_cat_tree
-    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, :action_tags, @sb, true, "#{current_tenant.name} Tags")
+    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, @sb, true, "#{current_tenant.name} Tags")
   end
 
   # Set action record variables to new values

--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -8,7 +8,7 @@ module MiqPolicyController::Rsop
         miq_task = MiqTask.find(params[:task_id]) # Not first time, read the task record
         if miq_task.results_ready?
           @sb[:rsop][:results] = miq_task.task_results
-          @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, :root => @sb[:rsop])
+          @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, @sb, true, :root => @sb[:rsop])
         else
           add_flash(_("Policy Simulation generation returned: %{error_message}") % {:error_message => miq_task.message}, :error)
         end
@@ -118,7 +118,7 @@ module MiqPolicyController::Rsop
       @sb[:rsop][:out_of_scope] = (params[:out_of_scope] == "1")
     end
     @sb[:rsop][:open] = false # reset the open state to select correct button in toolbar, need to replace partial to update checkboxes in form
-    @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, @sb, true, :root => @sb[:rsop])
+    @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, @sb, true, :root => @sb[:rsop])
     rsop_button_pressed
   end
 

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -49,7 +49,7 @@ module Mixins
       @showtype = "config"
 
       cluster = @record
-      @datacenter_tree = TreeBuilderVat.new(:vat_tree, :vat, @sb, true, :root => cluster, :vat => !!params[:vat])
+      @datacenter_tree = TreeBuilderVat.new(:vat_tree, @sb, true, :root => cluster, :vat => !!params[:vat])
       self.x_active_tree = :vat_tree
     end
 

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -143,7 +143,7 @@ module Mixins
       drop_breadcrumb(:name => _("%{name} (All VMs - Tree View)") % {:name => @record.name},
                       :url  => show_link(@record, :display => "descendant_vms", :treestate => true))
       self.x_active_tree = :datacenter_tree
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, @sb, true, :root => @record)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, @sb, true, :root => @record)
     end
 
     def display_all_vms

--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -35,7 +35,7 @@ module Mixins
     end
 
     def update_session_for_compliance_history
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, @sb, true, :root => @record)
     end
 
     def drop_breadcrumb_for_compliance_history(count)

--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -82,7 +82,7 @@ module OpsController::Db
 
   # Build a VMDB tree for Database accordion
   def build_vmdb_tree
-    TreeBuilderOpsVmdb.new("vmdb_tree", "vmdb", @sb)
+    TreeBuilderOpsVmdb.new("vmdb_tree", @sb)
   end
 
   # Get information for a DB tree node

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -854,9 +854,9 @@ module OpsController::Diagnostics
   # Method to build the server tree (parent is a zone or region instance)
   def build_server_tree(parent)
     @server_tree = if @sb[:diag_tree_type] == "roles"
-                     TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, :root => parent)
+                     TreeBuilderRolesByServer.new(:roles_by_server_tree, @sb, true, :root => parent)
                    else
-                     TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, :root => parent)
+                     TreeBuilderServersByRole.new(:servers_by_role_tree, @sb, true, :root => parent)
                    end
 
     # Pull out the selected node from the tree state and store it in the sandbox for future use
@@ -887,7 +887,7 @@ module OpsController::Diagnostics
   end
 
   def build_diagnostics_tree
-    TreeBuilderOpsDiagnostics.new("diagnostics_tree", "diagnostics", @sb)
+    TreeBuilderOpsDiagnostics.new("diagnostics_tree", @sb)
   end
 
   def build_supported_depots_for_select

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -817,7 +817,7 @@ module OpsController::OpsRbac
 
   # Build the main Access Control tree
   def build_rbac_tree
-    TreeBuilderOpsRbac.new("rbac_tree", "rbac", @sb)
+    TreeBuilderOpsRbac.new("rbac_tree", @sb)
   end
 
   # Get information for an access control node
@@ -903,7 +903,6 @@ module OpsController::OpsRbac
     case @sb[:active_rbac_group_tab]
     when 'rbac_customer_tags'
       @tags_tree = TreeBuilderTags.new(:tags_tree,
-                                       :tags,
                                        @sb,
                                        true,
                                        :edit    => @edit,
@@ -911,7 +910,6 @@ module OpsController::OpsRbac
                                        :group   => @group)
     when 'rbac_hosts_clusters'
       @hac_tree = TreeBuilderBelongsToHac.new(:hac_tree,
-                                              :hac,
                                               @sb,
                                               true,
                                               :edit           => @edit,
@@ -919,7 +917,6 @@ module OpsController::OpsRbac
                                               :selected_nodes => selected_nodes)
     when 'rbac_vms_templates'
       @vat_tree = TreeBuilderBelongsToVat.new(:vat_tree,
-                                              :vat,
                                               @sb,
                                               true,
                                               :edit           => @edit,
@@ -937,7 +934,7 @@ module OpsController::OpsRbac
   def build_rbac_feature_tree
     @role = @sb[:typ] == "copy" ? @record.dup : @record if @role.nil? # if on edit screen use @record
     @role.miq_product_features = @record.miq_product_features if @sb[:typ] == "copy"
-    TreeBuilderOpsRbacFeatures.new("features_tree", "features", @sb, true, :role => @role, :editable => @edit.present?)
+    TreeBuilderOpsRbacFeatures.new("features_tree", @sb, true, :role => @role, :editable => @edit.present?)
   end
 
   # Set form variables for role edit

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -126,8 +126,7 @@ module OpsController::Settings::CapAndU
       end
     end
     if @edit[:current][:clusters].present?
-      @cluster_tree = TreeBuilderClusters.new(:cluster,
-                                              :cluster_tree,
+      @cluster_tree = TreeBuilderClusters.new(:cluster_tree,
                                               @sb,
                                               true,
                                               :root => @edit[:current])
@@ -144,8 +143,7 @@ module OpsController::Settings::CapAndU
                                       :location   => s.location) # fields we need
     end
     if @edit[:current][:storages].present?
-      @datastore_tree = TreeBuilderDatastores.new(:datastore,
-                                                  :datastore_tree,
+      @datastore_tree = TreeBuilderDatastores.new(:datastore_tree,
                                                   @sb,
                                                   true,
                                                   :root => @edit[:current][:storages])

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -654,8 +654,7 @@ module OpsController::Settings::Common
     end
 
     if @selected_zone.miq_servers.select(&:is_a_proxy?).present?
-      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
-                                                                    :smartproxy_affinity_tree,
+      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity_tree,
                                                                     @sb,
                                                                     true,
                                                                     :data => @selected_zone)
@@ -1277,7 +1276,7 @@ module OpsController::Settings::Common
 
   # Build the main Settings tree
   def build_settings_tree
-    TreeBuilderOpsSettings.new("settings_tree", "settings", @sb)
+    TreeBuilderOpsSettings.new("settings_tree", @sb)
   end
 
   def settings_set_view_vars

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -227,11 +227,11 @@ class ProviderForemanController < ApplicationController
   end
 
   def build_configuration_manager_providers_tree(_type)
-    TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, :configuration_manager_providers, @sb)
+    TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, @sb)
   end
 
   def build_configuration_manager_cs_filter_tree(_type)
-    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter_tree, :configuration_manager_cs_filter, @sb)
+    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter_tree, @sb)
   end
 
   def get_node_info(treenodeid, show_list = true)

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -262,7 +262,7 @@ module PxeController::IsoDatastores
 
   # Get information for an event
   def build_iso_datastores_tree
-    TreeBuilderIsoDatastores.new("iso_datastores_tree", "iso_datastores", @sb)
+    TreeBuilderIsoDatastores.new("iso_datastores_tree", @sb)
   end
 
   def iso_datastore_get_node_info(treenodeid)

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -256,6 +256,6 @@ module PxeController::PxeCustomizationTemplates
 
   # Get information for an event
   def build_customization_templates_tree
-    TreeBuilderPxeCustomizationTemplates.new("customization_templates_tree", "customization_templates", @sb)
+    TreeBuilderPxeCustomizationTemplates.new("customization_templates_tree", @sb)
   end
 end

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -154,7 +154,7 @@ module PxeController::PxeImageTypes
 
   # Get information for an event
   def build_pxe_image_types_tree
-    TreeBuilderPxeImageTypes.new("pxe_image_types_tree", "pxe_image_types", @sb)
+    TreeBuilderPxeImageTypes.new("pxe_image_types_tree", @sb)
   end
 
   def pxe_image_type_get_node_info(treenodeid)

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -427,7 +427,7 @@ module PxeController::PxeServers
 
   # Get information for an event
   def build_pxe_servers_tree
-    TreeBuilderPxeServers.new("pxe_servers_tree", "pxe_servers", @sb)
+    TreeBuilderPxeServers.new("pxe_servers_tree", @sb)
   end
 
   def pxe_server_get_node_info(treenodeid)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -385,7 +385,7 @@ class ReportController < ApplicationController
 
   # Build the main import/export tree
   def build_export_tree
-    TreeBuilderReportExport.new('export_tree', 'export', @sb)
+    TreeBuilderReportExport.new('export_tree', @sb)
   end
 
   def determine_root_node_info

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -481,6 +481,6 @@ module ReportController::Dashboards
 
   # Build the main dashboards tree
   def build_db_tree
-    TreeBuilderReportDashboards.new('db_tree', 'db', @sb)
+    TreeBuilderReportDashboards.new('db_tree', @sb)
   end
 end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -324,7 +324,6 @@ module ReportController::Menus
   def build_menu_roles_tree(rpt_menu = nil)
     TreeBuilderMenuRoles.new(
       :menu_roles_tree, # name
-      :menu_roles,      # type
       @sb,              # sandbox
       true,             # build
       :role_choice => session[:role_choice],

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -231,6 +231,6 @@ module ReportController::Reports
   # Build the main reports tree
   def build_reports_tree
     populate_reports_menu
-    TreeBuilderReportReports.new('reports_tree', 'reports', @sb)
+    TreeBuilderReportReports.new('reports_tree', @sb)
   end
 end

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -139,6 +139,6 @@ module ReportController::SavedReports
 
   # Build the main Saved Reports tree
   def build_savedreports_tree
-    TreeBuilderReportSavedReports.new('savedreports_tree', 'savedreports', @sb)
+    TreeBuilderReportSavedReports.new('savedreports_tree', @sb)
   end
 end

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -464,7 +464,7 @@ module ReportController::Schedules
   end
 
   def build_schedules_tree
-    TreeBuilderReportSchedules.new('schedules_tree', 'schedules', @sb)
+    TreeBuilderReportSchedules.new('schedules_tree', @sb)
   end
 
   def get_schedule(nodeid)

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -455,7 +455,7 @@ module ReportController::Widgets
 
   # Build the main widgets tree
   def build_widgets_tree
-    TreeBuilderReportWidgets.new('widgets_tree', 'widgets', @sb)
+    TreeBuilderReportWidgets.new('widgets_tree', @sb)
   end
 
   # Get variables from edit form

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -496,7 +496,7 @@ class ServiceController < ApplicationController
 
   # Build a Services explorer tree
   def build_svcs_tree
-    TreeBuilderServices.new("svcs_tree", "svcs", @sb)
+    TreeBuilderServices.new("svcs_tree", @sb)
   end
 
   def show_record(id = nil)

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -32,7 +32,7 @@ module StorageController::StorageD
 
   # Get information for an event
   def build_storage_tree
-    TreeBuilderStorage.new("storage_tree", "storage", @sb)
+    TreeBuilderStorage.new("storage_tree", @sb)
   end
 
   def storage_get_node_info(treenodeid)

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -49,6 +49,6 @@ module StorageController::StoragePod
 
   # Get information for an event
   def build_storage_pod_tree
-    TreeBuilderStoragePod.new("storage_pod_tree", "storage_pod", @sb)
+    TreeBuilderStoragePod.new("storage_pod_tree", @sb)
   end
 end

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -5,19 +5,19 @@ class TreeController < ApplicationController
   before_action :check_privileges
 
   def automate_entrypoint
-    json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint, params[:id])
+    json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint_tree, params[:id])
     render :body => json, :content_type => 'application/json'
   end
 
   def automate_inline_methods
-    json = fetch_tree(TreeBuilderAutomateInlineMethod, :automate_inline_method, params[:id])
+    json = fetch_tree(TreeBuilderAutomateInlineMethod, :automate_inline_method_tree, params[:id])
     render :body => json, :content_type => 'application/json'
   end
 
   private
 
   def fetch_tree(klass, name, node_id = nil)
-    tree = klass.new(name, "#{name}_tree".to_sym, {})
+    tree = klass.new(name, {})
 
     if node_id
       TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(node_id)).to_json

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -194,7 +194,7 @@ module VmCommon
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
       session[:snap_selected] = nil if Snapshot.find_by(:id => session[:snap_selected]).nil?
       @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
-      @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
+      @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, @sb, true, :root => @record)
       selected_snapshot_node = x_node(@snapshot_tree.name)
       @active = if selected_snapshot_node && selected_snapshot_node != 'root'
                   snap_selected = Snapshot.find(selected_snapshot_node.split('-').last)
@@ -221,12 +221,12 @@ module VmCommon
         javascript_flash(:spinner_off => true)
         return
       else
-        @genealogy_tree = TreeBuilderGenealogy.new(:genealogy_tree, :genealogy, @sb, true, :root => @record)
+        @genealogy_tree = TreeBuilderGenealogy.new(:genealogy_tree, @sb, true, :root => @record)
         session[:genealogy_tree_root_id] = @record.parent.presence.try(:id) || @record.id
       end
     elsif @display == "compliance_history"
       count = params[:count] ? params[:count].to_i : 10
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, @sb, true, :root => @record)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, @sb, true, :root => @record)
       drop_breadcrumb({:name => @record.name, :url => "/#{rec_cls}/show/#{@record.id}"}, true)
       if count == 1
         drop_breadcrumb(:name => @record.name + _(" (Latest Compliance Check)"),
@@ -457,7 +457,6 @@ module VmCommon
     @policy_options[:passed] = true
     @policy_options[:failed] = true
     @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                              :policy_simulation,
                                                               @sb,
                                                               true,
                                                               :root      => @polArr,
@@ -490,7 +489,6 @@ module VmCommon
     end
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                              :policy_simulation,
                                                               @sb,
                                                               true,
                                                               :root      => @polArr,
@@ -505,7 +503,6 @@ module VmCommon
     @policy_options ||= {}
     @policy_options[:out_of_scope] = (params[:out_of_scope] == "1")
     @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                              :policy_simulation,
                                                               @sb,
                                                               true,
                                                               :root      => @polArr,

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -48,7 +48,7 @@ module AutomateTreeHelper
               TreeBuilderAutomateCatalog
             end
 
-    @automate_tree = klass.new(tree_name, type, @sb)
+    @automate_tree = klass.new(tree_name, @sb)
   end
 
   def at_tree_select_toggle(type, edit_key)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -1,7 +1,7 @@
 class TreeBuilder
   include TreeKids
 
-  attr_reader :name, :type, :tree_nodes, :bs_tree
+  attr_reader :name, :tree_nodes, :bs_tree
 
   def self.class_for_type(type)
     raise('Obsolete tree type.') if type == :filter
@@ -9,7 +9,7 @@ class TreeBuilder
     @x_tree_node_classes[type] ||= LEFT_TREE_CLASSES[type].constantize
   end
 
-  def initialize(name, type, sandbox, build = true, **_params)
+  def initialize(name, sandbox, build = true, **_params)
     @tree_state = TreeState.new(sandbox)
     @sb = sandbox # FIXME: some subclasses still access @sb
 
@@ -17,8 +17,6 @@ class TreeBuilder
     @name               = name.to_sym # includes _tree
     @options            = tree_init_options
     @tree_nodes         = {}.to_json
-    # FIXME: remove @name or @tree, unify
-    @type               = type.to_sym # *usually* same as @name but w/o _tree
 
     add_to_sandbox
     build_tree if build
@@ -135,8 +133,8 @@ class TreeBuilder
   end
 
   # Add child nodes to a tree below node 'id'
-  def self.tree_add_child_nodes(sandbox:, klass_name:, name:, type:, id:)
-    tree = klass_name.constantize.new(name, type, sandbox, false)
+  def self.tree_add_child_nodes(sandbox:, klass_name:, name:, id:)
+    tree = klass_name.constantize.new(name, sandbox, false)
     tree.x_get_child_nodes(id)
   end
 
@@ -206,7 +204,6 @@ class TreeBuilder
 
   # Build an explorer tree, from scratch
   # Options:
-  # :type                   # Type of tree, i.e. :handc, :vandt, :filtered, etc
   # :open_nodes             # Tree node ids of currently open nodes
   # :full_ids               # stack parent id on top of each node id
   # :lazy                   # set if tree is lazy

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -1,10 +1,10 @@
 class TreeBuilderAlertProfileObj < TreeBuilder
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @assign_to = params[:assign_to]
     @cat = params[:cat]
     @selected = params[:selected_nodes]
     @cat_tree = @assign_to.ends_with?("-tags")
-    super(name, type, sandbox, build, **params)
+    super(name, sandbox, build, **params)
   end
 
   def override(node, object, _pid, _options)

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -2,9 +2,9 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
   include MiqAeClassHelper
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -18,14 +18,14 @@ class TreeBuilderBelongsToHac < TreeBuilder
     node[:checkable] = @edit.present? || @assign_to.present?
   end
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @edit = params[:edit]
     @group = params[:group]
     @selected_nodes = params[:selected_nodes]
     @assign_to = params[:assign_to]
     # need to remove tree info
     TreeState.new(sandbox).remove_tree(name)
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -1,10 +1,10 @@
 class TreeBuilderClusters < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
     @data = EmsCluster.get_perf_collection_object_list
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -6,14 +6,14 @@ class TreeBuilderComplianceHistory < TreeBuilder
     node[:selectable] = false
   end
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     sandbox[:ch_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
     @root = params[:root]
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:ch_root])
       @root = model.constantize.find_by(:id => id)
     end
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -22,7 +22,7 @@ class TreeBuilderDatacenter < TreeBuilder
     node[:tooltip].concat(suffix) unless node[:tooltip].ends_with?(suffix)
   end
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     sandbox[:datacenter_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
     @root = params[:root]
     unless @root
@@ -30,7 +30,7 @@ class TreeBuilderDatacenter < TreeBuilder
       @root = model.constantize.find_by(:id => id)
     end
     @user_id = User.current_userid
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -1,10 +1,10 @@
 class TreeBuilderDatastores < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
     @data = Storage.all.each_with_object({}) { |st, h| h[st.id] = st; }
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -27,9 +27,9 @@ class TreeBuilderDefaultFilters < TreeBuilder
     end
   end
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @data = prepare_data(params[:data])
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -1,7 +1,7 @@
 class TreeBuilderDiagnostics < TreeBuilder
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -1,9 +1,9 @@
 class TreeBuilderGenealogy < TreeBuilder
   has_kids_for VmOrTemplate, [:x_get_vm_or_template_kids]
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @root = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -3,11 +3,11 @@ class TreeBuilderMenuRoles < TreeBuilder
 
   attr_reader :rpt_menu, :role_choice
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @rpt_menu    = params[:rpt_menu] || sandbox[:rpt_menu]
     @role_choice = params[:role_choice]
 
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   # Used for testing convenience and to satisfy need for

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -10,9 +10,9 @@ class TreeBuilderMiqActionCategory < TreeBuilder
     node
   end
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -6,14 +6,14 @@ class TreeBuilderNetwork < TreeBuilder
     node[:selectable] = false # if node[:image].nil? || !node[:image].include?('svg/currentstate-')
   end
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     sandbox[:network_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
     @root = params[:root]
     unless @root
       model, id = TreeBuilder.extract_node_model_and_id(sandbox[:network_root])
       @root = model.constantize.find_by(:id => id)
     end
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -3,7 +3,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   has_kids_for Menu::Item,        [:x_get_tree_item_kids]
   has_kids_for MiqProductFeature, [:x_get_tree_feature_kids]
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @role     = params[:role]
     @editable = params[:editable]
     @features = @role.miq_product_features.map(&:identifier)
@@ -13,7 +13,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
     # Make sure tree_state doesn't hold on to old data between requests
     TreeState.new(sandbox).remove_tree(name)
 
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -4,11 +4,11 @@ class TreeBuilderPolicySimulation < TreeBuilder
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @data = params[:root]
     @root_name = params[:root_name]
     @policy_options = params[:options]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -4,9 +4,9 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -1,9 +1,9 @@
 class TreeBuilderProtect < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @data = params[:data]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -3,10 +3,10 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
 
   private
 
-  def initialize(name, type, sandbox, build = true, **_params)
+  def initialize(name, sandbox, build = true, **_params)
     @rpt_menu  = sandbox[:rpt_menu]
     @grp_title = sandbox[:grp_title]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -1,12 +1,12 @@
 class TreeBuilderSections < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @data = params[:data]
     @controller_name = params[:controller_name]
     @current_tenant = params[:current_tenant]
     @sandbox = sandbox
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -2,9 +2,9 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
   has_kids_for MiqServer, [:x_get_server_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @data = params[:data]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -3,9 +3,9 @@ class TreeBuilderSnapshots < TreeBuilder
 
   attr_reader :selected_node
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     @record = params[:root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -2,10 +2,10 @@ class TreeBuilderStorageAdapters < TreeBuilder
   has_kids_for GuestDevice, [:x_get_tree_guest_device_kids]
   has_kids_for MiqScsiTarget, [:x_get_tree_target_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     sandbox[:sa_root] = params[:root] if params[:root]
     @root = sandbox[:sa_root]
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
   end
 
   private

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -1,7 +1,7 @@
 class TreeBuilderTags < TreeBuilder
   has_kids_for Classification, [:x_get_classification_kids]
 
-  def initialize(name, type, sandbox, build, **params)
+  def initialize(name, sandbox, build, **params)
     @edit = params[:edit]
     @filters = params[:filters]
     @group = params[:group]
@@ -9,7 +9,7 @@ class TreeBuilderTags < TreeBuilder
       c if c.show || !%w[folder_path_blue folder_path_yellow].include?(c.name)
     end
     @categories.sort_by! { |c| c.description.downcase }
-    super(name, type, sandbox, build)
+    super(name, sandbox, build)
     @tree_state.x_tree(name)[:open_nodes] = []
   end
 

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -2,11 +2,11 @@ class TreeBuilderVat < TreeBuilderDatacenter
   has_kids_for Datacenter, %i[x_get_tree_datacenter_kids]
   has_kids_for EmsFolder, %i[x_get_tree_folder_kids]
 
-  def initialize(name, type, sandbox, build = true, **params)
+  def initialize(name, sandbox, build = true, **params)
     sandbox[:vat] = params[:vat] if params[:vat]
     @vat = sandbox[:vat]
     @user_id = User.current_userid
-    super(name, type, sandbox, build, **params)
+    super(name, sandbox, build, **params)
   end
 
   private

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -5,7 +5,7 @@
     - @accords.each do |accord|
       = miq_accordion_panel(accord[:title], selected == accord, accord[:container]) do
         -# Set the first tree to be rendered if there is a mismatch with the name/type
-        - tree = @trees.find(-> { @trees.first }) { |t| t.type == accord[:name].to_sym  }
+        - tree = @trees.find(-> { @trees.first }) { |t| t.name == "#{accord[:name]}_tree".to_sym  }
         %miq-tree-view{:name       => tree.name,
                        :data       => "vm.data['#{tree.name}']",
                        :reselect   => tree.locals_for_render[:allow_reselect],

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -112,7 +112,7 @@ describe ReportController do
                                                                           :klass_name  => "TreeBuilderReportWidgets",
                                                                           :open_nodes  => []}},
                                        :active_tree => :widgets_tree)
-      TreeBuilderReportWidgets.new('widgets_tree', 'widgets', {})
+      TreeBuilderReportWidgets.new('widgets_tree', {})
       nodes = controller.send(:tree_add_child_nodes, 'xx-r')
       expected = [{:key        => "xx-r_-#{widget.id}",
                    :text       => "Foo",

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -264,16 +264,16 @@ describe AutomationManagerController do
     automation_manager2 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider2.id)
     automation_manager3 = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider3.id)
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb))
-    tree_builder = TreeBuilderAutomationManagerProviders.new("root", "", {})
+    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
+    tree_builder = TreeBuilderAutomationManagerProviders.new("root", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
     expected_objects = [automation_manager1, automation_manager2, automation_manager3]
     expect(objects).to match_array(expected_objects)
   end
 
   it "constructs the ansible tower inventory tree node" do
-    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb))
-    tree_builder = TreeBuilderAutomationManagerProviders.new("root", "", {})
+    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
+    tree_builder = TreeBuilderAutomationManagerProviders.new("root", {})
     objects = tree_builder.send(:x_get_tree_objects, @inventory_group, nil, false, nil)
     expected_objects = [@ans_configured_system, @ans_configured_system2a]
     expect(objects).to match_array(expected_objects)
@@ -281,8 +281,8 @@ describe AutomationManagerController do
 
   it "builds ansible tower job templates tree" do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, controller.instance_variable_get(:@sb))
-    tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
+    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, controller.instance_variable_get(:@sb))
+    tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
     expect(objects).to include(@automation_manager1)
     expect(objects).to include(@automation_manager2)
@@ -290,8 +290,8 @@ describe AutomationManagerController do
 
   it "constructs the ansible tower job templates tree node" do
     user = login_as user_with_feature(%w(providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
-    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, :configuration_scripts, controller.instance_variable_get(:@sb))
-    tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", "", {})
+    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, controller.instance_variable_get(:@sb))
+    tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", {})
     objects = tree_builder.send(:x_get_tree_cmat_kids, @automation_manager1, false)
     expect(objects).to include(@ans_job_template1)
     expect(objects).to include(@ans_job_template3)
@@ -449,7 +449,7 @@ describe AutomationManagerController do
   end
 
   it "renders tree_select as js" do
-    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb))
+    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
 
     allow(controller).to receive(:process_show_list)
     allow(controller).to receive(:replace_explorer_trees)
@@ -478,7 +478,7 @@ describe AutomationManagerController do
     end
 
     it "does not hide Configuration button in the toolbar" do
-      TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb))
+      TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
       key = ems_key_for_provider(automation_provider1)
       post :tree_select, :params => { :id => key, :format => :js }
       expect(response.status).to eq(200)
@@ -594,7 +594,7 @@ describe AutomationManagerController do
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [tags]}
       allow(@user).to receive(:get_filters).and_return(user_filters)
-      tree_json = TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, :automation_manager_providers, controller.instance_variable_get(:@sb)).tree_nodes
+      tree_json = TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb)).tree_nodes
       first_child = find_treenode_for_provider(automation_provider1, tree_json)
       expect(first_child).to eq(nil)
     end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -294,7 +294,7 @@ describe ProviderForemanController do
 
   it "builds foreman child tree" do
     controller.send(:build_configuration_manager_providers_tree, :configuration_manager_providers)
-    tree_builder = TreeBuilderConfigurationManager.new("root", "", {})
+    tree_builder = TreeBuilderConfigurationManager.new("root", {})
     objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false, {})
     expected_objects = [@config_mgr, @config_mgr2]
     expect(objects).to match_array(expected_objects)

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -42,10 +42,10 @@ describe TreeController do
 
     before { tree.instance_variable_set(:@bs_tree, :foo => :bar) }
 
-    subject { controller.send(:fetch_tree, klass, :foo, node_id) }
+    subject { controller.send(:fetch_tree, klass, :foo_tree, node_id) }
 
     it 'returns with a tree hash' do
-      expect(klass).to receive(:new).with(:foo, :foo_tree, {}).and_return(tree)
+      expect(klass).to receive(:new).with(:foo_tree, {}).and_return(tree)
       expect(subject).to eq(:foo => :bar)
     end
   end

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderAeClass do
     end
 
     it "a tree without filter" do
-      tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
+      tree = TreeBuilderAeClass.new(:automate_tree, @sb)
       domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
       expect(domains).to match_array %w(LUIGI MARIO)
     end
@@ -28,7 +28,7 @@ describe TreeBuilderAeClass do
     end
 
     it "should only return domains in a user's current tenant" do
-      tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
+      tree = TreeBuilderAeClass.new("ae_tree", {})
       domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
       expect(domains).to match_array %w(test1)
       expect(domains).not_to include %w(test2)
@@ -45,7 +45,7 @@ describe TreeBuilderAeClass do
     end
 
     it "should return domains in correct order" do
-      tree = TreeBuilderAeClass.new("ae_tree", "ae", {})
+      tree = TreeBuilderAeClass.new("ae_tree", {})
       domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
       expect(domains).to eq(%w(test2 test1))
     end

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderAeCustomization do
     end
 
     before do
-      TreeBuilderAeCustomization.new("dialog_import_export_tree", "dialog_import_export", sandbox)
+      TreeBuilderAeCustomization.new("dialog_import_export_tree", sandbox)
     end
 
     it "stores values into the sandbox" do

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -20,7 +20,7 @@ describe TreeBuilderAlertProfileObj do
 
   context 'classification tree' do
     subject do
-      described_class.new(:alert_profile_obj_tree, :alert_profile_obj,
+      described_class.new(:alert_profile_obj_tree,
                           {},
                           true,
                           :assign_to      => 'storage-tags',
@@ -98,7 +98,6 @@ describe TreeBuilderAlertProfileObj do
   context 'tenant tree' do
     subject do
       described_class.new(:alert_profile_obj_tree,
-                          :alert_profile_obj,
                           {},
                           true,
                           :assign_to      => 'tenant',

--- a/spec/presenters/tree_builder_automate_catalog_spec.rb
+++ b/spec/presenters/tree_builder_automate_catalog_spec.rb
@@ -2,7 +2,7 @@ describe TreeBuilderAutomateCatalog do
   include Spec::Support::AutomationHelper
 
   describe "#initialize" do
-    subject { described_class.new(:automate_tree, :automate, sb) }
+    subject { described_class.new(:automate_tree, sb) }
 
     let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree} }
     let(:domains) { JSON.parse(subject.tree_nodes).first['nodes'].collect { |h| h['text'] } }

--- a/spec/presenters/tree_builder_automate_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_automate_simulation_results_spec.rb
@@ -2,7 +2,7 @@ describe TreeBuilderAutomateSimulationResults do
   context 'TreeBuilderAutomateSimulationResults' do
     before do
       @data = "<MiqAeWorkspace>\\n<MiqAeObject namespace='ManageIQ/SYSTEM' class='PROCESS' instance='Automation'>\\n</MiqAeObject>\\n</MiqAeWorkspace>\\n"
-      @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, :ae_simulation, {}, true, :root => @data)
+      @ae_simulation_tree = TreeBuilderAutomateSimulationResults.new(:ae_simulation_tree, {}, true, :root => @data)
     end
 
     it 'no root is set' do

--- a/spec/presenters/tree_builder_automate_spec.rb
+++ b/spec/presenters/tree_builder_automate_spec.rb
@@ -4,7 +4,7 @@ describe TreeBuilderAutomate do
   describe "#initialize" do
     before { login_as FactoryBot.create(:user_with_group) }
 
-    subject { described_class.new(:automate_tree, :automate, sb) }
+    subject { described_class.new(:automate_tree, sb) }
 
     let(:ae_model) { create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C') }
     let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree, :domain_id => ae_model.id} }

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -55,8 +55,7 @@ describe TreeBuilderBelongsToHac do
   end
 
   subject do
-    described_class.new(:hac,
-                        :hac_tree,
+    described_class.new(:hac_tree,
                         {:trees => {}},
                         true,
                         :edit           => edit,

--- a/spec/presenters/tree_builder_belongs_to_vat_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_vat_spec.rb
@@ -26,8 +26,7 @@ describe TreeBuilderBelongsToVat do
   end
 
   subject do
-    described_class.new(:vat,
-                        :vat_tree,
+    described_class.new(:vat_tree,
                         {:trees => {}},
                         true,
                         :edit     => edit,

--- a/spec/presenters/tree_builder_chargeback_assignments_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_assignments_spec.rb
@@ -1,7 +1,7 @@
 describe TreeBuilderChargebackAssignments do
   context "#x_get_tree_roots" do
     it "correctly renders storage and compute nodes when no rates are available" do
-      tree = TreeBuilderChargebackAssignments.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackAssignments.new("cb_rates_tree", {})
       keys = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
       titles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
       rates = ChargebackRate.all

--- a/spec/presenters/tree_builder_chargeback_rates_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_rates_spec.rb
@@ -1,7 +1,7 @@
 describe TreeBuilderChargebackRates do
   context "#x_get_tree_roots" do
     it "correctly renders storage and compute nodes when no rates are available" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       keys = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['key'] }
       titles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
       rates = ChargebackRate.all

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderClusters do
                                                                                               :ho_disabled => @ho_disabled})
       @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
       @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-      @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, :root => @cluster)
+      @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true, :root => @cluster)
     end
 
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -18,7 +18,7 @@ describe TreeBuilderComplianceHistory do
       empty_compliance = FactoryBot.create(:compliance)
       compliance = FactoryBot.create(:compliance, :compliance_details => compliance_details)
       root = FactoryBot.create(:host, :compliances => [empty_compliance, compliance])
-      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, :ch, {}, true, :root => root)
+      @ch_tree = TreeBuilderComplianceHistory.new(:ch_tree, {}, true, :root => root)
     end
     it 'is not lazy' do
       tree_options = @ch_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_datacenter_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderDatacenter do
           [FactoryBot.create(:resource_pool)]
         end
       end
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, :root => cluster)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, {}, true, :root => cluster)
     end
 
     it 'returns EmsCluster as root' do
@@ -50,7 +50,7 @@ describe TreeBuilderDatacenter do
           [FactoryBot.create(:vm)]
         end
       end
-      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, :datacenter, {}, true, :root => cluster)
+      @datacenter_tree = TreeBuilderDatacenter.new(:datacenter_tree, {}, true, :root => cluster)
     end
 
     it 'returns ResourcePool as root' do

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -7,7 +7,7 @@ describe TreeBuilderDatastores do
       @host = FactoryBot.create(:host, :name => 'Host Name')
       FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
       @datastore = [{:id => 1, :name => 'Datastore', :location => 'Location', :capture => false}]
-      @datastores_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, :root => @datastore)
+      @datastores_tree = TreeBuilderDatastores.new(:datastore, {}, true, :root => @datastore)
     end
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -61,7 +61,7 @@ describe TreeBuilderDefaultFilters do
                                        :search_type => "default",
                                        :search_key  => "_hidden_"))
       @sb = {:active_tree => :default_filters_tree}
-      @default_filters_tree = TreeBuilderDefaultFilters.new(:df_tree, :df, @sb, true, :data => @filters)
+      @default_filters_tree = TreeBuilderDefaultFilters.new(:df_tree, @sb, true, :data => @filters)
     end
 
     it 'is not lazy' do

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderGenealogy do
   end
 
   subject do
-    described_class.new(:genealogy_tree, :genealogy, {}, true, :root => record)
+    described_class.new(:genealogy_tree, {}, true, :root => record)
   end
 
   describe '#tree_init_options' do

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -8,7 +8,7 @@ describe TreeBuilderImages do
 
     allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
-    @images_tree = TreeBuilderImages.new(:images_tree, :images, {}, nil)
+    @images_tree = TreeBuilderImages.new(:images_tree, {}, nil)
   end
 
   it 'sets tree to have leaf and not lazy' do

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -12,7 +12,7 @@ describe TreeBuilderInstances do
 
     allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
 
-    @instances_tree = TreeBuilderInstances.new(:instances_tree, :instances, {}, nil)
+    @instances_tree = TreeBuilderInstances.new(:instances_tree, {}, nil)
   end
 
   it 'sets tree to have leaf and not lazy' do

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -15,7 +15,7 @@ describe TreeBuilderMenuRoles do
     { :rpt_menu => rpt_menu }
   end
 
-  let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", sandbox, true, :role_choice => "cloud-execs") }
+  let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", sandbox, true, :role_choice => "cloud-execs") }
   let(:tree_hash) { JSON.parse(instance.tree_nodes) }
 
   describe "root node" do

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -21,7 +21,7 @@ describe TreeBuilderMiqActionCategory do
   let!(:tree_name) { :action_tags }
 
   subject do
-    described_class.new(:action_tags_tree, :action_tags, {}, true, :root => tenant)
+    described_class.new(:action_tags_tree, {}, true, :root => tenant)
   end
 
   describe '#tree_init_options' do

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -11,7 +11,7 @@ describe TreeBuilderNetwork do
       lan = FactoryBot.create(:lan, :guest_devices => [guest_device_with_vm])
       switch = FactoryBot.create(:switch, :guest_devices => [guest_device], :lans => [lan])
       network = FactoryBot.create(:host, :switches => [switch])
-      @network_tree = TreeBuilderNetwork.new(:network_tree, :network, {}, true, :root => network)
+      @network_tree = TreeBuilderNetwork.new(:network_tree, {}, true, :root => network)
     end
 
     it 'returns Host as root' do

--- a/spec/presenters/tree_builder_ops_rbac_features_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_features_spec.rb
@@ -19,7 +19,6 @@ describe TreeBuilderOpsRbacFeatures do
   let(:tree) do
     TreeBuilderOpsRbacFeatures.new(
       "features_tree",
-      "features",
       {:trees => {}},
       true,
       :role     => role,

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -6,7 +6,7 @@ describe TreeBuilderOpsRbac do
 
   describe ".new" do
     def assert_tree_nodes(expected)
-      tree_json  = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {}).tree_nodes
+      tree_json  = TreeBuilderOpsRbac.new("rbac_tree", {}).tree_nodes
       tree_nodes = JSON.parse(tree_json).first['nodes'].collect { |h| h['text'] }
       expect(tree_nodes).to match_array expected
     end
@@ -18,7 +18,7 @@ describe TreeBuilderOpsRbac do
 
     it "has :open_all set to false" do
       login_as FactoryBot.create(:user, :features => 'none')
-      tree = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
+      tree = TreeBuilderOpsRbac.new("rbac_tree", {})
       expect(tree.send(:tree_init_options)[:open_all]).to be_falsey
     end
 
@@ -55,7 +55,7 @@ describe TreeBuilderOpsRbac do
     end
 
     def x_get_tree_custom_kids_for_and_expect_objects(type_of_model, expected_objects)
-      tree_builder = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
+      tree_builder = TreeBuilderOpsRbac.new("rbac_tree", {})
       objects = tree_builder.send(:x_get_tree_custom_kids, {:id => type_of_model}, false, {})
       expect(objects).to match_array(expected_objects)
     end

--- a/spec/presenters/tree_builder_policy_profile_spec.rb
+++ b/spec/presenters/tree_builder_policy_profile_spec.rb
@@ -1,7 +1,7 @@
 describe TreeBuilderPolicyProfile do
   context '#tree_init_options' do
     it "is explicitly not lazy" do
-      tree = TreeBuilderPolicyProfile.new(:policy_profile_tree, :policy_profile, {}, true)
+      tree = TreeBuilderPolicyProfile.new(:policy_profile_tree, {}, true)
       options = tree.instance_variable_get(:@options)
       expect(options[:lazy]).not_to be_truthy
     end

--- a/spec/presenters/tree_builder_policy_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_results_spec.rb
@@ -27,7 +27,7 @@ describe TreeBuilderPolicySimulationResults do
                                                                                                     {:id          => 9,
                                                                                                      :description => "Shutdown Virtual Machine Guest OS",
                                                                                                      :result      => "deny"}]}]}]}]}
-      @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, :rsop, {}, true, :root => @data)
+      @rsop_tree = TreeBuilderPolicySimulationResults.new(:rsop_tree, {}, true, :root => @data)
     end
 
     it 'sets root correctly' do

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -31,7 +31,6 @@ describe TreeBuilderPolicySimulation do
                                                       'expression'  => exp}]}]}]
 
       @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                                :policy_simulation,
                                                                 {},
                                                                 true,
                                                                 :root      => @data,
@@ -121,7 +120,6 @@ describe TreeBuilderPolicySimulation do
       login_as FactoryBot.create(:user, :userid => 'no_node_wilma', :miq_groups => [@group])
       @policy_options = {:out_of_scope => true, :passed => true, :failed => true}
       @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                                :policy_simulaton,
                                                                 {},
                                                                 true,
                                                                 :root      => {},

--- a/spec/presenters/tree_builder_policy_spec.rb
+++ b/spec/presenters/tree_builder_policy_spec.rb
@@ -1,7 +1,7 @@
 describe TreeBuilderPolicy do
   context '#tree_init_options' do
     it "is explicitly not lazy" do
-      tree = TreeBuilderPolicy.new(:policy_tree, :policy, {}, true)
+      tree = TreeBuilderPolicy.new(:policy_tree, {}, true)
       options = tree.instance_variable_get(:@options)
       expect(options[:lazy]).not_to be_truthy
     end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -19,7 +19,7 @@ describe TreeBuilderProtect do
       @edit = {:controller_name => 'name'}
       @edit[:new] = @edit[:current] = {set1[:id] => 1}
       @edit[:pol_items] = [101]
-      @protect_tree = TreeBuilderProtect.new(:protect, :protect_tree, {}, true, :data => @edit)
+      @protect_tree = TreeBuilderProtect.new(:protect, {}, true, :data => @edit)
     end
 
     it 'set init options correctly' do

--- a/spec/presenters/tree_builder_report_dashboards_spec.rb
+++ b/spec/presenters/tree_builder_report_dashboards_spec.rb
@@ -15,7 +15,7 @@ describe TreeBuilderReportDashboards do
 
   describe "#x_get_tree_g_kids" do
     it "is listing widget sets for certain group" do
-      tree_builder = TreeBuilderReportDashboards.new("rbac_tree", "db", {})
+      tree_builder = TreeBuilderReportDashboards.new("rbac_tree", {})
       objects = tree_builder.send(:x_get_tree_g_kids, group, false)
       expect(objects).to match_array([miq_widget_set])
     end
@@ -24,7 +24,7 @@ describe TreeBuilderReportDashboards do
   describe "#x_get_tree_custom_kids" do
     it "is listing only user's groups, logged is self service user" do
       allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
-      tree_builder = TreeBuilderReportDashboards.new("rbac_tree", "db", {})
+      tree_builder = TreeBuilderReportDashboards.new("rbac_tree", {})
       objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "g"}, false, :type => :db)
       expect(objects).to match_array([group])
     end

--- a/spec/presenters/tree_builder_report_roles_spec.rb
+++ b/spec/presenters/tree_builder_report_roles_spec.rb
@@ -7,7 +7,7 @@ describe TreeBuilderReportRoles do
     end
 
     it "gets roles/group for the specified user" do
-      tree = TreeBuilderReportRoles.new("roles_tree", "roles", {})
+      tree = TreeBuilderReportRoles.new("roles_tree", {})
       roles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
       expect(roles).to eq([@group.description])
     end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -23,7 +23,7 @@ describe TreeBuilderReportSavedReports do
       describe "#x_get_tree_roots" do
         it "is allowed to see report created under Group1 for User2(with current group Group2)" do
           # there is calling of x_get_tree_roots
-          tree = TreeBuilderReportSavedReports.new('savedreports_tree', 'savedreports', {})
+          tree = TreeBuilderReportSavedReports.new('savedreports_tree', {})
 
           saved_reports_in_tree = JSON.parse(tree.tree_nodes).first['nodes']
 
@@ -40,7 +40,7 @@ describe TreeBuilderReportSavedReports do
         it "is allowed to see report results created under Group1 for User2(with current group Group2)" do
           report_result = MiqReportResult.first
 
-          tree = TreeBuilderReportSavedReports.new('savedreports_tree', 'savedreports', {})
+          tree = TreeBuilderReportSavedReports.new('savedreports_tree', {})
           tree_report_results = tree.send(:x_get_tree_custom_kids, {:id => @rpt.id.to_s}, false, {})
 
           expect(tree_report_results).to include(report_result)

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -1,5 +1,5 @@
 describe TreeBuilderReportWidgets do
-  subject { described_class.new("cb_rates_tree", "cb_rates", {}) }
+  subject { described_class.new("cb_rates_tree", {}) }
 
   it "#set_locals_for_render (private)" do
     expect(subject.send(:set_locals_for_render)).to include(:autoload => true)

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -31,7 +31,7 @@ describe TreeBuilderRolesByServer do
       parent = MiqRegion.my_region
       @sb[:selected_server_id] = parent.id
       @sb[:selected_typ] = "miq_region"
-      @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, :roles_by_server, @sb, true, :root => parent)
+      @server_tree = TreeBuilderRolesByServer.new(:roles_by_server_tree, @sb, true, :root => parent)
     end
 
     it "is not lazy" do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -45,8 +45,7 @@ describe TreeBuilderSections do
                                                                                       :checked => false,
                                                                                       :key     => :name,
                                                                                       :group   => "Properties"}}})
-      @sections_tree = TreeBuilderSections.new(:all_sections,
-                                               :all_sections_tree,
+      @sections_tree = TreeBuilderSections.new(:all_sections_tree,
                                                {},
                                                true,
                                                :data            => @compare,

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderServersByRole do
       parent = zone
       @sb[:selected_server_id] = parent.id
       @sb[:selected_typ] = "miq_region"
-      @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, :servers_by_role, @sb, true, :root => parent)
+      @server_tree = TreeBuilderServersByRole.new(:servers_by_role_tree, @sb, true, :root => parent)
     end
 
     it "is not lazy" do

--- a/spec/presenters/tree_builder_service_catalog_spec.rb
+++ b/spec/presenters/tree_builder_service_catalog_spec.rb
@@ -21,7 +21,7 @@ describe TreeBuilderServiceCatalog do
                        :name                     => "Display in Catalog Playbook",
                        :service_template_catalog => @catalog,
                        :display                  => true)
-    @tree = TreeBuilderServiceCatalog.new(:svccat_tree, "svccat", {})
+    @tree = TreeBuilderServiceCatalog.new(:svccat_tree, {})
   end
 
   it "#x_get_tree_roots" do

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -1,5 +1,5 @@
 describe TreeBuilderServices do
-  let(:builder) { TreeBuilderServices.new("x", "y", {}) }
+  let(:builder) { TreeBuilderServices.new("x", {}) }
 
   it "generates tree" do
     User.current_user = FactoryBot.create(:user)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -26,8 +26,7 @@ describe TreeBuilderSmartproxyAffinity do
       allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
       allow(MiqServer).to receive(:my_server).and_return(OpenStruct.new('id' => 0, :name => 'name'))
 
-      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
-                                                                    :smartproxy_affinity_tree,
+      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity_tree,
                                                                     {},
                                                                     true,
                                                                     :data => @selected_zone)

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -21,7 +21,7 @@ describe TreeBuilderSnapshots do
                                    :create_time => Time.zone.local(2000, "jan", 1, 20, 15, 1))
     end
 
-    let(:tree) { TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, :root => vm) }
+    let(:tree) { TreeBuilderSnapshots.new(:snapshot_tree, {}, true, :root => vm) }
 
     it 'sets root correctly' do
       root = tree.send(:root_options)

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -1,14 +1,14 @@
 describe TreeBuilder do
   context "initialize" do
     it "initializes a tree" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       expect(tree).to be_a_kind_of(TreeBuilder)
       expect(tree.name).to eq(:cb_rates_tree)
     end
 
     it "sets sandbox hash that can be accessed by other methods in the class" do
       sb = {}
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", sb)
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", sb)
       expect(tree).to be_a_kind_of(TreeBuilder)
       expect(tree.name).to eq(:cb_rates_tree)
       sb.key?(:trees)
@@ -18,7 +18,7 @@ describe TreeBuilder do
 
   context "title_and_tip" do
     it "sets title and tooltip for the passed in root node" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       root = tree.send(:root_options)
       expect(root).to eq(
         :text    => 'Rates',
@@ -29,7 +29,7 @@ describe TreeBuilder do
 
   context "build_tree" do
     it "builds tree object and sets all settings and add nodes to tree object" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       nodes = [{'key'     => "root",
                 'nodes'   => [{'key'        => "xx-Compute",
                                'tooltip'    => "Compute",
@@ -57,7 +57,7 @@ describe TreeBuilder do
 
   context "#locals_for_render" do
     it "returns the active node x_node from the TreeState as select_node" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
 
       active_node = 'foobar'
       allow_any_instance_of(TreeState).to receive(:x_node).and_return(active_node)
@@ -68,7 +68,7 @@ describe TreeBuilder do
 
   context "#reload!" do
     it "replaces @tree_nodes" do
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       tree.instance_eval { @tree_nodes = "{}" }
       tree.reload!
       expect(tree.tree_nodes).not_to eq("{}")
@@ -84,7 +84,7 @@ describe TreeBuilder do
             :tooltip => "Bar"
           }
         end
-      end.new("cb_rates_tree", "cb_rates", {})
+      end.new("cb_rates_tree", {})
     end
 
     it "descendants can set their own root_options" do
@@ -94,7 +94,7 @@ describe TreeBuilder do
 
   context '#x_get_child_nodes' do
     it 'returns for Hash models' do
-      builder = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      builder = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       nodes = builder.x_get_child_nodes('tf_xx-10')
       expect(nodes).to be_empty
     end
@@ -102,7 +102,7 @@ describe TreeBuilder do
 
   context '#node_by_tree_id' do
     it 'returns a correct Hash for Hash models' do
-      builder = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", {})
+      builder = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       node = builder.node_by_tree_id('tf_xx-10')
       expect(node).to be_a_kind_of(Hash)
       expect(node[:id]).to eq("10")
@@ -118,7 +118,7 @@ describe TreeBuilder do
     let(:builder) do
       Class.new(TreeBuilder) do
         public :count_only_or_objects
-      end.new(:test_tree, :test, {}, false)
+      end.new(:test_tree, {}, false)
     end
 
     it 'counts things in a Relation' do
@@ -169,7 +169,7 @@ describe TreeBuilder do
       sb = {}
       node = 'tf_xx-10'
 
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", sb)
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", sb)
       tree.send(:open_node, node)
 
       expect(sb[:trees][:cb_rates_tree][:open_nodes]).to include(node)
@@ -179,7 +179,7 @@ describe TreeBuilder do
       sb = {}
       node = 'tf_xx-10'
 
-      tree = TreeBuilderChargebackRates.new("cb_rates_tree", "cb_rates", sb)
+      tree = TreeBuilderChargebackRates.new("cb_rates_tree", sb)
       tree.send(:open_node, node)
       tree.send(:open_node, node)
 

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderStorageAdapters do
                                                                                      FactoryBot.create(:miq_scsi_lun)])])
         end
       end
-      @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, :sa, {}, true, :root => host)
+      @sa_tree = TreeBuilderStorageAdapters.new(:sa_tree, {}, true, :root => host)
     end
 
     it 'returns Host as root' do

--- a/spec/presenters/tree_builder_tags_spec.rb
+++ b/spec/presenters/tree_builder_tags_spec.rb
@@ -16,8 +16,7 @@ describe TreeBuilderTags do
   context 'read-only mode' do
     before do
       edit = nil
-      @tags_tree = TreeBuilderTags.new(:tag,
-                                       :tag_tree,
+      @tags_tree = TreeBuilderTags.new(:tag_tree,
                                        {},
                                        true,
                                        :edit => edit, :filters => @filters, :group => @group)
@@ -70,8 +69,7 @@ describe TreeBuilderTags do
   context "edit mode" do
     before do
       @edit = {:new => {:filters => {}}}
-      @tags_tree = TreeBuilderTags.new(:tag,
-                                       :tag_tree,
+      @tags_tree = TreeBuilderTags.new(:tag_tree,
                                        {},
                                        true,
                                        :edit => @edit, :filters => @filters, :group => nil)

--- a/spec/presenters/tree_builder_vat_spec.rb
+++ b/spec/presenters/tree_builder_vat_spec.rb
@@ -16,7 +16,7 @@ describe TreeBuilderVat do
           'cluster'
         end
       end
-      @vat_tree = TreeBuilderVat.new(:vat_tree, :vat, {}, true, :root => cluster, :vat => true)
+      @vat_tree = TreeBuilderVat.new(:vat_tree, {}, true, :root => cluster, :vat => true)
     end
 
     it 'returns EmsCluster as root' do

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "catalog/_form.html.haml" do
     login_as user
     create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
     create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
-    @automate_tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
+    @automate_tree = TreeBuilderAeClass.new(:automate_tree, @sb)
     @available_catalogs = [%w(test 1)]
   end
 

--- a/spec/views/layouts/listnav/_explorer_html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_explorer_html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'layouts/_explorer.html.haml' do
-  let(:tree_1) { TreeBuilderConfigurationManager.new('tree_1', 'tree_1', {}) }
+  let(:tree_1) { TreeBuilderConfigurationManager.new('tree_1', {}) }
   let(:accord) { {:title => 'foo', :name => 'tree_1'} }
 
   before do

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -20,7 +20,6 @@ describe 'ops/_rbac_group_details.html.haml' do
       view.instance_variable_set(:@sb, sb)
 
       @tags_tree = TreeBuilderTags.new(:tag_tree,
-                                       :tag,
                                        sb,
                                        true,
                                        :edit    => {},
@@ -28,14 +27,12 @@ describe 'ops/_rbac_group_details.html.haml' do
                                        :group   => @group)
       @ems_azure_network = FactoryBot.create(:ems_azure_network)
       @hac_tree = TreeBuilderBelongsToHac.new(:hac_tree,
-                                              :hac,
                                               sb,
                                               true,
                                               :edit           => nil,
                                               :group          => @group,
                                               :selected_nodes => {})
       @vat_tree = TreeBuilderBelongsToVat.new(:vat_tree,
-                                              :vat,
                                               sb,
                                               true,
                                               :edit           => nil,

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
                    :name     => 'Datastore',
                    :location => 'Location',
                    :capture  => false}]
-    @datastore_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, {}, true, :root => @datastore)
+    @datastore_tree = TreeBuilderDatastores.new(:datastore_tree, {}, true, :root => @datastore)
 
     @ho_enabled = [FactoryBot.create(:host)]
     @ho_disabled = [FactoryBot.create(:host)]
@@ -20,7 +20,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
                                                                                             :ho_disabled => @ho_disabled})
     @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
     @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-    @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, {}, true, :root => @cluster)
+    @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true, :root => @cluster)
   end
 
   it "Check All checkbox have unique id for Clusters trees" do


### PR DESCRIPTION
Now the `type` and `name` arguments are completely redundant and the `type` is not used anywhere so it is time to remove it.

There are some tree initialization calls where the two arguments were swapped in order. This might cause some problems with `x_tree` and `x_active_tree` in the area as the name of the tree might not had the `_tree` suffix. Here are those:
* `TreeBuilderSections`
* `TreeBuilderProtect`
* `TreeBuilderClusters`
* `TreeBuilderDatastores`
* `TreeBuilderSmartproxyAffinity`

Also I might have missed some cases where metaprogramming comes into the game so would be nice to go through some of the non-explorer trees a little.

@miq-bot add_label trees, cleanup, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 