### PR TITLE
Remove duplicate tagging edit buttons for Services

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -459,8 +459,8 @@ class ServiceController < ApplicationController
         presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
       else
         locals = {:record_id => @edit[:rec_id], :action_url => action_url}
+        presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals])
       end
-      presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals]) unless action == "ownership"
     elsif (action != "retire") && (record_showing ||
         (@pages && (@items_per_page == ONE_MILLION || @pages[:items] == 0)))
       # Added so buttons can be turned off even tho div is not being displayed it still pops up Abandon changes box


### PR DESCRIPTION
Remove duplicate tagging edit buttons for Services

Screenshots
----------------
Before:
![Screenshot from 2019-06-20 18-24-44](https://user-images.githubusercontent.com/9535558/60587027-be4d4880-9d93-11e9-9d68-6552438eb330.png)

After:
![Screenshot from 2019-07-03 13-09-53](https://user-images.githubusercontent.com/9535558/60587095-dfae3480-9d93-11e9-8d9d-5b99977346e2.png)



Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1722480


Steps for Testing/QA [Optional]
-------------------------------
1.Provision the service 
2.Go to My service page-> Go to Active service details page 
3.From Policy click on Edit Tags
