### PR TITLE
Rename Settings to User Settings in the RBAC tree

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -255,7 +255,7 @@ module Menu
       end
 
       def settings_menu_section
-        Menu::Section.new(:set, N_("Settings"), 'pficon pficon-settings', [
+        Menu::Section.new(:set, N_("User Settings"), 'pficon pficon-settings', [
           Menu::Item.new('configuration', N_('My Settings'),   'my_settings',  {:feature => 'my_settings', :any => true},  '/configuration/index'),
           Menu::Item.new('my_tasks',      N_('Tasks'),         'tasks',        {:feature => 'tasks', :any => true},        '/miq_task/index?jobs_tab=tasks')
         ], :top_right)


### PR DESCRIPTION
Related to, but doesn't depend on https://github.com/ManageIQ/manageiq-ui-classic/pull/5507

**Before:**
![Screenshot from 2019-04-30 13-43-06](https://user-images.githubusercontent.com/649130/56959513-e6c78500-6b4d-11e9-90cb-e150bf43c86d.png)

**After:**
![Screenshot from 2019-04-30 13-42-28](https://user-images.githubusercontent.com/649130/56959500-ddd6b380-6b4d-11e9-97ca-e2103ed52bdc.png)

Discussed this with @loicavenel, it's a little bit more meaningful.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label rbac, hammer/no