### PR TITLE
Drop IE

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -8,10 +8,9 @@ module.exports = {
       {
         targets: {
           browsers: [
-            "> 1%",
+            "> 3%",
             "last 2 versions",
             "Firefox ESR",
-            "IE 11",
           ],
         },
       },

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -644,12 +644,6 @@ ManageIQ.oneTransition.oneTrans = 0;
 
 // Function to generate an Ajax request, but only once for a drawn screen
 function miqSendOneTrans(url, observe) {
-  if (ManageIQ.oneTransition.IEButtonPressed) {
-    // page replace after clicking save/reset was making observe_field on
-    // text_area in IE send up a trascation to form_field_changed method
-    ManageIQ.oneTransition.IEButtonPressed = false;
-    return;
-  }
   if (ManageIQ.oneTransition.oneTrans) {
     return;
   }

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1711,11 +1711,7 @@ var fontIconChar = _.memoize(function(klass) {
   document.body.appendChild(tmp);
   var char = window.getComputedStyle(tmp, ':before').content.replace(/'|"/g, '');
   var font = window.getComputedStyle(tmp, ':before').fontFamily;
-  if (tmp.hasOwnProperty('remove')) {
-    tmp.remove();
-  } else { // IE11 doesn't support ChildNode.remove()
-    tmp.parentNode.removeChild(tmp);
-  }
+  tmp.remove();
   return {font: font, char: char};
 });
 

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -308,9 +308,6 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   if (data.resetOneTrans) {
     ManageIQ.oneTransition.oneTrans = 0;
   }
-  if (data.oneTransIE) {
-    ManageIQ.oneTransition.IEButtonPressed = true;
-  }
 
   ManageIQ.explorer.focus(data);
 

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -58,7 +58,6 @@ if (!window.ManageIQ) {
       queue: [], // a queue of pending requests
     },
     oneTransition: {
-      IEButtonPressed: false, // pressed save/reset button identificator
       oneTrans: null, // used to generate Ajax request only once for a drawn screen
     },
     qe: {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -324,11 +324,6 @@ class ApplicationController < ActionController::Base
             end
     end
 
-    # Following works around a caching issue that causes timeouts for charts in IE using SSL
-    if is_browser_ie?
-      response.headers["Cache-Control"] = "cache, must-revalidate"
-      response.headers["Pragma"] = "public"
-    end
     rpt.to_chart(settings(:display, :reporttheme), true, MiqReport.graph_options)
     render Charting.render_format => rpt.chart
   end
@@ -655,14 +650,7 @@ class ApplicationController < ActionController::Base
   # Disable client side caching of the response being sent
   def disable_client_cache
     response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
-
-    # IE will not allow downloads if no-cache is used because it won't save the file in the temp folder, so use private
-    response.headers["Pragma"] = if is_browser_ie?
-                                   'private'
-                                 else
-                                   'no-cache'
-                                 end
-
+    response.headers["Pragma"] = 'no-cache'
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -21,18 +21,13 @@ module ApplicationController::Automate
         add_flash(_("Automation Error: %{error_message}") % {:error_message => bang.message}, :error)
       end
     end
-    # IE7 doesn't redraw the tree until the screen is clicked, so redirect back to this method for a refresh
-    if is_browser_ie? && browser_info(:version) == "7"
-      javascript_redirect(:action => 'resolve')
-    else
-      render :update do |page|
-        page << javascript_prologue
-        page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
-        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-        page.replace_html("main_div", :partial => "results_tabs")
-        page << javascript_reload_toolbars
-        page << "miqSparkle(false);"
-      end
+    render :update do |page|
+      page << javascript_prologue
+      page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page.replace_html("main_div", :partial => "results_tabs")
+      page << javascript_reload_toolbars
+      page << "miqSparkle(false);"
     end
   end
   private :resolve_button_throw

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -870,6 +870,7 @@ class MiqAeClassController < ApplicationController
   # AJAX driven routine to check for changes in ANY field on the form
   def form_method_field_changed
     return unless load_edit("aemethod_edit__#{params[:id]}", "replace_cell__explorer")
+
     get_method_form_vars
 
     if @edit[:new][:location] == 'expression'
@@ -891,21 +892,20 @@ class MiqAeClassController < ApplicationController
     if @edit[:current][:location] == "inline" && @edit[:current][:data]
       @edit[:method_prev_data] = @edit[:current][:data]
     end
-    @edit[:new][:data] = if @edit[:new][:location] == "inline" && !params[:cls_method_data] &&
-                            !params[:method_data] && !params[:transOne]
-                            if !@edit[:method_prev_data]
-                              MiqAeMethod.default_method_text
-                            else
-                              @edit[:method_prev_data]
-                            end
-                          elsif params[:cls_method_location] || params[:method_location]
-                            # reset data if location is changed
-                            ''
-                          else
-                            @edit[:new][:data]
-                          end
+    @edit[:new][:data] = if @edit[:new][:location] == "inline" && !params[:cls_method_data] && !params[:method_data] && !params[:transOne]
+                           if !@edit[:method_prev_data]
+                             MiqAeMethod.default_method_text
+                           else
+                             @edit[:method_prev_data]
+                           end
+                         elsif params[:cls_method_location] || params[:method_location]
+                           # reset data if location is changed
+                           ''
+                         else
+                           @edit[:new][:data]
+                         end
     @changed = (@edit[:new] != @edit[:current])
-    @edit[:default_verify_status] = %w(builtin inline).include?(@edit[:new][:location]) && @edit[:new][:data] && @edit[:new][:data] != ""
+    @edit[:default_verify_status] = %w[builtin inline].include?(@edit[:new][:location]) && @edit[:new][:data] && @edit[:new][:data] != ""
 
     in_angular = playbook_style_location?(@edit[:new][:location])
     angular_form_specific_data if in_angular

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -392,7 +392,6 @@ class MiqAeCustomizationController < ApplicationController
     presenter[:build_calendar] = true
     # resetting ManageIQ.oneTransition.oneTrans when tab loads
     presenter.reset_one_trans
-    presenter.one_trans_ie if %w[save reset].include?(params[:button]) && is_browser_ie?
   end
 
   def setup_presenter_for_old_dialogs_tree(nodetype, presenter)
@@ -411,7 +410,6 @@ class MiqAeCustomizationController < ApplicationController
                          end
 
       presenter.reset_one_trans
-      presenter.one_trans_ie if %w[save reset].include?(params[:button]) && is_browser_ie?
     end
   end
 

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -670,7 +670,6 @@ class OpsController < ApplicationController
       if x_node.split("-").first == "svr" && my_server.id == active_id.to_i
         # show all the tabs if on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id]) # Reread the server record
-        presenter.one_trans_ie if %w[save reset].include?(params[:button]) && is_browser_ie?
       elsif x_node.split("-").first == "svr" && my_server.id != active_id.to_i
         # show only 4 tabs if not on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id]) # Reread the server record

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -11,12 +11,6 @@ module OpsController::Settings::Common
 
   # AJAX driven routine to check for changes in ANY field on the form
   def settings_form_field_changed
-    tab = params[:id] ? "settings_#{params[:id]}" : nil # workaround to prevent an error that happens when IE sends a transaction when tab is changed when there is text_area in the form, checking for tab id
-    if tab && tab != @sb[:active_tab] && params[:id] != 'new'
-      head :ok
-      return
-    end
-
     settings_get_form_vars
     return unless @edit
     @assigned_filters = []

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -177,7 +177,6 @@ class PxeController < ApplicationController
           end
         # resetting ManageIQ.oneTransition.oneTrans when tab loads
         presenter.reset_one_trans
-        presenter.one_trans_ie if %w[save reset].include?(params[:button]) && is_browser_ie?
       end
     when :iso_datastores_tree
       presenter.update(:main_div, r[:partial => "iso_datastore_list"])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -483,14 +483,6 @@ module ApplicationHelper
     ui_lookup(:model => (controller.camelize + "Controller").constantize.model.name)
   end
 
-  def is_browser_ie?
-    browser_info(:name) == "explorer"
-  end
-
-  def is_browser_ie7?
-    is_browser_ie? && browser_info(:version).starts_with?("7")
-  end
-
   def is_browser?(name)
     browser_name = browser_info(:name)
     name.kind_of?(Array) ? name.include?(browser_name) : (browser_name == name)

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -104,11 +104,6 @@ class ExplorerPresenter
     self
   end
 
-  def one_trans_ie
-    @options[:one_trans_ie] = true
-    self
-  end
-
   def focus(element_id)
     @options[:focus] = element_id
     self
@@ -317,7 +312,6 @@ class ExplorerPresenter
     data[:removeSand] = !!@options[:remove_sand]
     data[:removePaging] = !!@options[:remove_paging]
     data[:resetOneTrans] = !!@options[:reset_one_trans]
-    data[:oneTransIE] = !!@options[:one_trans_ie]
     data[:focus] = @options[:focus]
     data[:clearSearch] = @options[:clear_search_toggle] if @options.key?(:clear_search_toggle)
     data[:hideModal] if @options[:hide_modal]

--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -33,8 +33,7 @@
                          :class             => "form-control",
                          "data-miq_observe" => {:interval => '.5',
                                                 :url      => url}.to_json)
-        - unless is_browser_ie?
-          = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
+        = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
     .form-group
       %label.col-md-2.control-label
         = _("Request")

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,4 +1,1 @@
 = render :partial => "layouts/adv_search"
-- if is_browser_ie?
-  %script{:defer => "defer", :type => "text/javascript"}
-    miqOnLoad();

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,6 @@
     %meta{"http-equiv" => "Pragma", :content => "no-store"}
     %meta{"http-equiv" => "Pragma", :content => "must-revalidate"}
     %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
-    %meta{"http-equiv" => "X-UA-Compatible", :content => "IE=edge"}
 
     = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
@@ -29,7 +28,7 @@
       :javascript
         miqInitNotifications();
 
-  %body{:onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}
+  %body{:onload => 'miqOnLoad();', 'data-controller' => controller_name}
     = render :partial => "layouts/header"
     = render :partial => "layouts/content"
     = render :partial => 'layouts/footer'

--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -33,8 +33,7 @@
               = check_box_tag("display", "1", @edit[:new][:display],
                                "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
               = _('Display on Button')
-      - unless is_browser_ie?
-        = javascript_tag(javascript_focus('name'))
+      = javascript_tag(javascript_focus('name'))
     .form-group
       %label.control-label.col-md-2
         = _('Hover Text')

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -19,8 +19,7 @@
               = check_box_tag("display", "1", display,
                               "data-miq_observe_checkbox" => {:url => url}.to_json)
               = _('Display on Button')
-            - unless is_browser_ie?
-              = javascript_tag(javascript_focus('name'))
+            = javascript_tag(javascript_focus('name'))
     .form-group
       %label.control-label.col-md-2
         = _('Hover Text')

--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -3,15 +3,6 @@ const merge = require('webpack-merge')
 const { env, publicPath } = require('./configuration.js')
 const babelrc = require('../../.babelrc.js');
 
-// set WEBPACK_EXCLUDE_NODE_MODULES=1 to skip compiling code in node_modules
-let base = {};
-if (env.WEBPACK_EXCLUDE_NODE_MODULES) {
-  base.exclude = /node_modules/;
-} else {
-  // FIXME: won't be needed with d3 4+
-  base.exclude = /node_modules\/d3/;
-}
-
 let babelOptions = merge(babelrc, {
   babelrc: false,
   compact: false,
@@ -24,13 +15,14 @@ if (env.WEBPACK_VERBOSE) {
 }
 
 module.exports = [
-  merge(base, {
+  {
     test: /\.(js|jsx)$/,
     use: [{
       loader: 'babel-loader',
       options: babelOptions,
     }],
-  }),
+    exclude: /node_modules/,
+  },
 
   {
     test: require.resolve('bootstrap-datepicker'),

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -884,7 +884,8 @@ describe MiqAeClassController do
       stub_user(:features => :all)
       @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
                                    :language => "ruby", :class_id => "someid", :data => "exit MIQ_OK", :location => "inline")
-      controller.instance_variable_set(:@sb, :trees => {:ae_tree => {:active_node => "aec-someid"}},
+      controller.instance_variable_set(:@sb,
+                                       :trees       => {:ae_tree => {:active_node => "aec-someid"}},
                                        :active_tree => :ae_tree)
     end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -885,7 +885,7 @@ describe MiqAeClassController do
       @method = FactoryBot.create(:miq_ae_method, :name => "method01", :scope => "class",
                                    :language => "ruby", :class_id => "someid", :data => "exit MIQ_OK", :location => "inline")
       controller.instance_variable_set(:@sb, :trees => {:ae_tree => {:active_node => "aec-someid"}},
-                                       :active_tree => :ae_tree, :form_vars_set => true)
+                                       :active_tree => :ae_tree)
     end
 
     it "make sure data in data field still exists when edititng that field" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -514,38 +514,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#is_browser_ie7?" do
-    it "when browser's explorer version 7.x" do
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :name).and_return('explorer')
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :version).and_return('7.10')
-      expect(helper.is_browser_ie7?).to be_truthy
-    end
-
-    it "when browser's NOT explorer version 7.x" do
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :name).and_return('explorer')
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :version).and_return('6.10')
-      expect(helper.is_browser_ie7?).to be_falsey
-    end
-  end
-
-  context "#is_browser_ie?" do
-    it "when browser's explorer" do
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :name).and_return('explorer')
-      expect(helper.is_browser_ie?).to be_truthy
-    end
-
-    it "when browser's NOT explorer" do
-      allow_any_instance_of(ActionController::TestSession)
-        .to receive(:fetch_path).with(:browser, :name).and_return('safari')
-      expect(helper.is_browser_ie?).to be_falsey
-    end
-  end
-
   context "#is_browser?" do
     it "when browser's name is in the list" do
       allow_any_instance_of(ActionController::TestSession)

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -113,7 +113,6 @@ describe('miq_application.js', function() {
   describe('miqSendOneTrans', function () {
     beforeEach(function() {
       ManageIQ.oneTransition.oneTrans = undefined;
-      ManageIQ.oneTransition.IEButtonPressed = false;
 
       spyOn(window, 'miqObserveRequest');
       spyOn(window, 'miqJqueryRequest');


### PR DESCRIPTION
This drops IE11 support from the app, and attempts to remove all the older ie related hacks and workarounds:

* removed from babel browserlist - compiled JS may no longer be IE compatible
* stopped bin/webpack from compiling node_modules - `bin/webpack` goes from 140s to 46s
* removed 2 places which did `head :ok` as a workaround for an extra request from ie
* oneTrans logic was more complicated for IE
* caching settings were different
* miqOnLoad was called onload vs from footer
* removed is_browser_ie* helpers