### PR TITLE
Codemirror - :read_only => true didn't imply no cursor

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1183,7 +1183,7 @@ function miqInitCodemirror(options) {
     lineNumbers: options.line_numbers,
     matchBrackets: true,
     theme: 'eclipse',
-    readOnly: options.read_only,
+    readOnly: options.read_only ? 'nocursor' : false,
     viewportMargin: Infinity,
   });
 
@@ -1203,7 +1203,7 @@ function miqInitCodemirror(options) {
   $('.CodeMirror').css('height', options.height);
   $('.CodeMirror').css('width', options.width);
 
-  if (!options.no_focus) {
+  if (! options.no_focus && ! options.read_only) {
     ManageIQ.editor.focus();
   }
 }


### PR DESCRIPTION
Services > Catalogs > Orchestration Templates,
see a template detail screen

There is a read only code mirror view of the template .. with a blinking cursor.

This fixes the read only mode to disable cursor in the editor (https://codemirror.net/doc/manual.html#option_readOnly), and not focus the editor when read only.

(This was likely caused by updating the code mirror in https://github.com/ManageIQ/manageiq-ui-classic/pull/5672.)