### PR TITLE
[WIP] Replace sass-rails with sassc-rails

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -10,7 +10,7 @@ require 'sprockets/railtie'
 #
 # For this to work properly, it is dependent on patternfly/patternfly-sass#150
 if ENV["RAILS_ENV"] != "production" || defined?(Rake)
-  require 'sass-rails'
+  require 'sassc-rails'
   require 'coffee-rails'
   require 'font-fabulous'
   require 'patternfly-sass'

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "more_core_extensions", "~>3.2"
   s.add_dependency "novnc-rails", "~>0.2"
   s.add_dependency "patternfly-sass", "~> 3.59.1"
-  s.add_dependency "sass-rails"
+  s.add_dependency "sassc-rails"
   s.add_dependency "uglifier", "~>3.0.0"
   s.add_dependency "webpacker", "~>2.0.0"
 


### PR DESCRIPTION
As `sass-ruby` became [deprecated](http://sass.logdown.com/posts/7081811) we should stop using anything that depends on it.

@miq-bot add_reviewer @himdel 
@miq-bot add_label hammer/no, dependencies