### PR TITLE
Drop obsolete argument of generic_x_show

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -220,7 +220,7 @@ module ApplicationController::Explorer
           redirect_to(:action => "explorer")
           return
         end
-        params[:id] = x_build_node_id(@record, x_node_build_options)
+        params[:id] = x_build_node_id(@record)
         tree_select
       end
       format.html do # HTML, redirect to explorer

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -125,7 +125,7 @@ class ServiceController < ApplicationController
   # ST clicked on in the explorer right cell
   def x_show
     identify_service(params[:id])
-    generic_x_show(x_tree(:svcs_tree))
+    generic_x_show
   end
 
   def service_edit


### PR DESCRIPTION
The services tree has no special option related to the node id generation, therefore, the argument of `generic_x_show` is obsolete. This also allows to completely get rid of the optional argument.

@miq-bot add_label trees, refactoring, hammer/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 