### PR TITLE
Fix the wording Job -> Task.

### DIFF
--- a/app/helpers/application_helper/toolbar/tasks_center.rb
+++ b/app/helpers/application_helper/toolbar/tasks_center.rb
@@ -53,7 +53,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
       :miq_task_canceljob,
       'fa fa-ban fa-lg',
       N_('Cancel the selected task'),
-      N_('Cancel Job'),
+      N_('Cancel Task'),
       :url_parms    => "main_div",
       :send_checked => true,
       :confirm      => N_("Warning: The selected task will be cancelled. Are you sure you want to cancel the task?"),


### PR DESCRIPTION

![job](https://user-images.githubusercontent.com/51095/60995687-4a8edb00-a353-11e9-83eb-ad0e8427b324.png)
Fix inconsistend wording label vs tooltip vs rest of the UI.