### PR TITLE
fix event log entry markup

### DIFF
--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -19,7 +19,7 @@
         %td= _("<New Entry>")
         %td= _("<New Entry>")
         %td= _("<New Entry>")
-        %th.action-cell
+        %td.action-cell
           %button.btn.btn-default.btn-block.btn-sm
             = _("Add")
     - else


### PR DESCRIPTION
Incorrect tag was causing the automated tests to fail, although the screen looked fine to the user.

Old
<img width="828" alt="Screen Shot 2019-04-29 at 1 11 00 PM" src="https://user-images.githubusercontent.com/1287144/56913840-a3ebab80-6a80-11e9-8a32-73dfa80241fb.png">

New (no difference)
<img width="828" alt="Screen Shot 2019-04-29 at 1 11 00 PM" src="https://user-images.githubusercontent.com/1287144/56913849-ab12b980-6a80-11e9-8a9b-2616a8b657b8.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1703141