### PR TITLE
Fixed issue introduced in c7536077b36b56ebbaa9fe9ec6bbcf22aab32248

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -149,8 +149,8 @@ module MiqPolicyController::AlertProfiles
     return unless load_edit("alert_profile_edit__#{params[:id]}", "replace_cell__explorer")
     @alert_profile = @edit[:alert_profile_id] ? MiqAlertSet.find(@edit[:alert_profile_id]) : MiqAlertSet.new
 
-    @edit[:new][:description] = params[:description].presence
-    @edit[:new][:notes] = params[:notes].presence
+    @edit[:new][:description] = params[:description].presence if params[:description]
+    @edit[:new][:notes] = params[:notes].presence if params[:notes]
 
     send_button_changes
   end

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -94,6 +94,26 @@ describe MiqPolicyController do
       end
     end
 
+    context '#alert_profile_field_changed' do
+      before do
+        @ap = FactoryBot.create(:miq_alert_set)
+        allow(controller).to receive(:send_button_changes)
+        edit = {
+          :key => "alert_profile_edit__#{@ap.id}",
+          :new => {:name => "foo", :description => "foo description"}
+        }
+        session[:edit] = edit
+      end
+
+      it 'Edit of notes field does not reset value of description field' do
+        controller.params = {:id => @ap.id, :notes => 'foo note'}
+        controller.alert_profile_field_changed
+        edit_new = assigns(:edit)[:new]
+        expect((edit_new)[:description]).to eq("foo description")
+        expect((edit_new)[:notes]).to eq("foo note")
+      end
+    end
+
     context "#alert_profile_assign_changed" do
       before do
         alert_profile_set = FactoryBot.create(:miq_alert_set, :set_type => "MiqAlertSet", :mode => "MiqServer")


### PR DESCRIPTION
When saving `Notes` field value, it was setting `Description` to blank, causing flash error on screen

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1723815

before
![before](https://user-images.githubusercontent.com/3450808/60112894-a6941580-973e-11e9-985a-b1bce5c7a02e.png)

after
![after](https://user-images.githubusercontent.com/3450808/60112896-a72cac00-973e-11e9-937f-8d5f2e428343.png)
