### PR TITLE
Return nil when special breadcrumb title is empty

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -69,13 +69,14 @@ module Mixins
       # EMS has key instead of name
       return unless variable
       if variable.first[:key]
-        {:title => variable.first[:key]}
+        title = variable.first[:key]
       # FloatingIps do not have name
       elsif floating_ip_address?(variable.first)
-        {:title => variable.first[:address]}
+        title = variable.first[:address]
       else
-        {:title => variable.first[:name]}
+        title = variable.first[:name]
       end
+      {:title => title} if title
     end
 
     # Explorer controller methods

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -203,6 +203,16 @@ describe Mixins::BreadcrumbsMixin do
         )
       end
     end
+
+    context "when no title" do
+      before do
+        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}])
+      end
+
+      it "returns nil" do
+        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(nil)
+      end
+    end
   end
 
   describe "#ancestry_parents" do


### PR DESCRIPTION
Solves https://github.com/ManageIQ/manageiq-ui-classic/issues/5698

`Configuration` > `Access Control` > Select a group > `Policy` > `Edit tags...`

**Description**

When `special_breadcrumb` method (used for obtaining title when tagging, ownership, etc.) is empty, it returns `nil` instead of `{:title => nil}`. Nil is removed when breadcrumbs array is compacted.

**Before**

![image](https://user-images.githubusercontent.com/32869456/60261998-759e1700-98dd-11e9-8c4d-b9842961bfd0.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/60262042-92d2e580-98dd-11e9-89f1-3cfa7b030951.png)

@miq-bot add_label bug, breadcrumbs, hammer/no