### PR TITLE
Read-only pages for browsing firmware repository

### DIFF
--- a/app/controllers/firmware_binary_controller.rb
+++ b/app/controllers/firmware_binary_controller.rb
@@ -1,0 +1,51 @@
+class FirmwareBinaryController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
+  include Mixins::ListnavMixin
+  include Mixins::BreadcrumbsMixin
+
+  def self.display_methods
+    %w[firmware_targets]
+  end
+
+  def self.model
+    FirmwareBinary
+  end
+
+  def display_firmware_targets
+    nested_list(FirmwareTarget, :breadcrumb_title => _('Firmware Targets'))
+  end
+
+  private
+
+  def textual_group_list
+    [%i[properties relationships firmware_targets]]
+  end
+  helper_method :textual_group_list
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _('Cloud')},
+        {:title => _('Infrastructure')},
+        {:title => _('Firmware Registries')},
+        {
+          :title => @record.firmware_registry.name,
+          :url   => url_for(:controller => :firmware_registry, :id => @record.firmware_registry.id, :action => :show)
+        },
+        {
+          :title => _('Firmware Binaries'),
+          :url   => url_for(:controller => :firmware_registry, :id => @record.firmware_registry.id, :action => :show,
+                            :display => :firmware_binaries)
+        },
+      ],
+    }
+  end
+end

--- a/app/controllers/firmware_registry_controller.rb
+++ b/app/controllers/firmware_registry_controller.rb
@@ -1,0 +1,50 @@
+class FirmwareRegistryController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
+  include Mixins::ListnavMixin
+  include Mixins::BreadcrumbsMixin
+
+  menu_section :firmware_registry
+
+  def self.display_methods
+    %w[firmware_binaries]
+  end
+
+  def self.model
+    FirmwareRegistry
+  end
+
+  def title
+    _('Firmware Registry')
+  end
+
+  def display_firmware_binaries
+    nested_list(FirmwareBinary, :breadcrumb_title => _('Firmware Binaries'))
+  end
+
+  private
+
+  def textual_group_list
+    [
+      %i[properties relationships firmware_binaries],
+    ]
+  end
+  helper_method :textual_group_list
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _('Compute')},
+        {:title => _('Infrastructure')},
+        {:title => _('Firmware Registries'), :url => controller_url},
+      ],
+    }
+  end
+end

--- a/app/controllers/firmware_target_controller.rb
+++ b/app/controllers/firmware_target_controller.rb
@@ -1,0 +1,46 @@
+class FirmwareTargetController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
+  include Mixins::ListnavMixin
+  include Mixins::BreadcrumbsMixin
+
+  def self.display_methods
+    %w[firmware_binaries]
+  end
+
+  def self.model
+    FirmwareTarget
+  end
+
+  def display_firmware_binaries
+    nested_list(FirmwareBinary, :breadcrumb_title => _('Firmware Binaries'))
+  end
+
+  private
+
+  def textual_group_list
+    [%i[properties relationships]]
+  end
+  helper_method :textual_group_list
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _('Cloud')},
+        {:title => _('Infrastructure')},
+        {
+          :title => _('Firmware Registries'),
+          :url   => url_for(:controller => :firmware_registry, :action => :show_list)
+        },
+        {:title => _('Firmware Targets'), :url => controller_url},
+      ],
+    }
+  end
+end

--- a/app/helpers/application_helper/toolbar/firmware_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registry_center.rb
@@ -1,0 +1,16 @@
+class ApplicationHelper::Toolbar::FirmwareRegistryCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'firmware_registry_reload',
+    [
+      button(
+        :firmware_registry_reload,
+        'fa fa-refresh fa-lg',
+        N_('Refresh this page'),
+        N_('Refresh'),
+        :url_parms    => "main_div",
+        :send_checked => true,
+        :klass        => ApplicationHelper::Button::ButtonWithoutRbacCheck
+      )
+    ]
+  )
+end

--- a/app/helpers/firmware_binary_helper.rb
+++ b/app/helpers/firmware_binary_helper.rb
@@ -1,0 +1,3 @@
+module FirmwareBinaryHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/firmware_binary_helper/textual_summary.rb
+++ b/app/helpers/firmware_binary_helper/textual_summary.rb
@@ -1,0 +1,43 @@
+module FirmwareBinaryHelper::TextualSummary
+  include TextualMixins::TextualName
+  include TextualMixins::TextualDescription
+
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i[name description version created updated]
+    )
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(_("Relationships"), %i[firmware_registry firmware_targets])
+  end
+
+  def textual_group_firmware_targets
+    TextualTable.new(_('Firmware Targets'), firmware_targets, [_('Manufacturer'), _('Model')])
+  end
+
+  def textual_created
+    {:label => _("Created On"), :value => format_timezone(@record.created_at)}
+  end
+
+  def textual_updated
+    {:label => _("Updated On"), :value => format_timezone(@record.updated_at)}
+  end
+
+  def textual_version
+    @record.version
+  end
+
+  def textual_firmware_registry
+    textual_link(@record.firmware_registry)
+  end
+
+  def textual_firmware_targets
+    textual_link(@record.firmware_targets)
+  end
+
+  def firmware_targets
+    @record.firmware_targets.order('manufacturer, model').collect { |t| [textual_link(t) { t.manufacturer }, t.model] }
+  end
+end

--- a/app/helpers/firmware_registry_helper.rb
+++ b/app/helpers/firmware_registry_helper.rb
@@ -1,0 +1,3 @@
+module FirmwareRegistryHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/firmware_registry_helper/textual_summary.rb
+++ b/app/helpers/firmware_registry_helper/textual_summary.rb
@@ -1,0 +1,39 @@
+module FirmwareRegistryHelper::TextualSummary
+  include TextualMixins::TextualName
+
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i[name last_refresh_on last_refresh_error created updated])
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(_("Relationships"), %i[firmware_binaries])
+  end
+
+  def textual_group_firmware_binaries
+    TextualTable.new(_('Firmware Binaries'), firmware_binaries, [_('Name'), _('Version'), _('Description')])
+  end
+
+  def textual_last_refresh_on
+    {:label => _("Last Refresh"), :value => format_timezone(@record.last_refresh_on)}
+  end
+
+  def textual_last_refresh_error
+    @record.last_refresh_error
+  end
+
+  def textual_created
+    {:label => _("Created On"), :value => format_timezone(@record.created_at)}
+  end
+
+  def textual_updated
+    {:label => _("Updated On"), :value => format_timezone(@record.updated_at)}
+  end
+
+  def textual_firmware_binaries
+    textual_link(@record.firmware_binaries)
+  end
+
+  def firmware_binaries
+    @record.firmware_binaries.order('name, version DESC').collect { |b| [textual_link(b), b.version, b.description[0..30]] }
+  end
+end

--- a/app/helpers/firmware_target_helper.rb
+++ b/app/helpers/firmware_target_helper.rb
@@ -1,0 +1,3 @@
+module FirmwareTargetHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/firmware_target_helper/textual_summary.rb
+++ b/app/helpers/firmware_target_helper/textual_summary.rb
@@ -1,0 +1,32 @@
+module FirmwareTargetHelper::TextualSummary
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i[manufacturer model created updated]
+    )
+  end
+
+  def textual_group_relationships
+    TextualGroup.new(_("Relationships"), %i[firmware_binaries])
+  end
+
+  def textual_created
+    {:label => _("Created On"), :value => format_timezone(@record.created_at)}
+  end
+
+  def textual_updated
+    {:label => _("Updated On"), :value => format_timezone(@record.updated_at)}
+  end
+
+  def textual_manufacturer
+    @record.manufacturer
+  end
+
+  def textual_model
+    @record.model
+  end
+
+  def textual_firmware_binaries
+    textual_link(@record.firmware_binaries)
+  end
+end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -72,15 +72,16 @@ module Menu
         clusters_name = hybrid_name(EmsCluster, N_("Clusters"), N_("Deployment Roles"), N_("Clusters / Deployment Roles"))
 
         Menu::Section.new(:inf, N_("Infrastructure"), 'fa fa-plus', [
-          Menu::Item.new('ems_infra',        N_('Providers'),        'ems_infra',                  {:feature => 'ems_infra_show_list'},             '/ems_infra/show_list'),
-          Menu::Item.new('ems_cluster',      clusters_name,          'ems_cluster',                {:feature => 'ems_cluster_show_list'},           '/ems_cluster/show_list'),
-          Menu::Item.new('host',             hosts_name,             'host',                       {:feature => 'host_show_list'},                  '/host/show_list'),
-          Menu::Item.new('vm_infra',         N_('Virtual Machines'), 'vm_infra_explorer',          {:feature => 'vm_infra_explorer', :any => true}, '/vm_infra/explorer'),
-          Menu::Item.new('resource_pool',    N_('Resource Pools'),   'resource_pool',              {:feature => 'resource_pool_show_list'},         '/resource_pool/show_list'),
-          Menu::Item.new('storage',          N_('Datastores'),       'storage',                    {:feature => 'storage_show_list'},               '/storage/explorer'),
-          Menu::Item.new('pxe',              N_('PXE'),              'pxe',                        {:feature => 'pxe', :any => true},               '/pxe/explorer'),
-          Menu::Item.new('switch',           N_('Networking'),       'infra_networking',           {:feature => 'infra_networking', :any => true},  '/infra_networking/explorer'),
-          Menu::Item.new('infra_topology',   N_('Topology'), 'infra_topology',                     {:feature => 'infra_topology', :any => true},    '/infra_topology/show')
+          Menu::Item.new('ems_infra',         N_('Providers'),         'ems_infra',                  {:feature => 'ems_infra_show_list'},             '/ems_infra/show_list'),
+          Menu::Item.new('ems_cluster',       clusters_name,           'ems_cluster',                {:feature => 'ems_cluster_show_list'},           '/ems_cluster/show_list'),
+          Menu::Item.new('host',              hosts_name,              'host',                       {:feature => 'host_show_list'},                  '/host/show_list'),
+          Menu::Item.new('vm_infra',          N_('Virtual Machines'),  'vm_infra_explorer',          {:feature => 'vm_infra_explorer', :any => true}, '/vm_infra/explorer'),
+          Menu::Item.new('resource_pool',     N_('Resource Pools'),    'resource_pool',              {:feature => 'resource_pool_show_list'},         '/resource_pool/show_list'),
+          Menu::Item.new('storage',           N_('Datastores'),        'storage',                    {:feature => 'storage_show_list'},               '/storage/explorer'),
+          Menu::Item.new('pxe',               N_('PXE'),               'pxe',                        {:feature => 'pxe', :any => true},               '/pxe/explorer'),
+          Menu::Item.new('firmware_registry', N_('Firmware Registry'), 'firmware_registry',          {:feature => 'firmware_registry', :any => true}, '/firmware_registry/show_list'),
+          Menu::Item.new('switch',            N_('Networking'),        'infra_networking',           {:feature => 'infra_networking', :any => true},  '/infra_networking/explorer'),
+          Menu::Item.new('infra_topology',    N_('Topology'),          'infra_topology',             {:feature => 'infra_topology', :any => true},    '/infra_topology/show')
         ])
       end
 

--- a/app/views/firmware_binary/show.html.haml
+++ b/app/views/firmware_binary/show.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  - if %w(firmware_targets).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/firmware_registry/show.html.haml
+++ b/app/views/firmware_registry/show.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  - if %w(firmware_binaries).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/firmware_registry/show_list.html.haml
+++ b/app/views/firmware_registry/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/firmware_target/show.html.haml
+++ b/app/views/firmware_target/show.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  - if %w(firmware_binaries).include?(@display)
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - else
+    = render :partial => 'layouts/textual_groups_generic'

--- a/app/views/layouts/listnav/_firmware_binary.html.haml
+++ b/app/views/layouts/listnav/_firmware_binary.html.haml
@@ -1,0 +1,25 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to(_('Firmware Registry'),
+                    {:controller => "firmware_registry",
+                     :action     => 'show',
+                     :id         => @record.firmware_registry_id},
+                     :title      => _("Show Firmware Registry"))
+        %li
+          = li_link(:count     => @record.firmware_targets.size,
+                    :text      => _("Firmware Targets"),
+                    :display   => 'firmware_targets',
+                    :record_id => @record.id,
+                    :title     => _("Show all Firmware Targets"))

--- a/app/views/layouts/listnav/_firmware_registry.html.haml
+++ b/app/views/layouts/listnav/_firmware_registry.html.haml
@@ -1,0 +1,19 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = li_link(:count     => @record.firmware_binaries.size,
+                    :text      => _("Firmware Binaries"),
+                    :display   => 'firmware_binaries',
+                    :record_id => @record.id,
+                    :title     => _("Show all Firmware Binaries"))

--- a/app/views/layouts/listnav/_firmware_target.html.haml
+++ b/app/views/layouts/listnav/_firmware_target.html.haml
@@ -1,0 +1,19 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render :partial => 'shared/quadicon', :locals => {:record => @record}
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'), {:action => 'show', :id => @record, :display => 'main'},
+                              :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = li_link(:count     => @record.firmware_binaries.size,
+                    :text      => _("Firmware Binaries"),
+                    :display   => 'firmware_binaries',
+                    :record_id => @record.id,
+                    :title     => _("Show all Firmware Binaries"))

--- a/app/views/miq_request/_physical_server_firmware_update_show.html.haml
+++ b/app/views/miq_request/_physical_server_firmware_update_show.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  %h3
+    = _("Affected Physical Servers")
+  - if @view
+    - @embedded = true
+    - @gtl_type = "list"
+    = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -129,6 +129,8 @@
     = render :partial => "ae_prov_show"
   - elsif %w[PhysicalServerProvisionRequest PhysicalServerFirmwareUpdateRequest].include?(@miq_request.type)
     = render :partial => "physical_server_provision_show"
+  - elsif @miq_request.type == "PhysicalServerFirmwareUpdateRequest"
+    = render :partial => "physical_server_firmware_update_show"
   - else
     = render :partial => "reconfigure_show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3280,6 +3280,34 @@ Rails.application.routes.draw do
                pre_prov_post +
                snap_post
     },
+
+    :firmware_registry => {
+      :get => %w[
+        download_data
+        download_summary_pdf
+        show
+        show_list
+      ],
+      :post => %w[
+        show_list
+      ]
+    },
+
+    :firmware_binary => {
+      :get => %w[
+        download_data
+        download_summary_pdf
+        show
+      ]
+    },
+
+    :firmware_target => {
+      :get => %w[
+        download_data
+        download_summary_pdf
+        show
+      ]
+    },
   }
 
   if Rails.env.development?

--- a/product/views/FirmwareBinary.yaml
+++ b/product/views/FirmwareBinary.yaml
@@ -1,0 +1,71 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Firmware Binaries
+
+# Menu name
+name: Firmware Binaries
+
+# Main DB table report is based on
+db: FirmwareBinary
+
+# Columns to fetch from the main table
+cols:
+- name
+- version
+- description
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- version
+- description
+
+
+# Column titles, in order
+headers:
+- Name
+- Version
+- Description
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+- version
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/product/views/FirmwareRegistry.yaml
+++ b/product/views/FirmwareRegistry.yaml
@@ -1,0 +1,66 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Firmware Registries
+
+# Menu name
+name: Firmware Registries
+
+# Main DB table report is based on
+db: FirmwareRegistry
+
+# Columns to fetch from the main table
+cols:
+- name
+- last_refresh_on
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- last_refresh_on
+
+# Column titles, in order
+headers:
+- Name
+- Last Refreshed On
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/product/views/FirmwareTarget.yaml
+++ b/product/views/FirmwareTarget.yaml
@@ -1,0 +1,68 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Firmware Targets
+
+# Menu name
+name: Firmware Targets
+
+# Main DB table report is based on
+db: FirmwareTarget
+
+# Columns to fetch from the main table
+cols:
+- manufacturer
+- model
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- manufacturer
+- model
+
+
+# Column titles, in order
+headers:
+- Manufacturer
+- Model
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- manufacturer
+- model
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -25,7 +25,7 @@ describe Menu::DefaultMenu do
       FactoryBot.create(:host_openstack_infra, :ems_id => @ems_openstack.id)
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Nodes", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
 
@@ -33,7 +33,7 @@ describe Menu::DefaultMenu do
       FactoryBot.create(:host_vmware, :ems_id => @ems_vmware.id)
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
 
@@ -43,7 +43,7 @@ describe Menu::DefaultMenu do
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts / Nodes", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
 
@@ -52,7 +52,7 @@ describe Menu::DefaultMenu do
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
 
@@ -61,7 +61,7 @@ describe Menu::DefaultMenu do
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
 
@@ -71,7 +71,7 @@ describe Menu::DefaultMenu do
 
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters / Deployment Roles", "Hosts", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Networking", "Topology"]
+                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
   end


### PR DESCRIPTION
With this commit we add following pages to support firmware repository browsing:

```
- firmware registry list
- firmware registry details
   + display firmware_binaries
- firmware binary details
   + display firmware constraints
- firmware contstraint details
   + display firmware binaries
```

# Firmware registry list
![image](https://user-images.githubusercontent.com/8102426/58244230-7f6ab280-7d52-11e9-9304-c93fd0a12bbd.png)

![image](https://user-images.githubusercontent.com/8102426/58244274-90b3bf00-7d52-11e9-8453-2f5ffd42d2ab.png)

# Firmware registry details
![image](https://user-images.githubusercontent.com/8102426/58244323-aa550680-7d52-11e9-81f0-8005c9db78d7.png)

## Display firmware_binaries
![image](https://user-images.githubusercontent.com/8102426/58244366-bb9e1300-7d52-11e9-90ce-0cf9baccf5a6.png)

# Firmware binary details
![image](https://user-images.githubusercontent.com/8102426/58244412-d1abd380-7d52-11e9-9486-d4662bde1b9a.png)

## Display firmware constraints
![image](https://user-images.githubusercontent.com/8102426/58244438-e0928600-7d52-11e9-9cda-34882b41aaa9.png)

# Firmware contstraint details
![image](https://user-images.githubusercontent.com/8102426/58244481-ef793880-7d52-11e9-822d-f85143a6a4da.png)

## Display firmware binaries
![image](https://user-images.githubusercontent.com/8102426/58244505-facc6400-7d52-11e9-87a9-90a9b893dbd6.png)

@miq-bot add_label enhancement
@miq-bot assign @martinpovolny 
