### PR TITLE
[OpsController] Use .regions method not REGIONS

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -693,7 +693,7 @@ module OpsController::Settings::Schedules
   end
 
   def retrieve_aws_regions
-    ManageIQ::Providers::Amazon::Regions::REGIONS.collect { |region| [region[1][:name]] }
+    ManageIQ::Providers::Amazon::Regions.regions.collect { |region| [region[1][:name]] }
   end
 
   def retrieve_openstack_api_versions


### PR DESCRIPTION
Since we give users the option to disable certain regions in the configs, using the `Amazon::Regions.regions` method instead of the `REGIONS` constant will make sure that this reflects what is desired as allowable AWS regions.


Links
-----

* PR Originally adding this: https://github.com/ManageIQ/manageiq-ui-classic/pull/4300
* BZ:  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1710599