### PR TITLE
Fix failing cloud_tenant_controller_spec

### DIFF
--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -99,7 +99,7 @@ describe CloudTenantController do
     end
     let(:queue_options) do
       {
-        :class_name  => CloudTenant.class_by_ems(ems),
+        :class_name  => CloudTenant.class_by_ems(ems).name,
         :method_name => "create_cloud_tenant",
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => "ems_operations",


### PR DESCRIPTION
This is to reflect changes in https://github.com/ManageIQ/manageiq/pull/18827

The above changes caused the following failure:
```
1) CloudTenantController#create queues the create action
     Failure/Error: MiqTask.generic_action_with_callback(task_opts, queue_opts)
       #<MiqTask(id: integer, name: string, state: string, status: string, message: text, userid: string, created_on: datetime, updated_on: datetime, pct_complete: integer, context_data: text, results: text, miq_server_id: integer, identifier: string, started_on: datetime, zone: string, href_slug: string, region_number: integer, region_description: string, state_or_status: string) (class)> received :generic_action_with_callback with unexpected arguments
         expected: ({:action=>"creating Cloud Tenant for user user2897", :userid=>"user2897"}, {:args=>[11000000002025, {:name=>"foo"}], :class_name=>ManageIQ::Providers::Openstack::CloudManager::... ), :method_name=>"create_cloud_tenant", :priority=>20, :role=>"ems_operations", :zone=>"Zone 3000"})
              got: ({:action=>"creating Cloud Tenant for user user2897", :userid=>"user2897"}, {:args=>[11000000002025, {:name=>"foo"}], :class_name=>"ManageIQ::Providers::Openstack::CloudManager:...t", :method_name=>"create_cloud_tenant", :priority=>20, :role=>"ems_operations", :zone=>"Zone 3000"})
       Diff:
       @@ -1,7 +1,6 @@
        [{:action=>"creating Cloud Tenant for user user2897", :userid=>"user2897"},
         {:args=>[11000000002025, {:name=>"foo"}],
       -  :class_name=>
       -   ManageIQ::Providers::Openstack::CloudManager::CloudTenant(id: integer, name: string, description: text, enabled: boolean, ems_ref: string, ems_id: integer, created_at: datetime, updated_at: datetime, type: string, parent_id: integer, href_slug: string, region_number: integer, region_description: string, total_vms: integer, cloud_volume_types: ),
       +  :class_name=>"ManageIQ::Providers::Openstack::CloudManager::CloudTenant",
          :method_name=>"create_cloud_tenant",
          :priority=>20,
          :role=>"ems_operations",
     # ./spec/manageiq/app/models/cloud_tenant.rb:67:in `create_cloud_tenant_queue'
     # ./app/controllers/cloud_tenant_controller.rb:87:in `create'
     # ./spec/controllers/cloud_tenant_controller_spec.rb:120:in `block (3 levels) in <top (required)>'
```