### PR TITLE
Inform user about outdates belongsto filters

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1127,8 +1127,12 @@ module OpsController::OpsRbac
     # Build the belongsto filters hash
     @group.get_belongsto_filters.each do |b| # Go thru the belongsto tags
       bobj = MiqFilter.belongsto2object(b)   # Convert to an object
-      next unless bobj
-      @edit[:new][:belongsto][bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+      if bobj
+        @edit[:new][:belongsto][bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+      else
+        @deleted_belongsto_filters ||= []
+        @deleted_belongsto_filters.push(MiqFilter.belongsto2path_human(b))
+      end
     end
 
     # Build roles hash

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -686,6 +686,7 @@ module OpsController::OpsRbac
       AuditEvent.success(build_saved_audit(record, add_pressed))
       subkey = key == :group ? :description : :name
       add_flash(_("%{model} \"%{name}\" was saved") % {:model => what.titleize, :name => @edit[:new][subkey]})
+      add_flash(_("Outdated filters were removed from group \"%{name}\"") % {:name => @edit[:new][subkey]}) if what == "group" && @edit[:current][:deleted_belongsto_filters].present?
       @edit = session[:edit] = nil # clean out the saved info
       if add_pressed
         suffix = case rbac_suffix

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -886,8 +886,12 @@ module OpsController::OpsRbac
       # Build the belongsto filters hash
       @group.get_belongsto_filters.each do |b| # Go thru the belongsto tags
         bobj = MiqFilter.belongsto2object(b) # Convert to an object
-        next unless bobj
-        @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+        if bobj
+          @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+        else
+          @deleted_belongsto_filters ||= []
+          @deleted_belongsto_filters.push(MiqFilter.belongsto2path_human(b))
+        end
       end
       # Build the managed filters hash
       [@group.get_managed_filters].flatten.each do |f|

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -651,7 +651,7 @@ module OpsController::OpsRbac
     end
 
     @in_a_form = true
-    session[:changed] = false
+    session[:changed] = key == :group ? @deleted_belongsto_filters.present? : false
     add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
     @sb[:pre_edit_node] = x_node  unless params[:button] # Save active tree node before edit
     replace_right_cell(:nodetype => x_node)
@@ -1168,6 +1168,8 @@ module OpsController::OpsRbac
                        end
 
     rbac_group_right_tree(@edit[:new][:belongsto].keys)
+    @edit[:current][:deleted_belongsto_filters] = @deleted_belongsto_filters
+    @edit[:new][:belongsto].except!(*@deleted_belongsto_filters)
   end
 
   def rbac_group_filter_expression_vars(field_expression, field_expression_table)

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -7,6 +7,20 @@
 - can_lookup_groups = mode.downcase.start_with?('ldap')
 - can_lookup_groups = mode.downcase == "httpd" && ! (saml_enabled || oidc_enabled) unless can_lookup_groups
 = render :partial => "layouts/flash_msg"
+
+%div{:id => "warn_div", :style => ""}
+  - if @deleted_belongsto_filters.present?
+    .flash_text_div
+      .alert.alert-warning.alert-dismissable
+        %span.pficon-warning-triangle-o
+        %strong= h('These outdated filters need review as it affects their visibility. We suggest editing and saving the group to delete these outdated filters.')
+        %ul
+          %li
+            %strong= (_("%{title_for_hosts} & %{title_for_clusters}") % {:title_for_hosts => title_for_hosts, :title_for_clusters => title_for_clusters})
+            %ul
+              - @deleted_belongsto_filters.each do |deleted_filter|
+                %li
+                  %strong= h(deleted_filter)
 #group_info
   %h3
     = _("Group Information")

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -325,6 +325,106 @@ describe OpsController do
       allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
     end
 
+    context "outdated belongsto filters" do
+      let(:ems) { FactoryBot.create(:ems_vmware, :name => 'ems') }
+      let(:root) do
+        datacenters = FactoryBot.create(:ems_folder, :name => "Datacenters")
+        datacenters.parent = ems
+        datacenters
+      end
+
+      let(:dc) do
+        datacenter = FactoryBot.create(:ems_folder, :name => "Datacenter1")
+        datacenter.parent = root
+        datacenter
+      end
+
+      let(:hfolder) do
+        hfolder = FactoryBot.create(:ems_folder, :name => "host")
+        hfolder.parent = dc
+        hfolder
+      end
+      let(:cluster_1) do
+        cluster = FactoryBot.create(:ems_cluster, :name => "MTC Development 1")
+        cluster.parent = hfolder
+        cluster
+      end
+
+      let(:cluster_2) do
+        cluster = FactoryBot.create(:ems_cluster, :name => "MTC Development 2")
+        cluster.parent = hfolder
+        cluster
+      end
+
+      let(:vm_folder_path) { "/belongsto/ExtManagementSystem|#{ems.name}/EmsFolder|#{root.name}/EmsFolder|#{dc.name}/EmsFolder|#{hfolder.name}/EmsCluster|#{cluster_1.name}" }
+
+      let(:outdated_belongs_to_filters) { ["#{vm_folder_path}XXXX", "#{vm_folder_path}YYYY"] }
+
+      before do
+        @group.entitlement = Entitlement.new
+        @group.entitlement.set_belongsto_filters([vm_folder_path] + outdated_belongs_to_filters)
+        @group.entitlement.set_managed_filters([])
+        @group.save!
+      end
+
+      it "removes outdated belongs to filters" do
+        belongsto_filters = {}
+        @group.get_belongsto_filters.each do |b|
+          bobj = MiqFilter.belongsto2object(b)
+          belongsto_filters[bobj.class.to_s + "_" + bobj.id.to_s] = b if bobj
+        end
+
+        expect(@group.get_belongsto_filters).to match_array([vm_folder_path] + outdated_belongs_to_filters)
+
+        controller.instance_variable_set(:@edit, :new     => {:group_id              => @group.id,
+                                                              :use_filter_expression => false,
+                                                              :name                  => "Name",
+                                                              :description           => "Test",
+                                                              :role                  => @role.id,
+                                                              :filter_expression     => @exp.exp,
+                                                              :belongsto             => belongsto_filters,
+                                                              :filters               => {} },
+                                                 :current => {:deleted_belongsto_filters => outdated_belongs_to_filters})
+
+        controller.send(:rbac_group_set_record_vars, @group)
+
+        allow(controller).to receive(:load_edit).and_return(true)
+        allow(controller).to receive(:build_saved_audit).and_return({})
+        allow(controller).to receive(:get_node_info)
+        allow(controller).to receive(:replace_right_cell)
+        controller.send(:rbac_edit_save_or_add, "group")
+
+        expect(@group.get_belongsto_filters).to match_array([vm_folder_path])
+
+        controller.instance_variable_set(:@record, @group)
+
+        controller.send(:rbac_group_set_form_vars)
+      end
+
+      it "removes outdated belongs to filters" do
+        controller.instance_variable_set(:@record, @group)
+
+        allow(controller).to receive(:rbac_group_right_tree)
+        controller.send(:rbac_group_set_form_vars)
+
+        expect(controller.instance_variable_get(:@deleted_belongsto_filters)).to match_array(outdated_belongs_to_filters.map { |x| MiqFilter.belongsto2path_human(x) })
+      end
+    end
+
+    it "saves the filters when use_filter_expression is false" do
+      @group.entitlement = Entitlement.create!
+      controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,
+                                                        :name                  => 'Name',
+                                                        :description           => "Test",
+                                                        :role                  => @role.id,
+                                                        :filter_expression     => @exp.exp,
+                                                        :belongsto             => {},
+                                                        :filters               => {'managed/env' => '/managed/env'}})
+      controller.send(:rbac_group_set_record_vars, @group)
+      expect(@group.entitlement.filter_expression).to be_nil
+      expect(@group.entitlement.get_managed_filters).to match([["/managed/env"]])
+    end
+
     it "saves the filters when use_filter_expression is false" do
       @group.entitlement = Entitlement.create!
       controller.instance_variable_set(:@edit, :new => {:use_filter_expression => false,


### PR DESCRIPTION

- [x] https://github.com/ManageIQ/manageiq/pull/18651


Belongsto filters refer to objects(ExtManagementSystem, Host, Datacenters, Clusters,... ) but if this object is deleted, reference in belongsto filters is still present - it is ok that the reference is still present - but user needs to have way how to be informed about it and how to remove this outdated filters.

**Displaying outdated filters in detail of group.**

<img width="1461" alt="Screenshot 2019-04-30 at 18 45 14" src="https://user-images.githubusercontent.com/14937244/56979403-0b395680-6b7a-11e9-8a18-50536b74fbf2.png">

**Displaying outdated filters in detail of group when edit.** (Save is active - because when you click on it these outdated filter will be removed)
<img width="1456" alt="Screenshot 2019-04-30 at 18 45 45" src="https://user-images.githubusercontent.com/14937244/56979465-2efc9c80-6b7a-11e9-862e-b0ef83422e30.png">

**Message after saving a group and removing outdated filters**

<img width="1461" alt="Screenshot 2019-04-30 at 18 46 00" src="https://user-images.githubusercontent.com/14937244/56979521-4b003e00-6b7a-11e9-96af-4e1c8b381cec.png">


There is GIF with everything together:

![fTHjZ5G2rg](https://user-images.githubusercontent.com/14937244/56979578-666b4900-6b7a-11e9-9e1c-085aaefd2a38.gif)





@miq-bot assign @himdel 
@miq-bot add_label changelog/yes, enhancement


Links
-----
* https://github.com/ManageIQ/manageiq/pull/18651
* https://bugzilla.redhat.com/show_bug.cgi?id=1693183