### PR TITLE
Fix overrided color for disabled Timelines link

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -635,6 +635,9 @@ table.table tbody td img {
 
 /// Overrides patternfly style for disabled accordion items
 
+.nav-stacked > li.disabled > a {
+  color: #9c9c9c;
+}
 .nav-stacked > li.disabled:hover > a {
   background: transparent;
   border: transparent;


### PR DESCRIPTION
Before:
![1724496-before](https://user-images.githubusercontent.com/1630348/60518120-e151fc80-9cae-11e9-8b2f-2cab9a30b4bc.png)

After:
![1724496-after](https://user-images.githubusercontent.com/1630348/60518117-deefa280-9cae-11e9-9487-ed68f1cfcad8.png)

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1724496