### PR TITLE
Test emses with actual leaf subclasses

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -727,7 +727,7 @@ describe ApplicationController do
     end
 
     it "Verify @record is set for passed in ID" do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_vmware)
       record = controller.send(:identify_record, ems.id, ExtManagementSystem)
       expect(record).to be_a_kind_of(ExtManagementSystem)
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -63,7 +63,7 @@ describe ApplicationController do
     end
 
     it "Verify record gets set when valid id is passed in" do
-      ems = FactoryBot.create(:ext_management_system)
+      ems = FactoryBot.create(:ems_vmware)
       expect(controller.send(:find_record_with_rbac, ExtManagementSystem, ems.id)).to eq(ems)
     end
   end
@@ -161,7 +161,7 @@ describe ApplicationController do
       expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
     end
 
-    let(:ems)     { FactoryBot.create(:ext_management_system) }
+    let(:ems)     { FactoryBot.create(:ems_vmware) }
     let(:storage) { FactoryBot.create(:storage) }
 
     it "sets variables when Migrate button is pressed with list of VMware VMs" do

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -480,8 +480,8 @@ describe EmsCloudController do
     end
 
     it 'displays only associated storage_managers' do
-      FactoryBot.create(:ems_storage, :name => 'abc', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
-      FactoryBot.create(:ems_storage, :name => 'xyz', :type =>  "ManageIQ::Providers::Amazon::StorageManager::Ebs", :parent_ems_id => @ems.id)
+      FactoryBot.create(:ems_amazon_ebs, :parent_ems_id => @ems.id)
+      FactoryBot.create(:ems_amazon_ebs, :parent_ems_id => @ems.id)
       get :show, :params => { :display => "storage_managers", :id => @ems.id, :format => :js }
       expect(response).to render_template('layouts/angular/_gtl')
       expect(response.status).to eq(200)

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -214,7 +214,7 @@ describe EmsContainerController do
         expect(assigns(:flash_array).first[:message]).to include('does not apply')
       end
 
-      let(:ems)     { FactoryBot.create(:ext_management_system) }
+      let(:ems)     { FactoryBot.create(:ems_microsoft) }
       let(:storage) { FactoryBot.create(:storage) }
 
       it "when VM Migrate is pressed for supported type" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -69,7 +69,7 @@ describe EmsInfraController do
     end
 
     it "should set correct VM for right-sizing when on list of VM's of another CI" do
-      ems_infra = FactoryBot.create(:ext_management_system)
+      ems_infra = FactoryBot.create(:ems_microsoft)
       vm = FactoryBot.create(:vm_vmware, :ext_management_system => ems_infra)
       allow(controller).to receive(:find_records_with_rbac) { [vm] }
       post :button, :params => { :pressed => "vm_right_size", :id => ems_infra.id, :display => 'vms', "check_#{vm.id}" => '1' }

--- a/spec/controllers/ems_physical_infra_controller_spec.rb
+++ b/spec/controllers/ems_physical_infra_controller_spec.rb
@@ -97,7 +97,7 @@ describe EmsPhysicalInfraController do
     end
     context "when previous breadcrumbs path contained 'Cloud Providers'" do
       it "shows 'Physical Infrastructure Providers -> (Dashboard)' breadcrumb path" do
-        ems = FactoryBot.create(:ems_physical_infra)
+        ems = FactoryBot.create(:ems_redfish_physical_infra)
         get :show, :params => { :id => ems.id }
         breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
         expect(breadcrumbs).to eq([{:name => "#{ems.name} (Dashboard)", :url => "/ems_physical_infra/#{ems.id}"}])
@@ -107,7 +107,7 @@ describe EmsPhysicalInfraController do
 
   describe "#build_credentials" do
     before do
-      @ems = FactoryBot.create(:ems_physical_infra)
+      @ems = FactoryBot.create(:ems_redfish_physical_infra)
     end
     context "#build_credentials only contains credentials that it supports and has a username for in params" do
       let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -32,7 +32,7 @@ describe EmsStorageController do
 
     it "sets @ems in init_show for a selected record" do
       controller.action_name = 'show'
-      ems_storage = FactoryBot.create(:ems_storage, :name => "foo")
+      ems_storage = FactoryBot.create(:ems_amazon_ebs)
       allow(controller).to receive(:type_feature_role_check).and_return(true)
       controller.params = {:id => ems_storage.id}
       controller.send(:init_show)

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -16,7 +16,7 @@ describe OpsController do
         @host1 = FactoryBot.create(:host, :name => 'host1', :storages => [@storage1])
         @host2 = FactoryBot.create(:host, :name => 'host2', :storages => [@storage2])
 
-        @ems = FactoryBot.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @zone)
+        @ems = FactoryBot.create(:ems_vmware, :hosts => [@host1, @host2], :zone => @zone)
 
         @svr1 = FactoryBot.create(:miq_server, :name => 'svr1', :zone => @zone)
         @svr2 = FactoryBot.create(:miq_server, :name => 'svr2', :zone => @zone)

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -26,7 +26,7 @@ describe OpsController do
     end
 
     context "when the filter_type is 'ems'" do
-      let(:ext_management_system) { FactoryBot.create(:ext_management_system, :name => "emstest") }
+      let(:ext_management_system) { FactoryBot.create(:ems_vmware) }
       let(:filter_type) { "ems" }
 
       before do
@@ -36,7 +36,7 @@ describe OpsController do
 
       it "responds with a filtered ext management system list" do
         json = JSON.parse(response.body)
-        expect(json["filtered_item_list"]).to eq(["emstest"])
+        expect(json["filtered_item_list"]).to eq([ext_management_system.name])
       end
     end
 
@@ -240,7 +240,7 @@ describe OpsController do
 
     it "returns a filtered item list for ems providers that have hosts" do
       controller.instance_variable_set(:@settings, settings)
-      ems_cloud = FactoryBot.create(:ems_cloud)
+      ems_cloud = FactoryBot.create(:ems_openstack)
       ems_infra_no_hosts = FactoryBot.create(:ems_openstack_infra)
       ems_infra_with_hosts = FactoryBot.create(:ems_openstack_infra_with_stack)
       filtered_list = controller.send(:build_filtered_item_list, "host", "ems")

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -49,7 +49,7 @@ describe OrchestrationStackController do
     end
 
     context "orchestration templates" do
-      let(:ems) { FactoryBot.create(:ems_cloud) }
+      let(:ems) { FactoryBot.create(:ems_vmware_cloud) }
       let(:record) { FactoryBot.create(:orchestration_stack_cloud_with_template, :ext_management_system => ems, :name => 'stack01') }
 
       before do

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -267,16 +267,16 @@ describe VmOrTemplateController do
     end
 
     it 'returns id of Provider folder for infra VM/Template without blue folder' do
-      vm_infra = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
-      template_infra = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_infra))
+      vm_infra = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_vmware))
+      template_infra = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_vmware))
       expect(controller.parent_folder_id(vm_infra)).to eq(TreeBuilder.build_node_id(vm_infra.ext_management_system))
       expect(controller.parent_folder_id(template_infra)).to eq(TreeBuilder.build_node_id(template_infra.ext_management_system))
     end
 
     it 'returns id of Datacenter folder for infra VM/Template without blue folder but with Datacenter parent' do
       datacenter = FactoryBot.create(:datacenter, :hidden => true)
-      vm_infra_datacenter = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
-      template_infra_datacenter = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_infra))
+      vm_infra_datacenter = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_vmware))
+      template_infra_datacenter = FactoryBot.create(:template_infra, :ext_management_system => FactoryBot.create(:ems_vmware))
       vm_infra_datacenter.with_relationship_type("ems_metadata") { vm_infra_datacenter.parent = datacenter }
       allow(vm_infra_datacenter).to receive(:parent_datacenter).and_return(datacenter)
       template_infra_datacenter.with_relationship_type("ems_metadata") { template_infra_datacenter.parent = datacenter }
@@ -287,10 +287,10 @@ describe VmOrTemplateController do
 
     it 'returns id of blue folder for VM/Template with one' do
       folder = FactoryBot.create(:ems_folder)
-      vm_infra_folder = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra))
+      vm_infra_folder = FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_vmware))
       vm_infra_folder.with_relationship_type("ems_metadata") { vm_infra_folder.parent = folder } # add folder
       template_infra_folder = FactoryBot.create(:template_infra,
-                                                 :ext_management_system => FactoryBot.create(:ems_infra))
+                                                :ext_management_system => FactoryBot.create(:ems_vmware))
       template_infra_folder.with_relationship_type("ems_metadata") { template_infra_folder.parent = folder } # add folder
       expect(controller.parent_folder_id(vm_infra_folder)).to eq(TreeBuilder.build_node_id(folder))
       expect(controller.parent_folder_id(template_infra_folder)).to eq(TreeBuilder.build_node_id(folder))

--- a/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_refresh_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsRefresh do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryBot.create(:ems_infra) }
+  let(:record) { FactoryBot.create(:ems_vmware) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#disabled?' do

--- a/spec/helpers/application_helper/buttons/ems_storage_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_storage_timeline_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::EmsStorageTimeline do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryBot.create(:ext_management_system) }
+  let(:record) { FactoryBot.create(:ems_vmware) }
   let(:props) { {:options => {:feature => :timeline}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 

--- a/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
+++ b/spec/helpers/application_helper/buttons/physical_server_provision_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
   describe '#disabled?' do
     context "button should not be disabled" do
       before do
-        ems = FactoryBot.create(:ems_physical_infra)
+        ems = FactoryBot.create(:ems_redfish_physical_infra)
         @record = FactoryBot.create(:physical_server, :ems_id => ems.id)
       end
 
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
 
     context "button should be disabled when there are no Physical Servers" do
       before do
-        FactoryBot.create(:ems_physical_infra)
+        FactoryBot.create(:ems_redfish_physical_infra)
       end
 
       it "disable the Provision button" do
@@ -36,7 +36,7 @@ describe ApplicationHelper::Button::PhysicalServerProvision do
 
     context "button should be disabled when there are no Physical infrastructure providers that support VM Provisioning" do
       before do
-        ems = FactoryBot.create(:ems_physical_infra)
+        ems = FactoryBot.create(:ems_redfish_physical_infra)
         @record = FactoryBot.create(:physical_server, :ems_id => ems.id)
       end
 

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::SetOwnership do
   let(:view_context) { setup_view_context_with_sandbox({}) }
 
   let(:ext_management_system) do
-    FactoryBot.create(:ext_management_system, :tenant_mapping_enabled => tenant_mapping_enabled)
+    FactoryBot.create(:ems_vmware, :tenant_mapping_enabled => tenant_mapping_enabled)
   end
 
   let(:record) { FactoryBot.create(:vm, :ext_management_system => ext_management_system) }

--- a/spec/helpers/application_helper/buttons/zone_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_delete_spec.rb
@@ -18,7 +18,7 @@ describe ApplicationHelper::Button::ZoneDelete do
 
     context 'when selected zone is not the default one' do
       context 'and zone has ext_management_systems' do
-        let(:set_relationships) { selected_zone.ext_management_systems << FactoryBot.create(:ext_management_system) }
+        let(:set_relationships) { selected_zone.ext_management_systems << FactoryBot.create(:ems_vmware) }
         it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
       end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1261,7 +1261,7 @@ describe ApplicationHelper do
     subject { send(:provider_paused?, record) }
 
     context 'record is a provider' do
-      let(:record) { FactoryBot.create(:ems_infra) }
+      let(:record) { FactoryBot.create(:ems_vmware) }
 
       it "true if provider paused" do
         record.pause!
@@ -1274,7 +1274,7 @@ describe ApplicationHelper do
     end
 
     context 'record is a VM' do
-      let(:record) { FactoryBot.create(:vm, :ext_management_system => FactoryBot.create(:ems_infra)) }
+      let(:record) { FactoryBot.create(:vm, :ext_management_system => FactoryBot.create(:ems_vmware)) }
 
       it "true if provider paused" do
         record.ext_management_system.pause!

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -27,7 +27,7 @@ describe EmsCloudHelper::TextualSummary do
 
   context "#textual_groups" do
     before do
-      instance_variable_set(:@record, FactoryBot.create(:ems_cloud))
+      instance_variable_set(:@record, FactoryBot.create(:ems_vmware_cloud))
       allow(self).to receive(:textual_authentications).and_return([])
       allow(@record).to receive(:authentication_for_summary).and_return([])
     end
@@ -55,7 +55,7 @@ describe EmsCloudHelper::TextualSummary do
   end
 
   describe '#textual_description' do
-    let(:ems) { FactoryBot.create(:ems_cloud) }
+    let(:ems) { FactoryBot.create(:ems_vmware_cloud) }
 
     before do
       instance_variable_set(:@record, ems)

--- a/spec/helpers/ems_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_infra_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsInfraHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_vmware))
     allow(self).to receive(:textual_authentications).and_return([])
   end
 

--- a/spec/helpers/ems_network_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_network_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsNetworkHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_vmware))
     allow(self).to receive(:textual_authentications).and_return([])
   end
 

--- a/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsPhysicalInfraHelper::TextualSummary do
   before do
-    instance_variable_set(:@record, FactoryBot.create(:ems_infra))
+    instance_variable_set(:@record, FactoryBot.create(:ems_vmware))
     allow(@record).to receive(:authentication_userid_passwords).and_return([])
     allow(self).to receive(:textual_authentications).and_return([])
   end

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe EmsStorageHelper::TextualSummary do
   describe "for EmsInfra" do
     before do
-      instance_variable_set(:@record, FactoryBot.create(:ems_infra))
+      instance_variable_set(:@record, FactoryBot.create(:ems_vmware))
       allow(self).to receive(:textual_authentications).and_return([])
     end
 

--- a/spec/helpers/generic_object_helper/textual_summary_spec.rb
+++ b/spec/helpers/generic_object_helper/textual_summary_spec.rb
@@ -45,7 +45,7 @@ describe GenericObjectHelper::TextualSummary do
     it "displays the GO Associations when Associations exist" do
       vm1 = FactoryBot.create(:vm_vmware)
       vm2 = FactoryBot.create(:vm_openstack)
-      ems = FactoryBot.create(:ems_cloud)
+      ems = FactoryBot.create(:ems_openstack)
       @record = FactoryBot.create(:generic_object,
                                    :generic_object_definition_id => @generic_obj_defn.id,
                                    :cp                           => [ems],

--- a/spec/helpers/report_helper/editor_spec.rb
+++ b/spec/helpers/report_helper/editor_spec.rb
@@ -3,7 +3,7 @@ describe ReportHelper do
     let(:project) { FactoryBot.create(:container_project) }
     let(:image) { FactoryBot.create(:container_image) }
     let(:provider) do
-      FactoryBot.build(:ems_container).tap do |e|
+      FactoryBot.build(:ems_kubernetes).tap do |e|
         e.container_projects = [project]
         e.container_images = [image]
         e.save!

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderSmartproxyAffinity do
       @host1 = FactoryBot.create(:host, :name => 'host1', :storages => [@storage1])
       @host2 = FactoryBot.create(:host, :name => 'host2', :storages => [@storage2])
 
-      @ems = FactoryBot.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @selected_zone)
+      @ems = FactoryBot.create(:ems_vmware, :hosts => [@host1, @host2], :zone => @selected_zone)
 
       @svr1 = FactoryBot.create(:miq_server, :name => 'svr1', :zone => @selected_zone)
       @svr2 = FactoryBot.create(:miq_server, :name => 'svr2', :zone => @selected_zone)

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -30,7 +30,7 @@ describe TreeNode::ExtManagementSystem do
     :automation_manager_ansible_tower => { :key_prefix => 'at-' },
     :configuration_manager_foreman    => { :key_prefix => 'fr-' },
     :provisioning_manager_foreman     => {},
-    :ems_physical_infra               => {},
+    :ems_redfish_physical_infra       => {},
     :ems_openshift                    => {},
     :ems_azure_network                => {},
     :ems_amazon_network               => {},

--- a/spec/services/ems_cloud_dashboard_service_spec.rb
+++ b/spec/services/ems_cloud_dashboard_service_spec.rb
@@ -1,7 +1,7 @@
 describe EmsCloudDashboardService do
   context '#recentInstances' do
     before do
-      @ems1 = FactoryBot.create(:ems_cloud)
+      @ems1 = FactoryBot.create(:ems_openstack)
       @vm1 = FactoryBot.create(:vm_openstack, :ext_management_system => @ems1)
       @vm2 = FactoryBot.create(:vm_openstack, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
     end

--- a/spec/services/ems_infra_dashboard_service_spec.rb
+++ b/spec/services/ems_infra_dashboard_service_spec.rb
@@ -1,14 +1,14 @@
 describe EmsInfraDashboardService do
   context '#recentVms' do
     before do
-      @ems1 = FactoryBot.create(:ems_infra)
+      @ems1 = FactoryBot.create(:ems_vmware)
       @vm1 = FactoryBot.create(:vm_infra, :ext_management_system => @ems1)
       @vm2 = FactoryBot.create(:vm_infra, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
 
       @host1 = FactoryBot.create(:host, :ext_management_system => @ems1)
       @host2 = FactoryBot.create(:host, :ext_management_system => @ems1, :created_on => 1.day.ago.utc)
 
-      @ems2 = FactoryBot.create(:ems_infra)
+      @ems2 = FactoryBot.create(:ems_vmware)
       @vm3 = FactoryBot.create(:vm_infra, :ext_management_system => @ems2)
 
       @host4 = FactoryBot.create(:host, :ext_management_system => @ems2)

--- a/spec/services/topology_service_spec.rb
+++ b/spec/services/topology_service_spec.rb
@@ -72,7 +72,7 @@ describe TopologyService do
   end
 
   describe '#map_to_graph' do
-    let(:provider) { FactoryBot.create(:ext_management_system) }
+    let(:provider) { FactoryBot.create(:ems_vmware) }
     let(:tag) { FactoryBot.create(:tag) }
     let(:vm) { FactoryBot.create(:vm, :ext_management_system => provider, :tags => [tag]) }
     let(:graph) { {:vms => {:tags => nil}} }

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -49,7 +49,7 @@ describe "shared/views/ems_common/show" do
 
     let(:showtype) { "main" }
     let(:display) { 'cloud_volumes' }
-    let(:ems) { FactoryBot.create(:ems_storage, :hostname => '1.1.1.1') }
+    let(:ems) { FactoryBot.create(:ems_amazon, :hostname => '1.1.1.1') }
 
     it "should show render gtl for list of cloud_volumes" do
       render


### PR DESCRIPTION
This fixes a bunch of specs that aren't creating leaf subclasses for emses.

The original ticket is to remove GCE provider downstream but in order to do this, we have to validate that the provider being added is of a type that's supported. Which means that everywhere we have specs with providers without types, those tests will now 🐡

for https://github.com/ManageIQ/manageiq/pull/18842 but since it's just test cleanup could get in before that PR without any issues
