### PR TITLE
Add identifier to provider dialog modal's div

### DIFF
--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -44,6 +44,7 @@ function modal(title, Inner, closed, removeId) {
         show
         onHide={closed}
         onExited={closed}
+        id="provider-modal"
       >
         <Modal.Header>
           <button


### PR DESCRIPTION
The div ID will be derived from component's name: should the component be called `RemoveCatalogItemModal`, the ID assigned to the modal div will be `remove-catalog-item-modal`.

![modal-id](https://user-images.githubusercontent.com/6648365/58882052-bc805e80-86db-11e9-8d41-3462c935c1bf.png)

@himdel review please?

https://bugzilla.redhat.com/show_bug.cgi?id=1711046