### PR TITLE
Fix to_hash 5.1 deprecations

### DIFF
--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -19,7 +19,7 @@ module ApplicationController::WaitForTask
     if MiqTask.find(params[:task_id].to_i).state != "Finished" # Task not done --> retry
       browser_refresh_task(params[:task_id])
     else # Task done
-      @_params.instance_variable_get(:@parameters).merge!(session[:async][:params]) # Merge in the original parms and
+      session[:async][:params].each { |k, v| @_params[k] = v } # Merge in the original params and
       send(session.fetch_path(:async, :params, :action)) # call the orig. method
     end
   end

--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -131,9 +131,9 @@ module Mixins
         when 'ManageIQ::Providers::Openstack::CloudManager', 'ManageIQ::Providers::Openstack::InfraManager'
           case params[:cred_type]
           when 'default'
-            [password, params.to_hash.symbolize_keys.slice(*OPENSTACK_PARAMS)]
+            [password, params.to_unsafe_h.slice(*OPENSTACK_PARAMS)]
           when 'amqp'
-            [ManageIQ::Password.encrypt(params[:amqp_password]), params.to_hash.symbolize_keys.slice(*OPENSTACK_AMQP_PARAMS)]
+            [ManageIQ::Password.encrypt(params[:amqp_password]), params.to_unsafe_h.slice(*OPENSTACK_AMQP_PARAMS)]
           end
         when 'ManageIQ::Providers::Amazon::CloudManager'
           uri = URI.parse(WEBrick::HTTPUtils.escape(params[:default_url]))

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -155,8 +155,7 @@ module OpsController::OpsRbac
       if !params[:quotas]
         tenant.set_quotas({})
       else
-        tenant_quotas = params[:quotas].deep_symbolize_keys
-        tenant.set_quotas(tenant_quotas.to_hash)
+        tenant.set_quotas(params.permit[:quotas].to_h)
       end
     rescue => bang
       add_flash(_("Error when saving tenant quota: %{message}") % {:message => bang.message}, :error)

--- a/spec/controllers/mixins/ems_common/angular_spec.rb
+++ b/spec/controllers/mixins/ems_common/angular_spec.rb
@@ -85,25 +85,25 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for openstack cloud default tab" do
         @params[:cred_type] = "default"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
                                     {:default_security_protocol => "ssl",
                                      :default_hostname          => "host_default",
                                      :default_api_port          => "13000",
-                                     :default_userid            => "abc"}]
+                                     :default_userid            => "abc"}.with_indifferent_access]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
       end
 
       it "returns connect options for openstack cloud AMQP tab" do
         @params[:cred_type] = "amqp"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
                                     {:amqp_security_protocol => "non_ssl",
                                      :amqp_hostname          => "host_amqp",
                                      :amqp_api_port          => "5462",
-                                     :amqp_userid            => "xyz"}]
+                                     :amqp_userid            => "xyz"}.with_indifferent_access]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::CloudManager')).to eq(expected_connect_options)
       end
     end
@@ -126,7 +126,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for vmware cloud default tab" do
         @params[:cred_type] = "default"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["host_default", "443", "abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", nil, true]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::CloudManager')).to eq(expected_connect_options)
@@ -134,7 +134,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for vmware cloud AMQP tab" do
         @params[:cred_type] = "amqp"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["host_amqp", "5472", "xyz", "v2:{k8Sm5ygvDAvvY5zkvev1ag==}", nil, true]
         expect(@ems_cloud_controller.send(:get_task_args, 'ManageIQ::Providers::Vmware::CloudManager')).to eq(expected_connect_options)
@@ -160,25 +160,25 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for openstack infra default tab" do
         @params[:cred_type] = "default"
-        @ems_infra_controller.instance_variable_set(:@_params, @params)
+        @ems_infra_controller.params = @params
 
         expected_connect_options = ["v2:{XpADRTTI7f11hNT7AuDaKg==}",
                                     {:default_security_protocol => "ssl",
                                      :default_hostname          => "host_default",
                                      :default_api_port          => "13000",
-                                     :default_userid            => "abc"}]
+                                     :default_userid            => "abc"}.with_indifferent_access]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
       end
 
       it "returns connect options for openstack infra AMQP tab" do
         @params[:cred_type] = "amqp"
-        @ems_infra_controller.instance_variable_set(:@_params, @params)
+        @ems_infra_controller.params = @params
 
         expected_connect_options = ["v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
                                     {:amqp_security_protocol => "non_ssl",
                                      :amqp_hostname          => "host_amqp",
                                      :amqp_api_port          => "5462",
-                                     :amqp_userid            => "xyz"}]
+                                     :amqp_userid            => "xyz"}.with_indifferent_access]
         expect(@ems_infra_controller.send(:get_task_args, 'ManageIQ::Providers::Openstack::InfraManager')).to eq(expected_connect_options)
       end
     end
@@ -197,7 +197,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for vmware infra default tab" do
         @params[:cred_type] = "default"
-        @ems_infra_controller.instance_variable_set(:@_params, @params)
+        @ems_infra_controller.params = @params
 
         expected_connect_options = [{:pass       => "v2:{XpADRTTI7f11hNT7AuDaKg==}",
                                      :user       => "abc",
@@ -208,7 +208,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for vmware infra console tab" do
         @params[:cred_type] = "console"
-        @ems_infra_controller.instance_variable_set(:@_params, @params)
+        @ems_infra_controller.params = @params
 
         expected_connect_options = [{:pass       => "v2:{k8Sm5ygvDAvvY5zkvev1ag==}",
                                      :user       => "xyz",
@@ -232,7 +232,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for aws cloud" do
         @params[:cred_type] = "default"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", :EC2, nil, nil, true, URI.parse("http://abc.test/mypath")]
         expect(@ems_cloud_controller.send(:get_task_args, @ems)).to eq(expected_connect_options)
@@ -256,7 +256,7 @@ describe Mixins::EmsCommon::Angular do
 
       it "returns connect options for azure cloud" do
         @params[:cred_type] = "default"
-        @ems_cloud_controller.instance_variable_set(:@_params, @params)
+        @ems_cloud_controller.params = @params
 
         expected_connect_options = ["abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", "77ecefb6-cff0-4e8d-a446-757a69cb9444", "2586c64b-38b4-4527-a140-012d49dfc444", nil, "East US", URI.parse("http://abc.test/mypath")]
         expect(@ems_cloud_controller.send(:get_task_args, @ems)).to eq(expected_connect_options)

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -212,15 +212,16 @@ describe OpsController do
       end
 
       it "saves tenant quotas record changes" do
-        controller.instance_variable_set(:@_params,
-                                         :name      => "OneTenant",
-                                         :quotas    => {
-                                           :cpu_allocated => {:value => 1024.0},
-                                           :mem_allocated => {:value => 4096.0}
-                                         },
-                                         :id        => @tenant.id,
-                                         :button    => "save",
-                                         :divisible => "true")
+        controller.params = {
+          :name      => "OneTenant",
+          :id        => @tenant.id,
+          :button    => "save",
+          :divisible => "true",
+          :quotas    => {
+            :cpu_allocated => {:value => 1024.0},
+            :mem_allocated => {:value => 4096.0}
+          }
+        }
         expect(controller).to receive(:render)
         expect(response.status).to eq(200)
         controller.send(:rbac_tenant_manage_quotas)


### PR DESCRIPTION
Note, there's no longer a need to ivar set on @_params.  They have a
setter method we should be using as it will initialize the new
ActionController::Parameters object that is the default with rails 5.1:

https://github.com/rails/rails/blob/v5.0.7.2/actionpack/lib/action_controller/metal/strong_parameters.rb#L1059

Fixes:

```
   4 WARN -- : DEPRECATION WARNING: #to_hash unexpectedly ignores parameter filtering, and will change to enforce it in Rails 5.1. Enable `raise_on_unfiltered_parameters` to respect parameter filtering, which is the default in new applications. For the existing deprecated behaviour, call #to_unsafe_h instead. (called from get_task_args at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/mixins/ems_common/angular.rb:134)
   1 WARN -- : DEPRECATION WARNING: #to_hash unexpectedly ignores parameter filtering, and will change to enforce it in Rails 5.1. Enable `raise_on_unfiltered_parameters` to respect parameter filtering, which is the default in new applications. For the existing deprecated behaviour, call #to_unsafe_h instead. (called from get_task_args at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/mixins/ems_common/angular.rb:136)
 151 WARN -- : DEPRECATION WARNING: #to_hash unexpectedly ignores parameter filtering, and will change to enforce it in Rails 5.1. Enable `raise_on_unfiltered_parameters` to respect parameter filtering, which is the default in new applications. For the existing deprecated behaviour, call #to_unsafe_h instead. (called from wait_for_task at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/application_controller/wait_for_task.rb:22)
  71 WARN -- : DEPRECATION WARNING: Method deep_symbolize_keys is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.7.2/classes/ActionController/Parameters.html (called from rbac_tenant_manage_quotas_save_add at /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75776f82ef11/app/controllers/ops_controller/ops_rbac.rb:158)
```