### PR TITLE
Ensure replication related flash messages show task name

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -194,7 +194,7 @@ module OpsController::Settings::Common
     end
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
     add_flash(_("Replication configuration save initiated. Check status of task \"%{task_name}\" on MyTasks screen") %
-                {:task_name => task_opts[:action]})
+                {:task_name => task_opts[:name]})
     javascript_flash
   end
 

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -193,7 +193,7 @@ module OpsController::Settings::Common
       queue_opts = {:class_name => "MiqRegion", :method_name => "replication_type=", :args => [:none]}
     end
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
-    add_flash(_("Replication configuration save initiated. Check status of task \"%{task_name}\" on MyTasks screen") %
+    add_flash(_("Replication configuration save initiated. Check status of task \"%{task_name}\" on My Tasks screen") %
                 {:task_name => task_opts[:name]})
     javascript_flash
   end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -222,6 +222,12 @@ describe OpsController do
           queue_item = MiqQueue.find_by(:method_name => "replication_type=")
           expect(queue_item.args).to eq([:remote])
         end
+
+        it "task name is visible in the resulting flash message" do
+          controller.params = params
+          controller.send(:pglogical_save_subscriptions)
+          expect(assigns(:flash_array).first[:message]).to eq("Replication configuration save initiated. Check status of task \"Configure the database to be a replication remote region\" on MyTasks screen")
+        end
       end
 
       context "global" do

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -226,7 +226,7 @@ describe OpsController do
         it "task name is visible in the resulting flash message" do
           controller.params = params
           controller.send(:pglogical_save_subscriptions)
-          expect(assigns(:flash_array).first[:message]).to eq("Replication configuration save initiated. Check status of task \"Configure the database to be a replication remote region\" on MyTasks screen")
+          expect(assigns(:flash_array).first[:message]).to eq("Replication configuration save initiated. Check status of task \"Configure the database to be a replication remote region\" on My Tasks screen")
         end
       end
 


### PR DESCRIPTION
Fixes issue caused by https://github.com/ManageIQ/manageiq/pull/18578  Psst, @djberg96...

Before:
![1726306-before](https://user-images.githubusercontent.com/1630348/60535791-e759d480-9cd2-11e9-84ab-348761306514.png)

After:
![1726306-after](https://user-images.githubusercontent.com/1630348/60537941-9c8e8b80-9cd7-11e9-97c8-039159960050.png)

@miq-bot add_labels bug, settings

https://bugzilla.redhat.com/show_bug.cgi?id=1726306