### PR TITLE
TreeBuilders - replace @root_class = 'Klass' in constructor with a filter_root_class method

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -1,6 +1,5 @@
 class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   has_kids_for ManageIQ::Providers::AnsibleTower::AutomationManager, [:x_get_tree_cmat_kids]
-  attr_reader :tree_nodes
 
   private
 

--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -1,9 +1,4 @@
 class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSystems
-  def initialize(*args)
-    @root_class = 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
-    super(*args)
-  end
-
   private
 
   def root_options
@@ -21,5 +16,9 @@ class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSyste
       :tip           => t,
       :load_children => true
     }
+  end
+
+  def filter_root_class
+    'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
   end
 end

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -1,9 +1,4 @@
 class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSystems
-  def initialize(*args)
-    @root_class = 'ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem'
-    super(*args)
-  end
-
   private
 
   def root_options
@@ -21,5 +16,9 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSy
       :tip           => t,
       :load_children => true
     }
+  end
+
+  def filter_root_class
+    'ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem'
   end
 end

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -1,6 +1,4 @@
 class TreeBuilderConfiguredSystems < TreeBuilder
-  attr_reader :tree_nodes
-
   private
 
   def tree_init_options
@@ -21,11 +19,11 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   end
 
   def x_get_global_filter_search_results
-    MiqSearch.where(:db => @root_class).visible_to_all.sort_by { |a| a.description.downcase }
+    MiqSearch.where(:db => filter_root_class).visible_to_all.sort_by { |a| a.description.downcase }
   end
 
   def x_get_my_filter_search_results
-    MiqSearch.where(:db => @root_class, :search_type => "user", :search_key => User.current_user.userid)
+    MiqSearch.where(:db => filter_root_class, :search_type => "user", :search_key => User.current_user.userid)
              .sort_by { |a| a.description.downcase }
   end
 
@@ -44,5 +42,10 @@ class TreeBuilderConfiguredSystems < TreeBuilder
                  :tip        => _("My Personal Filters"),
                  :selectable => false)
     count_only_or_objects(count_only, objects)
+  end
+
+  # overriden in subclasses
+  def filter_root_class
+    nil
   end
 end

--- a/app/presenters/tree_builder_images_filter.rb
+++ b/app/presenters/tree_builder_images_filter.rb
@@ -1,13 +1,14 @@
 class TreeBuilderImagesFilter < TreeBuilderVmsFilter
-  def initialize(*args)
-    @root_class = 'ManageIQ::Providers::CloudManager::Template'
-    super(*args)
-  end
+  private
 
   def root_options
     {
       :text    => _("All Images"),
       :tooltip => _("All of the Images that I can see")
     }
+  end
+
+  def filter_root_class
+    'ManageIQ::Providers::CloudManager::Template'
   end
 end

--- a/app/presenters/tree_builder_instances_filter.rb
+++ b/app/presenters/tree_builder_instances_filter.rb
@@ -1,13 +1,14 @@
 class TreeBuilderInstancesFilter < TreeBuilderVmsFilter
-  def initialize(*args)
-    @root_class = 'ManageIQ::Providers::CloudManager::Vm'
-    super(*args)
-  end
+  private
 
   def root_options
     {
       :text    => _("All Instances"),
       :tooltip => _("All of the Instances that I can see")
     }
+  end
+
+  def filter_root_class
+    'ManageIQ::Providers::CloudManager::Vm'
   end
 end

--- a/app/presenters/tree_builder_template_filter.rb
+++ b/app/presenters/tree_builder_template_filter.rb
@@ -1,13 +1,14 @@
 class TreeBuilderTemplateFilter < TreeBuilderVmsFilter
-  def initialize(*args)
-    @root_class = 'ManageIQ::Providers::InfraManager::Template'
-    super(*args)
-  end
+  private
 
   def root_options
     {
       :text    => _("All Templates"),
       :tooltip => _("All of the Templates that I can see")
     }
+  end
+
+  def filter_root_class
+    'ManageIQ::Providers::InfraManager::Template'
   end
 end

--- a/app/presenters/tree_builder_templates_images_filter.rb
+++ b/app/presenters/tree_builder_templates_images_filter.rb
@@ -1,13 +1,14 @@
 class TreeBuilderTemplatesImagesFilter < TreeBuilderVmsFilter
-  def initialize(*args)
-    @root_class = 'MiqTemplate'
-    super(*args)
-  end
+  private
 
   def root_options
     {
       :text    => _("All Templates & Images"),
       :tooltip => _("All of the Templates & Images that I can see")
     }
+  end
+
+  def filter_root_class
+    'MiqTemplate'
   end
 end

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,9 +1,4 @@
 class TreeBuilderVmsFilter < TreeBuilder
-  def initialize(*args)
-    @root_class ||= 'ManageIQ::Providers::InfraManager::Vm'
-    super(*args)
-  end
-
   def tree_init_options
     {
       :open_all       => true,
@@ -28,7 +23,12 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    objects = MiqSearch.where(:db => @root_class).filters_by_type(object[:id])
+    objects = MiqSearch.where(:db => filter_root_class).filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
+  end
+
+  # overriden in subclasses
+  def filter_root_class
+    'ManageIQ::Providers::InfraManager::Vm'
   end
 end

--- a/app/presenters/tree_builder_vms_instances_filter.rb
+++ b/app/presenters/tree_builder_vms_instances_filter.rb
@@ -1,13 +1,14 @@
 class TreeBuilderVmsInstancesFilter < TreeBuilderVmsFilter
-  def initialize(*args)
-    @root_class = 'Vm'
-    super(*args)
-  end
+  private
 
   def root_options
     {
       :text    => _("All VMs & Instances"),
       :tooltip => _("All of the VMs & Instances that I can see")
     }
+  end
+
+  def filter_root_class
+    'Vm'
   end
 end


### PR DESCRIPTION
Makes the inheritance approach a bit clearer (I hope),
and removes the need for `super(*args)` constructor in every class.

Also added the method to `TreeBuilderConfiguredSystems` which is an abstract class using the value from descendants.

And removed two stray `attr_reader :tree_nodes`, now also in TreeBuilder itself.

And added `private` in places where it was obvious.

Cc @skateman WDYT? (context: https://github.com/ManageIQ/manageiq-ui-classic/pull/5658#discussion_r289135343)