### PR TITLE
Fix warning: found = in conditional, should be ==

### DIFF
--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -213,7 +213,7 @@
     - arr = [Vm.cpu_recommendation_minimum, MiqReport.new.format_mbytes_to_human_size(Vm.mem_recommendation_minimum)]
     = _("* Recommendations are subject to minimum of CPU: %{cpu} and Memory: %{memory}.") % {:cpu => arr[0], :memory => arr[1]}
 
-  - unless @explorer || @display = "download_pdf"
+  - unless @explorer || @display == "download_pdf"
     #buttons_on{:style => "float: right"}
       = button_tag((t = _('Back')),
         :class   => 'btn btn-default',


### PR DESCRIPTION
I saw this in the test suite while looking at rails 5.1 test output.

I'm able to recreate and verify this fix on rails 5.0 with ruby 2.4 using:

`bundle exec rspec `git grep -l right_size spec`