### PR TITLE
Enable Copy feature for ServiceRequests

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'realTargetType', 'openUrl', '$http', '$window', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, realTargetType, openUrl, $http, $window) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'realTargetType', 'openUrl', '$http', '$window', 'dialogReplaceData', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, realTargetType, openUrl, $http, $window, dialogReplaceData) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -21,6 +21,10 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     _.forEach(vm.dialog.dialog_tabs, function(tab) {
       _.forEach(tab.dialog_groups, function(group) {
         _.forEach(group.dialog_fields, function(field) {
+          const replaceField = dialogReplaceData ? JSON.parse(dialogReplaceData).find(replace => replace.name === field.name) : false;
+          if (replaceField) {
+            field.default_value = replaceField.value;
+          }
           if (field.type === 'DialogFieldDropDownList') {
             _.forEach(field.values, function(value) {
               if (value[0] === null) {

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -21,7 +21,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     _.forEach(vm.dialog.dialog_tabs, function(tab) {
       _.forEach(tab.dialog_groups, function(group) {
         _.forEach(group.dialog_fields, function(field) {
-          const replaceField = dialogReplaceData ? JSON.parse(dialogReplaceData).find(replace => replace.name === field.name) : false;
+          const replaceField = dialogReplaceData ? JSON.parse(dialogReplaceData).find(function (replace) { return replace.name === field.name }) : false;
           if (replaceField) {
             field.default_value = replaceField.value;
           }

--- a/app/helpers/application_helper/button/miq_request_copy.rb
+++ b/app/helpers/application_helper/button/miq_request_copy.rb
@@ -4,7 +4,8 @@ class ApplicationHelper::Button::MiqRequestCopy < ApplicationHelper::Button::Miq
   def visible?
     return false unless super
     resource_types_for_miq_request_copy = %w[MiqProvisionRequest
-                                             MiqProvisionConfiguredSystemRequest]
+                                             MiqProvisionConfiguredSystemRequest
+                                             ServiceTemplateProvisionRequest]
     return false if !resource_types_for_miq_request_copy.include?(@record.resource_type) ||
                     ((current_user.name != @record.requester_name ||
                     !@record.request_pending_approval?) &&

--- a/app/views/miq_request/prov_edit.html.haml
+++ b/app/views/miq_request/prov_edit.html.haml
@@ -1,5 +1,5 @@
 #main_div
-- if @new_dialog
-  = render :partial => "shared/dialogs/dialog_provision", :locals => @opts
-- else
-  = render :partial => "prov_edit"
+  - if @new_dialog
+    = render :partial => "shared/dialogs/dialog_provision", :locals => @opts
+  - else
+    = render :partial => "prov_edit"

--- a/app/views/miq_request/prov_edit.html.haml
+++ b/app/views/miq_request/prov_edit.html.haml
@@ -1,2 +1,5 @@
 #main_div
+- if @new_dialog
+  = render :partial => "shared/dialogs/dialog_provision", :locals => @opts
+- else
   = render :partial => "prov_edit"

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -29,4 +29,5 @@
   ManageIQ.angular.app.value('apiAction', '#{j_str(api_action)}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   ManageIQ.angular.app.value('openUrl', '#{open_url}');
+  ManageIQ.angular.app.value('dialogReplaceData', '#{@dialog_replace_data}');
   miq_bootstrap('.wrapper');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,7 +337,6 @@ Rails.application.routes.draw do
         st_form_field_changed
         st_tags_edit
         st_upload_image
-        svc_catalog_provision
         tag_edit_form_field_changed
         tree_autoload
         tree_select

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
@@ -42,6 +42,7 @@ describe('dialogUserController', function() {
       targetType: 'targettype',
       realTargetType: 'targettype',
       openUrl: false,
+      dialogReplaceData: null,
     });
   }));
 
@@ -123,6 +124,7 @@ describe('dialogUserController', function() {
           realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
+          dialogReplaceData: null,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});
@@ -158,6 +160,7 @@ describe('dialogUserController', function() {
           realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
+          dialogReplaceData: null,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -58,7 +58,6 @@ describe 'routes for CatalogController' do
     st_form_field_changed
     st_tags_edit
     st_upload_image
-    svc_catalog_provision
     tag_edit_form_field_changed
     tree_autoload
     tree_select


### PR DESCRIPTION
Enable Copy feature for ServiceRequests.

When buttons is pressed it shows new dialog, but without values filled in the request. It uses default values from automate. 



Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1689642
You need https://github.com/ManageIQ/manageiq/pull/18859


Steps for Testing/QA
-------------------------------
1. Make a Service request
Go to Services -> Requests -> Select Service Request -> Copy Service

