### PR TITLE
spec_helper - load MiqHashStruct

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ require 'manageiq-ui-classic'
 support_path = Pathname.new(__dir__).join('support')
 Dir[support_path.join("**/*.rb")].each { |f| require f }
 
+require 'miq-hash_struct'
+
 # TODO: isolate the helpers we need for UI specs instead of general Dir glob
 #
 # core_support_path = Rails.root.join('spec/support')


### PR DESCRIPTION
prevents

    $ rspec spec/controllers/ops_controller/settings/common_spec.rb:141
    ...
    uninitialized constant OpsController::Settings::RHN::MiqHashStruct

when running standalone tests which require [MiqHashStruct](https://github.com/ManageIQ/manageiq-gems-pending/blob/master/lib/gems/pending/util/miq-hash_struct.rb).
