### PR TITLE
Drop patternfly 4 support again

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -60,9 +60,9 @@
 
 .resizer-box {
   bottom: 100px;
-  left: -20px;
+  left: -18px;
   position: absolute;
-  width: 40px;
+  width: 38px;
 }
 
 .resizer .btn {
@@ -824,13 +824,6 @@ td.action > .btn.btn-default {
 
 .modal-body p {
   word-wrap: break-word;
-}
-
-/// override PF4 override of PF3 sidebar-pf
-.sidebar-pf {
-  background: #fafafa !important;
-  padding-right: 20px !important;
-  padding-left: 20px !important;
 }
 
 /// Panel in sidebar doesn't need bottom margin

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -1,7 +1,1 @@
-$pf-global--enable-reset: false;
-$pf-global--disable-fontawesome: true;
-
-@import '~@fortawesome/fontawesome-free/css/all.css';
-@import '~@fortawesome/fontawesome-free/scss/v4-shims.scss';
-@import '~@patternfly/patternfly/patternfly.scss';
 @import '~kubernetes-topology-graph/dist/topology-graph.css';

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -133,6 +133,8 @@ module.exports = {
       'bootstrap-select': '@pf3/select', // never use vanilla bootstrap-select
       'moment': resolveModule('moment'), // fix moment-strftime peerDependency issue
       'angular': resolveModule('angular'), // fix for "Tried to load angular more than once"
+      '@patternfly/patternfly': resolveModule('NONEXISTENT'),
+      '@patternfly/patternfly-next': resolveModule('NONEXISTENT'),
     },
     extensions: settings.extensions,
     modules: [],

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "^1.9.9",
     "@data-driven-forms/react-form-renderer": "^1.9.9",
-    "@fortawesome/fontawesome-free": "^5.8.1",
     "@manageiq/react-ui-components": "~0.11.17",
     "@manageiq/ui-components": "~1.2.5",
-    "@patternfly/patternfly": "^2.8.1",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",


### PR DESCRIPTION
The decision is to support patternfly 4 only in J-release, not Ivanchuk.
(IE11 support is still going away in Ivanchuk.)

So, reverting #5537, except for introduction of `app/stylesheet/application-webpack.scss`.
And adding guards to prevent accidental requires of patternfly 4 styling from plugins or depedencies.

Cc @skateman @epwinchell @mturley
