### PR TITLE
Do not depend on the TreeState options param in TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -258,7 +258,7 @@ class TreeBuilder
     # - the open_all setting is present in the tree_init_options
     # - the node is set as active_node in the tree state
     node[:expand] ||= Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) ||
-                      !!options[:open_all]                                               ||
+                      !!@options[:open_all]                                              ||
                       @tree_state.x_tree(@name)[:active_node] == node[:key]
     if ancestry_kids || load_children || node[:expand] || !@options[:lazy]
 


### PR DESCRIPTION
The idea is to get rid of the `options` that is coming from the `TreeState` and depend only on the `tree_init_options` instead.

@miq-bot add_label trees, refactoring, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 