### PR TITLE
Only need to set `@edit[:current][:add]` for new record

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -299,7 +299,7 @@ module MiqPolicyController::MiqActions
     @edit[:current] = copy_hash(@edit[:new])
     get_tags_tree
     @in_a_form = true
-    @edit[:current][:add] = @edit[:action_id].nil? # Force changed to be true if adding a record
+    @edit[:current][:add] = true if @edit[:action_id].nil? # Force changed to be true if adding a record
     session[:changed] = (@edit[:new] != @edit[:current])
   end
 


### PR DESCRIPTION
Reverting a change made in https://github.com/ManageIQ/manageiq-ui-classic/commit/1b4c63bd357c8dd9a0ca0cd5df68bf821ff7978a#diff-2ea3e6bb74ba2e128638b610176feeddR302, this change is causing Save/Reset button to be enabled on initial load of edit form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1708434

before
![before_fix](https://user-images.githubusercontent.com/3450808/57491652-a376c000-728b-11e9-8230-c8ef865ba574.png)

after
![after_fix](https://user-images.githubusercontent.com/3450808/57491615-8fcb5980-728b-11e9-807f-872036330e0b.png)
