### PR TITLE
Do not filter records when loading Pre Provisioning screen.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1145,8 +1145,9 @@ class ApplicationController < ActionController::Base
     # Don't apply sub_filter when viewing sub-list view of a CI.
     # This applies when search is active and you go Vm -->
     # {Processes,Users,...} in that case, search shoult NOT be applied.
+    # If loading a form such as provisioning, don't filter records
     # FIXME: This needs to be changed to apply search in some explicit way.
-    return nil if @display
+    return nil if @display || @in_a_form
 
     # If we came in through Chart pop-up menu click we don't filter records.
     return nil if session[:menu_click]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1723899

Apply named search 
![apply_named_search](https://user-images.githubusercontent.com/3450808/60135915-da882e80-9770-11e9-8e7f-1c27bcfe210f.png)

before
![before1](https://user-images.githubusercontent.com/3450808/60135954-f2f84900-9770-11e9-979f-e3cdc9dbce54.png)

after
![after1](https://user-images.githubusercontent.com/3450808/60135922-df4ce280-9770-11e9-868d-e58dd7677c2f.png)
