### PR TITLE
[WIP] Patternfly4 - only apply styling under .pf4

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -3,5 +3,7 @@ $pf-global--disable-fontawesome: true;
 
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~@fortawesome/fontawesome-free/scss/v4-shims.scss';
-@import '~@patternfly/patternfly-next/patternfly.scss';
+.pf4 {
+  @import '~@patternfly/patternfly-next/patternfly.scss';
+}
 @import '~kubernetes-topology-graph/dist/topology-graph.css';


### PR DESCRIPTION
Patternfly4 is assuming the pf-* namespace belongs to patternfly4 only.
One example being any class *starting* with `pf-u`|`pf-c`|`pf-l` will get background color changed.

Patternfly3 also assumes the pf-* namespace belongs to patternfly3 only.
One example being a `pf-utilization` class :).

Together - pf-utilization dashboard has the background randomly changed to transparent, yay.

Solving by only applying patternfly 4 styles only under a .pf4 class element.
This will make it a bit harder to consume global patternfly4 styles, but won't break random screens anymore.

~~Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1711913~~

Cc @skateman , @epwinchell 
This will require us to add `.pf4` above any use of patternfly4 styles - `<div class="pf4 pf-whatever">` won't work, but `<div class="pf4">...<div class="pf-whatever">` will.