### PR TITLE
Add /favicon.ico route to redirect to the right miq_favicon_path

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -6,4 +6,8 @@ class StaticController < ActionController::Base
 
   include HighVoltage::StaticPage
   helper ApplicationHelper
+
+  def favicon
+    redirect_to(ApplicationHelper.miq_favicon_path)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1294,8 +1294,12 @@ module ApplicationHelper
     "#{prefix}-#{rand(36**8).to_s(36)}"
   end
 
+  def self.miq_favicon_path
+    Settings.server.custom_favicon ? '/upload/custom_favicon.ico' : ActionController::Base.helpers.image_path('favicon.ico')
+  end
+
   def miq_favicon_link_tag
-    Settings.server.custom_favicon ? favicon_link_tag('/upload/custom_favicon.ico') : favicon_link_tag
+    favicon_link_tag(ApplicationHelper.miq_favicon_path)
   end
 
   def provider_paused?(record)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3337,6 +3337,9 @@ Rails.application.routes.draw do
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false
 
+  # prevent No route matches [GET] "/favicon.ico"
+  get '/favicon.ico' => 'static#favicon', :format => false
+
   resources :ems_cloud,          :as => :ems_clouds
   resources :ems_infra,          :as => :ems_infras
   resources :ems_physical_infra, :as => :ems_physical_infras


### PR DESCRIPTION
Fixes `ActionController::RoutingError (No route matches [GET] "/favicon.ico")`
happening whenever the browsers tries to load a favicon without parsing the html layout first.

We just redirect to the right image path.
(In `StaticController` because that one does not require login.)

Cc @djberg96 :)