### PR TITLE
Add a rubocop channel to the codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -73,6 +73,7 @@ plugins:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: rubocop-0-69
   stylelint:
     enabled: true
 prepare:


### PR DESCRIPTION
See ManageIQ/manageiq#18840 for more information

Unfortunately there's no way to use a centralized .codeclimate, so we have to set the configuration files individually.