### PR TITLE
Ids in specs

### DIFF
--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -292,7 +292,7 @@ describe EmsCloudController do
   end
 
   context "#update_ems_button_validate" do
-    let(:mocked_ems) { double(ManageIQ::Providers::Openstack::CloudManager, :id => 1) }
+    let(:mocked_ems) { FactoryBot.create(:ems_openstack) }
 
     it "calls authentication_check with save = false" do
       allow(controller).to receive(:set_ems_record_vars)

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -308,7 +308,7 @@ end
 
 describe EmsInfraController do
   context "#show_link" do
-    let(:ems) { double(EmsInfra, :id => 1) }
+    let(:ems) { FactoryBot.create(:ems_infra) }
     it "sets relative url" do
       controller.instance_variable_set(:@table_name, "ems_infra")
       link = controller.send(:show_link, ems, :display => "vms")

--- a/spec/controllers/guest_device_controller_spec.rb
+++ b/spec/controllers/guest_device_controller_spec.rb
@@ -7,7 +7,7 @@ describe GuestDeviceController do
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
-    @guest_device = FactoryBot.create(:guest_device, :id => 1)
+    @guest_device = FactoryBot.create(:guest_device)
   end
 
   describe "#show_list" do

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -80,7 +80,7 @@ describe MiqPolicyController do
           end
 
           context "when there is not an error while importing" do
-            let(:import_file_upload) { double("ImportFileUpload", :id => 123) }
+            let(:import_file_upload) { FactoryBot.create(:import_file_upload) }
 
             before do
               allow(miq_policy_import_service).to receive(:store_for_import).and_return(import_file_upload)
@@ -98,7 +98,7 @@ describe MiqPolicyController do
 
             it "redirects to import with the import_file_upload_id" do
               post :upload, :params => params
-              expect(response).to redirect_to(:action => "import", :dbtype => "dbtype", :import_file_upload_id => 123)
+              expect(response).to redirect_to(:action => "import", :dbtype => "dbtype", :import_file_upload_id => import_file_upload.id)
             end
           end
 

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -216,22 +216,22 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   describe "#ancestry_parents" do
-    let(:service1) { FactoryBot.create(:service, :id => 1, :name => "Level 1", :ancestry => nil) }
-    let(:service2) { FactoryBot.create(:service, :id => 2, :name => "Level 2", :ancestry => "1") }
-    let(:service3) { FactoryBot.create(:service, :id => 3, :name => "Level 3", :ancestry => "2") }
+    let(:service1) { FactoryBot.create(:service, :ancestry => nil) }
+    let(:service2) { FactoryBot.create(:service, :ancestry => service1.id) }
+    let(:service3) { FactoryBot.create(:service, :ancestry => service2.id) }
 
     it "creates one level nested breadcrumbs" do
       expect(Service).to receive(:find).and_return(service1)
-      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-1")
-      expect(mixin.ancestry_parents(Service, service2, :name)).to eq([{:title => service1.name, :key => "xx-1"}])
+      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service1.id}")
+      expect(mixin.ancestry_parents(Service, service2, :name)).to eq([{:title => service1.name, :key => "xx-#{service1.id}"}])
     end
 
     it "creates two level nested breadcrumbs" do
       expect(Service).to receive(:find).and_return(service2, service1)
-      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-2", "xx-1")
+      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service2.id}", "xx-#{service1.id}")
       expect(mixin.ancestry_parents(Service, service3, :name)).to eq([
-                                                                       {:title => service1.name, :key => "xx-1"},
-                                                                       {:title => service2.name, :key => "xx-2"},
+                                                                       {:title => service1.name, :key => "xx-#{service1.id}"},
+                                                                       {:title => service2.name, :key => "xx-#{service2.id}"},
                                                                      ])
     end
   end

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -1,7 +1,5 @@
 shared_examples "logs_collect" do |type|
   let(:klass) { type.classify.constantize }
-  let(:zone) { double("Zone", :name => "foo") }
-  let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
   before do
     sb_hash = {
       :trees            => {:diagnostics_tree => {:active_node => active_node}},
@@ -10,7 +8,7 @@ shared_examples "logs_collect" do |type|
       :active_tab       => "diagnostics_roles_servers"
     }
     controller.instance_variable_set(:@sb, sb_hash)
-    allow(MiqServer).to receive(:my_server).and_return(server)
+    EvmSpecHelper.local_miq_server
   end
 
   it "not running" do

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -1,8 +1,6 @@
 describe OpsController do
   let(:params) { {} }
   let(:session) { {} }
-  let(:zone) { double("Zone", :name => "foo") }
-  let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
   let(:schedule) { FactoryBot.create(:miq_automate_schedule) }
   let(:schedule_new) { MiqSchedule.new }
   let(:user) { stub_user(:features => :all) }
@@ -10,8 +8,7 @@ describe OpsController do
   include_context "valid session"
 
   before do
-    allow(MiqServer).to receive(:my_server).and_return(server)
-    allow(server).to receive(:zone_id).and_return(1)
+    EvmSpecHelper.local_miq_server
     stub_user(:features => :all)
   end
 

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -107,15 +107,12 @@ describe OpsController do
   end
 
   context "#schedule_set_record_vars" do
-    let(:zone) { double("Zone", :name => "foo") }
-    let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
     let(:user) { stub_user(:features => :all) }
     let(:schedule) { FactoryBot.create(:miq_automate_schedule) }
     let(:vm) { FactoryBot.create(:vm_vmware) }
 
     before do
-      allow(MiqServer).to receive(:my_server).and_return(server)
-      allow(server).to receive(:zone_id).and_return(1)
+      EvmSpecHelper.local_miq_server
       stub_user(:features => :all)
     end
 
@@ -169,14 +166,11 @@ describe OpsController do
   end
 
   context "#build_attrs_from_params" do
-    let(:zone) { double("Zone", :name => "foo") }
-    let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
     let(:user) { stub_user(:features => :all) }
     let(:vm) { FactoryBot.create(:vm_vmware) }
 
     before do
-      allow(MiqServer).to receive(:my_server).and_return(server)
-      allow(server).to receive(:zone_id).and_return(1)
+      EvmSpecHelper.local_miq_server
       stub_user(:features => :all)
     end
 

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -6,7 +6,7 @@ describe PhysicalChassisController do
   let(:physical_chassis) do
     ems = FactoryBot.create(:ems_redfish_physical_infra)
     asset_detail = FactoryBot.create(:asset_detail)
-    FactoryBot.create(:physical_chassis, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+    FactoryBot.create(:physical_chassis, :ems_id => ems.id, :asset_detail => asset_detail)
   end
 
   before do

--- a/spec/controllers/physical_rack_controller_spec.rb
+++ b/spec/controllers/physical_rack_controller_spec.rb
@@ -3,7 +3,7 @@ describe PhysicalRackController do
 
   let(:physical_rack) do
     ems = FactoryBot.create(:ems_redfish_physical_infra)
-    FactoryBot.create(:physical_rack, :ems_id => ems.id, :id => 1)
+    FactoryBot.create(:physical_rack, :ems_id => ems.id)
   end
 
   before do

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -13,8 +13,7 @@ describe PhysicalServerController do
     @physical_server = FactoryBot.create(:physical_server,
                                           :asset_detail    => asset_detail,
                                           :computer_system => computer_system,
-                                          :ems_id          => ems.id,
-                                          :id              => 1)
+                                          :ems_id          => ems.id)
   end
 
   describe "#provision" do

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -4,7 +4,7 @@ describe PhysicalStorageController do
   let(:physical_storage) do
     ems = FactoryBot.create(:ems_redfish_physical_infra)
     asset_detail = FactoryBot.create(:asset_detail)
-    FactoryBot.create(:physical_storage, :ems_id => ems.id, :id => 1, :asset_detail => asset_detail)
+    FactoryBot.create(:physical_storage, :ems_id => ems.id, :asset_detail => asset_detail)
   end
 
   before do

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -11,7 +11,6 @@ describe PhysicalSwitchController do
       :hardware     => hardware,
       :asset_detail => asset_detail,
       :ems_id       => ems.id,
-      :id           => 1
     )
   end
 

--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -1,6 +1,6 @@
 describe PictureController do
   let(:picture_content) { "BINARY IMAGE CONTENT" }
-  let(:picture) { FactoryBot.create(:picture, :id => 10_000_000_000_005, :extension => "jpg") }
+  let(:picture) { FactoryBot.create(:picture, :extension => "jpg") }
 
   before do
     stub_user(:features => :all)

--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -2,7 +2,7 @@ describe ComplianceSummaryHelper do
   include ApplicationHelper
 
   before do
-    server  = FactoryBot.build(:miq_server, :id => 0)
+    server  = FactoryBot.build(:miq_server)
     @record = FactoryBot.build(:vm_vmware, :miq_server => server)
     @compliance1 = FactoryBot.build(:compliance)
     @compliance2 = FactoryBot.build(:compliance)

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe VmHelper::TextualSummary do
   it "#textual_server" do
-    server  = FactoryBot.build(:miq_server, :id => 99999)
+    server  = FactoryBot.build(:miq_server)
     @record = FactoryBot.build(:vm_vmware, :miq_server => server)
     expect(helper.textual_server).to eq("#{server.name} [#{server.id}]")
   end

--- a/spec/helpers/vm_helper_spec.rb
+++ b/spec/helpers/vm_helper_spec.rb
@@ -3,7 +3,7 @@
 describe VmHelper do
   describe "#last_date_processes" do
     it "supports vm with os and processes" do
-      server = FactoryBot.build(:miq_server, :id => 99_999)
+      server = FactoryBot.build(:miq_server)
       operating_system = FactoryBot.build(:operating_system)
       @record = FactoryBot.create(:vm_vmware, :miq_server => server, :operating_system => operating_system)
       now = Time.now.utc

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -5,8 +5,8 @@ describe TreeBuilderDatastores do
       @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Datastores Group")
       login_as FactoryBot.create(:user, :userid => 'datastores_wilma', :miq_groups => [@group])
       @host = FactoryBot.create(:host, :name => 'Host Name')
-      FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
-      @datastore = [{:id => 1, :name => 'Datastore', :location => 'Location', :capture => false}]
+      storage = FactoryBot.create(:storage, :hosts => [@host])
+      @datastore = [{:id => storage.id, :name => 'Datastore', :location => 'Location', :capture => false}]
       @datastores_tree = TreeBuilderDatastores.new(:datastore, {}, true, :root => @datastore)
     end
     it 'sets tree to have full ids, not lazy and no root' do

--- a/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
@@ -1,13 +1,7 @@
 describe "catalog/_sandt_tree_show.html.haml" do
-  let(:admin_user) { FactoryBot.create(:user_admin, :userid => 'admin') }
-  let(:bundle) do
-    FactoryBot.create(:service_template, :name         => 'My Bundle',
-                                         :id           => 1,
-                                         :service_type => "composite",
-                                         :display      => true,
-                                         :tenant       => tenant)
-  end
-  let(:tenant) { FactoryBot.create(:tenant) }
+  let(:admin_user) { FactoryBot.create(:user_admin) }
+  let(:bundle)     { FactoryBot.create(:service_template, :service_type => "composite", :display => true, :tenant => tenant) }
+  let(:tenant)     { FactoryBot.create(:tenant) }
 
   before do
     set_controller_for_view("catalog")
@@ -20,7 +14,7 @@ describe "catalog/_sandt_tree_show.html.haml" do
 
   it "Renders bundle summary screen" do
     render
-    expect(rendered).to include('My Bundle')
+    expect(rendered).to include(bundle.name)
     expect(rendered).to include(bundle.tenant.name)
   end
 end

--- a/spec/views/layouts/list_grid.html.haml_spec.rb
+++ b/spec/views/layouts/list_grid.html.haml_spec.rb
@@ -3,7 +3,7 @@ describe "layouts/_list_grid.html.haml" do
     it "renders" do
       allow(view).to receive(:options).and_return(:grid_hash => {:head => [], :rows => []})
       allow(view).to receive(:js_options).and_return(:row_url => '_none_')
-      record = EmsInfra.new(:id => 1)
+      record = FactoryBot.create(:ems_infra)
       assign(:parent, record)
       render
     end


### PR DESCRIPTION
Don't set `id`, `name` and other things that are sequenced in tests unless it needs to be set.  `id` is particularly bad because our tests need to be region aware.

Unfortunately there are more... `git grep ":id\s*=>\s*[0-9]"`