### PR TITLE
Update travis excludes for 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ env:
   - TEST_SUITE=spec:jest
 matrix:
   exclude:
-  - rvm: 2.4.5
+  - rvm: 2.4.6
     env: TEST_SUITE=spec:javascript
-  - rvm: 2.4.5
+  - rvm: 2.4.6
     env: TEST_SUITE=spec:compile
-  - rvm: 2.4.5
+  - rvm: 2.4.6
     env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh

--- a/spec/other/travis_spec.rb
+++ b/spec/other/travis_spec.rb
@@ -1,0 +1,11 @@
+describe 'travis.yml' do
+  it "matches versions and excludes" do
+    travis = YAML.safe_load(File.open(ManageIQ::UI::Classic::Engine.root.join('.travis.yml')))
+
+    versions = travis['rvm']
+    excludes = travis.dig('matrix', 'exclude').map { |ex| ex['rvm'] }.sort.uniq
+
+    expect(excludes.length).to eq(1)
+    expect(versions.first).to eq(excludes.first)
+  end
+end


### PR DESCRIPTION
missed in #5572,

we explicitly exclude all non-ruby jobs on the newer ruby version
(no point in running javascript specs twice)

so, updating the excluded ruby version to match the new one we're using

(Drops the number of travis jobs from 8 back to 5.)

(similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/5111)