### PR TITLE
Pass the TreeBuilder instance to the TreeNode when building nodes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -283,7 +283,7 @@ class TreeBuilder
 
   def x_build_single_node(object, pid, options)
     # FIXME: to_h is for backwards compatibility with hash-trees, it needs to be removed in the future
-    node = TreeNode.new(object, pid, options).to_h
+    node = TreeNode.new(object, pid, options, self).to_h
     override(node, object, pid, options) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
     node
   end

--- a/app/presenters/tree_node.rb
+++ b/app/presenters/tree_node.rb
@@ -5,8 +5,8 @@ module TreeNode
     #   :open_nodes -- Tree node ids of currently open nodes
     #   FIXME: fill in missing docs
     #
-    def new(object, parent_id = nil, options = {})
-      subclass(object).new(object, parent_id, options)
+    def new(object, parent_id = nil, options = {}, tree = nil)
+      subclass(object).new(object, parent_id, options, tree)
     end
 
     def exists?(object)

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -1,9 +1,12 @@
 module TreeNode
   class Node
-    def initialize(object, parent_id, options)
+    attr_reader :tree
+
+    def initialize(object, parent_id, options, tree)
       @object = object
       @parent_id = parent_id
       @options = options
+      @tree = tree
     end
 
     def text

--- a/spec/presenters/tree_node/assigned_server_role_spec.rb
+++ b/spec/presenters/tree_node/assigned_server_role_spec.rb
@@ -1,7 +1,7 @@
 describe TreeNode::AssignedServerRole do
   include_context 'server roles'
   let(:object) { assigned_server_role }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   describe '#title' do
     it 'returns with the title' do

--- a/spec/presenters/tree_node/availability_zone_spec.rb
+++ b/spec/presenters/tree_node/availability_zone_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::AvailabilityZone do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(
     availability_zone_amazon

--- a/spec/presenters/tree_node/chargeback_rate_spec.rb
+++ b/spec/presenters/tree_node/chargeback_rate_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ChargebackRate do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:chargeback_rate) }
 
   include_examples 'TreeNode::Node#key prefix', 'cr-'

--- a/spec/presenters/tree_node/classification_spec.rb
+++ b/spec/presenters/tree_node/classification_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Classification do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   shared_examples 'TreeNode::Classification' do
     include_examples 'TreeNode::Node#key prefix', 'cl-'

--- a/spec/presenters/tree_node/compliance_detail_spec.rb
+++ b/spec/presenters/tree_node/compliance_detail_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ComplianceDetail do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:compliance_detail, :miq_policy_result => result) }
   let(:result) { true }
 

--- a/spec/presenters/tree_node/compliance_spec.rb
+++ b/spec/presenters/tree_node/compliance_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Compliance do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:compliance, :compliant => compliant) }
   let(:compliant) { true }
 

--- a/spec/presenters/tree_node/condition_spec.rb
+++ b/spec/presenters/tree_node/condition_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Condition do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:condition) }
 
   include_examples 'TreeNode::Node#key prefix', 'co-'

--- a/spec/presenters/tree_node/configuration_profile_spec.rb
+++ b/spec/presenters/tree_node/configuration_profile_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ConfigurationProfile do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:configuration_profile_foreman) }
 
   include_examples 'TreeNode::Node#key prefix', 'cp-'

--- a/spec/presenters/tree_node/configuration_script_base_spec.rb
+++ b/spec/presenters/tree_node/configuration_script_base_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ConfigurationScriptBase do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:ansible_configuration_script) }
 
   include_examples 'TreeNode::Node#key prefix', 'cf-'

--- a/spec/presenters/tree_node/configured_system_spec.rb
+++ b/spec/presenters/tree_node/configured_system_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ConfiguredSystem do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(
     configured_system

--- a/spec/presenters/tree_node/container_spec.rb
+++ b/spec/presenters/tree_node/container_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Container do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(container kubernetes_container).each do |factory|
     klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)

--- a/spec/presenters/tree_node/custom_button_set_spec.rb
+++ b/spec/presenters/tree_node/custom_button_set_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::CustomButtonSet do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:custom_button_set, :description => "custom button set description") }
 
   include_examples 'TreeNode::Node#key prefix', 'cbg-'

--- a/spec/presenters/tree_node/custom_button_spec.rb
+++ b/spec/presenters/tree_node/custom_button_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::CustomButton do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:custom_button, :applies_to_class => 'Host') }
 
   include_examples 'TreeNode::Node#key prefix', 'cb-'

--- a/spec/presenters/tree_node/customization_template_spec.rb
+++ b/spec/presenters/tree_node/customization_template_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::CustomizationTemplate do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(
     customization_template

--- a/spec/presenters/tree_node/dialog_field_spec.rb
+++ b/spec/presenters/tree_node/dialog_field_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::DialogField do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:dialog_field) }
 
   include_examples 'TreeNode::Node#key prefix', '-'

--- a/spec/presenters/tree_node/dialog_group_spec.rb
+++ b/spec/presenters/tree_node/dialog_group_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::DialogGroup do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:dialog_group) }
 
   include_examples 'TreeNode::Node#key prefix', '-'

--- a/spec/presenters/tree_node/dialog_spec.rb
+++ b/spec/presenters/tree_node/dialog_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Dialog do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:dialog) }
 
   include_examples 'TreeNode::Node#key prefix', 'dg-'

--- a/spec/presenters/tree_node/dialog_tab_spec.rb
+++ b/spec/presenters/tree_node/dialog_tab_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::DialogTab do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:dialog_tab) }
 
   include_examples 'TreeNode::Node#key prefix', '-'

--- a/spec/presenters/tree_node/ems_cluster_spec.rb
+++ b/spec/presenters/tree_node/ems_cluster_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::EmsCluster do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(ems_cluster ems_cluster_openstack).each do |factory|
     klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::EmsFolder do
-  subject { described_class.new(object, nil, options) }
+  subject { described_class.new(object, nil, options, nil) }
   let(:options) { {} }
 
   %i(

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ExtManagementSystem do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   describe 'ManageIQ::Providers::Redhat::InfraManager' do
     let(:object) { FactoryBot.create(:ems_redhat) }

--- a/spec/presenters/tree_node/guest_device_spec.rb
+++ b/spec/presenters/tree_node/guest_device_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::GuestDevice do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:guest_device, :controller_type => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', 'gd-'

--- a/spec/presenters/tree_node/host_spec.rb
+++ b/spec/presenters/tree_node/host_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Host do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(
     host

--- a/spec/presenters/tree_node/iso_datastore_spec.rb
+++ b/spec/presenters/tree_node/iso_datastore_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::IsoDatastore do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:iso_datastore) }
 
   include_examples 'TreeNode::Node#key prefix', 'isd-'

--- a/spec/presenters/tree_node/iso_image_spec.rb
+++ b/spec/presenters/tree_node/iso_image_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::IsoImage do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:iso_image) }
 
   include_examples 'TreeNode::Node#key prefix', 'isi-'

--- a/spec/presenters/tree_node/lan_spec.rb
+++ b/spec/presenters/tree_node/lan_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Lan do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:lan) }
 
   include_examples 'TreeNode::Node#key prefix', 'l-'

--- a/spec/presenters/tree_node/miq_action_spec.rb
+++ b/spec/presenters/tree_node/miq_action_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAction do
-  subject { described_class.new(object, nil, :tree => :action_tree) }
+  subject { described_class.new(object, nil, {:tree => :action_tree}, nil) }
   let(:object) { FactoryBot.create(:miq_action, :name => 'raise_automation_event', :action_type => 'default') }
 
   include_examples 'TreeNode::Node#key prefix', 'a-'

--- a/spec/presenters/tree_node/miq_ae_class_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_class_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAeClass do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) do
     ns = FactoryBot.create(:miq_ae_namespace)
     FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)

--- a/spec/presenters/tree_node/miq_ae_instance_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_instance_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAeInstance do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_ae_instance) }
 
   include_examples 'TreeNode::Node#key prefix', 'aei-'

--- a/spec/presenters/tree_node/miq_ae_method_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_method_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAeMethod do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_ae_method, :scope => :class, :language => :ruby, :location => :inline) }
 
   include_examples 'TreeNode::Node#key prefix', 'aem-'

--- a/spec/presenters/tree_node/miq_ae_namespace_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_namespace_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqAeNamespace do
   before { login_as FactoryBot.create(:user_with_group) }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   let(:object) do
     domain = FactoryBot.create(:miq_ae_domain)

--- a/spec/presenters/tree_node/miq_alert_set_spec.rb
+++ b/spec/presenters/tree_node/miq_alert_set_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAlertSet do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_alert_set) }
 
   include_examples 'TreeNode::Node#key prefix', 'ap-'

--- a/spec/presenters/tree_node/miq_alert_spec.rb
+++ b/spec/presenters/tree_node/miq_alert_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqAlert do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_alert) }
 
   include_examples 'TreeNode::Node#key prefix', 'al-'

--- a/spec/presenters/tree_node/miq_dialog_spec.rb
+++ b/spec/presenters/tree_node/miq_dialog_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqDialog do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_dialog) }
 
   include_examples 'TreeNode::Node#key prefix', 'odg-'

--- a/spec/presenters/tree_node/miq_event_definition_spec.rb
+++ b/spec/presenters/tree_node/miq_event_definition_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqEventDefinition do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_event_definition) }
 
   include_examples 'TreeNode::Node#key prefix', 'ev-'

--- a/spec/presenters/tree_node/miq_group_spec.rb
+++ b/spec/presenters/tree_node/miq_group_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqGroup do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_group) }
 
   include_examples 'TreeNode::Node#key prefix', 'g-'

--- a/spec/presenters/tree_node/miq_policy_set_spec.rb
+++ b/spec/presenters/tree_node/miq_policy_set_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqPolicySet do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_policy_set, :name => 'Just a set') }
 
   include_examples 'TreeNode::Node#key prefix', 'pp-'

--- a/spec/presenters/tree_node/miq_policy_spec.rb
+++ b/spec/presenters/tree_node/miq_policy_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqPolicy do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control') }
 
   include_examples 'TreeNode::Node#key prefix', 'p-'

--- a/spec/presenters/tree_node/miq_product_feature_spec.rb
+++ b/spec/presenters/tree_node/miq_product_feature_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqProductFeature do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:tenant) { FactoryBot.create(:tenant) }
 
   let(:feature_type) { "tenant" }

--- a/spec/presenters/tree_node/miq_region_spec.rb
+++ b/spec/presenters/tree_node/miq_region_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqRegion do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_region, :description => 'Elbonia') }
 
   include_examples 'TreeNode::Node#key prefix', 'mr-'

--- a/spec/presenters/tree_node/miq_report_result_spec.rb
+++ b/spec/presenters/tree_node/miq_report_result_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqReportResult do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   let(:object) { FactoryBot.create(:miq_report_result, :report => {}) }
 

--- a/spec/presenters/tree_node/miq_report_spec.rb
+++ b/spec/presenters/tree_node/miq_report_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqReport do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_report) }
 
   include_examples 'TreeNode::Node#key prefix', 'rep-'

--- a/spec/presenters/tree_node/miq_schedule_spec.rb
+++ b/spec/presenters/tree_node/miq_schedule_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqSchedule do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) do
     EvmSpecHelper.local_miq_server
     FactoryBot.create(:miq_schedule)

--- a/spec/presenters/tree_node/miq_scsi_lun_spec.rb
+++ b/spec/presenters/tree_node/miq_scsi_lun_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqScsiLun do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_scsi_lun, :canonical_name => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', 'sl-'

--- a/spec/presenters/tree_node/miq_scsi_target_spec.rb
+++ b/spec/presenters/tree_node/miq_scsi_target_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqScsiTarget do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_scsi_target) }
 
   include_examples 'TreeNode::Node#key prefix', 'sg-'

--- a/spec/presenters/tree_node/miq_search_spec.rb
+++ b/spec/presenters/tree_node/miq_search_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqSearch do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_search) }
 
   include_examples 'TreeNode::Node#key prefix', 'ms-'

--- a/spec/presenters/tree_node/miq_server_spec.rb
+++ b/spec/presenters/tree_node/miq_server_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqServer do
   before { EvmSpecHelper.local_miq_server }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) do
     zone = FactoryBot.create(:zone)
     FactoryBot.create(:miq_server, :zone => zone)

--- a/spec/presenters/tree_node/miq_user_role_spec.rb
+++ b/spec/presenters/tree_node/miq_user_role_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqUserRole do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_user_role) }
 
   include_examples 'TreeNode::Node#key prefix', 'ur-'

--- a/spec/presenters/tree_node/miq_widget_set_spec.rb
+++ b/spec/presenters/tree_node/miq_widget_set_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqWidgetSet do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_widget_set, :name => 'foo') }
 
   include_examples 'TreeNode::Node#key prefix', '-'

--- a/spec/presenters/tree_node/miq_widget_spec.rb
+++ b/spec/presenters/tree_node/miq_widget_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::MiqWidget do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:miq_widget) }
 
   include_examples 'TreeNode::Node#key prefix', '-'

--- a/spec/presenters/tree_node/node_spec.rb
+++ b/spec/presenters/tree_node/node_spec.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 describe TreeNode::Node do
   let(:parent) { nil }
   let(:options) { {} }
-  subject { described_class.new(object, parent, options) }
+  subject { described_class.new(object, parent, options, nil) }
 
   describe '#escape' do
     let(:object) { nil }

--- a/spec/presenters/tree_node/orchestration_template_spec.rb
+++ b/spec/presenters/tree_node/orchestration_template_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::OrchestrationTemplate do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   {
     :orchestration_template_amazon              => %w(ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate cfn),

--- a/spec/presenters/tree_node/physical_server_spec.rb
+++ b/spec/presenters/tree_node/physical_server_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::PhysicalServer do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:physical_server) }
 
   include_examples 'TreeNode::Node#key prefix', 'phys-'

--- a/spec/presenters/tree_node/pxe_image_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::PxeImage do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   %i(
     pxe_image

--- a/spec/presenters/tree_node/pxe_image_type_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_type_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::PxeImageType do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:pxe_image_type) }
 
   include_examples 'TreeNode::Node#key prefix', 'pit-'

--- a/spec/presenters/tree_node/pxe_server_spec.rb
+++ b/spec/presenters/tree_node/pxe_server_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::PxeServer do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:pxe_server) }
 
   include_examples 'TreeNode::Node#key prefix', 'ps-'

--- a/spec/presenters/tree_node/resource_pool_spec.rb
+++ b/spec/presenters/tree_node/resource_pool_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ResourcePool do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:resource_pool) }
 
   include_examples 'TreeNode::Node#key prefix', 'r-'

--- a/spec/presenters/tree_node/scan_item_set_spec.rb
+++ b/spec/presenters/tree_node/scan_item_set_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ScanItemSet do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:scan_item_set) }
 
   include_examples 'TreeNode::Node#icon', 'fa fa-search'

--- a/spec/presenters/tree_node/server_role_spec.rb
+++ b/spec/presenters/tree_node/server_role_spec.rb
@@ -1,7 +1,7 @@
 describe TreeNode::ServerRole do
   include_context 'server roles'
   let(:object) { server_role }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   include_examples 'TreeNode::Node#key prefix', 'role-'
   include_examples 'TreeNode::Node#icon', 'ff ff-user-role'

--- a/spec/presenters/tree_node/service_resource_spec.rb
+++ b/spec/presenters/tree_node/service_resource_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ServiceResource do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:service_resource) }
 
   include_examples 'TreeNode::Node#key prefix', 'sr-'

--- a/spec/presenters/tree_node/service_spec.rb
+++ b/spec/presenters/tree_node/service_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Service do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:service) }
 
   include_examples 'TreeNode::Node#key prefix', 's-'

--- a/spec/presenters/tree_node/service_template_catalog_spec.rb
+++ b/spec/presenters/tree_node/service_template_catalog_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ServiceTemplateCatalog do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) do
     tenant = FactoryBot.create(:tenant)
     FactoryBot.create(:service_template_catalog, :name => 'foo', :tenant => tenant)

--- a/spec/presenters/tree_node/service_template_spec.rb
+++ b/spec/presenters/tree_node/service_template_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::ServiceTemplate do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:tenant) { FactoryBot.create(:tenant) }
   %i(
     service_template

--- a/spec/presenters/tree_node/snapshot_spec.rb
+++ b/spec/presenters/tree_node/snapshot_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Snapshot do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) do
     EvmSpecHelper.local_miq_server
     vm = FactoryBot.create(:vm_vmware)

--- a/spec/presenters/tree_node/storage_spec.rb
+++ b/spec/presenters/tree_node/storage_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Storage do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:storage) }
 
   include_examples 'TreeNode::Node#key prefix', 'ds-'

--- a/spec/presenters/tree_node/switch_spec.rb
+++ b/spec/presenters/tree_node/switch_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Switch do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:switch, :name => "light") }
 
   include_examples 'TreeNode::Node#key prefix', 'sw-'

--- a/spec/presenters/tree_node/tenant_spec.rb
+++ b/spec/presenters/tree_node/tenant_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::Tenant do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:tenant) }
 
   include_examples 'TreeNode::Node#key prefix', 'tn-'

--- a/spec/presenters/tree_node/user_spec.rb
+++ b/spec/presenters/tree_node/user_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::User do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:user) }
 
   include_examples 'TreeNode::Node#key prefix', 'u-'

--- a/spec/presenters/tree_node/vm_or_template_spec.rb
+++ b/spec/presenters/tree_node/vm_or_template_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::VmOrTemplate do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   # FIXME: make this dynamic somehow by using VmOrTemplate.descendants
   # Template classes

--- a/spec/presenters/tree_node/vmdb_index_spec.rb
+++ b/spec/presenters/tree_node/vmdb_index_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::VmdbIndex do
   let(:object) { FactoryBot.create(:vmdb_index, :name => 'foo') }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   include_examples 'TreeNode::Node#key prefix', 'ti-'
   include_examples 'TreeNode::Node#icon', 'fa fa-table'

--- a/spec/presenters/tree_node/vmdb_table_spec.rb
+++ b/spec/presenters/tree_node/vmdb_table_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::VmdbTable do
   let(:object) { FactoryBot.create(:vmdb_table_evm, :name => 'foo') }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   include_examples 'TreeNode::Node#key prefix', 'tb-'
   include_examples 'TreeNode::Node#icon', 'fa fa-table'

--- a/spec/presenters/tree_node/windows_image_spec.rb
+++ b/spec/presenters/tree_node/windows_image_spec.rb
@@ -1,5 +1,5 @@
 describe TreeNode::WindowsImage do
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
   let(:object) { FactoryBot.create(:windows_image) }
 
   include_examples 'TreeNode::Node#key prefix', 'wi-'

--- a/spec/presenters/tree_node/zone_spec.rb
+++ b/spec/presenters/tree_node/zone_spec.rb
@@ -1,7 +1,7 @@
 describe TreeNode::Zone do
   before { EvmSpecHelper.local_miq_server }
   let(:object) { FactoryBot.create(:zone, :name => "foo") }
-  subject { described_class.new(object, nil, {}) }
+  subject { described_class.new(object, nil, {}, nil) }
 
   include_examples 'TreeNode::Node#key prefix', 'z-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-zone'

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -10,7 +10,8 @@ describe TreeNode do
   end
   let(:parent_id) { dup }
   let(:options) { {} }
-  subject { TreeNode.new(object, parent_id, options) }
+  let(:tree) { double }
+  subject { TreeNode.new(object, parent_id, options, tree) }
 
   describe '.new' do
     shared_examples 'instance variables' do
@@ -18,6 +19,7 @@ describe TreeNode do
         expect(subject.instance_variable_get(:@object)).to eq(object)
         expect(subject.instance_variable_get(:@parent_id)).to eq(parent_id)
         expect(subject.instance_variable_get(:@options)).to eq(options)
+        expect(subject.instance_variable_get(:@tree)).to eq(tree)
       end
     end
 


### PR DESCRIPTION
This will eventually make the `options` argument unnecessary as it is coming from the `TreeBuilder` anyway. Also it will allow some additional refactorings as we have access to the whole tree from the node level.

@miq-bot add_label enhancement, trees, hammer/no
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 