### PR TITLE
Trigger react code editor refresh after change and after mount.

### DIFF
--- a/app/javascript/components/code-editor/index.js
+++ b/app/javascript/components/code-editor/index.js
@@ -52,7 +52,11 @@ const CodeEditor = ({
           gutters: ['CodeMirror-lint-markers'],
         }}
         style={{ height: 'auto' }}
-        onBeforeChange={onBeforeChange}
+        onBeforeChange={(editor, ...rest) => {
+          editor.refresh();
+          onBeforeChange(editor, ...rest);
+        }}
+        editorDidMount={editor => editor.refresh()}
         {...props}
       />
     </div>

--- a/app/javascript/spec/code-editor/__snapshots__/code-editor.spec.js.snap
+++ b/app/javascript/spec/code-editor/__snapshots__/code-editor.spec.js.snap
@@ -4,7 +4,8 @@ exports[`CodeEditor component should render correctly 1`] = `
 <div>
   <Controlled
     className="miq-codemirror "
-    onBeforeChange={[MockFunction]}
+    editorDidMount={[Function]}
+    onBeforeChange={[Function]}
     options={
       Object {
         "autoCloseBrackets": true,
@@ -64,7 +65,8 @@ exports[`CodeEditor component should render mode switches 1`] = `
   </FormGroup>
   <Controlled
     className="miq-codemirror "
-    onBeforeChange={[MockFunction]}
+    editorDidMount={[Function]}
+    onBeforeChange={[Function]}
     options={
       Object {
         "autoCloseBrackets": true,


### PR DESCRIPTION
Code editor component for react was not rendering correctly if it contained long string. This was happening on first mount and if you copied long text into it.

Fixed by triggering refresh after component mount and also on the onChange event.

### Before
![59426822-abfd7180-8dc8-11e9-9193-8d230808d020](https://user-images.githubusercontent.com/22619452/59428159-d3f6d000-8ddc-11e9-8867-c955b5fbe4d0.png)

### After
![screenshot-localhost-3000-2019 06 13-13-12-19](https://user-images.githubusercontent.com/22619452/59428185-e113bf00-8ddc-11e9-8b93-6997db563da7.png)

