### PR TITLE
Eliminate the grp_title sandbox variable used in report menus

### DIFF
--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -594,7 +594,7 @@ module ReportController::Menus
     # calculating selected reports for selected folder
     if session[:node_selected] == "xx-b__Report Menus for #{session[:role_choice]}"
       @edit[:new].each do |arr|
-        if arr[0] != @sb[:grp_title]
+        if arr[0] != reports_group_title
           @folders.push(arr[0])
         end
       end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1588,7 +1588,7 @@ module ReportController::Reports::Editor
 
   def setnode_for_customreport
     @sb[:rpt_menu].each_with_index do |level1_nodes, i|
-      next unless level1_nodes[0] == @sb[:grp_title]
+      next unless level1_nodes[0] == reports_group_title
       level1_nodes[1].each_with_index do |level2_nodes, k|
         # Check for the existence of the Custom folder in the Reports tree and
         # check if at least one report exists underneath it

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -46,7 +46,7 @@ module ReportController::SavedReports
         self.x_node = "xx-#{rr.miq_report_id}"
       else
         @sb[:rpt_menu].each_with_index do |lvl1, i|
-          next unless lvl1[0] == @sb[:grp_title]
+          next unless lvl1[0] == reports_group_title
           lvl1[1].each_with_index do |lvl2, k|
             x_node_set("xx-#{i}_xx-#{i}-#{k}_rep-#{rr.miq_report_id}", :reports_tree) if lvl2[0].downcase == "custom"
           end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -120,13 +120,12 @@ module ReportHelper
   def get_reports_menu(hide_custom = false, group = current_group)
     reports = group.try(:settings).try(:[], :report_menus) || default_reports_menu
     unless hide_custom
-      @sb[:grp_title] = reports_group_title
       # Select all custom reports
       query = {:template_type => 'report', :rpt_type => 'Custom'}
       # If the current_user is not a report admin, restrict this to the current group only
       query[:miq_group_id] = current_group.try(:id) unless current_user.report_admin_user?
       # Add the custom reports in the required format in their own menu item
-      reports.push([@sb[:grp_title], [[_("Custom"), MiqReport.where(query).order(:name).pluck(:name)]]])
+      reports.push([reports_group_title, [[_("Custom"), MiqReport.where(query).order(:name).pluck(:name)]]])
     end
     reports
   end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -138,13 +138,13 @@ module ReportHelper
   end
 
   def reports_group_title
-    tenant_name = current_tenant.name
-    if current_user.report_admin_user?
+    tenant_name = User.current_tenant.name
+    if User.current_user.report_admin_user?
       _("%{tenant_name} (All Groups)") % {:tenant_name => tenant_name}
     else
       _("%{tenant_name} (Group): %{group_description}") %
         {:tenant_name       => tenant_name,
-         :group_description => current_user.current_group.description}
+         :group_description => User.current_user.current_group.description}
     end
   end
 end

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -26,7 +26,7 @@
                     = _("Name")
               %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('reports_tree','xx-#{i}');"}
                 %td.table-view-pf-select
-                  - if folder[0] == @sb[:grp_title]
+                  - if folder[0] == reports_group_title
                     - glyphicon = "pficon pficon-folder-close-blue"
                   - else
                     - glyphicon = "pficon pficon-folder-close"
@@ -45,7 +45,7 @@
                     = _('Name')
               %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('reports_tree','xx-#{nodes[1].to_i}_xx-#{nodes[1].to_i}-#{i}');"}
                 %td.table-view-pf-select
-                  %i.pficon{:class => "pficon-folder-close#{@sb[:rpt_menu][nodes[1].to_i][0] == @sb[:grp_title] ? '-blue' : ''}"}
+                  %i.pficon{:class => "pficon-folder-close#{@sb[:rpt_menu][nodes[1].to_i][0] == reports_group_title ? '-blue' : ''}"}
                 %td
                   -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree
                   -# custom reports will be shown in assigned folders and custom folder both


### PR DESCRIPTION
The `@sb[:grp_title]` is being generated by `ReportHelper#reports_group_title` and it's basically cached in the sandbox. However, the method itself isn't that expensive that it would worth to store it in such an evil place, so :scissors: :toilet: :fire: 

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cloud intel/reporting, technical debt, hammer/no