### PR TITLE
Catalog item delete: don't show duplicate service names

### DIFF
--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -89,7 +89,9 @@ class RemoveCatalogItemModal extends React.Component {
     const usedServicesMessage = (data) => {
       let warningItems = [];
       if (data.length === 1) { // We're deleting just one catalog item
-        warningItems = data[0].services.map(service => ({id: service.id, name: service.name}));
+        let services = {};
+        data[0].services.forEach(service => { services[service.name] = service.id })
+        warningItems = Object.keys(services).map(item => ({id: services[item], name: item}));
       } else {                 // We're deleting multiple catalog items
         warningItems = data.filter(item => item.services && item.services.length > 0);
       }


### PR DESCRIPTION
1. Create catalog item
2. Order the catalog item several times
3. Try to delete the catalog item

Before:
![catalog-delete-before](https://user-images.githubusercontent.com/6648365/57858987-5a29f180-77f2-11e9-9805-47c316d1321d.png)

After:
![catalog-delete-after](https://user-images.githubusercontent.com/6648365/57858994-5eeea580-77f2-11e9-9bb2-f71fe1d816eb.png)

I personally do not have a problem with showing multiple services with the same name, but I'll leave it for broader audience to decide.

https://bugzilla.redhat.com/show_bug.cgi?id=1706863