### PR TITLE
Do not reinitalize the @record when building Server/Roles trees

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -858,6 +858,8 @@ module OpsController::Diagnostics
                      TreeBuilderServersByRole.new(:servers_by_role_tree, @sb, true, :root => parent)
                    end
 
+    return if @record # Do not continue if the @record is already initialized
+
     # Pull out the selected node from the tree state and store it in the sandbox for future use
     prefix, @sb[:diag_selected_id] = x_node(@server_tree.name).split('-')
     @sb[:diag_selected_model] = TreeBuilder.get_model_for_prefix(prefix)


### PR DESCRIPTION
When building a server/roles tree, it is not necessary to reinitialize the `@record` variable from the tree state. This is just a quick fix to make the bug disappear, I'm refactoring stuff in the area so please forgive me for the ugliness here :pray: 

@miq-bot assign @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1715466