### PR TITLE
Remove the need for the options argument when fetching node kids in TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -241,7 +241,7 @@ class TreeBuilder
   end
 
   def x_get_tree_objects(parent, options, count_only, parents)
-    children_or_count = parent.nil? ? x_get_tree_roots(count_only, options) : x_get_tree_kids(parent, count_only, options, parents)
+    children_or_count = parent.nil? ? x_get_tree_roots(count_only, options) : x_get_tree_kids(parent, count_only, parents)
     children_or_count || (count_only ? 0 : [])
   end
 

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -19,15 +19,15 @@ class TreeBuilderIsoDatastores < TreeBuilder
     count_only_or_objects(count_only, IsoDatastore.all, "name")
   end
 
-  def x_get_tree_iso_datastore_kids(object, count_only, options)
+  def x_get_tree_iso_datastore_kids(object, count_only, _options)
     iso_images = object.iso_images
     if count_only
-      options[:open_nodes].push("xx-isd_xx-#{object.id}")
+      open_node("xx-isd_xx-#{object.id}")
       iso_images.size
     else
       objects = []
       unless iso_images.empty?
-        options[:open_nodes].push("isd_xx-#{object.id}")
+        open_node("isd_xx-#{object.id}")
         objects.push(
           :id   => "isd_xx-#{object.id}",
           :text => _("ISO Images"),

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -1,5 +1,5 @@
 class TreeBuilderIsoDatastores < TreeBuilder
-  has_kids_for IsoDatastore, %i[x_get_tree_iso_datastore_kids options]
+  has_kids_for IsoDatastore, %i[x_get_tree_iso_datastore_kids]
 
   private
 
@@ -19,7 +19,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
     count_only_or_objects(count_only, IsoDatastore.all, "name")
   end
 
-  def x_get_tree_iso_datastore_kids(object, count_only, _options)
+  def x_get_tree_iso_datastore_kids(object, count_only)
     iso_images = object.iso_images
     if count_only
       open_node("xx-isd_xx-#{object.id}")

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -28,12 +28,12 @@ class TreeBuilderOpsVmdb < TreeBuilder
     count_only_or_objects(count_only, vmdb_indexes, "name")
   end
 
-  def x_get_tree_vmdb_table_kids(object, count_only, options)
+  def x_get_tree_vmdb_table_kids(object, count_only, _options)
     if count_only
       1 # each table has any index
     else
       # load this node expanded on autoload
-      options[:open_nodes].push("xx-#{object.id}") unless options[:open_nodes].include?("xx-#{object.id}")
+      open_node("xx-#{object.id}")
       [
         {
           :id            => object.id.to_s,

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -1,5 +1,5 @@
 class TreeBuilderOpsVmdb < TreeBuilder
-  has_kids_for VmdbTableEvm, %i[x_get_tree_vmdb_table_kids options]
+  has_kids_for VmdbTableEvm, %i[x_get_tree_vmdb_table_kids]
 
   private
 
@@ -28,7 +28,7 @@ class TreeBuilderOpsVmdb < TreeBuilder
     count_only_or_objects(count_only, vmdb_indexes, "name")
   end
 
-  def x_get_tree_vmdb_table_kids(object, count_only, _options)
+  def x_get_tree_vmdb_table_kids(object, count_only)
     if count_only
       1 # each table has any index
     else

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -1,5 +1,5 @@
 class TreeBuilderPxeServers < TreeBuilder
-  has_kids_for PxeServer, %i[x_get_tree_pxe_server_kids options]
+  has_kids_for PxeServer, %i[x_get_tree_pxe_server_kids]
 
   private
 
@@ -19,7 +19,7 @@ class TreeBuilderPxeServers < TreeBuilder
     count_only_or_objects(count_only, PxeServer.all, "name")
   end
 
-  def x_get_tree_pxe_server_kids(object, count_only, _options)
+  def x_get_tree_pxe_server_kids(object, count_only)
     pxe_images = object.pxe_images
     win_images = object.windows_images
     if count_only

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -19,24 +19,24 @@ class TreeBuilderPxeServers < TreeBuilder
     count_only_or_objects(count_only, PxeServer.all, "name")
   end
 
-  def x_get_tree_pxe_server_kids(object, count_only, options)
+  def x_get_tree_pxe_server_kids(object, count_only, _options)
     pxe_images = object.pxe_images
     win_images = object.windows_images
     if count_only
-      options[:open_nodes].push("xx-pxe_xx-#{object.id}") unless options[:open_nodes].include?("xx-pxe_xx-#{object.id}")
-      options[:open_nodes].push("xx-win_xx-#{object.id}") unless options[:open_nodes].include?("xx-win_xx-#{object.id}")
+      open_node("xx-pxe_xx-#{object.id}")
+      open_node("xx-win_xx-#{object.id}")
       pxe_images.size + win_images.size
     else
       objects = []
       unless pxe_images.empty?
-        options[:open_nodes].push("pxe_xx-#{object.id}") unless options[:open_nodes].include?("pxe_xx-#{object.id}")
+        open_node("pxe_xx-#{object.id}")
         objects.push(:id   => "pxe_xx-#{object.id}",
                      :text => _("PXE Images"),
                      :icon => "pficon pficon-folder-close",
                      :tip  => _("PXE Images"))
       end
       unless win_images.empty?
-        options[:open_nodes].push("win_xx-#{object.id}") unless options[:open_nodes].include?("win_xx-#{object.id}")
+        open_node("win_xx-#{object.id}")
         objects.push(:id   => "win_xx-#{object.id}",
                      :text => _("Windows Images"),
                      :icon => "pficon pficon-folder-close",

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -23,10 +23,10 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   # Get root node and all children report folders. (will call get_tree_custom_kids to get report details)
-  def x_get_tree_roots(count_only, options)
+  def x_get_tree_roots(count_only, _options)
     return @rpt_menu.size if count_only
     @rpt_menu.each_with_index.each_with_object({}) do |(r, node_id), a|
-      options[:open_nodes].push("xx-#{node_id}")
+      open_node("xx-#{node_id}")
 
       root_node = folder_hash(node_id.to_s, r[0], @grp_title == r[0])
       child_nodes = @rpt_menu[node_id][1].each_with_index.each.map do |child_r, child_id|

--- a/app/presenters/tree_kids.rb
+++ b/app/presenters/tree_kids.rb
@@ -15,20 +15,13 @@ module TreeKids
   # Get objects (or count) to [put into a tree under a parent node.
   # TODO: Perhaps push the object sorting down to SQL, if possible -- no point where there are few items.
   # parent  --- Parent object for which we need child tree nodes returned
-  # options --- Options:
-  #   :count_only           # Return only the count if true -- remove this
-  #   :leaf                 # Model name of leaf nodes, i.e. "Vm"
-  #   :open_all             # if true open all node (no autoload)
-  #   :load_children
   # parents --- an Array of parent object ids, starting from tree root + 1, ending with parent's parent; only available when full_ids and not lazy
-  def x_get_tree_kids(parent, count_only, options, parents)
+  def x_get_tree_kids(parent, count_only, parents)
     generator = self.class.kids_generators.detect { |k, v| v if parent.kind_of?(k) }
     return nil unless generator
     method = generator[1][0]
     attributes = generator[1][1..-1].collect do |attribute_name|
       case attribute_name
-      when :options then options
-      when :type then options[:type]
       when :parents then parents
       end
     end


### PR DESCRIPTION
The `TreeBuilder#open_node` method already implements `options[:open_nodes].push`, therefore, it should be used across all the `TreeBuilder` classes. By making this change, the `options` argument for fetching tree kids becomes unnecessary, so it can be also deleted.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label refactoring, trees, hammer/no, changelog/yes