### PR TITLE
Do not let angular parse the treeview data as it can be 🐢 HUGE 🐌

### DIFF
--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -86,8 +86,9 @@
       vm.selectedNodes[tree] = vm.selectedNodes[tree] || { key: node };
     };
 
-    vm.initData = function(tree, data, selected) {
-      vm.data[tree] = vm.data[tree] || data;
+    vm.initData = function(tree, selected) {
+      vm.data[tree] = vm.data[tree] || ManageIQ.tree.data[tree];
+      ManageIQ.tree.data.delete(tree);
       vm.selectedNodes[tree] = vm.selectedNodes[tree] || { key: selected };
     };
 

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -83,6 +83,7 @@ if (!window.ManageIQ) {
       checkUrl: null,
       clickUrl: null,
       expandAll: true,
+      data: {},
     },
     widget: {
       dashboardUrl: null, // set dashboard widget drag drop url

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -6,10 +6,12 @@
       = miq_accordion_panel(accord[:title], selected == accord, accord[:container]) do
         -# Set the first tree to be rendered if there is a mismatch with the name/type
         - tree = @trees.find(-> { @trees.first }) { |t| t.name == "#{accord[:name]}_tree".to_sym  }
+        :javascript
+          ManageIQ.tree.data['#{tree.name}'] = #{tree.locals_for_render[:bs_tree]};
         %miq-tree-view{:name       => tree.name,
                        :data       => "vm.data['#{tree.name}']",
                        :reselect   => tree.locals_for_render[:allow_reselect],
-                       "ng-init"   => "vm.initData('#{tree.name}', #{tree.locals_for_render[:bs_tree]}, '#{tree.locals_for_render[:select_node]}')",
+                       "ng-init"   => "vm.initData('#{tree.name}', '#{tree.locals_for_render[:select_node]}')",
                        'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                        'selected'  => "vm.selectedNodes['#{tree.name}']",
                        'persist'   => 'key',

--- a/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
@@ -1,10 +1,12 @@
 - return if @display == 'generic_objects' || @display == 'main'
 = miq_accordion_panel(_("Generic Object Classes"), true, "god") do
+  :javascript
+    ManageIQ.tree.data['#{@tree.name}'] = #{@tree.locals_for_render[:bs_tree]};
   %tree_div{'ng-controller' => 'treeViewController as vm'}
     %miq-tree-view{:name       => @tree.name,
                    :data       => "vm.data['#{@tree.name}']",
                    :reselect   => @tree.locals_for_render[:allow_reselect],
-                   "ng-init"   => "vm.initData('#{@tree.name}', #{@tree.locals_for_render[:bs_tree]}, '#{@tree.locals_for_render[:select_node]}')",
+                   "ng-init"   => "vm.initData('#{@tree.name}', '#{@tree.locals_for_render[:select_node]}')",
                    'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
                    'selected'  => "vm.selectedNodes['#{@tree.name}']",
                    'persist'   => 'key',


### PR DESCRIPTION
I did some profiling around the TreeView with 5 thousand nodes and I realized that the bottleneck is in Angular and not the TreeView code. I asked @himdel about the problem and we realized that this was caused by a [bugfix](https://github.com/ManageIQ/manageiq-ui-classic/pull/3785) that started sending the tree data as an object instead of a string. The object is being parsed by angular and if it is 5MB, well :turtle: :snail: happens.

The solution is to get the data into the component in an alternative way, so preventing Angular from unnecessarily parsing it. Ideally this could be solved by having separate (UI-)API endpoints for trees, but we're not there yet. So our solution was to utilize the `ManageIQ.trees` global object by temporarily saving the data into it until the component gets a reference.

After this change the performance increase is significant, the bottleneck now is in the rendering which is totally fine. We can't really make the browser faster :wink: 

**Before:**
![Screenshot from 2019-06-20 13-57-40](https://user-images.githubusercontent.com/649130/59847659-665e1d00-9363-11e9-9ae5-7155e3e59403.png)

**After:**
![Screenshot from 2019-06-20 13-46-35](https://user-images.githubusercontent.com/649130/59847583-31ea6100-9363-11e9-9e0c-e73ad3b23d0e.png)

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 
@miq-bot add_label performance, bug, trees, hammer/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1703556