### PR TITLE
Use right title in breadcrumbs in ems_cluster and host controllers

### DIFF
--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -126,7 +126,7 @@ class EmsClusterController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Infrastructure")},
-        {:title => _("Clusters / Deployment Roles")},
+        {:title => title_for_clusters, :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -513,7 +513,7 @@ class HostController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Infrastructure")},
-        {:title => _("Hosts / Nodes"), :url => controller_url},
+        {:title => title_for_hosts, :url => controller_url},
       ],
       :record_info => @host,
     }.compact


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1705643

`Compute` > `Infrastructure` > `Clusters / Deployment Roles` || `Hosts / Nodes`

**Description**

`ems_cluster` and `host` controllers are using dynamic titles in their layouts depending on the content of their pages (`node_types` = `:non_openstack` or `:openstack` or `:mixed_xxx`). 

Breadcrumbs will look on this title and if it is different from the last menu item, it will append the title to breadcrumbs and make last item in breadcrumbs linked to `controller_url`.