### PR TITLE
Convert Tenants details page to textual summary and add Relationships with Services, Automate Domain and Providers

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -72,6 +72,7 @@ ManageIQ.explorer.processButtons = function(data) {
 };
 
 ManageIQ.explorer.processReplaceMainDiv = function(data) {
+  ManageIQ.explorer.updateRightCellText(data);
   ManageIQ.explorer.updatePartials(data);
 };
 
@@ -153,6 +154,13 @@ ManageIQ.explorer.focus = function(data) {
 
 ManageIQ.explorer.removePaging = function() {
   miqGtlSetExtraClasses();
+};
+
+ManageIQ.explorer.updateRightCellText = function(data) {
+  if (_.isString(data.rightCellText)) {
+    $('h1#explorer_title > span#explorer_title_text')
+      .html(data.rightCellText);
+  }
 };
 
 ManageIQ.explorer.processReplaceRightCell = function(data) {
@@ -252,11 +260,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   }
 
   ManageIQ.explorer.scrollTop(data);
-
-  if (_.isString(data.rightCellText)) {
-    $('h1#explorer_title > span#explorer_title_text')
-      .html(data.rightCellText);
-  }
+  ManageIQ.explorer.updateRightCellText(data);
 
   if (data.providerPaused === true) {
     $('#providerPaused').show();

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -74,6 +74,7 @@ ManageIQ.explorer.processButtons = function(data) {
 ManageIQ.explorer.processReplaceMainDiv = function(data) {
   ManageIQ.explorer.updateRightCellText(data);
   ManageIQ.explorer.updatePartials(data);
+  ManageIQ.explorer.setVisibility(data);
 };
 
 ManageIQ.explorer.processFlash = function(data) {
@@ -163,6 +164,20 @@ ManageIQ.explorer.updateRightCellText = function(data) {
   }
 };
 
+ManageIQ.explorer.setVisibility = function(data) {
+  if (_.isObject(data.setVisibility)) {
+    _.forEach(data.setVisibility, function(visible, element) {
+      if ( miqDomElementExists(element) ) {
+        if ( visible ) {
+          $('#' + element).show();
+        } else {
+          $('#' + element).hide();
+        }
+      }
+    });
+  }
+};
+
 ManageIQ.explorer.processReplaceRightCell = function(data) {
   /* variables for the expression editor */
   if (_.isObject(data.expEditor)) {
@@ -247,18 +262,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
     ManageIQ.grids.gtl_list_grid = undefined;
   }
 
-  if (_.isObject(data.setVisibility)) {
-    _.forEach(data.setVisibility, function(visible, element) {
-      if ( miqDomElementExists(element) ) {
-        if ( visible ) {
-          $('#' + element).show();
-        } else {
-          $('#' + element).hide();
-        }
-      }
-    });
-  }
-
+  ManageIQ.explorer.setVisibility(data);
   ManageIQ.explorer.scrollTop(data);
   ManageIQ.explorer.updateRightCellText(data);
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -16,6 +16,10 @@ module Mixins
     # Save actions buttons
     PROHIBITED_PARAMS_BUTTONS = %w[cancel save add].freeze
 
+    def add_to_breadcrumbs(breadcrumb)
+      @tail_breadcrumb = breadcrumb
+    end
+
     # Main method which creates all breadcrumbs and returns them (to view page which will parse them into breadcrumbs nav)
     def data_for_breadcrumbs(controller_options = {})
       options = breadcrumbs_options || {}
@@ -97,6 +101,7 @@ module Mixins
           breadcrumbs.push(:title => extra_title) if action_breadcrumb? && extra_title && title != extra_title
         end
       end
+      breadcrumbs << @tail_breadcrumb
       breadcrumbs.compact
     end
 

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -177,7 +177,7 @@ module Mixins
                       :url  => show_link(@record, :display => @display))
 
       view_options = {:parent => @record}
-      view_options.update(options.slice(:association, :parent_method, :where_clause, :named_scope, :clickable))
+      view_options.update(options.slice(:association, :parent_method, :where_clause, :named_scope, :clickable, :no_checkboxes))
 
       @view, @pages = get_view(model, view_options)
       @showtype = @display

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -286,7 +286,7 @@ class OpsController < ApplicationController
   def textual_group_list
     [
       %i[properties],
-      %i[smart_management]
+      %i[relationships smart_management]
     ]
   end
   helper_method :textual_group_list

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -283,6 +283,14 @@ class OpsController < ApplicationController
     features.map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
   end
 
+  def textual_group_list
+    [
+      %i[properties],
+      %i[smart_management]
+    ]
+  end
+  helper_method :textual_group_list
+
   def set_active_elements(feature, _x_node_to_set = nil)
     if feature
       self.x_active_tree ||= feature.tree_name

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -896,10 +896,18 @@ class OpsController < ApplicationController
   end
 
   def nested_list(model, options = {})
+    # Setup the instance variables for GTL.
     super # (from GenericShowMixin)
-    add_to_breadcrumbs(:title => options[:breadcrumb_title])
 
-    ex = ExplorerPresenter.main_div.update('ops_tabs', render_to_string(:partial => "layouts/gtl"))
+    # Update title and the content area (DOM ID 'ops_tabs')
+    title = _("%{name} (All %{title})") % {
+      :name  => @record.name,
+      :title => options[:breadcrumb_title]
+    }
+    ex = ExplorerPresenter.main_div(:right_cell_text => title).update('ops_tabs', render_to_string(:partial => "layouts/gtl"))
+
+    # Also update breadcrumbs.
+    add_to_breadcrumbs(:title => options[:breadcrumb_title])
     ex.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
 
     render :json => ex.for_render

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -904,7 +904,9 @@ class OpsController < ApplicationController
       :name  => @record.name,
       :title => options[:breadcrumb_title]
     }
-    ex = ExplorerPresenter.main_div(:right_cell_text => title).update('ops_tabs', render_to_string(:partial => "layouts/gtl"))
+    ex = ExplorerPresenter.main_div(:right_cell_text => title)
+                          .update('ops_tabs', render_to_string(:partial => "layouts/gtl"))
+                          .set_visibility(false, :toolbar)
 
     # Also update breadcrumbs.
     add_to_breadcrumbs(:title => options[:breadcrumb_title])

--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -21,6 +21,10 @@ module OpsHelper::TextualSummary
     TextualTags.new(_('Properties'), %i[description parent groups subtenant project])
   end
 
+  def textual_group_relationships
+    TextualGroup.new(_('Relationships'), %i[catalog_items automate_domains providers])
+  end
+
   def textual_group_smart_management
     TextualTags.new(_("Smart Management"), %i[tags])
   end
@@ -182,6 +186,51 @@ module OpsHelper::TextualSummary
     return nil if @record.all_subprojects.blank?
 
     {:label => _('Projects'), :value => subprojects_from_record}
+  end
+
+  def textual_catalog_items
+    cat_items_num = ServiceTemplate.with_tenant(@record.id).count # Number of relevant Catalog Items and Bundles
+    cat_items = {:label => _('Catalog Items and Bundles'),
+                 :value => cat_items_num,
+                 :icon  => 'ff ff-group'}
+
+    if cat_items_num.positive?
+      cat_items[:link] = url_for_only_path(:action => 'show', :id => @record.id, :display => 'service_templates')
+      cat_items[:title] = _('View the list of relevant Catalog Items and Bundles')
+      cat_items[:explorer] = true
+    end
+
+    cat_items
+  end
+
+  def textual_automate_domains
+    aedomains_num = MiqAeDomain.with_tenant(@record.id).count # Number of relevant Automate Domains
+    aedomains = {:label => _('Automate Domains'),
+                 :value => aedomains_num,
+                 :icon  => 'ff ff-group'}
+
+    if aedomains_num.positive?
+      aedomains[:link] = url_for_only_path(:action => 'show', :id => @record.id, :display => 'ae_namespaces')
+      aedomains[:title] = _('View the list of relevant Automate Domains')
+      aedomains[:explorer] = true
+    end
+
+    aedomains
+  end
+
+  def textual_providers
+    providers_num = ExtManagementSystem.with_tenant(@record.id).count # Number of relevant Providers
+    providers = {:label => _('Providers'),
+                 :value => providers_num,
+                 :icon  => 'ff ff-group'}
+
+    if providers_num.positive?
+      providers[:link] = url_for_only_path(:action => 'show', :id => @record.id, :display => 'providers')
+      providers[:title] = _('View the list of relevant Providers')
+      providers[:explorer] = true
+    end
+
+    providers
   end
 
   def groups_from_record

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -24,7 +24,7 @@ class ExplorerPresenter
   #   init_accords                     -- initialize accordion autoresize
   #   ajax_action                      -- Hash of options for AJAX action to fire
   #   clear_gtl_list_grid              -- Clear ManageIQ.grids.gtl_list_grid
-  #   right_cell_text
+  #   right_cell_text                  -- Page title (content of the title area)
   #
   #   :record_id    sets ManageIQ.record.recordId     -- record being displayed or edited
   #   :parent_id    sets ManageIQ.record.parentId     -- it's parent
@@ -221,6 +221,7 @@ class ExplorerPresenter
 
   def for_render_main_div
     data = check_spinner(:explorer => 'replace_main_div')
+    data[:rightCellText] = escape_if_unsafe(@options[:right_cell_text]) if @options[:right_cell_text]
     data[:updatePartials] = @options[:update_partials]
     data
   end

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -223,6 +223,7 @@ class ExplorerPresenter
     data = check_spinner(:explorer => 'replace_main_div')
     data[:rightCellText] = escape_if_unsafe(@options[:right_cell_text]) if @options[:right_cell_text]
     data[:updatePartials] = @options[:update_partials]
+    data[:setVisibility] = @options[:set_visible_elements]
     data
   end
 

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -4,7 +4,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => false, :lazy => true}
+    {:open_all => false}
   end
 
   def root_options

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -1,76 +1,7 @@
-= render :partial => "layouts/flash_msg"
+= render :partial => 'layouts/textual_groups_generic'
 #tenant_info
-  - type = @record.tenant? ? "Tenant" : "Project"
-  %h3
-    = _("%{type} Information") % {:type => type}
-  .form-horizontal
-    .form-group
-      %label.control-label.col-md-2
-        = _("Name")
-      .col-md-8
-        = h(@record.name)
-    .form-group
-      %label.control-label.col-md-2
-        = _("Description")
-      .col-md-8
-        = h(@record.description)
-    - parent = @record.parent
-    - if parent && parent.allowed?
-      .form-group
-        %label.control-label.col-md-2
-          = _("Parent")
-        .col-md-8.pointer{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{parent.id}');",
-          :title   => _("View Parent Tenant")}
-          = h(parent.name)
-    .form-group
-      %label.control-label.col-md-2
-        = _("Groups in this %{type}") % {:type => type}
-      .col-md-8
-        %table{:cellpadding => "0", :cellspacing => "0"}
-          - @record.miq_groups.non_tenant_groups.sort_by { |group| group.name.downcase }.each do |g|
-            - if role_allows?(:feature => "rbac_group_show")
-              - params = {:class   => "pointer",
-                          :onclick => "miqTreeActivateNode('rbac_tree', 'g-#{g.id}');",
-                          :title   => _("View this Group")}
-            - else
-              - params = {}
-            %tr{params}
-              %td
-                %i.ff.ff-group
-                = h(g.name)
-  - all_subtenants = @record.all_subtenants
-  - unless all_subtenants.blank?
-    %h3= _("Child Tenants")
-    %table.table.table-striped.table-bordered.table-hover
-      %thead
-        %th.table-view-pf-select
-        %th= _("Name")
-        %tbody
-          - all_subtenants.each do |tenant|
-            %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{tenant.id}');",
-              :title => _("Click to view child Tenant")}
-              %td.table-view-pf-select
-                %i.pficon.pficon-tenant
-              %td= tenant.name
-  - all_subprojects = @record.all_subprojects
-  - unless all_subprojects.blank?
-    %h3= _("Projects")
-    %table.table.table-striped.table-bordered.table-hover
-      %thead
-        %th.table-view-pf-select
-        %th= _("Name")
-        %tbody
-          - all_subprojects.each do |tenant|
-            %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{tenant.id}');",
-              :title => _("Click to view child TenantProject")}
-              %td.table-view-pf-select
-                %i.pficon.pficon-project
-              %td= tenant.name
   .row
     .col-md-12.col-lg-10
       = react 'TableListViewWrapper', TextualListview.data(textual_tenant_quota_allocations)
       %p
         = _("Note: Total quota can be restricted by quotas defined at upper levels")
-      %hr
-    .col-md-12.col-lg-10
-      = render :partial => "rbac_tag_box"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2478,6 +2478,7 @@ Rails.application.routes.draw do
         log_protocol_changed
         pglogical_subscriptions_form_fields
         schedule_form_fields
+        show
         show_product_update
         tenant_quotas_form_fields
         tenant_form_fields

--- a/product/views/ExtManagementSystem-nested_providers.yaml
+++ b/product/views/ExtManagementSystem-nested_providers.yaml
@@ -1,0 +1,68 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Providers
+
+# Menu name
+name: Providers
+
+# Main DB table report is based on
+db: ExtManagementSystem
+
+# Columns to fetch from the main table
+cols:
+- name
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  tenant:
+    columns:
+    - name
+
+# Order of columns (from all tables)
+col_order:
+- name
+- tenant.name
+
+# Column titles, in order
+headers:
+- Name
+- Tenant
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/product/views/MiqAeDomain-nested_ae_namespaces.yaml
+++ b/product/views/MiqAeDomain-nested_ae_namespaces.yaml
@@ -1,0 +1,68 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Automate Domains
+
+# Menu name
+name: Automate Domains
+
+# Main DB table report is based on
+db: MiqAeDomain
+
+# Columns to fetch from the main table
+cols:
+- name
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  tenant:
+    columns:
+    - name
+
+# Order of columns (from all tables)
+col_order:
+- name
+- tenant.name
+
+# Column titles, in order
+headers:
+- Name
+- Tenant
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/product/views/ServiceTemplate-nested_service_templates.yaml
+++ b/product/views/ServiceTemplate-nested_service_templates.yaml
@@ -1,0 +1,71 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Catalog Items and Bundles
+
+# Menu name
+name: Catalog Items and Bundles
+
+# Main DB table report is based on
+db: ServiceTemplate
+
+# Columns to fetch from the main table
+cols:
+- name
+- description
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  tenant:
+    columns:
+    - name
+
+# Order of columns (from all tables)
+col_order:
+- name
+- description
+- tenant.name
+
+# Column titles, in order
+headers:
+- Name
+- Description
+- Tenant
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/controllers/mixins/generic_show_mixin_spec.rb
+++ b/spec/controllers/mixins/generic_show_mixin_spec.rb
@@ -1,0 +1,33 @@
+describe Mixins::GenericShowMixin do
+  class GenericShowMixinTestController < ActionController::Base
+    include Mixins::GenericShowMixin
+  end
+
+  describe '#nested_list' do
+    context 'displaying Service Templates thru Tenant textual summary' do
+      let(:controller) { OpsController.new }
+      let(:opts) do
+        {
+          :association   => :nested_service_templates,
+          :parent        => tenant,
+          :no_checkboxes => true
+        }
+      end
+      let(:tenant) { FactoryBot.create(:tenant) }
+
+      before do
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:show_link)
+        allow(controller).to receive(:session).and_return(:view => nil)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@record, tenant)
+        controller.params = {}
+      end
+
+      it 'updates view_options also with :no_checkboxes' do
+        expect(controller).to receive(:get_view).with(ServiceTemplate, opts)
+        controller.send(:nested_list, ServiceTemplate, opts.merge(:breadcrumb_title => 'Catalog Items and Bundles'))
+      end
+    end
+  end
+end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -513,4 +513,20 @@ describe OpsController do
       expect { controller.rbac_tenant_manage_quotas }.to raise_error(MiqException::RbacPrivilegeException)
     end
   end
+
+  describe '#textual_group_list' do
+    subject { controller.send(:textual_group_list) }
+
+    it 'displays Properties in textual summary of a Tenant' do
+      expect(subject).to include(array_including(:properties))
+    end
+
+    it 'displays Relationships in textual summary of a Tenant' do
+      expect(subject).to include(array_including(:relationships))
+    end
+
+    it 'displays Smart Management in textual summary of a Tenant' do
+      expect(subject).to include(array_including(:smart_management))
+    end
+  end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -614,7 +614,10 @@ describe OpsController do
     end
 
     it 'updates right cell text' do
-      expect(controller).to receive(:render).with(:json => {:explorer => 'replace_main_div', :rightCellText => "#{record.name} (All #{opts[:breadcrumb_title]})", :updatePartials => {'ops_tabs' => '', :breadcrumbs => ''}})
+      expect(controller).to receive(:render).with(:json => {:explorer       => 'replace_main_div',
+                                                            :rightCellText  => "#{record.name} (All #{opts[:breadcrumb_title]})",
+                                                            :setVisibility  => {:toolbar => false},
+                                                            :updatePartials => {'ops_tabs' => '', :breadcrumbs => ''}})
       controller.send(:nested_list, ServiceTemplate, opts)
     end
   end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -159,7 +159,7 @@ describe OpsController do
     end
   end
 
-  context "#db_backup" do
+  describe "#db_backup" do
     it "posts db_backup action" do
       session[:settings] = {:default_search => ''}
 
@@ -182,7 +182,7 @@ describe OpsController do
     end
   end
 
-  context "#edit_changed?" do
+  describe "#edit_changed?" do
     it "should set session[:changed] as false" do
       edit = {
         :new     => {:foo => 'bar'},
@@ -287,7 +287,7 @@ describe OpsController do
     allow(controller).to receive(:data_for_breadcrumbs).and_return({})
   end
 
-  context "#explorer" do
+  describe "#explorer" do
     it "sets correct active accordion value" do
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:get_node_info)
@@ -305,7 +305,7 @@ describe OpsController do
     end
   end
 
-  context "#replace_explorer_trees" do
+  describe "#replace_explorer_trees" do
     it "build trees that are passed in and met other conditions" do
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:x_build_dyna_tree)
@@ -389,8 +389,8 @@ describe OpsController do
     end
   end
 
-  context '#dialog_replace_right_cell' do
-    describe 'for an User' do
+  describe '#dialog_replace_right_cell' do
+    context 'for an User' do
       before do
         user = FactoryBot.create(:user)
         allow(controller).to receive(:x_node).and_return("u-#{user.id}")
@@ -402,7 +402,7 @@ describe OpsController do
       end
     end
 
-    describe 'for a Group' do
+    context 'for a Group' do
       let(:group) { FactoryBot.create(:miq_group) }
 
       before do
@@ -417,7 +417,7 @@ describe OpsController do
     end
   end
 
-  context "#tree_selected_model" do
+  describe "#tree_selected_model" do
     it 'sets @tree_model_selected to User for user node' do
       allow(controller).to receive(:x_node).and_return('u-42')
       controller.tree_selected_model
@@ -473,7 +473,7 @@ describe OpsController do
     end
   end
 
-  context '#tree_select' do
+  describe '#tree_select' do
     it 'calls #tree_select_model' do
       controller.instance_variable_set(:@sb, {})
       controller.params[:id] = 'root'
@@ -527,6 +527,95 @@ describe OpsController do
 
     it 'displays Smart Management in textual summary of a Tenant' do
       expect(subject).to include(array_including(:smart_management))
+    end
+  end
+
+  context 'display methods for Tenant textual summary' do
+    let(:record) { FactoryBot.create(:tenant) }
+
+    before { controller.instance_variable_set(:@record, record) }
+
+    describe '#display_service_templates' do
+      let(:opts) do
+        {
+          :breadcrumb_title => _('Catalog Items and Bundles'),
+          :association      => :nested_service_templates,
+          :parent           => record,
+          :no_checkboxes    => true
+        }
+      end
+
+      it 'calls nested_list to display Catalog Items and Bundles' do
+        expect(controller).to receive(:nested_list).with(ServiceTemplate, opts)
+        controller.send(:display_service_templates)
+      end
+    end
+
+    describe '#display_providers' do
+      let(:opts) do
+        {
+          :breadcrumb_title => _('Providers'),
+          :association      => :nested_providers,
+          :parent           => record,
+          :no_checkboxes    => true,
+          :clickable        => false
+        }
+      end
+
+      it 'calls nested_list to display Providers' do
+        expect(controller).to receive(:nested_list).with(ExtManagementSystem, opts)
+        controller.send(:display_providers)
+      end
+    end
+
+    describe '#display_ae_namespaces' do
+      let(:opts) do
+        {
+          :breadcrumb_title => _('Automate Domains'),
+          :association      => :nested_ae_namespaces,
+          :parent           => record,
+          :no_checkboxes    => true,
+          :clickable        => false
+        }
+      end
+
+      it 'calls nested_list to display Providers' do
+        expect(controller).to receive(:nested_list).with(MiqAeDomain, opts)
+        controller.send(:display_ae_namespaces)
+      end
+    end
+  end
+
+  describe '#nested_list' do
+    let(:record) { FactoryBot.create(:tenant) }
+    let(:opts) do
+      {
+        :association      => :nested_service_templates,
+        :parent           => record,
+        :no_checkboxes    => true,
+        :breadcrumb_title => 'Catalog Items and Bundles'
+      }
+    end
+
+    before do
+      controller.instance_variable_set(:@record, record)
+      controller.instance_variable_set(:@breadcrumbs, [])
+      allow(controller).to receive(:render_to_string).and_return('')
+    end
+
+    context 'updating breadcrumbs' do
+      before { allow(controller).to receive(:render) }
+
+      it 'calls add_to_breadcrumbs and render_to_string' do
+        expect(controller).to receive(:render_to_string).with(:partial => 'layouts/gtl')
+        expect(controller).to receive(:add_to_breadcrumbs).with(:title => opts[:breadcrumb_title])
+        controller.send(:nested_list, ServiceTemplate, opts)
+      end
+    end
+
+    it 'updates right cell text' do
+      expect(controller).to receive(:render).with(:json => {:explorer => 'replace_main_div', :rightCellText => "#{record.name} (All #{opts[:breadcrumb_title]})", :updatePartials => {'ops_tabs' => '', :breadcrumbs => ''}})
+      controller.send(:nested_list, ServiceTemplate, opts)
     end
   end
 end

--- a/spec/helpers/ops_helper/textual_summary_spec.rb
+++ b/spec/helpers/ops_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe OpsHelper::TextualSummary do
-  before do
-    instance_variable_set(:@record, "")
-  end
+  let(:record) { '' }
+
+  before { instance_variable_set(:@record, record) }
 
   include_examples "textual_group", "Properties", %i(
     vmdb_connection_name
@@ -22,4 +22,185 @@ describe OpsHelper::TextualSummary do
     vmdb_connection_used_index_nodes
     vmdb_connection_free_index_nodes
   ), "vmdb_connection_capacity_data"
+
+  context 'Tenant Textual Summary' do
+    let(:record) { FactoryBot.create(:tenant) }
+
+    describe '#textual_group_properties' do
+      it 'returns Properties table for Tenant' do
+        expect(textual_group_properties).to be_kind_of(TextualTags)
+        expect(textual_group_properties.title).to eq("Properties")
+        expect(textual_group_properties.items).to eq(%i[description parent groups subtenant project])
+      end
+    end
+
+    include_examples 'textual_group', 'Relationships', %i[catalog_items automate_domains providers]
+
+    include_examples 'textual_group_smart_management'
+
+    describe '#textual_description' do
+      it 'returns Description of a Tenant' do
+        expect(textual_description[:label]).to eq('Description')
+        expect(textual_description[:value]).to eq(record.description)
+      end
+    end
+
+    describe '#textual_parent' do
+      let(:user) { FactoryBot.create(:user_admin) }
+
+      before { login_as user }
+
+      context 'Tenant without Parent' do
+        let(:record) { user.current_tenant }
+
+        it 'returns nil for root Tenant' do
+          expect(textual_parent).to be_nil
+        end
+      end
+
+      context 'Tenant with Parent' do
+        before do
+          allow(User).to receive(:server_timezone).and_return("UTC")
+          allow(MiqServer).to receive(:my_server).and_return(FactoryBot.create(:miq_server))
+          allow(self).to receive(:url_for_only_path).and_return("/ops/tree_select/tn-#{record.parent.id}")
+        end
+
+        it 'returns Parent Tenant info' do
+          expect(textual_parent[:label]).to eq('Parent')
+          expect(textual_parent[:explorer]).to be(true)
+          expect(textual_parent[:value]).to eq(record.parent.name)
+          expect(textual_parent[:title]).to eq('View Parent Tenant')
+          expect(textual_parent[:link]).to eq("/ops/tree_select/tn-#{record.parent.id}")
+        end
+      end
+    end
+
+    describe '#textual_groups' do
+      it 'returns nil for Tenant without Groups' do
+        expect(textual_groups).to be_nil
+      end
+
+      context 'Tenant with Groups' do
+        let(:group) { FactoryBot.create(:miq_group) }
+
+        before do
+          allow(@record).to receive(:miq_groups).and_return([group])
+          allow(@record.miq_groups).to receive(:non_tenant_groups).and_return([group])
+          allow(self).to receive(:role_allows?).with(:feature => 'rbac_group_show').and_return(true)
+          allow(self).to receive(:url_for_only_path).and_return("/ops/tree_select/g-#{group.id}")
+        end
+
+        it 'returns Groups' do
+          expect(textual_groups[:label]).to eq('Groups')
+          expect(textual_groups[:value]).to eq([{:value => group.name, :title => "Click to view #{group.name} Group", :explorer => true, :link => "/ops/tree_select/g-#{group.id}"}])
+        end
+      end
+    end
+
+    describe '#textual_subtenant' do
+      it 'returns nil for Tenant without Child Tenants' do
+        expect(textual_subtenant).to be_nil
+      end
+
+      context 'Tenant with Child Tenants' do
+        let(:subtenant) { FactoryBot.create(:tenant, :parent => record) }
+
+        before do
+          allow(@record).to receive(:all_subtenants).and_return([subtenant])
+          allow(self).to receive(:url_for_only_path).and_return("/ops/tree_select/tn-#{subtenant.id}")
+        end
+
+        it 'returns Child Tenants' do
+          expect(textual_subtenant[:label]).to eq('Child Tenants')
+          expect(textual_subtenant[:value]).to eq([{:value => subtenant.name, :title => "Click to view #{subtenant.name} Tenant", :explorer => true, :link => "/ops/tree_select/tn-#{subtenant.id}"}])
+        end
+      end
+    end
+
+    describe '#textual_project' do
+      it 'returns nil for Tenant without Projects' do
+        expect(textual_project).to be_nil
+      end
+
+      context 'Tenant with Projects' do
+        let(:subproject) { FactoryBot.create(:tenant_project) }
+
+        before do
+          allow(@record).to receive(:all_subprojects).and_return([subproject])
+          allow(self).to receive(:url_for_only_path).and_return("/ops/tree_select/tn-#{subproject.id}")
+        end
+
+        it 'returns Projects' do
+          expect(textual_project[:label]).to eq('Projects')
+          expect(textual_project[:value]).to eq([{:value => subproject.name, :title => "Click to view #{subproject.name} TenantProject", :explorer => true, :link => "/ops/tree_select/tn-#{subproject.id}"}])
+        end
+      end
+    end
+
+    describe '#textual_catalog_items' do
+      it 'returns Catalog Items related to the Tenant' do
+        expect(textual_catalog_items[:label]).to eq('Catalog Items and Bundles')
+        expect(textual_catalog_items[:icon]).to eq('ff ff-group')
+        expect(textual_catalog_items[:value]).to eq(0)
+      end
+
+      context 'positive number of relevant Catalog Items' do
+        before do
+          FactoryBot.create(:service_template, :tenant => record)
+          allow(self).to receive(:url_for_only_path).and_return("/ops/show/#{record.id}?display=service_templates")
+        end
+
+        it 'returns Catalog Items related to the Tenant' do
+          expect(textual_catalog_items[:value]).to eq(1)
+          expect(textual_catalog_items[:link]).to eq("/ops/show/#{record.id}?display=service_templates")
+          expect(textual_catalog_items[:title]).to eq('View the list of relevant Catalog Items and Bundles')
+          expect(textual_catalog_items[:explorer]).to be(true)
+        end
+      end
+    end
+
+    describe '#textual_automate_domains' do
+      it 'returns Automate Domains related to the Tenant' do
+        expect(textual_automate_domains[:label]).to eq('Automate Domains')
+        expect(textual_automate_domains[:icon]).to eq('ff ff-group')
+        expect(textual_automate_domains[:value]).to eq(0)
+      end
+
+      context 'positive number of relevant Automate Domains' do
+        before do
+          FactoryBot.create(:miq_ae_domain, :tenant => record)
+          allow(self).to receive(:url_for_only_path).and_return("/ops/show/#{record.id}?display=ae_namespaces")
+        end
+
+        it 'returns Catalog Items related to the Tenant' do
+          expect(textual_automate_domains[:value]).to eq(1)
+          expect(textual_automate_domains[:link]).to eq("/ops/show/#{record.id}?display=ae_namespaces")
+          expect(textual_automate_domains[:title]).to eq('View the list of relevant Automate Domains')
+          expect(textual_automate_domains[:explorer]).to be(true)
+        end
+      end
+    end
+
+    describe '#textual_providers' do
+      it 'returns Automate Domains related to the Tenant' do
+        expect(textual_providers[:label]).to eq('Providers')
+        expect(textual_providers[:icon]).to eq('ff ff-group')
+        expect(textual_providers[:value]).to eq(0)
+      end
+
+      context 'positive number of relevant Providers' do
+        before do
+          FactoryBot.create(:ext_management_system, :tenant => record)
+          allow(self).to receive(:url_for_only_path).and_return("/ops/show/#{record.id}?display=providers")
+        end
+
+        it 'returns Catalog Items related to the Tenant' do
+          expect(textual_providers[:value]).to eq(1)
+          expect(textual_providers[:link]).to eq("/ops/show/#{record.id}?display=providers")
+          expect(textual_providers[:title]).to eq('View the list of relevant Providers')
+          expect(textual_providers[:explorer]).to be(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/views/ops/_rbac_tenant_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_tenant_details.html.haml_spec.rb
@@ -1,0 +1,17 @@
+describe 'ops/_rbac_tenant_details.html.haml' do
+  let(:user) { FactoryBot.create(:user_admin) }
+  let(:tenant) { FactoryBot.create(:tenant) }
+
+  before do
+    allow(view).to receive(:textual_group_list).and_return([%i[properties], %i[relationships smart_management]])
+    allow(User).to receive(:server_timezone).and_return("UTC")
+    assign(:record, tenant)
+    login_as user
+  end
+
+  it 'renders textual summary of a Tenant' do
+    render :partial => 'ops/rbac_tenant_details.html.haml'
+    expect(rendered).to include("<div id='textual_summary'>", 'Properties', 'Relationships', 'Smart Management')
+    expect(rendered).to include(tenant.description)
+  end
+end


### PR DESCRIPTION
**RFE:** https://bugzilla.redhat.com/show_bug.cgi?id=1678124
Details about some changes: https://github.com/ManageIQ/manageiq-ui-classic/pull/6060
Tracking issue: https://github.com/ManageIQ/manageiq/issues/18734

**Depends on:** (all merged)
https://github.com/ManageIQ/manageiq/pull/18733
https://github.com/ManageIQ/manageiq/pull/18735
https://github.com/ManageIQ/manageiq-automation_engine/pull/318
https://github.com/ManageIQ/react-ui-components/pull/129
https://github.com/ManageIQ/manageiq/pull/19071

This PR includes converting Tenants details page to **textual summary** page. We need this to be able easily to add _Relationships_ table with related _Services, Automate Domain_ and _Providers_ info. This PR also adds this.

**Where:**
_Configuration :wheel_of_dharma: > Access Control_ accordion _> Tenants_ 

TODO:
- ~~convert an existing Tenants details page to textual summary~~
- ~~make _Parent, Child Tenants, Groups_ under _Properties_ clickable (if there are any)~~
- ~~edit existing `TagGroup` component to make items clickable:~~ https://github.com/ManageIQ/react-ui-components/pull/129
- ~~solve the background/lines of the items in the table - for _Child Tenants, Groups_~~
- ~~add _Relationships_ with related Service Catalog Items, Automate Domain and Providers info (number of items) and make them clickable~~
- ~~add yamls, list views for displaying Catalog Items and Bundles, Automate Domains, Providers~~
  - ~~display GTL, with pagination, accordion (only list view is enough to be displayed~~
- ~~fix breadcrumbs~~
- ~~specs~~
- ~~when clicking on some Group in textual summary of a Tenant, the Group should be highlighted in accordion~~

**Notes:**
We can find Automate Domains under _Automation -> Automate -> Explorer_.
Making Automate Domains and Providers in nested lists clickable will be done via following up PR.

---

**After:**
Displaying also Child Tenants of an actual Tenant in Properties table (and no Groups present):
![tenant_summ](https://user-images.githubusercontent.com/13417815/62135680-eec8c980-b2e2-11e9-9f00-eb0b4d49fbf7.png)
Displaying _Catalog Items_ from _Relationships_ table:
![nested_cat_items](https://user-images.githubusercontent.com/13417815/63448625-9a76bc80-c43e-11e9-853b-c7af29511d04.png)