### PR TITLE
Fix Object Attribute Type selection for Group and Tenant

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -436,7 +436,7 @@ Methods updated/added: %{method_stats}") % stat_options)
     #   @resolve[:new][:target_attr_name] = params[:target_attr_name] if params.has_key?(:target_attr_name)
     if params.key?(:target_class)
       @resolve[:new][:target_class] = params[:target_class]
-      targets = Rbac.filtered(params[:target_class]).select(:id, :name) if params[:target_class].present?
+      targets = Rbac.filtered(params[:target_class]).select(:id, *columns_for_klass(params[:target_class])) if params[:target_class].present?
       unless targets.nil?
         @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
         @resolve[:new][:target_id] = nil

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -17,20 +17,6 @@ module OpsController::Settings::AutomateSchedules
     }
   end
 
-  def name_included?(klass)
-    klass.safe_constantize.column_names.include?('name')
-  end
-
-  def columns_for_klass(klass)
-    if klass == 'Tenant'
-      [:name, :use_config_for_attributes]
-    elsif name_included?(klass)
-      [:name]
-    else
-      [:description]
-    end
-  end
-
   def fetch_target_ids
     if params[:target_class] && params[:target_class] != 'null'
       targets = Rbac.filtered(params[:target_class]).select(:id, *columns_for_klass(params[:target_class]))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1313,4 +1313,15 @@ module ApplicationHelper
 
     provider.try(:enabled?) == false
   end
+
+  # Return a proper column for an appropriate target klass
+  def columns_for_klass(klass)
+    if klass == 'Tenant'
+      [:name, :use_config_for_attributes]
+    elsif klass.safe_constantize.column_names.include?('name')
+      [:name]
+    else
+      [:description]
+    end
+  end
 end


### PR DESCRIPTION
**Fixes BZ:**
https://bugzilla.redhat.com/show_bug.cgi?id=1719322

**What:**
When selecting `Group` or `Tenant` _Type_ for _Object Attribute_ for Automation Simulation, errors occurred. This PR fixes them.
For EVM Group, there was only `description` column, instead of `name`.
For Tenant, `use_config_for_attributes` was missing.

**Details:**
The problem occurred here: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/miq_ae_tools_controller.rb#L439
The same problem was fixed here: https://github.com/ManageIQ/manageiq-ui-classic/pull/5321 so I moved the method to application helper, available for different controllers, so then scenario from https://github.com/ManageIQ/manageiq-ui-classic/pull/5321 remains working. Please, let me know if you think the method should be somewhere else.

**Steps to reproduce:**
1. Go to _Automation > Automate > Simulation_
2. Select `Group` or `Tenant` _Type_ for _Object Attribute_
3. See the _Selection_ dropdown
=> values are not loaded, the drop down with the values is completely missing + error:
```
[----] I, [2019-07-08T11:53:56.415601 #17371:3fb6aa783a5c]  INFO -- : NotificationChannel is transmitting the subscription confirmation
[----] I, [2019-07-08T11:53:56.415902 #17371:3fb6aa783a5c]  INFO -- : NotificationChannel is streaming from notifications_1
[----] I, [2019-07-08T11:54:02.488440 #17371:2ac32688f8c4]  INFO -- : Started POST "/miq_ae_tools/form_field_changed/new?target_class=MiqGroup" for 127.0.0.1 at 2019-07-08 11:54:02 +0200
[----] I, [2019-07-08T11:54:02.538719 #17371:2ac32688f8c4]  INFO -- : Processing by MiqAeToolsController#form_field_changed as JS
[----] I, [2019-07-08T11:54:02.538863 #17371:2ac32688f8c4]  INFO -- :   Parameters: {"target_class"=>"MiqGroup", "id"=>"new"}
[----] F, [2019-07-08T11:54:02.555835 #17371:2ac32688f8c4] FATAL -- : Error caught: [ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column "name" does not exist
LINE 1: SELECT "miq_groups"."id", "name" FROM "miq_groups"
                                  ^
: SELECT "miq_groups"."id", "name" FROM "miq_groups"
```
or
```
[----] I, [2019-07-08T11:56:45.190073 #17722:3febb84e832c]  INFO -- : NotificationChannel is transmitting the subscription confirmation
[----] I, [2019-07-08T11:56:45.190486 #17722:3febb84e832c]  INFO -- : NotificationChannel is streaming from notifications_1
[----] I, [2019-07-08T11:56:47.810093 #17722:2abb8cae4864]  INFO -- : Started POST "/miq_ae_tools/form_field_changed/new?target_class=Tenant" for 127.0.0.1 at 2019-07-08 11:56:47 +0200
[----] I, [2019-07-08T11:56:47.844772 #17722:2abb8cae4864]  INFO -- : Processing by MiqAeToolsController#form_field_changed as JS
[----] I, [2019-07-08T11:56:47.844959 #17722:2abb8cae4864]  INFO -- :   Parameters: {"target_class"=>"Tenant", "id"=>"new"}
[----] F, [2019-07-08T11:56:47.867035 #17722:2abb8cae4864] FATAL -- : Error caught: [ActiveModel::MissingAttributeError] missing attribute: use_config_for_attributes
```

**Before:**
![tenant_before](https://user-images.githubusercontent.com/13417815/60802183-a5b8a600-a178-11e9-8e33-1e37d75fe64d.png)

**After:**
Choosing _Group_ Object Attribute Type => displaying appropriate groups in the next drop down
![group_after](https://user-images.githubusercontent.com/13417815/60802420-1eb7fd80-a179-11e9-8fdd-c55537053c0b.png)
Choosing _Tenant_ Object Attribute Type => displaying appropriate tenant(s) in the next drop down
![tenant_after](https://user-images.githubusercontent.com/13417815/60802424-21b2ee00-a179-11e9-8a26-7c4183d27796.png)
