### PR TITLE
[HAMMER] Display the services tree hierarchy using lazy loading

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -48,8 +48,18 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    # Get My Filters and Global Filters
-    count_only_or_objects(count_only, x_get_search_results(object, options[:leaf])) if %w(my global).include?(object[:id])
+    case object[:id]
+    when 'my', 'global'
+      # Get My Filters and Global Filters
+      count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
+    when 'asrv', 'rsrv'
+      retired = object[:id] != 'asrv'
+      services = Rbac.filtered(Service.where(:retired => retired, :display => true))
+      return sevices.size if count_only
+
+      MiqPreloader.preload(services.to_a, :picture)
+      Service.arrange_nodes(services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
+    end
   end
 
   def x_get_search_results(object, leaf)

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -13,6 +13,21 @@ describe TreeBuilderServices do
       a_hash_including(:id => 'global'),
       a_hash_including(:id => 'my')
     ]
+
+    active_nodes = kid_nodes(root_nodes[0])
+    retired_nodes = kid_nodes(root_nodes[1])
+    expect(active_nodes).to eq(
+      @service => {
+        @service_c1 => {
+          @service_c11 => {},
+          @service_c12 => {
+            @service_c121 => {}
+          }
+        },
+        @service_c2 => {}
+      }
+    )
+    expect(retired_nodes).to eq(@service_c3 => {})
   end
 
   private

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -1,53 +1,47 @@
 describe TreeBuilderServices do
-  let(:builder) { TreeBuilderServices.new("x", "y", {}) }
+  subject { TreeBuilderServices.new("x", "y", {}, false) }
 
-  it "generates tree" do
-    User.current_user = FactoryGirl.create(:user)
+  let(:root_srv) { FactoryBot.create(:service, :display => true, :retired => false) }
+  let!(:reti_srv) { FactoryBot.create(:service, :service => root_srv, :display => true, :retired => true) }
+
+  before do
+    login_as FactoryBot.create(:user)
     allow(User).to receive(:server_timezone).and_return("UTC")
-    create_deep_tree
 
-    expect(root_nodes.size).to eq(4)
-    expect(root_nodes).to match [
-      a_hash_including(:id => 'asrv'),
-      a_hash_including(:id => 'rsrv'),
-      a_hash_including(:id => 'global'),
-      a_hash_including(:id => 'my')
-    ]
-
-    active_nodes = kid_nodes(root_nodes[0])
-    retired_nodes = kid_nodes(root_nodes[1])
-    expect(active_nodes).to eq(
-      @service => {
-        @service_c1 => {
-          @service_c11 => {},
-          @service_c12 => {
-            @service_c121 => {}
-          }
-        },
-        @service_c2 => {}
-      }
-    )
-    expect(retired_nodes).to eq(@service_c3 => {})
+    FactoryBot.create(:service, :service => root_srv, :display => true, :retired => false)
+    FactoryBot.create(:service, :service => root_srv, :display => true, :retired => false)
   end
 
-  private
+  describe '#x_get_tree_roots' do
+    it 'returns the four root nodes' do
+      root_nodes = subject.send(:x_get_tree_roots, false, {})
 
-  def root_nodes
-    builder.send(:x_get_tree_roots, false, {})
+      expect(root_nodes).to match [
+        a_hash_including(:id => 'asrv'),
+        a_hash_including(:id => 'rsrv'),
+        a_hash_including(:id => 'global'),
+        a_hash_including(:id => 'my')
+      ]
+    end
   end
 
-  def kid_nodes(node)
-    builder.send(:x_get_tree_custom_kids, node, false, {})
+  describe '#x_get_tree_custom_kids' do
+    it 'returns the root service node for active services' do
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'asrv'}, false, {})
+      expect(root_services).to match [root_srv]
+    end
+
+    it 'returns the retired child service node for retired services' do
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'rsrv'}, false, {})
+      expect(root_services).to match [reti_srv]
+    end
   end
 
-  def create_deep_tree
-    @service      = FactoryGirl.create(:service, :display => true, :retired => false)
-    @service_c1   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
-    @service_c11  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c12  = FactoryGirl.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c121 = FactoryGirl.create(:service, :service => @service_c12, :display => true, :retired => false)
-    @service_c2   = FactoryGirl.create(:service, :service => @service, :display => true, :retired => false)
-    # hidden
-    @service_c3   = FactoryGirl.create(:service, :service => @service, :retired => true, :display => true)
+  describe '#x_get_tree_nested_services' do
+    it 'returns the ancestry kids of a service' do
+      child_nodes = subject.send(:x_get_tree_nested_services, root_srv, false)
+
+      expect(child_nodes.length).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
Due to performance reasons, the services [have been set](https://github.com/ManageIQ/manageiq-ui-classic/pull/5335) not to be displayed in the services tree. This caused to lose some information about the service hierarchy in the case of having services nested into each other. To have the good from both worlds, I implemented lazy loading for the child services. This way we get the hierarchy back and until a user doesn't try to expand all the nodes, there will be no performance issues on the frontend.

I created some specs that deal with retired and non-retired services nested into each other. However, this might need some extra testing. The easiest way to create some services is to create a generic service catalog, order it a few times and set the hierarchy of the services from a `rails console`. I also suggest you to retire some of the services afterwards to test the correctness of `subtree_root_services_with_preload` that uses the [`arrange_nodes`](https://github.com/stefankroes/ancestry/blob/b609e68cd3b4391eb3a8ebd83a922a711395ee21/lib/ancestry/class_methods.rb#L39-L51) with a little twist in just taking the keys from the returned hash.

**Before:**
![Screenshot from 2019-05-04 09-59-22](https://user-images.githubusercontent.com/649130/57176040-52159d80-6e53-11e9-97e4-c020ac597e61.png)

**After:**
![Screenshot from 2019-05-04 10-07-43](https://user-images.githubusercontent.com/649130/57176144-7d4cbc80-6e54-11e9-9e95-09ce8c9a7559.png)

The PR is HAMMER only, we're working with UX for a more feasible solution in master,

@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @kbrock 
@miq-bot add_label trees, performance, bug, services

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1711981