### PR TITLE
vm_common#reload spec - prevent sporadic failure when folder id matches vm id

### DIFF
--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -52,6 +52,7 @@ describe VmOrTemplateController do
       allow(controller).to receive(:tree_select).and_return(nil)
       @folder = FactoryBot.create(:ems_folder)
       @vm = FactoryBot.create(:vm_cloud)
+      @vm = FactoryBot.create(:vm_cloud) if @folder.id == @vm.id # prevent sporadic failure
     end
 
     it 'sets params[:id] to hidden vm if its summary is displayed' do
@@ -60,7 +61,6 @@ describe VmOrTemplateController do
       controller.reload
       expect(controller.params[:id]).to eq("v-#{@vm.id}")
     end
-
   end
 
   describe "#show" do


### PR DESCRIPTION
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/555818466:
```
Failures:
  1) VmOrTemplateController#reload  sets params[:id] to hidden vm if its summary is displayed
     Failure/Error: expect(controller.params[:id]).to eq("v-#{@vm.id}")
       expected: "v-33000000000001"
            got: "f-33000000000001"
       (compared using ==)
     # ./spec/controllers/vm_common_spec.rb:61:in `block (3 levels) in <top (required)>'
```

The [controller code](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/vm_common.rb#L81-L85) is probably subtly wrong, but I'm not sure *how*:
  * If the id param should always win, maybe `params[:id].present? ? "v-#{params[:id]}" : x_node` would be the best solution in `reload`.
  * If `x_node` should win, it's not clear when.

But, when both the folder id and the vm id are the same, the code does not behave as expected.
Fixing in test for now.

(seed to reproduce sporadic failure: 47803)
