### PR TITLE
Fix GOD breadcrumbs

### DIFF
--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -74,6 +74,14 @@ function miq_bootstrap(selector, app) {
   return angular.bootstrap($(selector), [app], { strictDi: true });
 }
 
+function tree_action() {
+  listenToRx(function(payload) {
+    if (payload.breadcrumbSelect) {
+      window.location.href = "/generic_object_definition/show_list";
+    }
+  });
+};
+
 function miqCallAngular(data) {
   ManageIQ.angular.scope.$apply(function() {
     ManageIQ.angular.scope[data.name].apply(ManageIQ.angular.scope, data.args);

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -51,6 +51,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def button_actions
+    @button_acton = params[:pressed]
     javascript_redirect(
       case params[:pressed]
       when 'generic_object_definition_new'
@@ -71,14 +72,14 @@ class GenericObjectDefinitionController < ApplicationController
 
   def new
     assert_privileges('generic_object_definition_new')
-    drop_breadcrumb(:name => _("Add a new Generic Object Class"), :url => "/generic_object_definition/new")
+    @right_cell_text = _("Add a new Generic Object Definition")
     @in_a_form = true
   end
 
   def edit
     assert_privileges('generic_object_definition_edit')
-    drop_breadcrumb(:name => _("Edit Generic Object Class"), :url => "/generic_object_definition/edit/#{params[:id]}")
     @generic_object_definition = GenericObjectDefinition.find(params[:id])
+    @right_cell_text = _("Edit a Generic Object Definition '%{name}'") % {:name => @generic_object_definition.name}
     @in_a_form = true
   end
 
@@ -96,35 +97,35 @@ class GenericObjectDefinitionController < ApplicationController
 
   def custom_button_group_new
     assert_privileges('ab_group_new')
-    title = _("Add a new Custom Button Group")
+    @right_cell_text = _("Add a new Custom Button Group")
     @generic_object_definition = GenericObjectDefinition.find(params[:id])
-    render_form(title, 'custom_button_group_form')
+    render_form(@right_cell_text, 'custom_button_group_form')
   end
 
   def custom_button_group_edit
     assert_privileges('ab_group_edit')
     @custom_button_group = CustomButtonSet.find(params[:id])
-    title = _("Edit Custom Button Group '%{name}'") % {:name => @custom_button_group.name}
-    render_form(title, 'custom_button_group_form')
+    @right_cell_text = _("Edit Custom Button Group '%{name}'") % {:name => @custom_button_group.name}
+    render_form(@right_cell_text, 'custom_button_group_form')
   end
 
   def custom_button_new
     assert_privileges('ab_button_new')
-    title = _("Add a new Custom Button")
+    @right_cell_text = _("Add a new Custom Button")
     if node_type(x_node || params[:id]) == :button_group
       @custom_button_group = CustomButtonSet.find(params[:id])
       @generic_object_definition = GenericObjectDefinition.find(@custom_button_group.set_data[:applies_to_id])
     else
       @generic_object_definition = GenericObjectDefinition.find(params[:id])
     end
-    render_form(title, 'custom_button_form')
+    render_form(@right_cell_text, 'custom_button_form')
   end
 
   def custom_button_edit
     assert_privileges('ab_button_edit')
     @custom_button = CustomButton.find(params[:id])
-    title = _("Edit Custom Button '%{name}'") % {:name => @custom_button.name}
-    render_form(title, 'custom_button_form')
+    @right_cell_text = _("Edit Custom Button '%{name}'") % {:name => @custom_button.name}
+    render_form(@right_cell_text, 'custom_button_form')
   end
 
   def retrieve_distinct_instances_across_domains
@@ -209,10 +210,11 @@ class GenericObjectDefinitionController < ApplicationController
 
     @in_a_form = true
     presenter[:right_cell_text] = title
-    presenter.replace(:main_div, r[:partial => form_partial])
+    presenter.update(:main_div, r[:partial => form_partial])
     presenter.hide(:paging_div)
     presenter[:lock_sidebar] = true
     presenter.set_visibility(false, :toolbar)
+    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
 
     render :json => presenter.for_render
   end
@@ -297,12 +299,17 @@ class GenericObjectDefinitionController < ApplicationController
     }
   end
 
-  def build_breadcrumbs_from_tree
-    breadcrumbs = []
-    tree = build_tree if @tree.nil?
-    if x_node && tree
-      breadcrumbs = current_tree_path(JSON.parse(tree.bs_tree).first, x_node)
-    end
-    breadcrumbs
+  def features
+    [
+      {
+        :role  => "god_accord",
+        :name  => :god,
+        :title => _("Generic Object Classes"),
+      },
+    ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
+  end
+
+  def action_breadcrumb?
+    @right_cell_text && params[:action] != "tree_select"
   end
 end

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -45,10 +45,14 @@ module Mixins
         else
           # Append breadcrumb from the title of right cell
           breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems)) unless options[:hide_special_item]
-          breadcrumbs.push(:title => @right_cell_text) if @sb["action"] && @right_cell_text
+          breadcrumbs.push(:title => @right_cell_text) if action_breadcrumb?
         end
       end
       breadcrumbs.compact
+    end
+
+    def action_breadcrumb?
+      @sb["action"] && @right_cell_text
     end
 
     def build_breadcrumbs_no_explorer(record_info, record_title)

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -130,6 +130,7 @@ module Sandbox
     dialogs
     event
     export
+    god
     configuration_manager_providers
     images
     images_filter

--- a/app/views/generic_object_definition/_generic_object_definition_form.html.haml
+++ b/app/views/generic_object_definition/_generic_object_definition_form.html.haml
@@ -7,3 +7,4 @@
 
 :javascript
   miq_bootstrap('generic-object-definition');
+  tree_action();


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1719889

Go to Automate -> Automation -> Generic Objects -> click different items in a tree

I'm pretty sure that GOD controller was missing `features` method and was going the wrong way in `data_for_breadcrumbs`. I looked at Automate -> Automation -> Customization -> Custom buttons for reference on how a breadcrumb should look like.

**Known issue**: If you Edit Generic Object Definition and click on breadcrumbs it will redirect you to `show_list` with `All Generic Object Classes`. It can be fixed by rewriting the whole controller :D

Before:
<img width="853" alt="Screenshot 2019-06-13 at 15 32 49" src="https://user-images.githubusercontent.com/9210860/59436947-71cea880-8da5-11e9-81e3-c938c904da7c.png">

<img width="1446" alt="Screenshot 2019-06-13 at 16 16 46" src="https://user-images.githubusercontent.com/9210860/59440175-5ff00400-8dab-11e9-832e-1c038366c1ce.png">

After:
<img width="935" alt="Screenshot 2019-06-13 at 15 22 02" src="https://user-images.githubusercontent.com/9210860/59436573-bf96e100-8da4-11e9-9fde-58bf278ce8ec.png">

<img width="1443" alt="Screenshot 2019-06-13 at 16 14 51" src="https://user-images.githubusercontent.com/9210860/59440012-23bca380-8dab-11e9-8ceb-3daa769a378e.png">

@miq-bot add_label bug, hammer/no, changelog/no, generic objects

cc: @rvsia @martinpovolny 
