### PR TITLE
action_build_alert_choices - fix wrong argument order

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -305,7 +305,7 @@ module MiqPolicyController::MiqActions
 
   # Build the alert choice hash for evaluate_alerts action_type
   def action_build_alert_choices
-    @edit[:choices] = MiqAlert.all.each_with_object({}) { |h, a| h[a.description] = a.guid } # Build the hash of alert choices
+    @edit[:choices] = MiqAlert.all.each_with_object({}) { |a, h| h[a.description] = a.guid } # Build the hash of alert choices
     @edit[:new][:alerts] = {} # Clear out the alerts hash
   end
 


### PR DESCRIPTION
The code changed from `reduce` to `each_with_object` in https://github.com/ManageIQ/manageiq-ui-classic/pull/5286, (cc @PanSpagetka)
but while `reduce` puts the memo object first,
`each_with_object` puts it last.

Fixes #5523, cc @hstastna 