### PR TITLE
Enable Multivalue selection for all Ops RBAC Tags

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -910,7 +910,7 @@ module OpsController::OpsRbac
         {
           :id          => cat.id,
           :description => cat.description,
-          :singleValue => cat.single_value,
+          :singleValue => false,
           :values      => cat.entries.sort_by { |e| e[:description.downcase] }.map do |entry|
             { :id => entry.id, :description => entry.description }
           end


### PR DESCRIPTION
After discussion with @lpichler we agreed, that should be possible to select multiple tags for all tags. Some of them have set `single_value` restriction, but that should not apply to this screen but only to page where the tags are applied to entities. Before changes #5482 was also possible to select multiple values.

Links
----------------
#5482
#5515

Steps for Testing/QA
-------------------------------

Click on Cog wheel at right corner of the screen => Access Control => Groups => Add/Edit group
It should be possible to select multiple values for all categories.
