### PR TITLE
Replace instance_variable_set(:@_params, ...) with assignment to params

### DIFF
--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -34,7 +34,7 @@ describe AnsibleCredentialController do
 
   describe '#button' do
     before do
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'adding a new ansible credential' do

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -39,7 +39,7 @@ describe AnsiblePlaybookController do
 
   describe "#button" do
     before do
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'tagging one or more playbooks' do

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -54,7 +54,7 @@ describe AnsibleRepositoryController do
 
   describe '#button' do
     before do
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'editing an existing repository' do

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -52,7 +52,7 @@ describe MiqAeToolsController, "ApplicationController::Automate" do
         sb = {:name => 'test', :vmdb_object => nil, :attrs => {'a' => 1}}
         controller.instance_variable_set(:@resolve, resolve)
         controller.instance_variable_set(:@sb, sb)
-        controller.instance_variable_set(:@_params, :button => 'throw')
+        controller.params = {:button => 'throw'}
         allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(workspace)
         data = "<MiqAeWorkspace>\\n<MiqAeObject namespace='ManageIQ/SYSTEM'>\\n</MiqAeObject>\\n</MiqAeWorkspace>\\n"
         allow(workspace).to receive(:to_expanded_xml).and_return(data)
@@ -72,7 +72,7 @@ describe MiqAeToolsController, "ApplicationController::Automate" do
         sb = {:name => 'test', :vmdb_object => nil, :attrs => {'a' => 1}}
         controller.instance_variable_set(:@resolve, resolve)
         controller.instance_variable_set(:@sb, sb)
-        controller.instance_variable_set(:@_params, :button => 'retry')
+        controller.params = {:button => 'retry'}
         allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(workspace)
         data = "<MiqAeWorkspace>\\n<MiqAeObject namespace='ManageIQ/SYSTEM'>\\n</MiqAeObject>\\n</MiqAeWorkspace>\\n"
         allow(workspace).to receive(:to_expanded_xml).and_return(data)

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -366,7 +366,7 @@ describe ApplicationController do
       end
 
       it "to id of selected dialog" do
-        controller.params = {{:id => button.id, :dialog_id => 42}.with_indifferent_access}
+        controller.params = {:id => button.id, :dialog_id => 42}.with_indifferent_access
         controller.instance_variable_set(:@resolve, :target_class => "VM and Instance")
         controller.send(:automate_button_field_changed)
         expect(assigns(:edit)[:new][:dialog_id]).to eq(42)

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -8,7 +8,7 @@ describe ApplicationController do
 
     context "with a resource_action dialog" do
       it "Vm button" do
-        controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
+        controller.params = {:id => vm.id, :button_id => button.id}
         expect(controller).to receive(:dialog_initialize) do |action, options|
           expect(action).to eq(resource_action)
           expect(options[:target_id]).to eq(vm.id)
@@ -23,7 +23,7 @@ describe ApplicationController do
       it "Host button" do
         button.applies_to = host
         button.save
-        controller.instance_variable_set(:@_params, :id => host.id, :button_id => button.id)
+        controller.params = {:id => host.id, :button_id => button.id}
 
         expect(controller).to receive(:dialog_initialize) do |action, options|
           expect(action).to eq(resource_action)
@@ -39,7 +39,7 @@ describe ApplicationController do
 
     it "Host button with a subclass, not base_class in applies_to_class" do
       button.update_attributes(:applies_to_class => host.class.name)
-      controller.instance_variable_set(:@_params, :id => host.id, :button_id => button.id)
+      controller.params = {:id => host.id, :button_id => button.id}
       expect { controller.send(:custom_buttons) }.to raise_error(ArgumentError)
     end
 
@@ -51,7 +51,7 @@ describe ApplicationController do
       end
 
       it "Vm button" do
-        controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
+        controller.params = {:id => vm.id, :button_id => button.id}
         expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm, 'UI')
 
         controller.send(:custom_buttons)
@@ -67,7 +67,7 @@ describe ApplicationController do
       end
 
       it "Vm button" do
-        controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
+        controller.params = {:id => vm.id, :button_id => button.id}
         expect_any_instance_of(CustomButton).to receive(:invoke).with(vm, 'UI')
 
         controller.send(:custom_buttons)
@@ -78,7 +78,7 @@ describe ApplicationController do
       it "Host button" do
         button.applies_to = host
         button.save
-        controller.instance_variable_set(:@_params, :id => host.id, :button_id => button.id)
+        controller.params = {:id => host.id, :button_id => button.id}
         expect_any_instance_of(CustomButton).to receive(:invoke).with(host, 'UI')
 
         controller.send(:custom_buttons)
@@ -89,7 +89,7 @@ describe ApplicationController do
       it "ServiceTemplate button" do
         button.applies_to = ServiceTemplate
         button.save
-        controller.instance_variable_set(:@_params, :id => service.id, :button_id => button.id)
+        controller.params = {:id => service.id, :button_id => button.id}
         expect_any_instance_of(CustomButton).to receive(:invoke).with(service, 'UI')
 
         controller.send(:custom_buttons)
@@ -101,7 +101,7 @@ describe ApplicationController do
     context "#button_create_update" do
       it "no need to set @record when add/cancel form buttons are pressed" do
         custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
-        controller.instance_variable_set(:@_params, :button => "cancel", :id => custom_button.id)
+        controller.params = {:button => "cancel", :id => custom_button.id}
         edit = {
           :new           => {},
           :current       => {},
@@ -120,7 +120,7 @@ describe ApplicationController do
 
       it "the active tab is Advanced when the button pressed is an expression" do
         custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
-        controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
+        controller.params = {:button => "enablement_expression", :id => custom_button.id}
         edit = {:new           => {},
                 :current       => {},
                 :custom_button => custom_button}
@@ -138,7 +138,7 @@ describe ApplicationController do
 
       it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
         custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
-        controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
+        controller.params = {:button => "enablement_expression", :id => custom_button.id}
         edit = {:new           => {},
                 :current       => {},
                 :custom_button => custom_button}
@@ -155,7 +155,7 @@ describe ApplicationController do
 
       it "calls replace_right_cell with action='button_edit' when the edit expression button was pressed" do
         custom_button = FactoryBot.create(:custom_button, :applies_to_class => "Host")
-        controller.instance_variable_set(:@_params, :button => "enablement_expression", :id => custom_button.id)
+        controller.params = {:button => "enablement_expression", :id => custom_button.id}
         edit = {:new           => {},
                 :current       => {},
                 :custom_button => custom_button}
@@ -182,7 +182,7 @@ describe ApplicationController do
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "req"
       custom_button.save
-      controller.instance_variable_set(:@_params, :id => custom_button.id)
+      controller.params = {:id => custom_button.id}
       controller.instance_variable_set(:@custom_button, custom_button)
       controller.instance_variable_set(:@sb,
                                        :trees       => {
@@ -216,7 +216,7 @@ describe ApplicationController do
       custom_button.uri_attributes["request"] = "test_req"
       custom_button.resource_action.dialog_id = 42
       custom_button.save
-      controller.instance_variable_set(:@_params, :id => custom_button.id)
+      controller.params = {:id => custom_button.id}
       controller.instance_variable_set(:@custom_button, custom_button)
       controller.instance_variable_set(:@sb,
                                        :trees       => {:ab_tree => {:active_node => "-ub-Vm_cb-10r51"}},
@@ -253,7 +253,7 @@ describe ApplicationController do
       custom_button.uri_attributes[:inventory_type] = "localhost"
       custom_button.uri_attributes["request"] = "Order_Ansible_Playbook"
       custom_button.save
-      controller.instance_variable_set(:@_params, :id => custom_button.id)
+      controller.params = {:id => custom_button.id}
       controller.instance_variable_set(:@custom_button, custom_button)
       controller.instance_variable_set(:@sb,
                                        :trees       => {:ab_tree => {:active_node => "-ub-Vm_cb-10r51"}},
@@ -366,14 +366,14 @@ describe ApplicationController do
       end
 
       it "to id of selected dialog" do
-        controller.instance_variable_set(:@_params, {:id => button.id, :dialog_id => 42}.with_indifferent_access)
+        controller.params = {{:id => button.id, :dialog_id => 42}.with_indifferent_access}
         controller.instance_variable_set(:@resolve, :target_class => "VM and Instance")
         controller.send(:automate_button_field_changed)
         expect(assigns(:edit)[:new][:dialog_id]).to eq(42)
       end
 
       it "to nil if no dialog selected" do
-        controller.instance_variable_set(:@_params, "id" => button.id, "dialog_id" => "")
+        controller.params = {"id" => button.id, "dialog_id" => ""}
         controller.instance_variable_set(:@resolve, :target_class => "VM and Instance")
         controller.send(:automate_button_field_changed)
         expect(assigns(:edit)[:new][:dialog_id]).to eq(nil)
@@ -395,7 +395,7 @@ describe ApplicationController do
         session[:edit] = edit
       end
       it "to false for Vm and Template" do
-        controller.instance_variable_set(:@_params, "id" => button_for_vm.id, "dialog_id" => "")
+        controller.params = {"id" => button_for_vm.id, "dialog_id" => ""}
         controller.instance_variable_set(:@resolve, :target_class => "Vm")
         controller.instance_variable_set(:@custom_button, button_for_vm)
         controller.send(:automate_button_field_changed)
@@ -403,7 +403,7 @@ describe ApplicationController do
       end
 
       it "to true for Availability Zone" do
-        controller.instance_variable_set(:@_params, "id" => button_for_az.id, "dialog_id" => "")
+        controller.params = {"id" => button_for_az.id, "dialog_id" => ""}
         controller.instance_variable_set(:@resolve, :target_class => "Availability Zone")
         controller.instance_variable_set(:@custom_button, button_for_az)
         controller.send(:automate_button_field_changed)

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -687,12 +687,12 @@ describe ApplicationController do
       from_second = "1"
       from_third = "1"
       controller.params = {:from_first                   => from_first,
-                                       :from_second                  => from_second,
-                                       :from_third                   => from_third,
-                                       :from_fourth                  => "1",
-                                       :to_fourth                    => "0",
-                                       "discover_type_virtualcenter" => "1",
-                                       "start"                       => "45")
+                           :from_second                  => from_second,
+                           :from_third                   => from_third,
+                           :from_fourth                  => "1",
+                           :to_fourth                    => "0",
+                           "discover_type_virtualcenter" => "1",
+                           "start"                       => "45"}
       allow(controller).to receive(:drop_breadcrumb)
       expect(controller).to receive(:render)
       controller.send(:discover)
@@ -945,7 +945,7 @@ describe MiqTemplateController do
                                     :ext_management_system => FactoryBot.create(:ems_openstack_infra),
                                     :storage               => FactoryBot.create(:storage))
       controller.params = {:miq_grid_checks => template.id.to_s,
-                                       :pressed         => 'miq_template_set_ownership')
+                           :pressed         => 'miq_template_set_ownership'}
       expect(controller).to receive(:javascript_redirect).with(:controller => "miq_template",
                                                                :action     => 'ownership',
                                                                :rec_ids    => [template.id],

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -39,7 +39,7 @@ describe ApplicationController do
 
     context 'the UI action is also a queryable feature' do
       before do
-        controller.instance_variable_set(:@_params, :id => record.id)
+        controller.params = {:id => record.id}
         allow(controller).to receive(:render)
       end
 
@@ -57,7 +57,7 @@ describe ApplicationController do
 
     context 'the UI action is not a queryable feature' do
       before do
-        controller.instance_variable_set(:@_params, :id => record.id)
+        controller.params = {:id => record.id}
         allow(controller).to receive(:render)
       end
 
@@ -599,7 +599,7 @@ describe ApplicationController do
 
   it "Certain actions should not be allowed for a MiqTemplate record" do
     template = FactoryBot.create(:template_vmware)
-    controller.instance_variable_set(:@_params, :id => template.id)
+    controller.params = {:id => template.id}
     actions = %i(vm_right_size vm_reconfigure)
     actions.each do |action|
       expect(controller).to receive(:render)
@@ -613,7 +613,7 @@ describe ApplicationController do
     feature = MiqProductFeature.find_all_by_identifier(["everything"])
     login_as FactoryBot.create(:user, :features => feature)
     vm = FactoryBot.create(:vm_vmware)
-    controller.instance_variable_set(:@_params, :id => vm.id)
+    controller.params = {:id => vm.id}
     actions = %i(vm_right_size vm_reconfigure)
     actions.each do |action|
       expect(controller).to receive(:render)
@@ -625,7 +625,7 @@ describe ApplicationController do
   context "Verify the reconfigurable flag for VMs" do
     it "Reconfigure VM action should be allowed only for a VM marked as reconfigurable" do
       vm = FactoryBot.create(:vm_vmware)
-      controller.instance_variable_set(:@_params, :id => vm.id)
+      controller.params = {:id => vm.id}
       record = controller.send(:get_record, "vm")
       action = :vm_reconfigure
       expect(controller).to receive(:render)
@@ -637,7 +637,7 @@ describe ApplicationController do
     end
     it "Reconfigure VM action should not be allowed for a VM marked as reconfigurable" do
       vm = FactoryBot.create(:vm_microsoft)
-      controller.instance_variable_set(:@_params, :id => vm.id)
+      controller.params = {:id => vm.id}
       record = controller.send(:get_record, "vm")
       action = :vm_reconfigure
       expect(controller).to receive(:render)
@@ -737,7 +737,7 @@ describe ApplicationController do
   describe "#get_record" do
     it "use passed in db to set class for identify_record call" do
       host = FactoryBot.create(:host)
-      controller.instance_variable_set(:@_params, :id => host.id)
+      controller.params = {:id => host.id}
       record = controller.send(:get_record, "host")
       expect(record).to be_a_kind_of(Host)
     end
@@ -771,7 +771,7 @@ describe ApplicationController do
       @vm_or_template = FactoryBot.create(:vm_or_template)
       @ownership_items = [@vm_or_template.id]
       login_as(admin_user)
-      controller.instance_variable_set(:@_params, :controller => 'vm_or_template')
+      controller.params = {:controller => 'vm_or_template'}
       controller.instance_variable_set(:@user, nil)
 
       controller.build_ownership_info(@ownership_items)
@@ -876,7 +876,7 @@ describe HostController do
     it "when the vm_or_template supports scan,  returns false" do
       vm1 =  FactoryBot.create(:vm_microsoft)
       vm2 =  FactoryBot.create(:vm_vmware)
-      controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm1.id}, #{vm2.id}")
+      controller.params = {:miq_grid_checks => "#{vm1.id}, #{vm2.id}"}
       controller.send(:generic_button_operation,
                       'scan',
                       "Smartstate Analysis",
@@ -889,7 +889,7 @@ describe HostController do
       vm = FactoryBot.create(:vm_vmware,
                               :ext_management_system => FactoryBot.create(:ems_openstack_infra),
                               :storage               => FactoryBot.create(:storage))
-      controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
+      controller.params = {:miq_grid_checks => vm.id.to_s}
       process_proc = controller.send(:vm_button_action)
       expect(process_proc).to receive(:call)
       controller.send(:generic_button_operation,
@@ -920,7 +920,7 @@ describe ServiceController do
                                     :storage               => FactoryBot.create(:storage))
       service.update_attribute(:id, template.id)
       service.reload
-      controller.instance_variable_set(:@_params, :miq_grid_checks => service.id.to_s)
+      controller.params = {:miq_grid_checks => service.id.to_s}
       expect(controller).to receive(:show_list)
       process_proc = controller.send(:vm_button_action)
       controller.send(:generic_button_operation, 'retire_now', "Retirement", process_proc)
@@ -982,7 +982,7 @@ describe VmOrTemplateController do
         :ext_management_system => FactoryBot.create(:ems_openstack_infra),
         :storage               => FactoryBot.create(:storage)
       )
-      controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm.id}, #{template.id}")
+      controller.params = {:miq_grid_checks => "#{vm.id}, #{template.id}"}
       process_proc = controller.send(:vm_button_action)
       redirect_details = {
         :redirect => {
@@ -1002,7 +1002,7 @@ describe VmOrTemplateController do
         :storage               => FactoryBot.create(:storage)
       )
 
-      controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
+      controller.params = {:miq_grid_checks => vm.id.to_s}
       expect(controller).to receive(:show_list)
       process_proc = controller.send(:vm_button_action)
       controller.send(:generic_button_operation, 'retire_now', "Retirement", process_proc)
@@ -1028,7 +1028,7 @@ describe OrchestrationStackController do
     it "should render error flash message if OrchestrationStack doesn't exist" do
       id = orchestration_stack_deleted.id
       orchestration_stack_deleted.destroy
-      controller.instance_variable_set(:@_params, :miq_grid_checks => id.to_s) # Orchestration Stack id that doesn't exist
+      controller.params = {:miq_grid_checks => id.to_s} # Orchestration Stack id that doesn't exist
       expect(controller).to receive(:show_list)
       controller.send('orchestration_stack_delete')
       flash_messages = assigns(:flash_array)
@@ -1037,7 +1037,7 @@ describe OrchestrationStackController do
     end
 
     it "should render success flash message if OrchestrationStack deletion was initiated" do
-      controller.instance_variable_set(:@_params, :miq_grid_checks => orchestration_stack.id.to_s) # Orchestration Stack id that exists
+      controller.params = {:miq_grid_checks => orchestration_stack.id.to_s} # Orchestration Stack id that exists
       expect(controller).to receive(:show_list)
       controller.send('orchestration_stack_delete')
       flash_messages = assigns(:flash_array)
@@ -1071,7 +1071,7 @@ end
 describe VmInfraController do
   describe '#testable_action' do
     before do
-      controller.instance_variable_set(:@_params, :controller => 'vm_infra')
+      controller.params = {:controller => 'vm_infra'}
     end
 
     context 'power operations and vm infra controller' do

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -686,8 +686,7 @@ describe ApplicationController do
       from_first = "1"
       from_second = "1"
       from_third = "1"
-      controller.instance_variable_set(:@_params,
-                                       :from_first                   => from_first,
+      controller.params = {:from_first                   => from_first,
                                        :from_second                  => from_second,
                                        :from_third                   => from_third,
                                        :from_fourth                  => "1",
@@ -945,8 +944,7 @@ describe MiqTemplateController do
       template = FactoryBot.create(:template,
                                     :ext_management_system => FactoryBot.create(:ems_openstack_infra),
                                     :storage               => FactoryBot.create(:storage))
-      controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => template.id.to_s,
+      controller.params = {:miq_grid_checks => template.id.to_s,
                                        :pressed         => 'miq_template_set_ownership')
       expect(controller).to receive(:javascript_redirect).with(:controller => "miq_template",
                                                                :action     => 'ownership',

--- a/spec/controllers/application_controller/dialog_runner_spec.rb
+++ b/spec/controllers/application_controller/dialog_runner_spec.rb
@@ -146,7 +146,7 @@ describe CatalogController do
     end
 
     it "redirects to requests show list after the dialog is submitted if a request is created" do
-      controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
+      controller.params = {:button => 'submit', :id => 'foo'}
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(wf).to receive(:submit_request).and_return(:request => workflow.make_request(nil, {}))
       page = double('page')
@@ -159,7 +159,7 @@ describe CatalogController do
     end
 
     it "stay on the current model page after the dialog is submitted if a request is not created" do
-      controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
+      controller.params = {:button => 'submit', :id => 'foo'}
       st = FactoryBot.create(:service_template)
       controller.x_node = "xx-st st-#{st.id}"
       allow(controller).to receive(:role_allows?).and_return(true)

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -56,16 +56,16 @@ describe ApplicationController::Filter do
         edit[:new] = {:record_filter => {:test => "foo", :token => 1}}
         session[:edit] = edit
         controller.instance_variable_set(:@expkey, :record_filter)
-        controller.instance_variable_set(:@_params, :chosen_field => "PolicyEvent-chain_id")
+        controller.params = {:chosen_field => "PolicyEvent-chain_id"}
         expect(controller).to receive(:render)
         controller.send(:exp_changed)
         expect(expression.exp_key).to eq('=')
-        controller.instance_variable_set(:@_params, :chosen_field => "PolicyEvent.miq_actions-created_on")
+        controller.params = {:chosen_field => "PolicyEvent.miq_actions-created_on"}
         expect(controller).to receive(:render)
         controller.send(:exp_changed)
         expect(expression.exp_key).to eq('IS')
         controller.instance_variable_set(:@expkey, :record_filter)
-        controller.instance_variable_set(:@_params, :chosen_field => "Flavor.cloud_tenants-id")
+        controller.params = {:chosen_field => "Flavor.cloud_tenants-id"}
         expect(controller).to receive(:render)
         controller.send(:exp_changed)
         expect(expression.exp_key).to_not eq('CONTAINS')

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -54,7 +54,7 @@ describe ApplicationController, "::Filter" do
       edit = {:filter_expression => exp}
       edit[:new] = {:filter_expression => {:test => "foo", :token => 1}}
       session[:edit] = edit
-      controller.instance_variable_set(:@_params, :pressed => "discard")
+      controller.params = {:pressed => "discard"}
       controller.instance_variable_set(:@expkey, :filter_expression)
       expect(controller).to receive(:render)
       controller.send(:exp_button)
@@ -66,7 +66,7 @@ describe ApplicationController, "::Filter" do
       edit = {:expression => expression, :edit_exp => exp}
       edit[:new] = {:expression => {:test => "foo", :token => 1}}
       session[:edit] = edit
-      controller.instance_variable_set(:@_params, :pressed => "discard")
+      controller.params = {:pressed => "discard"}
       controller.instance_variable_set(:@expkey, :expression)
       expect(controller).to receive(:render)
       controller.send(:exp_button)
@@ -85,7 +85,7 @@ describe ApplicationController, "::Filter" do
       login_as user
       controller.instance_variable_set(:@settings, {})
       controller.instance_variable_set(:@_response, double.as_null_object)
-      controller.instance_variable_set(:@_params, :id => search.id)
+      controller.params = {:id => search.id}
       session[:view] = controller.send(:get_db_view, Host)
 
       controller.send(:save_default_search)

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -41,7 +41,7 @@ describe MiqRequestController do
       @wf.instance_variable_set(:@dialogs, :dialogs => {:environment => {:fields => {:placement_dc_name => {:values => {datacenter.id.to_s => datacenter.name}}}}})
       controller.instance_variable_set(:@edit, :wf => @wf, :new => {:src_vm_id => template.id.to_s})
       controller.instance_variable_set(:@last_vm_id, vm2.id)
-      controller.instance_variable_set(:@_params, 'service__src_vm_id' => template.id, :id => "new", :controller => "miq_request")
+      controller.params = {'service__src_vm_id' => template.id, :id => "new", :controller => "miq_request"}
       @wf.instance_variable_set(:@values, :placement_dc_name=>[datacenter.id.to_s, datacenter.name])
       edit = {:wf => @wf, :new => {:placement_dc_name => [datacenter.id, datacenter.name]}}
       @wf.instance_variable_set(:@edit, edit)
@@ -61,7 +61,7 @@ describe MiqRequestController do
       controller.instance_variable_set(:@breadcrumbs, [{:url => "/ems_infra/show_list?page=1&refresh=y"},
                                                        {:url => "/ems_infra/1000000000001?display=vms"},
                                                        {}])
-      controller.instance_variable_set(:@_params, :id => "new", :button => "cancel")
+      controller.params = {:id => "new", :button => "cancel"}
       allow(controller).to receive(:role_allows?).and_return(true)
       page = double('page')
       allow(page).to receive(:<<).with(any_args)
@@ -73,7 +73,7 @@ describe MiqRequestController do
 
   describe '#get_template_kls' do
     before do
-      controller.instance_variable_set(:@_params, :controller => ctrl, :template_klass => kls)
+      controller.params = {:controller => ctrl, :template_klass => kls}
       allow(request).to receive(:parameters).and_return(:template_klass => kls, :controller => ctrl)
     end
 

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -9,7 +9,7 @@ describe ApplicationController do
       login_as admin_user
       allow(User).to receive(:current_user).and_return(admin_user)
       allow(controller).to receive(:assert_privileges)
-      controller.instance_variable_set(:@_params, :id=> host.id)
+      controller.params = {:id=> host.id}
     end
 
     it "redirects to protect" do
@@ -41,7 +41,7 @@ describe ApplicationController do
   describe '#policy_sim_build_screen' do
     before do
       allow(controller).to receive(:session).and_return(:tag_items => [vm], :tag_db => VmOrTemplate)
-      controller.instance_variable_set(:@_params, :controller => vm_ctrl)
+      controller.params = {:controller => vm_ctrl}
     end
 
     context 'VM policy simulation and non explorer screen' do

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -19,8 +19,8 @@ describe ApplicationController do
       controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
     end
     it "should return report data for VM" do
-      controller.instance_variable_set(:@_params, :active_tree => "vandt_tree")
-      controller.instance_variable_set(:@_params, :model_name => "manageiq/providers/infra_manager/vms")
+      controller.params = {:active_tree => "vandt_tree"}
+      controller.params = {:model_name => "manageiq/providers/infra_manager/vms"}
       report_data = JSON.parse(controller.report_data)
       expect(report_data["settings"]).to eql(basic_settings)
       headder = report_data["data"]["head"]
@@ -42,7 +42,7 @@ describe ApplicationController do
     end
 
     it "should have default number of perpage records set for reports" do
-      controller.instance_variable_set(:@_params, :model_name => "MiqReportResult")
+      controller.params = {:model_name => "MiqReportResult"}
       allow(controller).to receive(:settings_default).with(10, :perpage, :reports).and_return(5)
       report_data = JSON.parse(controller.report_data)
       expect(report_data["settings"]["perpage"]).to eql(5)
@@ -53,9 +53,9 @@ describe ApplicationController do
       path_to_report = ManageIQ::UI::Classic::Engine.root.join("product", "views", report_name).to_s
       view = MiqReport.new(YAML.safe_load(File.open(path_to_report), [Symbol]))
       expect(controller).to_not receive(:get_db_view)
-      controller.instance_variable_set(:@_params, :active_tree => "instances_tree")
-      controller.instance_variable_set(:@_params, :model_name => "ManageIQ::Providers::CloudManager::Template")
-      controller.instance_variable_set(:@_params, :additional_options => { "report_name" => report_name })
+      controller.params = {:active_tree => "instances_tree"}
+      controller.params = {:model_name => "ManageIQ::Providers::CloudManager::Template"}
+      controller.params = {:additional_options => { "report_name" => report_name }}
       controller.report_data
       expect(assigns(:view).cols).to eq(view.cols)
     end

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -97,7 +97,7 @@ describe ApplicationController do
       allow(controller).to receive(:assert_privileges)
       allow(controller).to receive(:session).and_return(s)
 
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'resetting changes' do
@@ -118,7 +118,7 @@ describe ApplicationController do
   describe EmsInfraController do
     before do
       login_as FactoryBot.create(:user, :features => %w(storage_tag ems_infra_tag))
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'check for correct feature id when tagging selected storage thru Provider relationship and directly from summary screen' do

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -28,8 +28,7 @@ describe ApplicationController, "#Timelines" do
       end
 
       it "sets categories for policy timelines correctly" do
-        controller.instance_variable_set(:@_params,
-                                         :id            => @ems.id,
+        controller.params = {:id            => @ems.id,
                                          :tl_show       => "policy_timeline",
                                          :tl_categories => ["VM Operation"])
         expect(controller).to receive(:render)
@@ -39,8 +38,7 @@ describe ApplicationController, "#Timelines" do
       end
 
       it "selecting critical option of the selectpicker in the timeline should append them to events filter list" do
-        controller.instance_variable_set(:@_params,
-                                         :id            => @ems.id,
+        controller.params = {:id            => @ems.id,
                                          :tl_show       => "timeline",
                                          :tl_levels     => ["critical"],
                                          :tl_categories => ["Power Activity"])
@@ -52,8 +50,7 @@ describe ApplicationController, "#Timelines" do
       end
 
       it "selecting details option of the selectpicker in the timeline should append them to events filter list" do
-        controller.instance_variable_set(:@_params,
-                                         :id            => @ems.id,
+        controller.params = {:id            => @ems.id,
                                          :tl_show       => "timeline",
                                          :tl_levels     => ["detail"],
                                          :tl_categories => ["Power Activity"])
@@ -65,8 +62,7 @@ describe ApplicationController, "#Timelines" do
       end
 
       it "selecting two options of the selectpicker in the timeline should append both to events filter list" do
-        controller.instance_variable_set(:@_params,
-                                         :id            => @ems.id,
+        controller.params = {:id            => @ems.id,
                                          :tl_show       => "timeline",
                                          :tl_levels     => %w(critical detail),
                                          :tl_categories => ["Power Activity"])

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -14,7 +14,7 @@ describe ApplicationController, "#Timelines" do
         options.date.end   = dt
         options.date.start = dt
 
-        controller.instance_variable_set(:@_params, :id => @ems.id, :tl_show => "policy_timeline")
+        controller.params = {:id => @ems.id, :tl_show => "policy_timeline"}
         expect(controller).to receive(:render)
 
         expect(options.date[:start]).to eq(dt)

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -29,8 +29,8 @@ describe ApplicationController, "#Timelines" do
 
       it "sets categories for policy timelines correctly" do
         controller.params = {:id            => @ems.id,
-                                         :tl_show       => "policy_timeline",
-                                         :tl_categories => ["VM Operation"])
+                             :tl_show       => "policy_timeline",
+                             :tl_categories => ["VM Operation"]}
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
@@ -39,9 +39,9 @@ describe ApplicationController, "#Timelines" do
 
       it "selecting critical option of the selectpicker in the timeline should append them to events filter list" do
         controller.params = {:id            => @ems.id,
-                                         :tl_show       => "timeline",
-                                         :tl_levels     => ["critical"],
-                                         :tl_categories => ["Power Activity"])
+                             :tl_show       => "timeline",
+                             :tl_levels     => ["critical"],
+                             :tl_categories => ["Power Activity"]}
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
@@ -51,9 +51,9 @@ describe ApplicationController, "#Timelines" do
 
       it "selecting details option of the selectpicker in the timeline should append them to events filter list" do
         controller.params = {:id            => @ems.id,
-                                         :tl_show       => "timeline",
-                                         :tl_levels     => ["detail"],
-                                         :tl_categories => ["Power Activity"])
+                             :tl_show       => "timeline",
+                             :tl_levels     => ["detail"],
+                             :tl_categories => ["Power Activity"]}
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
@@ -63,9 +63,9 @@ describe ApplicationController, "#Timelines" do
 
       it "selecting two options of the selectpicker in the timeline should append both to events filter list" do
         controller.params = {:id            => @ems.id,
-                                         :tl_show       => "timeline",
-                                         :tl_levels     => %w(critical detail),
-                                         :tl_categories => ["Power Activity"])
+                             :tl_show       => "timeline",
+                             :tl_levels     => %w(critical detail),
+                             :tl_categories => ["Power Activity"]}
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -154,7 +154,7 @@ describe ApplicationController do
     it "returns flash message when Migrate button is pressed with list containing SCVMM VM" do
       vm1 = FactoryBot.create(:vm_vmware)
       vm2 = FactoryBot.create(:vm_microsoft)
-      controller.instance_variable_set(:@_params, :pressed         => "vm_migrate",
+      controller.params = {:pressed         => "vm_migrate",
                                                   :miq_grid_checks => "#{vm1.id},#{vm2.id}")
       controller.set_response!(response)
       controller.send(:prov_redirect, "migrate")
@@ -167,7 +167,7 @@ describe ApplicationController do
     it "sets variables when Migrate button is pressed with list of VMware VMs" do
       vm1 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
       vm2 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
-      controller.instance_variable_set(:@_params, :pressed         => "vm_migrate",
+      controller.params = {:pressed         => "vm_migrate",
                                                   :miq_grid_checks => "#{vm1.id},#{vm2.id}")
       controller.set_response!(response)
       controller.send(:prov_redirect, "migrate")
@@ -189,8 +189,7 @@ describe ApplicationController do
                                     :name     => "template 1",
                                     :vendor   => "vmware",
                                     :location => "template1.vmtx")
-      controller.instance_variable_set(:@_params,
-                                       :pressed         => "image_miq_request_new",
+      controller.params = {:pressed         => "image_miq_request_new",
                                        :miq_grid_checks => template.id.to_s)
       controller.set_response!(response)
       expect(controller).not_to receive(:vm_pre_prov)
@@ -207,8 +206,7 @@ describe ApplicationController do
                                     :vendor                => "vmware",
                                     :location              => "template1.vmtx",
                                     :ext_management_system => ems)
-      controller.instance_variable_set(:@_params,
-                                       :pressed         => "image_miq_request_new",
+      controller.params = {:pressed         => "image_miq_request_new",
                                        :miq_grid_checks => template.id.to_s)
       controller.instance_variable_set(:@breadcrumbs, [])
       controller.instance_variable_set(:@sb, {})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -155,7 +155,7 @@ describe ApplicationController do
       vm1 = FactoryBot.create(:vm_vmware)
       vm2 = FactoryBot.create(:vm_microsoft)
       controller.params = {:pressed         => "vm_migrate",
-                                                  :miq_grid_checks => "#{vm1.id},#{vm2.id}")
+                           :miq_grid_checks => "#{vm1.id},#{vm2.id}"}
       controller.set_response!(response)
       controller.send(:prov_redirect, "migrate")
       expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
@@ -168,7 +168,7 @@ describe ApplicationController do
       vm1 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
       vm2 = FactoryBot.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
       controller.params = {:pressed         => "vm_migrate",
-                                                  :miq_grid_checks => "#{vm1.id},#{vm2.id}")
+                           :miq_grid_checks => "#{vm1.id},#{vm2.id}"}
       controller.set_response!(response)
       controller.send(:prov_redirect, "migrate")
       expect(controller.send(:flash_errors?)).to be_falsey
@@ -190,7 +190,7 @@ describe ApplicationController do
                                     :vendor   => "vmware",
                                     :location => "template1.vmtx")
       controller.params = {:pressed         => "image_miq_request_new",
-                                       :miq_grid_checks => template.id.to_s)
+                           :miq_grid_checks => template.id.to_s}
       controller.set_response!(response)
       expect(controller).not_to receive(:vm_pre_prov)
       controller.send(:prov_redirect)
@@ -207,7 +207,7 @@ describe ApplicationController do
                                     :location              => "template1.vmtx",
                                     :ext_management_system => ems)
       controller.params = {:pressed         => "image_miq_request_new",
-                                       :miq_grid_checks => template.id.to_s)
+                           :miq_grid_checks => template.id.to_s}
       controller.instance_variable_set(:@breadcrumbs, [])
       controller.instance_variable_set(:@sb, {})
       controller.set_response!(response)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -19,7 +19,7 @@ describe ApplicationController do
 
     it "uses correct variables for rendering result of report" do
       controller.instance_variable_set(:@sb, :pages => { :rr_id => report_result_for_report.id })
-      controller.instance_variable_set(:@_params, :rr_id => report_result_for_report.id)
+      controller.params = {:rr_id => report_result_for_report.id}
 
       expect(controller).to receive(:render).with('shared/show_report', :layout => 'report_only')
       controller.send(:report_only)
@@ -32,7 +32,7 @@ describe ApplicationController do
 
     it "uses correct variables for rendering result of report" do
       controller.instance_variable_set(:@sb, :pages => { :rr_id => report_result_for_widget.id })
-      controller.instance_variable_set(:@_params, :rr_id => report_result_for_widget.id)
+      controller.params = {:rr_id => report_result_for_widget.id}
 
       expect(controller).to receive(:render).with('shared/show_report', :layout => 'report_only')
       controller.send(:report_only)
@@ -106,17 +106,17 @@ describe ApplicationController do
 
   describe "#find_checked_items" do
     it "returns empty array when button is pressed from summary screen with params as symbol" do
-      controller.instance_variable_set(:@_params, :id => "1")
+      controller.params = {:id => "1"}
       expect(controller.send(:find_checked_items)).to eq([])
     end
 
     it "returns empty array when button is pressed from summary screen with params as string" do
-      controller.instance_variable_set(:@_params, "id" => "1")
+      controller.params = {"id" => "1"}
       expect(controller.send(:find_checked_items)).to eq([])
     end
 
     it "returns list of items selected from list view" do
-      controller.instance_variable_set(:@_params, :miq_grid_checks => "1, 2, 3, 4")
+      controller.params = {:miq_grid_checks => "1, 2, 3, 4"}
       expect(controller.send(:find_checked_items)).to eq([1, 2, 3, 4])
     end
   end
@@ -128,17 +128,17 @@ describe ApplicationController do
     end
 
     it "returns true for list views" do
-      controller.instance_variable_set(:@_params, :action => "show_list")
+      controller.params = {:action => "show_list"}
       expect(controller.send(:render_gtl_view_tb?)).to be_truthy
     end
 
     it "returns true for list views when navigating thru relationships" do
-      controller.instance_variable_set(:@_params, :action => "show")
+      controller.params = {:action => "show"}
       expect(controller.send(:render_gtl_view_tb?)).to be_truthy
     end
 
     it "returns false for sub list views" do
-      controller.instance_variable_set(:@_params, :action => "host_services")
+      controller.params = {:action => "host_services"}
       expect(controller.send(:render_gtl_view_tb?)).to be_falsey
     end
   end

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -571,7 +571,7 @@ describe AutomationManagerController do
   context "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "userid",
-                                       :default_password => "password2")
+                           :default_password => "password2"}
       creds = {:userid => "userid", :password => "password2"}
       expect(controller.send(:build_credentials)).to include(:default => creds)
     end

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -322,26 +322,26 @@ describe AutomationManagerController do
     # throught the GTL component and the /report_data JSON endpoint.
     pending "renders the list view based on the nodetype(root,provider) and the search associated with it" do
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => "root")
+      controller.params = {:id => "root"}
       controller.instance_variable_set(:@search_text, "manager")
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data.size).to eq(3)
 
       ems_id = ems_key_for_provider(automation_provider1)
-      controller.instance_variable_set(:@_params, :id => ems_id)
+      controller.params = {:id => ems_id}
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].name).to eq("testinvgroup")
 
-      controller.instance_variable_set(:@_params, :id => "at")
+      controller.params = {:id => "at"}
       controller.instance_variable_set(:@search_text, "2")
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].name).to eq("ansibletest2 Automation Manager")
 
       invgroup_id2 = inventory_group_key(@inventory_group2)
-      controller.instance_variable_set(:@_params, :id => invgroup_id2)
+      controller.params = {:id => invgroup_id2}
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].hostname).to eq("test2b_ans_configured_system")
@@ -353,14 +353,14 @@ describe AutomationManagerController do
 
       allow(controller).to receive(:x_node).and_return("root")
       allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.instance_variable_set(:@_params, :id => "automation_manager_cs_filter")
+      controller.params = {:id => "automation_manager_cs_filter"}
       controller.send(:accordion_select)
       controller.instance_variable_set(:@search_text, "brew")
       allow(controller).to receive(:x_tree).and_return(:type => :providers)
-      controller.instance_variable_set(:@_params, :id => "automation_manager_providers")
+      controller.params = {:id => "automation_manager_providers"}
       controller.send(:accordion_select)
 
-      controller.instance_variable_set(:@_params, :id => "root")
+      controller.params = {:id => "root"}
       controller.send(:tree_select)
       search_text = controller.instance_variable_get(:@search_text)
       expect(search_text).to eq("manager")
@@ -373,9 +373,9 @@ describe AutomationManagerController do
     it "renders tree_select for ansible tower job templates tree node" do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => "configuration_scripts")
+      controller.params = {:id => "configuration_scripts"}
       controller.send(:accordion_select)
-      controller.instance_variable_set(:@_params, :id => "at-#{@automation_manager1.id}")
+      controller.params = {:id => "at-#{@automation_manager1.id}"}
       controller.send(:tree_select)
       # view = controller.instance_variable_get(:@view)
       show_adv_search = controller.instance_variable_get(:@show_adv_search)
@@ -395,7 +395,7 @@ describe AutomationManagerController do
       stub_user(:features => :all)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
-      controller.instance_variable_set(:@_params, :id => "cf-#{record.id}")
+      controller.params = {:id => "cf-#{record.id}"}
       controller.send(:tree_select)
       show_adv_search = controller.instance_variable_get(:@show_adv_search)
       title = controller.instance_variable_get(:@right_cell_text)
@@ -408,7 +408,7 @@ describe AutomationManagerController do
       allow(controller).to receive(:x_active_tree).and_return(:automation_manager_providers_tree)
       allow(controller).to receive(:x_active_accord).and_return(:automation_manager_providers)
       allow(controller).to receive(:build_listnav_search_list)
-      controller.instance_variable_set(:@_params, :id => "automation_manager_providers")
+      controller.params = {:id => "automation_manager_providers"}
       expect(controller).to receive(:get_view).with("ManageIQ::Providers::AnsibleTower::AutomationManager", :gtl_dbname => "automation_manager_providers").and_call_original
       controller.send(:accordion_select)
     end
@@ -417,7 +417,7 @@ describe AutomationManagerController do
       stub_user(:features => :all)
       allow(controller).to receive(:x_node).and_return("root")
       allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.instance_variable_set(:@_params, :id => "automation_manager_cs_filter")
+      controller.params = {:id => "automation_manager_cs_filter"}
       expect(controller).to receive(:get_view).with("ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem", :gtl_dbname => "automation_manager_configured_systems").and_call_original
       allow(controller).to receive(:build_listnav_search_list)
       controller.send(:accordion_select)
@@ -427,7 +427,7 @@ describe AutomationManagerController do
       stub_user(:features => :all)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
-      controller.instance_variable_set(:@_params, :id => "configuration_scripts")
+      controller.params = {:id => "configuration_scripts"}
       expect(controller).to receive(:get_view).with("ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
       controller.send(:accordion_select)
     end
@@ -578,7 +578,7 @@ describe AutomationManagerController do
     end
 
     it "uses the stored password for validation if params[:default_password] does not exist" do
-      controller.instance_variable_set(:@_params, :default_userid => "userid")
+      controller.params = {:default_userid => "userid"}
       controller.instance_variable_set(:@provider, automation_provider1)
       expect(automation_provider1).to receive(:authentication_password).and_return('password')
       creds = {:userid => "userid", :password => "password"}
@@ -627,7 +627,7 @@ describe AutomationManagerController do
     end
 
     it "Service Dialog is created from an Ansible Tower Job Template" do
-      controller.instance_variable_set(:@_params, :button => "save", :id => @cs.id)
+      controller.params = {:button => "save", :id => @cs.id}
       allow(controller).to receive(:replace_right_cell)
       controller.send(:configscript_service_dialog_submit)
       expect(assigns(:flash_array).first[:message]).to include("was successfully created")

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -570,8 +570,7 @@ describe AutomationManagerController do
 
   context "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => "userid",
+      controller.params = {:default_userid   => "userid",
                                        :default_password => "password2")
       creds = {:userid => "userid", :password => "password2"}
       expect(controller.send(:build_credentials)).to include(:default => creds)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -35,7 +35,7 @@ describe CatalogController do
     it "checks method x_edit_tags_reset when tagging from summary screen" do
       login_as admin_user
       allow(User).to receive(:current_user).and_return(admin_user)
-      controller.instance_variable_set(:@_params, :id => service_template_with_child_tenant.id.to_s)
+      controller.params = {:id => service_template_with_child_tenant.id.to_s}
       controller.instance_variable_set(:@sb, :action => nil)
       allow(controller).to receive(:checked_or_params).and_return([])
       allow(controller).to receive(:find_checked_items).and_return([])
@@ -142,7 +142,7 @@ describe CatalogController do
     describe "#atomic_st_edit" do
       it "Atomic Service Template and its valid Resource Actions are saved" do
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :button => "save")
+        controller.params = {:button => "save"}
         st = FactoryBot.create(:service_template)
         3.times.each do |i|
           ns = FactoryBot.create(:miq_ae_namespace, :name => "ns#{i}")
@@ -177,7 +177,7 @@ describe CatalogController do
       it "Atomic Service Template and its invalid Resource Actions are not saved" do
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :button => 'save')
+        controller.params = {:button => 'save'}
         st = FactoryBot.create(:service_template)
         retire_fqname    = 'ns/cls/inst'
         provision_fqname = 'ns1/cls1/inst1'
@@ -249,7 +249,7 @@ describe CatalogController do
         allow(controller).to receive(:replace_right_cell)
         allow(controller).to receive(:session).and_return(:edit => edit)
         controller.instance_variable_set(:@edit, edit)
-        controller.instance_variable_set(:@_params, :button => "add")
+        controller.params = {:button => "add"}
         controller.instance_variable_set(:@record, st)
         controller.instance_variable_set(:@sb, {})
       end
@@ -265,7 +265,7 @@ describe CatalogController do
         ApplicationController.handle_exceptions = true
 
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :button => "save")
+        controller.params = {:button => "save"}
         @st = FactoryBot.create(:service_template)
         3.times.each do |i|
           ns = FactoryBot.create(:miq_ae_namespace, :name => "ns#{i}")
@@ -312,7 +312,7 @@ describe CatalogController do
     describe "#ot_edit" do
       before do
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :button => "save")
+        controller.params = {:button => "save"}
         @new_name = "New Name"
         @new_description = "New Description"
         @new_content = "{\"AWSTemplateFormatVersion\" : \"new-version\"}\n"
@@ -379,7 +379,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template content cannot be empty during edit" do
-        controller.instance_variable_set(:@_params, :button => "save")
+        controller.params = {:button => "save"}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         ot = FactoryBot.create(:orchestration_template)
         session[:edit][:key] = "ot_edit__#{ot.id}"
@@ -412,7 +412,7 @@ describe CatalogController do
     describe "#ot_copy" do
       before do
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :button => "add")
+        controller.params = {:button => "add"}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         ot = FactoryBot.create(:orchestration_template_amazon)
         controller.x_node = "xx-otcfn_ot-#{ot.id}"
@@ -489,7 +489,7 @@ describe CatalogController do
     describe "#ot_delete" do
       before do
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :pressed => "orchestration_template_remove")
+        controller.params = {:pressed => "orchestration_template_remove"}
         allow(controller).to receive(:replace_right_cell)
       end
 
@@ -500,7 +500,7 @@ describe CatalogController do
       it "Orchestration Template is deleted" do
         ot = FactoryBot.create(:orchestration_template)
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
-        controller.instance_variable_set(:@_params, :id => ot.id)
+        controller.params = {:id => ot.id}
         controller.send(:ot_remove_submit)
         expect(controller.send(:flash_errors?)).not_to be_truthy
         expect(assigns(:flash_array).first[:message]).to include("was deleted")
@@ -538,7 +538,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template is created" do
-        controller.instance_variable_set(:@_params, :content => @new_content, :button => "add")
+        controller.params = {:content => @new_content, :button => "add"}
         allow(controller).to receive(:replace_right_cell)
         controller.send(:ot_add_submit)
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -549,7 +549,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template draft is created" do
-        controller.instance_variable_set(:@_params, :content => @new_content, :button => "add")
+        controller.params = {:content => @new_content, :button => "add"}
         session[:edit][:new][:draft] = true
         allow(controller).to receive(:replace_right_cell)
         controller.send(:ot_add_submit)
@@ -563,7 +563,7 @@ describe CatalogController do
       end
 
       it "Orchestration Template creation is cancelled" do
-        controller.instance_variable_set(:@_params, :content => @new_content, :button => "cancel")
+        controller.params = {:content => @new_content, :button => "cancel"}
         allow(controller).to receive(:replace_right_cell)
         controller.send(:ot_add_submit)
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -610,7 +610,7 @@ describe CatalogController do
         EvmSpecHelper.create_guid_miq_server_zone
 
         controller.instance_variable_set(:@sb, :action => "ot_tags_edit")
-        controller.instance_variable_set(:@_params, :miq_grid_checks => @ot.id.to_s)
+        controller.params = {:miq_grid_checks => @ot.id.to_s}
         allow(controller).to receive(:button_url).with("catalog", @ot.id, "save").and_return("save_url")
         allow(controller).to receive(:button_url).with("catalog", @ot.id, "cancel").and_return("cancel_url")
 
@@ -619,14 +619,14 @@ describe CatalogController do
       end
 
       it "cancels tags edit" do
-        controller.instance_variable_set(:@_params, :button => "cancel", :id => @ot.id)
+        controller.params = {:button => "cancel", :id => @ot.id}
         controller.send(:tags_edit, "OrchestrationTemplate")
         expect(assigns(:flash_array).first[:message]).to include("was cancelled")
         expect(assigns(:edit)).to be_nil
       end
 
       it "save tags" do
-        controller.instance_variable_set(:@_params, :button => "save", :id => @ot.id, 'data' => get_tags_json([@tag1, @tag2]))
+        controller.params = {:button => "save", :id => @ot.id, 'data' => get_tags_json([@tag1, @tag2])}
         controller.send(:tags_edit, "OrchestrationTemplate")
         expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
         expect(assigns(:edit)).to be_nil
@@ -653,7 +653,7 @@ describe CatalogController do
       end
 
       it "Service Dialog is created from an Orchestration Template" do
-        controller.instance_variable_set(:@_params, :button => "save", :id => @ot.id)
+        controller.params = {:button => "save", :id => @ot.id}
         allow(controller).to receive(:replace_right_cell)
         controller.send(:service_dialog_from_ot_submit)
         expect(assigns(:flash_array).first[:message]).to include("was successfully created")
@@ -800,7 +800,7 @@ describe CatalogController do
     describe "#st_catalog_new" do
       it "renders views successfully after button is pressed" do
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :pressed => 'st_catalog_new', :action => 'x_button')
+        controller.params = {:pressed => 'st_catalog_new', :action => 'x_button'}
         edit = {
           :new => {:name             => "",
                    :description      => "",
@@ -1266,7 +1266,7 @@ describe CatalogController do
         EvmSpecHelper.create_guid_miq_server_zone
 
         controller.instance_variable_set(:@sb, :action => "catalogitem_tag")
-        controller.instance_variable_set(:@_params, :miq_grid_checks => @st.id.to_s)
+        controller.params = {:miq_grid_checks => @st.id.to_s}
         allow(controller).to receive(:button_url).with("catalog", @st.id, "save").and_return("save_url")
         allow(controller).to receive(:button_url).with("catalog", @st.id, "cancel").and_return("cancel_url")
         controller.send(:st_tags_edit)
@@ -1274,14 +1274,14 @@ describe CatalogController do
       end
 
       it "cancels tags edit" do
-        controller.instance_variable_set(:@_params, :button => "cancel", :id => @st.id)
+        controller.params = {:button => "cancel", :id => @st.id}
         controller.send(:st_tags_edit)
         expect(assigns(:flash_array).first[:message]).to include("was cancelled")
         expect(assigns(:edit)).to be_nil
       end
 
       it "save tags" do
-        controller.instance_variable_set(:@_params, :button => "save", :id => @st.id, 'data' => get_tags_json([@tag1, @tag2]))
+        controller.params = {:button => "save", :id => @st.id, 'data' => get_tags_json([@tag1, @tag2])}
         controller.send(:st_tags_edit)
         expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
         expect(assigns(:edit)).to be_nil
@@ -1325,7 +1325,7 @@ describe CatalogController do
   describe '#get_form_vars' do
     before do
       controller.instance_variable_set(:@edit, :new => {:tenant_ids => []}, :key => 'prov_edit__new')
-      controller.instance_variable_set(:@_params, :id => 'tn-1', :check => '1')
+      controller.params = {:id => 'tn-1', :check => '1'}
       controller.instance_variable_set(:@sb, {})
     end
 
@@ -1359,7 +1359,7 @@ describe CatalogController do
     context 'unchecking Tenant in the tree' do
       before do
         controller.instance_variable_set(:@edit, :new => {:tenant_ids => [1, 2]}, :key => 'prov_edit__new')
-        controller.instance_variable_set(:@_params, :id => 'tn-2', :check => '0')
+        controller.params = {:id => 'tn-2', :check => '0'}
       end
 
       it 'removes Tenant id from @edit' do
@@ -1423,7 +1423,7 @@ describe CatalogController do
                                                         :rsc_groups   => {1 => {}},
                                                         :current      => {},
                                                         :tenant_ids   => []})
-      controller.instance_variable_set(:@_params, :grp_id => 1, :id => 1)
+      controller.params = {:grp_id => 1, :id => 1}
       controller.instance_variable_set(:@sb, {})
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -472,12 +472,12 @@ describe CatalogController do
 
         allow(controller).to receive(:replace_right_cell)
         controller.params = {:name        => new_name,
-                                         :description => new_description,
-                                         :id          => ot.id.to_s)
+                             :description => new_description,
+                             :id          => ot.id.to_s}
         controller.send(:ot_form_field_changed)
         controller.params = {:button           => "add",
-                                         :original_ot_id   => ot.id,
-                                         :template_content => new_content)
+                             :original_ot_id   => ot.id,
+                             :template_content => new_content}
         controller.send(:ot_copy_submit)
         expect(OrchestrationTemplate.where(:name        => new_name,
                                            :description => new_description).first).to_not be_nil

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -471,13 +471,11 @@ describe CatalogController do
         new_description = "New description for copied OT"
 
         allow(controller).to receive(:replace_right_cell)
-        controller.instance_variable_set(:@_params,
-                                         :name        => new_name,
+        controller.params = {:name        => new_name,
                                          :description => new_description,
                                          :id          => ot.id.to_s)
         controller.send(:ot_form_field_changed)
-        controller.instance_variable_set(:@_params,
-                                         :button           => "add",
+        controller.params = {:button           => "add",
                                          :original_ot_id   => ot.id,
                                          :template_content => new_content)
         controller.send(:ot_copy_submit)

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -41,7 +41,7 @@ describe ChargebackController do
 
     describe '#cb_assign_get_form_vars' do
       before do
-        controller.instance_variable_set(:@_params, :cblabel_key => 'null')
+        controller.params = {:cblabel_key => 'null'}
         controller.instance_variable_set(:@edit, :new => {:cbshow_typ => '-labels'}, :cb_assign => {})
       end
 
@@ -56,7 +56,7 @@ describe ChargebackController do
       end
 
       it "initializes hash when data are no available (params[:cblabel_key] == nil)" do
-        controller.instance_variable_set(:@_params, :cblabel_key => nil)
+        controller.params = {:cblabel_key => nil}
         controller.send(:cb_assign_get_form_vars)
         docker_label_values = controller.instance_variable_get(:@edit)[:cb_assign][:docker_label_values]
         expect(docker_label_values).to eq({})
@@ -85,7 +85,7 @@ describe ChargebackController do
       controller.instance_variable_set(:@report, report)
       controller.instance_variable_set(:@html, html)
       controller.instance_variable_set(:@layout, "chargeback")
-      controller.instance_variable_set(:@_params, :id => node)
+      controller.params = {:id => node}
       controller.send(:tree_select)
       expect(response).to                        render_template('layouts/_saved_report_paging_bar')
       expect(controller.send(:flash_errors?)).to be_falsey

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -641,7 +641,7 @@ describe ChargebackController do
       allow(controller).to receive(:x_node).and_call_original
       allow(controller).to receive(:render).and_return(true)
 
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
       controller.instance_variable_set(:@sb, sandbox)
     end
 

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -230,7 +230,7 @@ describe CloudNetworkController do
   end
 
   describe '#button' do
-    before { controller.instance_variable_set(:@_params, params) }
+    before { controller.params = params }
 
     context 'tagging instances from a list of instances, accessed from the details page of a network' do
       let(:params) { {:pressed => "instance_tag"} }

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -256,7 +256,7 @@ describe CloudNetworkController do
   describe "#delete_networks" do
     before do
       login_as FactoryBot.create(:user, :role => "super_administrator")
-      controller.instance_variable_set(:@_params, :id => network.id, :pressed => 'cloud_network_delete')
+      controller.params = {:id => network.id, :pressed => 'cloud_network_delete'}
       allow(controller).to receive(:process_cloud_networks).with([network], "destroy")
     end
 

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -211,8 +211,7 @@ describe CloudNetworkController do
     before do
       stub_user(:features => :all)
       session[:cloud_network_lastaction] = 'show'
-      controller.instance_variable_set(:@_params,
-                                       :pressed => "cloud_network_delete",
+      controller.params = {:pressed => "cloud_network_delete",
                                        :id      => network.id)
       controller.instance_variable_set(:@breadcrumbs, [{:url => "cloud_network/show_list"}, 'placeholder'])
     end

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -212,7 +212,7 @@ describe CloudNetworkController do
       stub_user(:features => :all)
       session[:cloud_network_lastaction] = 'show'
       controller.params = {:pressed => "cloud_network_delete",
-                                       :id      => network.id)
+                           :id      => network.id}
       controller.instance_variable_set(:@breadcrumbs, [{:url => "cloud_network/show_list"}, 'placeholder'])
     end
 

--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -93,7 +93,7 @@ describe CloudVolumeSnapshotController do
       allow(User).to receive(:current_user).and_return(admin_user)
       allow(controller).to receive(:assert_privileges)
       allow(controller).to receive(:render_flash)
-      controller.instance_variable_set(:@_params, :id => snapshot.id, :pressed => 'host_NECO')
+      controller.params = {:id => snapshot.id, :pressed => 'host_NECO'}
     end
 
     it "call cloud volume snapshots" do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -400,7 +400,7 @@ describe DashboardController do
     before do
       login_as user
 
-      controller.instance_variable_set(:@_params, :tab => wset.id)
+      controller.params = {:tab => wset.id}
       controller.instance_variable_set(
         :@sb,
         :active_db  => wset.name, :active_db_id => wset.id,
@@ -531,7 +531,7 @@ describe DashboardController do
 
       before do
         login_as user
-        controller.instance_variable_set(:@_params, 'uib-tab' => ws2.id.to_s)
+        controller.params = {'uib-tab' => ws2.id.to_s}
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@current_user, user)
         group.update_attributes(:settings => { :dashboard_order => [ws1.id.to_s, ws2.id.to_s] })

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -269,8 +269,7 @@ describe EmsCloudController do
     let(:amqp_creds)    { {:userid => "amqp_userid",    :password => "amqp_password"} }
 
     it "uses the passwords from params for validation if they exist" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => default_creds[:userid],
+      controller.params = {:default_userid   => default_creds[:userid],
                                        :default_password => default_creds[:password],
                                        :amqp_userid      => amqp_creds[:userid],
                                        :amqp_password    => amqp_creds[:password])
@@ -281,8 +280,7 @@ describe EmsCloudController do
     end
 
     it "uses the stored passwords for validation if passwords dont exist in params" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid => default_creds[:userid],
+      controller.params = {:default_userid => default_creds[:userid],
                                        :amqp_userid    => amqp_creds[:userid])
       expect(mocked_ems).to receive(:authentication_password).and_return(default_creds[:password])
       expect(mocked_ems).to receive(:authentication_password).with(:amqp).and_return(amqp_creds[:password])

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -270,9 +270,9 @@ describe EmsCloudController do
 
     it "uses the passwords from params for validation if they exist" do
       controller.params = {:default_userid   => default_creds[:userid],
-                                       :default_password => default_creds[:password],
-                                       :amqp_userid      => amqp_creds[:userid],
-                                       :amqp_password    => amqp_creds[:password])
+                           :default_password => default_creds[:password],
+                           :amqp_userid      => amqp_creds[:userid],
+                           :amqp_password    => amqp_creds[:password]}
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
       expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
@@ -281,7 +281,7 @@ describe EmsCloudController do
 
     it "uses the stored passwords for validation if passwords dont exist in params" do
       controller.params = {:default_userid => default_creds[:userid],
-                                       :amqp_userid    => amqp_creds[:userid])
+                           :amqp_userid    => amqp_creds[:userid]}
       expect(mocked_ems).to receive(:authentication_password).and_return(default_creds[:password])
       expect(mocked_ems).to receive(:authentication_password).with(:amqp).and_return(amqp_creds[:password])
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -311,7 +311,7 @@ describe EmsCloudController do
     let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default"} }
     before do
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@_params, mocked_params)
+      controller.params = mocked_params
       allow(ExtManagementSystem).to receive(:model_from_emstype).and_return(mocked_class)
     end
 

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -300,7 +300,7 @@ describe EmsCloudController do
       allow(controller).to receive(:set_ems_record_vars)
       allow(controller).to receive(:render)
       allow(controller).to receive(:find_record_with_rbac).and_return(mocked_ems)
-      controller.instance_variable_set(:@_params, :button => "validate", :id => mocked_ems.id, :cred_type => "default")
+      controller.params = {:button => "validate", :id => mocked_ems.id, :cred_type => "default"}
 
       expect(mocked_ems).to receive(:authentication_check).with("default", hash_including(:save => false))
       controller.send(:update_ems_button_validate)
@@ -503,7 +503,7 @@ describe EmsCloudController do
     end
 
     it "redirects to requests show list after dialog is submitted" do
-      controller.instance_variable_set(:@_params, :button => 'submit', :id => 'foo')
+      controller.params = {:button => 'submit', :id => 'foo'}
       allow(controller).to receive(:role_allows?).and_return(true)
       allow(wf).to receive(:submit_request).and_return({})
       page = double('page')

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -1,14 +1,14 @@
 describe EmsClusterController do
   context "#button" do
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
+      controller.params = {:pressed => "vm_right_size"}
       expect(controller).to receive(:vm_right_size)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Migrate button is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
+      controller.params = {:pressed => "vm_migrate"}
       controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
       expect(controller).to receive(:prov_redirect).with("migrate")
       expect(controller).to receive(:render)
@@ -17,42 +17,42 @@ describe EmsClusterController do
     end
 
     it "when VM Retire button is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
+      controller.params = {:pressed => "vm_retire"}
       expect(controller).to receive(:retirevms).once
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
+      controller.params = {:pressed => "vm_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
+      controller.params = {:pressed => "miq_template_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
+      controller.params = {:pressed => "vm_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
+      controller.params = {:pressed => "miq_template_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "host_analyze_check_compliance")
+      controller.params = {:pressed => "host_analyze_check_compliance"}
       allow(controller).to receive(:show)
       expect(controller).to receive(:analyze_check_compliance_hosts)
       expect(controller).to receive(:render)

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -104,8 +104,7 @@ describe EmsContainerController do
       def test_creating(emstype)
         raise ArgumentError, "Unsupported type [#{emstype}]" unless %w(kubernetes openshift).include?(emstype)
         @ems = ExtManagementSystem.model_from_emstype(emstype).new
-        controller.instance_variable_set(:@_params,
-                                         :name             => 'NimiCule',
+        controller.params = {:name             => 'NimiCule',
                                          :default_userid   => '_',
                                          :default_hostname => 'mytest.com',
                                          :default_api_port => '8443',
@@ -134,7 +133,7 @@ describe EmsContainerController do
         end
 
         def test_setting_many_fields
-          controller.instance_variable_set(:@_params, :name                      => 'EMS 2',
+          controller.params = {:name                      => 'EMS 2',
                                                       :default_userid            => '_',
                                                       :default_hostname          => '10.10.10.11',
                                                       :default_api_port          => '5000',
@@ -194,8 +193,7 @@ describe EmsContainerController do
         it 'updates provider options' do
           @type = 'openshift'
           @ems  = ManageIQ::Providers::Openshift::ContainerManager.new
-          controller.instance_variable_set(:@_params,
-                                           :provider_options_image_inspector_options_http_proxy => "example.com")
+          controller.params = {:provider_options_image_inspector_options_http_proxy => "example.com")
           controller.send(:set_ems_record_vars, @ems)
           expect(@ems.options[:image_inspector_options][:http_proxy]).to eq("example.com")
         end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -105,11 +105,11 @@ describe EmsContainerController do
         raise ArgumentError, "Unsupported type [#{emstype}]" unless %w(kubernetes openshift).include?(emstype)
         @ems = ExtManagementSystem.model_from_emstype(emstype).new
         controller.params = {:name             => 'NimiCule',
-                                         :default_userid   => '_',
-                                         :default_hostname => 'mytest.com',
-                                         :default_api_port => '8443',
-                                         :default_password => 'valid-token',
-                                         :emstype          => emstype)
+                             :default_userid   => '_',
+                             :default_hostname => 'mytest.com',
+                             :default_api_port => '8443',
+                             :default_password => 'valid-token',
+                             :emstype          => emstype}
         controller.send(:set_ems_record_vars, @ems)
         expect(@flash_array).to be_nil
       end
@@ -134,17 +134,17 @@ describe EmsContainerController do
 
         def test_setting_many_fields
           controller.params = {:name                      => 'EMS 2',
-                                                      :default_userid            => '_',
-                                                      :default_hostname          => '10.10.10.11',
-                                                      :default_api_port          => '5000',
-                                                      :default_security_protocol => 'ssl-with-validation-custom-ca',
-                                                      :default_tls_ca_certs      => '-----BEGIN DUMMY...',
-                                                      :default_password          => 'valid-token',
-                                                      :metrics_selection         => 'hawkular',
-                                                      :metrics_hostname          => '10.10.10.10',
-                                                      :metrics_api_port          => '8443',
-                                                      :metrics_security_protocol => 'ssl-with-validation',
-                                                      :emstype                   => @type)
+                               :default_userid            => '_',
+                               :default_hostname          => '10.10.10.11',
+                               :default_api_port          => '5000',
+                               :default_security_protocol => 'ssl-with-validation-custom-ca',
+                               :default_tls_ca_certs      => '-----BEGIN DUMMY...',
+                               :default_password          => 'valid-token',
+                               :metrics_selection         => 'hawkular',
+                               :metrics_hostname          => '10.10.10.10',
+                               :metrics_api_port          => '8443',
+                               :metrics_security_protocol => 'ssl-with-validation',
+                               :emstype                   => @type}
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           cc = @ems.connection_configurations
@@ -193,7 +193,7 @@ describe EmsContainerController do
         it 'updates provider options' do
           @type = 'openshift'
           @ems  = ManageIQ::Providers::Openshift::ContainerManager.new
-          controller.params = {:provider_options_image_inspector_options_http_proxy => "example.com")
+          controller.params = {:provider_options_image_inspector_options_http_proxy => "example.com"}
           controller.send(:set_ems_record_vars, @ems)
           expect(@ems.options[:image_inspector_options][:http_proxy]).to eq("example.com")
         end

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -166,7 +166,7 @@ describe EmsContainerController do
 
         def test_setting_few_fields
           controller.remove_instance_variable(:@_params)
-          controller.instance_variable_set(:@_params, :name => 'EMS 3', :default_userid => '_')
+          controller.params = {:name => 'EMS 3', :default_userid => '_'}
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           expect(@ems.authentication_token("bearer")).to eq('valid-token')
@@ -240,7 +240,7 @@ describe EmsContainerController do
           allow(controller).to receive(:javascript_redirect)
           allow(controller).to receive(:performed?).and_return(true)
           controller.instance_variable_set(:@display, display)
-          controller.instance_variable_set(:@_params, :pressed => press, :miq_grid_checks => item.id.to_s, :id => provider.id)
+          controller.params = {:pressed => press, :miq_grid_checks => item.id.to_s, :id => provider.id}
           controller.instance_variable_set(:@breadcrumbs, [])
         end
 

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -80,8 +80,7 @@ describe EmsContainerController do
       end
 
       it "detects openshift hawkular metric route" do
-        controller.instance_variable_set(:@_params,
-                                         :id                => openshift_manager.id,
+        controller.params = {:id                => openshift_manager.id,
                                          :current_tab       => "metrics",
                                          :metrics_selection => 'hawkular')
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
@@ -97,8 +96,7 @@ describe EmsContainerController do
       end
 
       it "detects openshift prometheus metric route" do
-        controller.instance_variable_set(:@_params,
-                                         :id                => openshift_manager.id,
+        controller.params = {:id                => openshift_manager.id,
                                          :current_tab       => "metrics",
                                          :metrics_selection => 'prometheus')
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
@@ -115,8 +113,7 @@ describe EmsContainerController do
 
       it "detects openshift prometheus alert route" do
         require 'kubeclient'
-        controller.instance_variable_set(:@_params,
-                                         :id          => openshift_manager.id,
+        controller.params = {:id          => openshift_manager.id,
                                          :current_tab => "alerts")
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
@@ -131,8 +128,7 @@ describe EmsContainerController do
       end
 
       it "tolerates detection exceptions" do
-        controller.instance_variable_set(:@_params,
-                                         :id                => openshift_manager.id,
+        controller.params = {:id                => openshift_manager.id,
                                          :current_tab       => "metrics",
                                          :metrics_selection => 'hawkular')
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
@@ -311,8 +307,7 @@ describe EmsContainerController do
         end
 
         def test_setting_many_fields
-          controller.instance_variable_set(:@_params,
-                                           :name                       => 'EMS 2',
+          controller.params = {:name                       => 'EMS 2',
                                            :default_userid             => '_',
                                            :default_hostname           => '10.10.10.11',
                                            :default_api_port           => '5000',

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -151,7 +151,7 @@ describe EmsContainerController do
 
     it "errors on kubernetes detection" do
       EvmSpecHelper.create_guid_miq_server_zone
-      controller.instance_variable_set(:@_params, :id => kubernetes_manager.id)
+      controller.params = {:id => kubernetes_manager.id}
       controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
       controller.send(:update_ems_button_detect)
@@ -352,7 +352,7 @@ describe EmsContainerController do
 
         def test_setting_few_fields
           controller.remove_instance_variable(:@_params)
-          controller.instance_variable_set(:@_params, :name => 'EMS 3', :default_userid => '_')
+          controller.params = {:name => 'EMS 3', :default_userid => '_'}
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           expect(@ems.authentication_token("default")).to eq('valid-token')

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -81,8 +81,8 @@ describe EmsContainerController do
 
       it "detects openshift hawkular metric route" do
         controller.params = {:id                => openshift_manager.id,
-                                         :current_tab       => "metrics",
-                                         :metrics_selection => 'hawkular')
+                             :current_tab       => "metrics",
+                             :metrics_selection => 'hawkular'}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
         expect(mock_client).to receive(:get_route).with('hawkular-metrics', 'openshift-infra')
@@ -97,8 +97,8 @@ describe EmsContainerController do
 
       it "detects openshift prometheus metric route" do
         controller.params = {:id                => openshift_manager.id,
-                                         :current_tab       => "metrics",
-                                         :metrics_selection => 'prometheus')
+                             :current_tab       => "metrics",
+                             :metrics_selection => 'prometheus'}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
         expect(mock_client).to receive(:get_route).with('prometheus', 'openshift-metrics')
@@ -114,7 +114,7 @@ describe EmsContainerController do
       it "detects openshift prometheus alert route" do
         require 'kubeclient'
         controller.params = {:id          => openshift_manager.id,
-                                         :current_tab => "alerts")
+                             :current_tab => "alerts"}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
         expect(mock_client).to receive(:get_route).with('alerts', 'openshift-metrics')
@@ -129,8 +129,8 @@ describe EmsContainerController do
 
       it "tolerates detection exceptions" do
         controller.params = {:id                => openshift_manager.id,
-                                         :current_tab       => "metrics",
-                                         :metrics_selection => 'hawkular')
+                             :current_tab       => "metrics",
+                             :metrics_selection => 'hawkular'}
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
 
         expect(mock_client).to receive(:get_route).with('hawkular-metrics', 'openshift-infra')
@@ -308,19 +308,19 @@ describe EmsContainerController do
 
         def test_setting_many_fields
           controller.params = {:name                       => 'EMS 2',
-                                           :default_userid             => '_',
-                                           :default_hostname           => '10.10.10.11',
-                                           :default_api_port           => '5000',
-                                           :default_security_protocol  => 'ssl-with-validation-custom-ca',
-                                           :default_tls_ca_certs       => '-----BEGIN DUMMY...',
-                                           :default_password           => 'valid-token',
-                                           :virtualization_selection   => 'kubevirt',
-                                           :kubevirt_hostname          => '10.10.10.11',
-                                           :kubevirt_api_port          => '5000',
-                                           :kubevirt_security_protocol => 'ssl-with-validation-custom-ca',
-                                           :kubevirt_tls_ca_certs      => '-----BEGIN DUMMY...',
-                                           :kubevirt_password          => 'other-valid-token',
-                                           :emstype                    => @type)
+                               :default_userid             => '_',
+                               :default_hostname           => '10.10.10.11',
+                               :default_api_port           => '5000',
+                               :default_security_protocol  => 'ssl-with-validation-custom-ca',
+                               :default_tls_ca_certs       => '-----BEGIN DUMMY...',
+                               :default_password           => 'valid-token',
+                               :virtualization_selection   => 'kubevirt',
+                               :kubevirt_hostname          => '10.10.10.11',
+                               :kubevirt_api_port          => '5000',
+                               :kubevirt_security_protocol => 'ssl-with-validation-custom-ca',
+                               :kubevirt_tls_ca_certs      => '-----BEGIN DUMMY...',
+                               :kubevirt_password          => 'other-valid-token',
+                               :emstype                    => @type}
           controller.send(:set_ems_record_vars, @ems)
           expect(@flash_array).to be_nil
           cc = @ems.connection_configurations

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -424,8 +424,7 @@ describe EmsInfraController do
       let(:ssh_keypair_creds) { {:userid => "ssh_keypair_userid", :auth_key => "ssh_keypair_password"} }
 
       it "uses the passwords from params for validation if they exist" do
-        controller.instance_variable_set(:@_params,
-                                         :default_userid       => default_creds[:userid],
+        controller.params = {:default_userid       => default_creds[:userid],
                                          :default_password     => default_creds[:password],
                                          :amqp_userid          => amqp_creds[:userid],
                                          :amqp_password        => amqp_creds[:password],
@@ -441,8 +440,7 @@ describe EmsInfraController do
       end
 
       it "uses the stored passwords for validation if passwords dont exist in params" do
-        controller.instance_variable_set(:@_params,
-                                         :default_userid     => default_creds[:userid],
+        controller.params = {:default_userid     => default_creds[:userid],
                                          :amqp_userid        => amqp_creds[:userid],
                                          :ssh_keypair_userid => ssh_keypair_creds[:userid])
         expect(@ems).to receive(:authentication_password).and_return(default_creds[:password])

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -425,11 +425,11 @@ describe EmsInfraController do
 
       it "uses the passwords from params for validation if they exist" do
         controller.params = {:default_userid       => default_creds[:userid],
-                                         :default_password     => default_creds[:password],
-                                         :amqp_userid          => amqp_creds[:userid],
-                                         :amqp_password        => amqp_creds[:password],
-                                         :ssh_keypair_userid   => ssh_keypair_creds[:userid],
-                                         :ssh_keypair_password => ssh_keypair_creds[:auth_key])
+                             :default_password     => default_creds[:password],
+                             :amqp_userid          => amqp_creds[:userid],
+                             :amqp_password        => amqp_creds[:password],
+                             :ssh_keypair_userid   => ssh_keypair_creds[:userid],
+                             :ssh_keypair_password => ssh_keypair_creds[:auth_key]}
         expect(@ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
         expect(@ems).to receive(:supports_authentication?).with(:ssh_keypair).and_return(true)
         expect(@ems).to receive(:supports_authentication?).with(:oauth)
@@ -441,8 +441,8 @@ describe EmsInfraController do
 
       it "uses the stored passwords for validation if passwords dont exist in params" do
         controller.params = {:default_userid     => default_creds[:userid],
-                                         :amqp_userid        => amqp_creds[:userid],
-                                         :ssh_keypair_userid => ssh_keypair_creds[:userid])
+                             :amqp_userid        => amqp_creds[:userid],
+                             :ssh_keypair_userid => ssh_keypair_creds[:userid]}
         expect(@ems).to receive(:authentication_password).and_return(default_creds[:password])
         expect(@ems).to receive(:authentication_password).with(:amqp).and_return(amqp_creds[:password])
         expect(@ems).to receive(:supports_authentication?).with(:amqp).and_return(true)

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -113,15 +113,13 @@ describe EmsPhysicalInfraController do
       let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
 
       it "uses the passwords from params for validation if they exist" do
-        controller.instance_variable_set(:@_params,
-                                         :default_userid   => default_creds[:userid],
+        controller.params = {:default_userid   => default_creds[:userid],
                                          :default_password => default_creds[:password])
         expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default => default_creds.merge!(:save => false))
       end
 
       it "uses the stored passwords for validation if passwords dont exist in params" do
-        controller.instance_variable_set(:@_params,
-                                         :default_userid => default_creds[:userid])
+        controller.params = {:default_userid => default_creds[:userid])
         expect(@ems).to receive(:authentication_password).and_return(default_creds[:password])
         expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default => default_creds.merge!(:save => false))
       end

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -114,12 +114,12 @@ describe EmsPhysicalInfraController do
 
       it "uses the passwords from params for validation if they exist" do
         controller.params = {:default_userid   => default_creds[:userid],
-                                         :default_password => default_creds[:password])
+                             :default_password => default_creds[:password]}
         expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default => default_creds.merge!(:save => false))
       end
 
       it "uses the stored passwords for validation if passwords dont exist in params" do
-        controller.params = {:default_userid => default_creds[:userid])
+        controller.params = {:default_userid => default_creds[:userid]}
         expect(@ems).to receive(:authentication_password).and_return(default_creds[:password])
         expect(controller.send(:build_credentials, @ems, :validate)).to eq(:default => default_creds.merge!(:save => false))
       end

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -34,7 +34,7 @@ describe EmsStorageController do
       controller.action_name = 'show'
       ems_storage = FactoryBot.create(:ems_storage, :name => "foo")
       allow(controller).to receive(:type_feature_role_check).and_return(true)
-      controller.instance_variable_set(:@_params, :id => ems_storage.id)
+      controller.params = {:id => ems_storage.id}
       controller.send(:init_show)
       expect(assigns(:record).id).to eq(ems_storage.id)
       expect(assigns(:ems).id).to eq(ems_storage.id)

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -38,7 +38,7 @@ describe FloatingIpController do
         login_as admin_user
         allow(controller).to receive(:assert_privileges)
         allow(controller).to receive(:performed?)
-        controller.instance_variable_set(:@_params, :id => floating_ip.id, :pressed => 'host_NECO')
+        controller.params = {:id => floating_ip.id, :pressed => 'host_NECO'}
       end
 
       it "delete floating ips" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -366,8 +366,7 @@ describe HostController do
   describe "#set_credentials" do
     let(:mocked_host) { double(Host) }
     it "uses params[:default_password] for validation if one exists" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => "default_userid",
+      controller.params = {:default_userid   => "default_userid",
                                        :default_password => "default_password2")
       creds = {:userid => "default_userid", :password => "default_password2"}
       expect(mocked_host).to receive(:update_authentication).with({:default => creds}, {:save => false})
@@ -383,8 +382,7 @@ describe HostController do
     end
 
     it "uses the passwords from param for validation if they exist" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => "default_userid",
+      controller.params = {:default_userid   => "default_userid",
                                        :default_password => "default_password2",
                                        :remote_userid    => "remote_userid",
                                        :remote_password  => "remote_password2")
@@ -398,8 +396,7 @@ describe HostController do
     end
 
     it "uses the stored passwords for validation if passwords dont exist in params" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid => "default_userid",
+      controller.params = {:default_userid => "default_userid",
                                        :remote_userid  => "remote_userid",)
       expect(mocked_host).to receive(:authentication_password).and_return('default_password')
       expect(mocked_host).to receive(:authentication_password).with(:remote).and_return('remote_password')
@@ -413,8 +410,7 @@ describe HostController do
     end
 
     it "uses the stored passwords/passwords from params to do validation" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => "default_userid",
+      controller.params = {:default_userid   => "default_userid",
                                        :default_password => "default_password2",
                                        :ws_userid        => "ws_userid",
                                        :ipmi_userid      => "ipmi_userid")

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -367,7 +367,7 @@ describe HostController do
     let(:mocked_host) { double(Host) }
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "default_userid",
-                                       :default_password => "default_password2")
+                           :default_password => "default_password2"}
       creds = {:userid => "default_userid", :password => "default_password2"}
       expect(mocked_host).to receive(:update_authentication).with({:default => creds}, {:save => false})
       expect(controller.send(:set_credentials, mocked_host, :validate)).to include(:default => creds)
@@ -383,9 +383,9 @@ describe HostController do
 
     it "uses the passwords from param for validation if they exist" do
       controller.params = {:default_userid   => "default_userid",
-                                       :default_password => "default_password2",
-                                       :remote_userid    => "remote_userid",
-                                       :remote_password  => "remote_password2")
+                           :default_password => "default_password2",
+                           :remote_userid    => "remote_userid",
+                           :remote_password  => "remote_password2"}
       default_creds = {:userid => "default_userid", :password => "default_password2"}
       remote_creds = {:userid => "remote_userid", :password => "remote_password2"}
       expect(mocked_host).to receive(:update_authentication).with({:default => default_creds,
@@ -397,7 +397,7 @@ describe HostController do
 
     it "uses the stored passwords for validation if passwords dont exist in params" do
       controller.params = {:default_userid => "default_userid",
-                                       :remote_userid  => "remote_userid",)
+                           :remote_userid  => "remote_userid"}
       expect(mocked_host).to receive(:authentication_password).and_return('default_password')
       expect(mocked_host).to receive(:authentication_password).with(:remote).and_return('remote_password')
       default_creds = {:userid => "default_userid", :password => "default_password"}
@@ -411,9 +411,9 @@ describe HostController do
 
     it "uses the stored passwords/passwords from params to do validation" do
       controller.params = {:default_userid   => "default_userid",
-                                       :default_password => "default_password2",
-                                       :ws_userid        => "ws_userid",
-                                       :ipmi_userid      => "ipmi_userid")
+                           :default_password => "default_password2",
+                           :ws_userid        => "ws_userid",
+                           :ipmi_userid      => "ipmi_userid"}
       expect(mocked_host).to receive(:authentication_password).with(:ws).and_return('ws_password')
       expect(mocked_host).to receive(:authentication_password).with(:ipmi).and_return('ipmi_password')
       default_creds = {:userid => "default_userid", :password => "default_password2"}

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -134,7 +134,7 @@ describe HostController do
         allow(request).to receive(:parameters).and_return(:pressed => 'vm_miq_request_new')
         controller.instance_variable_set(:@display, 'vms')
         controller.instance_variable_set(:@lastaction, 'show')
-        controller.instance_variable_set(:@_params, :pressed => 'vm_miq_request_new')
+        controller.params = {:pressed => 'vm_miq_request_new'}
       end
 
       it 'calls render_or_redirect_partial method' do
@@ -375,7 +375,7 @@ describe HostController do
     end
 
     it "uses the stored password for validation if params[:default_password] does not exist" do
-      controller.instance_variable_set(:@_params, :default_userid => "default_userid")
+      controller.params = {:default_userid => "default_userid"}
       expect(mocked_host).to receive(:authentication_password).and_return('default_password')
       creds = {:userid => "default_userid", :password => "default_password"}
       expect(mocked_host).to receive(:update_authentication).with({:default => creds}, {:save => false})

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -617,8 +617,8 @@ describe MiqAeClassController do
         }
       }
       controller.params = {"fields_default_value_0" => "Pebbles",
-                                       "fields_name_0"          => "freddie",
-                                       :id                      => @cls.id)
+                           "fields_name_0"          => "freddie",
+                           :id                      => @cls.id}
       allow(controller).to receive(:render)
       controller.send(:fields_form_field_changed)
       expect(@cls.ae_fields.first.default_value).to eq("Wilma")
@@ -647,9 +647,9 @@ describe MiqAeClassController do
         }
       }
       controller.params = {"fields_default_value" => "Foo",
-                                       "fields_name"          => "Bar",
-                                       :id                    => @cls.id,
-                                       :button                => 'accept')
+                           "fields_name"          => "Bar",
+                           :id                    => @cls.id,
+                           :button                => 'accept'}
       allow(controller).to receive(:render)
       controller.send(:fields_form_field_changed)
       controller.params = {:button => "save", :id => @cls.id}
@@ -691,7 +691,7 @@ describe MiqAeClassController do
 
     it "Should delete multiple selected items from list" do
       controller.params = {:miq_grid_checks => "aec-#{@ae_class.id},aen-#{@namespace.id}",
-                                       :id              => @namespace.id)
+                           :id              => @namespace.id}
       controller.send(:delete_namespaces_or_classes)
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("Automate Namespace \"foo_namespace\": Delete successful")
@@ -699,7 +699,7 @@ describe MiqAeClassController do
     end
 
     it "Should delete selected namespace in the tree" do
-      controller.params = {:id => @namespace.id)
+      controller.params = {:id => @namespace.id}
 
       controller.send(:delete_namespaces_or_classes)
       flash_messages = assigns(:flash_array)
@@ -708,7 +708,7 @@ describe MiqAeClassController do
 
     it "Should use description in flash message when available" do
       controller.params = {:miq_grid_checks => "aen-#{@namespace.id}",
-                                       :id              => @namespace.id)
+                           :id              => @namespace.id}
       @namespace.update_column(:description, "foo_description")
       @namespace.reload
       controller.send(:delete_namespaces_or_classes)
@@ -751,9 +751,9 @@ describe MiqAeClassController do
 
     it "Should use description in flash message when editing a namespace" do
       controller.params = {:button      => "save",
-                                       :name        => 'name',
-                                       :description => 'desc',
-                                       :id          => @namespace.id)
+                           :name        => 'name',
+                           :description => 'desc',
+                           :id          => @namespace.id}
       controller.send(:update_namespace)
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("Automate Namespace \"desc\" was saved")
@@ -774,7 +774,7 @@ describe MiqAeClassController do
 
     it "Should delete selected class in the tree" do
       controller.x_node = "aec-#{@ae_class.id}"
-      controller.params = {:id => @namespace.id)
+      controller.params = {:id => @namespace.id}
 
       controller.send(:deleteclasses)
       flash_messages = assigns(:flash_array)
@@ -965,15 +965,15 @@ describe MiqAeClassController do
     it "Should delete selected instance from details screen" do
       controller.x_node = "aei-#{@instance.id}"
       controller.params = {:pressed => "miq_ae_instance_delete",
-                                       :id      => @instance.id)
+                           :id      => @instance.id}
       controller.send(:deleteinstances)
     end
 
     it "Should delete selected instance in the list" do
       controller.x_node = "aec-#{@ae_class.id}"
       controller.params = {:miq_grid_checks => "aei-#{@instance.id}",
-                                       :pressed         => "miq_ae_instance_delete",
-                                       :id              => @ae_class.id)
+                           :pressed         => "miq_ae_instance_delete",
+                           :id              => @ae_class.id}
       controller.send(:deleteinstances)
     end
 
@@ -1003,15 +1003,15 @@ describe MiqAeClassController do
     it "Should delete selected method from details screen" do
       controller.x_node = "aem-#{@method.id}"
       controller.params = {:pressed => "miq_ae_method_delete",
-                                       :id      => @method.id)
+                           :id      => @method.id}
       controller.send(:deletemethods)
     end
 
     it "Should delete selected method in the list" do
       controller.x_node = "aec-#{@ae_class.id}"
       controller.params = {:miq_grid_checks => "aem-#{@method.id},aem-#{@method2.id}",
-                                       :pressed         => "miq_ae_method_delete",
-                                       :id              => @ae_class.id)
+                           :pressed         => "miq_ae_method_delete",
+                           :id              => @ae_class.id}
       controller.send(:deletemethods)
     end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -37,7 +37,7 @@ describe MiqAeClassController do
     it "Marks domain as locked/readonly" do
       stub_user(:features => :all)
       ns = FactoryBot.create(:miq_ae_domain_enabled)
-      controller.instance_variable_set(:@_params, :id => ns.id)
+      controller.params = {:id => ns.id}
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_lock)
       ns.reload
@@ -49,7 +49,7 @@ describe MiqAeClassController do
     it "Marks domain as unlocked/editable" do
       stub_user(:features => :all)
       ns = FactoryBot.create(:miq_ae_domain_disabled)
-      controller.instance_variable_set(:@_params, :id => ns.id)
+      controller.params = {:id => ns.id}
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_unlock)
       ns.reload
@@ -70,7 +70,7 @@ describe MiqAeClassController do
         :key     => "priority__edit",
         :current => {:domain_order => order},
       }
-      controller.instance_variable_set(:@_params, :button => "save")
+      controller.params = {:button => "save"}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, {})
       session[:edit] = edit
@@ -94,7 +94,7 @@ describe MiqAeClassController do
                                        :active_tree => :ae_tree,
                                        :action      => "miq_ae_class_copy",
                                        :trees       => {:ae_tree => {:active_node => node}})
-      controller.instance_variable_set(:@_params, :button => "reset", :id => cls1.id)
+      controller.params = {:button => "reset", :id => cls1.id}
       allow(controller).to receive(:open_parent_nodes)
       expect(controller).to receive(:reload_trees_by_presenter).with(anything, [])
       expect(controller).to receive(:render)
@@ -121,7 +121,7 @@ describe MiqAeClassController do
         :current        => new,
         :selected_items => selected_items,
       }
-      controller.instance_variable_set(:@_params, :button => "copy", :id => cls1.id)
+      controller.params = {:button => "copy", :id => cls1.id}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, :action => "miq_ae_class_copy")
       session[:edit] = edit
@@ -148,7 +148,7 @@ describe MiqAeClassController do
         :current        => new,
         :selected_items => selected_items,
       }
-      controller.instance_variable_set(:@_params, :button => "copy", :id => cls1.id)
+      controller.params = {:button => "copy", :id => cls1.id}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, :action => "miq_ae_class_copy")
       session[:edit] = edit
@@ -178,7 +178,7 @@ describe MiqAeClassController do
         :current        => new,
         :selected_items => selected_items,
       }
-      controller.instance_variable_set(:@_params, :button => "copy", :id => cls1.id)
+      controller.params = {:button => "copy", :id => cls1.id}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, :action => "miq_ae_class_copy")
       session[:edit] = edit
@@ -206,7 +206,7 @@ describe MiqAeClassController do
         :current        => new,
         :selected_items => selected_items,
       }
-      controller.instance_variable_set(:@_params, :button => "copy", :id => cls1.id)
+      controller.params = {:button => "copy", :id => cls1.id}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@sb, :action => "miq_ae_class_copy")
       session[:edit] = edit
@@ -405,7 +405,7 @@ describe MiqAeClassController do
     before do
       allow(GitBasedDomainImportService).to receive(:new).and_return(git_service)
       stub_user(:features => :all)
-      controller.instance_variable_set(:@_params, :miq_grid_checks => ids)
+      controller.params = {:miq_grid_checks => ids}
       allow(controller).to receive(:replace_right_cell)
     end
 
@@ -457,7 +457,7 @@ describe MiqAeClassController do
       field = {:aetype   => "attribute"}
       controller.instance_variable_set(:@edit, session[:edit])
       session[:field_data] = field
-      controller.instance_variable_set(:@_params, :button => "accept", :id => @cls.id)
+      controller.params = {:button => "accept", :id => @cls.id}
       controller.send(:field_accept)
 
       expect(assigns(:flash_array).first[:message]).to include("Name is required")
@@ -467,7 +467,7 @@ describe MiqAeClassController do
       field = {:name => "name"}
       controller.instance_variable_set(:@edit, session[:edit])
       session[:field_data] = field
-      controller.instance_variable_set(:@_params, :button => "accept", :id => @cls.id)
+      controller.params = {:button => "accept", :id => @cls.id}
       controller.send(:field_accept)
 
       expect(assigns(:flash_array).first[:message]).to include("Type is required")
@@ -477,7 +477,7 @@ describe MiqAeClassController do
       field = {}
       controller.instance_variable_set(:@edit, session[:edit])
       session[:field_data] = field
-      controller.instance_variable_set(:@_params, :button => "accept", :id => @cls.id)
+      controller.params = {:button => "accept", :id => @cls.id}
       controller.send(:field_accept)
 
       expect(assigns(:flash_array).first[:message]).to include("Name and Type is required")
@@ -488,7 +488,7 @@ describe MiqAeClassController do
                "datatype" => "string",
                "name"     => "name01"}
       session[:edit][:new][:fields] = [field, field]
-      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.params = {:button => "save", :id => @cls.id}
       controller.send(:update_fields)
       expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
     end
@@ -507,7 +507,7 @@ describe MiqAeClassController do
           :fields => [field, field]
         }
       }
-      controller.instance_variable_set(:@_params, :button => "save", :id => @method.id)
+      controller.params = {:button => "save", :id => @method.id}
       controller.send(:update_method)
       expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
     end
@@ -530,7 +530,7 @@ describe MiqAeClassController do
           :language     => "ruby"
         }
       }
-      controller.instance_variable_set(:@_params, :button => "add")
+      controller.params = {:button => "add"}
       controller.send(:create_method)
       expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
     end
@@ -573,7 +573,7 @@ describe MiqAeClassController do
           :fields   => [field]
         }
       }
-      controller.instance_variable_set(:@_params, :button => "save", :id => @method.id)
+      controller.params = {:button => "save", :id => @method.id}
       controller.send(:update_method)
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.status).to eq(200)
@@ -593,7 +593,7 @@ describe MiqAeClassController do
           :fields    => [field]
         }
       }
-      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.params = {:button => "save", :id => @cls.id}
       controller.send(:update_fields)
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.status).to eq(200)
@@ -623,7 +623,7 @@ describe MiqAeClassController do
       allow(controller).to receive(:render)
       controller.send(:fields_form_field_changed)
       expect(@cls.ae_fields.first.default_value).to eq("Wilma")
-      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.params = {:button => "save", :id => @cls.id}
       controller.send(:update_fields)
       @cls.reload
       expect(@cls.ae_fields.first.name).to eq("freddie")
@@ -654,7 +654,7 @@ describe MiqAeClassController do
                                        :button                => 'accept')
       allow(controller).to receive(:render)
       controller.send(:fields_form_field_changed)
-      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.params = {:button => "save", :id => @cls.id}
       controller.send(:update_fields)
       @cls.reload
       expect(@cls.ae_fields.last.name).to eq("Bar")
@@ -839,7 +839,7 @@ describe MiqAeClassController do
     it "moves selected field down" do
       controller.send(:fields_seq_edit_screen, @cls.id)
       expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name01)", "(name02)"])
-      controller.instance_variable_set(:@_params, :button => 'down', :id => 'seq', :seq_fields => "['(name01)']")
+      controller.params = {:button => 'down', :id => 'seq', :seq_fields => "['(name01)']"}
       expect(controller).to receive(:render)
       controller.fields_seq_field_changed
       expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name02)", "(name01)"])
@@ -848,7 +848,7 @@ describe MiqAeClassController do
     it "moves selected field up" do
       controller.send(:fields_seq_edit_screen, @cls.id)
       expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name01)", "(name02)"])
-      controller.instance_variable_set(:@_params, :button => 'up', :id => 'seq', :seq_fields => "['(name02)']")
+      controller.params = {:button => 'up', :id => 'seq', :seq_fields => "['(name02)']"}
       expect(controller).to receive(:render)
       controller.fields_seq_field_changed
       expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name02)", "(name01)"])
@@ -906,7 +906,7 @@ describe MiqAeClassController do
         :new              => new,
         :current          => new
       }
-      controller.instance_variable_set(:@_params, :transOne => "1", :id => @method.id)
+      controller.params = {:transOne => "1", :id => @method.id}
       allow(controller).to receive(:render)
       controller.send(:form_method_field_changed)
       expect(assigns(:edit)[:new][:data]).to eq("exit MIQ_OK...")

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -616,8 +616,7 @@ describe MiqAeClassController do
           :fields    => [@cls.ae_fields.first]
         }
       }
-      controller.instance_variable_set(:@_params,
-                                       "fields_default_value_0" => "Pebbles",
+      controller.params = {"fields_default_value_0" => "Pebbles",
                                        "fields_name_0"          => "freddie",
                                        :id                      => @cls.id)
       allow(controller).to receive(:render)
@@ -647,8 +646,7 @@ describe MiqAeClassController do
           :fields    => [@cls.ae_fields.first]
         }
       }
-      controller.instance_variable_set(:@_params,
-                                       "fields_default_value" => "Foo",
+      controller.params = {"fields_default_value" => "Foo",
                                        "fields_name"          => "Bar",
                                        :id                    => @cls.id,
                                        :button                => 'accept')
@@ -692,8 +690,7 @@ describe MiqAeClassController do
     end
 
     it "Should delete multiple selected items from list" do
-      controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => "aec-#{@ae_class.id},aen-#{@namespace.id}",
+      controller.params = {:miq_grid_checks => "aec-#{@ae_class.id},aen-#{@namespace.id}",
                                        :id              => @namespace.id)
       controller.send(:delete_namespaces_or_classes)
       flash_messages = assigns(:flash_array)
@@ -702,8 +699,7 @@ describe MiqAeClassController do
     end
 
     it "Should delete selected namespace in the tree" do
-      controller.instance_variable_set(:@_params,
-                                       :id => @namespace.id)
+      controller.params = {:id => @namespace.id)
 
       controller.send(:delete_namespaces_or_classes)
       flash_messages = assigns(:flash_array)
@@ -711,8 +707,7 @@ describe MiqAeClassController do
     end
 
     it "Should use description in flash message when available" do
-      controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => "aen-#{@namespace.id}",
+      controller.params = {:miq_grid_checks => "aen-#{@namespace.id}",
                                        :id              => @namespace.id)
       @namespace.update_column(:description, "foo_description")
       @namespace.reload
@@ -755,8 +750,7 @@ describe MiqAeClassController do
     end
 
     it "Should use description in flash message when editing a namespace" do
-      controller.instance_variable_set(:@_params,
-                                       :button      => "save",
+      controller.params = {:button      => "save",
                                        :name        => 'name',
                                        :description => 'desc',
                                        :id          => @namespace.id)
@@ -780,8 +774,7 @@ describe MiqAeClassController do
 
     it "Should delete selected class in the tree" do
       controller.x_node = "aec-#{@ae_class.id}"
-      controller.instance_variable_set(:@_params,
-                                       :id => @namespace.id)
+      controller.params = {:id => @namespace.id)
 
       controller.send(:deleteclasses)
       flash_messages = assigns(:flash_array)
@@ -971,16 +964,14 @@ describe MiqAeClassController do
 
     it "Should delete selected instance from details screen" do
       controller.x_node = "aei-#{@instance.id}"
-      controller.instance_variable_set(:@_params,
-                                       :pressed => "miq_ae_instance_delete",
+      controller.params = {:pressed => "miq_ae_instance_delete",
                                        :id      => @instance.id)
       controller.send(:deleteinstances)
     end
 
     it "Should delete selected instance in the list" do
       controller.x_node = "aec-#{@ae_class.id}"
-      controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => "aei-#{@instance.id}",
+      controller.params = {:miq_grid_checks => "aei-#{@instance.id}",
                                        :pressed         => "miq_ae_instance_delete",
                                        :id              => @ae_class.id)
       controller.send(:deleteinstances)
@@ -1011,16 +1002,14 @@ describe MiqAeClassController do
 
     it "Should delete selected method from details screen" do
       controller.x_node = "aem-#{@method.id}"
-      controller.instance_variable_set(:@_params,
-                                       :pressed => "miq_ae_method_delete",
+      controller.params = {:pressed => "miq_ae_method_delete",
                                        :id      => @method.id)
       controller.send(:deletemethods)
     end
 
     it "Should delete selected method in the list" do
       controller.x_node = "aec-#{@ae_class.id}"
-      controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => "aem-#{@method.id},aem-#{@method2.id}",
+      controller.params = {:miq_grid_checks => "aem-#{@method.id},aem-#{@method2.id}",
                                        :pressed         => "miq_ae_method_delete",
                                        :id              => @ae_class.id)
       controller.send(:deletemethods)

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -23,7 +23,7 @@ describe MiqAeCustomizationController do
         allow(controller).to receive(:replace_right_cell)
 
         # Now delete the Dialog
-        controller.instance_variable_set(:@_params, :id => dialog.id)
+        controller.params = {:id => dialog.id}
         controller.send(:dialog_delete)
 
         # Check for Dialog Label to be part of flash message displayed

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -19,7 +19,7 @@ describe MiqAeCustomizationController do
         allow(controller).to receive(:replace_right_cell)
 
         # Now delete the Dialog
-        controller.instance_variable_set(:@_params, "check_#{dialog1.id}" => "1", "check_#{dialog2.id}" => "1")
+        controller.params = {"check_#{dialog1.id}" => "1", "check_#{dialog2.id}" => "1"}
         controller.send(:old_dialogs_button_operation, 'destroy', 'Test Dialog')
 
         # Check for Dialog Label to be part of flash message displayed
@@ -39,7 +39,7 @@ describe MiqAeCustomizationController do
         allow(controller).to receive(:replace_right_cell)
 
         # Now delete the Dialog
-        controller.instance_variable_set(:@_params, :id => dialog.id)
+        controller.params = {:id => dialog.id}
         controller.send(:old_dialogs_button_operation, 'destroy', 'Test Dialog')
 
         # Check for Dialog Label to be part of flash message displayed

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -55,7 +55,7 @@ describe MiqAeCustomizationController do
 
       it 'will show a flash error without Dialog Type' do
         allow(controller).to receive(:load_edit).and_return(true)
-        controller.instance_variable_set(:@_params, :button => 'add',
+        controller.params = {:button => 'add',
                                                     :id     => 'new')
         controller.instance_variable_set(:@edit, :new    => {:name        => 'name',
                                                              :description => 'description',

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -56,7 +56,7 @@ describe MiqAeCustomizationController do
       it 'will show a flash error without Dialog Type' do
         allow(controller).to receive(:load_edit).and_return(true)
         controller.params = {:button => 'add',
-                                                    :id     => 'new')
+                             :id     => 'new'}
         controller.instance_variable_set(:@edit, :new    => {:name        => 'name',
                                                              :description => 'description',
                                                              :dialog_type => '',

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -11,7 +11,7 @@ describe MiqAeToolsController do
       }
       controller.instance_variable_set(:@resolve, :throw_ready => true, :new => new)
       expect(controller).to receive(:render)
-      controller.instance_variable_set(:@_params, :target_class => '', :id => 'new')
+      controller.params = {:target_class => '', :id => 'new'}
       controller.send(:form_field_changed)
       expect(assigns(:resolve)[:new][:target_class]).to eq('')
       expect(assigns(:resolve)[:new][:target_id]).to eq(nil)
@@ -24,7 +24,7 @@ describe MiqAeToolsController do
       }
       controller.instance_variable_set(:@resolve, :throw_ready => true, :new => new)
       expect(controller).to receive(:render)
-      controller.instance_variable_set(:@_params, :target_class => 'Vm', :id => 'new')
+      controller.params = {:target_class => 'Vm', :id => 'new'}
       controller.send(:form_field_changed)
       expect(assigns(:resolve)[:new][:target_class]).to eq('Vm')
       expect(assigns(:resolve)[:new][:target_id]).to eq(nil)

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -18,7 +18,7 @@ describe MiqPolicyController do
       end
 
       it "Test reset button" do
-        controller.instance_variable_set(:@_params, :id => @ap.id, :button => "reset")
+        controller.params = {:id => @ap.id, :button => "reset"}
         expect(controller).to receive(:alert_profile_build_assign_screen)
         controller.alert_profile_assign
         expect(assigns(:flash_array).first[:message]).to include("reset")
@@ -26,14 +26,14 @@ describe MiqPolicyController do
       end
 
       it "Test cancel button" do
-        controller.instance_variable_set(:@_params, :id => @ap.id, :button => "cancel")
+        controller.params = {:id => @ap.id, :button => "cancel"}
         controller.alert_profile_assign
         expect(assigns(:flash_array).first[:message]).to include("cancelled")
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
 
       it "Test save button without selecting category" do
-        controller.instance_variable_set(:@_params, :id => @ap.id, :button => "save")
+        controller.params = {:id => @ap.id, :button => "save"}
         controller.instance_variable_set(:@sb, :trees => {:alert_profile_tree => {:active_node => "xx-Vm_ap-#{@ap.id}"}}, :active_tree => :alert_profile_tree,
                                                 :assign => {:alert_profile => @ap, :new => {:assign_to => "Vm-tags", :objects => ["10000000000001"]}})
         controller.alert_profile_assign
@@ -42,7 +42,7 @@ describe MiqPolicyController do
       end
 
       it "Test save button with no errors" do
-        controller.instance_variable_set(:@_params, :id => @ap.id, :button => "save")
+        controller.params = {:id => @ap.id, :button => "save"}
         controller.instance_variable_set(:@sb, :trees => {:alert_profile_tree => {:active_node => "xx-Vm_ap-#{@ap.id}"}}, :active_tree => :alert_profile_tree,
                                                 :assign => {:alert_profile => @ap, :new => {:assign_to => "Vm-tags", :cat => "10000000000001", :objects => ["10000000000001"]}})
         controller.alert_profile_assign
@@ -59,13 +59,13 @@ describe MiqPolicyController do
       end
 
       it 'Refuses to delete a non-existent profile' do
-        controller.instance_variable_set(:@_params, :id => @ap.id + 1, :button => 'delete')
+        controller.params = {:id => @ap.id + 1, :button => 'delete'}
         controller.alert_profile_delete
         expect(assigns(:flash_array).first[:message]).to include("Alert Profile no longer exists")
       end
 
       it 'Deletes an existing profile' do
-        controller.instance_variable_set(:@_params, :id => @ap.id, :button => 'delete')
+        controller.params = {:id => @ap.id, :button => 'delete'}
         expect(controller).to receive(:process_alert_profiles).with([@ap.id], 'destroy').and_return(nil)
         controller.alert_profile_delete
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -87,7 +87,7 @@ describe MiqPolicyController do
       end
 
       it "Test cancel button" do
-        controller.instance_variable_set(:@_params, :id => 'new', :button => "cancel")
+        controller.params = {:id => 'new', :button => "cancel"}
         controller.alert_profile_edit
         expect(assigns(:flash_array).first[:message]).to include("Add of new Alert Profile was cancelled by the user")
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -105,14 +105,14 @@ describe MiqPolicyController do
       end
 
       it "Changing Assign Tos drop down value, initializes the tree" do
-        controller.instance_variable_set(:@_params, :chosen_assign_to => "miq_server")
+        controller.params = {:chosen_assign_to => "miq_server"}
         expect(controller).to receive(:render)
         controller.alert_profile_assign_changed
         expect(assigns(:assign)[:obj_tree]).not_to be_nil
       end
 
       it "does not throw an error when selecting items in the servers tree" do
-        controller.instance_variable_set(:@_params, :check => "1", :id => "svr-1")
+        controller.params = {:check => "1", :id => "svr-1"}
         expect(controller).to receive(:render)
         controller.alert_profile_assign_changed
         expect(assigns(:assign)[:new][:objects]).to eq([1, 10])

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -31,13 +31,13 @@ describe MiqPolicyController do
 
       describe "#alert_build_edit_screen" do
         it "it should skip id when copying all attributes of an existing alert" do
-          controller.instance_variable_set(:@_params, :id => @miq_alert.id, :copy => "copy")
+          controller.params = {:id => @miq_alert.id, :copy => "copy"}
           controller.send(:alert_build_edit_screen)
           expect(assigns(:alert).id).to eq(nil)
         end
 
         it "it should select correct record when editing an existing alert" do
-          controller.instance_variable_set(:@_params, :id => @miq_alert.id)
+          controller.params = {:id => @miq_alert.id}
           controller.send(:alert_build_edit_screen)
           expect(assigns(:alert).id).to eq(@miq_alert.id)
         end

--- a/spec/controllers/miq_policy_controller/events_spec.rb
+++ b/spec/controllers/miq_policy_controller/events_spec.rb
@@ -30,7 +30,7 @@ describe MiqPolicyController do
         }
         controller.instance_variable_set(:@edit, edit)
         session[:edit] = edit
-        controller.instance_variable_set(:@_params, :id => @event.id.to_s, :button => "save")
+        controller.params = {:id => @event.id.to_s, :button => "save"}
         controller.event_edit
         expect(@policy.actions_for_event(@event, :success)).to include(@action)
       end
@@ -50,7 +50,7 @@ describe MiqPolicyController do
         }
         controller.instance_variable_set(:@edit, edit)
         session[:edit] = edit
-        controller.instance_variable_set(:@_params, :id => @event.id.to_s, :button => "save")
+        controller.params = {:id => @event.id.to_s, :button => "save"}
         expect(controller).to receive(:render)
         controller.event_edit
         expect(assigns(:flash_array).first[:message]).to include("At least one action must be selected to save this Policy Event")

--- a/spec/controllers/miq_policy_controller/miq_actions_spec.rb
+++ b/spec/controllers/miq_policy_controller/miq_actions_spec.rb
@@ -16,7 +16,7 @@ describe MiqPolicyController do
       end
 
       it "Test reset button" do
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "reset")
+        controller.params = {:id => @action.id, :button => "reset"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).to include("reset")
         expect(controller.send(:flash_errors?)).not_to be_truthy
@@ -24,20 +24,20 @@ describe MiqPolicyController do
 
       it "Test cancel button" do
         controller.instance_variable_set(:@sb, :trees => {:action_tree => {:active_node => "a-#{@action.id}"}}, :active_tree => :action_tree)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "cancel")
+        controller.params = {:id => @action.id, :button => "cancel"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).to include("cancelled")
         expect(controller.send(:flash_errors?)).not_to be_truthy
       end
 
       it "Test saving an action without selecting a Tag" do
-        controller.instance_variable_set(:@_params, :id => @action.id)
+        controller.params = {:id => @action.id}
         controller.action_edit
         expect(controller.send(:flash_errors?)).not_to be_truthy
         edit = controller.instance_variable_get(:@edit)
         edit[:new][:action_type] = "tag"
         session[:edit] = assigns(:edit)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "save")
+        controller.params = {:id => @action.id, :button => "save"}
         expect(controller).to receive(:render)
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).to include("At least one Tag")
@@ -46,7 +46,7 @@ describe MiqPolicyController do
       end
 
       it "Test saving an action after selecting a Tag" do
-        controller.instance_variable_set(:@_params, :id => @action.id)
+        controller.params = {:id => @action.id}
         controller.action_edit
         expect(controller.send(:flash_errors?)).not_to be_truthy
         edit = controller.instance_variable_get(:@edit)
@@ -54,7 +54,7 @@ describe MiqPolicyController do
         edit[:new][:options] = {}
         edit[:new][:options][:tags] = "Some Tag"
         session[:edit] = assigns(:edit)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "save")
+        controller.params = {:id => @action.id, :button => "save"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).not_to include("At least one Tag")
         expect(assigns(:flash_array).first[:message]).to include("saved")
@@ -62,7 +62,7 @@ describe MiqPolicyController do
       end
 
       it "can edit an Ansible playbook action" do
-        controller.instance_variable_set(:@_params, :id => @action.id)
+        controller.params = {:id => @action.id}
         controller.action_edit
         edit = controller.instance_variable_get(:@edit)
         edit[:new][:action_type] = "run_ansible_playbook"
@@ -70,7 +70,7 @@ describe MiqPolicyController do
         edit[:new][:options][:hosts] = 'host1, host2'
         edit[:new][:options][:service_template_id] = '01'
         session[:edit] = assigns(:edit)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "save")
+        controller.params = {:id => @action.id, :button => "save"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).not_to include("At least one Playbook")
         expect(assigns(:flash_array).first[:message]).to include("saved")
@@ -79,7 +79,7 @@ describe MiqPolicyController do
 
       it "displays an error if no Ansible playbook is selected" do
         allow(controller).to receive(:javascript_flash)
-        controller.instance_variable_set(:@_params, :id => @action.id)
+        controller.params = {:id => @action.id}
         controller.action_edit
         edit = controller.instance_variable_get(:@edit)
         edit[:new][:action_type] = "run_ansible_playbook"
@@ -87,7 +87,7 @@ describe MiqPolicyController do
         edit[:new][:options][:use_event_target] = true
         edit[:new][:options][:use_event_localhost] = false
         session[:edit] = assigns(:edit)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "save")
+        controller.params = {:id => @action.id, :button => "save"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).to include("An Ansible Playbook must be selected")
         expect(controller.send(:flash_errors?)).to be_truthy
@@ -95,14 +95,14 @@ describe MiqPolicyController do
 
       it "displays an error if no hosts are slected for an Ansible playbook with 'manual' inventory" do
         allow(controller).to receive(:javascript_flash)
-        controller.instance_variable_set(:@_params, :id => @action.id)
+        controller.params = {:id => @action.id}
         controller.action_edit
         edit = controller.instance_variable_get(:@edit)
         edit[:new][:action_type] = "run_ansible_playbook"
         edit[:new][:inventory_type] = 'manual'
         edit[:new][:options][:service_template_id] = '01'
         session[:edit] = assigns(:edit)
-        controller.instance_variable_set(:@_params, :id => @action.id, :button => "save")
+        controller.params = {:id => @action.id, :button => "save"}
         controller.action_edit
         expect(assigns(:flash_array).first[:message]).to include("At least one host must be specified for manual mode")
         expect(controller.send(:flash_errors?)).to be_truthy

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -28,7 +28,7 @@ describe MiqPolicyController do
         allow(controller).to receive(:replace_right_cell)
         controller.instance_variable_set(:@sb, :trees       => {:policy_tree => {:active_node => active_node}},
                                                :active_tree => :policy_tree)
-        controller.instance_variable_set(:@_params, :button => "add")
+        controller.params = {:button => "add"}
         controller.policy_edit
         sb = assigns(:sb)
         expect(sb[:trees][sb[:active_tree]][:active_node]).to include("#{active_node}_p-")

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -268,7 +268,7 @@ describe MiqPolicyController do
       let(:tree) { :any_tree }
 
       before do
-        controller.instance_variable_set(:@_params, :action => 'adv_search_text_clear')
+        controller.params = {:action => 'adv_search_text_clear'}
         controller.instance_variable_set(:@sb, :active_tree => tree, :pol_search_text => {tree => search})
         controller.instance_variable_set(:@search_text, search)
       end
@@ -352,7 +352,7 @@ describe MiqPolicyController do
 
     before do
       login_as FactoryBot.create(:user, :features => 'condition_remove')
-      controller.instance_variable_set(:@_params, :policy_id => policy.id, :id => condition.id)
+      controller.params = {:policy_id => policy.id, :id => condition.id}
       controller.instance_variable_set(:@sb, {})
       allow(controller).to receive(:x_node).and_return("pp_pp-1r36_p-#{policy.id}_co-#{condition.id}")
     end

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -15,7 +15,7 @@ describe ReportController do
         new_hash = {:name => "New Name", :description => "New Description", :col1 => [1], :col2 => [], :col3 => []}
         current = {:name => "New Name", :description => "New Description", :col1 => [], :col2 => [], :col3 => []}
         controller.instance_variable_set(:@edit, :new => new_hash, :db_id => miq_widget_set.id, :current => current)
-        controller.instance_variable_set(:@_params, :id => miq_widget_set.id, :button => "save")
+        controller.params = {:id => miq_widget_set.id, :button => "save"}
         controller.db_edit
         expect(miq_widget_set.owner.id).to eq(owner.id)
         expect(assigns(:flash_array).first[:message]).to include("saved")

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -6,7 +6,7 @@ describe ReportController do
     before do
       controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@sb, :new => {})
-      controller.instance_variable_set(:@_params, :button => "default")
+      controller.params = {:button => "default"}
       allow(controller).to receive(:current_user).and_return(user)
       login_as user
       report
@@ -26,7 +26,7 @@ describe ReportController do
     context "report menu set to default" do
       it "clears the report_menus from the selected group settings" do
         controller.instance_variable_set(:@sb, :new => {}, :menu_default => true)
-        controller.instance_variable_set(:@_params, :button => "save")
+        controller.params = {:button => "save"}
 
         expect(controller).to receive(:menu_get_form_vars)
         expect(controller).to receive(:get_tree_data)

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -182,7 +182,7 @@ describe ReportController do
         allow(controller).to receive(:load_edit).and_return(true)
         allow(controller).to receive(:replace_right_cell)
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :id => rep.id)
+        controller.params = {:id => rep.id}
         controller.send(:miq_report_edit)
         expect(response.status).to eq(200)
       end
@@ -195,7 +195,7 @@ describe ReportController do
         allow(controller).to receive(:load_edit).and_return(true)
         allow(controller).to receive(:replace_right_cell)
         controller.instance_variable_set(:@sb, {})
-        controller.instance_variable_set(:@_params, :pressed => 'miq_report_new')
+        controller.params = {:pressed => 'miq_report_new'}
         controller.send(:miq_report_edit)
         expect(response.status).to eq(200)
       end
@@ -413,7 +413,7 @@ describe ReportController do
       it "check existence of flash message when tab is changed to #{title} without selecting (time) fields" do
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@edit, :new => {:fields => []})
-        controller.instance_variable_set(:@_params, :tab => "new_#{tab_number}")
+        controller.params = {:tab => "new_#{tab_number}"}
         controller.send(:check_tabs)
         flash_messages = assigns(:flash_array)
         flash_str = if tab_number == 6
@@ -431,7 +431,7 @@ describe ReportController do
                                            :fields  => [['Date Created', 'Vm-ems_created_on']],
                                            :sortby1 => 'some_field'
                                          })
-        controller.instance_variable_set(:@_params, :tab => "new_#{tab_number}")
+        controller.params = {:tab => "new_#{tab_number}"}
         controller.send(:check_tabs)
         expect(assigns(:flash_array)).to be_nil
       end
@@ -440,7 +440,7 @@ describe ReportController do
     it 'check existence of flash message when tab is changed to preview without selecting filters(chargeback report)' do
       controller.instance_variable_set(:@sb, {})
       controller.instance_variable_set(:@edit, :new => {:fields => [['Date Created']], :model => 'ChargebackVm'})
-      controller.instance_variable_set(:@_params, :tab => 'new_7') # preview
+      controller.params = {:tab => 'new_7'} # preview
       controller.send(:check_tabs)
       flash_messages = assigns(:flash_array)
       expect(flash_messages).not_to be_nil

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -21,7 +21,7 @@ describe ReportController do
 
     context "add new widget" do
       before do
-        controller.instance_variable_set(:@_params, :button => "add")
+        controller.params = {:button => "add"}
       end
 
       context "valid attributes" do

--- a/spec/controllers/mixins/actions/host_actions/misc_spec.rb
+++ b/spec/controllers/mixins/actions/host_actions/misc_spec.rb
@@ -12,7 +12,7 @@ describe Mixins::Actions::HostActions::Misc do
       login_as admin_user
       allow(User).to receive(:current_user).and_return(admin_user)
       allow(controller).to receive(:process_hosts).with([host.id], 'refresh_ems', 'Refresh')
-      controller.instance_variable_set(:@_params, :id => Host.all.ids)
+      controller.params = {:id => Host.all.ids}
     end
 
     it "tests that find_records_with_rbac is called and does not fail" do

--- a/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
@@ -95,7 +95,7 @@ describe Mixins::Actions::VmActions::Rename do
 
       before do
         allow(controller).to receive(:render).and_return(true)
-        controller.instance_variable_set(:@_params, :id => vm.id.to_s)
+        controller.params = {:id => vm.id.to_s}
       end
 
       it 'resets VM Rename changes' do

--- a/spec/controllers/mixins/menu_update_mixin_spec.rb
+++ b/spec/controllers/mixins/menu_update_mixin_spec.rb
@@ -13,7 +13,7 @@ describe Mixins::MenuUpdateMixin do
     end
 
     it "updates session[:tab_url]" do
-      controller.instance_variable_set(:@_params, :section => :vi, :url => '/url/after%26')
+      controller.params = {:section => :vi, :url => '/url/after%26'}
       controller.send(:menu_section_url)
       expect(session[:tab_url][:vi]).to eq('/url/after&')
     end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -205,7 +205,7 @@ describe NetworkRouterController do
     before do
       stub_user(:features => :all)
       setup_zone
-      controller.instance_variable_set(:@_params, :id => router.id)
+      controller.params = {:id => router.id}
       controller.instance_variable_set(:@lastaction, "show")
       controller.instance_variable_set(:@layout, "network_router")
     end
@@ -300,7 +300,7 @@ describe NetworkRouterController do
         stub_user(:features => :all)
         allow(controller).to receive(:drop_breadcrumb)
         controller.instance_variable_set(:@router, @router)
-        controller.instance_variable_set(:@_params, :id => @router.id)
+        controller.params = {:id => @router.id}
         controller.send(:add_interface_select)
         subnet_choices = controller.instance_variable_get(:@subnet_choices)
 
@@ -316,7 +316,7 @@ describe NetworkRouterController do
         before do
           allow(controller).to receive(:drop_breadcrumb)
           controller.instance_variable_set(:@router, @router)
-          controller.instance_variable_set(:@_params, :id => @router.id)
+          controller.params = {:id => @router.id}
 
           @router.tag_with(tag, :ns => '')
           subnet_2.tag_with(tag, :ns => '')
@@ -331,7 +331,7 @@ describe NetworkRouterController do
 
         it 'list subnet choices' do
           controller.instance_variable_set(:@router, @router)
-          controller.instance_variable_set(:@_params, :id => @router.id)
+          controller.params = {:id => @router.id}
 
           controller.send(:add_interface_select)
           subnet_choices = controller.instance_variable_get(:@subnet_choices)

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -248,7 +248,7 @@ describe NetworkRouterController do
       it "queues the delete action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
         controller.params = {:pressed => "network_router_delete",
-                                         :id      => @router.id)
+                             :id      => @router.id}
         controller.instance_variable_set(:@lastaction, "show")
         controller.instance_variable_set(:@layout, "network_router")
         controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -247,8 +247,7 @@ describe NetworkRouterController do
 
       it "queues the delete action" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        controller.instance_variable_set(:@_params,
-                                         :pressed => "network_router_delete",
+        controller.params = {:pressed => "network_router_delete",
                                          :id      => @router.id)
         controller.instance_variable_set(:@lastaction, "show")
         controller.instance_variable_set(:@layout, "network_router")

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -401,7 +401,7 @@ describe NetworkRouterController do
 
   describe '#button' do
     before do
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
     end
 
     context 'tagging instances from a list of instances, accessed from the details page of a network router' do

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -124,8 +124,7 @@ describe OpsController do
 
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       controller.instance_variable_set(:@record, @miq_server)
-      controller.instance_variable_set(:@_params,
-                                       :log_userid   => "default_userid",
+      controller.params = {:log_userid   => "default_userid",
                                        :log_password => "default_password2")
       default_creds = {:userid => "default_userid", :password => "default_password2"}
       expect(controller.send(:set_credentials)).to include(:default => default_creds)
@@ -141,8 +140,7 @@ describe OpsController do
       expect(@miq_server).to receive(:log_file_depot).and_return(file_depot)
       expect(file_depot).to receive(:authentication_password).and_return('default_password')
       controller.instance_variable_set(:@record, @miq_server)
-      controller.instance_variable_set(:@_params,
-                                       :log_userid => "default_userid")
+      controller.params = {:log_userid => "default_userid")
       default_creds = {:userid => "default_userid", :password => "default_password"}
       expect(controller.send(:set_credentials)).to include(:default => default_creds)
     end
@@ -339,8 +337,7 @@ describe OpsController do
         controller.instance_variable_set(:@sb, sb_hash)
         allow(controller).to receive(:set_credentials)
           .and_return(:default => {:userid => "testuser", :password => 'password'})
-        controller.instance_variable_set(:@_params,
-                                         :log_userid => "default_user",
+        controller.params = {:log_userid => "default_user",
                                          :button     => "validate",
                                          :id         => server_id)
         expect(controller).to receive(:render)

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -216,7 +216,7 @@ describe OpsController do
             :priority       => 1
           )
           controller.instance_variable_set(:@sb, sb_hash)
-          controller.instance_variable_set(:@_params, :pressed => "zone_delete_server")
+          controller.params = {:pressed => "zone_delete_server"}
           expect(controller).to receive :render
 
           controller.send(:delete_server)
@@ -295,7 +295,7 @@ describe OpsController do
           }
 
           controller.instance_variable_set(:@sb, sb_hash)
-          controller.instance_variable_set(:@_params, :pressed => "role_start", :action => "x_button")
+          controller.params = {:pressed => "role_start", :action => "x_button"}
           expect(controller).to receive :build_server_tree
           expect(controller).to receive(:render)
         end

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -125,7 +125,7 @@ describe OpsController do
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone
       controller.instance_variable_set(:@record, @miq_server)
       controller.params = {:log_userid   => "default_userid",
-                                       :log_password => "default_password2")
+                           :log_password => "default_password2"}
       default_creds = {:userid => "default_userid", :password => "default_password2"}
       expect(controller.send(:set_credentials)).to include(:default => default_creds)
     end
@@ -140,7 +140,7 @@ describe OpsController do
       expect(@miq_server).to receive(:log_file_depot).and_return(file_depot)
       expect(file_depot).to receive(:authentication_password).and_return('default_password')
       controller.instance_variable_set(:@record, @miq_server)
-      controller.params = {:log_userid => "default_userid")
+      controller.params = {:log_userid => "default_userid"}
       default_creds = {:userid => "default_userid", :password => "default_password"}
       expect(controller.send(:set_credentials)).to include(:default => default_creds)
     end
@@ -338,8 +338,8 @@ describe OpsController do
         allow(controller).to receive(:set_credentials)
           .and_return(:default => {:userid => "testuser", :password => 'password'})
         controller.params = {:log_userid => "default_user",
-                                         :button     => "validate",
-                                         :id         => server_id)
+                             :button     => "validate",
+                             :id         => server_id}
         expect(controller).to receive(:render)
         expect(response.status).to eq(200)
         controller.send(:log_depot_edit)

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -212,7 +212,8 @@ describe OpsController do
       end
 
       it "saves tenant quotas record changes" do
-        controller.params = {:name      => "OneTenant",
+        controller.params = {
+          :name      => "OneTenant",
           :id        => @tenant.id,
           :button    => "save",
           :divisible => "true",

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -106,7 +106,7 @@ describe OpsController do
           :active_tab  => "rbac_details"
         }
         controller.instance_variable_set(:@sb, sb_hash)
-        controller.instance_variable_set(:@_params, :id => @t.id)
+        controller.params = {:id => @t.id}
         expect(controller).to receive(:render)
       end
 
@@ -191,7 +191,7 @@ describe OpsController do
       end
 
       it "resets tenant manage quotas" do
-        controller.instance_variable_set(:@_params, :id => @tenant.id, :button => "reset")
+        controller.params = {:id => @tenant.id, :button => "reset"}
         expect(controller).to receive(:render)
         expect(response.status).to eq(200)
         controller.send(:rbac_tenant_manage_quotas)
@@ -201,7 +201,7 @@ describe OpsController do
       end
 
       it "cancels tenant manage quotas" do
-        controller.instance_variable_set(:@_params, :id => @tenant.id, :button => "cancel", :divisible => "true")
+        controller.params = {:id => @tenant.id, :button => "cancel", :divisible => "true"}
         expect(controller).to receive(:render)
         expect(response.status).to eq(200)
         controller.send(:rbac_tenant_manage_quotas)
@@ -273,14 +273,14 @@ describe OpsController do
         allow(controller).to receive(:button_url).with("ops", @tenant.id, "save").and_return("save_url")
         allow(controller).to receive(:button_url).with("ops", @tenant.id, "cancel").and_return("cancel_url")
         controller.instance_variable_set(:@sb, :action => "rbac_tenant_tags_edit")
-        controller.instance_variable_set(:@_params, :miq_grid_checks => @tenant.id.to_s)
+        controller.params = {:miq_grid_checks => @tenant.id.to_s}
         controller.send(:rbac_tenant_tags_edit)
         expect(assigns(:flash_array)).to be_nil
         expect(response.status).to eq(200)
       end
 
       it "cancels tags edit" do
-        controller.instance_variable_set(:@_params, :button => "cancel", :id => @tenant.id)
+        controller.params = {:button => "cancel", :id => @tenant.id}
         controller.send(:rbac_tenant_tags_edit)
         expect(assigns(:flash_array).first[:message]).to include("was cancelled")
         expect(assigns(:edit)).to be_nil
@@ -290,14 +290,14 @@ describe OpsController do
       it "resets tags edit" do
         allow(controller).to receive(:button_url).with("ops", @tenant.id, "save").and_return("save_url")
         allow(controller).to receive(:button_url).with("ops", @tenant.id, "cancel").and_return("cancel_url")
-        controller.instance_variable_set(:@_params, :button => "reset", :id => @tenant.id)
+        controller.params = {:button => "reset", :id => @tenant.id}
         controller.send(:rbac_tenant_tags_edit)
         expect(assigns(:flash_array).first[:message]).to include("All changes have been reset")
         expect(response.status).to eq(200)
       end
 
       it "save tags" do
-        controller.instance_variable_set(:@_params, :button => "save", :id => @tenant.id, 'data' => get_tags_json([@tag1, @tag2]))
+        controller.params = {:button => "save", :id => @tenant.id, 'data' => get_tags_json([@tag1, @tag2])}
         controller.send(:rbac_tenant_tags_edit)
         expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
         expect(assigns(:edit)).to be_nil
@@ -468,7 +468,7 @@ describe OpsController do
              :belongsto             => {},
              :filters               => {'managed/env' => '/managed/env'}}
       allow(controller).to receive(:replace_right_cell)
-      controller.instance_variable_set(:@_params, :use_filter_expression => "true", :id => "new")
+      controller.params = {:use_filter_expression => "true", :id => "new"}
 
       edit = {:key      => "rbac_group_edit__new",
               :new      => new,
@@ -504,7 +504,7 @@ describe OpsController do
              :belongsto             => {},
              :filters               => {'managed/env' => '/managed/env'}}
       allow(controller).to receive(:replace_right_cell)
-      controller.instance_variable_set(:@_params, :use_filter_expression => "true", :id => "new")
+      controller.params = {:use_filter_expression => "true", :id => "new"}
 
       edit = {:key      => "rbac_group_edit__new",
               :new      => new,
@@ -541,7 +541,7 @@ describe OpsController do
                                                      :belongsto             => {},
                                                      :filters               => {'managed/department' => '/managed/department/tag1'}})
       controller.instance_variable_set(:@sb, :active_rbac_group_tab => 'rbac_customer_tags')
-      controller.instance_variable_set(:@_params, :use_filter_expression => "false", :id => @group.id)
+      controller.params = {:use_filter_expression => "false", :id => @group.id}
       controller.send(:rbac_group_get_form_vars)
       expect(controller.instance_variable_get(:@group).name).to eq(@group.name)
     end
@@ -568,7 +568,7 @@ describe OpsController do
 
     it "creates a new user role successfully" do
       allow(controller).to receive(:replace_right_cell)
-      controller.instance_variable_set(:@_params, :button => "add")
+      controller.params = {:button => "add"}
       new = {:features => ["everything"], :name => "foo"}
       edit = {:key     => "rbac_role_edit__new",
               :new     => new,
@@ -599,7 +599,7 @@ describe OpsController do
       controller.instance_variable_set(:@record, record)
       allow(controller).to receive(:replace_right_cell)
       allow(controller).to receive(:build_rbac_feature_tree)
-      controller.instance_variable_set(:@_params, :button => "add")
+      controller.params = {:button => "add"}
 
       new = {:features => ["everything"], :name => "foo"}
       edit = {:key     => "rbac_role_edit__new",

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -665,7 +665,7 @@ describe OpsController do
       allow(controller).to receive(getvars).and_call_original
       allow(controller).to receive(:render).and_return(true)
 
-      controller.instance_variable_set(:@_params, params)
+      controller.params = params
       controller.instance_variable_set(:@edit, edit)
     end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -212,8 +212,7 @@ describe OpsController do
       end
 
       it "saves tenant quotas record changes" do
-        controller.params = {
-          :name      => "OneTenant",
+        controller.params = {:name      => "OneTenant",
           :id        => @tenant.id,
           :button    => "save",
           :divisible => "true",

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -69,8 +69,8 @@ describe OpsController do
       existing_user_edit(user, :group => "")
 
       controller.params = {:typ    => nil,
-                                                  :button => 'save', # attempt to save
-                                                  :id     => user.id)
+                           :button => 'save', # attempt to save
+                           :id     => user.id}
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it complains about the unset group in the first place
@@ -88,8 +88,8 @@ describe OpsController do
                                :name  => "") # fails record.valid?
 
       controller.params = {:typ    => nil,
-                                                  :button => 'save',
-                                                  :id     => user.id)
+                           :button => 'save',
+                           :id     => user.id}
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it complains about the name
@@ -109,8 +109,8 @@ describe OpsController do
       existing_user_edit(user, :name => "changed")
 
       controller.params = {:typ    => nil,
-                                                  :button => 'save',
-                                                  :id     => user.id)
+                           :button => 'save',
+                           :id     => user.id}
 
       controller.send(:rbac_edit_save_or_add, 'user')
 
@@ -138,7 +138,7 @@ describe OpsController do
       )
 
       controller.params = {:typ    => nil,
-                                                  :button => 'add')
+                           :button => 'add'}
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success
@@ -154,8 +154,8 @@ describe OpsController do
       existing_user_edit(user, :group => group.id.to_s)
 
       controller.params = {:typ    => nil,
-                                                  :button => 'save',
-                                                  :id     => user.id)
+                           :button => 'save',
+                           :id     => user.id}
       controller.send(:rbac_edit_save_or_add, 'user')
 
       # make sure it returned success

--- a/spec/controllers/ops_controller/ops_rbac_user_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_user_spec.rb
@@ -68,7 +68,7 @@ describe OpsController do
       old_groups = user.miq_groups.pluck(:id).sort
       existing_user_edit(user, :group => "")
 
-      controller.instance_variable_set(:@_params, :typ    => nil,
+      controller.params = {:typ    => nil,
                                                   :button => 'save', # attempt to save
                                                   :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
@@ -87,7 +87,7 @@ describe OpsController do
       existing_user_edit(user, :group => group.id.to_s,
                                :name  => "") # fails record.valid?
 
-      controller.instance_variable_set(:@_params, :typ    => nil,
+      controller.params = {:typ    => nil,
                                                   :button => 'save',
                                                   :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')
@@ -108,7 +108,7 @@ describe OpsController do
     it "updates record even for existing users" do
       existing_user_edit(user, :name => "changed")
 
-      controller.instance_variable_set(:@_params, :typ    => nil,
+      controller.params = {:typ    => nil,
                                                   :button => 'save',
                                                   :id     => user.id)
 
@@ -137,7 +137,7 @@ describe OpsController do
         :verify   => "foo",
       )
 
-      controller.instance_variable_set(:@_params, :typ    => nil,
+      controller.params = {:typ    => nil,
                                                   :button => 'add')
       controller.send(:rbac_edit_save_or_add, 'user')
 
@@ -153,7 +153,7 @@ describe OpsController do
     it "should set current_group when editing" do
       existing_user_edit(user, :group => group.id.to_s)
 
-      controller.instance_variable_set(:@_params, :typ    => nil,
+      controller.params = {:typ    => nil,
                                                   :button => 'save',
                                                   :id     => user.id)
       controller.send(:rbac_edit_save_or_add, 'user')

--- a/spec/controllers/ops_controller/settings/analysis_profiles_spec.rb
+++ b/spec/controllers/ops_controller/settings/analysis_profiles_spec.rb
@@ -32,7 +32,7 @@ describe OpsController do
         allow(controller).to receive(:get_node_info)
         allow(controller).to receive(:replace_right_cell)
         allow(controller).to receive(:session).and_return(:edit => edit)
-        controller.instance_variable_set(:@_params, :button => 'add')
+        controller.params = {:button => 'add'}
       end
 
       it 'sets the flash message for adding a new Analysis Profile properly' do

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -66,7 +66,7 @@ describe OpsController do
     let(:ops) { OpsController.new }
 
     before do
-      ops.instance_variable_set(:@params, {})
+      ops.params = {}
     end
 
     [nil, 'null'].each do |target|

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -196,7 +196,7 @@ describe OpsController do
 
       it "sets ldap_role to false to make forest entries div hidden" do
         controller.params = {:id                  => 'authentication',
-                                         :authentication_mode => 'database')
+                             :authentication_mode => 'database'}
         controller.send(:settings_get_form_vars)
         expect(assigns(:edit)[:new][:authentication][:ldap_role]).to eq(false)
       end
@@ -204,7 +204,7 @@ describe OpsController do
       it "resets ldap_role to it's original state so forest entries div can be displayed" do
         session[:edit][:new][:authentication][:mode] = 'database'
         controller.params = {:id                  => 'authentication',
-                                         :authentication_mode => 'ldap')
+                             :authentication_mode => 'ldap'}
         controller.send(:settings_get_form_vars)
         expect(assigns(:edit)[:new][:authentication][:ldap_role]).to eq(true)
       end
@@ -347,7 +347,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
                                            :selected_server_id => miq_server.id)
-          controller.params = {:id => 'advanced')
+          controller.params = {:id => 'advanced'}
           data = {:api => {:token_ttl => "1.day"}}.to_yaml
           controller.instance_variable_set(:@edit,
                                            :new     => {:file_data => data},
@@ -368,7 +368,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
                                            :selected_server_id => zone.id)
-          controller.params = {:id => 'advanced')
+          controller.params = {:id => 'advanced'}
           data = {:api => {:token_ttl => "1.day"}}.to_yaml
           controller.instance_variable_set(:@edit,
                                            :new     => {:file_data => data},
@@ -392,9 +392,9 @@ describe OpsController do
                                            :active_tab         => 'settings_workers',
                                            :selected_server_id => @miq_server.id)
           controller.params = {:action     => 'settings_update',
-                                           :button     => 'save',
-                                           :controller => 'ops',
-                                           :id         => 'workers')
+                               :button     => 'save',
+                               :controller => 'ops',
+                               :id         => 'workers'}
           @updated_memory_threshold = 600.megabytes
           @new = ::Settings.to_hash
           @new[:workers][:worker_base][:queue_worker_base][:generic_worker][:memory_threshold] = @updated_memory_threshold
@@ -422,7 +422,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_server',
                                            :selected_server_id => @miq_server.id)
-          controller.params = {:id => 'server')
+          controller.params = {:id => 'server'}
           @current = ::Settings.to_hash
           @new = ::Settings.to_hash
           @new[:server][:name] = ''

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -159,7 +159,7 @@ describe OpsController do
                                                :active_tree => :settings_tree,
                                                :active_tab  => 'settings_rhn_edit')
         allow(controller).to receive(:x_node).and_return("root")
-        controller.instance_variable_set(:@_params, :id => 'rhn_edit', :button => "save")
+        controller.params = {:id => 'rhn_edit', :button => "save"}
       end
 
       it "won't render form buttons after rhn settings submission" do

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -219,7 +219,7 @@ describe OpsController do
         let(:params) { {:replication_type => "remote"} }
 
         it "queues operation to set the region as a remote type" do
-          controller.instance_variable_set(:@_params, params)
+          controller.params = params
           controller.send(:pglogical_save_subscriptions)
           queue_item = MiqQueue.find_by(:method_name => "replication_type=")
           expect(queue_item.args).to eq([:remote])
@@ -233,7 +233,7 @@ describe OpsController do
         let(:params)        { {:replication_type => "global", :subscriptions => subscriptions} }
 
         it "queues operation to save and/or remove subscriptions settings for the global region" do
-          controller.instance_variable_set(:@_params, params)
+          controller.params = params
           controller.send(:pglogical_save_subscriptions)
           queue_item = MiqQueue.find_by(:method_name => "save_global_region")
           expect(queue_item.args[0][0].dbname).to eq(db_save)
@@ -243,7 +243,7 @@ describe OpsController do
         it "encrypts subscription's password before queuing save operation" do
           password = "some_password"
           subscriptions["0"] = {"password" => password}
-          controller.instance_variable_set(:@_params, params)
+          controller.params = params
           controller.send(:pglogical_save_subscriptions)
           queue_item = MiqQueue.find_by(:method_name => "save_global_region")
           queued_password = queue_item.args[0][0].password
@@ -256,7 +256,7 @@ describe OpsController do
         let(:params) { {:replication_type => "none"} }
 
         it "queues operations to set replication to none" do
-          controller.instance_variable_set(:@_params, params)
+          controller.params = params
           controller.send(:pglogical_save_subscriptions)
           queue_item = MiqQueue.find_by(:method_name => "replication_type=")
           expect(queue_item.args[0]).to eq(:none)

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -195,8 +195,7 @@ describe OpsController do
       end
 
       it "sets ldap_role to false to make forest entries div hidden" do
-        controller.instance_variable_set(:@_params,
-                                         :id                  => 'authentication',
+        controller.params = {:id                  => 'authentication',
                                          :authentication_mode => 'database')
         controller.send(:settings_get_form_vars)
         expect(assigns(:edit)[:new][:authentication][:ldap_role]).to eq(false)
@@ -204,8 +203,7 @@ describe OpsController do
 
       it "resets ldap_role to it's original state so forest entries div can be displayed" do
         session[:edit][:new][:authentication][:mode] = 'database'
-        controller.instance_variable_set(:@_params,
-                                         :id                  => 'authentication',
+        controller.params = {:id                  => 'authentication',
                                          :authentication_mode => 'ldap')
         controller.send(:settings_get_form_vars)
         expect(assigns(:edit)[:new][:authentication][:ldap_role]).to eq(true)
@@ -349,8 +347,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
                                            :selected_server_id => miq_server.id)
-          controller.instance_variable_set(:@_params,
-                                           :id => 'advanced')
+          controller.params = {:id => 'advanced')
           data = {:api => {:token_ttl => "1.day"}}.to_yaml
           controller.instance_variable_set(:@edit,
                                            :new     => {:file_data => data},
@@ -371,8 +368,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_advanced',
                                            :selected_server_id => zone.id)
-          controller.instance_variable_set(:@_params,
-                                           :id => 'advanced')
+          controller.params = {:id => 'advanced')
           data = {:api => {:token_ttl => "1.day"}}.to_yaml
           controller.instance_variable_set(:@edit,
                                            :new     => {:file_data => data},
@@ -395,8 +391,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_workers',
                                            :selected_server_id => @miq_server.id)
-          controller.instance_variable_set(:@_params,
-                                           :action     => 'settings_update',
+          controller.params = {:action     => 'settings_update',
                                            :button     => 'save',
                                            :controller => 'ops',
                                            :id         => 'workers')
@@ -427,8 +422,7 @@ describe OpsController do
           controller.instance_variable_set(:@sb,
                                            :active_tab         => 'settings_server',
                                            :selected_server_id => @miq_server.id)
-          controller.instance_variable_set(:@_params,
-                                           :id => 'server')
+          controller.params = {:id => 'server')
           @current = ::Settings.to_hash
           @new = ::Settings.to_hash
           @new[:server][:name] = ''

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -80,8 +80,7 @@ describe OpsController do
   context "#build_uri_settings" do
     let(:mocked_filedepot) { double(FileDepotSmb) }
     it "uses params[:log_password] for validation if one exists" do
-      controller.instance_variable_set(:@_params,
-                                       :log_userid   => "userid",
+      controller.params = {:log_userid   => "userid",
                                        :log_password => "password2",
                                        :uri_prefix   => "smb",
                                        :uri          => "samba_uri",
@@ -94,8 +93,7 @@ describe OpsController do
     end
 
     it "uses the stored password for validation if params[:log_password] does not exist" do
-      controller.instance_variable_set(:@_params,
-                                       :log_userid   => "userid",
+      controller.params = {:log_userid   => "userid",
                                        :uri_prefix   => "smb",
                                        :uri          => "samba_uri",
                                        :log_protocol => "Samba")

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -81,10 +81,10 @@ describe OpsController do
     let(:mocked_filedepot) { double(FileDepotSmb) }
     it "uses params[:log_password] for validation if one exists" do
       controller.params = {:log_userid   => "userid",
-                                       :log_password => "password2",
-                                       :uri_prefix   => "smb",
-                                       :uri          => "samba_uri",
-                                       :log_protocol => "Samba")
+                           :log_password => "password2",
+                           :uri_prefix   => "smb",
+                           :uri          => "samba_uri",
+                           :log_protocol => "Samba"}
       settings = {:username   => "userid",
                   :password   => "password2",
                   :uri        => "smb://samba_uri",
@@ -94,9 +94,9 @@ describe OpsController do
 
     it "uses the stored password for validation if params[:log_password] does not exist" do
       controller.params = {:log_userid   => "userid",
-                                       :uri_prefix   => "smb",
-                                       :uri          => "samba_uri",
-                                       :log_protocol => "Samba")
+                           :uri_prefix   => "smb",
+                           :uri          => "samba_uri",
+                           :log_protocol => "Samba"}
       expect(mocked_filedepot).to receive(:try).with(:authentication_password).and_return('password')
       settings = {:username   => "userid",
                   :password   => "password",

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -504,13 +504,13 @@ describe OpsController do
 
     it "doesn't perform any manage quota action on tenant_omega" do
       allow(controller).to receive(:rbac_tenant_manage_quotas_save_add)
-      controller.instance_variable_set(:@_params, :id => tenant_omega.id, :button => 'add')
+      controller.params = {:id => tenant_omega.id, :button => 'add'}
       expect { controller.rbac_tenant_manage_quotas }.not_to raise_error
     end
 
     it "does perform any manage quota action on tenant_alpha" do
       allow(controller).to receive(:rbac_tenant_manage_quotas_save_add)
-      controller.instance_variable_set(:@_params, :id => tenant_alpha.id, :button => 'add')
+      controller.params = {:id => tenant_alpha.id, :button => 'add'}
       expect { controller.rbac_tenant_manage_quotas }.to raise_error(MiqException::RbacPrivilegeException)
     end
   end

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -109,7 +109,7 @@ describe OpsController do
       it "#does not allow duplicate names when adding" do
         @params[:id] = "new"
         @params[:name] = @schedule.name
-        controller.instance_variable_set(:@_params, @params)
+        controller.params = @params
         controller.send(:schedule_edit)
         expect(controller.send(:flash_errors?)).to be_truthy
         expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
@@ -118,7 +118,7 @@ describe OpsController do
       it "#does not allow duplicate names when editing" do
         @params[:id] = @schedule.id
         @params[:name] = "schedule01"
-        controller.instance_variable_set(:@_params, @params)
+        controller.params = @params
         FactoryBot.create(:miq_schedule, :name => @params[:name], :userid => user.userid, :resource_type => "Vm")
         controller.send(:schedule_edit)
         expect(controller.send(:flash_errors?)).to be_truthy
@@ -152,7 +152,7 @@ describe OpsController do
                          :description => "description02",
                          :ntp         => {}}}
         controller.instance_variable_set(:@edit, edit)
-        controller.instance_variable_set(:@_params, @params)
+        controller.params = @params
         seed_session_trees('ops', :settings_tree)
         allow(controller).to receive(:load_edit).and_return(true)
         controller.send(:zone_edit)

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -185,7 +185,7 @@ describe OpsController do
         end
 
         it 'is an existing record' do
-          controller.instance_variable_set(:@_params, :user_proxies_mode => '', :user_proxies => @user_proxies)
+          controller.params = {:user_proxies_mode => '', :user_proxies => @user_proxies}
           session[:edit] = {:current => @vmdb, :new => {:authentication => {:user_proxies => [@user_proxies]}}}
           session[:entry] = @user_proxies
           controller.send(:forest_accept)
@@ -193,7 +193,7 @@ describe OpsController do
 
         it 'LDAP Host exists' do
           @user_proxies[:ldaphost] = ''
-          controller.instance_variable_set(:@_params, :user_proxies_mode => '', :user_proxies => @user_proxies)
+          controller.params = {:user_proxies_mode => '', :user_proxies => @user_proxies}
           session[:edit] = {:current => @vmdb, :new => {:authentication => {:user_proxies => [@user_proxies]}}}
           session[:entry] = @user_proxies
 
@@ -204,7 +204,7 @@ describe OpsController do
         end
 
         it 'LDAP Host is unique' do
-          controller.instance_variable_set(:@_params, :user_proxies_mode => '', :user_proxies => @user_proxies)
+          controller.params = {:user_proxies_mode => '', :user_proxies => @user_proxies}
           session[:edit] = {:current => @vmdb, :new => {:authentication => {:user_proxies => [@user_proxies, @user_proxies]}}}
           session[:entry] = 'new'
 

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -100,14 +100,14 @@ describe PhysicalServerController do
 
   context "#button" do
     it "when Physical Server Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "physical_server_protect")
+      controller.params = {:pressed => "physical_server_protect"}
       expect(controller).to receive(:assign_policies).with(PhysicalServer)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when Physical Server Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "physical_server_tag")
+      controller.params = {:pressed => "physical_server_tag"}
       expect(controller).to receive(:tag).with(PhysicalServer)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -595,8 +595,7 @@ describe ProviderForemanController do
 
   context "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
-      controller.instance_variable_set(:@_params,
-                                       :default_userid   => "userid",
+      controller.params = {:default_userid   => "userid",
                                        :default_password => "password2")
       creds = {:userid => "userid", :password => "password2"}
       expect(controller.send(:build_credentials)).to include(:default => creds)

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -130,10 +130,10 @@ describe ProviderForemanController do
     it "Provision action should not be allowed only for a Configured System marked as not provisionable" do
       allow(controller).to receive(:x_node).and_return("root")
       allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_cs_filter")
+      controller.params = {:id => "configuration_manager_cs_filter"}
       allow(controller).to receive(:replace_right_cell)
       allow(controller).to receive(:render)
-      controller.instance_variable_set(:@_params, :id => @configured_system2a.id)
+      controller.params = {:id => @configured_system2a.id}
       controller.send(:provision)
       expect(controller.send(:flash_errors?)).to_not be_truthy
     end
@@ -285,7 +285,7 @@ describe ProviderForemanController do
     it "renders right cell text for ConfigurationManagerForeman node" do
       controller.instance_variable_set(:@in_report_data, true)
       ems_id = ems_key_for_provider(@provider)
-      controller.instance_variable_set(:@_params, :id => ems_id)
+      controller.params = {:id => ems_id}
       controller.send(:tree_select)
       right_cell_text = controller.instance_variable_get(:@right_cell_text)
       expect(right_cell_text).to eq("Configuration Profiles under Foreman Provider \"testForeman Configuration Manager\"")
@@ -320,21 +320,21 @@ describe ProviderForemanController do
     end
 
     pending "renders the list view based on the nodetype(root,provider,config_profile) and the search associated with it" do
-      controller.instance_variable_set(:@_params, :id => "root")
+      controller.params = {:id => "root"}
       controller.instance_variable_set(:@search_text, "manager")
       controller.instance_variable_set(:@in_report_data, true)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data.size).to eq(2)
 
-      controller.instance_variable_set(:@_params, :id => "xx-fr")
+      controller.params = {:id => "xx-fr"}
       controller.instance_variable_set(:@search_text, "manager")
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data.size).to eq(2)
 
       ems_id = ems_key_for_provider(@provider)
-      controller.instance_variable_set(:@_params, :id => ems_id)
+      controller.params = {:id => ems_id}
       controller.send(:tree_select)
       gtl_init_data = controller.init_report_data('reportDataController')
       expect(gtl_init_data[:data][:model_name]).to eq("manageiq/providers/configuration_managers")
@@ -349,7 +349,7 @@ describe ProviderForemanController do
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].description).to eq("testprofile2")
       config_profile_id2 = config_profile_key(@config_profile2)
-      controller.instance_variable_set(:@_params, :id => config_profile_id2)
+      controller.params = {:id => config_profile_id2}
       controller.send(:tree_select)
       gtl_init_data = controller.init_report_data('reportDataController')
       expect(gtl_init_data[:data][:model_name]).to eq("manageiq/providers/configuration_managers")
@@ -366,14 +366,14 @@ describe ProviderForemanController do
 
       allow(controller).to receive(:x_node).and_return("root")
       allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_cs_filter")
+      controller.params = {:id => "configuration_manager_cs_filter"}
       controller.send(:accordion_select)
       controller.instance_variable_set(:@search_text, "brew")
       allow(controller).to receive(:x_tree).and_return(:type => :providers)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_providers")
+      controller.params = {:id => "configuration_manager_providers"}
       controller.send(:accordion_select)
 
-      controller.instance_variable_set(:@_params, :id => "root")
+      controller.params = {:id => "root"}
       controller.send(:tree_select)
       search_text = controller.instance_variable_get(:@search_text)
       expect(search_text).to eq("manager")
@@ -384,7 +384,7 @@ describe ProviderForemanController do
     pending "renders tree_select for a ConfigurationManagerForeman node that contains an unassigned profile" do
       ems_id = ems_key_for_provider(@provider)
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => ems_id)
+      controller.params = {:id => ems_id}
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       gtl_init_data = controller.init_report_data('reportDataController')
@@ -400,7 +400,7 @@ describe ProviderForemanController do
     pending "renders tree_select for a ConfigurationManagerForeman node that contains only an unassigned profile" do
       ems_id = ems_key_for_provider(@provider2)
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => ems_id)
+      controller.params = {:id => ems_id}
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0]).to include('description' => "Unassigned Profiles Group",
@@ -408,7 +408,7 @@ describe ProviderForemanController do
     end
 
     pending "renders tree_select for an 'Unassigned Profiles Group' node for the first provider" do
-      controller.instance_variable_set(:@_params, :id => "-#{ems_id_for_provider(@provider)}-unassigned")
+      controller.params = {:id => "-#{ems_id_for_provider(@provider)}-unassigned"}
       controller.instance_variable_set(:@in_report_data, true)
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
@@ -417,7 +417,7 @@ describe ProviderForemanController do
 
     pending "renders tree_select for an 'Unassigned Profiles Group' node for the second provider" do
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => "-#{ems_id_for_provider(@provider2)}-unassigned")
+      controller.params = {:id => "-#{ems_id_for_provider(@provider2)}-unassigned"}
       controller.send(:tree_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data[0].data).to include('hostname' => "configured_system_unprovisioned2")
@@ -428,7 +428,7 @@ describe ProviderForemanController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_providers_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_providers)
       allow(controller).to receive(:build_listnav_search_list)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_providers_accord")
+      controller.params = {:id => "configuration_manager_providers_accord"}
       expect(controller).to receive(:get_view).with("ManageIQ::Providers::ConfigurationManager",
                                                     :gtl_dbname => :cm_providers, :dbname => :cm_providers).and_call_original
       controller.send(:accordion_select)
@@ -440,7 +440,7 @@ describe ProviderForemanController do
       allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_providers)
       ems_id = ems_id_for_provider(@provider)
       controller.instance_variable_set(:@in_report_data, true)
-      controller.instance_variable_set(:@_params, :id => ems_key_for_provider(@provider))
+      controller.params = {:id => ems_key_for_provider(@provider)}
       allow(controller).to receive(:build_listnav_search_list)
       allow(controller).to receive(:apply_node_search_text)
       expect(controller).to receive(:get_view).with("ConfigurationProfile", :match_via_descendants => "ConfiguredSystem",
@@ -455,7 +455,7 @@ describe ProviderForemanController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_cs_filter)
       allow(controller).to receive(:build_listnav_search_list)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_cs_filter_accord")
+      controller.params = {:id => "configuration_manager_cs_filter_accord"}
       expect(controller).to receive(:get_view).with("ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem",
                                                     :gtl_dbname => :cm_configured_systems, :dbname => :cm_configured_systems).and_call_original
       allow(controller).to receive(:build_listnav_search_list)
@@ -469,7 +469,7 @@ describe ProviderForemanController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_cs_filter)
       allow(controller).to receive(:build_listnav_search_list)
-      controller.instance_variable_set(:@_params, :id => "configuration_manager_cs_filter_accord")
+      controller.params = {:id => "configuration_manager_cs_filter_accord"}
       controller.send(:accordion_select)
       view = controller.instance_variable_get(:@view)
       expect(view.table.data.size).to eq(5)
@@ -603,7 +603,7 @@ describe ProviderForemanController do
     end
 
     it "uses the stored password for validation if params[:default_password] does not exist" do
-      controller.instance_variable_set(:@_params, :default_userid => "userid")
+      controller.params = {:default_userid => "userid"}
       controller.instance_variable_set(:@provider, @provider)
       expect(@provider).to receive(:authentication_password).and_return('password')
       creds = {:userid => "userid", :password => "password"}

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -596,7 +596,7 @@ describe ProviderForemanController do
   context "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "userid",
-                                       :default_password => "password2")
+                           :default_password => "password2"}
       creds = {:userid => "userid", :password => "password2"}
       expect(controller.send(:build_credentials)).to include(:default => creds)
     end

--- a/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
+++ b/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
@@ -19,7 +19,7 @@ describe PxeController do
       controller.instance_variable_set(:@edit, edit)
       session[:edit] = edit
       controller.params = {:id     => customization_template.id,
-                                                                                            :button => "reset")
+                           :button => "reset"}
       expect(controller).to receive(:customization_template_edit)
       controller.template_create_update
       expect(assigns(:flash_array).first[:message]).to include("reset")

--- a/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
+++ b/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
@@ -18,7 +18,7 @@ describe PxeController do
       }
       controller.instance_variable_set(:@edit, edit)
       session[:edit] = edit
-      controller.instance_variable_set(:@_params,                                           :id     => customization_template.id,
+      controller.params = {:id     => customization_template.id,
                                                                                             :button => "reset")
       expect(controller).to receive(:customization_template_edit)
       controller.template_create_update

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -5,7 +5,7 @@ describe PxeController do
 
   describe '#tree_select ' do
     it 'calls methods with x_node as param' do
-      controller.instance_variable_set(:@_params, :id => 'root', :tree => :pxe_servers_tree)
+      controller.params = {:id => 'root', :tree => :pxe_servers_tree}
       expect(controller).to receive(:get_node_info).with("root")
       expect(controller).to receive(:replace_right_cell).with(:nodetype => "root")
       controller.tree_select
@@ -14,7 +14,7 @@ describe PxeController do
 
   describe '#accordion_select ' do
     it 'calls methods with x_node as param' do
-      controller.instance_variable_set(:@_params, :id => 'pxe_servers_accord', :tree => :pxe_servers_tree)
+      controller.params = {:id => 'pxe_servers_accord', :tree => :pxe_servers_tree}
       allow(controller).to receive(:x_node).and_return('root')
       expect(controller).to receive(:get_node_info).with("root")
       expect(controller).to receive(:replace_right_cell).with(:nodetype => "root")
@@ -45,7 +45,7 @@ describe PxeController do
 
     it "Pressing Refresh button should show display name in the flash message" do
       pxe = FactoryBot.create(:pxe_server)
-      controller.instance_variable_set(:@_params, :id => pxe.id)
+      controller.params = {:id => pxe.id}
       controller.instance_variable_set(:@sb,
                                        :trees       => {
                                          :pxe_tree => {:active_node => "ps-#{pxe.id}"}

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -65,8 +65,7 @@ describe PxeController do
       edit = {:pxe_id => ps.id, :new => {}}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@ps, ps)
-      controller.instance_variable_set(:@_params,
-                                       :restore_password => "true",
+      controller.params = {:restore_password => "true",
                                        :log_password     => "[FILTERED]",
                                        :log_verify       => "[FILTERED]")
       controller.send(:restore_password)

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -66,8 +66,8 @@ describe PxeController do
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@ps, ps)
       controller.params = {:restore_password => "true",
-                                       :log_password     => "[FILTERED]",
-                                       :log_verify       => "[FILTERED]")
+                           :log_password     => "[FILTERED]",
+                           :log_verify       => "[FILTERED]"}
       controller.send(:restore_password)
       expect(assigns(:edit)[:new][:log_password]).to eq(ps.authentication_password(:default))
     end

--- a/spec/controllers/report_controller/schedules_spec.rb
+++ b/spec/controllers/report_controller/schedules_spec.rb
@@ -26,7 +26,7 @@ describe ReportController do
     end
 
     it "reset rbac testing" do
-      controller.instance_variable_set(:@_params, :button => "reset", :id => schedule.id)
+      controller.params = {:button => "reset", :id => schedule.id}
       controller.send(:schedule_edit)
       expected_id = controller.instance_variable_get(:@schedule).id
       expect(expected_id).to eq(schedule.id)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -770,8 +770,9 @@ describe ReportController do
       end
 
       it "contains current group id in sched_action field" do
-        controller.params = {:button => "add", :controller => "report",
-                                                    :action => "schedule_edit")
+        controller.params = {:button => "add",
+                             :controller => "report",
+                             :action => "schedule_edit"}
         controller.miq_report_schedule_disable
         allow(controller).to receive_messages(:load_edit => true)
         allow(controller).to receive(:replace_right_cell)
@@ -1323,7 +1324,8 @@ describe ReportController do
         it "is allowed to see miq report result for User1(with current group Group2)" do
           report_result_id = @rpt.miq_report_results.first.id
           controller.params = {:id => report_result_id,
-                                                      :controller => "report", :action => "explorer")
+                               :controller => "report",
+                               :action => "explorer"}
           controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
           controller.instance_variable_set(:@settings, :perpage => { :reports => 20 })
           allow(controller).to receive(:get_all_reps)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -6,37 +6,37 @@ describe ReportController do
   context "Get form variables" do
     context "press col buttons" do
       it "moves columns left" do
-        controller.instance_variable_set(:@_params, :button => "left")
+        controller.params = {:button => "left"}
         expect(controller).to receive(:move_cols_left)
         controller.send(:gfv_move_cols_buttons)
       end
 
       it "moves columns right" do
-        controller.instance_variable_set(:@_params, :button => "right")
+        controller.params = {:button => "right"}
         expect(controller).to receive(:move_cols_right)
         controller.send(:gfv_move_cols_buttons)
       end
 
       it "moves columns up" do
-        controller.instance_variable_set(:@_params, :button => "up")
+        controller.params = {:button => "up"}
         expect(controller).to receive(:move_cols_up)
         controller.send(:gfv_move_cols_buttons)
       end
 
       it "moves columns down" do
-        controller.instance_variable_set(:@_params, :button => "down")
+        controller.params = {:button => "down"}
         expect(controller).to receive(:move_cols_down)
         controller.send(:gfv_move_cols_buttons)
       end
 
       it "moves columns top" do
-        controller.instance_variable_set(:@_params, :button => "top")
+        controller.params = {:button => "top"}
         expect(controller).to receive(:move_cols_top)
         controller.send(:gfv_move_cols_buttons)
       end
 
       it "moves columns bottom" do
-        controller.instance_variable_set(:@_params, :button => "bottom")
+        controller.params = {:button => "bottom"}
         expect(controller).to receive(:move_cols_bottom)
         controller.send(:gfv_move_cols_buttons)
       end
@@ -70,49 +70,49 @@ describe ReportController do
       context "handle report fields" do
         it "sets pdf page size" do
           ps = "US-Legal"
-          controller.instance_variable_set(:@_params, :pdf_page_size => ps)
+          controller.params = {:pdf_page_size => ps}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:pdf_page_size]).to eq(ps)
         end
 
         it "sets queue timeout" do
           to = "1"
-          controller.instance_variable_set(:@_params, :chosen_queue_timeout => to)
+          controller.params = {:chosen_queue_timeout => to}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:queue_timeout]).to eq(to.to_i)
         end
 
         it "clears queue timeout" do
           to = ""
-          controller.instance_variable_set(:@_params, :chosen_queue_timeout => to)
+          controller.params = {:chosen_queue_timeout => to}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:queue_timeout]).to be_nil
         end
 
         it "sets row limit" do
           rl = "10"
-          controller.instance_variable_set(:@_params, :row_limit => rl)
+          controller.params = {:row_limit => rl}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:row_limit]).to eq(rl)
         end
 
         it "clears row limit" do
           rl = ""
-          controller.instance_variable_set(:@_params, :row_limit => rl)
+          controller.params = {:row_limit => rl}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:row_limit]).to eq("")
         end
 
         it "sets report name" do
           rn = "Report Name"
-          controller.instance_variable_set(:@_params, :name => rn)
+          controller.params = {:name => rn}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:name]).to eq(rn)
         end
 
         it "sets report title" do
           rt = "Report Title"
-          controller.instance_variable_set(:@_params, :title => rt)
+          controller.params = {:title => rt}
           controller.send(:gfv_report_fields)
           expect(assigns(:edit)[:new][:title]).to eq(rt)
         end
@@ -121,7 +121,7 @@ describe ReportController do
       context "handle model changes" do
         it "sets CI model" do
           model = "Vm"
-          controller.instance_variable_set(:@_params, :chosen_model => model)
+          controller.params = {:chosen_model => model}
           controller.send(:gfv_model)
           expect(assigns(:edit)[:new][:model]).to eq(model)
           expect(assigns(:refresh_div)).to eq("form_div")
@@ -130,7 +130,7 @@ describe ReportController do
 
         it "sets performance model" do
           model = "VmPerformance"
-          controller.instance_variable_set(:@_params, :chosen_model => model)
+          controller.params = {:chosen_model => model}
           controller.send(:gfv_model)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:model]).to eq(model)
@@ -143,7 +143,7 @@ describe ReportController do
 
         it "sets chargeback model" do
           model = "ChargebackVm"
-          controller.instance_variable_set(:@_params, :chosen_model => model)
+          controller.params = {:chosen_model => model}
           controller.send(:gfv_model)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:model]).to eq(model)
@@ -162,7 +162,7 @@ describe ReportController do
           tc = "VmPerformance-derived_memory_used"
           allow(MiqExpression).to receive(:reporting_available_fields)
             .and_return([["Test", tc]]) # Hand back array of arrays
-          controller.instance_variable_set(:@_params, :chosen_trend_col => tc)
+          controller.params = {:chosen_trend_col => tc}
           controller.send(:gfv_trend)
           edit = assigns(:edit)
           edit_new = edit[:new]
@@ -180,7 +180,7 @@ describe ReportController do
           tc = "VmPerformance-derived_memory_used"
           allow(MiqExpression).to receive(:reporting_available_fields)
             .and_return([["Test (%)", tc]]) # Hand back array of arrays
-          controller.instance_variable_set(:@_params, :chosen_trend_col => tc)
+          controller.params = {:chosen_trend_col => tc}
           controller.send(:gfv_trend)
           edit = assigns(:edit)
           edit_new = edit[:new]
@@ -197,7 +197,7 @@ describe ReportController do
 
         it "clears trend column" do
           tc = "<Choose>"
-          controller.instance_variable_set(:@_params, :chosen_trend_col => tc)
+          controller.params = {:chosen_trend_col => tc}
           controller.send(:gfv_trend)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:perf_trend_db]).to be_nil
@@ -210,7 +210,7 @@ describe ReportController do
 
         it "sets trend limit column" do
           limit_col = "max_derived_cpu_reserved"
-          controller.instance_variable_set(:@_params, :chosen_limit_col => limit_col)
+          controller.params = {:chosen_limit_col => limit_col}
           controller.send(:gfv_trend)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:perf_limit_col]).to eq(limit_col)
@@ -221,7 +221,7 @@ describe ReportController do
 
         it "clears trend limit column" do
           limit_col = "<None>"
-          controller.instance_variable_set(:@_params, :chosen_limit_col => limit_col)
+          controller.params = {:chosen_limit_col => limit_col}
           controller.send(:gfv_trend)
           expect(assigns(:edit)[:new][:perf_limit_col]).to be_nil
           expect(assigns(:refresh_div)).to eq("columns_div")
@@ -230,28 +230,28 @@ describe ReportController do
 
         it "sets trend limit value" do
           limit_val = "50"
-          controller.instance_variable_set(:@_params, :chosen_limit_val => limit_val)
+          controller.params = {:chosen_limit_val => limit_val}
           controller.send(:gfv_trend)
           expect(assigns(:edit)[:new][:perf_limit_val]).to eq(limit_val)
         end
 
         it "sets trend limit percent 1" do
           pct = "70"
-          controller.instance_variable_set(:@_params, :percent1 => pct)
+          controller.params = {:percent1 => pct}
           controller.send(:gfv_trend)
           expect(assigns(:edit)[:new][:perf_target_pct1]).to eq(pct.to_i)
         end
 
         it "sets trend limit percent 2" do
           pct = "80"
-          controller.instance_variable_set(:@_params, :percent2 => pct)
+          controller.params = {:percent2 => pct}
           controller.send(:gfv_trend)
           expect(assigns(:edit)[:new][:perf_target_pct2]).to eq(pct.to_i)
         end
 
         it "sets trend limit percent 3" do
           pct = "90"
-          controller.instance_variable_set(:@_params, :percent3 => pct)
+          controller.params = {:percent3 => pct}
           controller.send(:gfv_trend)
           expect(assigns(:edit)[:new][:perf_target_pct3]).to eq(pct.to_i)
         end
@@ -260,7 +260,7 @@ describe ReportController do
       context "handle performance field changes" do
         it "sets perf interval" do
           perf_int = "hourly"
-          controller.instance_variable_set(:@_params, :chosen_interval => perf_int)
+          controller.params = {:chosen_interval => perf_int}
           controller.send(:gfv_performance)
           edit = assigns(:edit)
           edit_new = edit[:new]
@@ -273,28 +273,28 @@ describe ReportController do
 
         it "sets perf averages" do
           perf_avg = "active_data"
-          controller.instance_variable_set(:@_params, :perf_avgs => perf_avg)
+          controller.params = {:perf_avgs => perf_avg}
           controller.send(:gfv_performance)
           expect(assigns(:edit)[:new][:perf_avgs]).to eq(perf_avg)
         end
 
         it "sets perf start" do
           perf_start = 3.days.to_s
-          controller.instance_variable_set(:@_params, :chosen_start => perf_start)
+          controller.params = {:chosen_start => perf_start}
           controller.send(:gfv_performance)
           expect(assigns(:edit)[:new][:perf_start]).to eq(perf_start)
         end
 
         it "sets perf end" do
           perf_end = 1.day.to_s
-          controller.instance_variable_set(:@_params, :chosen_end => perf_end)
+          controller.params = {:chosen_end => perf_end}
           controller.send(:gfv_performance)
           expect(assigns(:edit)[:new][:perf_end]).to eq(perf_end)
         end
 
         it "sets perf time zone" do
           tz = "Pacific Time (US & Canada)"
-          controller.instance_variable_set(:@_params, :chosen_tz => tz)
+          controller.params = {:chosen_tz => tz}
           controller.send(:gfv_performance)
           expect(assigns(:edit)[:new][:tz]).to eq(tz)
         end
@@ -302,7 +302,7 @@ describe ReportController do
         it "sets perf time profile" do
           time_prof = FactoryBot.create(:time_profile, :description => "Test", :profile => {:tz => "UTC"})
           chosen_time_prof = time_prof.id.to_s
-          controller.instance_variable_set(:@_params, :chosen_time_profile => chosen_time_prof)
+          controller.params = {:chosen_time_profile => chosen_time_prof}
           controller.send(:gfv_performance)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:time_profile]).to eq(chosen_time_prof.to_i)
@@ -310,7 +310,7 @@ describe ReportController do
 
         it "clears perf time profile" do
           chosen_time_prof = ""
-          controller.instance_variable_set(:@_params, :chosen_time_profile => chosen_time_prof)
+          controller.params = {:chosen_time_profile => chosen_time_prof}
           controller.send(:gfv_performance)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:time_profile]).to be_nil
@@ -323,7 +323,7 @@ describe ReportController do
       context "handle chargeback field changes" do
         it "sets show costs" do
           show_type = "owner"
-          controller.instance_variable_set(:@_params, :cb_show_typ => show_type)
+          controller.params = {:cb_show_typ => show_type}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_show_typ]).to eq(show_type)
           expect(assigns(:refresh_div)).to eq("filter_div")
@@ -332,7 +332,7 @@ describe ReportController do
 
         it "clears show costs" do
           show_type = ""
-          controller.instance_variable_set(:@_params, :cb_show_typ => show_type)
+          controller.params = {:cb_show_typ => show_type}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_show_typ]).to be_nil
           expect(assigns(:refresh_div)).to eq("filter_div")
@@ -341,7 +341,7 @@ describe ReportController do
 
         it "sets tag category" do
           tag_cat = "department"
-          controller.instance_variable_set(:@_params, :cb_tag_cat => tag_cat)
+          controller.params = {:cb_tag_cat => tag_cat}
           cl_rec = FactoryBot.create(:classification, :name => "test_name", :description => "Test Description")
           expect(Classification).to receive(:find_by_name).and_return([cl_rec])
           controller.send(:gfv_chargeback)
@@ -353,7 +353,7 @@ describe ReportController do
 
         it "clears tag category" do
           tag_cat = ""
-          controller.instance_variable_set(:@_params, :cb_tag_cat => tag_cat)
+          controller.params = {:cb_tag_cat => tag_cat}
           controller.send(:gfv_chargeback)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:cb_tag_cat]).to be_nil
@@ -364,28 +364,28 @@ describe ReportController do
 
         it "sets owner id" do
           owner_id = "admin"
-          controller.instance_variable_set(:@_params, :cb_owner_id => owner_id)
+          controller.params = {:cb_owner_id => owner_id}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_owner_id]).to eq(owner_id)
         end
 
         it "sets tag value" do
           tag_val = "accounting"
-          controller.instance_variable_set(:@_params, :cb_tag_value => tag_val)
+          controller.params = {:cb_tag_value => tag_val}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_tag_value]).to eq(tag_val)
         end
 
         it "sets group by" do
           group_by = "vm"
-          controller.instance_variable_set(:@_params, :cb_groupby => group_by)
+          controller.params = {:cb_groupby => group_by}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_groupby]).to eq(group_by)
         end
 
         it "sets show costs by" do
           show_costs_by = "day"
-          controller.instance_variable_set(:@_params, :cb_interval => show_costs_by)
+          controller.params = {:cb_interval => show_costs_by}
           controller.send(:gfv_chargeback)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:cb_interval]).to eq(show_costs_by)
@@ -397,14 +397,14 @@ describe ReportController do
 
         it "sets interval size" do
           int_size = "2"
-          controller.instance_variable_set(:@_params, :cb_interval_size => int_size)
+          controller.params = {:cb_interval_size => int_size}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_interval_size]).to eq(int_size.to_i)
         end
 
         it "sets end interval offset" do
           end_int_offset = "2"
-          controller.instance_variable_set(:@_params, :cb_end_interval_offset => end_int_offset)
+          controller.params = {:cb_end_interval_offset => end_int_offset}
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_end_interval_offset]).to eq(end_int_offset.to_i)
         end
@@ -413,7 +413,7 @@ describe ReportController do
       context "handle chart field changes" do
         it "sets chart type" do
           chosen_graph = "Bar"
-          controller.instance_variable_set(:@_params, :chosen_graph => chosen_graph)
+          controller.params = {:chosen_graph => chosen_graph}
           controller.send(:gfv_charts)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:graph_type]).to eq(chosen_graph)
@@ -425,7 +425,7 @@ describe ReportController do
 
         it "clears chart type" do
           chosen_graph = "<No chart>"
-          controller.instance_variable_set(:@_params, :chosen_graph => chosen_graph)
+          controller.params = {:chosen_graph => chosen_graph}
           edit = assigns(:edit)
           edit[:current] = {:graph_count => ReportController::Reports::Editor::GRAPH_MAX_COUNT, :graph_other => true}
           controller.instance_variable_set(:@edit, edit)
@@ -440,7 +440,7 @@ describe ReportController do
 
         it "sets top values to show" do
           top_val = "3"
-          controller.instance_variable_set(:@_params, :chosen_count => top_val)
+          controller.params = {:chosen_count => top_val}
           controller.send(:gfv_charts)
           expect(assigns(:edit)[:new][:graph_count]).to eq(top_val)
           expect(assigns(:refresh_div)).to eq("chart_sample_div")
@@ -449,7 +449,7 @@ describe ReportController do
 
         it "sets sum other values" do
           sum_other = "null"
-          controller.instance_variable_set(:@_params, :chosen_other => sum_other)
+          controller.params = {:chosen_other => sum_other}
           controller.send(:gfv_charts)
           expect(assigns(:edit)[:new][:graph_other]).to be_falsey
           expect(assigns(:refresh_div)).to eq("chart_sample_div")
@@ -469,7 +469,7 @@ describe ReportController do
         end
 
         it "sets pivot 1" do
-          controller.instance_variable_set(:@_params, :chosen_pivot1 => P1)
+          controller.params = {:chosen_pivot1 => P1}
           controller.send(:gfv_pivots)
           expect(assigns(:edit)[:new][:pivot].by1).to eq(P1)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
@@ -477,7 +477,7 @@ describe ReportController do
         end
 
         it "sets pivot 2" do
-          controller.instance_variable_set(:@_params, :chosen_pivot2 => P2)
+          controller.params = {:chosen_pivot2 => P2}
           controller.send(:gfv_pivots)
           expect(assigns(:edit)[:new][:pivot].by2).to eq(P2)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
@@ -485,7 +485,7 @@ describe ReportController do
         end
 
         it "sets pivot 3" do
-          controller.instance_variable_set(:@_params, :chosen_pivot3 => P3)
+          controller.params = {:chosen_pivot3 => P3}
           controller.send(:gfv_pivots)
           expect(assigns(:edit)[:new][:pivot].by3).to eq(P3)
           expect(assigns(:refresh_div)).to eq("consolidate_div")
@@ -496,7 +496,7 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot1 => ReportHelper::NOTHING_STRING)
+          controller.params = {:chosen_pivot1 => ReportHelper::NOTHING_STRING}
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(ReportHelper::NOTHING_STRING)
@@ -510,7 +510,7 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot2 => ReportHelper::NOTHING_STRING)
+          controller.params = {:chosen_pivot2 => ReportHelper::NOTHING_STRING}
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P1)
@@ -524,7 +524,7 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot1 => P2)
+          controller.params = {:chosen_pivot1 => P2}
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P2)
@@ -538,7 +538,7 @@ describe ReportController do
           edit = assigns(:edit)
           edit[:new][:pivot] = ReportController::PivotOptions.new(P1, P2, P3)
           controller.instance_variable_set(:@edit, edit)
-          controller.instance_variable_set(:@_params, :chosen_pivot2 => P3)
+          controller.params = {:chosen_pivot2 => P3}
           controller.send(:gfv_pivots)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:pivot].by1).to eq(P1)
@@ -564,7 +564,7 @@ describe ReportController do
 
         it "sets first sort col" do
           new_sort = "Vm-new"
-          controller.instance_variable_set(:@_params, :chosen_sort1 => new_sort)
+          controller.params = {:chosen_sort1 => new_sort}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(new_sort)
@@ -574,7 +574,7 @@ describe ReportController do
         end
 
         it "set first sort col = second clears second" do
-          controller.instance_variable_set(:@_params, :chosen_sort1 => S2)
+          controller.params = {:chosen_sort1 => S2}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S2)
@@ -584,7 +584,7 @@ describe ReportController do
         end
 
         it "clearing first sort col clears both sort cols" do
-          controller.instance_variable_set(:@_params, :chosen_sort1 => ReportHelper::NOTHING_STRING)
+          controller.params = {:chosen_sort1 => ReportHelper::NOTHING_STRING}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(ReportHelper::NOTHING_STRING)
@@ -595,7 +595,7 @@ describe ReportController do
 
         it "sets first sort col suffix" do
           sfx = "hour"
-          controller.instance_variable_set(:@_params, :sort1_suffix => sfx)
+          controller.params = {:sort1_suffix => sfx}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq("#{S1}__#{sfx}")
@@ -604,14 +604,14 @@ describe ReportController do
 
         it "sets sort order" do
           sort_order = "Descending"
-          controller.instance_variable_set(:@_params, :sort_order => sort_order)
+          controller.params = {:sort_order => sort_order}
           controller.send(:gfv_sort)
           expect(assigns(:edit)[:new][:order]).to eq(sort_order)
         end
 
         it "sets sort breaks" do
           sort_group = "Yes"
-          controller.instance_variable_set(:@_params, :sort_group => sort_group)
+          controller.params = {:sort_group => sort_group}
           controller.send(:gfv_sort)
           expect(assigns(:edit)[:new][:group]).to eq(sort_group)
           expect(assigns(:refresh_div)).to eq("sort_div")
@@ -620,7 +620,7 @@ describe ReportController do
 
         it "sets hide detail rows" do
           hide_detail = "1"
-          controller.instance_variable_set(:@_params, :hide_details => hide_detail)
+          controller.params = {:hide_details => hide_detail}
           controller.send(:gfv_sort)
           expect(assigns(:edit)[:new][:hide_details]).to be_truthy
         end
@@ -628,7 +628,7 @@ describe ReportController do
         # TODO: Not sure why, but this test seems to take .5 seconds while others are way faster
         it "sets format on summary row" do
           fmt = "hour_am_pm"
-          controller.instance_variable_set(:@_params, :break_format => fmt)
+          controller.params = {:break_format => fmt}
           controller.send(:gfv_sort)
 
           # Check to make sure the proper value gets set in the col_options hash using the last part of the sortby1 col as key
@@ -640,7 +640,7 @@ describe ReportController do
 
         it "sets second sort col" do
           new_sort = "Vm-new"
-          controller.instance_variable_set(:@_params, :chosen_sort2 => new_sort)
+          controller.params = {:chosen_sort2 => new_sort}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S1)
@@ -648,7 +648,7 @@ describe ReportController do
         end
 
         it "clearing second sort col" do
-          controller.instance_variable_set(:@_params, :chosen_sort2 => ReportHelper::NOTHING_STRING)
+          controller.params = {:chosen_sort2 => ReportHelper::NOTHING_STRING}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S1)
@@ -657,7 +657,7 @@ describe ReportController do
 
         it "sets second sort col suffix" do
           sfx = "day"
-          controller.instance_variable_set(:@_params, :sort2_suffix => sfx)
+          controller.params = {:sort2_suffix => sfx}
           controller.send(:gfv_sort)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:sortby1]).to eq(S1)
@@ -684,19 +684,19 @@ describe ReportController do
       context "handle timeline field changes" do
         before do
           col = "Vm-created_on"
-          controller.instance_variable_set(:@_params, :chosen_tl => col)
+          controller.params = {:chosen_tl => col}
           controller.send(:gfv_timeline) # This will set the @edit timeline unit hash keys
         end
 
         it "sets timeline col" do
           col = "Vm-boot_time"
-          controller.instance_variable_set(:@_params, :chosen_tl => col)
+          controller.params = {:chosen_tl => col}
           controller.send(:gfv_timeline)
           expect(assigns(:edit)[:new][:tl_field]).to eq(col)
         end
 
         it "clears timeline col" do
-          controller.instance_variable_set(:@_params, :chosen_tl => ReportHelper::NOTHING_STRING)
+          controller.params = {:chosen_tl => ReportHelper::NOTHING_STRING}
           controller.send(:gfv_timeline)
           edit = assigns(:edit)
           expect(edit[:new][:tl_field]).to eq(ReportHelper::NOTHING_STRING)
@@ -704,7 +704,7 @@ describe ReportController do
 
         it "sets event to position at" do
           pos = "First"
-          controller.instance_variable_set(:@_params, :chosen_position => pos)
+          controller.params = {:chosen_position => pos}
           controller.send(:gfv_timeline)
           expect(assigns(:edit)[:new][:tl_position]).to eq(pos)
           expect(assigns(:tl_changed)).to be_truthy
@@ -1306,7 +1306,7 @@ describe ReportController do
 
         pending "is allowed to see report created under Group1 for User 1(with current group Group2)" do
           controller.instance_variable_set(:@in_report_data, true)
-          controller.instance_variable_set(:@_params, :controller => "report", :action => "explorer")
+          controller.params = {:controller => "report", :action => "explorer"}
           seed_session_trees('report', :saved_reports)
           allow(controller).to receive(:get_view_calculate_gtl_type).and_return("list")
           allow(controller).to receive(:get_view_pages_perpage).and_return(20)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -770,7 +770,7 @@ describe ReportController do
       end
 
       it "contains current group id in sched_action field" do
-        controller.instance_variable_set(:@_params, :button => "add", :controller => "report",
+        controller.params = {:button => "add", :controller => "report",
                                                     :action => "schedule_edit")
         controller.miq_report_schedule_disable
         allow(controller).to receive_messages(:load_edit => true)
@@ -1322,7 +1322,7 @@ describe ReportController do
 
         it "is allowed to see miq report result for User1(with current group Group2)" do
           report_result_id = @rpt.miq_report_results.first.id
-          controller.instance_variable_set(:@_params, :id => report_result_id,
+          controller.params = {:id => report_result_id,
                                                       :controller => "report", :action => "explorer")
           controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
           controller.instance_variable_set(:@settings, :perpage => { :reports => 20 })

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -5,14 +5,14 @@ describe ResourcePoolController do
     end
 
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
+      controller.params = {:pressed => "vm_right_size"}
       expect(controller).to receive(:vm_right_size)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
+      controller.params = {:pressed => "vm_migrate"}
       controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
       expect(controller).to receive(:prov_redirect).with("migrate")
       expect(controller).to receive(:render)
@@ -21,35 +21,35 @@ describe ResourcePoolController do
     end
 
     it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
+      controller.params = {:pressed => "vm_retire"}
       expect(controller).to receive(:retirevms).once
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
+      controller.params = {:pressed => "vm_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
+      controller.params = {:pressed => "miq_template_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
+      controller.params = {:pressed => "vm_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
+      controller.params = {:pressed => "miq_template_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -200,7 +200,7 @@ describe SecurityGroupController do
   end
 
   describe '#button' do
-    before { controller.instance_variable_set(:@_params, params) }
+    before { controller.params = params }
 
     context 'tagging instances from their list, accessed from the details page of a security group' do
       let(:params) { {:pressed => "instance_tag"} }

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -33,7 +33,7 @@ describe ServiceController do
       allow(service_template).to receive(:resource_actions).and_return(ar_association_dummy)
       allow(ar_association_dummy).to receive(:find_by).with(:action => 'Reconfigure').and_return(resource_action)
       allow(controller).to receive(:replace_right_cell)
-      controller.instance_variable_set(:@_params, :id => 321)
+      controller.params = {:id => 321}
     end
 
     it "sets the right cell text" do
@@ -66,7 +66,7 @@ describe ServiceController do
       allow(controller).to receive(:replace_right_cell)
 
       # Now delete the Service
-      controller.instance_variable_set(:@_params, :id => svc.id)
+      controller.params = {:id => svc.id}
       controller.send(:service_delete)
 
       # Check for Service Description to be part of flash message displayed
@@ -81,7 +81,7 @@ describe ServiceController do
       allow(controller).to receive(:x_build_tree)
       controller.instance_variable_set(:@settings, {})
       controller.instance_variable_set(:@sb, {})
-      controller.instance_variable_set(:@_params, :id => service.id)
+      controller.params = {:id => service.id}
       expect(controller).to receive(:render)
       expect(response.status).to eq(200)
       controller.send(:service_delete)
@@ -96,7 +96,7 @@ describe ServiceController do
 
       before do
         allow(controller).to receive(:replace_right_cell)
-        controller.instance_variable_set(:@_params, :id => service.id)
+        controller.params = {:id => service.id}
       end
 
       it 'sets x_node to return to Active Services' do
@@ -416,7 +416,7 @@ describe ServiceController do
 
       before do
         allow(controller).to receive(:session).and_return(s)
-        controller.instance_variable_set(:@_params, :action => 'tree_select')
+        controller.params = {:action => 'tree_select'}
         controller.instance_variable_set(:@sb, {})
       end
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -10,14 +10,14 @@ describe StorageController do
 
   context "#button" do
     it "when VM Right Size Recommendations is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_right_size")
+      controller.params = {:pressed => "vm_right_size"}
       expect(controller).to receive(:vm_right_size)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Migrate is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_migrate")
+      controller.params = {:pressed => "vm_migrate"}
       controller.instance_variable_set(:@refresh_partial, "layouts/gtl")
       expect(controller).to receive(:prov_redirect).with("migrate")
       expect(controller).to receive(:render)
@@ -26,42 +26,42 @@ describe StorageController do
     end
 
     it "when VM Retire is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_retire")
+      controller.params = {:pressed => "vm_retire"}
       expect(controller).to receive(:retirevms).once
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_protect")
+      controller.params = {:pressed => "vm_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Manage Policies is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_protect")
+      controller.params = {:pressed => "miq_template_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when VM Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "vm_tag")
+      controller.params = {:pressed => "vm_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when MiqTemplate Tag is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "miq_template_tag")
+      controller.params = {:pressed => "miq_template_tag"}
       expect(controller).to receive(:tag).with(VmOrTemplate)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
     it "when Host Analyze then Check Compliance is pressed" do
-      controller.instance_variable_set(:@_params, :pressed => "host_analyze_check_compliance")
+      controller.params = {:pressed => "host_analyze_check_compliance"}
       allow(controller).to receive(:show)
       expect(controller).to receive(:analyze_check_compliance_hosts)
       expect(controller).to receive(:render)
@@ -82,7 +82,7 @@ describe StorageController do
         command = button.split('_', 2)[1]
         allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
 
-        controller.instance_variable_set(:@_params, :pressed => button, :miq_grid_checks => host.id.to_s)
+        controller.params = {:pressed => button, :miq_grid_checks => host.id.to_s}
         controller.instance_variable_set(:@lastaction, "show_list")
         allow(controller).to receive(:show_list)
         expect(controller).to receive(:render)

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -44,7 +44,7 @@ describe VmCloudController do
             # get :x_button, :params => { :id => nil, :pressed => actual_action }
             # we mock a bit and use `send`. This saves 10s of test run.
             allow(controller).to receive(:performed?).and_return(true)
-            controller.instance_variable_set(:@_params, :id => nil, :pressed => actual_action)
+            controller.params = {:id => nil, :pressed => actual_action}
             controller.instance_variable_set(:@sb, {})
             controller.send(:x_button)
           end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -56,7 +56,7 @@ describe VmOrTemplateController do
 
     it 'sets params[:id] to hidden vm if its summary is displayed' do
       allow(controller).to receive(:x_node).and_return('f-' + @folder.id.to_s)
-      controller.instance_variable_set(:@_params, :id => @vm.id.to_s)
+      controller.params = {:id => @vm.id.to_s}
       controller.reload
       expect(controller.params[:id]).to eq("v-#{@vm.id}")
     end
@@ -323,13 +323,13 @@ describe VmOrTemplateController do
     end
 
     it 'does not set new server when params[:server_id] is not set' do
-      controller.instance_variable_set(:@_params, :server_id => '')
+      controller.params = {:server_id => ''}
       controller.send(:evm_relationship_get_form_vars)
       expect(assigns(:edit)[:new][:server]).to be(nil)
     end
 
     it 'sets new server when params[:server_id] is set' do
-      controller.instance_variable_set(:@_params, :server_id => '42')
+      controller.params = {:server_id => '42'}
       controller.send(:evm_relationship_get_form_vars)
       expect(assigns(:edit)[:new][:server]).to eq(controller.params[:server_id])
     end

--- a/spec/helpers/application_helper/buttons/basic_spec.rb
+++ b/spec/helpers/application_helper/buttons/basic_spec.rb
@@ -23,13 +23,13 @@ describe ApplicationHelper::Button::Basic do
     end
 
     it "doesn't displays button Manage Tenant Quota for alpha tenant without tenant product permission for alpha tenant" do
-      controller.instance_variable_set(:@_params, :id => "tn-#{tenant_alpha.id}")
+      controller.params = {:id => "tn-#{tenant_alpha.id}"}
 
       expect(button.role_allows_feature?).to be_falsey
     end
 
     it "displays button Manage Tenant Quota from a tenant omega with tenant product permission for omega tenant" do
-      controller.instance_variable_set(:@_params, :id => "tn-#{tenant_omega.id}")
+      controller.params = {:id => "tn-#{tenant_omega.id}"}
 
       expect(button.role_allows_feature?).to be_truthy
     end

--- a/spec/support/ops_user_helper.rb
+++ b/spec/support/ops_user_helper.rb
@@ -11,8 +11,8 @@ module Spec
 
       def existing_user_edit(user, data = {})
         controller.params = {:typ    => nil,
-                                                    :button => nil,
-                                                    :id     => user.id)
+                             :button => nil,
+                             :id     => user.id}
         controller.rbac_user_edit # set up @edit for the user
 
         edit = controller.instance_variable_get(:@edit)

--- a/spec/support/ops_user_helper.rb
+++ b/spec/support/ops_user_helper.rb
@@ -10,7 +10,7 @@ module Spec
       end
 
       def existing_user_edit(user, data = {})
-        controller.instance_variable_set(:@_params, :typ    => nil,
+        controller.params = {:typ    => nil,
                                                     :button => nil,
                                                     :id     => user.id)
         controller.rbac_user_edit # set up @edit for the user


### PR DESCRIPTION
Rails 5.1 related - comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/5682#discussion_r291666904

This replaces all `instance_variable_set(:@_params, ...` in our specs with `controller.params = {...}`.

Cc @jrafanie this should get rid of all of them :)