### PR TITLE
Remove wrong and redundant check

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -850,7 +850,7 @@ module ApplicationController::Buttons
       roles = []
       @edit[:new][:roles].each do |r|
         role = MiqUserRole.find_by(:id => r)
-        roles.push(role.name) if role && r == role.id.to_s
+        roles.push(role.name) if role
       end
       button.visibility[:roles] = roles
     else


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703588

Steps to reproduce:
- Go to Service -> Catalogs -> Catalog Items -> select any button -> Configuration -> Edit this button

- Advanced tab -> Role Access -> Show -> select `<By Role>` -> Add Role(s) to this button  -> Save

- Edit this button again adding Role(s) -> Save

- Role(s) from first saving are present

Make sure https://bugzilla.redhat.com/show_bug.cgi?id=1650090 isn't reintroduced.

Steps to reproduce:
- Go to Service -> Catalogs -> Catalog Items -> select any button -> Configuration -> Edit this button

- Advanced tab -> Role Access -> Show -> select `<By Role>` -> Add Role(s) to this button  -> Save

- Roles have to be showing on summary page

@miq-bot add_label hammer/yes, bug

@h-kataria please have a look, thanks :)
