### PR TITLE
Make AWS region dropdown under schedules consistent with add provider

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -693,7 +693,7 @@ module OpsController::Settings::Schedules
   end
 
   def retrieve_aws_regions
-    ManageIQ::Providers::Amazon::Regions.regions.collect { |region| [region[1][:name]] }
+    ManageIQ::Providers::Amazon::Regions.regions.flat_map { |region| [region[1].values_at(:description, :name)] }
   end
 
   def retrieve_openstack_api_versions


### PR DESCRIPTION
When adding a new schedule under OPS, there's an option to store DB backups on AWS S3. The region selector for this option is inconsistent with the AWS region selection for adding providers. With a small change I am making this consistent, having the human-readable form on this screen.

**Before:**
![Screenshot from 2019-05-20 14-50-31](https://user-images.githubusercontent.com/649130/58022845-a5077a00-7b0e-11e9-8329-80b3d24a97cc.png)

**After:**
![Screenshot from 2019-05-20 14-40-49](https://user-images.githubusercontent.com/649130/58022288-72a94d00-7b0d-11e9-8c46-d42b8b19f092.png)

@miq-bot add_label bug, hammer/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1710623