### PR TITLE
Fix for open_url in CustomButton

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -90,7 +90,7 @@ module ApplicationController::Buttons
     group_create_update("update")
   end
 
-  MODEL_WITH_OPEN_URL = ["VM and Instance"].freeze
+  MODEL_WITH_OPEN_URL = ["Vm"].freeze
 
   def automate_button_field_changed
     unless params[:target_class]
@@ -994,7 +994,6 @@ module ApplicationController::Buttons
     (ApplicationController::AE_MAX_RESOLUTION_FIELDS - @edit[:new][:attrs].length).times { @edit[:new][:attrs].push([]) }
     @edit[:new][:starting_object] ||= "SYSTEM/PROCESS"
     @edit[:new][:instance_name] ||= "Request"
-    @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
 
     @edit[:new].update(
       :target_class   => @resolve[:target_class],
@@ -1012,6 +1011,8 @@ module ApplicationController::Buttons
     )
     button_set_expression_vars(:enablement_expression, :enablement_expression_table)
     button_set_expression_vars(:visibility_expression, :visibility_expression_table)
+
+    @edit[:new][:disabled_open_url] = !(MODEL_WITH_OPEN_URL.include?(@resolve[:target_class]) && @edit[:new][:display_for] == 'single')
 
     @edit[:current] = copy_hash(@edit[:new])
 

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -195,6 +195,7 @@ describe ApplicationController do
       expect(assigns(:edit)[:new][:button_icon]).to eq('fa fa-info')
       expect(assigns(:edit)[:new][:open_url]).to eq(false)
       expect(assigns(:edit)[:new][:dialog_id]).to eq(nil)
+      expect(assigns(:edit)[:new][:disabled_open_url]).to eq(false)
 
       controller.instance_variable_set(:@sb,
                                        :trees       => {
@@ -228,6 +229,7 @@ describe ApplicationController do
       expect(assigns(:edit)[:new][:enablement_expression]).to eq(e_expression.exp)
       expect(assigns(:edit)[:new][:visibility_expression]).to eq(v_expression.exp)
       expect(assigns(:edit)[:new][:dialog_id]).to eq(42)
+      expect(assigns(:edit)[:new][:disabled_open_url]).to eq(false)
 
       controller.instance_variable_set(:@sb,
                                        :trees       => { :ab_tree => {:active_node => "xx-ab_Vm_cbg-10r96_cb-10r7"}},
@@ -265,6 +267,7 @@ describe ApplicationController do
       expect(assigns(:edit)[:new][:object_request]).to eq('Order_Ansible_Playbook')
       expect(assigns(:edit)[:new][:service_template_id]).to eq(service_template.id)
       expect(assigns(:edit)[:new][:inventory_type]).to eq('localhost')
+      expect(assigns(:edit)[:new][:disabled_open_url]).to eq(false)
 
       controller.instance_variable_set(:@sb,
                                        :trees       => {:ab_tree => {:active_node => "xx-ab_Vm_cbg-10r96_cb-10r7"}},
@@ -381,7 +384,7 @@ describe ApplicationController do
       end
       it "to false for Vm and Template" do
         controller.instance_variable_set(:@_params, "id" => button_for_vm.id, "dialog_id" => "")
-        controller.instance_variable_set(:@resolve, :target_class => "VM and Instance")
+        controller.instance_variable_set(:@resolve, :target_class => "Vm")
         controller.instance_variable_set(:@custom_button, button_for_vm)
         controller.send(:automate_button_field_changed)
         expect(assigns(:edit)[:new][:disabled_open_url]).to be false


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1706900

Go to Automate -> Automation -> Customization -> Custom Buttons -> Create a new button under Vm and Instance

`Open URL` should be ENABLED for `Vm and Instance` when `Display For` is set to `Single Entity`

Before:
![image](https://user-images.githubusercontent.com/9210860/57303172-0d9d3280-70dd-11e9-92d5-b5b92c68ead6.png)

After:
![image](https://user-images.githubusercontent.com/9210860/57303137-f9593580-70dc-11e9-85fa-49d7a4f57be2.png)

@miq-bot add_label bug, automation/automate, hammer/no, changelog/no, blocker
