### PR TITLE
Lock bootstrap-switch to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "array-includes": "~3.0.3",
     "awesome-debounce-promise": "^2.1.0",
     "bootstrap-filestyle": "~1.2.1",
-    "bootstrap-switch": "~3.3.4",
+    "bootstrap-switch": "3.3.4",
     "classnames": "~2.2.6",
     "codemirror": "~5.19.0",
     "connected-react-router": "^4.3.0",


### PR DESCRIPTION
bootstrap-switch 3.3.5 breaks initial state, forcing all switches to false (issue: https://github.com/Bttstrp/bootstrap-switch/issues/703)
(and 3.4.0 is using boostrap 4, so we can't use it)

Locking to 3.3.4 for now, will relax it if 3.3.6 comes out fixed.
(Hammer should not be affected because of [yarn.lock](https://github.com/ManageIQ/manageiq-ui-classic/blob/hammer/yarn.lock#L2090))



Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704337