### PR TITLE
Test if the @edit[:key] is set to prevent exceptions in Catalogs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -712,7 +712,7 @@ class CatalogController < ApplicationController
 
   def build_tenants_tree
     tenants = @record ? @record.additional_tenants : Tenant.where(:id => @edit[:new][:tenant_ids])
-    catalog_bundle = @edit.present? && @edit[:key].starts_with?('st_edit') # Get the info if adding/editing Catalog Item or Bundle; not important if only displaying
+    catalog_bundle = @edit.present? && @edit[:key] && @edit[:key].starts_with?('st_edit') # Get the info if adding/editing Catalog Item or Bundle; not important if only displaying
     TreeBuilderTenants.new('tenants_tree', @sb, true, :additional_tenants => tenants, :selectable => @edit.present?, :ansible_playbook => ansible_playbook_type?, :catalog_bundle => catalog_bundle)
   end
 


### PR DESCRIPTION
This bug has been indtroduced by #5445 and it's reproducible if you try to navigate to the catalog of a service from the service's summary screen. The problem is in `build_tenants_tree` where the existence of `@edit[:key]` is not tested properly before using its value.

This is just a simple fix to work around the issue, probably not the final solution as the whole implementation is a little messy. I am willing to do some cleanup, but I have other stuff to do right now and I. won't be available most of next week. Until then, this can work as a temporary solution.

@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @hstastna 
@miq-bot add_label bug, hammer/no, services

https://bugzilla.redhat.com/show_bug.cgi?id=1722478