### PR TITLE
Use a named scope for loading assignable EMSes in BelongsToHac 🌳

### DIFF
--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -46,7 +46,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+    count_only_or_objects(count_only, ExtManagementSystem.assignable)
   end
 
   def x_get_provider_kids(parent, count_only)


### PR DESCRIPTION
Scopes are better as @kbrock said, we should not refer to DB objects in the UI when possible.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label trees, hammer/no, pending core

Depends on: https://github.com/ManageIQ/manageiq/pull/18903