### PR TITLE
Show replication type on login screen

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -114,6 +114,8 @@
           = _('Region:')
           %span
             = (MiqRegion.my_region.description)
+            - if MiqRegion.replication_type != :none
+              = " #{MiqRegion.replication_type == :global ? _('(Global)') : _('(Remote)')}"
         %p
           = _('Zone:')
           %span


### PR DESCRIPTION
In case you have configured replication on your ManageIQ appliance, this change will render type of region you're logging into (global or remote) on login screen.

![region-global](https://user-images.githubusercontent.com/6648365/58562457-9402eb00-8229-11e9-9ddf-eaa345ff4cc4.png)
![region-remote](https://user-images.githubusercontent.com/6648365/58562458-9402eb00-8229-11e9-93a0-4fd49fa54d4a.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1678142