### PR TITLE
Policy Sim title fix

### DIFF
--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,9 +1,9 @@
 - url = url_for_only_path(:action => 'policy_sim_add')
 #main_div
-
-  %h1#explorer_title
-    %span#explorer_title_text
-      = @right_cell_text unless @explorer
+  - unless @explorer
+    %h1#explorer_title
+      %span#explorer_title_text
+        = @right_cell_text
   #flash_msg_div
     = render :partial => "layouts/flash_msg"
 


### PR DESCRIPTION
This PR is a followup to https://github.com/ManageIQ/manageiq-ui-classic/pull/5681, where my fix caused a double title when navigating via a VM summary screen.

https://bugzilla.redhat.com/show_bug.cgi?id=1717539

Old
<img width="1209" alt="Screen Shot 2019-06-20 at 10 10 08 AM" src="https://user-images.githubusercontent.com/1287144/59856202-6ef32b00-9344-11e9-8ae7-2f0ff44e458d.png">

New
<img width="1205" alt="Screen Shot 2019-06-20 at 10 09 44 AM" src="https://user-images.githubusercontent.com/1287144/59856201-6ef32b00-9344-11e9-8d6c-6d34ea64a243.png">
