### PR TITLE
Enable validate button when data is entered for builtin method type

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -913,7 +913,7 @@ class MiqAeClassController < ApplicationController
                              @edit[:new][:data]
                            end
       @changed = (@edit[:new] != @edit[:current])
-      @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
+      @edit[:default_verify_status] = %w(builtin inline).include?(@edit[:new][:location]) && @edit[:new][:data] && @edit[:new][:data] != ""
 
       in_angular = playbook_style_location?(@edit[:new][:location])
       angular_form_specific_data if in_angular


### PR DESCRIPTION
`@edit[:default_verify_status]` was not being set when method type was 'builtin', causing validate button to always remain disabled.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1708203

This issue is recreatable on master after fixing issue in https://github.com/ManageIQ/manageiq-ui-classic/pull/5555 , currently on master since value of `@edit[:new][:location]` always gets reset to "inline" validate button gets enabled when transaction is sent up to the server.

before:
![validate_button_before_fix](https://user-images.githubusercontent.com/3450808/57469818-83c4a500-7255-11e9-8a1d-fa32eabbb54f.png)

after:
![validate_button_after_fix](https://user-images.githubusercontent.com/3450808/57469523-d782be80-7254-11e9-9468-f49d0014fed9.png)

