### PR TITLE
Do not set the expand attribute of MiqReportResult, it's redundant

### DIFF
--- a/app/presenters/tree_node/miq_report_result.rb
+++ b/app/presenters/tree_node/miq_report_result.rb
@@ -1,19 +1,17 @@
 module TreeNode
   class MiqReportResult < Node
-    set_attributes(:text, :tooltip, :expand) do
-      expand = nil
+    set_attributes(:text, :tooltip) do
       if @object.last_run_on.nil? && %w[queued running].include?(@object.status.downcase)
         text    = _('Generating Report')
         tooltip = _('Generating Report for - %{report_name}') % {:report_name => @object.name}
       elsif @object.last_run_on.nil? && @object.status.downcase == 'error'
         text    = _('Error Generating Report')
         tooltip = _('Error Generating Report for %{report_name}') % {:report_name => @object.name}
-        expand  = !!@options[:open_all]
       else
         text    = format_timezone(@object.last_run_on, Time.zone, 'gtl')
         tooltip = nil
       end
-      [text, tooltip, expand]
+      [text, tooltip]
     end
   end
 end


### PR DESCRIPTION
The `@options[:open_all]` already sets the node as expanded in `x_build_node`, so there's no need for this attribute.

@miq-bot add_label cleanup, trees, hammer/no
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 