### PR TITLE
Fix displaying 'Add a Provider' page on a fresh appliance

### DIFF
--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -49,9 +49,8 @@ class UserValidationService
 
     # Start super admin at the main db if the main db has no records yet
     # If the main db has no records the default starting view is set to "Infrastructure Provider" view - the idea here is there is no point showing another view since it would be empty.
-    return validate_user_handle_no_records if db_user.super_admin_user? &&
-                                              ::Settings.product.maindb &&
-                                              !::Settings.product.maindb.constantize.first
+    # The above is true except Embedded Ansible provider which is added by default
+    return validate_user_handle_no_records if db_user.super_admin_user? && no_records?
 
     startpage = start_url_for_user(start_url)
     unless startpage
@@ -61,6 +60,12 @@ class UserValidationService
   end
 
   private
+
+  def no_records?
+    if ::Settings.product.maindb
+      ::Settings.product.maindb.constantize.count <= ::ManageIQ::Providers::EmbeddedAnsible::AutomationManager.count
+    end
+  end
 
   def validate_user_handle_no_records
     ValidateResult.new(:pass, nil, url_for_only_path(:controller => "ems_infra", :action => 'show_list'))

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -176,6 +176,33 @@ describe DashboardController do
       expect(validation.flash_msg).to be_nil
       expect(validation.url).to eq('some_url')
     end
+
+    context 'handling no records and super admin user' do
+      let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+      let(:emb_ansible) { FactoryBot.create(:provider_embedded_ansible) }
+      let(:providers) { [emb_ansible] }
+
+      before do
+        allow(User).to receive(:authenticate).and_return(user)
+        allow(controller).to receive(:session).and_return(:start_url => '/dashboard/show')
+        allow(::Settings.product.maindb).to receive(:constantize).and_return(providers)
+      end
+
+      subject { controller.send(:validate_user, user) }
+
+      it 'redirects to Infrastructure Providers page if no records found' do
+        expect(subject.url).to eq('/ems_infra/show_list')
+      end
+
+      context 'some provider present' do
+        let(:vmware) { FactoryBot.create(:ems_vmware) }
+        let(:providers) { [emb_ansible, vmware] }
+
+        it 'displays the dashboard' do
+          expect(subject.url).to eq('/dashboard/show')
+        end
+      end
+    end
   end
 
   context "Create Dashboard" do


### PR DESCRIPTION
**Fixes BZ:**
https://bugzilla.redhat.com/show_bug.cgi?id=1726721

**What:**
The core of the problem is that, newly, new provider was added (Embedded Ansible) and it is preinstalled on MIQ by default, so after user (super admin) logs in, it behaves according to the code => Default dashboard is displayed, instead of expected 'Add a Provider' page, as it was in the past. So the code needs to be updated according to the new circumstance. However, there are more options to solve the situation. I decided to fix this in the same place where the problem takes shape. Feel free to add comments, ideas.

**Note:**
I was able to reproduce the BZ locally. I've tested the fix with empty and non-empty DB, and it works.

**Before:**
![login_before](https://user-images.githubusercontent.com/13417815/60816430-073d3c80-a19a-11e9-86b5-226b8266100d.png)

**After:**
![login_after](https://user-images.githubusercontent.com/13417815/60816436-0ad0c380-a19a-11e9-80d9-076dd8d9c87d.png)
