### PR TITLE
Jasmine - use hamlit instead of haml

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -21,9 +21,14 @@ class StaticOrHaml
 
     scope.extend(ApplicationHelper)
 
-    compiled = Haml::Engine.new(raw).render(scope)
+    compiled = hamlit_compile(raw, scope)
 
     [200, {"Content-Type" => "text/html"}, [compiled]]
+  end
+
+  def hamlit_compile(template, scope)
+    code = Hamlit::Engine.new.call(template)
+    scope.instance_eval(code)
   end
 end
 


### PR DESCRIPTION
we're using hamlit everywhere else,
and recently https://github.com/ManageIQ/manageiq/pull/18886 was merged,
dropping the haml_lint dependency, but also the implied haml dependency.

=> Replacing with an equivalent hamlit invocation
