### PR TITLE
Storage managers should have target types of storage, not ems_infra

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -53,7 +53,18 @@ class DialogLocalService
                         end
     when /ExtManagementSystem/
       api_collection_name = "providers"
-      cancel_endpoint = obj.class.name.demodulize == "CloudManager" ? "/ems_cloud" : "/ems_infra"
+      class_name = obj.class.name.demodulize
+      cancel_endpoint =
+        case class_name
+        when "CloudManager"
+          "/ems_cloud"
+        when "CinderManager"
+          "/ems_block_storage"
+        when "SwiftManager"
+          "/ems_object_storage"
+        else
+          "/ems_infra"
+        end
     when /MiqGroup/
       api_collection_name = "groups"
       cancel_endpoint = "/ops/explorer"
@@ -88,6 +99,8 @@ class DialogLocalService
 
   def determine_target_type(obj)
     case obj.class.name.demodulize
+    when /^Ebs/
+      "ems_storage"
     when /^Template/
       "miq_template"
     when /InfraManager/

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -97,6 +97,34 @@ describe DialogLocalService do
                        "cloud_subnet", "cloud_subnets", "/cloud_subnet"
     end
 
+    context "when the object is an EmsStorage" do
+      let(:obj) { double(:class => ManageIQ::Providers::StorageManager, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "ext_management_system", "providers", "/ems_infra"
+    end
+
+    context "when the object is an Ebs" do
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::StorageManager::Ebs, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "ems_storage", "providers", "/ems_infra"
+    end
+
+    context "when the object is an CinderManager" do
+      let(:obj) { double(:class => ManageIQ::Providers::StorageManager::CinderManager, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "ext_management_system", "providers", "/ems_block_storage"
+    end
+
+    context "when the object is an SwiftManager" do
+      let(:obj) { double(:class => ManageIQ::Providers::StorageManager::SwiftManager, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "ext_management_system", "providers", "/ems_object_storage"
+    end
+
     context "when the object is a CloudTenant" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::CloudManager::CloudTenant, :id => 123) }
 


### PR DESCRIPTION
Running a custom button on a storage manager should return you to the page of storage managers, not infra emses. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1710350

