### PR TITLE
Drop the timeline listnav decision logic for dashboard/timelines

### DIFF
--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
       elsif @explorer
         "explorer"
       elsif @layout == "timeline"
-        controller.controller_name == "dashboard" ? "timeline" : controller.controller_name
+        controller.controller_name
       elsif common_layouts.include?(@layout)
         @layout
       end


### PR DESCRIPTION
We no longer have timelines under cloud intel, so this is not necessary...

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @romanblanco 