### PR TITLE
Advanced search modal - only render once, always, hidden

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -169,8 +169,8 @@ module ApplicationController::AdvancedSearch
     render :update do |page|
       page << javascript_prologue
       page.replace("#{tree_name}_div",  :partial => "shared/tree",               :locals => {:tree => tree, :name => tree_name})
-      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode})
-      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode})
+      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode, :force => true})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode, :force => true})
     end
   end
 
@@ -179,8 +179,8 @@ module ApplicationController::AdvancedSearch
     render :update do |page|
       page << javascript_prologue
       page.replace(:listnav_div, :partial => "layouts/listnav")
-      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode})
-      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode})
+      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode, :force => true})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode, :force => true})
     end
   end
 
@@ -228,8 +228,8 @@ module ApplicationController::AdvancedSearch
         @edit[@expkey][:exp_chosen_report] = nil
         @edit[@expkey][:exp_chosen_search] = nil
       end
-      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode})
-      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode})
+      page.replace("adv_search_body",   :partial => "layouts/adv_search_body",   :locals => {:mode => display_mode, :force => true})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:mode => display_mode, :force => true})
     end
   end
 

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -9,6 +9,10 @@ module ApplicationController::Explorer
                 .compact
   end
 
+  def replace_search_box(presenter, locals = {})
+    presenter.replace(:adv_searchbox_div, r[:partial => 'layouts/x_adv_searchbox', :locals => locals])
+  end
+
   def try_build_tree(tree_symbol)
     # Legacy support for build_*_tree methods
     # FIXME: delete this after all of them were converted (remaining: build_reports_tree)

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -11,6 +11,7 @@ module ApplicationController::Explorer
 
   def replace_search_box(presenter, locals = {})
     presenter.replace(:adv_searchbox_div, r[:partial => 'layouts/x_adv_searchbox', :locals => locals])
+    presenter.replace(:advsearchModal, r[:partial => 'layouts/adv_search'])
   end
 
   def try_build_tree(tree_symbol)

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -53,8 +53,8 @@ module ApplicationController::Filter
         # Don't need to replace flash div as it's included throught
         # exp_editor. That is rendered either throught adv_search_body or directly.
         if !@edit[:adv_search_open].nil?
-          page.replace("adv_search_body", :partial => "layouts/adv_search_body")
-          page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
+          page.replace("adv_search_body", :partial => "layouts/adv_search_body", :locals => {:force => true})
+          page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:force => true})
         else
           page.replace("exp_editor_div", :partial => "layouts/exp_editor")
         end
@@ -159,8 +159,8 @@ module ApplicationController::Filter
     render :update do |page|
       page << javascript_prologue
       page << "ManageIQ.explorer.clearSearchToggle(#{clear_search_status});"
-      page.replace("adv_search_body", :partial => "layouts/adv_search_body")
-      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
+      page.replace("adv_search_body", :partial => "layouts/adv_search_body", :locals => {:force => true})
+      page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:force => true})
       page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
       @edit[@expkey].render_values_to(page)
       page << set_spinner_off

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -411,13 +411,8 @@ class AutomationManagerController < ApplicationController
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
-    replace_search_box(presenter)
-  end
 
-  def replace_search_box(presenter)
-    presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => providers_active_tree?}])
+    replace_search_box(presenter, :nameonly => providers_active_tree?)
   end
 
   def group_summary_tab_selected?

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -343,7 +343,7 @@ class InfraNetworkingController < ApplicationController
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
 
-    replace_search_box(presenter)
+    replace_search_box(presenter, :nameonly => x_active_tree == :infra_networking_tree)
     handle_bottom_cell(presenter)
     rebuild_toolbars(record_showing, presenter)
     presenter[:right_cell_text] = @right_cell_text
@@ -483,11 +483,8 @@ class InfraNetworkingController < ApplicationController
     end
   end
 
-  def replace_search_box(presenter)
-    # Replace the searchbox
-    presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => x_active_tree == :infra_networking_tree}])
+  def replace_search_box(presenter, locals = {})
+    super(presenter, locals)
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
   end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -678,8 +678,7 @@ class MiqPolicyController < ApplicationController
 
     presenter.hide(:form_buttons_div) if options[:remove_form_buttons]
 
-    # Replace the searchbox
-    presenter.replace(:adv_searchbox_div, r[:partial => 'layouts/x_adv_searchbox', :locals => {:nameonly => true}])
+    replace_search_box(presenter, :nameonly => true)
 
     # Hide/show searchbox depending on if a list is showing
     presenter.set_visibility(@show_adv_search, :adv_searchbox_div)

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -439,10 +439,8 @@ module Mixins
       @sb["#{controller_name.underscore}_search_text".to_sym][:current_node] = x_node
     end
 
-    def replace_search_box(presenter)
-      # Replace the searchbox
-      presenter.replace(:adv_searchbox_div,
-                        r[:partial => 'layouts/x_adv_searchbox'])
+    def replace_search_box(presenter, locals = {})
+      super(presenter, locals)
 
       presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
     end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -364,13 +364,6 @@ class ProviderForemanController < ApplicationController
     node
   end
 
-  def replace_search_box(presenter)
-    # Replace the searchbox
-    presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => provider_active_tree?}])
-  end
-
   def update_partials(record_showing, presenter)
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
@@ -396,7 +389,8 @@ class ProviderForemanController < ApplicationController
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
-    replace_search_box(presenter)
+
+    replace_search_box(presenter, :nameonly => provider_active_tree?)
   end
 
   def group_summary_tab_selected?

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -351,7 +351,7 @@ class StorageController < ApplicationController
 
     presenter = rendering_objects
     update_partials(record_showing, presenter)
-    replace_search_box(presenter)
+    replace_search_box(presenter, :nameonly => x_active_tree == :storage)
     handle_bottom_cell(presenter)
     reload_trees_by_presenter(presenter, trees)
     rebuild_toolbars(record_showing, presenter)
@@ -389,11 +389,8 @@ class StorageController < ApplicationController
     end
   end
 
-  def replace_search_box(presenter)
-    # Replace the searchbox
-    presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => x_active_tree == :storage}])
+  def replace_search_box(presenter, locals = {})
+    super(presenter, locals)
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1245,11 +1245,7 @@ module VmCommon
       }
     end
 
-    # Replace the searchbox
-    presenter.replace(:adv_searchbox_div, r[
-      :partial => 'layouts/x_adv_searchbox',
-      :locals  => {:nameonly => %i[images_tree instances_tree vandt_tree].include?(x_active_tree)}
-    ])
+    replace_search_box(presenter, :nameonly => %i[images_tree instances_tree vandt_tree].include?(x_active_tree))
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
     if @sb[:action] == "policy_sim"

--- a/app/views/layouts/_adv_search.html.haml
+++ b/app/views/layouts/_adv_search.html.haml
@@ -1,32 +1,32 @@
-- if show_adv_search? && @edit && @edit[@expkey].present?
-  - mode ||= "search"
+- mode ||= "search"
 
-  .modal.fade#advsearchModal{"tabindex"        => "-1",
-                             "role"            => "dialog",
-                             "aria-labelledby" => "adv_search_label",
-                             "aria-describedby" => "modal",
-                             "aria-hidden"     => "true",
-                             "data-keyboard"   => "false",
-                             "data-backdrop"   => "static",
-                             :style            => "display: none"}
-    .modal-dialog.modal-xl
-      .modal-content
-        #search_notification{:style => "display: none;"}
-        .modal-header
-          %button.close{"data-dismiss" => "modal"}
-            %span{"aria-hidden" => "true"}
-              &times;
-            %span.sr-only
-              Close
-          %h4.modal-title#adv_search_label
-            = _("Advanced Search")
-        .modal-body
-          %div{:id => "searching_spinner_center", :style => "position: absolute;display: block;top: 50%;left: 50%;"}
-          = render(:partial => 'layouts/adv_search_body', :locals => {:mode => mode})
-        .modal-footer
-          = render(:partial => 'layouts/adv_search_footer', :locals => {:mode => mode})
+.modal.fade#advsearchModal{"tabindex"         => "-1",
+                           "role"             => "dialog",
+                           "aria-labelledby"  => "adv_search_label",
+                           "aria-describedby" => "modal",
+                           "aria-hidden"      => "true",
+                           "data-keyboard"    => "false",
+                           "data-backdrop"    => "static",
+                           :style             => "display: none"}
+  .modal-dialog.modal-xl
+    .modal-content
+      #search_notification{:style => "display: none;"}
+      .modal-header
+        %button.close{"data-dismiss" => "modal"}
+          %span{"aria-hidden" => "true"}
+            &times;
+          %span.sr-only
+            = _("Close")
+        %h4.modal-title#adv_search_label
+          = _("Advanced Search")
+      .modal-body
+        %div{:id => "searching_spinner_center", :style => "position: absolute; display: block; top: 50%; left: 50%;"}
+        = render(:partial => 'layouts/adv_search_body', :locals => {:mode => mode})
+      .modal-footer
+        = render(:partial => 'layouts/adv_search_footer', :locals => {:mode => mode})
+
 :javascript
-  $(function(){
+  $(function() {
     $('#advsearchModal').off("click");
     $('#advsearchModal').on('click', '[data-dismiss="modal"]', function() {
       miqJqueryRequest("adv_search_toggle", {beforeSend: true});

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -1,7 +1,8 @@
 - mode ||= "search"
+- force ||= false
 
 #adv_search_body
-  - if show_adv_search? && @edit && @edit[@expkey].present?
+  - if force || (show_adv_search? && @edit && @edit[@expkey].present?)
     - url = url_for_only_path(:action => 'adv_search_load_choice')
     - url2 = url_for_only_path(:action => 'adv_search_name_typed')
     - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -1,84 +1,87 @@
-- url = url_for_only_path(:action => 'adv_search_load_choice')
-- url2 = url_for_only_path(:action => 'adv_search_name_typed')
-- report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 - mode ||= "search"
+
 #adv_search_body
-  - if mode == "search"
-    - if @edit && @edit[@expkey] && @edit[@expkey][:selected]
-      = " (#{h(@edit[@expkey][:selected][:description])})"
-    - elsif @edit && @edit[:adv_search_report]
-      = " (from report #{h(@edit[:adv_search_report])})"
-    %br
-    - if @edit && @edit[@expkey][:expression]
-      = render(:partial => 'layouts/exp_editor')
-  - elsif mode == "load"
-    - if @exp_to_load
+  - if show_adv_search? && @edit && @edit[@expkey].present?
+    - url = url_for_only_path(:action => 'adv_search_load_choice')
+    - url2 = url_for_only_path(:action => 'adv_search_name_typed')
+    - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
+
+    - if mode == "search"
+      - if @edit && @edit[@expkey] && @edit[@expkey][:selected]
+        = " (#{h(@edit[@expkey][:selected][:description])})"
+      - elsif @edit && @edit[:adv_search_report]
+        = " (from report #{h(@edit[:adv_search_report])})"
+      %br
+      - if @edit && @edit[@expkey][:expression]
+        = render(:partial => 'layouts/exp_editor')
+    - elsif mode == "load"
+      - if @exp_to_load
+        %fieldset
+          %h3
+            = _("Search Expression Preview")
+          - @exp_to_load.each do |token|
+            - if ! ["AND", "OR", "(", ")"].include?([token].flatten.first)
+              = h([token].flatten.first)
+            - else
+              %font{:color => "black"}
+                %b= h([token].flatten.first)
       %fieldset
-        %h3
-          = _("Search Expression Preview")
-        - @exp_to_load.each do |token|
-          - if ! ["AND", "OR", "(", ")"].include?([token].flatten.first)
-            = h([token].flatten.first)
-          - else
-            %font{:color => "black"}
-              %b= h([token].flatten.first)
-    %fieldset
-      .form-horizontal
-        - unless @edit[@expkey].available_adv_searches.blank?
-          .form-group
-            %label.control-label.col-md-2
-              %font{:color => "black"}
-                = _("Choose a saved %{model} filter:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
-            .col-md-8
-              = select_tag("chosen_search",
-                           options_for_select([[_("<Choose>"), "0"]] + @edit[@expkey].available_adv_searches,
-                                                  @edit[@expkey][:exp_chosen_search]),
-                           :multiple          => false,
-                           :class             => "selectpicker")
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent('chosen_search', '#{url}')
-        - unless @edit[@expkey].available_adv_searches.blank? || report_expressions.blank?
-          .form-group
-            %label.control-label.col-md-2
-              = _("-- OR --")
-        - unless report_expressions.blank?
-          .form-group
-            %label.control-label.col-md-2
-              %font{:color => "black"}
-                = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
-  - elsif mode == "save"
-    = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'} if params[:button] != 'save'
-    .modal-body
-      .form-horizontal.static
-        .form-group
-          %label.control-label.col-md-5
-            = _("Search Expression")
-          .col-md-6
-            - @edit[@expkey][:exp_table].each do |token|
-              - if ! ["AND", "OR", "(", ")"].include?([token].flatten.first)
-                = h([token].flatten.first)
-              - else
+        .form-horizontal
+          - unless @edit[@expkey].available_adv_searches.blank?
+            .form-group
+              %label.control-label.col-md-2
                 %font{:color => "black"}
-                  %b= h([token].flatten.first)
-      .form-horizontal
-        .form-group
-          %label.control-label.col-md-5
-            = _("Save this %{model} search as:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
-          .col-md-6
-            %span#search_name_span
-              = text_field_tag("search_name",
-                               h(@edit[:new_search_name]) || h(@edit[:adv_search_name]),
-                               :maxlength         => 30,
-                               :class             => "form-control",
-                               "data-miq_focus"   => true,
-                               "data-miq_observe" => {:interval => ".5", :url => url2}.to_json)
-        - if report_admin_user?
+                  = _("Choose a saved %{model} filter:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
+              .col-md-8
+                = select_tag("chosen_search",
+                             options_for_select([[_("<Choose>"), "0"]] + @edit[@expkey].available_adv_searches,
+                                                    @edit[@expkey][:exp_chosen_search]),
+                             :multiple          => false,
+                             :class             => "selectpicker")
+                :javascript
+                  miqInitSelectPicker();
+                  miqSelectPickerEvent('chosen_search', '#{url}')
+          - unless @edit[@expkey].available_adv_searches.blank? || report_expressions.blank?
+            .form-group
+              %label.control-label.col-md-2
+                = _("-- OR --")
+          - unless report_expressions.blank?
+            .form-group
+              %label.control-label.col-md-2
+                %font{:color => "black"}
+                  = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
+    - elsif mode == "save"
+      = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'} if params[:button] != 'save'
+      .modal-body
+        .form-horizontal.static
           .form-group
             %label.control-label.col-md-5
-              = _("Global search:")
+              = _("Search Expression")
             .col-md-6
-              - checked = @edit && @edit[:expression] && @edit[:expression][:selected] && @edit[:expression][:selected][:typ] == "global"
-              = check_box_tag("search_type", "1", checked,
-                :style                      => "width: 20px",
-                "data-miq_observe_checkbox" => {:url => url2}.to_json)
+              - @edit[@expkey][:exp_table].each do |token|
+                - if ! ["AND", "OR", "(", ")"].include?([token].flatten.first)
+                  = h([token].flatten.first)
+                - else
+                  %font{:color => "black"}
+                    %b= h([token].flatten.first)
+        .form-horizontal
+          .form-group
+            %label.control-label.col-md-5
+              = _("Save this %{model} search as:") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
+            .col-md-6
+              %span#search_name_span
+                = text_field_tag("search_name",
+                                 h(@edit[:new_search_name]) || h(@edit[:adv_search_name]),
+                                 :maxlength         => 30,
+                                 :class             => "form-control",
+                                 "data-miq_focus"   => true,
+                                 "data-miq_observe" => {:interval => ".5", :url => url2}.to_json)
+          - if report_admin_user?
+            .form-group
+              %label.control-label.col-md-5
+                = _("Global search:")
+              .col-md-6
+                - checked = @edit && @edit[:expression] && @edit[:expression][:selected] && @edit[:expression][:selected][:typ] == "global"
+                = check_box_tag("search_type", "1", checked,
+                  :style                      => "width: 20px",
+                  "data-miq_observe_checkbox" => {:url => url2}.to_json)

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -1,7 +1,8 @@
 - mode ||= "search"
+- force ||= false
 
 #adv_search_footer
-  - if show_adv_search? && @edit && @edit[@expkey].present?
+  - if force || (show_adv_search? && @edit && @edit[@expkey].present?)
     - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 
     - if mode == "search"

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -1,92 +1,94 @@
-- report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
 - mode ||= "search"
 
 #adv_search_footer
-  - if mode == "search"
-    - if @edit[@expkey].available_adv_searches.blank? && report_expressions.blank?
-      = button_tag(_("Load"),
-                   :class => "btn btn-primary disabled pull-left",
-                   :alt   => t = _("No saved filters or report filters are available to load"),
-                   :title => t)
-    - else
-      = button_tag(_('Load'),
-                   :class   => "btn btn-primary pull-left",
-                   :alt     => t = _("Load a filter"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "load")}');")
-    - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Apply"),
-                   :class => "btn btn-primary disabled",
-                   :alt   => t = _("No filter available"),
-                   :title => t)
-    - else
-      = button_tag(_('Apply'),
-                   :class   => "btn btn-primary",
-                   :alt     => t = _("Apply the current filter"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
-    - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
-      - if report_admin_user? || @edit[@expkey][:selected][:typ] == "user"
-        - actual_filter = @edit[@expkey][:selected][:description]
-        - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_model]),
-                                                                            :filter => actual_filter}
-        - t = _("Delete the filter named %{filter_name}") % {:filter_name => actual_filter}
-        = link_to('Delete',
-                  url_for_only_path(:action => 'adv_search_button',
-                                    :button => "delete"),
-                  :alt           => t,
-                  :class         => "btn btn-danger",
-                  'data-confirm' => confirm_msg,
-                  "data-method"  => :post,
-                  :remote        => true,
-                  :title         => t)
-    - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Save"),
-                   :class => "btn btn-primary disabled",
-                   :alt   => t = _("No filter available"),
-                   :title => t)
-    - else
+  - if show_adv_search? && @edit && @edit[@expkey].present?
+    - report_expressions = MiqReport.get_expressions_by_model(@edit[@expkey][:exp_model])
+
+    - if mode == "search"
+      - if @edit[@expkey].available_adv_searches.blank? && report_expressions.blank?
+        = button_tag(_("Load"),
+                     :class => "btn btn-primary disabled pull-left",
+                     :alt   => t = _("No saved filters or report filters are available to load"),
+                     :title => t)
+      - else
+        = button_tag(_('Load'),
+                     :class   => "btn btn-primary pull-left",
+                     :alt     => t = _("Load a filter"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "load")}');")
+      - if @edit[@expkey][:exp_table].flatten.first == "???"
+        = button_tag(_("Apply"),
+                     :class => "btn btn-primary disabled",
+                     :alt   => t = _("No filter available"),
+                     :title => t)
+      - else
+        = button_tag(_('Apply'),
+                     :class   => "btn btn-primary",
+                     :alt     => t = _("Apply the current filter"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
+      - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
+        - if report_admin_user? || @edit[@expkey][:selected][:typ] == "user"
+          - actual_filter = @edit[@expkey][:selected][:description]
+          - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_model]),
+                                                                              :filter => actual_filter}
+          - t = _("Delete the filter named %{filter_name}") % {:filter_name => actual_filter}
+          = link_to('Delete',
+                    url_for_only_path(:action => 'adv_search_button',
+                                      :button => "delete"),
+                    :alt           => t,
+                    :class         => "btn btn-danger",
+                    'data-confirm' => confirm_msg,
+                    "data-method"  => :post,
+                    :remote        => true,
+                    :title         => t)
+      - if @edit[@expkey][:exp_table].flatten.first == "???"
+        = button_tag(_("Save"),
+                     :class => "btn btn-primary disabled",
+                     :alt   => t = _("No filter available"),
+                     :title => t)
+      - else
+        = button_tag(_('Save'),
+                     :class   => "btn btn-primary",
+                     :alt     => t = _("Save the current filter"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "save")}');")
+      - if @edit[@expkey][:exp_table].flatten.first == "???"
+        = button_tag(_("Reset"),
+                     :class => "btn btn-default disabled",
+                     :alt   => t = _("No filter available"),
+                     :title => t)
+      - else
+        = button_tag(_('Reset'),
+                     :class   => "btn btn-default",
+                     :alt     => t = _("Reset the filter"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "reset")}');")
+    - elsif mode == "load"
+      - if @edit[@expkey][:exp_chosen_report].nil? && @edit[@expkey][:exp_chosen_search].nil?
+        = button_tag(_("Load"),
+                     :class => "btn btn-primary disabled pull-left",
+                     :alt   => t = _("Choose a saved filter or report filter to load"),
+                     :title => t)
+      - else
+        = button_tag(_('Load'),
+                     :class   => "btn btn-primary pull-left",
+                     :alt     => t = _("Load the filter shown above"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "loadit")}');")
+      = button_tag(_('Cancel'),
+                     :class   => "btn btn-primary",
+                     :alt     => t = _("Cancel the load"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")
+    - elsif mode == "save"
       = button_tag(_('Save'),
-                   :class   => "btn btn-primary",
-                   :alt     => t = _("Save the current filter"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "save")}');")
-    - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Reset"),
-                   :class => "btn btn-default disabled",
-                   :alt   => t = _("No filter available"),
-                   :title => t)
-    - else
-      = button_tag(_('Reset'),
-                   :class   => "btn btn-default",
-                   :alt     => t = _("Reset the filter"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "reset")}');")
-  - elsif mode == "load"
-    - if @edit[@expkey][:exp_chosen_report].nil? && @edit[@expkey][:exp_chosen_search].nil?
-      = button_tag(_("Load"),
-                   :class => "btn btn-primary disabled pull-left",
-                   :alt   => t = _("Choose a saved filter or report filter to load"),
-                   :title => t)
-    - else
-      = button_tag(_('Load'),
-                   :class   => "btn btn-primary pull-left",
-                   :alt     => t = _("Load the filter shown above"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "loadit")}');")
-    = button_tag(_('Cancel'),
-                   :class   => "btn btn-primary",
-                   :alt     => t = _("Cancel the load"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")
-  - elsif mode == "save"
-    = button_tag(_('Save'),
-                   :class   => "btn btn-primary",
-                   :alt     => t = _("Save the current search"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "saveit")}');")
-    = button_tag(_('Cancel'),
-                   :class   => "btn btn-default",
-                   :alt     => t = _("Cancel the save"),
-                   :title   => t,
-                   :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")
+                     :class   => "btn btn-primary",
+                     :alt     => t = _("Save the current search"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "saveit")}');")
+      = button_tag(_('Cancel'),
+                     :class   => "btn btn-default",
+                     :alt     => t = _("Cancel the save"),
+                     :title   => t,
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "cancel")}');")

--- a/app/views/layouts/_searchbar.html.haml
+++ b/app/views/layouts/_searchbar.html.haml
@@ -1,7 +1,4 @@
 - if @lastaction == "show_list" && !session[:menu_click] && display_adv_search? && !@in_a_form
-  = hidden_div_if(@edit && @edit[:adv_search_open] != true, :id => "adv_search_div") do
-    - if @edit && @edit[:adv_search_open]
-      = render :partial => 'layouts/adv_search'
   = render :partial => 'layouts/quick_search'
   #searchbox
     = form_tag({:action => 'show_list'},

--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -1,11 +1,7 @@
 -# If set, don't show advanced search and add nameonly class to name fields
 - nameonly ||= false
-#adv_searchbox_div{:style => "display: none;"}
-  -# Hidden advanced search box
-  = hidden_div_if(@edit && @edit[:adv_search_open] != true, :id => "adv_search_div") do
-    - if @edit && @edit[:adv_search_open]
-      = render :partial => 'layouts/adv_search'
 
+#adv_searchbox_div{:style => "display: none;"}
   -# Name based search box
   #searchbox.search-pf.has-button.form-group.pull-right{:class => ::Settings.server.custom_logo ? "whitelabeled" : ""}
     .form-group.has-clear

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -193,6 +193,7 @@ describe VmOrTemplateController do
                                                             :locals  => {:controller => "vm"}).exactly(1).times
       expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_adv_searchbox",
                                                             :locals  => {:nameonly => true}).exactly(1).times
+      expect(controller).to receive(:render_to_string).with(:partial => "layouts/adv_search").exactly(1).times
       expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_edit_buttons",
                                                             :locals  => {:action_url      => "prov_edit",
                                                                          :record_id       => vm.id,


### PR DESCRIPTION
Currently the advanced search **modal** (`layouts/_adv_search`) is rendered twice on most screens:

* from `layouts/_footer`, unconditionally called from application layout
* from `layouts/_x_adv_searchbox` called from explorer controller explorer views
* from `layouts/_searchbar` called from the `center_div_with_listnav` layout

And the inside of the modal contains logic asking for `show_adv_search?` and `@edit[@expkey]`,
to deteremine whether to render the inside of the modal too.

**But**, all the ajax transition logic assumes the modal is always there, hidden, and tries to replace the inner divs' content (`#adv_search_body`, `#adv_search_footer`), failing when missing.

---

So.. this PR:

* removes any advanced search modal rendering from anywhere but the footer
  * this does not affect rendering the trigger button, or a searchbox, only the modal
  * the modal gets rendered always, once
* moves the "do I render the inner divs?" logic *inside* those divs, so that they always get rendered, but empty if no suitable content exists at the point
* fixes all ajax `x_adv_searchbox` replaces to also replace the modal divs
* fixes all ajax `adv_search_body` and `adv_search_footer` replaces to ignore the condition moved inside those templates when rendered standalone

---

Testing:

* get to a vm detail screen
* do a full screen reload
* switch to the VMs accordion (or click the tree root if already there)
* click Advanced Search

Before: the modal won't appear
After: the modal will appear

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1712872