### PR TITLE
Show affected servers on PhysicalServerFirmwareUpdateRequest

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -806,7 +806,7 @@ module ApplicationController::MiqRequestMethods
       if (service_id = @miq_request.options[:src_ids].first) && (service = Service.find_by(:id => service_id)) && Rbac.filtered_object(service)
         @view, @pages = get_view(Vm, :parent => service, :view_suffix => 'OrchestrationStackRetireRequest')
       end
-    elsif @miq_request.resource_type == 'PhysicalServerProvisionRequest'
+    elsif %w[PhysicalServerProvisionRequest PhysicalServerFirmwareUpdateRequest].include?(@miq_request.resource_type)
       @selected_ids = @miq_request.options[:src_ids]
       @view, @pages = get_view(PhysicalServer, :view_suffix => 'PhysicalServerProvisionRequest')
     else

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -127,7 +127,7 @@
     = render :partial => "service_retire_show"
   - elsif @miq_request.type == "AutomationRequest"
     = render :partial => "ae_prov_show"
-  - elsif @miq_request.type == "PhysicalServerProvisionRequest"
+  - elsif %w[PhysicalServerProvisionRequest PhysicalServerFirmwareUpdateRequest].include?(@miq_request.type)
     = render :partial => "physical_server_provision_show"
   - else
     = render :partial => "reconfigure_show"


### PR DESCRIPTION
Same as https://github.com/ManageIQ/manageiq-ui-classic/pull/5461, but for firmware update instead provisioning.

@miq-bot add_label enhancement
@miq-bot assign @mzazrivec 
