### PR TITLE
Remove redundant tagging buttons for Group Tag edit

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -760,7 +760,7 @@ class OpsController < ApplicationController
 
   def handle_bottom_cell(nodetype, presenter, locals)
     # Handle bottom cell
-    if @pages || @in_a_form
+    if @pages || @in_a_form && locals[:action_url] != "rbac_tags_edit"
       if @pages
         presenter.hide(:form_buttons_div)
       elsif @in_a_form


### PR DESCRIPTION
Remove redundant tagging buttons for Group Tag edit.

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1710736

Steps for Testing/QA [Optional]
-------------------------------
Configuration -> Group -> Policy -> Edit Tags

Screenshots
----------------
Before:
![bug_tag_5 11](https://user-images.githubusercontent.com/9535558/58009749-67dfbf80-7aef-11e9-9a72-6bb568873cf5.png)

After:
![Screenshot from 2019-05-20 11-07-22](https://user-images.githubusercontent.com/9535558/58009820-8645bb00-7aef-11e9-8ce5-201102692722.png)

