### PR TITLE
Clean up the RBAC features tree

### DIFF
--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -6,7 +6,7 @@ module Menu
     class << self
       extend Forwardable
 
-      delegate %i[menu item_in_section? item section section_id_string_to_symbol
+      delegate %i[menu item_in_section? item items section section_id_string_to_symbol
                   section_for_item_id each map detect select] => :instance
     end
 
@@ -18,6 +18,10 @@ module Menu
       @menu.each do |menu_section|
         yield menu_section if menu_section.placement == placement
       end
+    end
+
+    def items
+      @menu
     end
 
     def item(item_id)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -54,11 +54,7 @@ class TreeBuilder
   # * open_all - expand all expandable nodes
   # * lazy - is the tree lazily-loadable
   # * checkboxes - show checkboxes for the nodes
-  # * features - used by the RBAC features tree only
-  # * editable - used by the RBAC features tree only
-  # * node_id_prefix - used by the RBAC features tree only
   # * allow_reselect - fire the onclick event if a selected node is reselected
-  # * highlight_changes - highlight the changes in checkboxes differing from initial
   # * three_checks - hierarchically check the parent if all children are checked
   # * post_check - some kind of post-processing hierarchical checks
   # * silent_activate - whether to activate the active_node silently or not (by default for explorers)

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -3,7 +3,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   has_kids_for Menu::Item,        [:x_get_tree_item_kids]
   has_kids_for MiqProductFeature, [:x_get_tree_feature_kids]
 
-  attr_reader :node_id_prefix, :features
+  attr_reader :node_id_prefix, :features, :editable
 
   def initialize(name, sandbox, build, **params)
     @node_id_prefix = params[:role].id || "new"
@@ -51,7 +51,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def tree_init_options
     {
-      :editable     => @editable,
       :checkboxes   => true,
       :three_checks => true,
       :post_check   => true,

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -19,13 +19,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   private
 
   def x_get_tree_roots(count_only = false, _options)
-    top_nodes = Menu::Manager.map do |section|
-      next if section.id == :cons && !Settings.product.consumption
-      next if section.name.nil?
-      next unless Vmdb::PermissionStores.instance.can?(section.id)
-
-      section
-    end
+    top_nodes = Menu::Manager.items.select { |section| Vmdb::PermissionStores.instance.can?(section.id) }
 
     top_nodes += %w[all_vm_rules api_exclusive sui ops_explorer].collect do |additional_feature|
       MiqProductFeature.obj_features[additional_feature] &&
@@ -37,9 +31,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def x_get_tree_section_kids(parent, count_only = false)
     kids = parent.items.reject do |item|
-      if item.kind_of?(Menu::Item)
-        item.feature.nil? || !MiqProductFeature.feature_exists?(item.feature)
-      end
+      item.kind_of?(Menu::Item) && !MiqProductFeature.feature_exists?(item.feature)
     end
 
     count_only_or_objects(count_only, kids)

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -3,7 +3,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   has_kids_for Menu::Item,        [:x_get_tree_item_kids]
   has_kids_for MiqProductFeature, [:x_get_tree_feature_kids]
 
-  attr_reader :node_id_prefix
+  attr_reader :node_id_prefix, :features
 
   def initialize(name, sandbox, build, **params)
     @node_id_prefix = params[:role].id || "new"
@@ -51,7 +51,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def tree_init_options
     {
-      :features     => @features,
       :editable     => @editable,
       :checkboxes   => true,
       :three_checks => true,

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -3,7 +3,10 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   has_kids_for Menu::Item,        [:x_get_tree_item_kids]
   has_kids_for MiqProductFeature, [:x_get_tree_feature_kids]
 
+  attr_reader :node_id_prefix
+
   def initialize(name, sandbox, build, **params)
+    @node_id_prefix = params[:role].id || "new"
     @role     = params[:role]
     @editable = params[:editable]
     @features = @role.miq_product_features.map(&:identifier)
@@ -49,21 +52,20 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def tree_init_options
     {
-      :role           => @role,
-      :features       => @features,
-      :editable       => @editable,
-      :node_id_prefix => node_id_prefix,
-      :checkboxes     => true,
-      :three_checks   => true,
-      :post_check     => true,
-      :check_url      => "/ops/rbac_role_field_changed/",
-      :oncheck        => @editable ? "miqOnCheckGeneric" : false
+      :role         => @role,
+      :features     => @features,
+      :editable     => @editable,
+      :checkboxes   => true,
+      :three_checks => true,
+      :post_check   => true,
+      :check_url    => "/ops/rbac_role_field_changed/",
+      :oncheck      => @editable ? "miqOnCheckGeneric" : false
     }
   end
 
   def root_options
     {
-      :key        => "#{node_id_prefix}__#{root_feature}",
+      :key        => "#{@node_id_prefix}__#{root_feature}",
       :icon       => "pficon pficon-folder-close",
       :text       => _(root_details[:name]),
       :tooltip    => _(root_details[:description]) || _(root_details[:name]),
@@ -90,10 +92,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
     false
   end
 
-  def node_id_prefix
-    @role.id || "new"
-  end
-
   def root_feature
     @root_feature ||= MiqProductFeature.feature_root
   end
@@ -103,7 +101,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
     checked = @features.include?("all_vm_rules") || root_select_state
 
     {
-      :key     => "#{node_id_prefix}___tab_all_vm_rules",
+      :key     => "#{@node_id_prefix}___tab_all_vm_rules",
       :text    => text,
       :tooltip => text,
       :icon    => "pficon pficon-folder-close",

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -74,26 +74,4 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   def root_feature
     @root_feature ||= MiqProductFeature.feature_root
   end
-
-  def all_vm_options
-    text = _("Access Rules for all Virtual Machines")
-    checked = @features.include?("all_vm_rules") || @features.include?(root_feature)
-
-    {
-      :key     => "#{@node_id_prefix}___tab_all_vm_rules",
-      :text    => text,
-      :tooltip => text,
-      :icon    => "pficon pficon-folder-close",
-      :select  => checked
-    }
-  end
-
-  def override(node, object, _, _)
-    case object
-    when MiqProductFeature
-      if object.identifier == "all_vm_rules"
-        node.merge!(all_vm_options)
-      end
-    end
-  end
 end

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -58,6 +58,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   end
 
   def root_options
+    root_details = MiqProductFeature.feature_details(root_feature)
+
     {
       :key        => "#{@node_id_prefix}__#{root_feature}",
       :icon       => "pficon pficon-folder-close",
@@ -67,10 +69,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :selectable => false,
       :checkable  => @editable
     }
-  end
-
-  def root_details
-    @root_details ||= MiqProductFeature.feature_details(root_feature)
   end
 
   def root_feature

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -58,6 +58,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
   end
 
   def root_options
+    root_feature = MiqProductFeature.feature_root
     root_details = MiqProductFeature.feature_details(root_feature)
 
     {
@@ -69,9 +70,5 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :selectable => false,
       :checkable  => @editable
     }
-  end
-
-  def root_feature
-    @root_feature ||= MiqProductFeature.feature_root
   end
 end

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -7,9 +7,8 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def initialize(name, sandbox, build, **params)
     @node_id_prefix = params[:role].id || "new"
-    @role     = params[:role]
     @editable = params[:editable]
-    @features = @role.miq_product_features.map(&:identifier)
+    @features = params[:role].miq_product_features.map(&:identifier)
 
     @root_counter = []
 
@@ -52,7 +51,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   def tree_init_options
     {
-      :role         => @role,
       :features     => @features,
       :editable     => @editable,
       :checkboxes   => true,

--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -2,26 +2,18 @@ module TreeNode
   module Menu
     class Item < TreeNode::Menu::Node
       set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.feature}" }
-      set_attribute(:text) { _(details[:name]) }
-      set_attribute(:tooltip) { _(details[:description]) || _(details[:name]) }
-      set_attribute(:selected) { parent_selected? || self_selected? }
 
-      private
-
-      def details
-        ::MiqProductFeature.obj_features[@object.feature].try(:[], :feature).try(:details)
+      set_attribute(:text, :tooltip) do
+        details = ::MiqProductFeature.obj_features[@object.feature].try(:[], :feature).try(:details)
+        [_(details[:name]), _(details[:description]) || _(details[:name])]
       end
 
-      def feature_parent
-        ::MiqProductFeature.obj_features[::MiqProductFeature.feature_parent(@object.feature)][:feature]
-      end
+      set_attribute(:selected) do
+        parent_feature = ::MiqProductFeature.obj_features[::MiqProductFeature.feature_parent(@object.feature)][:feature]
 
-      def parent_selected?
-        @tree.features.include?(feature_parent.identifier)
-      end
-
-      def self_selected?
-        @tree.features.include?(@object.feature)
+        [parent_feature.identifier, @object.feature].any? do |item|
+          @tree.features.include?(item)
+        end
       end
     end
   end

--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -17,11 +17,11 @@ module TreeNode
       end
 
       def parent_selected?
-        @options[:features].include?(feature_parent.identifier)
+        @tree.features.include?(feature_parent.identifier)
       end
 
       def self_selected?
-        @options[:features].include?(@object.feature)
+        @tree.features.include?(@object.feature)
       end
     end
   end

--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -1,7 +1,7 @@
 module TreeNode
   module Menu
     class Item < TreeNode::Menu::Node
-      set_attribute(:key) { "#{@options[:node_id_prefix]}__#{@object.feature}" }
+      set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.feature}" }
       set_attribute(:text) { _(details[:name]) }
       set_attribute(:tooltip) { _(details[:description]) || _(details[:name]) }
       set_attribute(:selected) { parent_selected? || self_selected? }

--- a/app/presenters/tree_node/menu/node.rb
+++ b/app/presenters/tree_node/menu/node.rb
@@ -3,7 +3,7 @@ module TreeNode
     class Node < TreeNode::Node
       set_attribute(:selectable, false)
       set_attribute(:icon, "pficon pficon-folder-close")
-      set_attribute(:checkable) { @options[:editable] }
+      set_attribute(:checkable) { @tree.editable }
     end
   end
 end

--- a/app/presenters/tree_node/menu/section.rb
+++ b/app/presenters/tree_node/menu/section.rb
@@ -1,7 +1,7 @@
 module TreeNode
   module Menu
     class Section < TreeNode::Menu::Node
-      set_attribute(:key) { "#{@options[:node_id_prefix]}___tab_#{@object.id}" }
+      set_attribute(:key) { "#{@tree.node_id_prefix}___tab_#{@object.id}" }
       set_attribute(:text) { _(@object.name) }
       set_attribute(:tooltip) { _("%{title} Main Tab") % {:title => @object.name} }
     end

--- a/app/presenters/tree_node/miq_product_feature.rb
+++ b/app/presenters/tree_node/miq_product_feature.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class MiqProductFeature < TreeNode::Menu::Node
-    set_attribute(:key) { "#{@options[:node_id_prefix]}__#{@object.identifier}" }
+    set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.identifier}" }
     set_attribute(:text) { _(@object.name) }
     set_attribute(:tooltip) { _(@object.description) || _(@object.name) }
     set_attribute(:selected) { @options[:features].include?(@object.identifier.sub(/_accords$/, '')) }

--- a/app/presenters/tree_node/miq_product_feature.rb
+++ b/app/presenters/tree_node/miq_product_feature.rb
@@ -3,7 +3,7 @@ module TreeNode
     set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.identifier}" }
     set_attribute(:text) { _(@object.name) }
     set_attribute(:tooltip) { _(@object.description) || _(@object.name) }
-    set_attribute(:selected) { @options[:features].include?(@object.identifier.sub(/_accords$/, '')) }
+    set_attribute(:selected) { @tree.features.include?(@object.identifier.sub(/_accords$/, '')) }
 
     set_attribute(:icon) do
       case @object.feature_type


### PR DESCRIPTION
Well, this is long, :beers: for anyone who reviews it :laughing: 
* I moved the retrieval of some specific options from the tree state to the tree object instead
* The node enumeration has been simplified, some conditions were unnecessary
* Counting the nodes for selecting parents is unnecessary, `post_check` does it for free
* The method overriding all_vm_options doesn't do anything useful so deleted
* Cached root_feature/root_details is no longer shared between methods, no need for caching
* The helper methods in the `TreeNode::Menu::Item` were unnecessary, moved them into the blocks
* We got rid of 3 additional options from `tree_init_options` :trophy: 

@miq-bot add_label trees, refactoring, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 