### PR TITLE
Migrate service dialog from orchestration template from to data driven forms

### DIFF
--- a/app/javascript/components/orchestration-template/service-dialog-from-ot.jsx
+++ b/app/javascript/components/orchestration-template/service-dialog-from-ot.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'patternfly-react';
+
+import MiqFormRenderer from '../../forms/data-driven-form';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
+import { API } from '../../http_api';
+import serviceDialogFromOtSchema from './service-dialog-from-ot.schema';
+
+const ServiceDialogFromOt = ({ otId }) => {
+  const onSubmit = values => API.post('/api/service_dialogs', {
+    action: 'orchestration_template_service_dialog',
+    resource: {
+      ...values,
+      ot_id: otId,
+    },
+  }).then(() => miqRedirectBack(
+    sprintf(__('Service Dialog "%s" was successfully created'), values.label),
+    'success', '/catalog/explorer',
+  ));
+
+  return (
+    <Grid fluid>
+      <MiqFormRenderer
+        schema={serviceDialogFromOtSchema}
+        onSubmit={onSubmit}
+        onCancel={() => miqRedirectBack(__('Creation of a new Service Dialog was cancelled by the user'), 'success', '/catalog/explorer')}
+        buttonsLabels={{ submitLabel: __('Save') }}
+      />
+    </Grid>
+  );
+};
+
+ServiceDialogFromOt.propTypes = {
+  otId: PropTypes.number.isRequired,
+};
+
+export default ServiceDialogFromOt;

--- a/app/javascript/components/orchestration-template/service-dialog-from-ot.schema.js
+++ b/app/javascript/components/orchestration-template/service-dialog-from-ot.schema.js
@@ -1,0 +1,29 @@
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import { API } from '../../http_api';
+import debouncePromise from '../../helpers/promise-debounce';
+
+const asyncValidator = label => API.get(`/api/service_dialogs?filter[]=label=${label}`)
+  .then(({ subcount }) => {
+    if (!label) {
+      return __('Required');
+    }
+    if (subcount !== 0) {
+      return __('Name has already been taken');
+    }
+    return undefined;
+  });
+
+const asyncValidatorDebounced = debouncePromise(asyncValidator);
+
+const serviceDialogFromOtSchema = ({
+  fields: [{
+    component: componentTypes.TEXT_FIELD,
+    name: 'label',
+    label: __('Service Dialog Name'),
+    isRequired: true,
+    validateOnMount: true,
+    validate: [asyncValidatorDebounced],
+  }],
+});
+
+export default serviceDialogFromOtSchema;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -16,6 +16,7 @@ import ImportDatastoreViaGit from '../components/automate-import-export-form/imp
 import MiqAboutModal from '../components/miq-about-modal';
 import OrcherstrationTemplateForm from '../components/orchestration-template/orcherstration-template-form';
 import RemoveCatalogItemModal from '../components/remove-catalog-item-modal';
+import ServiceDialogFromOtForm from '../components/orchestration-template/service-dialog-from-ot';
 import ServiceForm from '../components/service-form';
 import SetServiceOwnershipForm from '../components/set-service-ownership-form';
 import TableListViewWrapper from '../react/table_list_view_wrapper';
@@ -44,6 +45,7 @@ ManageIQ.component.addReact('ImportDatastoreViaGit', ImportDatastoreViaGit);
 ManageIQ.component.addReact('MiqAboutModal', MiqAboutModal);
 ManageIQ.component.addReact('OrcherstrationTemplateForm', OrcherstrationTemplateForm);
 ManageIQ.component.addReact('RemoveCatalogItemModal', RemoveCatalogItemModal);
+ManageIQ.component.addReact('ServiceDialogFromOtForm', ServiceDialogFromOtForm);
 ManageIQ.component.addReact('ServiceForm', ServiceForm);
 ManageIQ.component.addReact('SetServiceOwnershipForm', SetServiceOwnershipForm);
 ManageIQ.component.addReact('TableListView', TableListView);

--- a/app/javascript/spec/orchestration-template/service-dialog-from-ot.spec.js
+++ b/app/javascript/spec/orchestration-template/service-dialog-from-ot.spec.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import fetchMock from 'fetch-mock';
+
+import '../helpers/addFlash';
+import '../helpers/miqFlashLater';
+import '../helpers/miqSparkle';
+import '../helpers/sprintf';
+
+import ServiceDialogFromOt from '../../components/orchestration-template/service-dialog-from-ot';
+
+describe('<ServiceDialogFromOt />', () => {
+  let initialProps;
+
+  beforeEach(() => {
+    initialProps = {
+      otId: 123,
+    };
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  it('should submit data correctly', (done) => {
+    fetchMock.postOnce('/api/service_dialogs', {});
+    fetchMock.getOnce('/api/service_dialogs?filter[]=label=undefined', { subcount: 0 });
+    fetchMock.getOnce('/api/service_dialogs?filter[]=label=Foo', { subcount: 0 });
+
+    const wrapper = mount(<ServiceDialogFromOt {...initialProps} />);
+    // need to use timeout because of debounced request
+    setTimeout(() => {
+      // should check if label is unique
+      expect(fetchMock.calls()).toHaveLength(1);
+      // form is invalid so should not call submit;
+      wrapper.find('button').first().simulate('click');
+      wrapper.find('input').simulate('change', { target: { value: 'Foo' } });
+      setTimeout(() => {
+        wrapper.find('button').first().simulate('click');
+        expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual({
+          action: 'orchestration_template_service_dialog',
+          resource: { label: 'Foo', ot_id: 123 },
+        });
+        done();
+      }, 500);
+    }, 500);
+  });
+
+  it('should fail async label validation', (done) => {
+    fetchMock.getOnce('/api/service_dialogs?filter[]=label=undefined', { subcount: 1 });
+    fetchMock.getOnce('/api/service_dialogs?filter[]=label=Bla', { subcount: 1 });
+
+    const wrapper = mount(<ServiceDialogFromOt {...initialProps} />);
+
+    setTimeout(() => {
+      wrapper.find('input').simulate('change', { target: { value: 'Bla' } });
+      setTimeout(() => {
+        wrapper.update();
+        expect(wrapper.find('button').first().props().disabled).toEqual(true);
+        done();
+      }, 500);
+    }, 500);
+  });
+});

--- a/app/views/catalog/_service_dialog_from_ot.html.haml
+++ b/app/views/catalog/_service_dialog_from_ot.html.haml
@@ -1,17 +1,4 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for_only_path(:action => "ot_form_field_changed", :id => @edit[:rec_id])
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _('Service Dialog Name')
-        .col-md-8
-          = text_field_tag("dialog_name",
-                           "",
-                           :autocomplete => 'off',
-                           :diabled => false,
-                           :class => "form-control",
-                           :maxlength => 255,
-                           "data-miq_observe" => {:interval => '.5',
-                                                  :url      => url}.to_json)
+    = react('ServiceDialogFromOtForm', { :otId => @edit[:rec_id] })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,7 +311,6 @@ Rails.application.routes.draw do
         orchestration_template_copy
         orchestration_template_edit
         ot_add_form_field_changed
-        ot_form_field_changed
         ot_tags_edit
         ownership_form_fields
         ownership_update

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -419,34 +419,6 @@ describe CatalogController do
       end
     end
 
-    describe "#service_dialog_create_from_ot" do
-      before do
-        @ot = FactoryBot.create(:orchestration_template_amazon_in_json)
-        @dialog_label = "New Dialog 01"
-        session[:edit] = {
-          :new    => {:dialog_name => @dialog_label},
-          :key    => "ot_edit__#{@ot.id}",
-          :rec_id => @ot.id
-        }
-        controller.instance_variable_set(:@sb, :trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree)
-        controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
-      end
-
-      after(:each) do
-        expect(controller.send(:flash_errors?)).not_to be_truthy
-        expect(assigns(:edit)).to be_nil
-        expect(response.status).to eq(200)
-      end
-
-      it "Service Dialog is created from an Orchestration Template" do
-        controller.params = {:button => "save", :id => @ot.id}
-        allow(controller).to receive(:replace_right_cell)
-        controller.send(:service_dialog_from_ot_submit)
-        expect(assigns(:flash_array).first[:message]).to include("was successfully created")
-        expect(Dialog.where(:label => @dialog_label).first).not_to be_nil
-      end
-    end
-
     describe "#ot_rendering" do
       render_views
       before do

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -40,13 +40,11 @@ describe 'routes for CatalogController' do
     orchestration_template_add
     orchestration_template_copy
     orchestration_template_edit
-    ot_form_field_changed
     ot_tags_edit
     prov_field_changed
     reload
     resolve
     resource_delete
-    service_dialog_from_ot_submit
     servicetemplate_edit
     sort_ds_grid
     sort_host_grid


### PR DESCRIPTION
Form is at `Service > Catalogs >  Orchestration Templates tab > select template > open Configuration dropdown > Create service Dialog from orchestration template`

### Before
![screenshot-localhost-3000-2019 06 19-11-09-36](https://user-images.githubusercontent.com/22619452/59752547-bdd88c00-9282-11e9-8e85-84c948135e3c.png)

### After
![screenshot-localhost-3000-2019 06 19-11-08-29](https://user-images.githubusercontent.com/22619452/59752464-95509200-9282-11e9-84bd-9c4155586ff5.png)


waiting for: ~https://github.com/ManageIQ/manageiq-api/pull/596~ and ~#5552~