### PR TITLE
Introduce AzureStack cloud provider

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -249,7 +249,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.prometheus_alerts_auth_status   = data.prometheus_alerts_auth_status;
       $scope.emsCommonModel.prometheus_alerts_security_protocol = data.prometheus_alerts_security_protocol;
       $scope.emsCommonModel.prometheus_alerts_tls_ca_certs  = data.prometheus_alerts_tls_ca_certs;
-      $scope.emsCommonModel.api_version                     = 'v2';
+      if (["openstack", "openstack_infra"].includes($scope.emsCommonModel.ems_controller)) {
+        $scope.emsCommonModel.api_version                   = 'v2';
+      }
       $scope.emsCommonModel.ems_controller                  = data.ems_controller;
       $scope.emsCommonModel.ems_controller === 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
       $scope.emsCommonModel.metrics_api_port                = '443';
@@ -373,6 +375,15 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       return true;
     } else if ($scope.emsCommonModel.emstype === 'kubevirt') {
       return true;
+    } else if ($scope.emsCommonModel.emstype === 'azure_stack') {
+      return !!$scope.emsCommonModel.azure_tenant_id &&
+        !!$scope.emsCommonModel.subscription &&
+        !!$scope.emsCommonModel.api_version &&
+        !!$scope.emsCommonModel.default_hostname &&
+        !!$scope.emsCommonModel.default_security_protocol &&
+        !!$scope.emsCommonModel.default_api_port &&
+        !!$scope.emsCommonModel.default_userid &&
+        !!$scope.emsCommonModel.default_password
     }
     return false;
   };

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -535,6 +535,7 @@ module Mixins
       @scvmm_security_protocols = [[_('Basic (SSL)'), 'ssl'], ['Kerberos', 'kerberos']]
       @openstack_api_versions = retrieve_openstack_api_versions
       @vmware_cloud_api_versions = retrieve_vmware_cloud_api_versions
+      @azure_stack_api_versions = retrieve_azure_stack_api_versions
       @emstype_display = model.supported_types_and_descriptions_hash[@ems.emstype]
       if @ems.respond_to?(:description)
         @ems_region_display = @ems.description
@@ -569,6 +570,10 @@ module Mixins
 
     def retrieve_nuage_api_versions
       [['Version 3.2', 'v3_2'], ['Version 4.0', 'v4_0'], ['Version 5.0', 'v5.0']]
+    end
+
+    def retrieve_azure_stack_api_versions
+      [['2017-03-09 Profile', 'V2017_03_09'], ['2018-03-01 Profile', 'V2018_03_01']]
     end
 
     def retrieve_security_protocols

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -20,10 +20,11 @@
                             "emsCommonModel.emstype == 'scvmm' || " +                                  |
                             "emsCommonModel.ems_controller == 'ems_container' || " +                   |
                             "emsCommonModel.emstype === 'kubevirt' || " +                              |
+                            "emsCommonModel.emstype === 'azure_stack' || " +                           |
                             "emsCommonModel.emstype == 'hawkular'"}                                    |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud' || emsCommonModel.emstype == 'azure_stack'"}
       - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @openstack_security_protocols
       = select_tag("#{prefix}_security_protocol",
                        options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, :disabled => ["<#{_('Choose')}>", nil]),
@@ -238,6 +239,7 @@
                          "emsCommonModel.emstype == 'hawkular'               || " + |
                          "emsCommonModel.emstype == 'lenovo_ph_infra'        || " + |
                          "emsCommonModel.emstype == 'redfish_ph_infra'       || " + |
+                         "emsCommonModel.emstype === 'azure_stack'           || " + |
                          "emsCommonModel.ems_controller == 'ems_container'"}        |
     %label.col-md-2.control-label{"for" => "#{prefix}_api_port"}
       = _('API Port')

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -92,7 +92,7 @@
                                             :prefix                 => "service_account",
                                             :basic_info_needed      => true}
         .col-md-12{"ng-if" => "#{ng_model}.emstype != 'gce' && #{ng_model}.emstype != 'ec2'" || "#{ng_model}" != "emsCommonModel"}
-          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || (#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype != 'rhevm' && #{ng_model}.emstype != 'kubevirt')  || #{ng_model}.emstype == 'vmware_cloud'"}
+          %div{"ng-if" => "#{ng_model}.emstype == 'openstack' || (#{ng_model}.ems_controller == 'ems_infra' && #{ng_model}.emstype != 'rhevm' && #{ng_model}.emstype != 'kubevirt')  || #{ng_model}.emstype == 'vmware_cloud' || #{ng_model}.emstype == 'azure_stack'"}
             = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
                                                 :ng_model               => "#{ng_model}",
@@ -169,7 +169,7 @@
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'gce'"}
           %span{:style => "color:black"}
             = _("Used to authenticate as a service account against your provider.")
-        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'" && "#{ng_model}.ems_controller != 'ems_container'" && "#{ng_model}.emstype != 'kubevirt'"}
+        .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype != 'gce'" && "#{ng_model}.ems_controller != 'ems_container'" && "#{ng_model}.emstype != 'kubevirt'" && "#{ng_model}.emstype != 'azure_stack'"}
           %span{:style => "color:black"}
             = _("Required. Should have privileged access, such as root or administrator.")
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
@@ -486,6 +486,7 @@
                 "#{ng_model}.emstype == 'scvmm'                  || " + |
                 "#{ng_model}.emstype == 'lenovo_ph_infra'        || " + |
                 "#{ng_model}.emstype == 'redfish_ph_infra'       || " + |
+                "#{ng_model}.emstype == 'azure_stack'            || " + |
                 "#{ng_model}.emstype == 'hawkular'"}                    |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -97,7 +97,22 @@
         %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
 
-    .form-group{"ng-class" => "{'has-error': angularForm.subscription.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
+    .form-group{"ng-class" => "{'has-error': angularForm.azure_tenant_id.$invalid}", "ng-if" => "emsCommonModel.emstype == 'azure_stack'"}
+      %label.col-md-2.control-label{"for" => "ems_tenant_id"}
+        = _('Tenant ID')
+      .col-md-4
+        %input.form-control{"type"                    => "text",
+                            "id"                      => "ems_tenant_id",
+                            "name"                    => "azure_tenant_id",
+                            "ng-model"                => "emsCommonModel.azure_tenant_id",
+                            "required"                => "",
+                            "checkchange"             => "",
+                            "prefix"                  => "default",
+                            "reset-validation-status" => "default_auth_status"}
+        %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.subscription.$invalid}", "ng-if" => "['azure', 'azure_stack'].includes(emsCommonModel.emstype)"}
       %label.col-md-2.control-label{"for" => "ems_subscription"}
         = _('Subscription ID')
       .col-md-4
@@ -106,7 +121,7 @@
                             "name"                    => "subscription",
                             "ng-model"                => "emsCommonModel.subscription",
                             "checkchange"             => "",
-                            "required"                => "",
+                            "required"                => true,
                             "prefix"                  => "default",
                             "ng-readonly"             => @ems.id ? true : false,
                             "is-uuid"                 => 4,
@@ -137,6 +152,20 @@
                      "id"                          => "ems_vmware_cloud_api_version",
                      "checkchange"                 => "",
                      "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'azure_stack'"}
+      %label.col-md-2.control-label{"for" => "ems_api_version"}
+        = _("API Version")
+      .col-md-8
+        = select_tag('api_version',
+                     options_for_select(@azure_stack_api_versions),
+                     "ng-model"                    => "emsCommonModel.api_version",
+                     "id"                          => "ems_azure_stack_api_version",
+                     "required"                    => true,
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+        %span.help-block{"ng-show" => "angularForm.api_version.$error.required"}
+          = _("Required")
 
     .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}",
                 "ng-if"    => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -79,8 +79,8 @@ describe('emsCommonFormController', function() {
       expect($scope.emsCommonModel.amqp_api_port).toEqual('5672');
     });
 
-    it('sets the api_version to v2', function() {
-      expect($scope.emsCommonModel.api_version).toEqual('v2');
+    it('sets the api_version to blank', function() {
+      expect($scope.emsCommonModel.api_version).toEqual('');
     });
 
     it('sets the current tab to default', function() {
@@ -515,8 +515,8 @@ describe('emsCommonFormController in the context of container provider', functio
       expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
 
-    it('sets the api_version to v2', function () {
-      expect($scope.emsCommonModel.api_version).toEqual('v2');
+    it('sets the api_version to blank', function () {
+      expect($scope.emsCommonModel.api_version).toEqual('');
     });
 
     it('sets the current tab to default', function() {
@@ -718,8 +718,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
       expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
 
-    it('sets the api_version to v2', function () {
-      expect($scope.emsCommonModel.api_version).toEqual('v2');
+    it('sets the api_version to blank', function () {
+      expect($scope.emsCommonModel.api_version).toEqual('');
     });
 
     it('sets the current tab to default', function() {


### PR DESCRIPTION
With this commit we support basic CRUD operations for Azure Stack cloud provider:

- add a new provider
- open provider details
- update provider credentials
- destroy provider

Below please find some screenshots:

![Capture](https://user-images.githubusercontent.com/8102426/59106893-c0a8b800-8937-11e9-8f05-9ccb3ae6dab2.PNG)

![02_cloud_inventory-overview](https://user-images.githubusercontent.com/8102426/59106928-d918d280-8937-11e9-9236-b009e6b3376f.PNG)

![03_cloud_inventory-instances](https://user-images.githubusercontent.com/8102426/59106954-e9c94880-8937-11e9-8d71-43b47c6e497f.PNG)

![04_instance_operations](https://user-images.githubusercontent.com/8102426/59106972-f3eb4700-8937-11e9-9299-3abf54c1b60f.PNG)

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/18843
- [x] https://github.com/ManageIQ/manageiq-decorators/pull/10

@miq-bot add_label enhancement

/cc @Fryguy @chessbyte 