### PR TITLE
Evaluate the current server/zone in the TreeNode instead of globally

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -252,9 +252,6 @@ class TreeBuilder
   def x_build_node(object, pid, options)
     parents = pid.to_s.split('_')
 
-    options[:is_current] = ((object.kind_of?(MiqServer) && MiqServer.my_server.id == object.id) ||
-                             (object.kind_of?(Zone) && MiqServer.my_server.my_zone == object.name))
-
     object, ancestry_kids = object_from_ancestry(object)
     node = x_build_single_node(object, pid, options)
 

--- a/app/presenters/tree_node/miq_server.rb
+++ b/app/presenters/tree_node/miq_server.rb
@@ -3,7 +3,7 @@ module TreeNode
     set_attribute(:expand, true)
 
     set_attributes(:text, :tooltip) do
-      if @options[:is_current]
+      if ::MiqServer.my_server.id == @object.id
         tooltip  = _("%{server}: %{server_name} [%{server_id}] (current)") %
                    {:server => ui_lookup(:model => @object.class.to_s), :server_name => @object.name, :server_id => @object.id}
         tooltip += " (#{@object.status})" if @options[:tree] == :roles_by_server_tree

--- a/app/presenters/tree_node/zone.rb
+++ b/app/presenters/tree_node/zone.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class Zone < Node
     set_attributes(:text, :tooltip) do
-      if @options[:is_current]
+      if ::MiqServer.my_server.my_zone == @object.name
         tooltip = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.description} (#{_('current')})"
         text   = ViewHelper.content_tag(:strong, ERB::Util.html_escape(tooltip))
       else

--- a/spec/presenters/tree_node/miq_server_spec.rb
+++ b/spec/presenters/tree_node/miq_server_spec.rb
@@ -1,4 +1,5 @@
 describe TreeNode::MiqServer do
+  before { EvmSpecHelper.local_miq_server }
   subject { described_class.new(object, nil, {}) }
   let(:object) do
     zone = FactoryBot.create(:zone)

--- a/spec/presenters/tree_node/zone_spec.rb
+++ b/spec/presenters/tree_node/zone_spec.rb
@@ -1,4 +1,5 @@
 describe TreeNode::Zone do
+  before { EvmSpecHelper.local_miq_server }
   let(:object) { FactoryBot.create(:zone, :name => "foo") }
   subject { described_class.new(object, nil, {}) }
 


### PR DESCRIPTION
When building trees with servers and/or zones, the appliance's current server and/or zone is marked with a `current` suffix. This logic has been added globally into the `TreeBuilder#x_build_node` but it's very specific for only `TreeNode::Zone` and `TreeNode::MiqServer` objects.

@miq-bot add_reviewer @martinpovolny  
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label refactoring, trees, hammer/no