### PR TITLE
EvmSpecHelper.local_miq_server already creates a zone

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -1,6 +1,5 @@
 describe ApplicationController do
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.create(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   before do
     EvmSpecHelper.local_miq_server
@@ -781,8 +780,7 @@ describe ApplicationController do
 end
 
 describe HostController do
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.create(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   describe "#show_association" do
     before do

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -1,6 +1,5 @@
 describe GenericObjectController do
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.build(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   describe "#show" do
     render_views

--- a/spec/controllers/generic_object_definition_controller_spec.rb
+++ b/spec/controllers/generic_object_definition_controller_spec.rb
@@ -1,6 +1,5 @@
 describe GenericObjectDefinitionController do
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.build(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   describe "#show" do
     render_views

--- a/spec/controllers/guest_device_controller_spec.rb
+++ b/spec/controllers/guest_device_controller_spec.rb
@@ -1,8 +1,7 @@
 describe GuestDeviceController do
   render_views
 
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.build(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   before do
     stub_user(:features => :all)

--- a/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/rename_spec.rb
@@ -42,8 +42,7 @@ describe Mixins::Actions::VmActions::Rename do
 
   describe '#rename_save' do
     let(:controller) { VmInfraController.new }
-    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryBot.create(:zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server }
 
     before do
       allow(controller).to receive(:session).and_return(:userid => 'admin')

--- a/spec/controllers/physical_chassis_controller_spec.rb
+++ b/spec/controllers/physical_chassis_controller_spec.rb
@@ -11,7 +11,7 @@ describe PhysicalChassisController do
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
+    EvmSpecHelper.local_miq_server
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
   end

--- a/spec/controllers/physical_rack_controller_spec.rb
+++ b/spec/controllers/physical_rack_controller_spec.rb
@@ -8,7 +8,7 @@ describe PhysicalRackController do
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
+    EvmSpecHelper.local_miq_server
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
   end

--- a/spec/controllers/physical_server_controller_spec.rb
+++ b/spec/controllers/physical_server_controller_spec.rb
@@ -1,8 +1,7 @@
 describe PhysicalServerController do
   render_views
 
-  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-  let(:zone) { FactoryBot.build(:zone) }
+  let!(:server) { EvmSpecHelper.local_miq_server }
 
   before do
     stub_user(:features => :all)

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -9,7 +9,7 @@ describe PhysicalStorageController do
 
   before do
     stub_user(:features => :all)
-    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
+    EvmSpecHelper.local_miq_server
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
   end

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -16,7 +16,7 @@ describe PhysicalSwitchController do
   end
 
   before do
-    EvmSpecHelper.local_miq_server(:zone => FactoryBot.build(:zone))
+    EvmSpecHelper.local_miq_server
     stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)

--- a/spec/controllers/physical_switch_controller_spec.rb
+++ b/spec/controllers/physical_switch_controller_spec.rb
@@ -18,7 +18,6 @@ describe PhysicalSwitchController do
   before do
     EvmSpecHelper.local_miq_server
     stub_user(:features => :all)
-    EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
   end
 

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -23,8 +23,7 @@ describe PxeController do
   end
 
   describe 'x_button' do
-    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryBot.create(:zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server }
 
     before do
       ApplicationController.handle_exceptions = true

--- a/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
+++ b/spec/views/shared/views/ems_common/_show.html.haml_spec.rb
@@ -4,9 +4,8 @@ describe "shared/views/ems_common/show" do
     TestSetup.new(:ems_openstack, EmsCloudHelper::TextualSummary),
     TestSetup.new(:ems_vmware,    EmsInfraHelper::TextualSummary),
   ].each do |setup|
-    let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
-    let(:zone) { FactoryBot.create(:zone) }
-    let(:ems) { FactoryBot.create(setup.ems_type, :hostname => '1.1.1.1', :zone => zone) }
+    let!(:server) { EvmSpecHelper.local_miq_server }
+    let(:ems) { FactoryBot.create(setup.ems_type, :zone => server.zone) }
     let(:action) { 'index' }
 
     before do
@@ -49,7 +48,7 @@ describe "shared/views/ems_common/show" do
 
     let(:showtype) { "main" }
     let(:display) { 'cloud_volumes' }
-    let(:ems) { FactoryBot.create(:ems_storage, :hostname => '1.1.1.1') }
+    let(:ems) { FactoryBot.create(:ems_storage) }
 
     it "should show render gtl for list of cloud_volumes" do
       render


### PR DESCRIPTION
No need to set the zone if it isn't used somewhere else in the spec.  The factory for `:miq_server` will create a zone for you.