### PR TITLE
Make Organization required on RHN updates upon 1+ available orgs

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -210,6 +210,7 @@ module OpsController::Settings::RHN
     :server_url        => _('Server Address'),
     :repo_name         => _('Repository Name'),
     :proxy_address     => _('HTTP Proxy Address'),
+    :customer_org      => _('Organization'),
   }.freeze
 
   # FIXME: once we have a way to separately allow 'Save' and 'Reset' buttons
@@ -217,6 +218,7 @@ module OpsController::Settings::RHN
   # fields are filled-in.
   def rhn_allow_save?
     obligatory_fields = %i[customer_password customer_userid server_url repo_name]
+    obligatory_fields << :customer_org if @edit[:organizations].length > 1
     obligatory_fields << :proxy_address if @edit[:new][:use_proxy].to_i == 1
 
     obligatory_fields.find_all do |field|

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -139,10 +139,12 @@ describe OpsController do
     end
 
     context "#settings_update" do
-      it "won't render form buttons after rhn settings submission" do
+      let(:orgs) { [1] }
+      before do
         session[:edit] = {
-          :key => "settings_rhn_edit__rhn_edit",
-          :new => {
+          :key           => "settings_rhn_edit__rhn_edit",
+          :organizations => orgs,
+          :new           => {
             :register_to       => "sm_hosted",
             :customer_userid   => "username",
             :customer_password => "password",
@@ -158,9 +160,21 @@ describe OpsController do
                                                :active_tab  => 'settings_rhn_edit')
         allow(controller).to receive(:x_node).and_return("root")
         controller.instance_variable_set(:@_params, :id => 'rhn_edit', :button => "save")
+      end
+
+      it "won't render form buttons after rhn settings submission" do
         controller.send(:settings_update)
         expect(response).to render_template('ops/_settings_rhn_tab')
         expect(response).not_to render_template(:partial => "layouts/_x_edit_buttons")
+      end
+
+      context "number of orgs > 1" do
+        let(:orgs) { [1, 2] }
+
+        it "makes organization field obligatory" do
+          controller.send(:settings_update)
+          expect(controller.instance_variable_get(:@flash_array)).to include(a_hash_including(:message => "Organization is required"))
+        end
       end
     end
 


### PR DESCRIPTION
When setting up updates under the region config (see screenshot) the *Organization*, the Satellite option supports having multiple organizations. However, the dropdown for selecting the organizations is not mandatory which causes further issues in the registration process. With my change the field becomes mandatory if the Satellite server has more than one organization.

![after](https://user-images.githubusercontent.com/649130/57283731-1fb4ac00-70b0-11e9-87d7-4e01504cf04a.png)

@miq-bot add_label hammer/yes, bug
@miq-bot assign @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687086