### PR TITLE
Move kubernetes-topology-graph from assets pipeline to webpack

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 //= require_tree ./directives/
 //= require_tree ./components/
 //= require_tree ./services/
-//= require kubernetes-topology-graph/dist/topology-graph
 //= require ./miq_browser_detect
 //= require ./miq_application
 //= require ./miq_flash

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,7 +11,6 @@
  *= require ./miq_tree
  *= require codemirror/lib/codemirror
  *= require codemirror/theme/eclipse
- *= require kubernetes-topology-graph/dist/topology-graph
  *= require ./timeline
  *= require ./topology
  *= require ./container_topology

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -30,6 +30,7 @@ require('angular-dragdrop'); // ngDragDrop, used by ui-components
 require('angular-ui-sortable'); // ui.sortable, used by ui-components
 require('angular-patternfly');
 require('angular-bootstrap-switch');
+require('kubernetes-topology-graph');
 
 window._ = require('lodash');
 window.numeral = require('numeral');

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -4,3 +4,4 @@ $pf-global--disable-fontawesome: true;
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~@fortawesome/fontawesome-free/scss/v4-shims.scss';
 @import '~@patternfly/patternfly-next/patternfly.scss';
+@import '~kubernetes-topology-graph/dist/topology-graph.css';

--- a/spec/javascripts/globals_pack_spec.js
+++ b/spec/javascripts/globals_pack_spec.js
@@ -45,6 +45,10 @@ describe('packs/global.js', function() {
     it('loads angular-ui-bootstrap', function() {
       expect(angular.module('ui.bootstrap')).toBeDefined();
     });
+
+    it('loads kubernetes-topology-graph', function() {
+      expect(angular.module('kubernetesUI')).toBeDefined();
+    });
   });
 
   context('d3 plugins', function() {


### PR DESCRIPTION
Steps to verify:
- `bin/webpack` runs without error

- Compute -> Containers -> Providers -> select one -> switch to Topology view -> it looks same as before

@miq-bot add_label dependencies, hammer/no, changelog/no, test, technical debt

@miq-bot assign @himdel 