### PR TITLE
Added Dialog name info on the Catalog Item summary screen

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -28,6 +28,12 @@
           .col-md-8
             %p.form-control-static#long_description
               %miq-sanitize{:value => @record.long_description}
+        .form-group
+          %label.col-md-2.control-label
+            = _('Dialog')
+          .col-md-8
+            %p.form-control-static
+              = @sb[:dialog_label]
 
     .form-group
       .col-md-1{:align => "center"}


### PR DESCRIPTION
This info was already being set, only needed to be displayed in view.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1461487

before
![before](https://user-images.githubusercontent.com/3450808/57888419-205fe780-7800-11e9-8f17-d3315a995e05.png)

after
![after](https://user-images.githubusercontent.com/3450808/57888439-3077c700-7800-11e9-84c3-5519a3ef0c3c.png)

