### PR TITLE
Fix adding new trusted forests for LDAP authentication

### DIFF
--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -19,7 +19,7 @@
         - if entry != "new"
           %tr
             %td
-              %button.btn.btn-default{:onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => "new"}), :title => _("Click to add a new forest")}
+              %button.btn.btn-default{:type => 'button', :onclick => remote_function(:url => {:action => 'forest_select', :ldaphost_id => "new"}), :title => _("Click to add a new forest")}
                 %i.fa.fa-plus
             %td
               = _("<Click on this row to create a new forest>")
@@ -71,7 +71,7 @@
             - unless forest.blank?
               %tr
                 %td
-                  %button.btn.btn-default{:onclick => remote_function(:url => {:action => 'forest_delete',
+                  %button.btn.btn-default{:type => 'button', :onclick => remote_function(:url => {:action => 'forest_delete',
                   :ldaphost_id => forest[:ldaphost].to_s}, :confirm => _("Are you sure you want to delete forest %{ldaphost} ?") % {:ldaphost => forest[:ldaphost]}),
                   :title => _("Click to delete this forest")}
                     %i.pficon.pficon-delete

--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -47,7 +47,7 @@
               = text_field("user_proxies", "bind_dn", "size" => 20, "maxlength" => 50)
             %td
               = password_field("user_proxies", "bind_pwd", "size" => 20, "maxlength" => 128)
-        - @edit[:new][:authentication][:user_proxies].sort_by { |a| a[:ldaphost] }.each do |forest|
+        - @edit[:new][:authentication][:user_proxies].sort_by { |a| a[:ldaphost].to_s }.each do |forest|
           - if entry != nil && entry != "new" && entry[:ldaphost] == forest[:ldaphost]
             %tr
               %td


### PR DESCRIPTION
When setting authentication to LDAP under the server settings, it is possible to map the LDAP's user groups to our groups. This enables the trusted forest settings, which has a button that fires two events instead of one.

Also, when you try to add the second trusted forest, you get an exception from the server about a comparison between `nil` and a string. This is because the new forest's `ldaphost` is implicitly set to `nil` and we're trying to sort all the forests. The solution is simple, force-convert the values into string while sorting...

@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @himdel 
@miq-bot add_label bug, hammer/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1706764