### PR TITLE
 Expression Editor fix

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -66,7 +66,6 @@ module ApplicationController::Filter
         if %w[not discard commit remove].include?(params[:pressed])
           page << javascript_hide("exp_buttons_on")
           page << javascript_hide("exp_buttons2_on")
-          page << javascript_hide("exp_buttons_not")
           page << javascript_hide("exp_buttons2_not")
           page << javascript_show("exp_buttons_off")
           page << javascript_show("exp_buttons2_off")
@@ -106,12 +105,10 @@ module ApplicationController::Filter
         page << javascript_hide("exp_buttons_off")
         page << javascript_hide("exp_buttons2_off")
         if exp.key?("not") || @parent_is_not
-          page << javascript_hide("exp_buttons_on")
-          page << javascript_show("exp_buttons_not")
+          page << javascript_show("exp_buttons_on")
           page << javascript_hide("exp_buttons2_on")
           page << javascript_show("exp_buttons2_not")
         else
-          page << javascript_hide("exp_buttons_not")
           page << javascript_show("exp_buttons_on")
           page << javascript_hide("exp_buttons2_not")
           page << javascript_show("exp_buttons2_on")


### PR DESCRIPTION
This PR fixes a bug where the 'NOT' element could not be deleted in the Expression Editor.

https://bugzilla.redhat.com/show_bug.cgi?id=1720216

Old
<img width="1040" alt="Screen Shot 2019-06-14 at 11 55 12 AM" src="https://user-images.githubusercontent.com/1287144/59524122-0ff36900-8ea1-11e9-8b5d-dd1c90403bee.png">

New
<img width="1078" alt="Screen Shot 2019-06-14 at 11 52 57 AM" src="https://user-images.githubusercontent.com/1287144/59524123-108bff80-8ea1-11e9-804a-6bb37819bd09.png">