### PR TITLE
Handle nil options and missing keys in ansible credentials

### DIFF
--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -17,17 +17,22 @@ module AnsibleCredentialHelper::TextualSummary
 
       define_singleton_method "textual_#{key}" do
         h = {:label => _(value[:label]), :title => _(value[:help_text])}
-        h[:value] = if value[:type] == :password && (@record.try(key).present? || @record.options[key].present?)
-                      '●●●●●●●●'
-                    else
-                      @record.try(key) || @record.options[key]
-                    end
+        h[:value] = attribute_value(value[:type], key, @record)
         h
       end
     end
 
     TextualGroup.new(_("Credential Options"), options)
   end
+
+  def attribute_value(attr_type, key, rec)
+    if attr_type == :password && (rec.try(key).present? || rec.options[key].present?)
+      '●●●●●●●●'
+    else
+      rec.try(key) || rec.options[key]
+    end
+  end
+  private :attribute_value
 
   def textual_group_smart_management
     TextualTags.new(_("Smart Management"), %i[tags])

--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -26,10 +26,10 @@ module AnsibleCredentialHelper::TextualSummary
   end
 
   def attribute_value(attr_type, key, rec)
-    if attr_type == :password && (rec.try(key).present? || rec.options[key].present?)
+    if attr_type == :password && (rec.try(key).present? || rec.options.try(:[], key).present?)
       '●●●●●●●●'
     else
-      rec.try(key) || rec.options[key]
+      rec.try(key) || rec.options.try(:[], key)
     end
   end
   private :attribute_value

--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -16,9 +16,11 @@ module AnsibleCredentialHelper::TextualSummary
       options << key
 
       define_singleton_method "textual_#{key}" do
-        h = {:label => _(value[:label]), :title => _(value[:help_text])}
-        h[:value] = attribute_value(value[:type], key, @record)
-        h
+        {
+          :label => _(value[:label]),
+          :title => _(value[:help_text]),
+          :value => attribute_value(value[:type], key, @record)
+        }
       end
     end
 
@@ -26,11 +28,8 @@ module AnsibleCredentialHelper::TextualSummary
   end
 
   def attribute_value(attr_type, key, rec)
-    if attr_type == :password && (rec.try(key).present? || rec.options.try(:[], key).present?)
-      '●●●●●●●●'
-    else
-      rec.try(key) || rec.options.try(:[], key)
-    end
+    val = (rec.try(key) || rec.options.try(:[], key)).presence
+    attr_type == :password && val ? '●●●●●●●●' : val
   end
   private :attribute_value
 

--- a/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
+++ b/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
@@ -2,4 +2,36 @@ describe AnsibleCredentialHelper::TextualSummary do
   include_examples "textual_group_smart_management"
   include_examples "textual_group", "Properties", %i(name type created updated)
   include_examples "textual_group", "Relationships", %i(repositories)
+
+  describe "#attribute_value (private)" do
+    it "returns a masked password for present passwords" do
+      rec = double(:secret => "password", :options => nil)
+      expect(send(:attribute_value, :password, :secret, rec)).to eq("●●●●●●●●")
+    end
+
+    it "returns a masked password for password typed options" do
+      rec = double(:options => {:secret => "password"})
+      expect(send(:attribute_value, :password, :secret, rec)).to eq("●●●●●●●●")
+    end
+
+    it "returns nil if a password field isn't present" do
+      rec = double(:thing => "stuff", :options => nil)
+      expect(send(:attribute_value, :password, :secret, rec)).to be_nil
+    end
+
+    it "returns a non-password attribute" do
+      rec = double(:thing => "stuff", :options => nil)
+      expect(send(:attribute_value, :string, :thing, rec)).to eq("stuff")
+    end
+
+    it "returns a non-password option" do
+      rec = double(:options => {:thing => "stuff"})
+      expect(send(:attribute_value, :string, :thing, rec)).to eq("stuff")
+    end
+
+    it "returns nil if a key isn't present" do
+      rec = double(:secret => "password", :options => nil)
+      expect(send(:attribute_value, :string, :thing, rec)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
The options field for ansible credentials can be nil as the options column in the authentications table is nullable.

This PR fixes the ansible credential textual summary helper to handle situations where we attempt to display fields that could be in options and are not and adds tests for these situations.

Gist of an example failure => https://gist.github.com/carbonin/06148fb88ccba952a2f4f43d332b3d20
This happens when navigating to the credential details page for a machine credential with a `nil` `options` column.

@miq-bot assign @mzazrivec 