### PR TITLE
Make Service Catalog Item ownership visible on detail screen

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -94,6 +94,16 @@
               .col-md-9
                 = h(@sb[entry_points_op[1]])
         .form-group
+          %label.col-md-3.control-label
+            = _('Owner')
+          .col-md-9
+            = h(@record.try(:evm_owner).try(:name))
+        .form-group
+          %label.col-md-3.control-label
+            = _('Ownership Group')
+          .col-md-9
+            = h(@record.try(:miq_group).try(:name))
+        .form-group
           .col-md-9
             #tag_group
             :javascript


### PR DESCRIPTION
Responding https://github.com/ManageIQ/manageiq-ui-classic/pull/5592#issuecomment-496655751 by adding ownership information visible on detail screen of Service Catalog Item

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/5592#issuecomment-496655751
* https://bugzilla.redhat.com/show_bug.cgi?id=1641905

Steps for Testing/QA
-------------------------------

1. Services -> Catalog
2. Catalog Items accordion -> Add a New Catalog Item
3. Select the created Catalog Item -> Set Ownership
4. Ownership is expected to be visible

Before:

![Screenshot_2019-05-29 ManageIQ Catalogs(3)](https://user-images.githubusercontent.com/1187051/58558354-1979a180-8210-11e9-812c-09430389083d.png)


After:

![Screenshot_2019-05-29 ManageIQ Catalogs(2)](https://user-images.githubusercontent.com/1187051/58558232-cbfd3480-820f-11e9-94cb-36ba840c221f.png)

