### PR TITLE
[HAMMER] Rescue the right kind of error from the dialog field circular reference checker

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -48,7 +48,7 @@ class MiqAeCustomizationController < ApplicationController
         add_flash(_("Error: the file uploaded is not of the supported format"), :error)
       rescue DialogImportValidator::ParsedNonDialogYamlError
         add_flash(_("Error during upload: incorrect Dialog format, only service dialogs can be imported"), :error)
-      rescue DialogImportValidator::DialogFieldAssociationCircularReferenceError
+      rescue DialogFieldAssociationValidator::DialogFieldAssociationCircularReferenceError
         add_flash(_("Error during upload: the following dialog fields to be imported contain circular association references: %{error}") % {:error => $ERROR_INFO}, :error)
       rescue DialogImportValidator::InvalidDialogFieldTypeError
         add_flash(_("Error during upload: one of the DialogField types is not supported"), :error)

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -289,13 +289,13 @@ describe MiqAeCustomizationController do
       context "when the dialog importer raises a circular reference error" do
         before do
           allow(dialog_import_service).to receive(:store_for_import)
-            .and_raise(DialogImportValidator::DialogFieldAssociationCircularReferenceError)
+            .and_raise(DialogFieldAssociationValidator::DialogFieldAssociationCircularReferenceError)
         end
 
         it "redirects with an error message" do
           post :upload_import_file, :params => params, :xhr => true
           expect(controller.instance_variable_get(:@flash_array))
-            .to include(:message => "Error during upload: the following dialog fields to be imported contain circular association references: DialogImportValidator::DialogFieldAssociationCircularReferenceError",
+            .to include(:message => "Error during upload: the following dialog fields to be imported contain circular association references: DialogFieldAssociationValidator::DialogFieldAssociationCircularReferenceError",
                         :level   => :error)
         end
       end


### PR DESCRIPTION
The dialog field circular reference checker got refactored (https://github.com/ManageIQ/manageiq/pull/18890) and backported to hammer and this fixes the specs broken by that and changes the error inheritance to be correct. 

Related master PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5755

@miq-bot assign @simaishi 