### PR TITLE
Fix deprecation warnings in TreeBuilder root_class instance vars

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSystems
   def initialize(*args)
-    @root_class = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
+    @root_class = 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -1,6 +1,6 @@
 class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSystems
   def initialize(*args)
-    @root_class = ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+    @root_class = 'ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderImagesFilter < TreeBuilderVmsFilter
   def initialize(*args)
-    @root_class = ManageIQ::Providers::CloudManager::Template
+    @root_class = 'ManageIQ::Providers::CloudManager::Template'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
   def initialize(*args)
-    @root_class = ManageIQ::Providers::CloudManager::Vm
+    @root_class = 'ManageIQ::Providers::CloudManager::Vm'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
   def initialize(*args)
-    @root_class = ManageIQ::Providers::InfraManager::Template
+    @root_class = 'ManageIQ::Providers::InfraManager::Template'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
   def initialize(*args)
-    @root_class = MiqTemplate
+    @root_class = 'MiqTemplate'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderVmsFilter < TreeBuilder
   def initialize(*args)
-    @root_class = ManageIQ::Providers::InfraManager::Vm
+    @root_class = 'ManageIQ::Providers::InfraManager::Vm'
     super(*args)
   end
 

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
   def initialize(*args)
-    @root_class = Vm
+    @root_class = 'Vm'
     super(*args)
   end
 


### PR DESCRIPTION
Rails doesn't like to pass the `:db` argument as a class, it says it's better as a string:
```
DEPRECATION WARNING: Passing a class as a value in an Active Record query is deprecated and
will be removed. Pass a string instead. (called from x_get_global_filter_search_results at ...)
```

@miq-bot add_label technical debt, trees, hammer/no
@miq-bot add_reviewer @mzazrivec
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @PanSpagetka 