### PR TITLE
Get rid of the parent_kls/parent_name options in TreeBuilderDiagnostics

### DIFF
--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -1,4 +1,6 @@
 class TreeBuilderDiagnostics < TreeBuilder
+  attr_reader :root
+
   def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
     super(name, sandbox, build)
@@ -13,11 +15,5 @@ class TreeBuilderDiagnostics < TreeBuilder
       :onclick         => "miqOnClickDiagnostics",
       :silent_activate => true
     }
-  end
-
-  def x_build_single_node(object, pid, options)
-    options[:parent_kls]  = @root.class.name
-    options[:parent_name] = @root.name
-    super(object, pid, options)
   end
 end

--- a/app/presenters/tree_node/assigned_server_role.rb
+++ b/app/presenters/tree_node/assigned_server_role.rb
@@ -32,7 +32,7 @@ module TreeNode
         end
         klass = "red" if @object.priority == 1
       end
-      if @options[:parent_kls] == "Zone" && @object.server_role.regional_role?
+      if @tree.root.kind_of?(::Zone) && @object.server_role.regional_role?
         klass = "opacity"
       end
 

--- a/app/presenters/tree_node/server_role.rb
+++ b/app/presenters/tree_node/server_role.rb
@@ -6,8 +6,9 @@ module TreeNode
       status = "stopped"
       @object.assigned_server_roles.where(:active => true).each do |asr| # Go thru all active assigned server roles
         next unless asr.miq_server.started? # Find a started server
-        if @options[:parent_kls] == "MiqRegion" || # it's in the region
-           (@options[:parent_kls] == "Zone" && asr.miq_server.my_zone == @options[:parent_name]) # it's in the zone
+
+        if @tree.root.kind_of?(::MiqRegion) || # it's in the region
+           (@tree.root.kind_of?(::Zone) && asr.miq_server.my_zone == @tree.root.try(:name)) # it's in the zone
           status = "active"
           break
         end

--- a/spec/presenters/tree_node/assigned_server_role_spec.rb
+++ b/spec/presenters/tree_node/assigned_server_role_spec.rb
@@ -1,7 +1,10 @@
 describe TreeNode::AssignedServerRole do
   include_context 'server roles'
   let(:object) { assigned_server_role }
-  subject { described_class.new(object, nil, {}, nil) }
+  let(:tree) { double }
+  subject { described_class.new(object, nil, {}, tree) }
+
+  before { allow(tree).to receive(:root) }
 
   describe '#title' do
     it 'returns with the title' do


### PR DESCRIPTION
Instead of using the `options`, passing the data through the `@tree` object when building `TreeNode` subclasses.

@miq-bot add_label refactoring, hammer/no, trees
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 