### PR TITLE
Restore the service tree hiearachy and implement lazy loading for nested services

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -4,7 +4,7 @@ class TreeBuilderServices < TreeBuilder
   private
 
   def tree_init_options
-    {:lazy => true, :allow_reselect => true}
+    {:lazy => true}
   end
 
   def root_node(id, text, tip)
@@ -36,8 +36,18 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
-    # Get My Filters and Global Filters
-    count_only_or_objects(count_only, x_get_search_results(object)) if %w[my global].include?(object[:id])
+    case object[:id]
+    when 'my', 'global'
+      # Get My Filters and Global Filters
+      count_only_or_objects(count_only, x_get_search_results(object))
+    when 'asrv', 'rsrv'
+      retired = object[:id] != 'asrv'
+      services = Rbac.filtered(Service.where(:retired => retired, :display => true))
+      return sevices.size if count_only
+
+      MiqPreloader.preload(services.to_a, :picture)
+      Service.arrange_nodes(services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
+    end
   end
 
   def x_get_search_results(object)

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -13,6 +13,21 @@ describe TreeBuilderServices do
       a_hash_including(:id => 'global'),
       a_hash_including(:id => 'my')
     ]
+
+    active_nodes = kid_nodes(root_nodes[0])
+    retired_nodes = kid_nodes(root_nodes[1])
+    expect(active_nodes).to eq(
+      @service => {
+        @service_c1 => {
+          @service_c11 => {},
+          @service_c12 => {
+            @service_c121 => {}
+          }
+        },
+        @service_c2 => {}
+      }
+    )
+    expect(retired_nodes).to eq(@service_c3 => {})
   end
 
   private

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -1,53 +1,47 @@
 describe TreeBuilderServices do
-  let(:builder) { TreeBuilderServices.new("x", {}) }
+  subject { TreeBuilderServices.new("x", {}, false) }
 
-  it "generates tree" do
-    User.current_user = FactoryBot.create(:user)
+  let(:root_srv) { FactoryBot.create(:service, :display => true, :retired => false) }
+  let!(:reti_srv) { FactoryBot.create(:service, :service => root_srv, :display => true, :retired => true) }
+
+  before do
+    login_as FactoryBot.create(:user)
     allow(User).to receive(:server_timezone).and_return("UTC")
-    create_deep_tree
 
-    expect(root_nodes.size).to eq(4)
-    expect(root_nodes).to match [
-      a_hash_including(:id => 'asrv'),
-      a_hash_including(:id => 'rsrv'),
-      a_hash_including(:id => 'global'),
-      a_hash_including(:id => 'my')
-    ]
-
-    active_nodes = kid_nodes(root_nodes[0])
-    retired_nodes = kid_nodes(root_nodes[1])
-    expect(active_nodes).to eq(
-      @service => {
-        @service_c1 => {
-          @service_c11 => {},
-          @service_c12 => {
-            @service_c121 => {}
-          }
-        },
-        @service_c2 => {}
-      }
-    )
-    expect(retired_nodes).to eq(@service_c3 => {})
+    FactoryBot.create(:service, :service => root_srv, :display => true, :retired => false)
+    FactoryBot.create(:service, :service => root_srv, :display => true, :retired => false)
   end
 
-  private
+  describe '#x_get_tree_roots' do
+    it 'returns the four root nodes' do
+      root_nodes = subject.send(:x_get_tree_roots, false, {})
 
-  def root_nodes
-    builder.send(:x_get_tree_roots, false, {})
+      expect(root_nodes).to match [
+        a_hash_including(:id => 'asrv'),
+        a_hash_including(:id => 'rsrv'),
+        a_hash_including(:id => 'global'),
+        a_hash_including(:id => 'my')
+      ]
+    end
   end
 
-  def kid_nodes(node)
-    builder.send(:x_get_tree_custom_kids, node, false, {})
+  describe '#x_get_tree_custom_kids' do
+    it 'returns the root service node for active services' do
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'asrv'}, false, {})
+      expect(root_services).to match [root_srv]
+    end
+
+    it 'returns the retired child service node for retired services' do
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'rsrv'}, false, {})
+      expect(root_services).to match [reti_srv]
+    end
   end
 
-  def create_deep_tree
-    @service      = FactoryBot.create(:service, :display => true, :retired => false)
-    @service_c1   = FactoryBot.create(:service, :service => @service, :display => true, :retired => false)
-    @service_c11  = FactoryBot.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c12  = FactoryBot.create(:service, :service => @service_c1, :display => true, :retired => false)
-    @service_c121 = FactoryBot.create(:service, :service => @service_c12, :display => true, :retired => false)
-    @service_c2   = FactoryBot.create(:service, :service => @service, :display => true, :retired => false)
-    # hidden
-    @service_c3   = FactoryBot.create(:service, :service => @service, :retired => true, :display => true)
+  describe '#x_get_tree_nested_services' do
+    it 'returns the ancestry kids of a service' do
+      child_nodes = subject.send(:x_get_tree_nested_services, root_srv, false)
+
+      expect(child_nodes.length).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
Same fix as I did for [hammer](https://github.com/ManageIQ/manageiq-ui-classic/pull/5530), just adjusted to the latest master. This isn't the complete fix, I'm also working on a way to stop the tree from rendering if the number of nodes exceeds a threshold.

To avoid an N+1, the whole tree is being cached in an instance variable, so we can leverage the same data in `x_get_tree_nested_services` without additional querying. The method is being called for all nodes, to determine if it has any children, i.e. it is lazily loadable or not so this is a big help. cc @kbrock 

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label trees, bug, hammer/no, services

https://bugzilla.redhat.com/show_bug.cgi?id=1703556