### PR TITLE
Display the custom login logo on the about modal

### DIFF
--- a/app/assets/stylesheets/about_modal_background.scss
+++ b/app/assets/stylesheets/about_modal_background.scss
@@ -7,10 +7,13 @@
   background-image: image-url($modal-about-pf-bg-img);
 }
 
-.about-modal-pf.whitelabel {
- background-image: image-url($img-bg-login-whitelabel);
-  background-size: 100% 100%;
+body.whitelabel {
+  .about-modal-pf {
+    background-image: image-url($img-bg-login-whitelabel);
+    background-size: 100% 100%;
+  }
 }
+
 
 .about-visible-scrollbar::-webkit-scrollbar {
   width: 10px;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -60,7 +60,7 @@ $login-container-details-border-color-rgba: rgba(0, 0, 0, 0.5);
 
 // styling of custom logo in header
 
-body.whitelabel {
+body.login.whitelabel {
   background: url($img-bg-login-whitelabel);
   background-size: 100% auto;
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,7 @@
       :javascript
         miqInitNotifications();
 
-  %body{:onload => 'miqOnLoad();', 'data-controller' => controller_name}
+  %body{:onload => 'miqOnLoad();', 'data-controller' => controller_name, :class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
     = render :partial => "layouts/header"
     = render :partial => "layouts/content"
     = render :partial => 'layouts/footer'

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -13,7 +13,7 @@
 
     = render :partial => 'layouts/i18n_js'
 
-  %body{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
+  %body.login{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
     - if MiqServer.my_server(true).logon_status == :starting
       :javascript
         self.setTimeout("miqAjax('/dashboard/login_retry')",10000);


### PR DESCRIPTION
This is an ugly hack that adds a class on each page's body element that will trigger the custom background image on the about modal. Eventually we would like to have a [feature](https://github.com/patternfly/patternfly-react/issues/2185) in PF for this.

@miq-bot add_label bug, graphics
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @himdel 

https://bugzilla.redhat.com/show_bug.cgi?id=1717116
