### PR TITLE
Drop useless expand attribute setting from TreeNode::Node

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -50,7 +50,7 @@ module TreeNode
     end
 
     def expand
-      @options[:open_all].present? && @options[:open_all] && @options[:expand] != false
+      false
     end
 
     def hide_checkbox

--- a/spec/presenters/tree_node/node_spec.rb
+++ b/spec/presenters/tree_node/node_spec.rb
@@ -70,47 +70,6 @@ describe TreeNode::Node do
     end
   end
 
-  describe '#expand' do
-    let(:object) { nil }
-    let(:options) { {:expand => expand, :open_all => open_all} }
-
-    context 'open_all is true, expand is nil' do
-      let(:open_all) { true }
-      let(:expand) { nil }
-
-      it 'returns true' do
-        expect(subject.expand).to be_truthy
-      end
-    end
-
-    context 'open_all is true, expand is false' do
-      let(:open_all) { true }
-      let(:expand) { false }
-
-      it 'returns false' do
-        expect(subject.expand).to be_falsey
-      end
-    end
-
-    context 'both open_all and expand are true' do
-      let(:open_all) { true }
-      let(:expand) { true }
-
-      it 'returns true' do
-        expect(subject.expand).to be_truthy
-      end
-    end
-
-    context 'both open_all and expand are nil' do
-      let(:open_all) { nil }
-      let(:expand) { nil }
-
-      it 'returns false' do
-        expect(subject.expand).to be_falsey
-      end
-    end
-  end
-
   describe '#key' do
     context 'object id is nil' do
       let(:object) { OpenStruct.new(:key => nil, :name => 'foo') }


### PR DESCRIPTION
We're never setting the `@options[:expand]` parameter, therefore, this line is always false.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label technical debt, trees, hammer/no