### PR TITLE
Clean up datastore fetching in TreeBuilderBelongsTo* trees

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -66,15 +66,17 @@ class TreeBuilderBelongsToHac < TreeBuilder
   end
 
   def x_get_tree_datacenter_kids(parent, count_only)
-    kids = []
-    parent.folders.each do |child|
-      kids.concat([child]) if child.kind_of?(EmsFolder) && child.name == 'datastore'
-      next unless child.kind_of?(EmsFolder) && child.name == "host"
-      kids.concat(child.folders_only)
-      kids.concat(child.clusters)
-      kids.concat(child.hosts)
+    children = parent.folders.each_with_object([]) do |child, arr|
+      next unless child.kind_of?(EmsFolder)
+
+      case child.name
+      when 'datastore'
+        arr.push(child)
+      when 'host'
+        [:folders_only, :clusters, :hosts].each { |m| arr.concat(child.send(m)) }
+      end
     end
-    count_only_or_objects(count_only, kids)
+    count_only_or_objects(count_only, children)
   end
 
   def x_get_tree_cluster_kids(parent, count_only)

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -24,16 +24,12 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
   end
 
   def x_get_tree_datacenter_kids(parent, count_only)
-    kids = []
-    parent.folders.each do |child|
-      next unless child.kind_of?(EmsFolder)
-      next if child.name == "host"
-      if child.name == "vm"
-        kids.concat(child.folders_only)
-      else
-        kids.push(child)
-      end
+    children = parent.folders.each_with_object([]) do |child, arr|
+      next if !child.kind_of?(EmsFolder) || child.name == 'host'
+
+      child.name == 'vm' ? arr.concat(child.folders_only) : arr.push(child)
     end
-    count_only_or_objects(count_only, kids)
+
+    count_only_or_objects(count_only, children)
   end
 end


### PR DESCRIPTION
These methods are a little complex, even after the refactoring, but it's getting better :wink: 

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label refactoring, hammer/no, trees 