### PR TITLE
fix miq task conditions

### DIFF
--- a/product/views/MiqTask.yaml
+++ b/product/views/MiqTask.yaml
@@ -61,7 +61,7 @@ headers:
 - Server
 
 # Condition(s) string for the SQL query
-conditions: {}
+conditions:
 
 # Order string for the SQL query
 order: Descending


### PR DESCRIPTION
In report.yaml file, `conditions:` contain an MiqExpression or null
It should not contain a hash.

No other reports or views contain a hash

This PR changes the conditions to a null

@miq-bot add_label hammer/no, technical debt, automation/ansible tower, changelog/no