### PR TITLE
Use numeric comparison for IDs

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -174,9 +174,11 @@ module ApplicationController::Filter
               self.exp_key = nil
             else
               # for date time fields we should show After/Before etc. options
+              chosen_field_col_type = MiqExpression.get_col_type(params[:chosen_field])
               if exp_model != '_display_filter_' &&
                  MiqExpression::Field.parse(exp_field).plural? &&
-                 !%i[date datetime].include?(MiqExpression.get_col_type(params[:chosen_field]))
+                 !%i[date datetime].include?(chosen_field_col_type) &&
+                 chosen_field_col_type.object_id != :integer.object_id
                 self.exp_key = 'CONTAINS' # CONTAINS is valid only for plural tables
               else
                 self.exp_key = nil unless MiqExpression.get_col_operators(exp_field).include?(exp_key)

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -64,6 +64,12 @@ describe ApplicationController::Filter do
         expect(controller).to receive(:render)
         controller.send(:exp_changed)
         expect(expression.exp_key).to eq('IS')
+        controller.instance_variable_set(:@expkey, :record_filter)
+        controller.instance_variable_set(:@_params, :chosen_field => "Flavor.cloud_tenants-id")
+        expect(controller).to receive(:render)
+        controller.send(:exp_changed)
+        expect(expression.exp_key).to_not eq('CONTAINS')
+        expect(expression.exp_key).to eq('=')
       end
     end
   end


### PR DESCRIPTION
Fixes a bug where Expression Editor was comparing integer fields with 'Contains' rather than using a numeric comparison.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698168
