### PR TITLE
Set product_name and product_name_full as global javascript variable

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,6 +23,8 @@
       ManageIQ.charts.provider = "#{Charting.backend}";
       ManageIQ.browser = "#{j browser_info(:name_ui)}";
       ManageIQ.controller = "#{j controller_name}";
+      ManageIQ.product_name = "#{j I18n.t("product.name")}";
+      ManageIQ.product_name_full = "#{j I18n.t("product.name_full")}";
 
     - if ::Settings.server.asynchronous_notifications
       :javascript


### PR DESCRIPTION
This change is to make productization of certain UI strings, which live purely in React, possible.

```
> ManageIQ.product_name;
"ManageIQ"
> ManageIQ.product_name_full;
"ManageIQ"
```

while in productized version this would become:
```
> ManageIQ.product_name;
"CFME"
> ManageIQ.product_name_full;
"Red Hat CloudForms Management Engine"
```


![product-name](https://user-images.githubusercontent.com/6648365/59756616-62120100-928a-11e9-8466-78f39177443b.png)

@mturley

@himdel review please?