### PR TITLE
Make the custom reports tree node blue again

### DIFF
--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -1,11 +1,13 @@
 class TreeBuilderReportReports < TreeBuilderReportReportsClass
   REPORTS_IN_TREE = true
 
+  include ReportHelper
+
   private
 
   def initialize(name, sandbox, build = true, **_params)
     @rpt_menu  = sandbox[:rpt_menu]
-    @grp_title = sandbox[:grp_title]
+    @grp_title = reports_group_title
     super(name, sandbox, build)
   end
 

--- a/spec/presenters/tree_builder_report_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_reports_spec.rb
@@ -1,0 +1,15 @@
+describe TreeBuilderReportReports do
+  describe "#initialize" do
+    let(:role) { MiqUserRole.find_by(:name => "EvmRole-operator") }
+    let(:tenant) { FactoryGirl.create(:tenant) }
+    let(:group) { FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Test Group", :tenant => tenant) }
+
+    before { login_as FactoryGirl.create(:user, :userid => 'wilma', :miq_groups => [group]) }
+
+    subject { described_class.new(:roles_tree, {}, false) }
+
+    it "sets the group title correctly" do
+      expect(subject.instance_variable_get(:@grp_title)).to include("Test Group")
+    end
+  end
+end


### PR DESCRIPTION
I forgot to stage this change into #5518, so caused a bug :see_no_evil:. It's under `Cloud Intel -> Reports -> Reports`, the last 2nd level node should be blue.

**Before:**
![Screenshot from 2019-05-02 13-51-57](https://user-images.githubusercontent.com/649130/57073506-89643d00-6ce1-11e9-974d-440d6a259531.png)

**After:**
![Screenshot from 2019-05-02 13-48-46](https://user-images.githubusercontent.com/649130/57073510-8cf7c400-6ce1-11e9-9d77-ef1e38a7a15b.png)

@miq-bot add_label bug, trees, cloud intel/reporting, hammer/no
@miq-bot assign @martinpovolny 
