### PR TITLE
Remove password fields from ansible credentials details page

### DIFF
--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -12,14 +12,16 @@ module AnsibleCredentialHelper::TextualSummary
   def textual_group_options
     options = []
 
-    @record.type.constantize::API_ATTRIBUTES.each do |key, value|
+    @record.class::API_ATTRIBUTES.each do |key, value|
+      next if value[:type] == :password
+
       options << key
 
       define_singleton_method "textual_#{key}" do
         {
           :label => _(value[:label]),
           :title => _(value[:help_text]),
-          :value => attribute_value(value[:type], key, @record)
+          :value => attribute_value(key, @record)
         }
       end
     end
@@ -27,9 +29,8 @@ module AnsibleCredentialHelper::TextualSummary
     TextualGroup.new(_("Credential Options"), options)
   end
 
-  def attribute_value(attr_type, key, rec)
-    val = (rec.try(key) || rec.options.try(:[], key)).presence
-    attr_type == :password && val ? '●●●●●●●●' : val
+  def attribute_value(key, rec)
+    (rec.try(key) || rec.options.try(:[], key)).presence
   end
   private :attribute_value
 

--- a/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
+++ b/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
@@ -3,35 +3,66 @@ describe AnsibleCredentialHelper::TextualSummary do
   include_examples "textual_group", "Properties", %i(name type created updated)
   include_examples "textual_group", "Relationships", %i(repositories)
 
+  class TestClass
+    API_ATTRIBUTES = {
+      :userid          => {
+        :label     => N_('Username'),
+        :help_text => N_('Username for this credential')
+      },
+      :password        => {
+        :type      => :password,
+        :label     => N_('Password'),
+        :help_text => N_('Password for this credential')
+      },
+      :ssh_key_data    => {
+        :type      => :password,
+        :multiline => true,
+        :label     => N_('Private key'),
+        :help_text => N_('RSA or DSA private key to be used instead of password')
+      },
+      :become_method   => {
+        :type      => :choice,
+        :label     => N_('Privilege Escalation'),
+        :help_text => N_('Privilege escalation method'),
+        :choices   => ['', 'sudo', 'su', 'pbrun', 'pfexec']
+      },
+      :become_username => {
+        :type       => :string,
+        :label      => N_('Privilege Escalation Username'),
+        :help_text  => N_('Privilege escalation username'),
+        :max_length => 1024
+      }
+    }.freeze
+  end
+
+  describe "#textual_group_options" do
+    before { @record = TestClass.new }
+
+    it "doesn't return options for password types" do
+      expect(textual_group_options.items).to match_array(%i[userid become_method become_username])
+    end
+
+    context "defines the textual methods" do
+      before { textual_group_options }
+
+      include_examples "method_exists", %i[textual_userid textual_become_method textual_become_username]
+    end
+  end
+
   describe "#attribute_value (private)" do
-    it "returns a masked password for present passwords" do
-      rec = double(:secret => "password", :options => nil)
-      expect(send(:attribute_value, :password, :secret, rec)).to eq("●●●●●●●●")
-    end
-
-    it "returns a masked password for password typed options" do
-      rec = double(:options => {:secret => "password"})
-      expect(send(:attribute_value, :password, :secret, rec)).to eq("●●●●●●●●")
-    end
-
-    it "returns nil if a password field isn't present" do
+    it "returns an attributes value" do
       rec = double(:thing => "stuff", :options => nil)
-      expect(send(:attribute_value, :password, :secret, rec)).to be_nil
+      expect(send(:attribute_value, :thing, rec)).to eq("stuff")
     end
 
-    it "returns a non-password attribute" do
-      rec = double(:thing => "stuff", :options => nil)
-      expect(send(:attribute_value, :string, :thing, rec)).to eq("stuff")
-    end
-
-    it "returns a non-password option" do
+    it "returns an options value" do
       rec = double(:options => {:thing => "stuff"})
-      expect(send(:attribute_value, :string, :thing, rec)).to eq("stuff")
+      expect(send(:attribute_value, :thing, rec)).to eq("stuff")
     end
 
     it "returns nil if a key isn't present" do
       rec = double(:secret => "password", :options => nil)
-      expect(send(:attribute_value, :string, :thing, rec)).to be_nil
+      expect(send(:attribute_value, :thing, rec)).to be_nil
     end
   end
 end


### PR DESCRIPTION
This removes the need for masking passwords. Also add specs to
ensure that #textual_group_options doesn't return any fields
marked as a password type

Here's a before and after of the credentials details page

Before:
![image](https://user-images.githubusercontent.com/12697904/60625981-5577c780-9db7-11e9-9215-7d4cd9a80238.png)

After:
![image](https://user-images.githubusercontent.com/12697904/60625811-e39f7e00-9db6-11e9-97f8-21a563be1791.png)

---------------------------------------

Marking this as WIP initially as it builds on #5770 
