### PR TITLE
Fix the path to the PF stylesheets as it was renamed

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -3,5 +3,5 @@ $pf-global--disable-fontawesome: true;
 
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~@fortawesome/fontawesome-free/scss/v4-shims.scss';
-@import '~@patternfly/patternfly-next/patternfly.scss';
+@import '~@patternfly/patternfly/patternfly.scss';
 @import '~kubernetes-topology-graph/dist/topology-graph.css';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@manageiq/react-ui-components": "~0.11.14",
     "@manageiq/ui-components": "~1.2.5",
-    "@patternfly/patternfly": "^2.6.6",
+    "@patternfly/patternfly": "^2.8.1",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",


### PR DESCRIPTION
The repo folder has been renamed from `patternfly-next` to `patternfly` probably in a patch version. This is something we should try to avoid, because it can break tests without us doing any changes :cry: 

Anyway, I'm updating PF4 to the latest and updating the path...

@miq-bot add_reviewer @Hyperkid123 
@miq-bot assign @martinpovolny 
@miq-bot add_label bug, dependencies, hammer/no