### PR TITLE
Remove get_col_type from filter/expression.rb

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -174,7 +174,7 @@ module ApplicationController::Filter
               self.exp_key = nil
             else
               # for date time fields we should show After/Before etc. options
-              chosen_field_col_type = MiqExpression.get_col_type(params[:chosen_field])
+              chosen_field_col_type = MiqExpression.parse_field_or_tag(params[:chosen_field]).try(:column_type)
               if exp_model != '_display_filter_' &&
                  MiqExpression::Field.parse(exp_field).plural? &&
                  !%i[date datetime].include?(chosen_field_col_type) &&


### PR DESCRIPTION
other step of effort to remove get_col_type.
(previous PR https://github.com/ManageIQ/manageiq-ui-classic/pull/5210 )

cc @kbrock 

@miq-bot assign @mzazrivec 

## Steps to reach changed code
1. open expression editor (in report for example)
2. Edit Selected Element of expression
3. select `Field`
4.  select any concrete Field


