### PR TITLE
Reset user's dashboard upon login

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -216,11 +216,11 @@ class DashboardController < ApplicationController
       # get user dashboard version
       ws = MiqWidgetSet.where_unique_on(db.name, current_user).first
       # update user's copy if group dashboard has been updated by admin
-      if ws&.set_data && (!ws.set_data[:last_group_db_updated] ||
-         (ws.set_data[:last_group_db_updated] && db.updated_on > ws.set_data[:last_group_db_updated]))
+      if ws&.set_data && (db.set_data[:reset_upon_login] || (!ws.set_data[:last_group_db_updated] ||
+         (ws.set_data[:last_group_db_updated] && db.updated_on > ws.set_data[:last_group_db_updated])))
         # if group dashboard was locked earlier but now it is unlocked,
         # reset everything  OR if admin makes changes to a locked db do a reset on user's copies
-        if (db.set_data[:locked] && !ws.set_data[:locked]) || (db.set_data[:locked] && ws.set_data[:locked])
+        if db.set_data[:reset_upon_login] || (db.set_data[:locked] && !ws.set_data[:locked]) || (db.set_data[:locked] && ws.set_data[:locked])
           ws.set_data = db.set_data
           ws.set_data[:last_group_db_updated] = db.updated_on
           ws.save

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -254,6 +254,7 @@ module ReportController::Dashboards
       @sb[:new][:name] = @dashboard.name
       @sb[:new][:description] = @dashboard.description
       @sb[:new][:locked] = @dashboard[:set_data] && @dashboard[:set_data][:locked] ? @dashboard[:set_data][:locked] : true
+      @sb[:new][:reset_upon_login] = @dashboard[:set_data] && @dashboard[:set_data][:reset_upon_login] ? @dashboard[:set_data][:reset_upon_login] : true
       @sb[:new][:col1] = @dashboard[:set_data] && @dashboard[:set_data][:col1] ? @dashboard[:set_data][:col1] : []
       @sb[:new][:col2] = @dashboard[:set_data] && @dashboard[:set_data][:col2] ? @dashboard[:set_data][:col2] : []
       @sb[:new][:col3] = @dashboard[:set_data] && @dashboard[:set_data][:col3] ? @dashboard[:set_data][:col3] : []
@@ -272,6 +273,9 @@ module ReportController::Dashboards
       if params[:locked]
         @edit[:new][:locked] = params[:locked].to_i == 1
       end
+
+      @edit[:new][:reset_upon_login] = params[:reset_upon_login].to_i == 1 if params[:reset_upon_login].present?
+
       if params[:widget] # Make sure we got a widget in
         w = params[:widget].to_i
         if @edit[:new][:col3].length < @edit[:new][:col1].length &&
@@ -300,6 +304,7 @@ module ReportController::Dashboards
     @dashboard.set_data[:col2] = @edit[:new][:col2]
     @dashboard.set_data[:col3] = @edit[:new][:col3]
     @dashboard.set_data[:locked] = @edit[:new][:locked]
+    @dashboard.set_data[:reset_upon_login] = @edit[:new][:reset_upon_login]
   end
 
   def db_save_members
@@ -345,6 +350,7 @@ module ReportController::Dashboards
     @edit[:new][:name] = @dashboard.name
     @edit[:new][:description] = @dashboard.description
     @edit[:new][:locked] = @dashboard[:set_data] && @dashboard[:set_data][:locked] ? @dashboard[:set_data][:locked] : false
+    @edit[:new][:reset_upon_login] = @dashboard[:set_data] && @dashboard[:set_data][:reset_upon_login] ? @dashboard[:set_data][:reset_upon_login] : false
     @edit[:new][:col1] = @dashboard[:set_data] && @dashboard[:set_data][:col1] ? @dashboard[:set_data][:col1] : []
     @edit[:new][:col2] = @dashboard[:set_data] && @dashboard[:set_data][:col2] ? @dashboard[:set_data][:col2] : []
     @edit[:new][:col3] = @dashboard[:set_data] && @dashboard[:set_data][:col3] ? @dashboard[:set_data][:col3] : []

--- a/app/views/report/_db_form.html.haml
+++ b/app/views/report/_db_form.html.haml
@@ -34,6 +34,12 @@
       .col-md-8
         = check_box_tag("locked", "1", @edit[:new][:locked],
                         "data-miq_observe_checkbox" => {:url => url}.to_json)
+    .form-group
+      %label.control-label.col-md-2
+        = _('Reset Dashboard upon login')
+      .col-md-8
+        = check_box_tag("reset_upon_login", "1", @edit[:new][:reset_upon_login],
+                        "data-miq_observe_checkbox" => {:url => url}.to_json)
   %hr
   = render :partial => "db_widgets"
   - if read_only

--- a/app/views/report/_db_show.html.haml
+++ b/app/views/report/_db_show.html.haml
@@ -19,5 +19,11 @@
     .col-md-8
       %p.form-control-static
         = h(widget.set_data[:locked])
+  .form-group
+    %label.control-label.col-md-2
+      = _('Reset Dashboard upon login')
+    .col-md-8
+      %p.form-control-static
+        = h(widget.set_data[:reset_upon_login])
 %hr
 = render :partial => 'db_widgets', :locals => {:widget => widget}


### PR DESCRIPTION
Added a new checkbox "Reset Dashboard upon login" on Group Dashboard add/edit form, if that's set to true when user logs in, their dashboard will be reset and they will loose any changes(i.e add/remove widgets) they have made during their previous session and dashboard will be reset to user's group dashboard. This resolves a case where Admin has edited a group's dashboard and would like the changes to take effect without relying on the user to issue a reset of their dashboard.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1295839

after:
Log in as admin, and verify the user's group dasboard has 'Reset dashboard upon login' set to false
![db_reset1](https://user-images.githubusercontent.com/3450808/57794781-70f91700-7712-11e9-9b62-680211726d04.png)

Now login as a user that's part of the group you verified above, verify dashboard looks same as the screenshot above
![db_rest2_login_as_user](https://user-images.githubusercontent.com/3450808/57794794-75253480-7712-11e9-8ef9-380d6930d5c0.png)

Now make some changes to dashboard, move widgets around add/remove widget.
![db_reset3_make_changes_to_dashboard](https://user-images.githubusercontent.com/3450808/57794801-77878e80-7712-11e9-91cb-f8d7553ec229.png)

Go back to Dashboard editor as an admin, and set the checkbox to Reset Dashboard upon login as true and make changes to group dashboard, add/remove/move widgets etc.
![db_reset4_edit_group_dashboard_record](https://user-images.githubusercontent.com/3450808/57794806-79e9e880-7712-11e9-8d4e-435e8b56b185.png)

Save Group Dashboard changes made above
![db_reset5](https://user-images.githubusercontent.com/3450808/57794815-7ce4d900-7712-11e9-80bd-0e3f054ee48e.png)

Now logout and log back in as the user of the group for above dashboard, it should reset Dashboard with changes that Admin has made to dashboard for the group. User can make changes to dashboard during their session(only if dashboard is not locked) but when they logout and log back in it should again reset the dashboard to what the user's Group is allowed to see
![db_rest6_logout_log_back_in](https://user-images.githubusercontent.com/3450808/57794829-840be700-7712-11e9-840a-f10fd239883f.png)
