### PR TITLE
Extend toolbar pluggability to all plugins.

### DIFF
--- a/app/helpers/application_helper/toolbar/basic.rb
+++ b/app/helpers/application_helper/toolbar/basic.rb
@@ -12,13 +12,19 @@ class ApplicationHelper::Toolbar::Basic < ApplicationHelper::Toolbar::Base
   end
 
   def extension_classes_filtered(record)
-    return extension_classes if record.nil?
-
-    # Example:
+    # If the toolbar class reponds to `record_valid?`, we call it. Even for null record.
+    #
+    # Else we use a mechanism that matches records with provider names.
+    # In this case null record means "match".
+    #
+    # Example for matching:
+    #
     # "ManageIQ::Providers::Amazon::ToolbarOverrides::EmsCloudCenter" is a match for
     #   "ManageIQ::Providers::Amazon::CloudManager
     extension_classes.find_all do |ext|
-      ext.name.split('::')[0..2] == record.class.name.split('::')[0..2]
+      ext.respond_to?(:record_valid?) ?
+        ext.record_valid?(record) :
+        (record.nil? || ext.name.split('::')[0..2] == record.class.name.split('::')[0..2])
     end
   end
 

--- a/spec/helpers/application_helper/toolbar/basic_spec.rb
+++ b/spec/helpers/application_helper/toolbar/basic_spec.rb
@@ -1,0 +1,34 @@
+describe ApplicationHelper::Toolbar::Basic do
+  describe "extension_classes_filtered" do
+    it "filteres toolbar extensions using record_valid? if available" do
+ 
+      # create a Vmdb plugin
+      ext_name = 'MyExtension'
+      Object.const_set(
+        ext_name,
+        Class.new(Rails::Engine) do
+          def vmdb_plugin?
+            true
+          end
+        end
+      )
+      # force reload of plugins to catch a new one
+      Vmdb::Plugins.send(:instance).instance_eval { @all = nil }
+
+      # create a toolbar under the plugin
+      overrides = MyExtension.const_set('ToolbarOverrides', Module.new)
+      toolbar_ext_name = 'Basic'
+      overrides.const_set(
+        toolbar_ext_name,
+        Class.new(ApplicationHelper::Toolbar::Override) do
+          def self.record_valid?(rec)
+            true
+          end
+        end
+      )
+
+      expect(MyExtension::ToolbarOverrides::Basic).to receive(:record_valid?).with(record = 'foobar')
+      described_class.definition(record)
+    end
+  end
+end


### PR DESCRIPTION
Newly any plugin can add content to to toolbars. Not only providers.

Plugged-in toolbars should implement class method:

```
def self.record_valid?(record)
    ...
end
```
that decides if the toolbar is to be displayed for a particular record.

Example display only for vmWare VMs:

```
def self.record_valid?(record)
  record.kind_of?(ManageIQ::Providers::Vmware::InfraManager::Vm)
end
```
Please note that such level of control is only available for the
toolbars on the detail pages. Not for the toolbars on the listing pages.


Bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1678194

Example:
https://github.com/martinpovolny/miq_plugin_example/pull/10


# ~~TODO:~~

The below should actually be already done. Just I am not sure how well it is documented.

 * backend changes: need something like https://github.com/Ladas/manageiq-providers-nuage/blob/e86e67c9b50aab213622db5b97ded3d32b9ef68e/app/models/manageiq/providers/nuage/network_manager.rb#L118
 * https://github.com/Ladas/manageiq-providers-nuage/blob/79fbd748618700c1bec9baca2a78c69b067e1902/app/models/manageiq/providers/nuage/network_manager/cloud_subnet.rb#L35
https://github.com/ManageIQ/manageiq-providers-redfish/pull/67/files#diff-76ec0fe4572d8ade5e76f4943b001e46R21