### PR TITLE
Added missing Model name to return that is used to load advanced search

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -877,7 +877,7 @@ module ApplicationHelper
 
   def configuration_manager_scripts_tree(tree)
     case tree
-    when :automation_manager_cs_filter_tree
+    when :automation_manager_cs_filter_tree, :automation_manager_providers_tree
       "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem"
     when :configuration_manager_cs_filter_tree
       "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1722487

@himdel please review, prior to changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/5629 Advanced search was not visible in Automation Manager explorer which in itself was a bug but no one noticed that, after changes in above mentioned PR, model is being passed in an empty string from https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/automation_manager_controller.rb#L64 
Causing an error 
```
[----] F, [2019-06-20T11:47:52.978663 #6136:4f8de4c] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `name' for nil:NilClass
/home/hkataria/dev/manageiq/lib/miq_expression.rb:935:in `build_relats'
/home/hkataria/dev/manageiq/lib/miq_expression.rb:890:in `get_relats'
/home/hkataria/dev/manageiq/lib/miq_expression.rb:801:in `model_details'
/home/hkataria/dev/manageiq/lib/miq_expression.rb:901:in `miq_adv_search_lists'
/home/hkataria/dev/manageiq-ui-classic/app/views/layouts/exp_atom/_editor.html.haml:18:in `__home_hkataria_dev_manageiq_ui_classic_app_views_layouts_exp_atom__editor_html_haml__3781712013198181142_70283350359100'
```
This PR fixes to pass in correct model to `adv_search_build` call.