### PR TITLE
Remove @patternfly/patternfly-next references

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -3,5 +3,5 @@ $pf-global--disable-fontawesome: true;
 
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~@fortawesome/fontawesome-free/scss/v4-shims.scss';
-@import '~@patternfly/patternfly-next/patternfly.scss';
+@import '~@patternfly/patternfly/patternfly.scss';
 @import '~kubernetes-topology-graph/dist/topology-graph.css';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@data-driven-forms/pf3-component-mapper": "^1.9.9",
     "@data-driven-forms/react-form-renderer": "^1.9.9",
     "@fortawesome/fontawesome-free": "^5.8.1",
-    "@manageiq/react-ui-components": "~0.11.14",
+    "@manageiq/react-ui-components": "~0.11.17",
     "@manageiq/ui-components": "~1.2.5",
     "@patternfly/patternfly": "^2.6.6",
     "@pf3/select": "~1.12.6",


### PR DESCRIPTION
we never depended on the -next version (deprecated), except via react-ui-components
and we now updated react-ui-components to use the current patternfly package

So, fixing here too :)

This fixes travis breaking with..

```
ERROR in ./app/stylesheet/application-webpack.scss (./node_modules/css-loader??ref--8-1!./node_modules/postcss-loader/lib??ref--8-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js??ref--8-4!./app/stylesheet/application-webpack.scss)
Module build failed (from ./node_modules/sass-loader/lib/loader.js):
@import '~@patternfly/patternfly-next/patternfly.scss';
^
      File to import not found or unreadable: ~@patternfly/patternfly-next/patternfly.scss.
```

Caused by https://github.com/ManageIQ/react-ui-components/pull/117 (because it removed patternfly-next from dependencies)