### PR TITLE
Add Tenant relationship in Providers, Automate Domain and Services

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -19,7 +19,8 @@ module EmsCloudHelper::TextualSummary
       _("Relationships"),
       %i[
         ems_infra network_manager availability_zones host_aggregates cloud_tenants flavors
-        security_groups instances images cloud_volumes orchestration_stacks storage_managers custom_button_events
+        security_groups instances images cloud_volumes orchestration_stacks storage_managers
+        custom_button_events tenant
       ]
     )
   end
@@ -162,5 +163,11 @@ module EmsCloudHelper::TextualSummary
      :icon  => "pficon pficon-topology",
      :link  => url_for_only_path(:controller => 'cloud_topology', :action => 'show', :id => @record.id),
      :title => _("Show topology")}
+  end
+
+  def textual_tenant
+    return nil unless User.current_user.super_admin_user?
+
+    {:label => _('Tenant'), :value => @record.tenant.name}
   end
 end

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -16,7 +16,7 @@ module EmsInfraHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i[clusters hosts datastores vms templates orchestration_stacks ems_cloud network_manager custom_button_events]
+      %i[clusters hosts datastores vms templates orchestration_stacks ems_cloud network_manager custom_button_events tenant]
     )
   end
 
@@ -169,5 +169,11 @@ module EmsInfraHelper::TextualSummary
       :link  => num.positive? ? ems_infra_path(:id => @record, :display => 'custom_button_events') : nil,
       :icon  => CustomButtonEvent.decorate.fonticon,
     }
+  end
+
+  def textual_tenant
+    return nil unless User.current_user.super_admin_user?
+
+    {:label => _('Tenant'), :value => @record.tenant.name}
   end
 end

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -93,6 +93,12 @@
                 #{entry_points_op[0]} #{_('Entry Point')}
               .col-md-9
                 = h(@sb[entry_points_op[1]])
+        - if User.current_user.super_admin_user?
+          .form-group
+            %label.col-md-3.control-label
+              = _('Tenant')
+            .col-md-8
+              = h(@record.tenant.name)
         .form-group
           %label.col-md-3.control-label
             = _('Owner')

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -11,6 +11,8 @@
         %th= _('Name')
         %th= _('Description')
         %th= _('Enabled')
+        - if User.current_user.super_admin_user?
+          %th= _('Tenant')
       %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
         - @grid_data.each do |record|
           - next if record.name == '$'
@@ -33,6 +35,9 @@
               = record.description
             %td
               = record.enabled
+            - if User.current_user.super_admin_user?
+              %td
+                = record.tenant.name
     :javascript
       $(function () {
         $('#ns_list_grid').miqGrid();

--- a/product/views/ManageIQ_Providers_CloudManager.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager.yaml
@@ -33,6 +33,9 @@ include:
   zone:
     columns:
     - name
+  tenant:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -47,6 +50,7 @@ col_order:
 - total_cloud_vcpus
 - total_cloud_memory
 - total_miq_templates
+- tenant.name
 - region_description
 
 col_formats:
@@ -66,6 +70,7 @@ headers:
 - VCpus
 - Memory
 - Images
+- Tenant
 - Region
 
 # Condition(s) string for the SQL query

--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -37,6 +37,9 @@ include:
   zone:
     columns:
     - name
+  tenant:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -55,6 +58,7 @@ col_order:
 - total_storages
 - total_vms
 - total_miq_templates
+- tenant.name
 - region_description
 
 # Format of columns
@@ -81,6 +85,7 @@ headers:
 - Datastores
 - VMs
 - Templates
+- Tenant
 - Region
 
 # Condition(s) string for the SQL query

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -46,7 +46,9 @@ describe EmsCloudHelper::TextualSummary do
       orchestration_stacks
       storage_managers
       custom_button_events
+      tenant
     )
+
     include_examples "textual_group", "Properties", %i(description hostname ipaddress type port guid region keystone_v3_domain_id)
 
     include_examples "textual_group", "Status", %i(refresh_status refresh_date)
@@ -57,9 +59,7 @@ describe EmsCloudHelper::TextualSummary do
   describe '#textual_description' do
     let(:ems) { FactoryBot.create(:ems_cloud) }
 
-    before do
-      instance_variable_set(:@record, ems)
-    end
+    before { instance_variable_set(:@record, ems) }
 
     context "EMS instance doesn't support :description" do
       include_examples 'textual_description', nil
@@ -67,7 +67,32 @@ describe EmsCloudHelper::TextualSummary do
 
     context "EMS instance has :description" do
       before { allow(ems).to receive(:description).and_return('EmsCloud instance description') }
+
       include_examples 'textual_description', :label => _("Description"), :value => 'EmsCloud instance description'
+    end
+  end
+
+  describe '#textual_tenant' do
+    let(:ems) { FactoryBot.create(:ems_cloud) }
+    let(:tenant) { FactoryBot.create(:tenant) }
+
+    before do
+      login_as user
+      instance_variable_set(:@record, ems)
+      allow(ems).to receive(:tenant).and_return(tenant)
+      allow(tenant).to receive(:name).and_return('Tenant name')
+    end
+
+    context 'Tenant is not available for non admin user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      include_examples 'textual_tenant', nil
+    end
+
+    context 'Tenant is available for admin user' do
+      let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+
+      include_examples 'textual_tenant', :label => _("Tenant"), :value => 'Tenant name'
     end
   end
 end

--- a/spec/helpers/ems_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_infra_helper/textual_summary_spec.rb
@@ -14,6 +14,7 @@ describe EmsInfraHelper::TextualSummary do
     ems_cloud
     network_manager
     custom_button_events
+    tenant
   )
 
   include_examples "textual_group", "Properties", %i(
@@ -32,4 +33,28 @@ describe EmsInfraHelper::TextualSummary do
   include_examples "textual_group", "Status", %i(refresh_status refresh_date orchestration_stacks_status)
 
   include_examples "textual_group_smart_management", %i(zone)
+
+  describe '#textual_tenant' do
+    let(:ems) { FactoryBot.create(:ems_infra) }
+    let(:tenant) { FactoryBot.create(:tenant) }
+
+    before do
+      login_as user
+      instance_variable_set(:@record, ems)
+      allow(ems).to receive(:tenant).and_return(tenant)
+      allow(tenant).to receive(:name).and_return('Tenant name')
+    end
+
+    context 'Tenant is not available for non admin user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      include_examples 'textual_tenant', nil
+    end
+
+    context 'Tenant is available for admin user' do
+      let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+
+      include_examples 'textual_tenant', :label => _("Tenant"), :value => 'Tenant name'
+    end
+  end
 end

--- a/spec/shared/helpers/textual_summary_helper_methods.rb
+++ b/spec/shared/helpers/textual_summary_helper_methods.rb
@@ -38,3 +38,11 @@ shared_examples_for 'textual_description' do |value|
     it { is_expected.to eq(value) }
   end
 end
+
+shared_examples_for 'textual_tenant' do |value|
+  describe "#textual_tenant" do
+    subject { send("textual_tenant") }
+
+    it { is_expected.to eq(value) }
+  end
+end

--- a/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
@@ -1,19 +1,26 @@
 describe "catalog/_sandt_tree_show.html.haml" do
+  let(:admin_user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+  let(:bundle) do
+    FactoryBot.create(:service_template, :name         => 'My Bundle',
+                                         :id           => 1,
+                                         :service_type => "composite",
+                                         :display      => true,
+                                         :tenant       => tenant)
+  end
+  let(:tenant) { FactoryBot.create(:tenant) }
+
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful
-    bundle = FactoryBot.create(:service_template,
-                                :name         => 'My Bundle',
-                                :id           => 1,
-                                :service_type => "composite",
-                                :display      => true)
     assign(:record, bundle)
     assign(:sb, {})
     assign(:tenants_tree, TreeBuilderTenants.new('tenants_tree', {}, true, :additional_tenants => [], :selectable => false))
+    login_as admin_user
   end
 
   it "Renders bundle summary screen" do
     render
     expect(rendered).to include('My Bundle')
+    expect(rendered).to include(bundle.tenant.name)
   end
 end

--- a/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
@@ -77,5 +77,35 @@ describe "miq_ae_class/_ns_list.html.haml" do
         expect(response).to have_css("namespace-form[namespace_path='namespace/path']")
       end
     end
+
+    context 'displaying Tenant name for each Domain in the list view' do
+      let(:tenant) { FactoryBot.create(:tenant) }
+      let(:domain) { FactoryBot.create(:miq_ae_domain) }
+
+      before do
+        assign(:grid_data, [domain])
+        allow(domain).to receive(:tenant).and_return(tenant)
+        allow(domain).to receive(:editable?)
+        login_as user
+      end
+
+      context 'non admin user' do
+        let(:user) { FactoryBot.create(:user) }
+
+        it 'does not render Tenant name' do
+          render
+          expect(rendered).not_to include(domain.tenant.name)
+        end
+      end
+
+      context 'admin user' do
+        let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+
+        it 'renders Tenant name' do
+          render
+          expect(rendered).to include(domain.tenant.name)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**RFE:**
https://bugzilla.redhat.com/show_bug.cgi?id=1678122

More:
https://docs.google.com/document/d/1rpgBQA_MAfqZY00dnbRLMiOzqhbrB60UdnvSgg7X--Y/edit

**What:**
This PR adds displaying Tenant name in _Providers, Automate Domain_ and _Services_. Tenant name will be displayed with this PR in _Summary View_ of cloud or infra provider, in _Relationships_ table. Also a new column with the Tenant name will be displayed in the _List view_ of a Provider, Automate Domain or a Service Catalog Item/Catalog Bundle (it will not be included in: _Grid View, Tile View, Dashboard view_).

**How to test:**
- For providers:
  _Compute -> Infrastructure/Clouds -> Provider_
  and choose some provider if you want to check the Summary view
- For Automate Domain:
  _Automation -> Automate -> Explorer_
- For Services:
  _Services -> Catalogs -> Catalog Items -> choose some Catalog Item/Catalog Bundle

TODO:
- ~~display Tenant name in _Summary View_ of any provider, in _Relationships_ table~~
- ~~display Tenant name as a new column in list view of providers~~
- **hide Tenant name from the list view of providers if user is not admin**
(we need https://github.com/ManageIQ/manageiq-ui-classic/pull/5616 and https://github.com/ManageIQ/manageiq/pull/18812)
- ~~add column Tenant name for Automate Domain~~
- ~~add column Tenant name for Service Catalog Items/Catalog Bundles (Summary screens)~~
- ~~specs~~

**Note:**
Tenant names are displayed only for admin users.

---

**After:**
Cloud Provider Summary View:
![cloud_prov_t](https://user-images.githubusercontent.com/13417815/57704710-c0800a00-7662-11e9-8016-e3e9a6afd575.png)
Infrastructure Provider Summary View:
![infra_prov_t](https://user-images.githubusercontent.com/13417815/57704713-c2e26400-7662-11e9-9f7f-877e7703b40e.png)
Cloud Providers' List View:
![cloud_list](https://user-images.githubusercontent.com/13417815/57772521-e3b7c180-7715-11e9-8bfb-7ad125d261b2.png)
Infra Providers' List View:
![infra_list](https://user-images.githubusercontent.com/13417815/57773489-68a3da80-7718-11e9-8c05-3c1a2e055ed8.png)
Automate Domain:
![ae_after](https://user-images.githubusercontent.com/13417815/57925777-af750a00-78a9-11e9-91fd-08f3118779e6.png)
Service Catalog Item - Summary screen:
![service_after](https://user-images.githubusercontent.com/13417815/58089776-eb6be000-7bc5-11e9-92dd-5ee64acb327b.png)
Service Catalog Bundle - Summary screen:
![bundle_after](https://user-images.githubusercontent.com/13417815/58089781-ee66d080-7bc5-11e9-8e99-c7945051f62b.png)
