### PR TITLE
Display container Map Tag delete confirmation message

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -240,6 +240,7 @@ module OpsController::Settings::LabelTagMapping
       label_tag_mapping_get_all
       render :update do |page|
         page << javascript_prologue
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace_html('settings_label_tag_mapping', :partial => 'settings_label_tag_mapping_tab')
       end
     else

--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -30,7 +30,7 @@
                        :disabled          => disabled,
                        "data-miq_observe" => {:interval => '.5',
                                               :url      => url}.to_json)
-  %h3= _("Choose a tag category to map to")
+  %h3= _("Enter tag category to map to")
   .form-group
     %label.col-md-2.control-label
       = _("Category")


### PR DESCRIPTION
Fixes display of delete Map Tag delete action confirmation messages when successful. Also, changes wording on the Add Map tag page to say "Enter category for text box (as opposed to prior "Choose..." implying more than one selection. 
 
https://bugzilla.redhat.com/show_bug.cgi?id=1707328

Screen shot of Add Map Tag page with "Choose..." wording prior to code fix:
![Add new mapping prior to code fix](https://user-images.githubusercontent.com/552686/59804910-8aa6f480-92a4-11e9-910c-f77661df747f.png)

No "delete successful" confirmation message displayed prior to code fix, notice message from prior action of Add still displayed:
![Delete map tag message missing prior to code fix](https://user-images.githubusercontent.com/552686/59804945-a611ff80-92a4-11e9-9d6c-5c2276556c1d.png)

Add new Map Tag page post code fix with "Enter..." for category text box:
![Add new mapping post code fix](https://user-images.githubusercontent.com/552686/59805044-04d77900-92a5-11e9-9580-6bccd10ab161.png)

Delete Map Tag confirmation message displayed post code fix:
![Delete map tag message post code fix](https://user-images.githubusercontent.com/552686/59805083-1fa9ed80-92a5-11e9-8226-b66a98ab2f07.png)
