### PR TITLE
Allow angular in layouts/tree

### DIFF
--- a/app/assets/javascripts/components/tree.js
+++ b/app/assets/javascripts/components/tree.js
@@ -1,0 +1,12 @@
+angular.module('miq.helpers').component('miqTree', {
+  bindings: {
+    name: '@',
+    options: '<',
+    bsTree: '<',
+  },
+  controller: function() {
+    this.$onInit = function() {
+      miqInitTree(this.options, this.bsTree);
+    };
+  },
+});

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -7,6 +7,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miq.api',
   'miq.card',
   'miq.compat',
+  'miq.helpers',
   'miq.util',
   'miqStaticAssets.dialogEditor',
   'miqStaticAssets.dialogUser',

--- a/app/views/layouts/_tree.html.haml
+++ b/app/views/layouts/_tree.html.haml
@@ -12,6 +12,7 @@
 - tree_id                     ||= "tree_div"
 - tree_name                   ||= "tree"
 - silent_activate             ||= @explorer && tree_name == x_active_tree.to_s
+- angular                     ||= false
 
 - options = {:tree_id            => tree_id,
              :tree_name          => tree_name,
@@ -31,8 +32,11 @@
              :highlight_changes  => checkboxes,
              :active_tree        => x_active_tree}
 
-:javascript
-  miqInitTree(#{options.to_json.html_safe}, #{bs_tree.html_safe})
+- if angular
+  %miq-tree{:name => tree_name, :options => options.to_json, 'bs-tree' => bs_tree}
+- else
+  :javascript
+    miqInitTree(#{options.to_json.html_safe}, #{bs_tree.html_safe})
 
 - if session[:group_changed]
   - session[:group_changed] = false

--- a/app/views/shared/_tree.html.haml
+++ b/app/views/shared/_tree.html.haml
@@ -1,3 +1,5 @@
+- angular ||= false
+
 %div{:id => "#{name}_div"}
   .treeview-pf-hover.treeview-pf-select{:id => "#{name}box", :style => "overflow: hidden"}
-    = render :partial  => "layouts/tree", :locals => tree.locals_for_render
+    = render :partial  => "layouts/tree", :locals => tree.locals_for_render.merge(:angular => angular)

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -412,7 +412,7 @@ describe EmsCloudController do
 
     it 'manage cloud provider policies' do
       allow(controller).to receive(:protect_build_tree).and_return(nil)
-      controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+      controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name", :locals_for_render => {}))
       ems = FactoryBot.create(:ems_amazon)
       post :button, :params => { :miq_grid_checks => ems.id, :pressed => "ems_cloud_protect" }
       expect(response.status).to eq(200)

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -8,7 +8,7 @@ describe VmInfraController do
 
     allow(controller).to receive(:protect_build_tree).and_return(nil)
     allow(controller).to receive(:data_for_breadcrumbs).and_return({})
-    controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+    controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name", :locals_for_render => {}))
 
     MiqRegion.seed
     EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -110,7 +110,7 @@ shared_examples :shared_examples_for_ems_network_controller do |providers|
 
         it 'manage network provider policies' do
           allow(controller).to receive(:protect_build_tree).and_return(nil)
-          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name", :locals_for_render => {}))
 
           post :button, :params => {:miq_grid_checks => @ems.id, :pressed => "ems_network_protect"}
           expect(response.status).to eq(200)

--- a/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
@@ -57,7 +57,7 @@ shared_examples :shared_examples_for_ems_storage_controller do |providers|
 
         it 'manage storage provider policies' do
           allow(controller).to receive(:protect_build_tree).and_return(nil)
-          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name"))
+          controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name", :locals_for_render => {}))
 
           post :button, :params => {:miq_grid_checks => @ems.id, :pressed => "ems_storage_protect"}
           expect(response.status).to eq(200)


### PR DESCRIPTION
An angular tree in a form is needed for #5445.
The current tree mostly works in angular, except `miqInitTree` needs to happen after angular is finished.

* added a `miq-tree` angular component, which pretty much just calls `miqInitTree` at the right time
* added a `layouts/tree` angular path, which uses `miq-tree` instead of calling `miqInitTree` directly.

@miq-bot add_reviewer @skateman
Cc @hstastna