### PR TITLE
Add ancestry parents to breadcrumbs

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -36,6 +36,10 @@ module Mixins
         if (options[:include_record] || breadcrumbs_from_tree.blank?) && options[:record_info].present? && options[:record_info][options[:record_title]] &&
            !(@tagitems || @politems || @ownershipitems || @retireitems)
           # Append breadcrumb created from record_info if included or if result from tree was empty (eg filters page)
+
+          # Ancestry parents breadcrumbs
+          breadcrumbs.concat(ancestry_parents(options[:ancestry], options[:record_info], options[:record_title])) if options[:ancestry]
+
           breadcrumbs.push(:title => options[:record_info][options[:record_title]], :key => x_node_right_cell)
           breadcrumbs.push(:title => @right_cell_text) if options[:show_header] && @right_cell_text
         else
@@ -100,6 +104,18 @@ module Mixins
       end
 
       breadcrumbs
+    end
+
+    # Build ancestry parents if user provides an ancestry key
+    def ancestry_parents(parent_class, record, title)
+      breadcrumbs = []
+
+      while record.ancestry
+        record = parent_class.find(record.ancestry)
+        breadcrumbs.push(:title => record[title], :key => TreeBuilder.build_node_id(record))
+      end
+
+      breadcrumbs.reverse
     end
 
     # Helper methods

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -541,6 +541,7 @@ class ServiceController < ApplicationController
       ],
       :show_header => @sb[:action],
       :record_info => @service,
+      :ancestry    => Service,
     }
   end
 

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -204,4 +204,25 @@ describe Mixins::BreadcrumbsMixin do
       end
     end
   end
+
+  describe "#ancestry_parents" do
+    let(:service1) { FactoryBot.create(:service, :id => 1, :name => "Level 1", :ancestry => nil) }
+    let(:service2) { FactoryBot.create(:service, :id => 2, :name => "Level 2", :ancestry => "1") }
+    let(:service3) { FactoryBot.create(:service, :id => 3, :name => "Level 3", :ancestry => "2") }
+
+    it "creates one level nested breadcrumbs" do
+      expect(Service).to receive(:find).and_return(service1)
+      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-1")
+      expect(mixin.ancestry_parents(Service, service2, :name)).to eq([{:title => service1.name, :key => "xx-1"}])
+    end
+
+    it "creates two level nested breadcrumbs" do
+      expect(Service).to receive(:find).and_return(service2, service1)
+      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-2", "xx-1")
+      expect(mixin.ancestry_parents(Service, service3, :name)).to eq([
+                                                                       {:title => service1.name, :key => "xx-1"},
+                                                                       {:title => service2.name, :key => "xx-2"},
+                                                                     ])
+    end
+  end
 end


### PR DESCRIPTION
**Description**
- Display the ancestry hiearchy in breadcrumbs (Service controller)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5390

**Before**

![image](https://user-images.githubusercontent.com/32869456/56895283-f4ff9d80-6a88-11e9-9859-0bdc2a11eba3.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/56895268-e6b18180-6a88-11e9-8d7b-12ffbb3f889d.png)

@miq-bot add_label hammer/no, enhancement, services

@miq-bot add_reviewer @skateman
