### PR TITLE
[WIP] Replace TreeBuilder#tree_init_options with a DSL 

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -61,7 +61,42 @@ class TreeBuilder
       tree = klass_name.constantize.new(name, sandbox, false)
       tree.x_get_child_nodes(id)
     end
+
+    # DSL for specifying the options for the tree (formerly tree_init_options)
+    #
+    # It sets an instance variable on the TreeBuilder itself and it is being delegated to the instance as well
+    # All the allowed options should be specified below in the ALLOWED_OPTIONS constant
+    #
+    # Usage: tree_init_option :option, value = true
+
+    ALLOWED_OPTIONS = [
+      :allow_reselect,
+      :check_url,
+      :checkboxes,
+      :click_url,
+      :full_ids,
+      :lazy,
+      :oncheck,
+      :onclick,
+      :open_all,
+      :post_check,
+      :silent_activate,
+      :three_checks,
+    ].freeze
+
+    attr_reader(*ALLOWED_OPTIONS)
+
+    private
+
+    def tree_init_option(option, value = true)
+      raise ArgumentError unless ALLOWED_OPTIONS.include?(option)
+
+      instance_variable_set("@#{option}".to_sym, value)
+    end
   end
+
+  # Delegate the values from the tree option DSL to the parent class
+  delegate(*singleton_class::ALLOWED_OPTIONS, :to => :class)
 
   def initialize(name, sandbox, build = true, **_params)
     @tree_state = TreeState.new(sandbox)


### PR DESCRIPTION
I need this DSL to have a nicer access to some of the options from outside of the `TreeBuilder`'s context in some controllers. It is still a work in progress, but it will eventually replace the tree_init_options method in each of our TreeBuilder subclasses with the following syntax:
```ruby
class TreeBuilderServices < TreeBuilder
  tree_init_option :lazy
  tree_init_option :allow_reselect
  tree_init_option :click_url, "/foo"
  # ...
end
```
Accessing these values will no longer need to call the method, it will be accessible using attr_accessors called both on the class áand their instances using delegation:
```ruby
TreeBuilderServices.lazy
 => true
TreeBuilderServices.new(:services, {}, false).lazy
 => true
```

There are some `tree_init_options` definitions that contain 🦛🦛 conditionals 🦛🦛, so first those have to be addressed before I can continue on this. However, I'd like to ask for a review of the idea itself.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label trees, refactoring, hammer/no