### PR TITLE
[WIP] Migrate add cloud provider form to data driven forms

### DIFF
--- a/app/javascript/components/async-credentials/async-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-credentials.jsx
@@ -76,26 +76,23 @@ const AsyncCredentials = ({
       <FieldProvider initialValue={!!edit} name={name} validate={value => (value === false ? asyncError : undefined)}>
         {({ input, meta }) => (
           <FormGroup validationState={meta.error ? 'error' : null}>
-            <Col md={2} componentClass="label" className="control-label" />
-            <Col md={8}>
-              <input type="hidden" {...input} />
-              <CheckErrors subscription={{ valid: true, invalid: true, active: true }} names={asyncFields} FieldProvider={FieldProvider}>
-                {valid => (
-                  <Fragment>
-                    <Button
-                      bsSize="small"
-                      bsStyle="primary"
-                      onClick={() => handleAsyncValidation(formOptions, name, asyncFields)}
-                      disabled={valid.includes(false) || validating}
-                    >
-                      {validating ? validationProgressLabel : validateLabel}
-                      {validating && <ButtonSpinner /> }
-                    </Button>
-                    {meta.error && <HelpBlock>{asyncError}</HelpBlock>}
-                  </Fragment>
-                )}
-              </CheckErrors>
-            </Col>
+            <input type="hidden" {...input} />
+            <CheckErrors subscription={{ valid: true, invalid: true, active: true }} names={asyncFields} FieldProvider={FieldProvider}>
+              {valid => (
+                <Fragment>
+                  <Button
+                    bsSize="small"
+                    bsStyle="primary"
+                    onClick={() => handleAsyncValidation(formOptions, name, asyncFields)}
+                    disabled={valid.includes(false) || validating}
+                  >
+                    {validating ? validationProgressLabel : validateLabel}
+                    {validating && <ButtonSpinner /> }
+                  </Button>
+                  {meta.error && <HelpBlock>{asyncError}</HelpBlock>}
+                </Fragment>
+              )}
+            </CheckErrors>
           </FormGroup>
         )}
       </FieldProvider>

--- a/app/javascript/components/cloud-provider/cloud-azure-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-azure-provider.schema.js
@@ -1,5 +1,35 @@
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
-import { asyncValidate, guidRegex } from './validators';
+import get from 'lodash/get';
+import { guidRegex } from './validators';
+
+const prefix = 'ManageIQ::Providers::Azure::CloudManager';
+
+const asyncValidate = formValues => new Promise((resolve, reject) => {
+  const azureValues = formValues[prefix] || {};
+
+  const values = {
+    button: 'validate',
+    name: get(formValues, 'name'),
+    emstype: 'azure', // get(formValues, 'type'),
+    provider_region: get(azureValues, 'region'),
+    azure_tenant_id: get(azureValues, 'uid_ems'),
+    subscription: get(azureValues, 'subscription'),
+    zone: 'default',
+    default_url: get(azureValues, 'endpoints[0].url'),
+    default_userid: get(azureValues, 'credentials.userid'),
+    default_password: get(azureValues, 'credentials.password'),
+  };
+  // should be replaced by endpoint
+  $.post('/ems_cloud', values, (response) => {
+    if (response.level === 'error') {
+      add_flash(response.message, response.level, response.options);
+      return reject(__('Validation Required'));
+    }
+
+    return resolve('Valid');
+  });
+});
+
 
 export const createAzureEndpointsFields = () => [{
   component: componentTypes.SUB_FORM,
@@ -7,11 +37,11 @@ export const createAzureEndpointsFields = () => [{
   title: __('Credentials'),
   condition: {
     when: 'type',
-    is: 'ManageIQ::Providers::Azure::CloudManager',
+    is: prefix,
   },
   fields: [{
     component: componentTypes.TEXT_FIELD,
-    name: 'azure_url',
+    name: `${prefix}.endpoints[0].url`,
     label: __('Endpoint URL'),
     validateOnMount: true,
     validate: [{
@@ -24,15 +54,20 @@ export const createAzureEndpointsFields = () => [{
     fields: [{
       component: componentTypes.TEXT_FIELD,
       label: __('Client ID'),
-      name: 'azure_userid',
+      name: `${prefix}.credentials.userid`,
       validateOnMount: true,
       validate: [{
         type: validatorTypes.REQUIRED,
+      }, {
+        type: validatorTypes.PATTERN_VALIDATOR,
+        pattern: guidRegex,
+        showPattern: false,
+        message: __('Invalid input format, please enter a GUID'),
       }],
     }, {
       component: componentTypes.TEXT_FIELD,
       label: __('Client Key'),
-      name: 'azure_password',
+      name: `${prefix}.credentials.password`,
       type: 'password',
       validateOnMount: true,
       validate: [{
@@ -43,41 +78,47 @@ export const createAzureEndpointsFields = () => [{
 }];
 
 export const createAzureGeneralFields = providerRegions => [{
-  component: componentTypes.SELECT,
-  name: 'azure_provider_region',
-  label: __('Region'),
+  component: componentTypes.SUB_FORM,
+  name: `${prefix}-general-fields`,
   condition: {
     when: 'type',
-    is: 'ManageIQ::Providers::Azure::CloudManager',
+    is: prefix,
   },
-  options: providerRegions.map(([label, value]) => ({ value, label })),
-  validateOnMount: true,
-  validate: [{
-    type: validatorTypes.REQUIRED,
-  }],
-}, {
-  component: componentTypes.TEXT_FIELD,
-  name: 'ems_tenant_id',
-  label: __('Tenant ID'),
-  condition: {
-    when: 'type',
-    is: 'ManageIQ::Providers::Azure::CloudManager',
-  },
-  validateOnMount: true,
-  validate: [{
-    type: validatorTypes.REQUIRED,
-  }, {
-    type: validatorTypes.PATTERN_VALIDATOR,
-    pattern: guidRegex,
-    showPattern: false,
-    message: __('Invalid input format, please enter a GUID'),
-  }],
-}, {
-  component: componentTypes.TEXT_FIELD,
-  name: 'subscription',
-  label: __('Subscription ID'),
-  condition: {
-    when: 'type',
-    is: 'ManageIQ::Providers::Azure::CloudManager',
-  },
+  fields: [
+    {
+      component: componentTypes.SELECT,
+      name: `${prefix}.region`,
+      label: __('Region'),
+      options: providerRegions.map(([label, value]) => ({ value, label })),
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      name: `${prefix}.uid_ems`,
+      label: __('Tenant ID'),
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }, {
+        type: validatorTypes.PATTERN_VALIDATOR,
+        pattern: guidRegex,
+        showPattern: false,
+        message: __('Invalid input format, please enter a GUID'),
+      }],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      name: `${prefix}.subscription`,
+      label: __('Subscription ID'),
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }, {
+        type: validatorTypes.PATTERN_VALIDATOR,
+        pattern: guidRegex,
+        showPattern: false,
+        message: __('Invalid input format, please enter a GUID'),
+      }],
+    },
+  ],
 }];

--- a/app/javascript/components/cloud-provider/cloud-azure-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-azure-provider.schema.js
@@ -1,0 +1,83 @@
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { asyncValidate, guidRegex } from './validators';
+
+export const createAzureEndpointsFields = () => [{
+  component: componentTypes.SUB_FORM,
+  name: 'azure-endpoints',
+  title: __('Credentials'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Azure::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    name: 'azure_url',
+    label: __('Endpoint URL'),
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED, // switch for URL validation
+    }],
+  }, {
+    component: 'validate-credentials',
+    name: 'azure-endpoints-valid',
+    asyncValidate,
+    fields: [{
+      component: componentTypes.TEXT_FIELD,
+      label: __('Client ID'),
+      name: 'azure_userid',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Client Key'),
+      name: 'azure_password',
+      type: 'password',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }],
+  }],
+}];
+
+export const createAzureGeneralFields = providerRegions => [{
+  component: componentTypes.SELECT,
+  name: 'azure_provider_region',
+  label: __('Region'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Azure::CloudManager',
+  },
+  options: providerRegions.map(([label, value]) => ({ value, label })),
+  validateOnMount: true,
+  validate: [{
+    type: validatorTypes.REQUIRED,
+  }],
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'ems_tenant_id',
+  label: __('Tenant ID'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Azure::CloudManager',
+  },
+  validateOnMount: true,
+  validate: [{
+    type: validatorTypes.REQUIRED,
+  }, {
+    type: validatorTypes.PATTERN_VALIDATOR,
+    pattern: guidRegex,
+    showPattern: false,
+    message: __('Invalid input format, please enter a GUID'),
+  }],
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'subscription',
+  label: __('Subscription ID'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Azure::CloudManager',
+  },
+}];

--- a/app/javascript/components/cloud-provider/cloud-ec2-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-ec2-provider.schema.js
@@ -1,0 +1,58 @@
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { asyncValidate } from './validators';
+
+export const createEc2EndpointsFields = () => [{
+  component: componentTypes.SUB_FORM,
+  name: 'ec2-endpoints',
+  title: __('Endpoints'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Amazon::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    name: 'ec2_url',
+    label: __('Endpoint URL'),
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED, // switch for URL validation
+    }],
+  }, {
+    component: 'validate-credentials',
+    name: 'ec2-endpoints-valid',
+    asyncValidate,
+    fields: [{
+      component: componentTypes.TEXT_FIELD,
+      label: __('Access Key ID'),
+      name: 'ec2_userid',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Secret Access Key'),
+      name: 'ec2_password',
+      type: 'password',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }],
+  }],
+}];
+
+export const createEc2GeneralFields = providerRegions => [{
+  component: componentTypes.SELECT,
+  name: 'ec2_provider_region',
+  label: __('Region'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Amazon::CloudManager',
+  },
+  options: providerRegions.map(([label, value]) => ({ value, label })),
+  validateOnMount: true,
+  validate: [{
+    type: validatorTypes.REQUIRED,
+  }],
+}];

--- a/app/javascript/components/cloud-provider/cloud-openstack-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-openstack-provider.schema.js
@@ -1,0 +1,247 @@
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { hostnameValidator, asyncValidate } from './validators';
+
+const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
+  component: componentTypes.SUB_FORM,
+  name: 'openstack-endpoints',
+  title: __('Default Endpoints'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.SELECT,
+    name: 'openstacl_security_protocol',
+    label: __('Security Protocol'),
+    placeholder: `<${__('Choose')}>`,
+    options: openstackSecurityProtocols.map(([label, value]) => ({ value, label })),
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    type: 'number',
+    name: 'openstack_api_port',
+    label: __('API Port'),
+    initialValue: 13000,
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }, {
+    component: 'validate-credentials',
+    name: 'openstack-endpoints-valid',
+    asyncValidate,
+    fields: [{
+      component: componentTypes.TEXT_FIELD,
+      label: __('Hostname (or IPv4 or IPv6 address)'),
+      name: 'openstack_hostname',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      },
+      value => hostnameValidator(value, __('Wrong hostname format')),
+      ],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Client ID'),
+      name: 'azure_userid',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Client Key'),
+      name: 'azure_password',
+      type: 'password',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }],
+
+  }],
+}];
+
+const createOpenstackEventsFields = amqpSecurityProtocol => [{
+  component: componentTypes.SUB_FORM,
+  name: 'openstack-events',
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.RADIO,
+    label: 'Event',
+    name: 'openstack_event_stream_selection',
+    options: [{
+      label: 'Ceilometer',
+      value: 'ceilometer',
+    }, {
+      label: 'AMQP',
+      value: 'amqp',
+    }],
+  }, {
+    component: componentTypes.SUB_FORM,
+    name: 'openstack-amqp-fields',
+    condition: {
+      when: 'openstack_event_stream_selection',
+      is: 'amqp',
+    },
+    fields: [{
+      component: componentTypes.SELECT,
+      name: 'openstack_amqp_security_protocol',
+      label: 'Security Protocol',
+      options: amqpSecurityProtocol.map(([label, value]) => ({ value, label })),
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Hostname (or IPv4 or IPv6 address)'),
+      name: 'amqp_hostname',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      },
+      value => hostnameValidator(value, __('Wrong hostname format'))],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Fallback Hostname 1'),
+      placeholder: __('Hostname or IPV4 or IPV6 address'),
+      name: 'amqp_fallback_hostname1',
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      },
+      value => hostnameValidator(value, __('Wrong hostname format'))],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      label: __('Fallback Hostname 2'),
+      placeholder: __('Hostname or IPV4 or IPV6 address'),
+      name: 'amqp_fallback_hostname2',
+      validateOnMount: true,
+      validate: [value => hostnameValidator(value, __('Wrong hostname format'))],
+    }, {
+      component: componentTypes.TEXT_FIELD,
+      type: 'number',
+      name: 'amqp_api_port',
+      label: __('API Port'),
+      validateOnMount: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }, {
+      component: 'validate-credentials',
+      name: 'amqp-endpoints-valid',
+      asyncValidate,
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        label: __('Username'),
+        name: 'amqp_userid',
+        validateOnMount: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }, {
+        component: componentTypes.TEXT_FIELD,
+        label: __('Password'),
+        name: 'amqp_password',
+        type: 'password',
+        validateOnMount: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }],
+    }],
+  }],
+}];
+
+const createRsaFields = () => [{
+  component: componentTypes.SUB_FORM,
+  name: 'opstanc-rsa-key-pair-fields',
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    label: __('Username'),
+    name: 'ssh_keypair_userid',
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    label: __('Private Key'),
+    name: 'ssh_keypair_password',
+    type: 'file',
+  }],
+}];
+
+export const createOpenstackTabs = (openstackSecurityProtocols, amqpSecurityProtocol) => [{
+  component: componentTypes.TABS,
+  name: 'open-stack-tabs',
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.TAB_ITEM,
+    key: 'default',
+    title: __('Default'),
+    fields: createOpenstackEndpointsFields(openstackSecurityProtocols),
+  }, {
+    component: componentTypes.TAB_ITEM,
+    key: 'events',
+    title: __('Events'),
+    fields: createOpenstackEventsFields(amqpSecurityProtocol),
+  }, {
+    component: componentTypes.TAB_ITEM,
+    key: 'rsa',
+    title: __('RSA key pair'),
+    fields: createRsaFields(),
+  }],
+}];
+
+export const createOpenStackGeneralFields = (openStackApiVersion, openstackInfraProviders) => [{
+  component: componentTypes.SELECT,
+  name: 'api_version',
+  label: __('API Version'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  initialValue: 'v2',
+  options: openStackApiVersion.map(([label, value]) => ({ value, label })),
+  validateOnMount: true,
+  validate: [{
+    type: validatorTypes.REQUIRED,
+  }],
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'openstac_provider_region',
+  label: __('Region'),
+  validateOnMount: true,
+  validate: [{
+    type: validatorTypes.REQUIRED,
+  }],
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'openstack_keystone_domain_id',
+  label: __('Keystone V3 Domain ID'),
+  condition: {
+    when: 'api_version',
+    is: 'v3',
+  },
+}, {
+  component: componentTypes.SELECT,
+  name: 'provider_id',
+  label: __('Openstack Infra Provider'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Openstack::CloudManager',
+  },
+  placeholder: `<${__('blank')}>`,
+  options: openstackInfraProviders,
+}];

--- a/app/javascript/components/cloud-provider/cloud-openstack-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-openstack-provider.schema.js
@@ -1,17 +1,19 @@
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import { hostnameValidator, asyncValidate } from './validators';
 
+const prefix = 'ManageIQ::Providers::Openstack::CloudManager';
+
 const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
   component: componentTypes.SUB_FORM,
   name: 'openstack-endpoints',
   title: __('Default Endpoints'),
   condition: {
     when: 'type',
-    is: 'ManageIQ::Providers::Openstack::CloudManager',
+    is: prefix,
   },
   fields: [{
     component: componentTypes.SELECT,
-    name: 'openstacl_security_protocol',
+    name: `${prefix}.security_protocol`,
     label: __('Security Protocol'),
     placeholder: `<${__('Choose')}>`,
     options: openstackSecurityProtocols.map(([label, value]) => ({ value, label })),
@@ -22,7 +24,7 @@ const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
   }, {
     component: componentTypes.TEXT_FIELD,
     type: 'number',
-    name: 'openstack_api_port',
+    name: `${prefix}.port`,
     label: __('API Port'),
     initialValue: 13000,
     validateOnMount: true,
@@ -36,7 +38,7 @@ const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
     fields: [{
       component: componentTypes.TEXT_FIELD,
       label: __('Hostname (or IPv4 or IPv6 address)'),
-      name: 'openstack_hostname',
+      name: `${prefix}.hostname`,
       validateOnMount: true,
       validate: [{
         type: validatorTypes.REQUIRED,
@@ -46,7 +48,7 @@ const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
     }, {
       component: componentTypes.TEXT_FIELD,
       label: __('Client ID'),
-      name: 'azure_userid',
+      name: `${prefix}.credentials.userid`,
       validateOnMount: true,
       validate: [{
         type: validatorTypes.REQUIRED,
@@ -54,7 +56,7 @@ const createOpenstackEndpointsFields = openstackSecurityProtocols => [{
     }, {
       component: componentTypes.TEXT_FIELD,
       label: __('Client Key'),
-      name: 'azure_password',
+      name: `${prefix}.credentials.password`,
       type: 'password',
       validateOnMount: true,
       validate: [{
@@ -70,7 +72,7 @@ const createOpenstackEventsFields = amqpSecurityProtocol => [{
   name: 'openstack-events',
   condition: {
     when: 'type',
-    is: 'ManageIQ::Providers::Openstack::CloudManager',
+    is: prefix,
   },
   fields: [{
     component: componentTypes.RADIO,
@@ -228,7 +230,7 @@ export const createOpenStackGeneralFields = (openStackApiVersion, openstackInfra
   },
 }, {
   component: componentTypes.TEXT_FIELD,
-  name: 'openstack_keystone_domain_id',
+  name: `${prefix}.keystone_domain_id`,
   label: __('Keystone V3 Domain ID'),
   condition: {
     when: 'api_version',

--- a/app/javascript/components/cloud-provider/cloud-provider-form.jsx
+++ b/app/javascript/components/cloud-provider/cloud-provider-form.jsx
@@ -43,6 +43,11 @@ const CloudProviderForm = ({
     openstackInfraProviders,
   } = state;
 
+  const handleSubmit = (values) => {
+    console.log('Cloud provider form', values);
+    return values;
+  };
+
   if (!isLoaded) return null;
   return (
     <Grid fluid>
@@ -50,7 +55,7 @@ const CloudProviderForm = ({
         <Col md={6}>
           <h1>There will be dragons</h1>
           <MiqFormRenderer
-            onSubmit={console.log}
+            onSubmit={handleSubmit}
             onCancel={() => console.log('Cancel clicked')}
             buttonsLabels={{
               submitLabel: __('Add'),

--- a/app/javascript/components/cloud-provider/cloud-provider-form.jsx
+++ b/app/javascript/components/cloud-provider/cloud-provider-form.jsx
@@ -1,0 +1,75 @@
+import React, { useReducer, useEffect } from 'react';
+import { Grid, Row, Col } from 'patternfly-react';
+import MiqFormRenderer from '../../forms/data-driven-form';
+import createCloudProviderschema from './cloud-provider-form.schema';
+import { loadFormData } from './cloud-provider-helper';
+
+const SET_FORM_OPTIONS = 'SET_FORM_OPTIONS';
+
+const initialState = {
+  serverZones: [],
+  emsTypes: [],
+  isLoaded: false,
+};
+
+const cloudProviderFormReducer = (state, { type, payload }) => {
+  switch (type) {
+    case SET_FORM_OPTIONS:
+      return { ...state, ...payload, isLoaded: true };
+    default: throw new Error(`Tried to update Cloud Provider reducer with uknown action type: ${type}`);
+  }
+};
+
+const CloudProviderForm = ({
+  providerRegions,
+  openStackApiVersion,
+  vmWareCloudApiVersions,
+  openstackSecurityProtocols,
+  amqpSecurityProtocol,
+}) => {
+  const [state, dispatch] = useReducer(cloudProviderFormReducer, initialState);
+
+  useEffect(() => {
+    miqSparkleOn();
+    loadFormData()
+      .then(formData => dispatch({ type: SET_FORM_OPTIONS, payload: formData }))
+      .then(miqSparkleOff);
+  }, []);
+
+  const {
+    serverZones,
+    isLoaded,
+    emsTypes,
+    openstackInfraProviders,
+  } = state;
+
+  if (!isLoaded) return null;
+  return (
+    <Grid fluid>
+      <Row>
+        <Col md={6}>
+          <h1>There will be dragons</h1>
+          <MiqFormRenderer
+            onSubmit={console.log}
+            onCancel={() => console.log('Cancel clicked')}
+            buttonsLabels={{
+              submitLabel: __('Add'),
+            }}
+            schema={createCloudProviderschema(
+              emsTypes,
+              serverZones,
+              providerRegions,
+              openStackApiVersion,
+              openstackInfraProviders,
+              vmWareCloudApiVersions,
+              openstackSecurityProtocols,
+              amqpSecurityProtocol,
+            )}
+          />
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+export default CloudProviderForm;

--- a/app/javascript/components/cloud-provider/cloud-provider-form.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-provider-form.schema.js
@@ -1,0 +1,74 @@
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+
+import { createVMwareTabs, createVMwareGeneralFields } from './cloud-vmware-provider.schema';
+import { createEc2EndpointsFields, createEc2GeneralFields } from './cloud-ec2-provider.schema';
+import { createAzureEndpointsFields, createAzureGeneralFields } from './cloud-azure-provider.schema';
+import { createOpenstackTabs, createOpenStackGeneralFields } from './cloud-openstack-provider.schema';
+
+const generalFields = (emsTypes, serverZones, providerRegions, openStackApiVersion, openstackInfraProviders, vmWareCloudApiVersions) => [[
+  {
+    component: componentTypes.TEXT_FIELD,
+    name: 'name',
+    label: __('Name'),
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }, {
+    component: componentTypes.SELECT,
+    name: 'type',
+    label: __('Type'),
+    placeholder: `<${__('Choose')}>`,
+    options: emsTypes,
+  },
+  ...createEc2GeneralFields(providerRegions.ec2),
+  ...createAzureGeneralFields(providerRegions.azure),
+  ...createOpenStackGeneralFields(openStackApiVersion, openstackInfraProviders),
+  ...createVMwareGeneralFields(vmWareCloudApiVersions),
+  {
+    component: componentTypes.SELECT,
+    name: 'zone_id',
+    label: __('Zone'),
+    options: serverZones,
+    validateOnMount: true,
+    validate: [{
+      type: 'required-validator',
+    }],
+  }, {
+    component: componentTypes.SWITCH,
+    label: __('Tenant Mapping Enabled'),
+    name: 'ems_tenant_mapping_enabled',
+    bsSize: 'mini',
+    onText: __('Yes'),
+    offText: __('No'),
+    condition: {
+      when: 'type',
+      is: 'ManageIQ::Providers::Openstack::CloudManager',
+    },
+  },
+]];
+
+const createSchema = (
+  emsTypes,
+  serverZones,
+  providerRegions,
+  openStackApiVersion,
+  openstackInfraProviders,
+  vmWareCloudApiVersions,
+  openstackSecurityProtocols,
+  amqpSecurityProtocol,
+) => ({
+  fields: [
+    ...generalFields(emsTypes, serverZones, providerRegions, openStackApiVersion, openstackInfraProviders, vmWareCloudApiVersions),
+    {
+      component: 'hr',
+      name: 'tabs-separator',
+    },
+    ...createEc2EndpointsFields(),
+    ...createAzureEndpointsFields(),
+    ...createOpenstackTabs(openstackSecurityProtocols, amqpSecurityProtocol),
+    ...createVMwareTabs(amqpSecurityProtocol),
+  ],
+});
+
+export default createSchema;

--- a/app/javascript/components/cloud-provider/cloud-provider-form.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-provider-form.schema.js
@@ -37,7 +37,7 @@ const generalFields = (emsTypes, serverZones, providerRegions, openStackApiVersi
   }, {
     component: componentTypes.SWITCH,
     label: __('Tenant Mapping Enabled'),
-    name: 'ems_tenant_mapping_enabled',
+    name: 'ManageIQ::Providers::Openstack::CloudManager.tenant_mapping_enabled',
     bsSize: 'mini',
     onText: __('Yes'),
     offText: __('No'),

--- a/app/javascript/components/cloud-provider/cloud-provider-helper.js
+++ b/app/javascript/components/cloud-provider/cloud-provider-helper.js
@@ -1,0 +1,23 @@
+import { API } from '../../http_api';
+
+const loadProviderServerZones = () =>
+  API.get('/api/zones?expand=resources&attributes=id,name,visible&filter[]=visible!=false&sort_by=name')
+    .then(({ resources }) => ({ serverZones: resources.map(({ name, id }) => ({ value: id, label: name })) }));
+
+const loadProviderTypes = () =>
+  API.options('/api/providers')
+    .then(({ data: { supported_providers } }) => supported_providers // eslint-disable-line camelcase
+      .filter(({ kind }) => kind === 'cloud')
+      .map(({ title, type }) => ({ value: type, label: title })))
+    .then(types => ({ emsTypes: types }));
+
+const loadOpenStackInfraProviders = () =>
+  API.get('/api/providers?expand=resources&filter[]=type=ManageIQ::Providers::Openstack::InfraManager&attributes=name,provider_id&sort_by=name')
+    .then(({ resources }) => resources.map(({ name, provider_id }) => ({ value: provider_id, label: name }))) // eslint-disable-line camelcase
+    .then(openstackInfraProviders => ({ openstackInfraProviders: [{ label: `<${__('blank')}>` }, ...openstackInfraProviders] }));
+
+export const loadFormData = () => Promise.all([loadProviderServerZones(), loadProviderTypes(), loadOpenStackInfraProviders()])
+  .then(responses => responses.reduce((acc, curr) => ({
+    ...acc,
+    ...curr,
+  }), {}));

--- a/app/javascript/components/cloud-provider/cloud-vmware-provider.schema.js
+++ b/app/javascript/components/cloud-provider/cloud-vmware-provider.schema.js
@@ -1,0 +1,147 @@
+import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { hostnameValidator, asyncValidate } from './validators';
+
+const createVMwareEndpoints = () => [{
+  component: 'validate-credentials',
+  name: 'vmware-endpoints-valid',
+  asyncValidate,
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    label: __('Hostname (or IPv4 or IPv6 address)'),
+    name: 'vmware_hostname',
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    },
+    value => hostnameValidator(value, __('Wrong hostname format')),
+    ],
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    type: 'number',
+    name: 'vmware_api_port',
+    label: __('API Port'),
+    initialValue: 443,
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    label: __('Username'),
+    name: 'vmware_userid',
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }, {
+    component: componentTypes.TEXT_FIELD,
+    label: __('Password'),
+    name: 'vmware_password',
+    type: 'password',
+    validateOnMount: true,
+    validate: [{
+      type: validatorTypes.REQUIRED,
+    }],
+  }],
+}];
+
+const createVMwareEvents = amqpSecurityProtocol => [
+  {
+    component: 'validate-credentials',
+    name: 'vmware-events-valid',
+    asyncValidate,
+    fields: [{
+      component: componentTypes.RADIO,
+      label: 'Event',
+      name: 'vmware_event_stream_selection',
+      options: [{
+        label: 'Ceilometer',
+        value: 'ceilometer',
+      }, {
+        label: 'AMQP',
+        value: 'amqp',
+      }],
+    }, {
+      component: componentTypes.SUB_FORM,
+      name: 'vmware-amqp-fields',
+      condition: {
+        when: 'vmware_event_stream_selection',
+        is: 'amqp',
+      },
+      fields: [{
+        component: componentTypes.SELECT,
+        name: 'vmware_amqp_security_protocol',
+        label: __('Security Protocol'),
+        options: amqpSecurityProtocol.map(([label, value]) => ({ value, label })),
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }, {
+        component: componentTypes.TEXT_FIELD,
+        label: __('Hostname (or IPv4 or IPv6 address)'),
+        name: 'vmware_event_hostname',
+        validateOnMount: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        },
+        value => hostnameValidator(value, __('Wrong hostname format')),
+        ],
+      }, {
+        component: componentTypes.TEXT_FIELD,
+        type: 'number',
+        name: 'vmware_events_api_port',
+        label: __('API Port'),
+        initialValue: 5672,
+      }, {
+        component: componentTypes.TEXT_FIELD,
+        label: __('Username'),
+        name: 'vmware_events_userid',
+        validateOnMount: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }, {
+        component: componentTypes.TEXT_FIELD,
+        label: __('Password'),
+        name: 'vmware_events_password',
+        type: 'password',
+        validateOnMount: true,
+        validate: [{
+          type: validatorTypes.REQUIRED,
+        }],
+      }],
+    }],
+  }];
+
+export const createVMwareTabs = amqpSecurityProtocol => [{
+  component: componentTypes.TABS,
+  name: 'vmware-tabs',
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Vmware::CloudManager',
+  },
+  fields: [{
+    component: componentTypes.TAB_ITEM,
+    key: 'default',
+    title: __('Default'),
+    fields: createVMwareEndpoints(),
+  }, {
+    component: componentTypes.TABS,
+    key: 'events',
+    title: __('Events'),
+    fields: createVMwareEvents(amqpSecurityProtocol),
+  }],
+}];
+
+export const createVMwareGeneralFields = vmWareCloudApiVersions => [{
+  component: componentTypes.SELECT,
+  name: 'vmware_cloud_api_version',
+  label: __('API Version'),
+  condition: {
+    when: 'type',
+    is: 'ManageIQ::Providers::Vmware::CloudManager',
+  },
+  initialValue: '9.0',
+  placeholder: `<${__('blank')}>`,
+  options: vmWareCloudApiVersions.map(([label, value]) => ({ value, label })),
+}];

--- a/app/javascript/components/cloud-provider/validators.js
+++ b/app/javascript/components/cloud-provider/validators.js
@@ -1,0 +1,29 @@
+
+const isHostname = function(value) {
+  return /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/.test(value);
+};
+
+/**
+   * Verifies if the informed value is a valid IP (IPV4 or IPV6).
+   *
+   * @param {string} value - Value to be validated
+   * @returns {boolean} True if the value is a valid IP address (IPV4 or IPV6)
+   */
+const isIpAddress = function(value) {
+  return /((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))/.test(value); // eslint-disable-line max-len
+};
+
+export const hostnameValidator = (value, message) => {
+  if (!value) {
+    return undefined;
+  }
+
+  return isHostname(value) || isIpAddress(value) ? undefined : message;
+};
+
+export const asyncValidate = (formValues, asyncFieldsNames) => new Promise((resolve) => {
+  console.log('validating: ', formValues, asyncFieldsNames);
+  setTimeout(() => resolve('Valid'), 500);
+});
+
+export const guidRegex = /^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/;

--- a/app/javascript/components/miq-wizard/index.jsx
+++ b/app/javascript/components/miq-wizard/index.jsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { Wizard as PfWizard, Modal, Icon } from 'patternfly-react';
+import ProviderIcon from './provider-icon';
+import WizardStep from './wizard-step';
+
+const defaultButtonLabels = {
+  cancel: 'Cancel',
+  back: 'Back',
+  next: 'Next',
+  submit: 'Submit',
+};
+
+const stepsHeaders = {
+  ec2: [{
+    title: 'General Information',
+  }, {
+    title: 'Endpoints',
+  }, {
+    title: 'Summary',
+  }],
+  azure: [{
+    title: 'General Information',
+  }, {
+    title: 'Credentials',
+  }, {
+    title: 'Summary',
+  }],
+  gce: [{
+    title: 'General Information',
+  }, {
+    title: 'Endpoints',
+  }, {
+    title: 'Summary',
+  }],
+  openstack: [{
+    title: 'General Information',
+  }, {
+    title: 'Endpoints',
+  }, {
+    title: 'Events',
+  }, {
+    title: 'RSA key pair',
+  }, {
+    title: 'Summary',
+  }],
+  vmware_cloud: [{
+    title: 'General Information',
+  }, {
+    title: 'Endpoints',
+  }, {
+    title: 'Summary',
+  }],
+};
+
+const StepsInfo = ({ steps, prevSteps, startStep }) => (
+  <PfWizard.Steps steps={steps.map(({ title }, stepIndex) => (
+    <PfWizard.Step
+      activeStep={prevSteps.length - startStep}
+      title={title}
+      label={`${stepIndex + 1}`}
+      step={stepIndex}
+      key={stepIndex}
+      stepIndex={stepIndex + 1}
+    />))}
+  />
+);
+
+StepsInfo.defaultProps = {
+  prevSteps: [],
+  steps: [],
+  startStep: 0,
+};
+
+const handleNextStep = (prevSteps, activeStep) => [...prevSteps, activeStep];
+
+export const InitialWizardStep = ({ providers, FieldProvider, validate }) => (
+  <FieldProvider name="emstype" validate={validate}>
+    {({ input, meta }) => (
+      <div>
+        {providers.map(item => <ProviderIcon key={item.value} active={input.value === item.value} {...item} onClick={() => input.onChange(item.value)} />)}
+        {meta.error && meta.error}
+      </div>
+    )}
+  </FieldProvider>
+);
+
+const findCurrentStep = (activeStep, fields) => fields.find(({ stepKey }) => stepKey === activeStep);
+
+
+const MiqWizard = ({
+  FieldProvider,
+  formOptions,
+  providers,
+  fields,
+  stepKey,
+  hideStepperSteps,
+}) => {
+  const [activeStep, setActiveStep] = useState(stepKey);
+  const [prevSteps, setPrevSteps] = useState([]);
+  const [registeredFields, setRegisteredFields] = useState([]);
+  const [fullSteps] = useState([{
+    name: 'provider-select',
+    nextStep: 'general',
+    fields: [{
+      component: 'provider-initial-step',
+      name: 'provider-initial-step',
+      providers,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }],
+    }],
+    stepKey,
+  }, ...fields]);
+
+  return (
+    <PfWizard.Body>
+      {!hideStepperSteps.includes(activeStep) && (
+        <FieldProvider name="emstype">
+          {({ input: { value } }) => (
+            <StepsInfo steps={stepsHeaders[value]} prevSteps={prevSteps} startStep={hideStepperSteps.length} />
+          )}
+        </FieldProvider>
+      )}
+      <WizardStep
+        handleNext={(nextStep) => {
+          setRegisteredFields([...registeredFields, formOptions.getRegisteredFields()]);
+          setActiveStep(nextStep);
+          setPrevSteps(handleNextStep(prevSteps, activeStep));
+        }}
+        handlePrev={() => {
+          registeredFields.pop();
+          setActiveStep(prevSteps.pop());
+          setRegisteredFields([...registeredFields]);
+          setPrevSteps([...prevSteps]);
+        }}
+        disableBack={prevSteps.length === 0}
+        buttonLabels={defaultButtonLabels}
+        {...findCurrentStep(activeStep, fullSteps)}
+        formOptions={formOptions}
+        FieldProvider={FieldProvider}
+        registeredFields={registeredFields}
+      />
+    </PfWizard.Body>
+  );
+};
+
+MiqWizard.defaultProps = {
+  stepKey: 'initial',
+  hideStepperSteps: ['initial'],
+};
+
+export default MiqWizard;

--- a/app/javascript/components/miq-wizard/provider-icon.jsx
+++ b/app/javascript/components/miq-wizard/provider-icon.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const ProviderIcon = ({
+  label,
+  value,
+  onClick,
+  active,
+}) => (
+  <div onClick={onClick} style={{ border: active ? '1px solid red' : 'none' }}>
+    {label}
+  </div>
+);
+
+export default ProviderIcon;

--- a/app/javascript/components/miq-wizard/step-buttons.jsx
+++ b/app/javascript/components/miq-wizard/step-buttons.jsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon, Wizard, Button } from 'patternfly-react';
+
+const SimpleNext = ({
+  next,
+  handleNext,
+  buttonLabels,
+  disabled,
+}) => (
+  <Button
+    bsStyle="primary"
+    type="button"
+    onClick={() => (handleNext(next))}
+    disabled={disabled}
+  >
+    { buttonLabels.next }
+    <Icon type="fa" name="angle-right" />
+  </Button>
+);
+
+SimpleNext.propTypes = {
+  next: PropTypes.string,
+  valid: PropTypes.bool,
+  handleNext: PropTypes.func.isRequired,
+  submit: PropTypes.func.isRequired,
+  buttonLabels: PropTypes.object.isRequired,
+};
+
+const ConditionalNext = ({
+  nextStep,
+  FieldProvider,
+  ...rest
+}) => (
+  <FieldProvider
+    name={nextStep.when}
+    subscription={{ value: true }}
+  >
+    { ({ input: { value } }) => <SimpleNext next={nextStep.stepMapper[value]} {...rest} /> }
+  </FieldProvider>
+);
+
+ConditionalNext.propTypes = {
+  nextStep: PropTypes.shape({
+    when: PropTypes.string.isRequired,
+    stepMapper: PropTypes.object.isRequired,
+  }).isRequired,
+  FieldProvider: PropTypes.func.isRequired,
+};
+
+const getOnlyVisited = (values, registeredFields) => {
+  console.log(registeredFields);
+  return registeredFields.reduce((acc, curr) => [...acc, ...curr], [])
+    .reduce((acc, curr) => ({ ...acc, [curr]: values[curr] }), {});
+};
+
+const submitButton = (handleSubmit, submitText, registeredFields, valid, getState) => (
+  <Button type="button" bsStyle="primary" onClick={() => handleSubmit(getOnlyVisited(getState().values, registeredFields))} disabled={!valid}>
+    { submitText }
+  </Button>
+);
+
+const renderNextButton = ({
+  nextStep,
+  handleSubmit,
+  onSubmit,
+  buttonLabels,
+  valid,
+  registeredFields,
+  getState,
+  ...rest
+}) =>
+  (!nextStep
+    ? submitButton(onSubmit, buttonLabels.submit, registeredFields, valid, getState)
+    : typeof nextStep === 'object'
+      ? <ConditionalNext nextStep={nextStep} buttonLabels={buttonLabels} {...rest} disabled={!valid} />
+      : <SimpleNext next={nextStep} buttonLabels={buttonLabels} {...rest} disabled={!valid} />);
+
+const WizardStepButtons = ({
+  formOptions, disableBack, handlePrev, nextStep, FieldProvider, handleNext, buttonLabels, registeredFields,
+}) => (
+  <Wizard.Footer>
+    { formOptions.onCancel && (
+      <Button
+        style={{ marginRight: 20 }}
+        type="button"
+        variant="contained"
+        color="secondary"
+        onClick={formOptions.onCancel}
+      >
+        { buttonLabels.cancel }
+      </Button>
+    ) }
+
+    <Button
+      type="button"
+      variant="contained"
+      disabled={disableBack}
+      onClick={handlePrev}
+    >
+      <Icon type="fa" name="angle-left" />
+      { buttonLabels.back }
+    </Button>
+    { renderNextButton({
+      ...formOptions,
+      handleNext,
+      nextStep,
+      FieldProvider,
+      buttonLabels,
+      registeredFields,
+    }) }
+  </Wizard.Footer>
+);
+
+WizardStepButtons.propTypes = {
+  formOptions: PropTypes.shape({
+    onCancel: PropTypes.func,
+    handleSubmit: PropTypes.func,
+  }),
+  disableBack: PropTypes.bool,
+  handlePrev: PropTypes.func.isRequired,
+  handleNext: PropTypes.func.isRequired,
+  nextStep: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      when: PropTypes.string.isRequired,
+      stepMapper: PropTypes.object.isRequired,
+    }),
+  ]),
+  FieldProvider: PropTypes.func.isRequired,
+  buttonLabels: PropTypes.object.isRequired,
+};
+
+WizardStepButtons.defaultProps = {
+  formOptions: undefined,
+};
+
+export default WizardStepButtons;

--- a/app/javascript/components/miq-wizard/wizard-step.jsx
+++ b/app/javascript/components/miq-wizard/wizard-step.jsx
@@ -1,0 +1,40 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Wizard as PfWizard } from 'patternfly-react';
+import WizardStepButtons from './step-buttons';
+
+const WizardStep = ({
+  fields,
+  formOptions,
+  registeredFields,
+  ...rest
+}) => (
+  <Fragment>
+    <PfWizard.Row>
+      <PfWizard.Main>
+        <div className="form-horizontal">
+          { fields.map(item => formOptions.renderForm([item], formOptions)) }
+        </div>
+      </PfWizard.Main>
+    </PfWizard.Row>
+    <WizardStepButtons
+      formOptions={formOptions}
+      registeredFields={registeredFields}
+      {...rest}
+    />
+  </Fragment>
+);
+
+WizardStep.propTypes = {
+  fields: PropTypes.array,
+  formOptions: PropTypes.shape({
+    renderForm: PropTypes.func,
+  }),
+};
+
+WizardStep.defaultProps = {
+  formOptions: undefined,
+  fields: [],
+};
+
+export default WizardStep;

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -8,13 +8,13 @@ Validators.messages = {
   required: __('Required'),
 };
 
-const buttonLabels = {
+const defaultButtonsLabels = {
   submitLabel: __('Save'),
   resetLabel: __('Reset'),
   cancelLabel: __('Cancel'),
 };
 
-const MiqFormRenderer = props => (
+const MiqFormRenderer = ({ buttonsLabels, ...props }) => (
   <FormRender
     formFieldsMapper={formFieldsMapper}
     layoutMapper={layoutMapper}
@@ -22,8 +22,12 @@ const MiqFormRenderer = props => (
       'pristine',
       'invalid',
     ]}
-    {...buttonLabels}
+    buttonsLabels={{
+      ...defaultButtonsLabels,
+      ...buttonsLabels,
+    }}
     {...props}
   />
 );
+
 export default MiqFormRenderer;

--- a/app/javascript/forms/mappers/formsFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formsFieldsMapper.jsx
@@ -1,9 +1,21 @@
 import React from 'react';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
 import { formFieldsMapper } from '@data-driven-forms/pf3-component-mapper';
 import DualListSelect from '../../components/dual-list-select';
 import AsyncCredentials from '../../components/async-credentials/async-credentials';
 import EditSecretField from '../../components/async-credentials/edit-secret-field';
 import SecretSwitchField from '../../components/async-credentials/secret-switch-field';
+import MiqWizard, { InitialWizardStep } from '../../components/miq-wizard';
+
+const summary = ({ formOptions }) => (
+  <div>
+    <h1>Summary</h1>
+    <pre>
+      {JSON.stringify(formOptions.getState().values, null, 2)}
+    </pre>
+  </div>
+);
+
 
 const fieldsMapper = {
   ...formFieldsMapper,
@@ -12,6 +24,9 @@ const fieldsMapper = {
   'validate-credentials': AsyncCredentials,
   'credentials-password-edit': EditSecretField,
   'secret-switch-field': SecretSwitchField,
+  wizard: MiqWizard,
+  'provider-initial-step': InitialWizardStep,
+  summary,
 };
 
 export default fieldsMapper;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -19,6 +19,7 @@ import TaggingWrapperConnected from '../components/taggingWrapper';
 import '@manageiq/react-ui-components/dist/tagging.css';
 import RemoveCatalogItemModal from '../components/remove-catalog-item-modal.jsx';
 
+import CloudProviderForm from '../components/cloud-provider/cloud-provider-form';
 /**
 * Add component definitions to this file.
 * example of component definition:
@@ -44,3 +45,4 @@ ManageIQ.component.addReact('CatalogForm', CatalogForm);
 ManageIQ.component.addReact('Breadcrumbs', Breadcrumbs);
 ManageIQ.component.addReact('TaggingWrapperConnected', TaggingWrapperConnected);
 ManageIQ.component.addReact('RemoveCatalogItemModal', RemoveCatalogItemModal);
+ManageIQ.component.addReact('CloudProviderForm', CloudProviderForm);

--- a/app/views/ems_cloud/new.html.haml
+++ b/app/views/ems_cloud/new.html.haml
@@ -1,4 +1,10 @@
 - url = @ems.persisted? ? ems_clouds_path(@ems) : ems_clouds_path
+= react('CloudProviderForm', {:openStackApiVersion => @openstack_api_versions,
+                              :providerRegions => @provider_regions,
+                              :vmWareCloudApiVersions => @vmware_cloud_api_versions,
+                              :openstackSecurityProtocols => @openstack_security_protocols,
+                              :amqpSecurityProtocol => @amqp_security_protocols})
+
 = form_for(@ems,
            :url    => url,
            :method => :post,

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -1,5 +1,4 @@
 - @angular_form = true
-
 .form-horizontal{'ng-cloak' => '',
                  'ng-show'  => 'afterGet'}
   = render :partial => "layouts/flash_msg"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "numeral": "~2.0.6",
     "patternfly": "~3.59.1",
     "patternfly-bootstrap-treeview": "~2.1.7",
-    "patternfly-react": "2.10.1",
+    "patternfly-react": "2.30.6",
     "prop-types": "^15.6.0",
     "proxy-polyfill": "^0.1.7",
     "react": "~16.8.2",


### PR DESCRIPTION
## Changes
- Implemented in React (data-driven-forms)
- Uses API to collect and submit data
- Uses fields name spacing to avoid field names collisions and rewriting when changing provider type
  - if you set provider specific field it will be store under that type
  - `openstack.userid` for instance

## Dependencies
- https://github.com/ManageIQ/manageiq-api/pull/579
- https://github.com/ManageIQ/manageiq-api/pull/581
- https://github.com/ManageIQ/manageiq-api/issues/585
- https://github.com/ManageIQ/manageiq-api/pull/584

## TO DO
- [x] create form field schemas
- [ ] add types specific field namespacing
  - [x] azure
  - [x] amazon
  - [ ] openstack - don't have API support for sub collections so i don't know how to name these fields
  - [ ] vmware - don't have API support for sub collections so i don't know how to name these fields
  - [ ] google? should be deprecated
- [ ] use API driven endpoints credentials validation https://github.com/ManageIQ/manageiq-api/issues/585
- [ ] miq specific validations
  - [x] hostname
  - [ ] url
  - [x] guiid
- [ ] use API to create entities
- [ ] tests
- [ ] remove old code
- [ ] clean up