### PR TITLE
make react forms responsive

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -1074,3 +1074,23 @@ table.table-compressed tr td .piechart {
 .miq-toolbar-actions {
   margin-top: -20px !important;
 }
+
+/* responsive styling for new react forms (refactor after all forms are converted )*/
+
+@media (max-width: $screen-sm){
+  .container-fluid form.form-react {
+    width: 100%;
+  }
+}
+
+@media (min-width: $screen-md) {
+  .container-fluid form.form-react {
+    width: 75%
+  }
+}
+
+@media (min-width: $screen-lg) {
+  .container-fluid form.form-react {
+    width: 50%
+  }
+}


### PR DESCRIPTION
This PR adjusts the width of react data driven forms based on existing breakpoints.
Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/5649

50% width
<img width="1400" alt="Screen Shot 2019-05-29 at 1 07 06 PM" src="https://user-images.githubusercontent.com/1287144/58576709-f3a1cc00-8212-11e9-9feb-903912eb9397.png">

75% width
<img width="1017" alt="Screen Shot 2019-05-29 at 1 07 21 PM" src="https://user-images.githubusercontent.com/1287144/58576744-02887e80-8213-11e9-8715-c854951c8e20.png">

100% width
<img width="884" alt="Screen Shot 2019-05-29 at 1 07 37 PM" src="https://user-images.githubusercontent.com/1287144/58576780-0fa56d80-8213-11e9-9a33-a480250ebdb4.png">

100% width (mobile)
<img width="628" alt="Screen Shot 2019-05-29 at 1 07 47 PM" src="https://user-images.githubusercontent.com/1287144/58577477-87c06300-8214-11e9-83be-518e682625c4.png">

