### PR TITLE
Do not set the hide_checkbox attribute on TreeNodes from options

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -54,7 +54,7 @@ module TreeNode
     end
 
     def hide_checkbox
-      @options.key?(:hideCheckbox) && @options[:hideCheckbox]
+      nil
     end
 
     def key
@@ -87,7 +87,7 @@ module TreeNode
         :iconBackground => icon_background,
         :iconColor      => color,
         :expand         => expand,
-        :hideCheckbox   => hide_checkbox ? hide_checkbox : nil,
+        :hideCheckbox   => hide_checkbox,
         :addClass       => klass,
         :selectable     => selectable,
         :select         => selected,


### PR DESCRIPTION
The `hide_checkbox` isn't a valid attribute of the `@options` hash, therefore, the value will be always false.

@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label refactoring, trees, hammer/no