### PR TITLE
Fixes display text for Policy Server Compliance accordion nodes

### DIFF
--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -17,7 +17,7 @@ class TreeBuilderPolicy < TreeBuilder
                                  :ContainerImage      => _("Container Image Compliance Policies"),
                                  :ContainerProject    => _("Container Project Compliance Policies"),
                                  :ExtManagementSystem => _("Provider Compliance Policies"),
-                                 :PhysicalServer      => _("Physical Infrastructure Compliance Policies")},
+                                 :PhysicalServer      => _("Physical Server Compliance Policies")},
                  :control    => {:Host                => _("Host Control Policies"),
                                  :Vm                  => _("Vm Control Policies"),
                                  :ContainerReplicator => _("Replicator Control Policies"),
@@ -26,7 +26,7 @@ class TreeBuilderPolicy < TreeBuilder
                                  :ContainerImage      => _("Container Image Control Policies"),
                                  :ContainerProject    => _("Container Project Control Policies"),
                                  :ExtManagementSystem => _("Provider Control Policies"),
-                                 :PhysicalServer      => _("Physical Infrastructure Control Policies")}}
+                                 :PhysicalServer      => _("Physical Server Control Policies")}}
 
     MiqPolicyController::UI_FOLDERS.collect do |model|
       text = text_i18n[mode.to_sym][model.name.to_sym]


### PR DESCRIPTION
Fixes mismatched displays between accordion nodes for Policy Physical Servers Compliance node description and that of page Header and toolbar Configuration drop down menu.  

https://bugzilla.redhat.com/show_bug.cgi?id=1700070

Screen shot prior to code fix:
![Policies Accord with Physical Infrastructure Compliance node prior to code fix](https://user-images.githubusercontent.com/552686/56773246-34b94300-6772-11e9-96e3-f53bab13b883.png)

Screen shot post code fix:
![Policies Accord with Physical Server Compliance node post code fix](https://user-images.githubusercontent.com/552686/56773257-3e42ab00-6772-11e9-95be-832e51a35e39.png)

