### PR TITLE
Revert the sandbox variable refactoring on Settings/Diagnostics trees

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -857,14 +857,10 @@ module OpsController::Diagnostics
                    else
                      TreeBuilderServersByRole.new(:servers_by_role_tree, @sb, true, :root => parent)
                    end
-
-    return if @record # Do not continue if the @record is already initialized
-
-    # Pull out the selected node from the tree state and store it in the sandbox for future use
-    prefix, @sb[:diag_selected_id] = x_node(@server_tree.name).split('-')
-    @sb[:diag_selected_model] = TreeBuilder.get_model_for_prefix(prefix)
-    @record = @sb[:diag_selected_model].constantize.find(@sb[:diag_selected_id]) # Set the current record
-    @rec_status = @record.assigned_server_roles.find_by(:active => true) ? "active" : "stopped" if @record.class == ServerRole
+    if @sb[:diag_selected_id]
+      @record = @sb[:diag_selected_model].constantize.find(@sb[:diag_selected_id]) # Set the current record
+      @rec_status = @record.assigned_server_roles.find_by(:active => true) ? "active" : "stopped" if @record.class == ServerRole
+    end
   end
 
   # Get information for a node

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -9,11 +9,6 @@ class TreeBuilderDiagnostics < TreeBuilder
   private
 
   def tree_init_options
-    {
-      :open_all        => true,
-      :click_url       => "/ops/diagnostics_tree_select/",
-      :onclick         => "miqOnClickDiagnostics",
-      :silent_activate => true
-    }
+    {:open_all => true, :click_url => "/ops/diagnostics_tree_select/", :onclick => "miqOnClickDiagnostics"}
   end
 end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -7,8 +7,18 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
     x_get_tree_miq_servers
   end
 
+  def override(node, _object, _pid, _options)
+    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+      node[:highlighted] = true
+    end
+  end
+
   def x_get_tree_miq_servers
     @root.miq_servers.sort_by { |s| s.name.to_s }.each_with_object([]) do |server, objects|
+      unless @sb[:diag_selected_id] # Set default selected record vars
+        @sb[:diag_selected_model] = server.class.to_s
+        @sb[:diag_selected_id] = server.id
+      end
       objects.push(server)
     end
   end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -7,12 +7,22 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
     x_get_tree_server_roles
   end
 
+  def override(node, _object, _pid, _options)
+    if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
+      node[:highlighted] = true
+    end
+  end
+
   def x_get_tree_server_roles
     ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region
       next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
                   (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
       next if r.name == "database_owner"
+      unless @sb[:diag_selected_id] # Set default selected record vars
+        @sb[:diag_selected_model] = r.class.to_s
+        @sb[:diag_selected_id] = r.id
+      end
       objects.push(r)
     end
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -64,7 +64,7 @@ describe TreeBuilderRolesByServer do
                                   'state'          => {'expanded' => true},
                                   'selectable'     => true,
                                   'class'          => ''},],
-                'state'      => {'expanded' => true},
+                'state'      => {'expanded' => true, 'selected' => true},
                 'class'      => ''}]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -66,7 +66,7 @@ describe TreeBuilderServersByRole do
                                   'state'          => { 'expanded' => true },
                                   'selectable'     => true,
                                   'class'          => ''}],
-                'state'      => { 'expanded' => true},
+                'state'      => { 'expanded' => true, "selected" => true},
                 'class'      => '' }]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end


### PR DESCRIPTION
These two issues with diagnostics (server by roles and roles by server) trees under configuration have been introduced by #5389 and #5661. As some parts of the first PR are being used elsewhere, I reverted the related commits only.

We will need more tests in the area trying to refactor this for the second run. Setting a sandbox variable inside a `TreeBuilder` is a bad practice and we should avoid it, but here it created a technical debt so complex that the refactoring is painful (as you see the bugs).

@miq-bot assign @h-kataria 
@miq-bot add_label bug, trees, hammer/no

* Revert "Do not reinitalize the @record when building Server/Roles trees"
This reverts commit 452a00f6db3315bf7d6aad202fd434bd0bcf6dc8.

* Revert "Extract the sandbox variables from the Server/Roles tree builders"
This reverts commit a0ef88b2d700805795cf9d7563e5ca4ac15488ee.

* Revert "Highlight the tree node in Roles/Servers trees using silent_activate"
This reverts commit c4ce58146012bf4912710c3f4d34b9761af0e7f7.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724747
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726345