### PR TITLE
set `@root_class` only if it is not already set by subclass

### DIFF
--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,6 +1,6 @@
 class TreeBuilderVmsFilter < TreeBuilder
   def initialize(*args)
-    @root_class = 'ManageIQ::Providers::InfraManager::Vm'
+    @root_class ||= 'ManageIQ::Providers::InfraManager::Vm'
     super(*args)
   end
 


### PR DESCRIPTION
setting `@root_class` here was causing incorrect filters to load for Instances/Images Accordions in Cloud/Instances explorer.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1715462

before
![before1](https://user-images.githubusercontent.com/3450808/58655303-d7bc2a00-82e7-11e9-973d-1027b0c42418.png)

![before2](https://user-images.githubusercontent.com/3450808/58655310-dab71a80-82e7-11e9-9c4c-5216e78c4d44.png)


after
![aftr1](https://user-images.githubusercontent.com/3450808/58655238-b0fdf380-82e7-11e9-82b1-6d15c440510d.png)

![after2](https://user-images.githubusercontent.com/3450808/58655244-b3604d80-82e7-11e9-8d8f-d40745771c2b.png)
