### PR TITLE
[WIP] Add generic objects as default menu item

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -233,14 +233,14 @@ module Menu
 
       def automate_menu_section
         Menu::Section.new(:automate, N_("Automate"), 'pficon pficon-automation', [
-          Menu::Item.new('miq_ae_class',         N_('Explorer'),        'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},            '/miq_ae_class/explorer'),
-          Menu::Item.new('miq_ae_tools',         N_('Simulation'),      'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},       '/miq_ae_tools/resolve'),
-          Menu::Item.new('generic_object_definition', N_('Generic Object Definitions'), 'generic_object_definition', {:feature => 'generic_object_definition'},   '/generic_object_definition/show_list'),
-          Menu::Item.new('generic_object', N_('Generic Objects'), 'generic_object', {:feature => 'generic_object'},   '/generic_object/show_list'),
-          Menu::Item.new('miq_ae_customization', N_('Customization'),   'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer', :any => true}, '/miq_ae_customization/explorer'),
-          Menu::Item.new('miq_ae_export',        N_('Import / Export'), 'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},    '/miq_ae_tools/import_export'),
-          Menu::Item.new('miq_ae_logs',          N_('Log'),             'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},              '/miq_ae_tools/log'),
-          Menu::Item.new('miq_request_ae',       N_('Requests'),        'ae_miq_request',                {:feature => 'ae_miq_request_show_list'},      '/miq_request/show_list?typ=ae')
+          Menu::Item.new('miq_ae_class',              N_('Explorer'),                   'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},                          '/miq_ae_class/explorer'),
+          Menu::Item.new('miq_ae_tools',              N_('Simulation'),                 'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},                     '/miq_ae_tools/resolve'),
+          Menu::Item.new('generic_object_definition', N_('Generic Object Definitions'), 'generic_object_definition',     {:feature => 'generic_object_definition'},                   '/generic_object_definition/show_list'),
+          Menu::Item.new('generic_object',            N_('Generic Objects'),            'generic_object',                {:feature => 'generic_object'},                              '/generic_object/show_list'),
+          Menu::Item.new('miq_ae_customization',      N_('Customization'),              'miq_ae_customization_explorer', {:feature => 'miq_ae_customization_explorer', :any => true}, '/miq_ae_customization/explorer'),
+          Menu::Item.new('miq_ae_export',             N_('Import / Export'),            'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},                  '/miq_ae_tools/import_export'),
+          Menu::Item.new('miq_ae_logs',               N_('Log'),                        'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},                            '/miq_ae_tools/log'),
+          Menu::Item.new('miq_request_ae',            N_('Requests'),                   'ae_miq_request',                {:feature => 'ae_miq_request_show_list'},                    '/miq_request/show_list?typ=ae')
         ].compact)
       end
 

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -151,13 +151,13 @@ describe Menu::DefaultMenu do
         )
 
         expect(menu.automate_menu_section.items.map(&:rbac_feature)). to match_array([{:feature => "miq_ae_domain_view"},
-                                                                             {:feature => "miq_ae_class_simulation"},
-                                                                             {:feature => "miq_ae_customization_explorer", :any => true},
-                                                                             {:feature => "generic_object_definition"},
-                                                                             {:feature => "generic_object"},
-                                                                             {:feature => "miq_ae_class_import_export"},
-                                                                             {:feature => "miq_ae_class_log"},
-                                                                             {:feature => "ae_miq_request_show_list"}])
+                                                                                      {:feature => "miq_ae_class_simulation"},
+                                                                                      {:feature => "miq_ae_customization_explorer", :any => true},
+                                                                                      {:feature => "generic_object_definition"},
+                                                                                      {:feature => "generic_object"},
+                                                                                      {:feature => "miq_ae_class_import_export"},
+                                                                                      {:feature => "miq_ae_class_log"},
+                                                                                      {:feature => "ae_miq_request_show_list"}])
       end
     end
   end

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -154,6 +154,7 @@ describe Menu::DefaultMenu do
                                                                              {:feature => "miq_ae_class_simulation"},
                                                                              {:feature => "miq_ae_customization_explorer", :any => true},
                                                                              {:feature => "generic_object_definition"},
+                                                                             {:feature => "generic_object"},
                                                                              {:feature => "miq_ae_class_import_export"},
                                                                              {:feature => "miq_ae_class_log"},
                                                                              {:feature => "ae_miq_request_show_list"}])


### PR DESCRIPTION
unable to use generic objects in API as user and in default menu items generic objects is absent , only generic object definitions