### PR TITLE
Require and permit the :quotas subhash

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -155,7 +155,7 @@ module OpsController::OpsRbac
       if !params[:quotas]
         tenant.set_quotas({})
       else
-        tenant.set_quotas(params.permit[:quotas].to_h)
+        tenant.set_quotas(params.require(:quotas).permit!.to_h.deep_symbolize_keys)
       end
     rescue => bang
       add_flash(_("Error when saving tenant quota: %{message}") % {:message => bang.message}, :error)

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -226,6 +226,10 @@ describe OpsController do
         expect(response.status).to eq(200)
         controller.send(:rbac_tenant_manage_quotas)
         flash_message = assigns(:flash_array).first
+        @tenant.reload
+        tenant_quotas = @tenant.get_quotas
+        expect(tenant_quotas[:cpu_allocated][:value]).to be(1024.0)
+        expect(tenant_quotas[:mem_allocated][:value]).to be(4096.0)
         expect(flash_message[:message]).to include("Quotas for Tenant \"OneTenant\" were saved")
         expect(flash_message[:level]).to be(:success)
       end


### PR DESCRIPTION
Note, permit doesn't permit non-scaler values by default and since
:quotas is a subhash, we need to permit the entire hash.

See also:
https://edgeguides.rubyonrails.org/action_controller_overview.html#permitted-scalar-values

Also, the code expects symbol keys so we need to keep them as symbols.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721130

The change for rails 5.1 AC::Parameters not being a hash was added in:
cd71601#diff-8078c760e06b820719715450b2a112e0R158