### PR TITLE
Fixed  deleting users

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -255,8 +255,7 @@ module OpsController::OpsRbac
       else
         restricted_users = []
         users.each do |u|
-          user = User.find(u)
-          restricted_users.push(user) if rbac_user_delete_restriction?(user)
+          restricted_users.push(u) if rbac_user_delete_restriction?(u)
         end
         # deleting elements in temporary array, had to create temp array to hold id's to be delete, .each gets confused if i deleted them in above loop
         restricted_users.each do |u|


### PR DESCRIPTION
Before upgrading rails to `5.1` it was permitted to pass ```ActiveRecord::Base```  ```find``` method. After upgrade:
```
FATAL -- : Error caught: [ArgumentError] You are passing an instance of ActiveRecord::Baseto `find`. Please pass the id of the object by calling `.id`.
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:451:in `find_one'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:440:in `find_with_ids'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/relation/finder_methods.rb:66:in `find'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/querying.rb:3:in `find'
/opt/rh/cfme-gemset/gems/activerecord-5.1.7/lib/active_record/core.rb:178:in `find'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-0ec3c0afca82/app/controllers/ops_controller/ops_rbac.rb:258:in `block in rbac_user_delete'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-0ec3c0afca82/app/controllers/ops_controller/ops_rbac.rb:257:in `each'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-0ec3c0afca82/app/controllers/ops_controller/ops_rbac.rb:257:in `rbac_user_delete'

```

**BEFORE:** no Flash message, test-admin user not deleted and above error message in the log

**AFTER:**
![Screen Shot 2019-07-03 at 8 48 06 AM](https://user-images.githubusercontent.com/6556758/60592898-90560d00-9d6f-11e9-9d02-786f4532c131.png)




https://bugzilla.redhat.com/show_bug.cgi?id=1720273

@miq-bot add-label rails5.1,  bug, changelog/no