### PR TITLE
Flash message for import ae_datastore with invalid playbook method.

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -166,6 +166,8 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
           end
         rescue MiqAeException::DomainNotAccessible
           add_flash(_('Error: Selected domain is locked'), :error)
+        rescue MiqAeException::AttributeNotFound => e
+          add_flash(e.message, :error)
         end
       else
         add_flash(_("Error: Datastore import file upload expired"), :error)

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -180,6 +180,20 @@ describe MiqAeToolsController do
           MESSAGE
           expect(response.body).to eq([{:message => expected_message.chomp, :level => :success}].to_json)
         end
+
+        context 'when importing playbook method type' do
+          let(:error_msg) { "Error: Playbook method 'method_name' contains below listed error(s):" }
+
+          it 'returns the flash message' do
+            allow(automate_import_service).to receive(:import_datastore).and_raise(
+              MiqAeException::AttributeNotFound, error_msg
+            )
+            post :import_automate_datastore, :params => params, :xhr => true
+            expect(response.body).to eq(
+              [{:message => error_msg, :level => :error}].to_json
+            )
+          end
+        end
       end
 
       context "when the import file does not exist" do


### PR DESCRIPTION
This PR contains a new flash message for import datastore with the invalid playbook method and it depends on the second PR inside the automation_engine(link bellow).

Links [Optional]
----------------
* Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/303
* Based on https://bugzilla.redhat.com/show_bug.cgi?id=1677575