### PR TITLE
Validate Classification before accessing description

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -33,4 +33,5 @@
     - when 'DialogFieldTagControl'
       - value = wf.value(field.name) || '' # it returns in format Clasification::id
       - _, classification_id = value.split('::')
-      = h(Classification.find(classification_id).description)
+      - current_classification = Classification.find_by(:id => classification_id)
+      = h(current_classification.nil? ? '' : current_classification.description)

--- a/app/views/miq_request/_st_prov_show.html.haml
+++ b/app/views/miq_request/_st_prov_show.html.haml
@@ -13,12 +13,12 @@
           #dialog_tabs
             %ul.nav.nav-tabs
               - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
-                - options = {:class => "active"} if tab_index == 0
+                - options = tab_index == 0 ? {:class => "active"} : {}
                 = miq_tab_header(tab.id, nil, options) do
                   = tab.label
             .tab-content
               - wf.dialog.dialog_tabs.each_with_index do |tab, tab_index|
-                - options = {:class => "active"} if tab_index == 0
+                - options = tab_index == 0 ? {:class => "active"} : {}
                 = miq_tab_content(tab.id, nil, options) do
                   - tab.dialog_groups.each do |group|
                     %div{:id => "group_#{group.id}_div"}

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -64,7 +64,8 @@
       - else
         - value = wf.value(field.name) || '' # it returns in format for example Clasification::id
         - _, classification_id = value.split('::')
-        = h(Classification.find(classification_id).description)
+        - current_classification = Classification.find_by(:id => classification_id)
+        = h(current_classification.nil? ? '' : current_classification.description)
 
     :javascript
       dialogFieldRefresh.setVisible($('#field_#{field.id}_tr'), #{field.visible});


### PR DESCRIPTION
Checking if the Classification is `nil` prior to accessing it's description.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1696697
