### PR TITLE
Show whole header in show page breadcrumbs

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -15,14 +15,14 @@ module Mixins
       # Different methods for controller with explorers and for non-explorers controllers
 
       if !features?
-        # Append breadcrumb from @record item (eg "Openstack")
-        breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title]))
+        # Append breadcrumb from @record item (eg "Openstack") when on some action page (not show, display)
+        breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title])) if not_show_page?
 
         # Append tag and policy breadcrumb if they exist
         breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))
 
         # Append title breadcrumb if they exist and not same as previous breadcrumb (eg "Editing name")
-        if @title && not_show_page? && @title != breadcrumbs.compact.last.try(:[], :title)
+        if @title && @title != breadcrumbs.compact.last.try(:[], :title)
           breadcrumbs.push(:title => @title)
         end
       else
@@ -141,7 +141,7 @@ module Mixins
 
     # User is not on show page
     def not_show_page?
-      (action_name == "show" && params["display"]) || (action_name != "show")
+      (action_name == "show" && params["display"] && !%w[dashboard main].include?(params["display"])) || (action_name != "show")
     end
 
     # Controls on tagging screen if the tagged item is floating_ip


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703744

**Steps to reproduce**

1. Go to Compute > Infrastructure > Providers
2. Select one (look on breadcrumbs)
3. Switch Summary/Dashboard view (look again on breadcrumbs)

**Description**

Initially, I designed breadcrumbs to not contain header of show pages, because they contain titles (ex. `(Summary)`, `(Dashboard)`), which are lost after getting deeper in the hierarchy. However, after UX discussion, this behavior is not bad.

So from now the breadcrumbs on show pages will include the whole header (includes `summary`, etc.) and when getting deeper, only name of the record will be used.

Please see [breadcrumbs documentation](https://github.com/ManageIQ/manageiq-ui-classic/wiki/Breadcrumbs)

**Before**

Show page

![image](https://user-images.githubusercontent.com/32869456/58408414-0929c100-806e-11e9-8cac-2bff2307ff5f.png)

Edit action

![image](https://user-images.githubusercontent.com/32869456/58408431-15ae1980-806e-11e9-88eb-72f801c87747.png)


**After**

Show page

![image](https://user-images.githubusercontent.com/32869456/58408251-b94afa00-806d-11e9-8214-79e34ff93a5d.png)

Edit action 

- same as before


@miq-bot add_label bug