### PR TITLE
Test against tree name and not type in TreeNode::CustomButtonSet

### DIFF
--- a/app/presenters/tree_node/custom_button_set.rb
+++ b/app/presenters/tree_node/custom_button_set.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class CustomButtonSet < Node
     set_attribute(:text) do
-      if @options[:type] == :sandt || @options[:type] == :generic_object_definitions_tree
+      if %i[sandt_tree generic_object_definitions_tree].include?(@options[:tree])
         _("%{button_group_name} (Group)") % {:button_group_name => @object.name.split("|").first}
       else
         @object.name.split("|").first

--- a/spec/presenters/tree_node/custom_button_set_spec.rb
+++ b/spec/presenters/tree_node/custom_button_set_spec.rb
@@ -1,6 +1,7 @@
 describe TreeNode::CustomButtonSet do
-  subject { described_class.new(object, nil, {}, nil) }
+  subject { described_class.new(object, nil, options, nil) }
   let(:object) { FactoryBot.create(:custom_button_set, :description => "custom button set description") }
+  let(:options) { {} }
 
   include_examples 'TreeNode::Node#key prefix', 'cbg-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
@@ -8,6 +9,16 @@ describe TreeNode::CustomButtonSet do
   describe "#tooltip" do
     it "returns the prefixed title" do
       expect(subject.tooltip).to eq("Button Group: custom button set description")
+    end
+  end
+
+  describe '#text' do
+    context 'service catalogs tree' do
+      let(:options) { {:tree => :sandt_tree} }
+
+      it 'appends a (Group) suffix' do
+        expect(subject.text).to end_with('(Group)')
+      end
     end
   end
 end


### PR DESCRIPTION
**Before:**
![](https://user-images.githubusercontent.com/649130/57618558-1762e200-7584-11e9-8742-b372a147bf90.png)

**After:**
![](https://user-images.githubusercontent.com/649130/57618560-1762e200-7584-11e9-9c87-0421cf836adf.png)

Fixes #5565 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, hammer/no, trees