### PR TITLE
Test against tree name and not type in TreeNode::EmsFolder

### DIFF
--- a/app/presenters/tree_node/ems_folder.rb
+++ b/app/presenters/tree_node/ems_folder.rb
@@ -6,7 +6,7 @@ module TreeNode
         tooltip = _("Datacenter: %{datacenter_name}") % {:datacenter_name => @object.name}
       else
         # TODO: move this logic into TreeBuilder#override for the specific trees
-        icon = %i[vandt vat].include?(@options[:type]) ? 'pficon pficon-folder-close-blue' : @object.decorate.fonticon
+        icon = %i[vandt_tree vat_tree].include?(@options[:tree]) ? 'pficon pficon-folder-close-blue' : @object.decorate.fonticon
         tooltip = _("Folder: %{folder_name}") % {:folder_name => @object.name}
       end
       [icon, tooltip]

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -17,7 +17,7 @@ describe TreeNode::EmsFolder do
       include_examples 'TreeNode::Node#tooltip prefix', 'Folder'
 
       context 'type is vat' do
-        let(:options) { {:type => :vat} }
+        let(:options) { {:tree => :vat_tree} }
 
         include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close-blue'
       end


### PR DESCRIPTION
Regression caused by #5495 and also mentioned in #5565, the folder icons should be blue.

**Before:**
![Screenshot from 2019-05-13 14-03-37](https://user-images.githubusercontent.com/649130/57620062-f8fee580-7587-11e9-9807-4bfa22772fc4.png)

**After:**
![Screenshot from 2019-05-13 14-02-46](https://user-images.githubusercontent.com/649130/57620060-f8664f00-7587-11e9-9add-ffe454dee9be.png)

@miq-bot add_label bug, trees, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 