### PR TITLE
Do not load advanced search on pre-provisioning screen.

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -173,6 +173,7 @@ module ApplicationController::MiqRequestMethods
 
       @report_data_additional_options = ApplicationController::ReportDataAdditionalOptions.from_options(options)
       @report_data_additional_options.with_no_checkboxes(true)
+      @report_data_additional_options.in_a_form(true)
 
       @edit[:template_kls] = get_template_kls
     end

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -77,5 +77,9 @@ class ApplicationController
     def with_no_checkboxes(no_checkboxes)
       self.no_checkboxes = no_checkboxes
     end
+
+    def in_a_form(in_a_form)
+      self.in_a_form = in_a_form
+    end
   end
 end


### PR DESCRIPTION
Due to absence of `@in_a_form` setting, code was trying to load advanced search data on pre-provisioning screen and throwing a `nil` error.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1710097

@ZitaNemeckova @himdel please review/test