### PR TITLE
Open the homonymic tree nodes for dialog editor entrypoint selection

### DIFF
--- a/app/assets/javascripts/services/dialog_editor_http_service.js
+++ b/app/assets/javascripts/services/dialog_editor_http_service.js
@@ -12,8 +12,8 @@ ManageIQ.angular.app.service('DialogEditorHttp', ['$http', 'API', function($http
     });
   };
 
-  this.treeSelectorLoadData = function(fqdn) {
-    var url = '/tree/automate_entrypoint' + (fqdn ? '?fqdn=' + encodeURIComponent(fqdn) : '');
+  this.treeSelectorLoadData = function(fqname) {
+    var url = '/tree/automate_entrypoint' + (fqname ? '?fqname=' + encodeURIComponent(fqname) : '');
     return $http.get(url).then(function(response) {
       return response.data;
     });

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -5,7 +5,30 @@ class TreeController < ApplicationController
   before_action :check_privileges
 
   def automate_entrypoint
-    json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint_tree, params[:id])
+    json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint_tree, params[:id]) do |tree|
+      if params[:fqname].present?
+        MiqAeInstance.get_homonymic_across_domains_noprefix(current_user, params[:fqname], true).each do |instance|
+          # Parse the namespace, class and instance from the fqname
+          namespace, klass, instance, _ = MiqAeEngine::MiqAePath.split(instance.fqname)
+
+          begin
+            # Collect all the db records based on the parsed fqname
+            open_nodes = namespace.split('/').each_with_object([]) do |ns, items|
+              items << MiqAeNamespace.find_by!(:name => ns, :parent => items.last)
+            end
+            open_nodes << MiqAeClass.find_by!(:name => klass, :namespace_id => open_nodes.last.id)
+            open_nodes << MiqAeInstance.find_by!(:name => instance, :class_id => open_nodes.last.id)
+          rescue ActiveRecord::RecordNotFound
+            # Skip the iteration steop if one of the records is not found
+            # FIXME: we probably need foreign keys instead of this magic
+            next
+          else
+            # Set the related tree nodes to open if all the records have been found
+            open_nodes.each { |node| tree.open_node(TreeNode.new(node, {}, {}).key) }
+          end
+        end
+      end
+    end
     render :body => json, :content_type => 'application/json'
   end
 

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -16,8 +16,18 @@ class TreeController < ApplicationController
 
   private
 
+  # This method returns with a JSON that can be directly consumed by a frontend
+  # treeview component. If a node_id is set, it only returns the subtree under
+  # the node represented by this id. There's also an option to pass a block to
+  # the method and customize the tree before building it. This way we can easily
+  # define custom behavior without creating an if/else spaghetti.
   def fetch_tree(klass, name, node_id = nil)
-    tree = klass.new(name, {})
+    tree = klass.new(name, {}, false)
+
+    # FIXME: maybe here we would need instance_exec/eval instead
+    yield(tree) if block_given?
+
+    tree.reload!
 
     if node_id
       TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(node_id)).to_json

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -108,6 +108,11 @@ class TreeBuilder
     build_tree
   end
 
+  def open_node(id)
+    open_nodes = @tree_state.x_tree(@name)[:open_nodes]
+    open_nodes.push(id) unless open_nodes.include?(id)
+  end
+
   # FIXME: temporary conversion, needs to be moved into the generation
   def self.convert_bs_tree(nodes)
     return [] if nodes.nil?
@@ -332,11 +337,6 @@ class TreeBuilder
 
   def count_only_or_objects_filtered(count_only, objects, sort_by = nil, options = {}, &block)
     count_only_or_objects(count_only, Rbac.filtered(objects, options), sort_by, &block)
-  end
-
-  def open_node(id)
-    open_nodes = @tree_state.x_tree(@name)[:open_nodes]
-    open_nodes.push(id) unless open_nodes.include?(id)
   end
 
   def prefixed_title(prefix, title)

--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -45,7 +45,8 @@ describe TreeController do
     subject { controller.send(:fetch_tree, klass, :foo_tree, node_id) }
 
     it 'returns with a tree hash' do
-      expect(klass).to receive(:new).with(:foo_tree, {}).and_return(tree)
+      expect(klass).to receive(:new).with(:foo_tree, {}, false).and_return(tree)
+      expect(tree).to receive(:reload!)
       expect(subject).to eq(:foo => :bar)
     end
   end


### PR DESCRIPTION
The dialog editor has an option to set a field dynamic, if this is enable there's an entry point selection tree available under the *Options* tab. If you're editing an already existing field with an entry point selected, the tree nodes to the entry point aren't expanded.

However, the entry point doesn't include a domain prefix, it is possible that the same entry point is available under a different domain. We discussed this with the automate folks and the only solution is to expand all the homonymic nodes under all possible automate domain prefixes. 

I added an optional block evaluation to the `TreeController#fetch_tree` method that runs before the tree is being build. By passing a block to this method, we can easily define different behavior for certain trees without defining extra arguments for the method. We might want to redesign this block evaluation in the future to run directly in the `TreeBuilder` but for now it is good as it is.

Depends on: https://github.com/ManageIQ/manageiq/pull/18722

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label pending core, changelog/yes, angular dialogs, automation/automate, trees