### PR TITLE
Unify sorting in GOD of Button Groups

### DIFF
--- a/app/views/generic_object_definition/_show_actions.html.haml
+++ b/app/views/generic_object_definition/_show_actions.html.haml
@@ -12,7 +12,7 @@
           %th
             = _('Hover Text')
         %tbody
-          - @record.custom_button_sets.each do |obj|
+          - @record.custom_button_sets.sort_by{ |group | group.name }.each do |obj|
             %tr
               %td.table-view-pf-select
                 %i{:class => obj.set_data[:button_icon], :style => obj.set_data.key?(:button_color) ? "color: #{obj.set_data[:button_color]};" : nil}


### PR DESCRIPTION
GOD tree sorts Button Groups by their name. Fixing table to have same sort as tree.

Go to Automation -> Automate -> Generic Objects -> Add few Button Groups with names that go from Z to A (so their chronological and alphabetical orders are different!) -> see tree and table orders are different

Before:
![image](https://user-images.githubusercontent.com/9210860/57015171-a03c5e00-6c13-11e9-96f7-6052a0462770.png)

After:
![image](https://user-images.githubusercontent.com/9210860/57015173-a4687b80-6c13-11e9-8ae7-dbb422bda528.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1665031

https://github.com/ManageIQ/manageiq-ui-classic/pull/5146 didn't fix the problem completely.

@miq-bot add_label bug, generic objects, automate/automation, hammer/yes, gaprindashvili/yes, bugzilla needed
