### PR TITLE
Fix catalog item delete when part of catalog bundle

### DIFF
--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -5,8 +5,11 @@ import { Modal } from 'patternfly-react';
 import { API } from '../http_api';
 
 const parseApiError = (error) => {
-  const { data: { error: { message } } } = error;
-  return message;
+  if (error.hasOwnProperty('data')) {
+    return error.data.error.message;
+  } else if (error.hasOwnProperty('message')) {
+    return error.message;
+  }
 };
 
 export const removeCatalogItems = (catalogItems) => {
@@ -15,7 +18,7 @@ export const removeCatalogItems = (catalogItems) => {
   miqSparkleOn();
   catalogItems.forEach(item => {
     apiPromises.push(API.post(`/api/service_templates/${item.id}`, {action: 'delete'}, {skipErrors: [400, 500]})
-                       .then((apiResult) => ({result: 'success', data: apiResult, name: item.name}))
+                       .then((apiResult) => ({result: apiResult.success ? 'success' : 'error', data: apiResult, name: item.name}))
                        .catch((apiResult) => ({result: 'error', data: apiResult, name: item.name})))
   });
   Promise.all(apiPromises)


### PR DESCRIPTION
1. Create catalog item `catalog01`
2. Create catalog bundle `bundle01` with `catalog01` in it
3. Try to delete `catalog01` in UI

Previously, the UI would report successful deletion, although in truth no deletion would take place. In this particular case, for the delete request the API returns `http/200` and the following JSON:
```json
{"success":false,"message":"Cannot delete a service that is the child of another service."}
```
so we need to adjust our code accordingly.

With the proposed fix in place:
![catalog-item-delete](https://user-images.githubusercontent.com/6648365/60194340-6a91ab00-9839-11e9-81fe-b567955bdb47.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1356086