### PR TITLE
Opening URLs through automate

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'openUrl', '$http', '$window', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, openUrl, $http, $window) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'realTargetType', 'openUrl', '$http', '$window', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, realTargetType, openUrl, $http, $window) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -50,6 +50,7 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
       resourceActionId: resourceActionId,
       targetId: targetId,
       targetType: targetType,
+      realTargetType: realTargetType,
     };
 
     return dialogFieldRefreshService.refreshField(vm.dialogData, [field.name], vm.refreshUrl, idList);
@@ -73,13 +74,23 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     }
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]})
       .then(function(response) {
+        console.log(response);
+        console.log(vm.openUrl);
+
         if (vm.openUrl === 'true') {
+          console.log('it is true');
           return API.wait_for_task(response.task_id)
             .then(function() {
-              return $http.post('open_url_after_dialog', {targetId: vm.targetId});
+              console.log('calling open_url_after_dialog');
+              console.log('realTargetType: ' + realTargetType);
+              return $http.post('open_url_after_dialog', {targetId: vm.targetId, realTargetType: realTargetType});
             })
             .then(function(response) {
+              console.log('phase 2');
+              console.log(response);
               if (response.data.open_url) {
+                console.log('opening.....');
+                console.log(response.data.open_url);
                 $window.open(response.data.open_url);
                 miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
               } else {

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -74,23 +74,14 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
     }
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]})
       .then(function(response) {
-        console.log(response);
-        console.log(vm.openUrl);
 
         if (vm.openUrl === 'true') {
-          console.log('it is true');
           return API.wait_for_task(response.task_id)
             .then(function() {
-              console.log('calling open_url_after_dialog');
-              console.log('realTargetType: ' + realTargetType);
               return $http.post('open_url_after_dialog', {targetId: vm.targetId, realTargetType: realTargetType});
             })
             .then(function(response) {
-              console.log('phase 2');
-              console.log(response);
               if (response.data.open_url) {
-                console.log('opening.....');
-                console.log(response.data.open_url);
                 $window.open(response.data.open_url);
                 miqService.redirectBack(__('Order Request was Submitted'), 'success', finishSubmitEndpoint);
               } else {

--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -9,6 +9,7 @@ ManageIQ.angular.app.service('dialogFieldRefreshService', ['API', function(API) 
         resource_action_id: idList.resourceActionId,
         target_id: idList.targetId,
         target_type: idList.targetType,
+        real_target_type: idList.realTargetType,
       },
     });
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -246,8 +246,18 @@ module ApplicationController::Buttons
   end
 
   def open_url_after_dialog
-    system_console = SystemConsole.find_by(:vm_id => params[:targetId])
-    url = system_console.try(:url)
+    saved_url = SavedUrl.find_by(
+      :refers_to_id   => params[:targetId],
+      :refers_to_type => params[:realTargetType]
+    )
+    # FIXME: remove this fallback, once the form passes the targetClass
+    saved_url ||= SavedUrl.find_by(:refers_to_id   => params[:targetId])
+
+    # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
+    saved_url = SystemConsole.find_by(:vm_id => params[:targetId])
+
+    url = saved_url.try(:url)
+
     render :json => {:open_url => url}
   end
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -268,7 +268,7 @@ module ApplicationController::Buttons
   def custom_button_done
     external_url = ExternalUrl.find_by(
       :resource_id   => params[:id],
-      :resource_type => params[:cls],
+      :resource_type => params[:base_cls],
       :user          => User.current_user
     )
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
@@ -345,7 +345,11 @@ module ApplicationController::Buttons
     elsif button.options.present? && button.options.fetch_path(:open_url)
       # not supported for objs: cannot do wait for task for multiple tasks
       task_id = button.invoke_async(obj, 'UI')
-      initiate_wait_for_task(:task_id => task_id, :action => :custom_button_done)
+      initiate_wait_for_task(
+        :task_id => task_id,
+        :action => :custom_button_done,
+        :extra_params => { :base_cls => cls.base_class.to_s }
+      )
 
     else
       begin

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -92,7 +92,7 @@ module ApplicationController::Buttons
 
   # Provider, Service, User, Group, Tenant, Cloud Tenant, Generic Object
   # TODO: test each
-  MODEL_WITH_OPEN_URL = %w(Provider Service User MiqGroup Tenant CloudTenant GenericObject Vm).freeze
+  MODEL_WITH_OPEN_URL = %w[Provider Service User MiqGroup Tenant CloudTenant GenericObject Vm].freeze
 
   def automate_button_field_changed
     unless params[:target_class]
@@ -251,13 +251,8 @@ module ApplicationController::Buttons
     external_url = ExternalUrl.find_by(
       :resource_id   => params[:targetId],
       :resource_type => params[:realTargetType],
-      :user           => User.current_user
+      :user          => User.current_user
     )
-    binding.pry if external_url.nil?
-
-    # FIXME: remove this fallback, once the form passes the targetClass
-    #external_url ||= ExternalUrl.find_by(:resource_id => params[:targetId])
-
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
     external_url ||= SystemConsole.find_by(:vm_id => params[:targetId])
 
@@ -274,13 +269,8 @@ module ApplicationController::Buttons
     external_url = ExternalUrl.find_by(
       :resource_id   => params[:id],
       :resource_type => params[:cls],
-      :user           => User.current_user
+      :user          => User.current_user
     )
-    binding.pry if external_url.nil?
-
-    # FIXME: remove this fallback once we have the class here
-    external_url ||= ExternalUrl.find_by(:resource_id => params[:id])
-
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
     external_url ||= SystemConsole.find_by(:vm_id => params[:id])
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -248,17 +248,20 @@ module ApplicationController::Buttons
   end
 
   def open_url_after_dialog
-    saved_url = SavedUrl.find_by(
+    external_url = ExternalUrl.find_by(
       :refers_to_id   => params[:targetId],
-      :refers_to_type => params[:realTargetType]
+      :refers_to_type => params[:realTargetType],
+      :user           => User.current_user
     )
+    binding.pry if external_url.nil?
+
     # FIXME: remove this fallback, once the form passes the targetClass
-    saved_url ||= SavedUrl.find_by(:refers_to_id => params[:targetId])
+    #external_url ||= ExternalUrl.find_by(:refers_to_id => params[:targetId])
 
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
-    saved_url ||= SystemConsole.find_by(:vm_id => params[:targetId])
+    external_url ||= SystemConsole.find_by(:vm_id => params[:targetId])
 
-    url = saved_url.try(:url)
+    url = external_url.try(:url)
 
     render :json => {:open_url => url}
   end
@@ -268,18 +271,20 @@ module ApplicationController::Buttons
   BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
 
   def custom_button_done
-    saved_url = SavedUrl.find_by(
+    external_url = ExternalUrl.find_by(
       :refers_to_id   => params[:id],
-      :refers_to_type => params[:cls]
+      :refers_to_type => params[:cls],
+      :user           => User.current_user
     )
+    binding.pry if external_url.nil?
 
     # FIXME: remove this fallback once we have the class here
-    saved_url ||= SavedUrl.find_by(:refers_to_id => params[:id])
+    external_url ||= ExternalUrl.find_by(:refers_to_id => params[:id])
 
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
-    saved_url ||= SystemConsole.find_by(:vm_id => params[:id])
+    external_url ||= SystemConsole.find_by(:vm_id => params[:id])
 
-    url = saved_url.try(:url)
+    url = external_url.try(:url)
     if url.present?
       javascript_open_window(url)
     else

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -253,10 +253,10 @@ module ApplicationController::Buttons
       :refers_to_type => params[:realTargetType]
     )
     # FIXME: remove this fallback, once the form passes the targetClass
-    saved_url ||= SavedUrl.find_by(:refers_to_id   => params[:targetId])
+    saved_url ||= SavedUrl.find_by(:refers_to_id => params[:targetId])
 
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
-    saved_url = SystemConsole.find_by(:vm_id => params[:targetId])
+    saved_url ||= SystemConsole.find_by(:vm_id => params[:targetId])
 
     url = saved_url.try(:url)
 
@@ -268,8 +268,18 @@ module ApplicationController::Buttons
   BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
 
   def custom_button_done
-    url = SystemConsole.find_by(:vm => params[:id]).try(:url)
+    saved_url = SavedUrl.find_by(
+      :refers_to_id   => params[:id],
+      :refers_to_type => params[:cls]
+    )
 
+    # FIXME: remove this fallback once we have the class here
+    saved_url ||= SavedUrl.find_by(:refers_to_id => params[:id])
+
+    # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
+    saved_url ||= SystemConsole.find_by(:vm_id => params[:id])
+
+    url = saved_url.try(:url)
     if url.present?
       javascript_open_window(url)
     else

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -346,8 +346,8 @@ module ApplicationController::Buttons
       # not supported for objs: cannot do wait for task for multiple tasks
       task_id = button.invoke_async(obj, 'UI')
       initiate_wait_for_task(
-        :task_id => task_id,
-        :action => :custom_button_done,
+        :task_id      => task_id,
+        :action       => :custom_button_done,
         :extra_params => { :base_cls => cls.base_class.to_s }
       )
 

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -249,14 +249,14 @@ module ApplicationController::Buttons
 
   def open_url_after_dialog
     external_url = ExternalUrl.find_by(
-      :refers_to_id   => params[:targetId],
-      :refers_to_type => params[:realTargetType],
+      :resource_id   => params[:targetId],
+      :resource_type => params[:realTargetType],
       :user           => User.current_user
     )
     binding.pry if external_url.nil?
 
     # FIXME: remove this fallback, once the form passes the targetClass
-    #external_url ||= ExternalUrl.find_by(:refers_to_id => params[:targetId])
+    #external_url ||= ExternalUrl.find_by(:resource_id => params[:targetId])
 
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
     external_url ||= SystemConsole.find_by(:vm_id => params[:targetId])
@@ -272,14 +272,14 @@ module ApplicationController::Buttons
 
   def custom_button_done
     external_url = ExternalUrl.find_by(
-      :refers_to_id   => params[:id],
-      :refers_to_type => params[:cls],
+      :resource_id   => params[:id],
+      :resource_type => params[:cls],
       :user           => User.current_user
     )
     binding.pry if external_url.nil?
 
     # FIXME: remove this fallback once we have the class here
-    external_url ||= ExternalUrl.find_by(:refers_to_id => params[:id])
+    external_url ||= ExternalUrl.find_by(:resource_id => params[:id])
 
     # FIXME: remove this fallback once the ':remote_console_url=' is removed from automate
     external_url ||= SystemConsole.find_by(:vm_id => params[:id])

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -90,7 +90,9 @@ module ApplicationController::Buttons
     group_create_update("update")
   end
 
-  MODEL_WITH_OPEN_URL = ["Vm"].freeze
+  # Provider, Service, User, Group, Tenant, Cloud Tenant, Generic Object
+  # TODO: test each
+  MODEL_WITH_OPEN_URL = %w(Provider Service User MiqGroup Tenant CloudTenant GenericObject Vm).freeze
 
   def automate_button_field_changed
     unless params[:target_class]

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -47,7 +47,8 @@ module ApplicationController::WaitForTask
     session[:async][:interval] ||= 1000 # Default interval to 1 second
     session[:async][:params] ||= {}
 
-    session[:async][:params] = params.deep_dup # Save the incoming parms
+    # save the incoming parms + extra_params
+    session[:async][:params] = params.deep_dup.merge(options[:extra_params] || {})
     session[:async][:params][:task_id] = task_id
 
     # override method to be called, when the task is done

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -6,6 +6,7 @@ class DialogLocalService
       :resource_action_id     => resource_action.id,
       :target_id              => target.id,
       :target_type            => target.kind_of?(ServiceTemplate) ? "service_template" : target.class.name.underscore,
+      :real_target_type       => target.class.name, # FIXME: or Service?
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => api_submit_endpoint,
@@ -23,6 +24,7 @@ class DialogLocalService
       :resource_action_id     => resource_action.id,
       :target_id              => obj.id,
       :target_type            => determine_target_type(obj),
+      :real_target_type       => obj.class.name,
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => submit_endpoint,

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -6,7 +6,7 @@ class DialogLocalService
       :resource_action_id     => resource_action.id,
       :target_id              => target.id,
       :target_type            => target.kind_of?(ServiceTemplate) ? "service_template" : target.class.name.underscore,
-      :real_target_type       => target.class.name, # FIXME: or Service?
+      :real_target_type       => target.class.base_class.name,
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => api_submit_endpoint,
@@ -24,7 +24,7 @@ class DialogLocalService
       :resource_action_id     => resource_action.id,
       :target_id              => obj.id,
       :target_type            => determine_target_type(obj),
-      :real_target_type       => obj.class.name,
+      :real_target_type       => obj.class.base_class.name,
       :dialog_id              => resource_action.dialog_id,
       :force_old_dialog_use   => false,
       :api_submit_endpoint    => submit_endpoint,

--- a/app/views/shared/buttons/_ab_options_form.html.haml
+++ b/app/views/shared/buttons/_ab_options_form.html.haml
@@ -79,7 +79,7 @@
         = check_box_tag("open_url", "1", @edit[:new][:open_url], "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json, disabled: @edit[:new][:disabled_open_url])
         - if @edit[:new][:disabled_open_url]
           .note
-            = _("Only available for VM with \"Display for\" set to \"Single\"")
+            = _("Only available for VM, Provider, Service, User, Group, Tenant, Cloud Tenant and Generic Object with \"Display for\" set to \"Single\"")
     .form-group
       %label.control-label.col-md-2
         = _('Display for')

--- a/app/views/shared/dialogs/_dialog_provision.html.haml
+++ b/app/views/shared/dialogs/_dialog_provision.html.haml
@@ -7,6 +7,7 @@
   - cancel_endpoint ||= @dialog_locals[:cancel_endpoint]
   - target_id ||= @dialog_locals[:target_id]
   - target_type ||= @dialog_locals[:target_type]
+  - real_target_type ||= @dialog_locals[:real_target_type]
   - dialog_id ||= @dialog_locals[:dialog_id]
   - resource_action_id ||= @dialog_locals[:resource_action_id]
   - force_old_dialog_use = @dialog_locals[:force_old_dialog_use].to_s == "true"
@@ -48,6 +49,7 @@
                 :resource_action_id     => resource_action_id,
                 :target_id              => target_id,
                 :target_type            => target_type,
+                :real_target_type       => real_target_type,
                 :finish_submit_endpoint => finish_submit_endpoint,
                 :api_submit_endpoint    => api_submit_endpoint,
                 :api_action             => api_action,

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -22,6 +22,7 @@
   ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
   ManageIQ.angular.app.value('targetId', '#{target_id}');
   ManageIQ.angular.app.value('targetType', '#{target_type}');
+  ManageIQ.angular.app.value('realTargetType', '#{real_target_type}');
   ManageIQ.angular.app.value('dialogId', '#{dialog_id}');
   ManageIQ.angular.app.value('finishSubmitEndpoint', '#{finish_submit_endpoint}');
   ManageIQ.angular.app.value('apiSubmitEndpoint', '#{api_submit_endpoint}');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
@@ -40,6 +40,7 @@ describe('dialogUserController', function() {
       resourceActionId: '789',
       targetId: '987',
       targetType: 'targettype',
+      realTargetType: 'targettype',
       openUrl: false,
     });
   }));
@@ -85,7 +86,7 @@ describe('dialogUserController', function() {
         'dialogData',
         ['dialogName'],
         '/api/service_dialogs/',
-        {dialogId: '1234', resourceActionId: '789', targetId: '987', targetType: 'targettype'}
+        {dialogId: '1234', resourceActionId: '789', targetId: '987', targetType: 'targettype', realTargetType: 'targettype'}
       );
     });
   });
@@ -119,6 +120,7 @@ describe('dialogUserController', function() {
           resourceActionId: '789',
           targetId: '987',
           targetType: 'targettype',
+          realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
         });
@@ -153,6 +155,7 @@ describe('dialogUserController', function() {
           resourceActionId: '789',
           targetId: '987',
           targetType: 'targettype',
+          realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
         });

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -14,6 +14,7 @@ describe DialogLocalService do
         :resource_action_id     => 456,
         :target_id              => 321,
         :target_type            => 'service_template',
+        :real_target_type       => "ServiceTemplate",
         :dialog_id              => 654,
         :force_old_dialog_use   => false,
         :api_submit_endpoint    => "/api/service_catalogs/123/service_templates/321",
@@ -29,6 +30,7 @@ describe DialogLocalService do
       expect(service.determine_dialog_locals_for_svc_catalog_provision(resource_action, target_ansible, finish_submit_endpoint)).to eq(:resource_action_id     => 456,
                                                                                                                                        :target_id              => 987,
                                                                                                                                        :target_type            => 'service_template',
+                                                                                                                                       :real_target_type       => "ServiceTemplate",
                                                                                                                                        :dialog_id              => 654,
                                                                                                                                        :force_old_dialog_use   => false,
                                                                                                                                        :api_submit_endpoint    => "/api/service_catalogs/798/service_templates/987",
@@ -44,13 +46,14 @@ describe DialogLocalService do
     let(:resource_action) { instance_double("ResourceAction", :id => 321, :dialog_id => 654) }
     let(:display_options) { {} }
 
-    shared_examples_for "DialogLocalService#determine_dialog_locals_for_custom_button return value" do |target_type, collection_name, finish_endpoint|
+    shared_examples_for "DialogLocalService#determine_dialog_locals_for_custom_button return value" do |target_type, real_target_type, collection_name, finish_endpoint|
       it "returns a hash with the proper parameters" do
         expect(service.determine_dialog_locals_for_custom_button(obj, button_name, resource_action, display_options))
           .to eq(
             :resource_action_id     => 321,
             :target_id              => 123,
             :target_type            => target_type,
+            :real_target_type       => real_target_type,
             :dialog_id              => 654,
             :force_old_dialog_use   => false,
             :api_submit_endpoint    => "/api/#{collection_name}/123",
@@ -66,238 +69,237 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "availability_zone", "availability_zones", "/availability_zone"
+                       "availability_zone", "AvailabilityZone", "availability_zones", "/availability_zone"
     end
 
     context "when the object is a CloudNetwork" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_network", "cloud_networks", "/cloud_network"
+                       "cloud_network", "CloudNetwork", "cloud_networks", "/cloud_network"
     end
 
     context "when the object is a private CloudNetwork" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private, :id => 123) }
-
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_network", "cloud_networks", "/cloud_network"
+                       "cloud_network", "CloudNetwork", "cloud_networks", "/cloud_network"
     end
 
     context "when the object is a CloudObjectStoreContainer" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_object_store_container", "cloud_object_store_containers", "/cloud_object_store_container"
+                       "cloud_object_store_container", "CloudObjectStoreContainer", "cloud_object_store_containers", "/cloud_object_store_container"
     end
 
     context "when the object is a CloudSubnet" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_subnet", "cloud_subnets", "/cloud_subnet"
+                       "cloud_subnet", "CloudSubnet", "cloud_subnets", "/cloud_subnet"
     end
 
     context "when the object is an EmsStorage" do
       let(:obj) { double(:class => ManageIQ::Providers::StorageManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "providers", "/ems_infra"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_infra"
     end
 
     context "when the object is an Ebs" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::StorageManager::Ebs, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ems_storage", "providers", "/ems_infra"
+                       "ems_storage", "ExtManagementSystem", "providers", "/ems_infra"
     end
 
     context "when the object is an CinderManager" do
       let(:obj) { double(:class => ManageIQ::Providers::StorageManager::CinderManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "providers", "/ems_block_storage"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_block_storage"
     end
 
     context "when the object is an SwiftManager" do
       let(:obj) { double(:class => ManageIQ::Providers::StorageManager::SwiftManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "providers", "/ems_object_storage"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_object_storage"
     end
 
     context "when the object is a CloudTenant" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::CloudManager::CloudTenant, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_tenant", "cloud_tenants", "/cloud_tenant"
+                       "cloud_tenant", "CloudTenant", "cloud_tenants", "/cloud_tenant"
     end
 
     context "when the object is a CloudVolume" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::CloudManager::CloudVolume, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "cloud_volume", "cloud_volumes", "/cloud_volume"
+                       "cloud_volume", "CloudVolume", "cloud_volumes", "/cloud_volume"
     end
 
     context "when the object is a ContainerGroup" do
       let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_group", "container_groups", "/container_group"
+                       "container_group", "ContainerGroup", "container_groups", "/container_group"
     end
 
     context "when the object is a ContainerImage" do
       let(:obj) { double(:class => ManageIQ::Providers::Openshift::ContainerManager::ContainerImage, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_image", "container_images", "/container_image"
+                       "container_image", "ContainerImage", "container_images", "/container_image"
     end
 
     context "when the object is a ContainerNode" do
       let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_node", "container_nodes", "/container_node"
+                       "container_node", "ContainerNode", "container_nodes", "/container_node"
     end
 
     context "when the object is a ContainerProject" do
       let(:obj) { double(:class => ContainerProject, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_project", "container_projects", "/container_project"
+                       "container_project", "ContainerProject", "container_projects", "/container_project"
     end
 
     context "when the object is a ContainerTemplate" do
       let(:obj) { double(:class => ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplate, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_template", "container_templates", "/container_template"
+                       "container_template", "ContainerTemplate", "container_templates", "/container_template"
     end
 
     context "when the object is a ContainerVolume" do
       let(:obj) { double(:class => ContainerVolume, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "container_volume", "container_volumes", "/persistent_volume/show/123"
+                       "container_volume", "ContainerVolume", "container_volumes", "/persistent_volume/show/123"
     end
 
     context "when the object is an EmsCluster" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::InfraManager::EmsCluster, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ems_cluster", "clusters", "/ems_cluster"
+                       "ems_cluster", "EmsCluster", "clusters", "/ems_cluster"
     end
 
     context "when the object is a GenericObject" do
       let(:obj) { double(:class => GenericObject, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "generic_object", "generic_objects", "/service/explorer"
+                       "generic_object", "GenericObject", "generic_objects", "/service/explorer"
     end
 
     context "when the object is a Host" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Host, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "host", "hosts", "/host"
+                       "host", "Host", "hosts", "/host"
     end
 
     context "when the object is a HostEsx" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::HostEsx, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "host", "hosts", "/host"
+                       "host", "Host", "hosts", "/host"
     end
 
     context "when the object is an InfraManager" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "providers", "/ems_infra"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_infra"
     end
 
     context "when the object is a CloudManager" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "providers", "/ems_cloud"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_cloud"
     end
 
     context "when the object is a NetworkRouter" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::NetworkRouter, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "network_router", "network_routers", "/network_router"
+                       "network_router", "NetworkRouter", "network_routers", "/network_router"
     end
 
     context "when the object is an OrchestrationStack" do
       let(:obj) { double(:class => ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "orchestration_stack", "orchestration_stacks", "/orchestration_stack"
+                       "orchestration_stack", "OrchestrationStack", "orchestration_stacks", "/orchestration_stack"
     end
 
     context "when the object is a SecurityGroup" do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "security_group", "security_groups", "/security_group"
+                       "security_group", "SecurityGroup", "security_groups", "/security_group"
     end
 
     context "when the object is a Service" do
       let(:obj) { double(:class => Service, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceAnsiblePlaybook" do
       let(:obj) { double(:class => ServiceAnsiblePlaybook, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceAnsibleTower" do
       let(:obj) { double(:class => ServiceAnsibleTower, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceContainerTemplate" do
       let(:obj) { double(:class => ServiceContainerTemplate, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceGeneric" do
       let(:obj) { double(:class => ServiceGeneric, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a ServiceOrchestration" do
       let(:obj) { double(:class => ServiceOrchestration, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "service", "services", "/service/explorer"
+                       "service", "Service", "services", "/service/explorer"
     end
 
     context "when the object is a Storage" do
       let(:obj) { double(:class => Storage, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "storage", "data_stores", "/storage/explorer"
+                       "storage", "Storage", "data_stores", "/storage/explorer"
     end
 
     context "when the object is a Switch" do
       let(:obj) { double(:class => Switch, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "switch", "switches", "/infra_networking/explorer"
+                       "switch", "Switch", "switches", "/infra_networking/explorer"
     end
 
     context "when the object is a Template" do
@@ -306,14 +308,14 @@ describe DialogLocalService do
         let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                         "miq_template", "templates", "/vm_cloud/explorer"
+                         "miq_template", "VmOrTemplate", "templates", "/vm_cloud/explorer"
       end
 
       context "when there is not a cancel endpoint in the display options" do
         let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Template, :id => 123) }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                         "miq_template", "templates", "/vm_or_template/explorer"
+                         "miq_template", "VmOrTemplate", "templates", "/vm_or_template/explorer"
       end
     end
 
@@ -323,14 +325,14 @@ describe DialogLocalService do
         let(:display_options) { {:cancel_endpoint => "/vm_cloud/explorer"} }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                         "vm", "vms", "/vm_cloud/explorer"
+                         "vm", "VmOrTemplate", "vms", "/vm_cloud/explorer"
       end
 
       context "when there is not a cancel endpoint in the display options" do
         let(:obj) { double(:class => ManageIQ::Providers::Vmware::InfraManager::Vm, :id => 123) }
 
         include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                         "vm", "vms", "/vm_infra/explorer"
+                         "vm", "VmOrTemplate", "vms", "/vm_infra/explorer"
       end
     end
   end


### PR DESCRIPTION
RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1550002

Requires: 
 * https://github.com/ManageIQ/manageiq/pull/18849 (merged)
 * https://github.com/ManageIQ/manageiq-automation_engine/pull/328 (merged)
 * https://github.com/ManageIQ/manageiq-schema/pull/380 (merged)

Doc PR: https://github.com/ManageIQ/guides/pull/355

### TODO

 * specs (existing specs are updated, but more tests would be good, will do that in a follow-up PR)
 * ~~pass the targetClass though the form,~~ (needs to be checked)
 * ~~allow the `OpenURL` checkbox when editing custom buttons for all relevant classes.~~
 * ~~update the documentation (from here: https://github.com/ManageIQ/manageiq-ui-classic/pull/4334) and put it to guides~~


#### Tested automate code for User
```
$evm.log(:info, "Current user_id #{$evm.root['user_id']}")
object = $evm.vmdb($evm.root['vmdb_object_type']).find_by(:id => $evm.root['user_id'])
$evm.log(:info, "Current object #{object}")
object.external_url = "https://www.linkedin.com"
```
(the `vmdb_object_type` would work for other entities as well, but the ID is stored elsewhere)

#### Tested automate code for VM
```
vm = $evm.root['vm']
$evm.log(:info, "VM to launch SSH for is #{vm.hostnames[0]}")
vm.external_url = "https://www.redhat.com"
```

#### A screenshot to help navigate in the UI
(it's best to follow the Guides article in the above PR)

![url-example-2019-07-14_13-49](https://user-images.githubusercontent.com/51095/61183202-5c67cb00-a63e-11e9-8975-447a8eac9ddf.png)
