### PR TITLE
Adjust the test against the accordion name at saved reports

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -10,7 +10,7 @@ module ReportController::SavedReports
   end
 
   def show_saved_report
-    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && params[:id] != "savedreports"
+    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && !params[:id].to_s.start_with?("savedreports")
     fetch_saved_report(@sb[:last_savedreports_id])
   end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1338,6 +1338,13 @@ describe ReportController do
           fetched_report.id = @rpt.id # Reports serialized into the report column don't have ids
           expect(fetched_report).to eq(@rpt)
         end
+
+        it "doesn't set the report id upon an accordion change" do
+          controller.params = {:id => "savedreports_accord"}
+          controller.instance_variable_set(:@sb, :last_savedreports_id => 123)
+          expect(controller).to receive(:fetch_saved_report).with(123)
+          controller.send(:show_saved_report)
+        end
       end
     end
   end


### PR DESCRIPTION
The accordion name got an extra prefix (guessing since the angular-bootstrap update) but a test for fetching a saved report hasn't been adjusted to that.

@miq-bot assign @h-kataria 
@miq-bot add_label bug, hammer/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724209