### PR TITLE
Remove the replication exclude tables

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -5,7 +5,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       subscriptions: [],
       addEnabled: false,
       updateEnabled: false,
-      exclusion_list: null,
     };
     $scope.formId = pglogicalReplicationFormId;
     $scope.afterGet = false;
@@ -45,14 +44,9 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
         object.splice(index, 1);
       }
     });
-    var updated_exclusion_list = '';
-    if ($scope.pglogicalReplicationModel.replication_type === 'remote' && !angular.equals($scope.pglogicalReplicationModel.exclusion_list, $scope.modelCopy.exclusion_list) ) {
-      updated_exclusion_list = angular.copy($scope.pglogicalReplicationModel.exclusion_list);
-    }
     pglogicalManageSubscriptionsButtonClicked('save', {
       'replication_type': $scope.pglogicalReplicationModel.replication_type,
       'subscriptions': $scope.pglogicalReplicationModel.subscriptions,
-      'exclusion_list': updated_exclusion_list,
     });
   };
 
@@ -85,10 +79,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
     if (new_value !== 'global') {
       $scope.pglogicalReplicationModel.subscriptions = [];
-    }
-
-    if (new_value !== 'remote') {
-      $scope.pglogicalReplicationModel.exclusion_list = angular.copy($scope.modelCopy.exclusion_list);
     }
 
     if (new_value === 'global' && original_value === 'global') {
@@ -216,12 +206,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
       return false;
     }
-    saveable = form.$dirty && form.$valid;
-    if (saveable && (($scope.modelCopy.replication_type !== 'remote') || !angular.equals($scope.pglogicalReplicationModel.exclusion_list, $scope.modelCopy.exclusion_list))) {
-      return true;
-    }
-
-    return false;
+    return form.$dirty && form.$valid;
   };
 
   // method to set flag to disable certain buttons when add of subscription in progress
@@ -307,7 +292,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
     $scope.pglogicalReplicationModel.replication_type = data.replication_type;
     $scope.pglogicalReplicationModel.subscriptions = angular.copy(data.subscriptions);
-    $scope.pglogicalReplicationModel.exclusion_list = angular.copy(data.exclusion_list);
 
     if ($scope.pglogicalReplicationModel.replication_type === 'none') {
       miqService.miqFlash('warn', __('No replication role has been set'));

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -181,12 +181,10 @@ module OpsController::Settings::Common
     replication_type = MiqRegion.replication_type
     subscriptions = replication_type == :global ? PglogicalSubscription.all : []
     subscriptions = get_subscriptions_array(subscriptions) unless subscriptions.empty?
-    exclusion_list = replication_type == :remote ? MiqPglogical.new.active_excludes : MiqPglogical.default_excludes
 
     render :json => {
       :replication_type => replication_type,
-      :subscriptions    => subscriptions,
-      :exclusion_list   => exclusion_list.to_yaml
+      :subscriptions    => subscriptions
     }
   end
 
@@ -198,10 +196,9 @@ module OpsController::Settings::Common
       queue_opts = {:class_name => "MiqPglogical", :method_name => "save_global_region",
                     :args       => [subscriptions_to_save, subsciptions_to_remove]}
     when "remote"
-      task_opts  = {:action => "Save list of table excluded from replication for remote region",
+      task_opts  = {:action => "Configure the database to be a replication remote region",
                     :userid => session[:userid]}
-      queue_opts = {:class_name => "MiqPglogical", :method_name => "save_remote_region",
-                    :args       => [params[:exclusion_list]]}
+      queue_opts = {:class_name => "MiqRegion", :method_name => "replication_type=", :args => [:remote]}
     when "none"
       task_opts  = {:action => "Set replication type to none", :userid => session[:userid]}
       queue_opts = {:class_name => "MiqRegion", :method_name => "replication_type=", :args => [:none]}

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -183,15 +183,6 @@
                   %li
                     %a{"ng-click" => "discardSubscription($index)"}
                       = _('Discard')
-    .exclusion_list_div{"ng-if" => "pglogicalReplicationModel.replication_type == 'remote'"}
-      %h3
-        = _('Excluded Tables')
-      %br
-        %textarea{"ui-codemirror" => "",
-                  "ui-refresh"    => "codeMirrorRefresh",
-                  :name           => "exclusion_list",
-                  'ng-model'      => 'pglogicalReplicationModel.exclusion_list',
-                  'checkchange'   => ''}
 
     .button-group{:align => "right"}
       %miq-button{:name      => t = _("Save"),

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -202,14 +202,13 @@ describe OpsController do
       before { allow(controller).to receive(:javascript_flash) }
 
       context "remote" do
-        let(:to_exlude) { "---\n- vmdb_databases\n- vmdb_indexes" }
-        let(:params)    { {:replication_type => "remote", :exclusion_list => to_exlude} }
+        let(:params) { {:replication_type => "remote"} }
 
-        it "queues operation to updates exclude tables for the remote region" do
+        it "queues operation to set the region as a remote type" do
           controller.instance_variable_set(:@_params, params)
           controller.send(:pglogical_save_subscriptions)
-          queue_item = MiqQueue.find_by(:method_name => "save_remote_region")
-          expect(queue_item.args).to eq([to_exlude])
+          queue_item = MiqQueue.find_by(:method_name => "replication_type=")
+          expect(queue_item.args).to eq([:remote])
         end
       end
 

--- a/spec/javascripts/controllers/ops/pglogical_replication_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/pglogical_replication_form_controller_spec.js
@@ -12,8 +12,7 @@ describe('pglogicalReplicationFormController', function() {
     $scope = $rootScope.$new();
     $scope.pglogicalReplicationModel = {
       replication_type: 'none',
-      subscriptions   : [],
-      exclusion_list  : ""
+      subscriptions   : []
     };
     $httpBackend = _$httpBackend_;
     $controller = _$controller_('pglogicalReplicationFormController', {
@@ -26,8 +25,7 @@ describe('pglogicalReplicationFormController', function() {
   beforeEach(inject(function(_$controller_) {
     var pglogicalReplicationFormResponse = {
       replication_type: 'none',
-      subscriptions   : [],
-      exclusion_list  : ""
+      subscriptions   : []
     };
     $httpBackend.whenGET('/ops/pglogical_subscriptions_form_fields/new').respond(pglogicalReplicationFormResponse);
     $httpBackend.flush();
@@ -45,10 +43,6 @@ describe('pglogicalReplicationFormController', function() {
 
     it('sets the subscriptions value returned with http request', function() {
       expect($scope.pglogicalReplicationModel.subscriptions).toEqual([]);
-    });
-
-    it('sets the exclusion list to the value returned by the http request', function() {
-      expect($scope.pglogicalReplicationModel.exclusion_list).toEqual("");
     });
   });
 
@@ -81,8 +75,7 @@ describe('pglogicalReplicationFormController', function() {
     it('delegates to miqJqueryRequest', function() {
       var submitContent = {
         replication_type: $scope.pglogicalReplicationModel.replication_type,
-        subscriptions:    $scope.pglogicalReplicationModel.subscriptions,
-        exclusion_list:   $scope.pglogicalReplicationModel.exclusion_list};
+        subscriptions:    $scope.pglogicalReplicationModel.subscriptions};
 
       expect(miqJqueryRequest).toHaveBeenCalledWith('/ops/pglogical_save_subscriptions/new?button=save', {data: submitContent, complete: true});
     });


### PR DESCRIPTION
With the new backend replication technology, making a new set of
excluded tables take effect requires action on both the remote and
global regions. Because of this the user experience would be much
worse for a feature that is not really necessary.

Requires https://github.com/ManageIQ/manageiq/pull/18686

@miq-bot add_label wip, hammer/no, pending core

---------------------------------------
Before:
![image](https://user-images.githubusercontent.com/12697904/57465786-583dbc80-724d-11e9-8b15-c9067c0f1642.png)

After:
![image](https://user-images.githubusercontent.com/12697904/57464583-f714e980-724a-11e9-8b71-71522ecedee3.png)
