### PR TITLE
Correct multiselect default value for Ansible Job template survey

### DIFF
--- a/app/services/ansible_tower_job_template_dialog_service.rb
+++ b/app/services/ansible_tower_job_template_dialog_service.rb
@@ -90,13 +90,17 @@ class AnsibleTowerJobTemplateDialogService
 
   def create_parameter_dropdown_list(parameter, group, position)
     dropdown_list = parameter['choices'].split("\n").collect { |v| [v, v] }
-    # currently we do not support multi-selected dropdown, has to take only the first default value
-    default_value = parameter['default'].try(:split, "\n").try(:first)
+    default_value = if parameter['type'] == 'multiselect'
+                      parameter['default'].try(:split, "\n")
+                    else # 'multiplechoice'
+                      parameter['default'].try(:split, "\n").try(:first)
+                    end
     group.dialog_fields.build(
       :type           => "DialogFieldDropDownList",
       :name           => "param_#{parameter['variable']}",
       :display        => "edit",
       :required       => parameter['required'],
+      :options        => {:force_multi_value => parameter["type"] == "multiselect"},
       :values         => dropdown_list,
       :default_value  => default_value || dropdown_list.first,
       :label          => parameter['question_name'],

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -73,8 +73,8 @@ describe AnsibleTowerJobTemplateDialogService do
     assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
     assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
     assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
-    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
-    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), %w(opt1 opt1), %w(opt3 opt3)])
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w[Apple Apple], %w[Banana Banana], %w[Peach Peach]], :options => {:force_multi_value => false})
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "[\"opt1\", \"222\"]",  :values => [%w[222 222], %w[opt1 opt1], %w[opt3 opt3]], :options => {:force_multi_value => true})
     assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
   end
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1707614

These changes correct the behaviour of generating default value while creating Service Dialog from Ansible Job Template with a survey

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1707614

Steps for Testing/QA
-------------------------------

1. have an Ansible Tower provider with a created Job Template with a survey
2. go to Automation - Ansible Tower - Explorer
3. select the Job Template from Templates accordion
4. push Create Service Dialog from this Template button

according to type of field in the survey (multiselect / singleselect), the default value should be set corectly in the generated Service Dialog (Automate - Customization)  