### PR TITLE
Fix filter of schedules in widget imports in WidgetImportService

### DIFF
--- a/app/services/widget_import_service.rb
+++ b/app/services/widget_import_service.rb
@@ -25,7 +25,7 @@ class WidgetImportService
     log_widget_import_message(new_or_existing_widget)
 
     new_or_existing_widget.update_attributes(widget)
-    new_or_existing_widget.miq_schedule = build_miq_schedule(schedule_from_widget.merge("widget_id" => new_or_existing_widget.id))
+    new_or_existing_widget.update(:miq_schedule => build_miq_schedule(schedule_from_widget.merge("widget_id" => new_or_existing_widget.id))) if schedule_from_widget
     new_or_existing_widget
   end
 
@@ -93,6 +93,7 @@ class WidgetImportService
 
   def build_miq_schedule(schedule_contents)
     return if schedule_contents.blank?
+    new_widget_id = schedule_contents.delete("widget_id")
 
     new_or_existing_schedule = MiqSchedule.where(
       :name          => schedule_contents["name"],

--- a/app/services/widget_import_service.rb
+++ b/app/services/widget_import_service.rb
@@ -19,12 +19,14 @@ class WidgetImportService
     new_or_existing_widget.title ||= widget["title"]
     new_or_existing_widget.content_type ||= "report"
     new_or_existing_widget.resource = build_report_contents(widget)
-    new_or_existing_widget.miq_schedule = build_miq_schedule(widget)
     widget.delete("resource_id")
+    schedule_from_widget = widget.delete("MiqSchedule")
 
     log_widget_import_message(new_or_existing_widget)
 
     new_or_existing_widget.update_attributes(widget)
+    new_or_existing_widget.miq_schedule = build_miq_schedule(schedule_from_widget.merge("widget_id" => new_or_existing_widget.id))
+    new_or_existing_widget
   end
 
   def import_widgets(import_file_upload, widgets_to_import)
@@ -89,9 +91,7 @@ class WidgetImportService
     new_or_existing_report
   end
 
-  def build_miq_schedule(widget)
-    schedule_contents = widget.delete("MiqSchedule")
-
+  def build_miq_schedule(schedule_contents)
     return if schedule_contents.blank?
 
     new_or_existing_schedule = MiqSchedule.where(
@@ -99,6 +99,11 @@ class WidgetImportService
       :resource_type => schedule_contents["resource_type"]
     ).first_or_initialize
     new_or_existing_schedule.update_attributes(schedule_contents) if new_or_existing_schedule.new_record?
+
+    if new_or_existing_schedule
+      filter = MiqExpression.new("=" => {"field" => "MiqWidget-id", "value" => new_widget_id})
+      new_or_existing_schedule.update(:filter => filter)
+    end
 
     new_or_existing_schedule
   end

--- a/spec/services/widget_import_service_spec.rb
+++ b/spec/services/widget_import_service_spec.rb
@@ -33,16 +33,33 @@ describe WidgetImportService do
   end
 
   describe "#import_widget_from_hash" do
+    let(:miq_widget_id) { 500 }
+    let(:expression) { MiqExpression.new("=" => {"field" => "MiqWidget-id", "value" => miq_widget_id}) }
+    let(:schedule_to_import) do
+      {
+        :name          => 'vms1',
+        :description   => 'vms1',
+        :sched_action  => {:method => 'generate_widget'},
+        :filter        => expression,
+        :resource_type => "MiqWidget",
+        :run_at        => { :start_time => "2019-05-30 00:00:00 UTC", :tz => "UTC", :interval => { :unit => "hourly", :value => 1 } }
+      }
+    end
+
     let(:widget_to_import) do
       {
         "description" => "Test2",
-        "title"       => "potato"
+        "title"       => "potato",
+        "MiqSchedule" => schedule_to_import
       }
     end
 
     it "builds a new widget" do
       expect(MiqWidget.first).to be_nil
-      widget_import_service.import_widget_from_hash(widget_to_import)
+      miq_widget = widget_import_service.import_widget_from_hash(widget_to_import)
+
+      expect(miq_widget.miq_schedule.filter.exp["="]["value"]).to eq(miq_widget.id)
+      expect(miq_widget.miq_schedule.filter.exp["="]["value"]).not_to eq(miq_widget_id)
       expect(MiqWidget.first).not_to be_nil
     end
   end


### PR DESCRIPTION
When widget is imported, there is related schedule also created.
Schedule(`MiqSchedule`) contains filter (`MiqExpression`) with filter for `MiqWidget` and widget's id (`MiqWidget-id =id of MiqWidget`)

yaml of MiqWidget:
```yaml
- MiqWidget:
    guid: 9fd5b5e0-3a89-4247-9601-966c045f9131
    description: vms2
    MiqSchedule:
      name: vms1
      description: vms1
      sched_action:
        :method: generate_widget
      filter: !ruby/object:MiqExpression
        exp:
          "=":
            field: MiqWidget-id
            value: 500
        context_type: 
        resource_type: MiqWidget
       ...
```

see`filter` part.

but when it was created after import than filter was using the origin widget id and it was causing that widget have not been generated. 

This fix updates this filter (`MiqExpression`) when new widget is created and it adds id of newly created widget to filter  (`MiqExpression`) 

@miq-bot add_label bug

@miq-bot assign @gtanzillo 