### PR TITLE
Fix fourth param to be Hash for TreeBuilderMiqActionCategory call

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -310,7 +310,7 @@ module MiqPolicyController::MiqActions
   end
 
   def action_build_cat_tree
-    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, @sb, true, "#{current_tenant.name} Tags")
+    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, @sb, true, :root => "#{current_tenant.name} Tags")
   end
 
   # Set action record variables to new values


### PR DESCRIPTION
Steps to reproduce:
- Navigate to Control > Explorer, then Actions accordion
- Configuration > Add a new Action

Blocked by https://github.com/ManageIQ/manageiq-ui-classic/pull/5525 (it fixes an error that shows before this one)

Before:
```
[----] F, [2019-05-03T16:24:33.276198 #87988:3ff37ae5051c] FATAL -- : Error caught: [ArgumentError] wrong number of arguments (given 4, expected 2..3)
/ManageIQ/manageiq-ui-classic/app/presenters/tree_builder_miq_action_category.rb:13:in `initialize'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:313:in `new'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:313:in `action_build_cat_tree'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:183:in `get_tags_tree'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:300:in `action_build_edit_screen'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller/miq_actions.rb:20:in `action_edit'
/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:204:in `generic_x_button'
/ManageIQ/manageiq-ui-classic/app/controllers/miq_policy_controller.rb:118:in `x_button'
```
After: It works

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5309

@miq-bot add_label changelog/no, hammer/no, refactoring

cc: @skateman 
