### PR TITLE
Fix problem with canceling policy sim if clicking on Back before Cancel

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/policy_simulation.rb
+++ b/app/controllers/mixins/actions/vm_actions/policy_simulation.rb
@@ -20,7 +20,7 @@ module Mixins
             @refresh_partial = "layouts/flash_msg"
           else
             session[:tag_items] = records   # Set the array of tag items
-            session[:tag_db] = VmOrTemplate # Remember the DB
+            session[:tag_db] = model_for_vm(records.first) # Remember the DB
             if @explorer
               @edit ||= {}
               @edit[:explorer] = true       # Since no @edit, create @edit and save explorer to use while building url for vms in policy sim grid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3016,6 +3016,7 @@ Rails.application.routes.draw do
         launch_html5_console
         launch_vmrc_console
         perf_chart_chooser
+        policies
         protect
         retire
         right_size_print

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -226,9 +226,9 @@ describe VmInfraController do
 
   it 'policy simulation has no clickable quadicons' do
     expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
-      :model_name                     => 'VmOrTemplate',
+      :model_name                     => 'ManageIQ::Providers::InfraManager::Vm',
       :report_data_additional_options => {
-        :model     => "VmOrTemplate",
+        :model     => 'ManageIQ::Providers::InfraManager::Vm',
         :clickable => false
       }
     )


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1670456

**What:**
If you try to cancel a policy simulation on a Cloud Instance (or also VM) after carrying out the steps below (especially after using _Back_ button), the _Cancel_ button doesn't work, nothing happens in the UI. This PR fixes the problem.

**Steps to reproduce:**
1. Add a cloud/infra provider if you don't have any (you need at least 1 VM or Instance)
2. _Compute > Clouds/Infra > Providers_, select a provider and navigate to its Instances/VMs
3. Choose some Instance/VM and _Policy > Policy Simulation_
   **Note**: if you don't go to the Summary page of an Instance/VM but check the checkbox, the bug will not occur because there is missing _Back_ button (after step 5, and this is another BZ)
4. Choose any Policy from the dropdown
    **Note**: if you click on _Cancel_ button at this point, the bug will not occur at all
5. Click on the Instance/VM quadicon below
6. Click on _Back_ button
7. Click on _Cancel_ to cancel policy simulation
=> error:
```
[----] I, [2019-05-15T17:47:54.380107 #26353:2add2036c824]  INFO -- : Started POST "/vm_or_template/x_history?item=0" for ::1 at 2019-05-15 17:47:54 +0200
[----] I, [2019-05-15T17:47:54.431528 #26353:2add2036c824]  INFO -- : Processing by VmOrTemplateController#x_history as JS
[----] I, [2019-05-15T17:47:54.431638 #26353:2add2036c824]  INFO -- :   Parameters: {"item"=>"0"}
[----] F, [2019-05-15T17:47:54.442390 #26353:2add2036c824] FATAL -- : Error caught: [NoMethodError] undefined method `[]' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:26:in `x_history'
```

**Notes:**
The core of the problem was changing the controller while clicking on quadicon (step 5) to `vm_or_template` controller.
I've tested this fix also for all _Compute > Clouds/Infra > whatever_ where we can access Instances/VMs (nested lists) and it works.
I've added `policies` to routes, otherwise problem fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5405 would occur, if displaying Instances/VMs as a nested list and checking the checkbox of some Instance/VM (and then providing policy simulation).
Don't look at the breadcrumbs on my screenshots, they've suddenly changed right after I clicked on the Instace/VM (step 3) and I am not sure if they are ok.

---

**Before:** (nothing happens after clicking on _Cancel_ button)
![cancel_before](https://user-images.githubusercontent.com/13417815/57790037-47ec7c80-773a-11e9-9f6e-7eaa72a2ef7d.png)

**After:** (after clicking on _Cancel_ button, we are back in the Summary screen of a VM)
![cancel_after](https://user-images.githubusercontent.com/13417815/57790411-fa244400-773a-11e9-916d-69d103e80e80.png)

