### PR TITLE
Add Copy option to Catalog Item/Bundle

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,28 +111,28 @@ class CatalogController < ApplicationController
 
   def save_copy_catalog
     record = find_record_with_rbac(ServiceTemplate, params[:id])
-    message  = nil
+    message = nil
     if record.present?
       saved = record.template_copy(params[:name])
     else
       saved = false
       message = _("Record not found.")
     end
-    render :json => {:message => message} , :status => saved ? 200 : 400
+    render :json => {:message => message}, :status => saved ? 200 : 400
   end
 
   def servicetemplate_copy_cancel
     add_flash(_("Copy of a Service Catalog Item was cancelled by the user"), :warning)
     @sb[:action] = @edit = @record = nil
     @in_a_form = false
-    replace_right_cell
+    replace_right_cell(:replace_trees => trees_to_replace([:sandt]))
   end
 
   def servicetemplate_copy_saved
-      add_flash(_("Copy of a Service Catalog Item was successfully saved"))
-      @sb[:action] = @edit = @record = nil
-      @in_a_form = false
-      replace_right_cell
+    add_flash(_("Copy of a Service Catalog Item was successfully saved"))
+    @sb[:action] = @edit = @record = nil
+    @in_a_form = false
+    replace_right_cell(:replace_trees => trees_to_replace(%i[sandt svccat stcat]))
   end
 
   def servicetemplates_names

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -94,11 +94,19 @@ class CatalogController < ApplicationController
   def servicetemplate_copy
     checked_id = find_checked_items.first || params[:id]
     @record = find_record_with_rbac(ServiceTemplate, checked_id)
-    @tabactive = false
-    @in_a_form = true
-    @edit = {}
-    session[:changed] = false
-    replace_right_cell(:action => "copy_catalog")
+    if !@record.template_valid?
+      add_flash(_("This item is not valid and cannot be copied."), :error)
+      javascript_flash
+    elsif @record.type == 'ServiceTemplateAnsiblePlaybook'
+      add_flash(_("ServiceTemplateAnsiblePlaybook cannot be copied."), :error)
+      javascript_flash
+    else
+      @tabactive = false
+      @in_a_form = true
+      @edit = {}
+      session[:changed] = false
+      replace_right_cell(:action => "copy_catalog")
+    end
   end
 
   def save_copy_catalog

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -120,11 +120,15 @@ class CatalogController < ApplicationController
     replace_right_cell
   end
 
-  def servicetemplate_copy_saved()
+  def servicetemplate_copy_saved
       add_flash(_("Copy of a Service Catalog Item was successfully saved"))
       @sb[:action] = @edit = @record = nil
       @in_a_form = false
       replace_right_cell
+  end
+
+  def servicetemplates_names
+    render :json => {:names => ServiceTemplate.all.pluck(:name)}
   end
 
   def atomic_st_edit

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -33,6 +33,7 @@ class CatalogController < ApplicationController
     'atomic_catalogitem_edit'       => :servicetemplate_edit,
     'atomic_catalogitem_new'        => :servicetemplate_edit,
     'catalogitem_edit'              => :servicetemplate_edit,
+    'catalogitem_copy'              => :servicetemplate_copy,
     'catalogitem_new'               => :servicetemplate_edit,
 
     'catalogitem_tag'               => :st_tags_edit,
@@ -88,6 +89,11 @@ class CatalogController < ApplicationController
 
   def ot_orchestration_managers
     render :json => available_orchestration_managers_for_template_type(params['template_type'])
+  end
+
+  def servicetemplate_copy
+    checked_id = find_checked_items.first || params[:id]
+    @record = find_record_with_rbac(ServiceTemplate, checked_id)
   end
 
   def atomic_st_edit

--- a/app/helpers/application_helper/button/catalog_item_copy_button.rb
+++ b/app/helpers/application_helper/button/catalog_item_copy_button.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::CatalogItemCopyButton < ApplicationHelper::Button::Basic
+  def disabled?
+    !@record.template_valid? || @record.type == 'ServiceTemplateAnsiblePlaybook'
+  end
+end

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -30,9 +30,11 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
         button(
           :catalogitem_copy,
           'pficon pficon-edit fa-lg',
-          N_('Select a single Item to copy'),
+          N_('This Item cannot be copied'),
           N_('Copy Selected Item'),
-          :send_checked => true),
+          :send_checked => true,
+          :klass        => ApplicationHelper::Button::CatalogItemCopyButton
+        ),
         button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -28,6 +28,12 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
           :url_parms    => "main_div",
           :send_checked => true),
         button(
+          :catalogitem_copy,
+          'pficon pficon-edit fa-lg',
+          N_('Select a single Item to copy'),
+          N_('Copy Selected Item'),
+          :send_checked => true),
+        button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
           N_('Delete this Catalog Item'),

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -28,6 +28,15 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           :enabled      => false,
           :onwhen       => "1"),
         button(
+          :catalogitem_copy,
+          'pficon pficon-edit fa-lg',
+          N_('Select a single Item to copy'),
+          N_('Copy Selected Item'),
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1"
+        ),
+        button(
           :catalogitem_delete,
           'pficon pficon-delete fa-lg',
           N_('Delete selected Catalog Items'),

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -48,6 +48,7 @@ class CopyCatalogForm extends Component {
           buttonsLabels={{
             submitLabel: __('Add'),
           }}
+          disableSubmit={['invalid']}
         />
       </Grid>
     );

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -25,7 +25,7 @@ class CopyCatalogForm extends Component {
 
   handleError = (error) => {
     const { data: { error: { message } } } = error;
-    return !!message ? message : __('There was an error in copying. Item is not valid or Ansible.');
+    return !!message ? message : __('Selected item can not be copied. Because it\'s Ansible Playbook or not valid.');
   };
 
   submitValues = (values) => {

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'patternfly-react';
+import MiqFormRenderer from '../../forms/data-driven-form';
+import createSchema from './copy-catalog-form.schema';
+import { http } from '../../http_api';
+
+class CopyCatalogForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoaded: false,
+    };
+  }
+
+  componentDidMount() {
+    this.setState(() => ({
+      schema: createSchema(),
+      initialValues: {
+        name: 'Copy of',
+      },
+      isLoaded: true,
+    }));
+  };
+
+  handleError = (error) => {
+    const { data: { error: { message } } } = error;
+    return !!message ? message : __('There was an error in copying. Item is not valid or Ansible.');
+  };
+
+  submitValues = (values) => {
+    http.post('/catalog/save_copy_catalog', { id: this.props.catalogId, name: values.name }, { skipErrors: [400] })
+      .then(() => miqAjaxButton('/catalog/servicetemplate_copy_saved'))
+      .catch((error) => add_flash(this.handleError(error), 'error'));
+  };
+
+  render() {
+    if (!this.state.isLoaded) return null;
+    const cancelUrl = `/catalog/servicetemplate_copy_cancel/${this.props.catalogId}`;
+
+    return (
+      <Grid fluid>
+        <MiqFormRenderer
+          initialValues={this.state.initialValues}
+          schema={this.state.schema}
+          onSubmit={this.submitValues}
+          onCancel={() => miqAjaxButton(cancelUrl)}
+          buttonsLabels={{
+            submitLabel: __('Add'),
+          }}
+        />
+      </Grid>
+    );
+  }
+}
+
+CopyCatalogForm.propTypes = {
+  catalogId: PropTypes.string,
+};
+
+CopyCatalogForm.defaultProps = {
+  catalogId: undefined,
+};
+
+export default CopyCatalogForm;

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -17,7 +17,7 @@ class CopyCatalogForm extends Component {
     this.setState(() => ({
       schema: createSchema(),
       initialValues: {
-        name: 'Copy of',
+        name: 'Copy of ' + this.props.originName,
       },
       isLoaded: true,
     }));
@@ -56,10 +56,12 @@ class CopyCatalogForm extends Component {
 
 CopyCatalogForm.propTypes = {
   catalogId: PropTypes.string,
+  originName: PropTypes.string,
 };
 
 CopyCatalogForm.defaultProps = {
   catalogId: undefined,
+  originName: '',
 };
 
 export default CopyCatalogForm;

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
@@ -1,10 +1,28 @@
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import debouncePromise from '../../helpers/promise-debounce';
+import { http } from '../../http_api';
+
+export const asyncValidator = value =>
+  http.get('/catalog/servicetemplates_names')
+    .then((json) => {
+      if (json.names.includes(value)) {
+        return __('Name has already been taken');
+      }
+      if (value === '' || value === undefined) {
+        return __("Name can't be blank");
+      }
+      return undefined;
+    });
+const asyncValidatorDebounced = debouncePromise(asyncValidator);
 
 function createSchema() {
   const fields = [
     {
       component: componentTypes.TEXT_FIELD,
       name: 'name',
+      validate: [
+        value => asyncValidatorDebounced(value),
+      ],
       label: __('Name'),
       maxLength: 40,
     }];

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
@@ -1,0 +1,14 @@
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+
+function createSchema() {
+  const fields = [
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'name',
+      label: __('Name'),
+      maxLength: 40,
+    }];
+  return { fields };
+}
+
+export default createSchema;

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
@@ -25,6 +25,8 @@ function createSchema() {
       ],
       label: __('Name'),
       maxLength: 40,
+      autoFocus: true,
+      validateOnMount: true,
     }];
   return { fields };
 }

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -8,11 +8,8 @@ import Breadcrumbs from '../components/breadcrumbs';
 import CatalogForm from '../components/catalog-form/catalog-form';
 import CloudNetworkForm from '../components/cloud-network-form/cloud-network-form';
 import CloudTenantForm from '../components/cloud-tenant-form/cloud-tenant-form';
-<<<<<<< HEAD
 import CopyDashboardForm from '../components/copy-dashboard-form/copy-dashboard-form';
-=======
 import CopyCatalogForm from '../components/copy-catalog-form/copy-catalog-form';
->>>>>>> Add React component CopyCatalogForm
 import FlavorForm from '../components/flavor-form/flavor-form';
 import FormButtonsRedux from '../forms/form-buttons-redux';
 import GenericGroupWrapper from '../react/generic_group_wrapper';

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -8,7 +8,11 @@ import Breadcrumbs from '../components/breadcrumbs';
 import CatalogForm from '../components/catalog-form/catalog-form';
 import CloudNetworkForm from '../components/cloud-network-form/cloud-network-form';
 import CloudTenantForm from '../components/cloud-tenant-form/cloud-tenant-form';
+<<<<<<< HEAD
 import CopyDashboardForm from '../components/copy-dashboard-form/copy-dashboard-form';
+=======
+import CopyCatalogForm from '../components/copy-catalog-form/copy-catalog-form';
+>>>>>>> Add React component CopyCatalogForm
 import FlavorForm from '../components/flavor-form/flavor-form';
 import FormButtonsRedux from '../forms/form-buttons-redux';
 import GenericGroupWrapper from '../react/generic_group_wrapper';
@@ -37,6 +41,7 @@ ManageIQ.component.addReact('Breadcrumbs', Breadcrumbs);
 ManageIQ.component.addReact('CatalogForm', CatalogForm);
 ManageIQ.component.addReact('CloudNetworkForm', CloudNetworkForm);
 ManageIQ.component.addReact('CloudTenantForm', CloudTenantForm);
+ManageIQ.component.addReact('CopyCatalogForm', CopyCatalogForm);
 ManageIQ.component.addReact('CopyDashboardForm', CopyDashboardForm);
 ManageIQ.component.addReact('FlavorForm', FlavorForm);
 ManageIQ.component.addReact('FormButtonsRedux', FormButtonsRedux);

--- a/app/views/catalog/_copy_catalog.html.haml
+++ b/app/views/catalog/_copy_catalog.html.haml
@@ -1,3 +1,3 @@
 = render :partial => "layouts/flash_msg"
 .col-md-12
-  = react('CopyCatalogForm', { :catalogId => @record.id.to_s})
+  = react('CopyCatalogForm', { :catalogId => @record.id.to_s, :originName => @record.name})

--- a/app/views/catalog/_copy_catalog.html.haml
+++ b/app/views/catalog/_copy_catalog.html.haml
@@ -1,0 +1,3 @@
+= render :partial => "layouts/flash_msg"
+.col-md-12
+  = react('CopyCatalogForm', { :catalogId => @record.id.to_s})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -289,6 +289,7 @@ Rails.application.routes.draw do
         ot_edit
         ot_orchestration_managers
         ot_show
+        servicetemplates_names
         show
       ),
       :post => %w(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,6 +283,7 @@ Rails.application.routes.draw do
     :catalog                  => {
       :get  => %w(
         catalog_item_form_fields
+        copy_catalog
         download_data
         explorer
         ot_edit
@@ -318,8 +319,12 @@ Rails.application.routes.draw do
         reload
         resolve
         resource_delete
+        save_copy_catalog
         service_dialog_from_ot_submit
         servicetemplate_edit
+        servicetemplate_copy
+        servicetemplate_copy_cancel
+        servicetemplate_copy_saved
         sort_ds_grid
         sort_host_grid
         sort_iso_img_grid


### PR DESCRIPTION
Go to Services -> Catalogs -> Catalog Items -> select one -> Configuration -> Copy this Item

Backend PR(merged) https://github.com/ManageIQ/manageiq/pull/18464 . Only valid and non-`ServiceTemplateAnsiblePlaybook` items can be copied. 

Not all attributes are copied. Tracked in https://github.com/ManageIQ/manageiq/issues/18949
It's not possible to copy a copy with custom buttons. Tracked in https://github.com/ManageIQ/manageiq/issues/18954 => Fixed in https://github.com/ManageIQ/manageiq/pull/18960

Toolbar:
<img width="871" alt="Screenshot 2019-07-02 at 15 43 33" src="https://user-images.githubusercontent.com/9210860/60517694-67d30200-9ce0-11e9-98c2-c7535d0adc4e.png">

Form:
<img width="1006" alt="Screenshot 2019-07-02 at 15 45 47" src="https://user-images.githubusercontent.com/9210860/60518051-09f2ea00-9ce1-11e9-95af-039bb79d804b.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678149

@miq-bot add_label wip