### PR TITLE
Add a "print" webpack pack, move ui-components css there

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,9 +1,3 @@
-/*
- * Unfortunately ui-components needs to be loaded like this :(
- * This is due to the fact that we have ui-components through yarn
- *= require @manageiq/ui-components/dist/css/ui-components
- */
-
 @import 'patternfly-sprockets';
 @import 'patternfly/variables';
 @import 'patternfly/icons';

--- a/app/javascript/packs/print.js
+++ b/app/javascript/packs/print.js
@@ -1,0 +1,2 @@
+// styles for the print layout
+require('@manageiq/ui-components/dist/css/ui-components.css');

--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -4,6 +4,8 @@
     %title= @options[:title]
     = miq_favicon_link_tag
     = stylesheet_link_tag 'print', :media => 'all'
+    = javascript_essential_dependencies
+    = javascript_pack_tag 'manageiq-ui-classic/print.js'
     -# Mock the gettext calls in javascript
     :javascript
       window.__ = function (data) { return data };


### PR DESCRIPTION
We're running the `spec` spec without yarn -> no node_modules/@manageiq/ui-components .
Since https://github.com/ManageIQ/manageiq/pull/18869 (Rails 5.1 preparations), tests are failing because the print.scss file started failing when the file is missing.

https://github.com/ManageIQ/manageiq-ui-classic/pull/5679 is moving all of app/assets/stylesheets to webpack,
but is not ready yet.

=> created a "print" webpack pack,
included in the print layout,
and moved the ui-components css include there.

(Any subsequent cleanup will happen as part of https://github.com/ManageIQ/manageiq-ui-classic/pull/5679 , need this quickly in to fix travis.)