### PR TITLE
AC Parameters each_key is deprecated use each

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -663,7 +663,7 @@ module ApplicationController::MiqRequestMethods
     @edit[:new][:start_min]     = params[:start_min] if params[:start_min]
     @edit[:new][:schedule_time] = Time.zone.parse("#{@edit[:new][:start_date]} #{@edit[:new][:start_hour]}:#{@edit[:new][:start_min]}")
 
-    params.each_key do |key|
+    params.each do |key, _value|
       next unless key.include?("__")
       d, f  = key.split("__") # Parse dialog and field names from the parameter key
       field = @edit[:wf].get_field(f.to_sym, d.to_sym) # Get the field hash

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -846,7 +846,7 @@ class MiqAeClassController < ApplicationController
           session[:field_data][:default_value] =
             @edit[:new_field][:default_value] = ''
         end
-        params.each_key do |field|
+        params.each do |field, _value|
           next unless field.to_s.starts_with?("fields_datatype")
 
           f = field.split('fields_datatype')
@@ -951,7 +951,7 @@ class MiqAeClassController < ApplicationController
           end
         end
 
-        params.each_key do |field|
+        params.each do |field, _value|
           if field.to_s.starts_with?("cls_fields_datatype_")
             f = field.split('cls_fields_datatype_')
             def_field = "cls_fields_value_" << f[1].to_s

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1046,7 +1046,7 @@ class MiqPolicyController < ApplicationController
     @edit[:new][subkey][:trap_id]      = params[:trap_id] if params[:trap_id]
     refresh = true if params[:snmp_version]
     if process_variables
-      params.each_key do |var|
+      params.each do |var, _value|
         vars = var.split("__")
         next unless %w[oid var_type value].include?(vars[0])
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -167,7 +167,7 @@ module MiqPolicyController::Policies
       @edit[:new][:notes] = params[:notes].presence if params[:notes]
       @edit[:new][:active] = (params[:active] == "1") if params.key?(:active)
     when "events"
-      params.each_key do |field|
+      params.each do |field, _value|
         if field.to_s.starts_with?("event_")
           event = field.to_s.split("_").last
           if params[field] == "true"

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -402,7 +402,7 @@ module Mixins
            %i[vmConnectCDRoms cdrom_connect],
            %i[vmDisconnectCDRoms cdrom_disconnect]].each do |params_key, options_key|
              next if params[params_key].blank?
-             params[params_key].each_value do |p|
+             params[params_key].each do |_key, p|
                p.transform_values! { |v| eval_if_bool_string(v) }
              end
              options[options_key] = params[params_key].values

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -255,7 +255,7 @@ module OpsController::Settings::Tags
                                                                      :name        => entry.name}
     event = "classification_entry_add"
     i = 0
-    params["entry"].each_key do |k|
+    params["entry"].each do |k, _v|
       msg += ", " if i.positive?
       i += 1
       msg = msg + k.to_s + ":[" + params["entry"][k].to_s + "]"


### PR DESCRIPTION
Similar to: https://github.com/ManageIQ/manageiq-ui-classic/pull/5244

Some of these were seen in the QE test suite, prefixed with the
frequency:

```
  11 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from ce_created_audit at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/ops_controller/settings/tags.rb:258)
  18 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from block in fields_form_field_changed at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/miq_ae_class_controller.rb:853)
  21 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from build_snmp_options at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/miq_policy_controller.rb:1049)
  60 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from block in form_method_field_changed at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/miq_ae_class_controller.rb:958)
 133 WARN -- : DEPRECATION WARNING: Method each_value is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from block in reconfigure_handle_submit_button at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/mixins/actions/vm_actions/reconfigure.rb:405)
 138 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from policy_field_changed at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/miq_policy_controller/policies.rb:170)
1047 WARN -- : DEPRECATION WARNING: Method each_key is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from prov_get_form_vars at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/application_controller/miq_request_methods.rb:666)
```