### PR TITLE
Orchestration templates - fix Cannot read property refresh of null

### DIFF
--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -45,6 +45,5 @@
                   :mode         => "yaml",
                   :line_numbers => true,
                   :read_only    => true}
-
-  :javascript
-    ManageIQ.editor.refresh();
+    :javascript
+      ManageIQ.editor.refresh();


### PR DESCRIPTION
We're rendering codemirror only sometimes,
so we can't refresh it when not rendering it.

Moving the refresh call inside the condition.

---

Services > Catalogs > Orchestration Templates,
see a template detail screen, reload the page

there will be an error in the console without this change