### PR TITLE
[HAMMER] Do not fire two events when adding LDAP trusted forest entities

### DIFF
--- a/app/views/ops/_ldap_forest_entries.html.haml
+++ b/app/views/ops/_ldap_forest_entries.html.haml
@@ -31,7 +31,7 @@
         - else
           %tr
             %td
-              %button.btn.btn-default#accept{:type => 'submit', :name => 'accept', :title => _("Add this entry")}
+              %button.btn.btn-default{:type => 'submit', :name => 'accept', :title => _("Add this entry")}
                 %i.pficon.pficon-import
             %td
               = text_field("user_proxies", "ldaphost", "maxlength" => 50)
@@ -51,7 +51,7 @@
           - if entry != nil && entry != "new" && entry[:ldaphost] == forest[:ldaphost]
             %tr
               %td
-                %button.btn.btn-default#accept{:type => :submit, :name => 'accept', :title => _("Update this entry")}
+                %button.btn.btn-default{:type => :submit, :name => 'accept', :title => _("Update this entry")}
                   %i.pficon.pficon-import
               %td
                 = text_field("user_proxies", "ldaphost", "maxlength" => 50, "value" => entry[:ldaphost])


### PR DESCRIPTION
When setting authentication to LDAP under the server settings, it is possible to map the LDAP's user groups to our groups. This enables the trusted forest settings, which has some kind of weird issue on hammer when running with Chrome. This is probably due an old(er) version of some JS library and the existence of the `#accept` on the buttons.

As the issue is hammer-only, there is no need for an upstream-master PR, however, I found another [bug](https://github.com/ManageIQ/manageiq-ui-classic/pull/5548) that blocks adding a second trusted forest entity which also happens on upstream-master. 

@miq-bot add_reviewer @h-kataria 
@miq-bot assign @simaishi 
@miq-bot add_label bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1706764