### PR TITLE
Remove messages for superadmins in group's detail

### DIFF
--- a/app/views/ops/rbac_group/_hosts_clusters.html.haml
+++ b/app/views/ops/rbac_group/_hosts_clusters.html.haml
@@ -1,5 +1,6 @@
-%br
-= _("This user is limited to the selected items and their children.")
-%br
-%br
+- unless super_admin_user?
+  %br
+  = _("This user is limited to the selected items and their children.")
+  %br
+  %br
 = render(:partial => 'shared/tree', :locals => {:tree => @hac_tree, :name => @hac_tree.name})

--- a/app/views/ops/rbac_group/_vms_templates.html.haml
+++ b/app/views/ops/rbac_group/_vms_templates.html.haml
@@ -1,5 +1,6 @@
-%br
-= _("This user is limited to the selected folders and their children.")
-%br
-%br
+- unless super_admin_user?
+  %br
+  = _("This user is limited to the selected folders and their children.")
+  %br
+  %br
 = render(:partial => 'shared/tree', :locals => {:tree => @vat_tree, :name => @vat_tree.name})


### PR DESCRIPTION
I think that those message are just for non-super admin users.


**before** 
tab **Clusters, Datastores, Hosts, Managers & Providers** 
<img width="854" alt="Screenshot 2019-05-17 at 15 06 19" src="https://user-images.githubusercontent.com/14937244/57930413-38923e00-78b6-11e9-8a17-f05bbe40ffa6.png">

tab **VMs & Templates**

<img width="574" alt="Screenshot 2019-05-17 at 15 06 24" src="https://user-images.githubusercontent.com/14937244/57930391-27e1c800-78b6-11e9-8874-2389bf06771b.png">

**after**
tab **Clusters, Datastores, Hosts, Managers & Providers** 
<img width="794" alt="Screenshot 2019-05-17 at 15 06 46" src="https://user-images.githubusercontent.com/14937244/57930341-f832c000-78b5-11e9-8715-4feb5f5c0fea.png">

tab **VMs & Templates**
<img width="874" alt="Screenshot 2019-05-17 at 15 06 42" src="https://user-images.githubusercontent.com/14937244/57930342-fbc64700-78b5-11e9-98d3-c33bb73eb33f.png">


@miq-bot assign @mzazrivec 

