### PR TITLE
Make root node fetching for BelongsTo* trees consistent

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -46,11 +46,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    if @assign_to.present?
-      count_only_or_objects(count_only, ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
-    else
-      count_only_or_objects(count_only, ExtManagementSystem.all)
-    end
+    count_only_or_objects(count_only, ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
   end
 
   def x_get_provider_kids(parent, count_only)

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -86,14 +86,7 @@ describe TreeBuilderBelongsToHac do
   end
 
   describe '#x_get_tree_roots' do
-    it 'returns all ExtManagementSystems' do
-      expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.all)
-    end
-  end
-
-  describe '#x_get_tree_roots' do
-    it 'returns all ExtManagementSystems except the Embedded Ansible when @assign_to is present' do
-      subject.instance_variable_set(:@assign_to, "ems_folder")
+    it 'returns all ExtManagementSystems except the Embedded Ansible' do
       expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
     end
   end


### PR DESCRIPTION
As discussed with @lfu and @lgalis, the policy profile assignment and RBAC host and cluster trees should consistently not display the embedded Ansible provider.

@miq-bot add_reviewer @lfu 
@miq-bot add_reviewer @lgalis 
@miq-bot add_reviewer @kbrock 
@miq-bot add_label bug, trees