### PR TITLE
Display the missing Main Configuration in the RBAC roles tree

### DIFF
--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -27,7 +27,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       section
     end
 
-    top_nodes += %w[all_vm_rules api_exclusive sui].collect do |additional_feature|
+    top_nodes += %w[all_vm_rules api_exclusive sui ops_explorer].collect do |additional_feature|
       MiqProductFeature.obj_features[additional_feature] &&
         MiqProductFeature.obj_features[additional_feature][:feature]
     end


### PR DESCRIPTION
After the [extraction](https://github.com/ManageIQ/manageiq-ui-classic/pull/5453) of the `Configuration` from `Settings` the RBAC role tree was not updated with the new structure. The incomplete tree caused a side-effect that is described in the BZ below.

**Before:**
![Screenshot from 2019-04-30 13-30-29](https://user-images.githubusercontent.com/649130/56958945-268d6d00-6b4c-11e9-8967-3ce534833600.png)

**After:**
![Screenshot from 2019-04-30 13-31-49](https://user-images.githubusercontent.com/649130/56959010-56d50b80-6b4c-11e9-8581-69d04d1f66b4.png)

As there would be two `Configuration` node on the same level in the tree, I'm renaming the latter one to `Main Configuration` in a [depending core PR](https://github.com/ManageIQ/manageiq/pull/18707).

@miq-bot add_label bug, rbac, hammer/no
@miq-bot add_reviewer @martinpovolny 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704163