### PR TITLE
Add missing title to edit of Log Depot Settings

### DIFF
--- a/app/assets/javascripts/components/ops/log-collection-form.js
+++ b/app/assets/javascripts/components/ops/log-collection-form.js
@@ -8,6 +8,7 @@ ManageIQ.angular.app.component('logCollectionForm', {
     'logCollectionFormFieldsUrl': '@',
     'saveUrl': '@',
     'logProtocolChangedUrl': '@',
+    'message': '@',
   },
 
 });

--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -2,6 +2,10 @@
                      'select-options'                 => (@supported_depots_for_select).to_json,
                      'log-collection-form-fields-url' => "/#{controller_name}/log_collection_form_fields/",
                      'save-url'                       => "/#{controller_name}/log_depot_edit/",
-                     'log-protocol-changed-url'       => "/#{controller_name}/log_protocol_changed/"}
+                     'log-protocol-changed-url'       => "/#{controller_name}/log_protocol_changed/",
+                     'message'                        =>  _("Editing Log Depot Settings for %{class}: %{display}") % {:class  => Dictionary.gettext(@record.class.name,
+                                                                                                                                                    :type     => :model,
+                                                                                                                                                    :notfound => :titleize),
+                                                                                                                      :display => @record.display_name}}
 :javascript
   miq_bootstrap('log-collection-form');


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1717902

Steps to Reproduce:
1. Configuration -> Diagnostics
2. Select server -> "Collect Logs" tab
3. Click "Edit"

Before:
<img width="1438" alt="Screenshot 2019-06-07 at 15 45 32" src="https://user-images.githubusercontent.com/9210860/59108526-edd17800-88ef-11e9-886e-960f04b2a01b.png">

After:
<img width="1439" alt="Screenshot 2019-06-07 at 14 52 08" src="https://user-images.githubusercontent.com/9210860/59108271-5cfa9c80-88ef-11e9-851e-b1d565315045.png">

@miq-bot hammer/no, blocker, bug

@h-kataria please review, thanks :)
