### PR TITLE
Corrected icon for editing Custom Button Group

### DIFF
--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonGroupCenter < App
       :items => [
         button(
           :ab_group_edit,
-          'pficon pficon-add-circle-o fa-lg',
+          'pficon pficon-edit fa-lg',
           N_('Edit this Button Group'),
           :url => 'custom_button_group_edit',
         ),


### PR DESCRIPTION
Before:
![Screenshot_2019-05-14 ManageIQ Generic Object Definitions(1)](https://user-images.githubusercontent.com/1187051/57700949-7723c080-764a-11e9-98c1-4492a50fc4ce.png)

After:
![Screenshot_2019-05-14 ManageIQ Generic Object Definitions](https://user-images.githubusercontent.com/1187051/57700948-768b2a00-764a-11e9-9726-2b35f3a58c68.png)


Steps for Testing/QA
-------------------------------
in Automate - Automation - Generic Objects:
1) add Custom Button Set
2) edit Custom Button Set
