### PR TITLE
Get current_tenant in TreeBuilderMiqActionCategory not via params

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -310,7 +310,7 @@ module MiqPolicyController::MiqActions
   end
 
   def action_build_cat_tree
-    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, @sb, true, :root => "#{current_tenant.name} Tags")
+    @category_tree = TreeBuilderMiqActionCategory.new(:action_tags_tree, @sb, true)
   end
 
   # Set action record variables to new values

--- a/app/presenters/tree_builder_miq_action_category.rb
+++ b/app/presenters/tree_builder_miq_action_category.rb
@@ -10,8 +10,9 @@ class TreeBuilderMiqActionCategory < TreeBuilder
     node
   end
 
-  def initialize(name, sandbox, build = true, **params)
-    @root = params[:root]
+  def initialize(name, sandbox, build = true)
+    current_tenant = User.current_user.try(:current_tenant) || Tenant.default_tenant
+    @root = "#{current_tenant.name} Tags"
     super(name, sandbox, build)
   end
 

--- a/spec/presenters/tree_builder_miq_action_category_spec.rb
+++ b/spec/presenters/tree_builder_miq_action_category_spec.rb
@@ -3,6 +3,7 @@ describe TreeBuilderMiqActionCategory do
     role = MiqUserRole.find_by(:name => "EvmRole-operator")
     group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Tags Group")
     login_as FactoryBot.create(:user, :userid => 'tags_wilma', :miq_groups => [group])
+    allow(Tenant).to receive(:default_tenant).and_return(tenant)
   end
 
   let!(:tag1) { FactoryBot.create(:classification, :name => 'tag1', :show => false) }
@@ -17,11 +18,11 @@ describe TreeBuilderMiqActionCategory do
     f2.entries.push(tag2)
     f2
   end
-  let!(:tenant) { "TestTenant Tags" }
+  let!(:tenant) { FactoryBot.create(:tenant, :name => "TestTenant") }
   let!(:tree_name) { :action_tags }
 
   subject do
-    described_class.new(:action_tags_tree, {}, true, :root => tenant)
+    described_class.new(:action_tags_tree, {}, true)
   end
 
   describe '#tree_init_options' do
@@ -51,8 +52,8 @@ describe TreeBuilderMiqActionCategory do
   describe '#root_options' do
     it 'sets root_options correctly' do
       expect(subject.send(:root_options)).to eq(
-        :text    => tenant,
-        :tooltip => tenant,
+        :text    => "#{tenant.name} Tags",
+        :tooltip => "#{tenant.name} Tags",
         :icon    => "fa fa-tag"
       )
     end


### PR DESCRIPTION
Following requested changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/5529#issuecomment-489172759

@miq-bot add_label refactoring, hammer/no, changelog/no

Maybe closed in favor of https://github.com/ManageIQ/manageiq-ui-classic/pull/5535