### PR TITLE
Server Settings Timezone dropdown fix

### DIFF
--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -71,6 +71,7 @@
         = select_tag('server_timezone',
                       options_for_select(ViewHelper::ALL_TIMEZONES, @edit[:new][:server][:timezone]),
                       "data-live-search" => "true",
+                      "data-container"   => "body",
                       :class             => "selectpicker")
     :javascript
       miqSelectPickerEvent('server_timezone', "#{url}")


### PR DESCRIPTION
The PR adds a data-container target of "body" to bootstrap select to prevent dropdown from being cut off.

https://bugzilla.redhat.com/show_bug.cgi?id=1718834

Old
<img width="801" alt="Screen Shot 2019-06-17 at 9 49 30 AM" src="https://user-images.githubusercontent.com/1287144/59609717-e9723f80-90e5-11e9-8603-646e5b7ef18e.png">

New
<img width="677" alt="Screen Shot 2019-06-17 at 9 50 08 AM" src="https://user-images.githubusercontent.com/1287144/59609668-cf386180-90e5-11e9-96ff-1be301da22fc.png">