### PR TITLE
Fix vm_edit when entering from providers screen

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1687,4 +1687,8 @@ module VmCommon
   def breadcrumb_prohibited_for_action?
     !%w[accordion_select explorer tree_select].include?(action_name)
   end
+
+  def gtl_url
+    "/show"
+  end
 end


### PR DESCRIPTION
Fiexs https://bugzilla.redhat.com/show_bug.cgi?id=1705611

**Steps to Reproduce:**
1. Add a provider (tested with RHV 4.3)
2. Navigate to VMs from provider's dashboard
3. Select any VM
4. Configuration -> Edit Selected item

**Description**

- When user go to `vm_controller` from **provider** screen, he is redirected to nonexplorer screen and breadcrumbs are missing the **gtl_url** method for generating a link to the item.
- All VM controllers are using explorer screen, so this method should not mess them up.

**Before**

![Selection_123](https://user-images.githubusercontent.com/32869456/57126978-347f0000-6d8f-11e9-8630-92809c9b8274.png)

```ruby
[----] F, [2019-05-03T10:38:49.852856 #15071:557b110] FATAL -- : ActionView::Template::Error (undefined local variable or method `gtl_url' for #<VmController:0x00007f843bcecab8>):
[----] F, [2019-05-03T10:38:49.852966 #15071:557b110] FATAL -- :     1: = react('Breadcrumbs', { :items => (data_for_breadcrumbs if respond_to?(:data_for_breadcrumbs)), :controllerName => controller_name, :title => @title })
[----] F, [2019-05-03T10:38:49.853013 #15071:557b110] FATAL -- :   
[----] F, [2019-05-03T10:38:49.853092 #15071:557b110] FATAL -- : /home/rvsianskz/miq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:56:in `build_breadcrumbs_no_explorer'
/home/rvsianskz/miq/manageiq-ui-classic/app/controllers/mixins/breadcrumbs_mixin.rb:19:in `data_for_breadcrumbs'
actionpack (5.0.7.2) lib/abstract_controller/helpers.rb:68:in `data_for_breadcrumbs'
/home/rvsianskz/miq/manageiq-ui-classic/app/views/layouts/_breadcrumbs_new.html.haml:1:in `__home_rvsianskz_miq_manageiq_ui_classic_app_views_layouts__breadcrumbs_new_html_haml___2367852785535644947_70102611170360'
```

**After**

![image](https://user-images.githubusercontent.com/32869456/57126974-29c46b00-6d8f-11e9-958b-c02628609f0d.png)

@miq-bot add_label hammer/no, changelog/no, breadcrumbs, bug
