### PR TITLE
Use feature detection to determine whether AZ should be selectable

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -136,7 +136,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,parent_manager.availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
+    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,parent_manager.volume_availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
@@ -254,9 +254,9 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudVolumeModel.size = data.size / 1073741824;
     vm.cloudVolumeModel.cloud_tenant_id = data.cloud_tenant_id;
     vm.cloudVolumeModel.volume_type = data.volume_type;
+    vm.cloudVolumeModel.availability_zone_id = data.availability_zone.ems_ref;
     // Currently, this is only relevant for AWS volumes so we are prefixing the
     // model attribute with AWS.
-    vm.cloudVolumeModel.aws_availability_zone_id = data.availability_zone.ems_ref;
     vm.cloudVolumeModel.aws_encryption = data.encrypted;
     vm.cloudVolumeModel.aws_iops = data.iops;
 
@@ -274,10 +274,11 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
   var getStorageManagerFormData = function(data) {
     vm.cloudVolumeModel.emstype = data.type;
     vm.cloudTenantChoices = data.parent_manager.cloud_tenants;
-    vm.availabilityZoneChoices = data.parent_manager.availability_zones;
+    vm.availabilityZoneChoices = data.parent_manager.volume_availability_zones;
     vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
     vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
     vm.supportsVolumeResizing = data.supports_volume_resizing;
+    vm.supportsVolumeAvailabilityZones = data.supports_volume_availability_zones;
     if (vm.supportsCinderVolumeTypes) {
       vm.volumeTypes = data.parent_manager.cloud_volume_types;
     } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -579,6 +579,7 @@ class CloudVolumeController < ApplicationController
     cloud_tenant = find_record_with_rbac(CloudTenant, cloud_tenant_id)
     options[:cloud_tenant] = cloud_tenant
     options[:ems] = cloud_tenant.ext_management_system
+    options[:availability_zone] = params[:availability_zone_id] if params[:availability_zone_id]
     options
   end
 
@@ -587,7 +588,7 @@ class CloudVolumeController < ApplicationController
     options[:volume_type] = params[:volume_type] if params[:volume_type]
     # Only set IOPS if io1 (provisioned IOPS) and IOPS available
     options[:iops] = params[:aws_iops] if options[:volume_type] == 'io1' && params[:aws_iops]
-    options[:availability_zone] = params[:aws_availability_zone_id] if params[:aws_availability_zone_id]
+    options[:availability_zone] = params[:availability_zone_id] if params[:availability_zone_id]
     options[:snapshot_id] = params[:aws_base_snapshot_id] if params[:aws_base_snapshot_id]
     options[:encrypted] = params[:aws_encryption]
 

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -32,13 +32,13 @@
     %span.help-block{"ng-show" => "angularForm.cloud_tenant_id.$error.required"}
       = _("Required")
 
-.form-group{"ng-class" => "{'has-error': angularForm.aws_availability_zone_id.$invalid}",
-            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
+.form-group{"ng-class" => "{'has-error': angularForm.availability_zone_id.$invalid}",
+            "ng-if"    => "vm.supportsVolumeAvailabilityZones || (vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs')"}
   %label.col-md-2.control-label
     = _('Availability Zone')
   .col-md-8
-    %select{"name"        => "aws_availability_zone_id",
-            "ng-model"    => "vm.cloudVolumeModel.aws_availability_zone_id",
+    %select{"name"        => "availability_zone_id",
+            "ng-model"    => "vm.cloudVolumeModel.availability_zone_id",
             "ng-options"  => "az.ems_ref as az.name for az in vm.availabilityZoneChoices",
             "required"    => "",
             "ng-disabled" => "!vm.newRecord",
@@ -46,7 +46,7 @@
             "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"
-    %span.help-block{"ng-show" => "angularForm.aws_availability_zone_id.$error.required"}
+    %span.help-block{"ng-show" => "angularForm.availability_zone_id.$error.required"}
       = _("Required")
 
 .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -257,10 +257,18 @@ describe CloudVolumeController do
       before do
         @ems = FactoryBot.create(:ems_openstack)
         @tenant = FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => @ems)
+        @availability_zone = FactoryBot.create(:availability_zone,
+                                                :ems_ref               => "nova",
+                                                :ext_management_system => @ems)
 
-        @form_params = { :name => "volume", :size => 1, :cloud_tenant_id => @tenant.id,
-                         :emstype => "ManageIQ::Providers::StorageManager::CinderManager" }
-        @task_options = [@ems.id, { :name => "volume", :size => 1, :cloud_tenant => @tenant }]
+        @form_params = {
+          :name                 => "volume",
+          :size                 => 1,
+          :cloud_tenant_id      => @tenant.id,
+          :emstype              => "ManageIQ::Providers::StorageManager::CinderManager",
+          :availability_zone_id => @availability_zone.ems_ref
+        }
+        @task_options = [@ems.id, { :name => "volume", :size => 1, :cloud_tenant => @tenant, :availability_zone => @availability_zone.ems_ref }]
       end
 
       it_behaves_like "queue create volume task"
@@ -280,7 +288,7 @@ describe CloudVolumeController do
           :storage_manager_id       => @ems.id,
           :name                     => "volume",
           :size                     => 1,
-          :aws_availability_zone_id => @availability_zone.ems_ref,
+          :availability_zone_id => @availability_zone.ems_ref,
         }
         # Common EC2 client options
         @aws_options = {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1549128

This PR is part of the implementation to allow choosing an availability zone when creating a new Openstack Cinder volume. It makes the existing AWS-specific AZ selection code generic, and allows it to be enabled by checking the `supports_volume_availability_zones` feature. Depends on the core PR which adds `supports_volume_availability_zones`.