### PR TITLE
Simplify the condition for checking nodes in TreeBuilderBelongsTo*

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -6,13 +6,11 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
   def override(node, object, _pid, options)
-    if [ExtManagementSystem, EmsCluster, Datacenter, EmsFolder, ResourcePool, Host].any? { |klass| object.kind_of?(klass) }
-      node[:select] = if @assign_to
-                        @selected_nodes&.include?("ResourcePool_#{object[:id]}")
-                      else
-                        @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
-                      end
-    end
+    node[:select] = if @assign_to
+                      @selected_nodes&.include?("ResourcePool_#{object[:id]}")
+                    else
+                      @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
+                    end
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:selectable] = false
     node[:checkable] = @edit.present? || @assign_to.present?


### PR DESCRIPTION
I was trying to wrap my head around this for an hour and I think this top-level `if` is not necessary. Maybe I am wrong, but even if it would break stuff, we should not feed data to the trees that we're not using inside. Therefore, if my changes break something, I'd rather move the conditional outside of the tree when we're building the `selected_nodes`.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, trees, hammer/no