### PR TITLE
Fix rails 5-1 issues

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -236,7 +236,7 @@ module OpsController::Settings::Common
   def prepare_subscriptions_for_saving
     to_save = []
     to_remove = []
-    params[:subscriptions].each_value do |subscription_params|
+    params[:subscriptions].each do |_k, subscription_params|
       subscription = find_or_new_subscription(subscription_params['id'])
       if subscription.id && subscription_params['remove'] == "true"
         to_remove << subscription

--- a/spec/services/infra_topology_service_spec.rb
+++ b/spec/services/infra_topology_service_spec.rb
@@ -84,8 +84,10 @@ describe InfraTopologyService do
       expect(infra_topology_service).to receive(:entity_display_type).exactly(2).times.and_call_original
 
       icons = infra_topology_service.build_icons
-      expect(icons["Openstack"]).to eq(:type => "image", :icon  => "/images/svg/vendor-openstack_infra.svg")
-      expect(icons["Vmware"]).to    eq(:type => "image", :icon  => "/images/svg/vendor-vmwarews.svg")
+      expect(icons["Openstack"][:type]).to eq("image")
+      expect(icons["Openstack"][:icon]).to include("vendor-openstack_infra")
+      expect(icons["Vmware"][:type]).to eq("image")
+      expect(icons["Vmware"][:icon]).to include("vendor-vmwarews")
       expect(icons[:EmsCluster]).to eq(:type => "glyph", :class => "pficon pficon-cluster")
       expect(icons[:Host]).to       eq(:type => "glyph", :class => "pficon pficon-container-node")
     end


### PR DESCRIPTION
Extracted from #5676 

* Use a general path that works for compiled/uncompiled assets
* 5.1 AC::Parameters doesn't have each_value, use each 

