### PR TITLE
Move jquery.hotkeys from assets pipeline to webpack

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,6 @@
 //= require codemirror/mode/shell/shell
 //= require codemirror/mode/xml/xml
 //= require codemirror/mode/yaml/yaml
-//= require jquery-hotkeys
 //= require ./miq_formatters
 //= require ./miq_grid
 //= require ./miq_list_grid

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -19,6 +19,7 @@ require('jquery-ujs');
 require('jquery.observe_field');
 require('patternfly-bootstrap-treeview');
 require('patternfly/dist/js/patternfly.min');
+require('jquery.hotkeys');
 
 window.angular = require('angular');
 require('angular-ui-bootstrap');

--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -22,7 +22,6 @@ else
 end
 
 require 'high_voltage'
-require 'jquery-hotkeys-rails'
 require "novnc-rails"
 require 'webpacker'
 

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.3"
   s.add_dependency "high_voltage", "~> 3.0.0"
-  s.add_dependency "jquery-hotkeys-rails"
   s.add_dependency "more_core_extensions", "~>3.2"
   s.add_dependency "novnc-rails", "~>0.2"
   s.add_dependency "patternfly-sass", "~> 3.59.1"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jquery": "~2.2.4",
     "jquery-ui": "~1.12.1",
     "jquery-ujs": "~1.2.2",
+    "jquery.hotkeys": "~0.1.0",
     "jquery.observe_field": "~0.1.0",
     "kubernetes-topology-graph": "~0.0.25",
     "lodash": "~4.17.10",

--- a/spec/javascripts/globals_pack_spec.js
+++ b/spec/javascripts/globals_pack_spec.js
@@ -31,6 +31,10 @@ describe('packs/global.js', function() {
     it('loads eonasdan-bootstrap-datetimepicker', function() {
       expect($.fn.datetimepicker).toBeDefined();
     });
+
+    it('loads jquery.hotkeys', function() {
+      expect($.hotkeys).toBeDefined();
+    });
   });
 
   context('angular modules', function() {


### PR DESCRIPTION
Steps to verify:
- `bin/webpack` runs without error

- Compute -> Containers -> Providers -> add new one -> click verify (or any other screen with spinner that will spin forever)-> ctrl+shift+x -> spinner stops

@miq-bot add_label dependencies, hammer/no, changelog/no, test, technical debt

@miq-bot assign @himdel 