### PR TITLE
Don't repeat error message

### DIFF
--- a/app/assets/javascripts/components/generic_object/custom-image.js
+++ b/app/assets/javascripts/components/generic_object/custom-image.js
@@ -35,7 +35,7 @@ function customImageController($timeout) {
     var imageFile;
 
     if (angular.element('#generic_object_definition_image_file')[0].files.length === 0) {
-      add_flash(__("No file chosen."), 'error');
+      add_flash(__("No file chosen."), 'error', {id: "image-missing"});
       vm.imageMissing = true;
       return;
     }


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1650104

Introduced by #5265

Go to Automation -> Automate -> Generic Objects -> Configuration -> Add a new Generic Object Class -> DO NOT chose a file for Custom Image -> click chosen image

Before:
<img width="1433" alt="Screenshot 2019-06-11 at 10 13 09" src="https://user-images.githubusercontent.com/9210860/59255088-45206280-8be6-11e9-8f4d-ef4d60e739df.png">

After:
<img width="1429" alt="Screenshot 2019-06-11 at 10 09 36" src="https://user-images.githubusercontent.com/9210860/59255111-4f426100-8be6-11e9-8158-ff94df9499ce.png">

@miq-bot add_label bug, hammer/yes, generic objects, automation/automate