### PR TITLE
Fix highlighting the condition in accordion after editing it

### DIFF
--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -2,7 +2,7 @@ class TreeBuilderCondition < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true}
+    {:full_ids => true}
   end
 
   # level 0 - root


### PR DESCRIPTION
**Fixes BZ:**
https://bugzilla.redhat.com/show_bug.cgi?id=1704380

**What:**
This PR fixes highlighting the condition in accordion right after editing it: the edited condition was not highlighted in accordion as expected, instead of that, _All Conditions_ node was highlighted. Everything else regarding editing conditions seems to work.

**Steps to reproduce:**
This is little bit tricky, don't follow the original steps in the BZ, otherwise you will not be able to reproduce, or just rarely. Follow these steps instead:
1. Navigate to _Control > Explorer_, then _Conditions_ accordion 
2. Choose some type of conditions where there is no condition created yet (important!), click on it
3. Create a new condition: choose _Configuration > Add a New Container Replicator Condition_ or any other type of condition (depends on step 2)
4. Fill in required fields (description and expression), values are not important, click on _Add_ button
 => the newly created condition's name is immediately highlighted in accordion, this already works
5. Edit this condition (_Configuration > Edit this Condition_) and save the changes
=> _All Conditions_ node highlighted in accordion instead of just edited condition!

---

This is how it should look like in the step 2 - there is no condition created yet:
![no_replic](https://user-images.githubusercontent.com/13417815/57088079-cccea380-6d01-11e9-882f-e6952e5ad000.png)

Step 4:
![new_cond](https://user-images.githubusercontent.com/13417815/57088327-567e7100-6d02-11e9-9c32-a7c33749f25e.png)

**Before:** (after step 5)
![new_before](https://user-images.githubusercontent.com/13417815/57088423-87f73c80-6d02-11e9-9847-a4434732409a.png)

**After:**
![new_after](https://user-images.githubusercontent.com/13417815/57088903-909c4280-6d03-11e9-843c-63a0c0485022.png)

---

**Notes:**
Similar problem was fixed here: https://github.com/ManageIQ/manageiq-ui-classic/pull/5302
I've fixed the problem in accordion simply by editing `tree_init_options` of `TreeBuilderCondition` the same way as it is already for Policies or Policy Profiles accordions/trees in the same page, where this works well https://github.com/hstastna/manageiq-ui-classic/blob/master/app/presenters/tree_builder_policy.rb#L8

