### PR TITLE
Use leaf subclasses with assets

### DIFF
--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -24,7 +24,7 @@ describe EmsPhysicalInfraController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryBot.create(:user, :features => "none")
-      @ems = FactoryBot.create(:ems_physical_infra)
+      @ems = FactoryBot.create(:ems_redfish_physical_infra)
     end
 
     let(:url_params) { {} }

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -4,7 +4,7 @@ describe PhysicalChassisController do
   render_views
 
   let(:physical_chassis) do
-    ems = FactoryBot.create(:ems_physical_infra)
+    ems = FactoryBot.create(:ems_redfish_physical_infra)
     asset_detail = FactoryBot.create(:asset_detail)
     FactoryBot.create(:physical_chassis, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
   end

--- a/spec/controllers/physical_rack_controller_spec.rb
+++ b/spec/controllers/physical_rack_controller_spec.rb
@@ -2,7 +2,7 @@ describe PhysicalRackController do
   render_views
 
   let(:physical_rack) do
-    ems = FactoryBot.create(:ems_physical_infra)
+    ems = FactoryBot.create(:ems_redfish_physical_infra)
     FactoryBot.create(:physical_rack, :ems_id => ems.id, :id => 1)
   end
 

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -8,7 +8,7 @@ describe PhysicalServerController do
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
-    ems = FactoryBot.create(:ems_physical_infra)
+    ems = FactoryBot.create(:ems_redfish_physical_infra)
     asset_detail = FactoryBot.create(:asset_detail)
     computer_system = FactoryBot.create(:computer_system, :hardware => FactoryBot.create(:hardware))
     @physical_server = FactoryBot.create(:physical_server,

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -2,7 +2,7 @@ describe PhysicalStorageController do
   render_views
 
   let(:physical_storage) do
-    ems = FactoryBot.create(:ems_physical_infra)
+    ems = FactoryBot.create(:ems_redfish_physical_infra)
     asset_detail = FactoryBot.create(:asset_detail)
     FactoryBot.create(:physical_storage, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
   end

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -2,7 +2,7 @@ describe PhysicalSwitchController do
   render_views
 
   let(:physical_switch) do
-    ems = FactoryBot.create(:ems_physical_infra)
+    ems = FactoryBot.create(:ems_redfish_physical_infra)
     hardware = FactoryBot.create(:hardware)
     asset_detail = FactoryBot.create(:asset_detail)
 


### PR DESCRIPTION
Physical Infra Manager doesn't have assets as it's a pseudo abstract
class.

Fixes rails 5.1 deprecations such as:

```
DEPRECATION WARNING: The asset "svg/vendor-physical_infra_manager.svg" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.
This behavior is deprecated and will be removed.
To bypass the asset pipeline and preserve this behavior,
use the `skip_pipeline: true` option.
 (called from quadrant_output at /Users/joerafaniello/.gem/ruby/2.4.6/bundler/gems/manageiq-decorators-fbb4695da1fb/app/helpers/quadicon_helper.rb:98)
```
```
DEPRECATION WARNING: The asset "svg/vendor-physical_infra_manager.svg" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.
This behavior is deprecated and will be removed.
To bypass the asset pipeline and preserve this behavior,
use the `skip_pipeline: true` option.
 (called from post_process_textual_summary at /Users/joerafaniello/Code/manageiq-ui-classic/app/helpers/textual_summary_helper.rb:40)
```