### PR TITLE
Do not refresh breadcrumbs when clicking in policy_sim

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -93,7 +93,7 @@ module ApplicationController::PolicySupport
       @in_a_form = true
       if params[:action] == "policy_sim"
         @refresh_partial = "layouts/policy_sim"
-        replace_right_cell
+        replace_right_cell(:refresh_breadcrumbs => false)
       end
     end
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -469,7 +469,7 @@ module VmCommon
         return
       end
       @in_a_form = true
-      replace_right_cell(:action => 'policy_sim')
+      replace_right_cell(:action => 'policy_sim', :refresh_breadcrumbs => false)
     else
       render :template => 'vm/show'
     end
@@ -1114,7 +1114,8 @@ module VmCommon
 
   # Replace the right cell of the explorer
   def replace_right_cell(options = {})
-    action, presenter = options.values_at(:action, :presenter)
+    action, presenter, refresh_breadcrumbs = options.values_at(:action, :presenter, :refresh_breadcrumbs)
+    refresh_breadcrumbs = true unless options.key?(:refresh_breadcrumbs)
 
     @explorer = true
     @sb[:action] = action unless action.nil?
@@ -1313,7 +1314,7 @@ module VmCommon
     presenter[:hide_modal] = true
     presenter[:lock_sidebar] = @in_a_form && @edit
 
-    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new'])
+    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs_new']) if refresh_breadcrumbs
 
     render :json => presenter.for_render
   end


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704424 https://github.com/ManageIQ/manageiq-ui-classic/issues/5378

**Steps to reproduce**

1. Compute > Cloud > Instances
click on some instance => its summary page

2. Policy > Policy Simulation
select some Policy Profile from the drop down
=> check the breadcrumbs

3. click on a quadicon of the instance
=> breadcrumbs changed!

4. click on Back button
=> breadcrumbs remain unchanged (the same asi in step 5) but different to the ones in step 4!

**Description**

VM controllers are using shared methods and when they are doing it, the breadcrumbs do not know which controller is used.

**Solution**

Breadcrumbs are not re-rendered when clicking in policy simulation screen, so they remain the same.

**Before** (pleease, ignore the VSCode window :smile_cat:  )

![before](https://user-images.githubusercontent.com/32869456/57124760-380e8900-6d87-11e9-94a6-871a91c1beca.gif)

**After**

![after](https://user-images.githubusercontent.com/32869456/57124764-42308780-6d87-11e9-839a-81b9dbb96a58.gif)
