### PR TITLE
Fix cancel, save and select_tree actions in breadcrumbs and title in PXE menu section

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -10,13 +10,20 @@ module Mixins
       c.after_action(:x_node_text_save_to_session)
     end
 
+    # These actions won't generate additional breadcrumb with their right_cell_text
+    PROHIBITED_ACTIONS_TREE = %w[explorer tree_select accordion_select].freeze
+
+    # Save actions buttons
+    PROHIBITED_PARAMS_BUTTONS = %w[cancel save add].freeze
+
     # Main method which creates all breadcrumbs and returns them (to view page which will parse them into breadcrumbs nav)
-    def data_for_breadcrumbs
+    def data_for_breadcrumbs(controller_options = {})
       options = breadcrumbs_options || {}
       options[:record_info] ||= (@record || {})
       options[:record_title] ||= :name
       options[:not_tree] ||= false
       options[:hide_title] ||= false
+
       breadcrumbs = options[:breadcrumbs] || []
 
       # Different methods for controller with explorers and for non-explorers controllers
@@ -35,6 +42,7 @@ module Mixins
         end
       else
         options[:x_node] ||= x_node
+        right_cell_text = controller_options[:right_cell_text] || title_for_breadcrumbs
 
         self.x_node_text = params[:text] if action_name == "tree_select" # get text of the active node
 
@@ -44,7 +52,7 @@ module Mixins
         # On special page (tagitems, politems, etc.)
         if @tagitems || @politems || @ownershipitems || @retireitems
           breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems, true, options[:x_node])) unless options[:hide_special_item]
-          breadcrumbs.push(:title => @right_cell_text)
+          breadcrumbs.push(:title => right_cell_text)
         else
           # Ancestry parents breadcrumbs (only in services)
           breadcrumbs.concat(ancestry_parents(options[:ancestry], options[:record_info], options[:record_title])) if options[:ancestry]
@@ -71,7 +79,7 @@ module Mixins
           #          4. Fallbacks (sent text, title of the record, title_for_breadcrumbs)
           key = node ? node.key : options[:x_node]
           title = if options[:x_node] == 'root' # After switching accordion, there is no way how to get root text
-                    title_for_breadcrumbs
+                    right_cell_text
                   elsif node                    # Use node's text and key
                     node.text
                   elsif @trees.present?         # Select a node when coming from different page (the tree is built)
@@ -85,15 +93,16 @@ module Mixins
           # Append seperate action header breadcrumb when there is some action
           # (User is not on show page)
           # i.e. editing, copying, adding, etc.
-          extra_title = title_for_breadcrumbs || @title
+          extra_title = right_cell_text || @title
           breadcrumbs.push(:title => extra_title) if action_breadcrumb? && extra_title && title != extra_title
         end
       end
       breadcrumbs.compact
     end
 
+    # append action right_cell_text if actions is not prohibited
     def action_breadcrumb?
-      @sb["action"]
+      !PROHIBITED_ACTIONS_TREE.include?(action_name) && !PROHIBITED_PARAMS_BUTTONS.include?(params[:button])
     end
 
     def build_breadcrumbs_no_explorer(record_info, record_title)

--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -31,7 +31,7 @@ class OptimizationController < ApplicationController
     }
   end
 
-  def data_for_breadcrumbs
+  def data_for_breadcrumbs(*)
     breadcrumbs_options[:breadcrumbs].compact
   end
   helper_method :data_for_breadcrumbs

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -193,6 +193,7 @@ class PxeController < ApplicationController
 
     # FIXME: check where @right_cell_text is set and replace that with loca variable
     presenter[:right_cell_text] = right_cell_text || @right_cell_text
+
     if !@view || @in_a_form ||
        (@pages && (@items_per_page == ONE_MILLION || @pages[:items]&.zero?))
       if @in_a_form
@@ -250,7 +251,12 @@ class PxeController < ApplicationController
     presenter[:osf_node] = x_node
     presenter[:lock_sidebar] = @in_a_form && @edit
 
-    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
+    presenter.update(:breadcrumbs, r[
+      :partial => "layouts/breadcrumbs",
+      :locals  => {
+        :right_cell_text => right_cell_text || @right_cell_text,
+      }
+    ])
 
     render :json => presenter.for_render
   end
@@ -266,7 +272,6 @@ class PxeController < ApplicationController
   end
 
   def breadcrumbs_options
-    @right_cell_text = "editing" unless @edit.nil?
     {
       :breadcrumbs => [
         {:title => _("Compute")},

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,1 +1,5 @@
-= react('Breadcrumbs', { :items => (data_for_breadcrumbs if respond_to?(:data_for_breadcrumbs)), :controllerName => controller_name, :title => @title })
+- right_cell_text ||= @right_cell_text
+= react('Breadcrumbs',
+        :items => (data_for_breadcrumbs({:right_cell_text => right_cell_text}) if respond_to?(:data_for_breadcrumbs)),
+        :controllerName => controller_name,
+        :title => @title)

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -82,6 +82,7 @@ describe Mixins::BreadcrumbsMixin do
       before do
         allow(subject).to receive(:x_node).and_return("xx-1")
         allow(subject).to receive(:x_node_right_cell).and_return("xx-1")
+        allow(subject).to receive(:params).and_return({})
         allow(TreeBuilderUtilization).to receive(:new).and_return(tree)
         allow(tree).to receive(:tree_nodes).and_return(tree_nodes)
       end
@@ -140,6 +141,41 @@ describe Mixins::BreadcrumbsMixin do
               {:title => service_2.name, :key => "xx-#{service_2.id}"},
             ]
           )
+        end
+      end
+
+      describe "#action_breadcrumb?" do
+        let(:options) do
+          {
+            :right_cell_text => 'Record Edit of Item 1'
+          }
+        end
+
+        before do
+          subject.instance_variable_set(:@sb, :explorer => true, :action => 'record_edit')
+          subject.instance_variable_set(:@trees, [tree])
+        end
+
+        it "returns action breadcrumb" do
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Record Edit of Item 1")
+        end
+
+        it "not return action breadcrumb if cancel button" do
+          allow(subject).to receive(:params).and_return(:button => 'cancel')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
+        end
+
+        it "not return action breadcrumb if actions is prohibited to build breadcrumb" do
+          allow(subject).to receive(:action_name).and_return('tree_select')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
+        end
+
+        it "not return action breadcrumb if save button" do
+          allow(subject).to receive(:params).and_return(:button => 'save')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
         end
       end
 


### PR DESCRIPTION
**Description**

- fixes breadcrumbs after pressing cancel and selecting in trees - breadcrumbs won't show headers of action after the cancel, save, add or selecting in a tree, there is no need to clear `sb :action` anymore
- fixes breadcrumbs in PXE menu section - breadcrumb mixin accepts 'right_cell_text' as a local parameter from presenter

**Before**

![image](https://user-images.githubusercontent.com/32869456/61304918-397a1a00-a7ea-11e9-98b7-1915d13e7927.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/61304896-2ff0b200-a7ea-11e9-970e-ce473f1e961d.png)

@miq-bot add_label breadcrumbs, changelog/no, hammer/no, compute/infrastructure, bug