### PR TITLE
Removed 'type' argument passed to the tree builder

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -171,10 +171,10 @@ module MiqPolicyController::AlertProfiles
     end
     if params.key?(:id)
       if params[:check] == "1"
-        @assign[:new][:objects].push(params[:id].split("-").last)
+        @assign[:new][:objects].push(params[:id].split("-").last.to_i)
         @assign[:new][:objects].sort!
       else
-        @assign[:new][:objects].delete(params[:id].split("-").last)
+        @assign[:new][:objects].delete(params[:id].split("-").last.to_i)
       end
     end
 
@@ -198,19 +198,18 @@ module MiqPolicyController::AlertProfiles
   def alert_profile_build_obj_tree
     return nil if alert_profile_get_assign_to_objects_empty?
     if @assign[:new][:assign_to] == "ems_folder"
-      instantiate_tree("TreeBuilderBelongsToVat", :vat_tree, :vat,
+      instantiate_tree("TreeBuilderBelongsToVat", :vat_tree,
                        @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
     elsif @assign[:new][:assign_to] == "resource_pool"
-      instantiate_tree("TreeBuilderBelongsToHac", :hac_tree, :hac,
+      instantiate_tree("TreeBuilderBelongsToHac", :hac_tree,
                        @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
     else
-      instantiate_tree("TreeBuilderAlertProfileObj", :object_tree, :object, @assign[:new][:objects])
+      instantiate_tree("TreeBuilderAlertProfileObj", :object_tree, @assign[:new][:objects])
     end
   end
 
-  def instantiate_tree(tree_class, tree_name, type, selected_nodes)
+  def instantiate_tree(tree_class, tree_name, selected_nodes)
     tree_class.constantize.new(tree_name,
-                               type,
                                @sb,
                                true,
                                :assign_to      => @assign[:new][:assign_to],

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -93,5 +93,30 @@ describe MiqPolicyController do
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
     end
+
+    context "#alert_profile_assign_changed" do
+      before do
+        alert_profile_set = FactoryBot.create(:miq_alert_set, :set_type => "MiqAlertSet", :mode => "MiqServer")
+        assign = {
+          :new            => {:assign_to => "miq_server", :objects => [10]},
+          "alert_profile" => alert_profile_set,
+        }
+        controller.instance_variable_set(:@sb, :assign => assign)
+      end
+
+      it "Changing Assign Tos drop down value, initializes the tree" do
+        controller.instance_variable_set(:@_params, :chosen_assign_to => "miq_server")
+        expect(controller).to receive(:render)
+        controller.alert_profile_assign_changed
+        expect(assigns(:assign)[:obj_tree]).not_to be_nil
+      end
+
+      it "does not throw an error when selecting items in the servers tree" do
+        controller.instance_variable_set(:@_params, :check => "1", :id => "svr-1")
+        expect(controller).to receive(:render)
+        controller.alert_profile_assign_changed
+        expect(assigns(:assign)[:new][:objects]).to eq([1, 10])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixed 2 issues
- Fixed `wrong number of arguments (given 4, expected 3)` error, removed 'type' argument that was being passed in to tree builder code, was introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5495
- Fixed `comparison of Integer with String failed` error for `@assign[:new][:objects].sort!`, changed to push integer into objects array to fix comparison error on the sort when selecting nodes in the tree in 'Selections' box.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1707871
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1707886

![Screenshot from 2019-05-08 16-24-05](https://user-images.githubusercontent.com/3450808/57405988-bd41d580-71ad-11e9-9c4a-8ac38a21f70e.png)


