### PR TITLE
Fix specs for validation of embedded methods

### DIFF
--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -524,6 +524,7 @@ describe MiqAeClassController do
         :new         => {
           :name         => "method01",
           :display_name => nil,
+          :embedded_methods => [],
           :fields       => [field, field],
           :scope        => "instance",
           :language     => "ruby"
@@ -567,6 +568,7 @@ describe MiqAeClassController do
           :name     => @method.name,
           :language => 'ruby',
           :scope    => 'instance',
+          :embedded_methods => [],
           :location => 'inline',
           :fields   => [field]
         }


### PR DESCRIPTION
My change yesterday that removed the ```allows_nil => false``` broke https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/533531882#L2681, so this should fix that. 

thanks, sorry @himdel 