### PR TITLE
Revert faster services PR 5366 

### DIFF
--- a/product/views/Service.yaml
+++ b/product/views/Service.yaml
@@ -17,9 +17,6 @@ name: Service
 # Main DB table report is based on
 db: Service
 
-db_options:
-  :use_sql_view: true
-
 # Columns to fetch from the main table
 cols:
 - name


### PR DESCRIPTION
We were able to speed up the services page, but we lost sorting and proper pagination. So we are temporarily reverting #5366

This reverts commit 3f609dab512cf49350cb10545d2a80ca9b343a0d, reversing
changes made to 2f31e65a702754ef962432a3f1e10bd4ff8b1b55.

Fixes:  https://bugzilla.redhat.com/show_bug.cgi?id=1722491

NOTE: This page is now slow again. This change and other code fixes will need to be introduced again in another PR.

@miq-bot add_label bug, hammer/yes, services
