### PR TITLE
Added Zone drop down to angular and non-angular catalog item editor & Automate Task Schedules

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -9,6 +9,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
       prov_type: 'generic_ansible_playbook',
       location: 'playbook',
       catalog_id: '',
+      zone_id: '',
       key: '',
       key_value: '',
       provisioning_repository_id: '',
@@ -57,6 +58,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
     vm.afterGet = false;
     vm.inventory_mode = 'localhost';
     vm.all_catalogs = allCatalogsNames;
+    vm.zones = [];
 
     ManageIQ.angular.scope = $scope;
 
@@ -74,6 +76,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
         vm.catalogItemModel.long_description = catalogItemData.long_description;
         vm.catalogItemModel.display = catalogItemData.display;
         vm.catalogItemModel.catalog_id = catalogItemData.service_template_catalog_id === undefined ? '' : catalogItemData.service_template_catalog_id;
+        vm.catalogItemModel.zone_id = catalogItemData.zone_id === undefined ? '' : catalogItemData.zone_id;
         vm.catalogItemModel.provisioning_dialog_id = catalogItemData.config_info.provision.dialog_id;
         playbookReusableCodeMixin.formOptions(vm);
         playbookReusableCodeMixin.formCloudCredentials(vm, catalogItemData.config_info.provision.cloud_credential_id, catalogItemData.config_info.retirement.cloud_credential_id);
@@ -245,6 +248,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
       long_description: configData.long_description,
       display: configData.display,
       service_template_catalog_id: configData.catalog_id,
+      zone_id: configData.zone_id,
       prov_type: 'generic_ansible_playbook',
       type: 'ServiceTemplateAnsiblePlaybook',
       additional_tenant_ids: configData.additional_tenant_ids,
@@ -447,7 +451,7 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
   };
 
   // watch for all the drop downs on screen
-  'catalog provisioning_playbook retirement_playbook provisioning_machine_credential retirement_machine_credential provisioning_vault_credential retirement_vault_credential provisioning_network_credential retirement_network_credential provisioning_cloud_credential retirement_cloud_credential provisioning_dialog'.split(' ').forEach(idWatch);
+  'catalog provisioning_playbook retirement_playbook provisioning_machine_credential retirement_machine_credential provisioning_vault_credential retirement_vault_credential provisioning_network_credential retirement_network_credential provisioning_cloud_credential retirement_cloud_credential provisioning_dialog zone'.split(' ').forEach(idWatch);
 
   function idWatch(name) {
     var fieldName = 'vm._' + name;

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -141,7 +141,7 @@ function playbookReusableCodeMixin(API, $q, miqService) {
       );
     }
 
-    allApiPromises.push(API.get('/api/zones/?expand=resources&attributes=id,description' + sortOptions)
+    allApiPromises.push(API.get('/api/zones/?expand=resources&attributes=id,description&sort_by=description&sort_order=ascending')
       .then(function(data) {
         vm.zones = data.resources;
         vm._zone = _.find(vm.zones, {id: vm[vm.model].zone_id});

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -141,6 +141,14 @@ function playbookReusableCodeMixin(API, $q, miqService) {
       );
     }
 
+    allApiPromises.push(API.get('/api/zones/?expand=resources&attributes=id,description' + sortOptions)
+      .then(function(data) {
+        vm.zones = data.resources;
+        vm._zone = _.find(vm.zones, {id: vm[vm.model].zone_id});
+      })
+      .catch(miqService.handleFailure)
+    );
+
     // list of service dialogs
     if (vm[vm.model].provisioning_dialog_id !== undefined) {
       allApiPromises.push(API.get('/api/service_dialogs/?expand=resources&attributes=id,label&sort_by=label&sort_order=ascending')

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1238,6 +1238,7 @@ class CatalogController < ApplicationController
                                   end
     st.prov_type = @edit[:new][:st_prov_type]
     st.generic_subtype = @edit[:new][:generic_subtype] if @edit[:new][:st_prov_type] == 'generic'
+    st.zone_id = @edit[:new][:zone_id]
     st.additional_tenants = Tenant.where(:id => @edit[:new][:tenant_ids]) # Selected Additional Tenants in the tree
   end
 
@@ -1291,6 +1292,8 @@ class CatalogController < ApplicationController
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
     available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower)
     available_container_managers if @record.kind_of?(ServiceTemplateContainerTemplate)
+    fetch_zones
+    @edit[:new][:zone_id] = @record.zone_id
 
     # initialize fqnames
     @edit[:new][:fqname] = @edit[:new][:reconfigure_fqname] = @edit[:new][:retire_fqname] = ""
@@ -1311,6 +1314,10 @@ class CatalogController < ApplicationController
                          _("Editing Service Catalog Item \"%{name}\"") % {:name => @record.name}
                        end
     build_automate_tree(:automate_catalog) # Build Catalog Items tree
+  end
+
+  def fetch_zones
+    @zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :id)
   end
 
   def st_set_form_vars
@@ -1418,12 +1425,13 @@ class CatalogController < ApplicationController
   end
 
   def get_form_vars
-    copy_params_if_set(@edit[:new], params, %i[name description provision_cost catalog_id dialog_id generic_subtype long_description])
+    copy_params_if_set(@edit[:new], params, %i[name description provision_cost catalog_id dialog_id generic_subtype long_description zone_id])
 
     @edit[:new][:display] = params[:display] == "1" if params[:display]
     # saving it in @edit as well, to use it later because prov_set_form_vars resets @edit[:new]
     @edit[:st_prov_type] = @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]
+    fetch_zones
     checked_tenants if params[:check] # Save checked Additional Tenants to @edit
 
     @tenants_tree = build_tenants_tree # Build the tree with available tenants

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -191,7 +191,8 @@ module OpsController::Settings::Schedules
         :targets         => automate_request[:targets],
         :target_id       => automate_request[:target_id],
         :ui_attrs        => automate_request[:ui_attrs],
-        :filter_type     => nil
+        :filter_type     => nil,
+        :zone_id         => schedule.zone_id.to_s
       )
     end
     render :json => schedule_hash
@@ -487,6 +488,7 @@ module OpsController::Settings::Schedules
       uri_settings[:save] = true
       schedule.verify_file_depot(uri_settings)
     elsif params[:action_typ] == "automation_request"
+      schedule.zone_id = params[:zone_id].presence || MiqServer.my_server.zone_id
       ui_attrs = []
       ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
         next unless params[:ui_attrs] && params[:ui_attrs][i.to_s]

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -51,6 +51,17 @@
                         :class                => "selectpicker")
           :javascript
             miqSelectPickerEvent('dialog_id', '#{url}')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Zone')
+      .col-md-4
+        %p.form-control-static
+          = select_tag('zone_id',
+                        options_for_select([["<Choose>", nil]] + @zones, @edit[:new][:zone_id]),
+                        "data-miq_sparkle_on" => true,
+                        :class                => "selectpicker")
+          :javascript
+            miqSelectPickerEvent('zone_id', '#{url}')
     - if @edit[:new][:st_prov_type] == "generic"
       .form-group
         %label.col-md-2.control-label

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -35,6 +35,12 @@
               = _('Catalog')
             .col-md-9
               = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
+        .form-group
+          %label.col-md-3.control-label
+            = _('Zone')
+          .col-md-9
+            %p.form-control-static
+              = @record.zone ? @record.zone.name : ''
         - unless @record.prov_type == "generic_ansible_playbook"
           .form-group
             %label.col-md-3.control-label

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -67,6 +67,17 @@
                   'miq-select'        => true}
       = render(:partial => "tenants_tree_show", :locals => {:angular => true})
 
+      .form-group
+        %label.col-md-2.control-label{"for" => "zone_id"}
+          = _('Zone')
+        .col-md-8
+          %select{"ng-model"         => "vm._zone",
+                  "name"             => "zone_id",
+                  'ng-options'       => 'zone as zone.description for zone in vm.zones',
+                  "data-live-search" => "true",
+                  'miq-select'        => true}
+            %option{"value" => ""} &lt;Choose&gt;
+
     = render :partial => "layouts/angular/multi_tab_ansible_form_options",
              :locals  => {:record => @record, :ng_model => "vm.catalogItemModel"}
     = render :partial => "layouts/angular/x_edit_buttons_angular"

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -11,7 +11,6 @@
                             "name"             => "zone_id",
                             "ng-options"       => "zone as zone.description for zone in zones",
                             "data-live-search" => "true",
-                            "ng-change"        => "",
                             "checkchange"      => "",
                             "miq-select"       => true}
               %option{"disabled" => "", "value" => ""} &lt;Choose&gt;

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -2,8 +2,8 @@
   .div
     .div
       -# %h4 {{buildLegend()}}
-      %div{"ng-switch" => "", "on" => "automateRequest()"}
-        .form-group{"ng-class" => "{'has-error': angularForm.target_id.$invalid}", "ng-show" => "!dbBackup() && automateRequest()"}
+      %div{"ng-switch" => "", "on" => "scheduleModel.action_typ"}
+        .form-group{"ng-class" => "{'has-error': angularForm.target_id.$invalid}", "ng-show" => "automateRequest()"}
           %label.col-md-2.control-label{"for" => "zone_id"}
             = _("Zone")
           .col-md-8
@@ -94,14 +94,6 @@
                                  "ng-required"                => "!automateRequest() && filterValueRequired(scheduleModel.filter_value)",
                                  "checkchange"                => ""}
               %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
-
-            -#%select#zone_id{"ng-model"         => "scheduleModel",
-            -#                "ng-show"          => "automateRequest()",
-            -#                "name"             => "zone_id",
-            -#                'ng-options'       => 'zone as zone.description for zone in zones',
-            -#                "data-live-search" => "true",
-            -#                'miq-select'       => true}
-            -#  %option{"value" => ""} &lt;Choose&gt;
 
         %ae-resolve-options{"ng-if"                 => "automateRequest()",
                             "instance-name"         => "scheduleModel.instance_name",

--- a/app/views/ops/_schedule_form_filter.html.haml
+++ b/app/views/ops/_schedule_form_filter.html.haml
@@ -2,7 +2,19 @@
   .div
     .div
       -# %h4 {{buildLegend()}}
-      %div{"ng-switch" => "", "on" => "scheduleModel.action_typ"}
+      %div{"ng-switch" => "", "on" => "automateRequest()"}
+        .form-group{"ng-class" => "{'has-error': angularForm.target_id.$invalid}", "ng-show" => "!dbBackup() && automateRequest()"}
+          %label.col-md-2.control-label{"for" => "zone_id"}
+            = _("Zone")
+          .col-md-8
+            %select#zone_id{"ng-model"         => "_zone",
+                            "name"             => "zone_id",
+                            "ng-options"       => "zone as zone.description for zone in zones",
+                            "data-live-search" => "true",
+                            "ng-change"        => "",
+                            "checkchange"      => "",
+                            "miq-select"       => true}
+              %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
         .form-group
           %label.col-md-2.control-label{"for" => "filter_typ", "ng-hide" => "dbBackup() || automateRequest()"}
             = _("Filter")
@@ -82,6 +94,14 @@
                                  "ng-required"                => "!automateRequest() && filterValueRequired(scheduleModel.filter_value)",
                                  "checkchange"                => ""}
               %option{"disabled" => "", "value" => ""} &lt;Choose&gt;
+
+            -#%select#zone_id{"ng-model"         => "scheduleModel",
+            -#                "ng-show"          => "automateRequest()",
+            -#                "name"             => "zone_id",
+            -#                'ng-options'       => 'zone as zone.description for zone in zones',
+            -#                "data-live-search" => "true",
+            -#                'miq-select'       => true}
+            -#  %option{"value" => ""} &lt;Choose&gt;
 
         %ae-resolve-options{"ng-if"                 => "automateRequest()",
                             "instance-name"         => "scheduleModel.instance_name",

--- a/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
+++ b/spec/javascripts/controllers/catalog/catalog_item_form_controller_spec.js
@@ -21,6 +21,7 @@ describe('catalogItemFormController', function() {
       long_description:             'catalogItemLongDescription',
       display:                      true,
       service_template_catalog_id:  10000000000012,
+      zone_id:                      10000000000001,
       prov_type: 'generic_ansible_playbook',
       type: 'ServiceTemplateAnsiblePlaybook',
       additional_tenant_ids: additionalTenantIds,

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -12,6 +12,7 @@ describe "catalog/_form.html.haml" do
     create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
     @automate_tree = TreeBuilderAeClass.new(:automate_tree, @sb)
     @available_catalogs = [%w(test 1)]
+    @zones = [{1 => 'zone 1', 2 => 'zone 2'}]
     assign(:tenants_tree, TreeBuilderTenants.new('tenants_tree', @sb, true, :additional_tenants => [], :selectable => true))
   end
 


### PR DESCRIPTION
This commit adds a zone drop down to angular and non-angular catalog item add/edit forms.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1415106

Non- Angular form
![after1](https://user-images.githubusercontent.com/3450808/58290476-df2f8080-7d87-11e9-995d-2822cd2bf87a.png)

Angular form
![after2](https://user-images.githubusercontent.com/3450808/58290484-e5bdf800-7d87-11e9-9d00-ff0ae6f83a3c.png)

Details screen
![after3](https://user-images.githubusercontent.com/3450808/58290489-e9ea1580-7d87-11e9-9331-d991100cee60.png)

Automation Task Schedule edit screen
![Screenshot from 2019-05-29 13-40-26](https://user-images.githubusercontent.com/3450808/58578742-788ee480-8217-11e9-8771-4c18c391fa9c.png)

Automation Task Schedule details
![Screenshot from 2019-05-29 13-40-59](https://user-images.githubusercontent.com/3450808/58578756-817fb600-8217-11e9-8b4f-498226b27b38.png)

