### PR TITLE
Fix for broken automate tree picker in dialog editor.

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -7,7 +7,7 @@ class TreeController < ApplicationController
   def automate_entrypoint
     json = fetch_tree(TreeBuilderAutomateEntrypoint, :automate_entrypoint_tree, params[:id]) do |tree|
       if params[:fqname].present?
-        MiqAeInstance.get_homonymic_across_domains_noprefix(current_user, params[:fqname], true).each do |instance|
+        MiqAeInstance.get_homonymic_across_domains(current_user, params[:fqname], true, :prefix => false).each do |instance|
           # Parse the namespace, class and instance from the fqname
           namespace, klass, instance, _ = MiqAeEngine::MiqAePath.split(instance.fqname)
 


### PR DESCRIPTION
Description:
----------------------
Fix broken automate treepicker in dialog editor.

Steps to reproduce:
--------------------------------
1) Create automate dialog
2) Add dynamic field with selected `ae_instance`(Options tab)
3) Save the field from step 2
4) Edit field from step 2
5) Go to Options tab and try to change the seleceted `ae_instance`

**old result:** Error and no tree
**new result:** automate tree

**Before:**
![New Project(3)](https://user-images.githubusercontent.com/19405716/59435128-3b1c8080-8ded-11e9-9ba2-94e0a702b6f8.jpg)

**After:**
![New Project(2)](https://user-images.githubusercontent.com/19405716/59435144-3fe13480-8ded-11e9-93aa-bb70b2745cb3.jpg)

