### PR TITLE
Set value of hash to be deleted from saved data.

### DIFF
--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -529,9 +529,8 @@ module OpsController::Settings::AnalysisProfiles
     temp = {}
     CATEGORY_CHOICES.each_key do |checkbox_name|
       if params["check_#{checkbox_name}"]
-        if params["check_#{checkbox_name}"] != "null"
-          temp["target"] = checkbox_name
-        else
+        temp["target"] = checkbox_name
+        if params["check_#{checkbox_name}"] == "null"
           @edit[:new][item_type][:definition]["content"].delete(temp)
           temp = {}
         end


### PR DESCRIPTION
When a category is unchecked in the UI, correct data was not being set to be deleted from saved version of data.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1727929

after
![after](https://user-images.githubusercontent.com/3450808/60844453-4d4ccd00-a1a7-11e9-89d9-8c9ce75976ea.png)
