### PR TITLE
Use the Feature#build_tree instead of the individual build*tree methods in explorers

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -186,7 +186,7 @@ module ApplicationController::AdvancedSearch
 
   def adv_search_redraw_left_div
     if x_active_tree.to_s == "configuration_manager_cs_filter_tree"
-      build_configuration_manager_cs_filter_tree(x_active_tree)
+      build_configuration_manager_cs_filter_tree
       build_accordions_and_trees
       load_or_clear_adv_search
     elsif @edit[:in_explorer] || %w[storage_tree configuration_scripts_tree svcs_tree].include?(x_active_tree.to_s)

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -186,7 +186,6 @@ module ApplicationController::AdvancedSearch
 
   def adv_search_redraw_left_div
     if x_active_tree.to_s == "configuration_manager_cs_filter_tree"
-      build_configuration_manager_cs_filter_tree
       build_accordions_and_trees
       load_or_clear_adv_search
     elsif @edit[:in_explorer] || %w[storage_tree configuration_scripts_tree svcs_tree].include?(x_active_tree.to_s)

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -11,7 +11,7 @@ module ApplicationController::Explorer
 
   def try_build_tree(tree_symbol)
     # Legacy support for build_*_tree methods
-    # FIXME: delete this after all of them were converted
+    # FIXME: delete this after all of them were converted (remaining: build_reports_tree)
     method_name = :"build_#{tree_symbol}_tree"
     if respond_to?(method_name, true)
       method(method_name).call

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -10,12 +10,14 @@ module ApplicationController::Explorer
   end
 
   def try_build_tree(tree_symbol)
-    method_name = "build_#{tree_symbol}_tree"
-    return unless respond_to?(method_name, true)
-    build_method = method(method_name)
-    # FIXME: This is temporary, we actually need to remove all the build_*_tree methods and
-    # use the Feature::build_tree instead.
-    build_method.call
+    # Legacy support for build_*_tree methods
+    # FIXME: delete this after all of them were converted
+    method_name = :"build_#{tree_symbol}_tree"
+    if respond_to?(method_name, true)
+      method(method_name).call
+    else
+      features.find { |f| f.name == tree_symbol }.try(:build_tree, @sb)
+    end
   end
 
   # Historical tree item selected

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -15,7 +15,7 @@ module ApplicationController::Explorer
     build_method = method(method_name)
     # FIXME: This is temporary, we actually need to remove all the build_*_tree methods and
     # use the Feature::build_tree instead.
-    build_method.arity == 1 ? build_method.call(tree_symbol) : build_method.call
+    build_method.call
   end
 
   # Historical tree item selected

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -348,15 +348,15 @@ class AutomationManagerController < ApplicationController
     end
   end
 
-  def build_automation_manager_providers_tree(_type)
+  def build_automation_manager_providers_tree
     TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, @sb)
   end
 
-  def build_automation_manager_cs_filter(_type)
+  def build_automation_manager_cs_filter
     TreeBuilderAutomationManagerConfiguredSystems.new(:automation_manager_cs_filter_tree, @sb)
   end
 
-  def build_configuration_scripts_tree(_type)
+  def build_configuration_scripts_tree
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, @sb)
   end
 

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -348,18 +348,6 @@ class AutomationManagerController < ApplicationController
     end
   end
 
-  def build_automation_manager_providers_tree
-    TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, @sb)
-  end
-
-  def build_automation_manager_cs_filter
-    TreeBuilderAutomationManagerConfiguredSystems.new(:automation_manager_cs_filter_tree, @sb)
-  end
-
-  def build_configuration_scripts_tree
-    TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, @sb)
-  end
-
   def rebuild_trees(replace_trees)
     build_replaced_trees(replace_trees, %i[automation_manager_providers automation_manager_cs_filter configuration_scripts])
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2080,26 +2080,6 @@ class CatalogController < ApplicationController
       @record.prov_type == "generic_container_template"
   end
 
-  # Build a Catalog Items explorer tree
-  def build_sandt_tree
-    TreeBuilderCatalogItems.new('sandt_tree', @sb)
-  end
-
-  # Build a Services explorer tree
-  def build_svccat_tree
-    TreeBuilderServiceCatalog.new('svccat_tree', @sb)
-  end
-
-  # Build a Catalogs explorer tree
-  def build_stcat_tree
-    TreeBuilderCatalogs.new('stcat_tree', @sb)
-  end
-
-  # Build a Orchestration Templates explorer tree
-  def build_ot_tree
-    TreeBuilderOrchestrationTemplates.new('ot_tree', @sb)
-  end
-
   def show_record(id = nil)
     @sb[:action] = nil
     @display = params[:display] || "main" unless pagination_or_gtl_request?

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -258,10 +258,6 @@ class MiqAeClassController < ApplicationController
     existing_node
   end
 
-  def build_ae_tree
-    TreeBuilderAeClass.new(:ae, @sb)
-  end
-
   def replace_right_cell(options = {})
     @explorer = true
     replace_trees = options[:replace_trees]

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -415,18 +415,6 @@ class MiqAeCustomizationController < ApplicationController
     end
   end
 
-  def build_old_dialogs_tree
-    TreeBuilderProvisioningDialogs.new("old_dialogs_tree", @sb)
-  end
-
-  def build_dialogs_tree
-    TreeBuilderServiceDialogs.new("dialogs_tree", @sb)
-  end
-
-  def build_ab_tree
-    TreeBuilderButtons.new("ab_tree", @sb)
-  end
-
   def group_button_add_save(typ)
     # override for AE Customization Buttons - the label doesn't say Description
     if @edit[:new][:description].blank?

--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -80,11 +80,6 @@ module OpsController::Db
 
   private #######################
 
-  # Build a VMDB tree for Database accordion
-  def build_vmdb_tree
-    TreeBuilderOpsVmdb.new("vmdb_tree", @sb)
-  end
-
   # Get information for a DB tree node
   def db_get_info
     if x_node == "root"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -885,10 +885,6 @@ module OpsController::Diagnostics
     end
   end
 
-  def build_diagnostics_tree
-    TreeBuilderOpsDiagnostics.new("diagnostics_tree", @sb)
-  end
-
   def build_supported_depots_for_select
     depots_for_select = FileDepot.supported_depots.values.sort
     # S3 and Swift not currently supported for Log Collection

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -664,8 +664,7 @@ module OpsController::Diagnostics
     @explorer = true
     if params[:pressed] == "delete_server" || params[:pressed] == "zone_delete_server"
       @sb[:diag_selected_id] = nil
-      build_settings_tree
-      build_diagnostics_tree
+      build_replaced_trees(%i[settings diagnostics], %i[settings diagnostics])
     end
     parent = if x_node == "root"
                MiqRegion.my_region

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -815,11 +815,6 @@ module OpsController::OpsRbac
     process_elements(tenants, Tenant, task, _("Tenant"), "name")
   end
 
-  # Build the main Access Control tree
-  def build_rbac_tree
-    TreeBuilderOpsRbac.new("rbac_tree", @sb)
-  end
-
   # Get information for an access control node
   def rbac_get_info
     node, id = x_node.split("-")

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1274,11 +1274,6 @@ module OpsController::Settings::Common
     end
   end
 
-  # Build the main Settings tree
-  def build_settings_tree
-    TreeBuilderOpsSettings.new("settings_tree", @sb)
-  end
-
   def settings_set_view_vars
     if @sb[:active_tab] == "settings_details"
       # Enterprise Details tab

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -226,11 +226,11 @@ class ProviderForemanController < ApplicationController
     ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
   end
 
-  def build_configuration_manager_providers_tree(_type)
+  def build_configuration_manager_providers_tree
     TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, @sb)
   end
 
-  def build_configuration_manager_cs_filter_tree(_type)
+  def build_configuration_manager_cs_filter_tree
     TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter_tree, @sb)
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -226,14 +226,6 @@ class ProviderForemanController < ApplicationController
     ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
   end
 
-  def build_configuration_manager_providers_tree
-    TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, @sb)
-  end
-
-  def build_configuration_manager_cs_filter_tree
-    TreeBuilderConfigurationManagerConfiguredSystems.new(:configuration_manager_cs_filter_tree, @sb)
-  end
-
   def get_node_info(treenodeid, show_list = true)
     @sb[:action] = nil
     @nodetype, id = parse_nodetype_and_id(valid_active_node(treenodeid))

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -260,11 +260,6 @@ module PxeController::IsoDatastores
     process_elements(elements, IsoDatastore, task, display_name, "ems_id")
   end
 
-  # Get information for an event
-  def build_iso_datastores_tree
-    TreeBuilderIsoDatastores.new("iso_datastores_tree", @sb)
-  end
-
   def iso_datastore_get_node_info(treenodeid)
     if treenodeid == "root"
       iso_datastore_list

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -253,9 +253,4 @@ module PxeController::PxeCustomizationTemplates
       end
     end
   end
-
-  # Get information for an event
-  def build_customization_templates_tree
-    TreeBuilderPxeCustomizationTemplates.new("customization_templates_tree", @sb)
-  end
 end

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -152,11 +152,6 @@ module PxeController::PxeImageTypes
     process_elements(pxes, PxeImageType, task)
   end
 
-  # Get information for an event
-  def build_pxe_image_types_tree
-    TreeBuilderPxeImageTypes.new("pxe_image_types_tree", @sb)
-  end
-
   def pxe_image_type_get_node_info(treenodeid)
     if treenodeid == "root"
       pxe_image_type_list

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -425,11 +425,6 @@ module PxeController::PxeServers
     process_elements(pxes, PxeServer, task, display_name)
   end
 
-  # Get information for an event
-  def build_pxe_servers_tree
-    TreeBuilderPxeServers.new("pxe_servers_tree", @sb)
-  end
-
   def pxe_server_get_node_info(treenodeid)
     if treenodeid == "root"
       pxe_server_list

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -383,11 +383,6 @@ class ReportController < ApplicationController
     build_trees
   end
 
-  # Build the main import/export tree
-  def build_export_tree
-    TreeBuilderReportExport.new('export_tree', @sb)
-  end
-
   def determine_root_node_info
     case x_active_tree
     when :db_tree

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -478,9 +478,4 @@ module ReportController::Dashboards
       return [true, first_idx, last_idx]
     end
   end
-
-  # Build the main dashboards tree
-  def build_db_tree
-    TreeBuilderReportDashboards.new('db_tree', @sb)
-  end
 end

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -229,6 +229,7 @@ module ReportController::Reports
   end
 
   # Build the main reports tree
+  # FIXME: get rid of the data passing through session and delete this method
   def build_reports_tree
     populate_reports_menu
     TreeBuilderReportReports.new('reports_tree', @sb)

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -134,11 +134,4 @@ module ReportController::SavedReports
     session["#{x_active_tree}_sortcol".to_sym] = @sortcol
     session["#{x_active_tree}_sortdir".to_sym] = @sortdir
   end
-
-  private
-
-  # Build the main Saved Reports tree
-  def build_savedreports_tree
-    TreeBuilderReportSavedReports.new('savedreports_tree', @sb)
-  end
 end

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -463,10 +463,6 @@ module ReportController::Schedules
     end
   end
 
-  def build_schedules_tree
-    TreeBuilderReportSchedules.new('schedules_tree', @sb)
-  end
-
   def get_schedule(nodeid)
     @record = @schedule = MiqSchedule.find(nodeid.split('__').last.to_i)
     show_schedule

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -453,11 +453,6 @@ module ReportController::Widgets
     @edit[:new][:fields] = fields
   end
 
-  # Build the main widgets tree
-  def build_widgets_tree
-    TreeBuilderReportWidgets.new('widgets_tree', @sb)
-  end
-
   # Get variables from edit form
   def widget_get_form_vars
     @widget = @edit[:widget_id] ? MiqWidget.find(@edit[:widget_id]) : MiqWidget.new

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -494,11 +494,6 @@ class ServiceController < ApplicationController
     render :json => presenter.for_render
   end
 
-  # Build a Services explorer tree
-  def build_svcs_tree
-    TreeBuilderServices.new("svcs_tree", @sb)
-  end
-
   def show_record(id = nil)
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @lastaction = "show"

--- a/app/controllers/storage_controller/storage_d.rb
+++ b/app/controllers/storage_controller/storage_d.rb
@@ -30,11 +30,6 @@ module StorageController::StorageD
 
   private #######################
 
-  # Get information for an event
-  def build_storage_tree
-    TreeBuilderStorage.new("storage_tree", @sb)
-  end
-
   def storage_get_node_info(treenodeid)
     if treenodeid == "root"
       options = {:model => "Storage"}

--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -46,9 +46,4 @@ module StorageController::StoragePod
       end
     end
   end
-
-  # Get information for an event
-  def build_storage_pod_tree
-    TreeBuilderStoragePod.new("storage_pod_tree", @sb)
-  end
 end

--- a/spec/controllers/application_controller/advanced_search_spec.rb
+++ b/spec/controllers/application_controller/advanced_search_spec.rb
@@ -7,10 +7,11 @@ describe ProviderForemanController, "::AdvancedSearch" do
   describe "#adv_search_redraw_left_div" do
     before { controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_cs_filter_tree) }
 
-    it "calls build_configuration_manager_cs_filter_tree method in Config Mgmt Configured Systems when saving a filter" do
+    it "calls build_accordions_and_trees method in Config Mgmt Configured Systems when saving a filter" do
       allow(controller).to receive(:adv_search_redraw_listnav_and_main)
 
-      expect(controller).to receive(:build_configuration_manager_cs_filter_tree).once
+      expect(controller).to receive(:build_accordions_and_trees).and_call_original.once
+      expect(TreeBuilderConfigurationManagerConfiguredSystems).to receive(:new).and_call_original
       controller.send(:adv_search_redraw_left_div)
     end
   end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -293,8 +293,7 @@ describe ProviderForemanController do
   end
 
   it "builds foreman child tree" do
-    controller.send(:build_configuration_manager_providers_tree, :configuration_manager_providers)
-    tree_builder = TreeBuilderConfigurationManager.new("root", {})
+    tree_builder = TreeBuilderConfigurationManager.new("root", controller.instance_variable_get(:@sb))
     objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false, {})
     expected_objects = [@config_mgr, @config_mgr2]
     expect(objects).to match_array(expected_objects)
@@ -504,7 +503,7 @@ describe ProviderForemanController do
   end
 
   it "renders tree_select as js" do
-    controller.send(:build_configuration_manager_providers_tree, :configuration_manager_providers)
+    TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, controller.instance_variable_get(:@sb))
 
     allow(controller).to receive(:process_show_list)
     allow(controller).to receive(:add_unassigned_configuration_profile_record)
@@ -535,7 +534,7 @@ describe ProviderForemanController do
     end
 
     it "does not hide Configuration button in the toolbar" do
-      controller.send(:build_configuration_manager_providers_tree, :providers)
+      TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, controller.instance_variable_get(:@sb))
       key = ems_key_for_provider(@provider)
       post :tree_select, :params => { :id => key }
       expect(response.status).to eq(200)
@@ -619,7 +618,7 @@ describe ProviderForemanController do
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [tags]}
       allow_any_instance_of(User).to receive(:get_filters).and_return(user_filters)
-      tree = controller.send(:build_configuration_manager_providers_tree, :configuration_manager_providers)
+      tree = TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, controller.instance_variable_get(:@sb))
       first_child = find_treenode_for_foreman_provider(tree, @provider)
       expect(first_child).to eq(nil)
     end
@@ -633,7 +632,7 @@ describe ProviderForemanController do
                                        :object_ids => @configured_system.id,
                                        :add_ids    => quota_2gb_tag.id,
                                        :delete_ids => [])
-      tree = controller.send(:build_configuration_manager_providers_tree, :configuration_manager_providers)
+      tree = TreeBuilderConfigurationManager.new(:configuration_manager_providers_tree, controller.instance_variable_get(:@sb))
       node1 = find_treenode_for_foreman_provider(tree, @provider)
       node2 = find_treenode_for_foreman_provider(tree, @provider2)
       expect(node1).not_to be_nil


### PR DESCRIPTION
Right now we use a `build*tree` method for each explorer tree reload, usually for adding/editing/deleting nodes. When the tree is being built for other purposes, we use the `Feature#build_tree` method. They are *kinda redundant* but the latter one is a little bit cleaner and needs less code.

The `build_reports_tree` is a little special, as it relies on a session parameter set by `populate_reports_menu` which has to run before building the tree. The idea is to not use the session in such way, I'm discussing with @kbrock about the alternatives and their performance issues. Until this is solved, there's an `if` 🦛 marked with a FIXME :evergreen_tree: that runs the old code. For the other trees we can use the new stuff.

I'm pretty sure @martinpovolny will :heart: these changes :wink: 

@miq-bot add_label trees, refactoring, cleanup, hammer/no