### PR TITLE
Do not rely on the tree name from options in TreeNode subclasses

### DIFF
--- a/app/presenters/tree_node/assigned_server_role.rb
+++ b/app/presenters/tree_node/assigned_server_role.rb
@@ -2,7 +2,7 @@ module TreeNode
   class AssignedServerRole < Node
     set_attributes(:text, :icon, :icon_background, :klass) do
       text = ViewHelper.content_tag(:strong) do
-        if @options[:tree] == :servers_by_role_tree
+        if @tree.instance_of?(TreeBuilderServersByRole)
           "#{_('Server')}: #{@object.name} [#{@object.id}]"
         else
           "Role: #{@object.server_role.description}"

--- a/app/presenters/tree_node/custom_button_set.rb
+++ b/app/presenters/tree_node/custom_button_set.rb
@@ -1,7 +1,8 @@
 module TreeNode
   class CustomButtonSet < Node
     set_attribute(:text) do
-      if %i[sandt_tree generic_object_definitions_tree].include?(@options[:tree])
+      case @tree
+      when TreeBuilderCatalogItems, TreeBuilderGenericObjectDefinition
         _("%{button_group_name} (Group)") % {:button_group_name => @object.name.split("|").first}
       else
         @object.name.split("|").first

--- a/app/presenters/tree_node/ems_folder.rb
+++ b/app/presenters/tree_node/ems_folder.rb
@@ -1,7 +1,12 @@
 module TreeNode
   class EmsFolder < Node
     set_attribute(:icon) do
-      %i[vandt_tree vat_tree].include?(@options[:tree]) ? 'pficon pficon-folder-close-blue' : @object.decorate.fonticon
+      case @tree
+      when TreeBuilderVat, TreeBuilderVandt
+        'pficon pficon-folder-close-blue'
+      else
+        @object.decorate.fonticon
+      end
     end
 
     set_attribute(:tooltip) { _("Folder: %{folder_name}") % {:folder_name => @object.name} }

--- a/app/presenters/tree_node/miq_action.rb
+++ b/app/presenters/tree_node/miq_action.rb
@@ -2,10 +2,10 @@ module TreeNode
   class MiqAction < Node
     set_attribute(:text, &:description)
     set_attribute(:icon) do
-      if @options[:tree] != :action_tree
-        flag_of(@object) == :success ? "pficon pficon-ok" : "pficon pficon-error-circle-o"
-      else
+      if @tree.instance_of?(TreeBuilderAction)
         @object.decorate.fonticon
+      else
+        flag_of(@object) == :success ? "pficon pficon-ok" : "pficon pficon-error-circle-o"
       end
     end
 

--- a/app/presenters/tree_node/miq_policy.rb
+++ b/app/presenters/tree_node/miq_policy.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class MiqPolicy < Node
     set_attribute(:text) do
-      if @options[:tree] == :policy_profile_tree
+      if @tree.instance_of?(TreeBuilderPolicyProfile)
         ViewHelper.capture do
           ViewHelper.concat(ViewHelper.content_tag(:strong, "#{ui_lookup(:model => @object.towhat)} #{@object.mode.titleize}: "))
           ViewHelper.concat(ERB::Util.html_escape(@object.description))

--- a/app/presenters/tree_node/miq_server.rb
+++ b/app/presenters/tree_node/miq_server.rb
@@ -6,11 +6,11 @@ module TreeNode
       if ::MiqServer.my_server.id == @object.id
         tooltip  = _("%{server}: %{server_name} [%{server_id}] (current)") %
                    {:server => ui_lookup(:model => @object.class.to_s), :server_name => @object.name, :server_id => @object.id}
-        tooltip += " (#{@object.status})" if @options[:tree] == :roles_by_server_tree
+        tooltip += " (#{@object.status})" if @tree.instance_of?(TreeBuilderRolesByServer)
         text = ViewHelper.content_tag(:strong, ERB::Util.html_escape(tooltip))
       else
         tooltip  = "#{ui_lookup(:model => @object.class.to_s)}: #{@object.name} [#{@object.id}]"
-        tooltip += " (#{@object.status})" if @options[:tree] == :roles_by_server_tree
+        tooltip += " (#{@object.status})" if @tree.instance_of?(TreeBuilderRolesByServer)
         text = tooltip
       end
       [text, tooltip]

--- a/spec/presenters/tree_node/custom_button_set_spec.rb
+++ b/spec/presenters/tree_node/custom_button_set_spec.rb
@@ -1,5 +1,6 @@
 describe TreeNode::CustomButtonSet do
-  subject { described_class.new(object, nil, options, nil) }
+  let(:tree) { TreeBuilderCatalogItems.new(:sandt_tree, {}, false) }
+  subject { described_class.new(object, nil, options, tree) }
   let(:object) { FactoryBot.create(:custom_button_set, :description => "custom button set description") }
   let(:options) { {} }
 

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::EmsFolder do
-  subject { described_class.new(object, nil, options, nil) }
-  let(:options) { {} }
+  let(:tree) { nil }
+  subject { described_class.new(object, nil, {}, tree) }
 
   %i(
     ems_folder
@@ -17,7 +17,7 @@ describe TreeNode::EmsFolder do
       include_examples 'TreeNode::Node#tooltip prefix', 'Folder'
 
       context 'type is vat' do
-        let(:options) { {:tree => :vat_tree} }
+        let(:tree) { TreeBuilderVat.allocate }
 
         include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close-blue'
       end

--- a/spec/presenters/tree_node/miq_action_spec.rb
+++ b/spec/presenters/tree_node/miq_action_spec.rb
@@ -1,5 +1,6 @@
 describe TreeNode::MiqAction do
-  subject { described_class.new(object, nil, {:tree => :action_tree}, nil) }
+  let(:tree) { TreeBuilderAction.new(:action_tree, {}, false) }
+  subject { described_class.new(object, nil, {:tree => :action_tree}, tree) }
   let(:object) { FactoryBot.create(:miq_action, :name => 'raise_automation_event', :action_type => 'default') }
 
   include_examples 'TreeNode::Node#key prefix', 'a-'


### PR DESCRIPTION
The `options` is coming from the `TreeState` that's coming from the session, let's not rely on it where possible. We have access to the whole tree instead...

@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label refactoring, trees, hammer/no