### PR TITLE
Replace fa-share with fa-mail-forward alias - adblock fix

### DIFF
--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -33,10 +33,10 @@
           :remote       => true,
           "data-method" => :post,
           :title        => t}
-            %i.fa.fa-share
+            %i.fa.fa-mail-forward
         - else
           %button.btn.btn-default.disabled
-            %i.fa.fa-share
+            %i.fa.fa-mail-forward
         %span#exp_buttons_off
           %button.btn.btn-default.disabled
             %i.fa-lg.pficon.pficon-close


### PR DESCRIPTION
Without adblock, this does absolutely nothing. `fa-share` and `fa-mail-forward` are the same (fontawesome 4) icon.

But, adblock removes `fa-share`, presumably because it gets interpreted as a facebook sharing button:

![](https://camo.githubusercontent.com/4473d89ac2c0b3429713031c518c289fdb106064/68747470733a2f2f66696c65732e6769747465722e696d2f68696d64656c2f544671682f626c65652e706e67)

(the forward button is missing an icon ^)

Fixing to also work with adblock :).
Fixes #5643