### PR TITLE
Only initialize value of `@edit[:new][:location]` when it's not set

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2245,7 +2245,8 @@ class MiqAeClassController < ApplicationController
       # for method_inputs view
       @edit[:new][:name] = params[:method_name].presence if params[:method_name]
       @edit[:new][:display_name] = params[:method_display_name].presence if params[:method_display_name]
-      @edit[:new][:location] = params[:method_location] || 'inline'
+      @edit[:new][:location] ||= 'inline'
+      @edit[:new][:location] = params[:method_location] if params[:method_location]
       @edit[:new][:data] = params[:method_data] if params[:method_data]
       method_form_vars_process_fields
       session[:field_data][:name] = @edit[:new_field][:name] = params[:field_name] if params[:field_name]
@@ -2256,7 +2257,7 @@ class MiqAeClassController < ApplicationController
       # for class_methods view
       @edit[:new][:name] = params[:cls_method_name].presence if params[:cls_method_name]
       @edit[:new][:display_name] = params[:cls_method_display_name].presence if params[:cls_method_display_name]
-      @edit[:new][:location] = params[:cls_method_location] || 'inline'
+      @edit[:new][:location] = params[:cls_method_location] if params[:cls_method_location]
       @edit[:new][:data] = params[:cls_method_data] if params[:cls_method_data]
       @edit[:new][:data] += "..." if params[:transOne] && params[:transOne] == "1" # Update the new data to simulate a change
       method_form_vars_process_fields('cls_')


### PR DESCRIPTION
Changing value of Expression Object field in UI was causing value of `@edit[:new][:location]` to be reset to "inline" causing incorrect partial to render on screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1705587

To recreate add a new Expression type method, and change value of Expression Object in the drop down.

before:
![before](https://user-images.githubusercontent.com/3450808/57468831-3e06dd00-7253-11e9-8015-84233c7b990f.png)

after:
![after](https://user-images.githubusercontent.com/3450808/57468683-f5e7ba80-7252-11e9-895f-d8e195563377.png)
