### PR TITLE
Replace TreeBuilder.build_node_cid calls with build_node_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -866,7 +866,7 @@ class ApplicationController < ActionController::Base
         new_row[:parent_id] = "xx-#{row.data['miq_report_id']}" if row.data['miq_report_id']
       end
       new_row[:parent_id] = "xx-#{CONTENT_TYPE_ID[target[:content_type]]}" if target && target[:content_type]
-      new_row[:tree_id] = TreeBuilder.build_node_cid(target) if target
+      new_row[:tree_id] = TreeBuilder.build_node_id(target) if target
       if row.data["job.target_class"] && row.data["job.target_id"]
         controller = view_to_hash_controller_from_job_target_class(row.data["job.target_class"])
         new_row[:parent_path] = (url_for_only_path(:controller => controller, :action => "show") rescue nil)

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -390,7 +390,7 @@ module ApplicationController::Performance
         @_params[:refresh] = "n"
         show_timeline
       elsif data_row["resource_type"] == "VmOrTemplate"
-        tree_node_id = TreeBuilder.build_node_id(@record.class.base_model, @record.id)
+        tree_node_id = TreeBuilder.build_node_id(@record)
         session[:exp_parms] = {:display => "timeline", :refresh => "n", :id => tree_node_id}
         javascript_redirect(:controller => data_row["resource_type"].underscore.downcase.singularize,
                             :action     => "explorer")

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -164,7 +164,7 @@ class MiqAeCustomizationController < ApplicationController
     record = Dialog.find_by(:id =>nodes.last)
     self.x_active_accord = "dialogs"
     self.x_active_tree   = "#{x_active_accord}_tree"
-    self.x_node = TreeBuilder.build_node_cid(record)
+    self.x_node = TreeBuilder.build_node_id(record)
     get_node_info
     redirect_to(:controller => "miq_ae_customization",
                 :action     => "explorer",

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -842,18 +842,18 @@ module VmCommon
     elsif vm.archived
       "xx-arch"
     elsif vm.cloud && vm.template
-      TreeBuilder.build_node_cid(vm.ext_management_system)
+      TreeBuilder.build_node_id(vm.ext_management_system)
     elsif vm.cloud && vm.availability_zone_id.nil?
-      TreeBuilder.build_node_cid(vm.ext_management_system)
+      TreeBuilder.build_node_id(vm.ext_management_system)
     elsif vm.cloud
-      TreeBuilder.build_node_cid(AvailabilityZone.find_by(:id => vm.availability_zone_id))
+      TreeBuilder.build_node_id(vm.availability_zone)
     elsif (blue_folder = vm.parent_blue_folder) && !blue_folder.hidden
-      TreeBuilder.build_node_cid(blue_folder)
+      TreeBuilder.build_node_id(blue_folder)
     elsif vm.ems_id # has no folder parent but is in the tree
       if vm.parent_datacenter
-        TreeBuilder.build_node_cid(vm.parent_datacenter)
+        TreeBuilder.build_node_id(vm.parent_datacenter)
       else
-        TreeBuilder.build_node_cid(vm.ext_management_system)
+        TreeBuilder.build_node_id(vm.ext_management_system)
       end
     end
   end
@@ -1124,7 +1124,7 @@ module VmCommon
     end
 
     if !@in_a_form && !@sb[:action]
-      id = @record.present? ? TreeBuilder.build_node_cid(@record) : x_node
+      id = @record.present? ? TreeBuilder.build_node_id(@record) : x_node
       id = @sb[@sb[:active_accord]] if @sb[@sb[:active_accord]].present? && params[:action] != 'tree_select'
       get_node_info(id)
       type, _id = parse_nodetype_and_id(id)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -842,18 +842,18 @@ module VmCommon
     elsif vm.archived
       "xx-arch"
     elsif vm.cloud && vm.template
-      TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      TreeBuilder.build_node_cid(vm.ext_management_system)
     elsif vm.cloud && vm.availability_zone_id.nil?
-      TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+      TreeBuilder.build_node_cid(vm.ext_management_system)
     elsif vm.cloud
-      TreeBuilder.build_node_cid(vm.availability_zone_id, 'AvailabilityZone')
+      TreeBuilder.build_node_cid(AvailabilityZone.find_by(:id => vm.availability_zone_id))
     elsif (blue_folder = vm.parent_blue_folder) && !blue_folder.hidden
-      TreeBuilder.build_node_cid(blue_folder.id, 'EmsFolder')
+      TreeBuilder.build_node_cid(blue_folder)
     elsif vm.ems_id # has no folder parent but is in the tree
       if vm.parent_datacenter
-        TreeBuilder.build_node_cid(vm.parent_datacenter.id, 'Datacenter')
+        TreeBuilder.build_node_cid(vm.parent_datacenter)
       else
-        TreeBuilder.build_node_cid(vm.ems_id, 'ExtManagementSystem')
+        TreeBuilder.build_node_cid(vm.ext_management_system)
       end
     end
   end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -82,17 +82,6 @@ class TreeBuilder
     "#{prefix}-#{record.id}"
   end
 
-  def self.build_node_cid(record_or_id, type = nil)
-    if record_or_id.kind_of?(Integer)
-      prefix = get_prefix_for_model(type)
-      id = record_or_id
-    else
-      prefix = get_prefix_for_model(record_or_id.class.base_model)
-      id = record_or_id.id
-    end
-    "#{prefix}-#{id}"
-  end
-
   # return this nodes model and record id
   def self.extract_node_model_and_id(node_id)
     prefix, record_id = node_id.split("_").last.split('-')

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -280,8 +280,8 @@ describe VmOrTemplateController do
       allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
       template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
       allow(template_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
-      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
-      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter.id, 'Datacenter'))
+      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter))
+      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter))
     end
 
     it 'returns id of blue folder for VM/Template with one' do

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -247,7 +247,7 @@ describe VmOrTemplateController do
                                             :ext_management_system => FactoryBot.create(:ems_google),
                                             :storage               => FactoryBot.create(:storage),
                                             :availability_zone     => FactoryBot.create(:availability_zone_google))
-      expect(controller.parent_folder_id(vm_cloud_with_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_with_az.availability_zone))
+      expect(controller.parent_folder_id(vm_cloud_with_az)).to eq(TreeBuilder.build_node_id(vm_cloud_with_az.availability_zone))
     end
 
     it 'returns id of Provider folder for Cloud VM without Availability Zone' do
@@ -255,21 +255,21 @@ describe VmOrTemplateController do
                                                :ext_management_system => FactoryBot.create(:ems_google),
                                                :storage               => FactoryBot.create(:storage),
                                                :availability_zone     => nil)
-      expect(controller.parent_folder_id(vm_cloud_without_az)).to eq(TreeBuilder.build_node_cid(vm_cloud_without_az.ext_management_system))
+      expect(controller.parent_folder_id(vm_cloud_without_az)).to eq(TreeBuilder.build_node_id(vm_cloud_without_az.ext_management_system))
     end
 
     it 'returns id of Provider folder for Cloud Template' do
       template_cloud = FactoryBot.create(:template_cloud,
                                           :ext_management_system => FactoryBot.create(:ems_google),
                                           :storage               => FactoryBot.create(:storage))
-      expect(controller.parent_folder_id(template_cloud)).to eq(TreeBuilder.build_node_cid(template_cloud.ext_management_system))
+      expect(controller.parent_folder_id(template_cloud)).to eq(TreeBuilder.build_node_id(template_cloud.ext_management_system))
     end
 
     it 'returns id of Provider folder for infra VM/Template without blue folder' do
       vm_infra = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
       template_infra = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_infra))
-      expect(controller.parent_folder_id(vm_infra)).to eq(TreeBuilder.build_node_cid(vm_infra.ext_management_system))
-      expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_cid(template_infra.ext_management_system))
+      expect(controller.parent_folder_id(vm_infra)).to eq(TreeBuilder.build_node_id(vm_infra.ext_management_system))
+      expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_id(template_infra.ext_management_system))
     end
 
     it 'returns id of Datacenter folder for infra VM/Template without blue folder but with Datacenter parent' do
@@ -280,8 +280,8 @@ describe VmOrTemplateController do
       allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
       template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
       allow(template_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
-      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter))
-      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_cid(datacenter))
+      expect(controller.parent_folder_id(vm_infra_datacenter)).to eq(TreeBuilder.build_node_id(datacenter))
+      expect(controller.parent_folder_id(template_infra_datacenter)).to eq(TreeBuilder.build_node_id(datacenter))
     end
 
     it 'returns id of blue folder for VM/Template with one' do
@@ -291,8 +291,8 @@ describe VmOrTemplateController do
       template_infra_folder = FactoryBot.create(:template_infra,
                                                  :ext_management_system => FactoryBot.create(:ems_infra))
       template_infra_folder.with_relationship_type("ems_metadata") { template_infra_folder.parent = folder } # add folder
-      expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
-      expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeBuilder.build_node_cid(folder))
+      expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeBuilder.build_node_id(folder))
+      expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeBuilder.build_node_id(folder))
     end
   end
 
@@ -309,7 +309,7 @@ describe VmOrTemplateController do
 
     it 'when VM hidden select parent in tree but show VMs info' do
       allow(vm_common).to receive(:x_node=) { |id| expect(id).to eq(controller.parent_folder_id(@vm_arch)) }
-      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_cid(@vm_arch)) }
+      allow(vm_common).to receive(:get_node_info) { |id| expect(id).to eq(TreeBuilder.build_node_id(@vm_arch)) }
       vm_common.resolve_node_info("v-#{@vm_arch[:id]}")
     end
   end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -187,10 +187,10 @@ describe TreeBuilder do
     end
   end
 
-  context "#build_node_cid" do
-    it "returns correct cid for VM" do
+  context "#build_node_id" do
+    it "returns correct id for VM" do
       vm = FactoryBot.create(:vm)
-      expect(TreeBuilder.build_node_cid(vm)).to eq("v-#{vm.id}")
+      expect(TreeBuilder.build_node_id(vm)).to eq("v-#{vm.id}")
     end
   end
 end


### PR DESCRIPTION
These two methods are doing the same, however, the `build_node_cid` can handle both a record and an id + type. Unifying them can allow us to drop some code :scissors: 

@miq-bot add_label refactoring, hammer/no, trees
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 