### PR TITLE
Ansible Credential textual summary - show nicer error when credential class is missing API_ATTRIBUTES

### DIFF
--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -9,8 +9,16 @@ module AnsibleCredentialHelper::TextualSummary
     TextualGroup.new(_("Relationships"), %i[repositories])
   end
 
+  def textual_error_missing_attributes
+    {:label => _("Missing API_ATTRIBUTES on class"), :value => @record.type}
+  end
+
   def textual_group_options
     options = []
+
+    unless @record.type.constantize.const_defined?(:API_ATTRIBUTES)
+      return TextualGroup.new(_("Credential Options ERROR"), %i[error_missing_attributes])
+    end
 
     @record.type.constantize::API_ATTRIBUTES.each do |key, value|
       options << key


### PR DESCRIPTION
Before:

![badder](https://user-images.githubusercontent.com/289743/59345095-edc1e580-8cfe-11e9-9fe9-f8ec3434bb5d.png)

After:

![](https://www.himdel.eu/ansible-credentials-bad.png)
(sans the green smudge)

It's a fatal error, it should be a fatal error, but since embedded ansible is in the process of being rewritten,
maybe it should not be a fatal error quite yet - comes from https://github.com/ManageIQ/manageiq/pull/18687, Cc @NickLaMuro 

Any credentials need the `API_ATTRIBUTES` class constant to tell the UI what fields are actually relevent,
but when it's missing, we would now show a full textual summary with missing credentials (and a non-flash warning),
instead of an error screen.

The main point of this PR is to fix travis. How we present the error .. this is a simple way, a flash message would be nicer but we have no mechanism for it on the textual summary endpoint yet.