### PR TITLE
Fix the title/tooltip attribute setting for TreeNode::Menu::Item

### DIFF
--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -3,7 +3,7 @@ module TreeNode
     class Item < TreeNode::Menu::Node
       set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.feature}" }
 
-      set_attribute(:text, :tooltip) do
+      set_attributes(:text, :tooltip) do
         details = ::MiqProductFeature.obj_features[@object.feature].try(:[], :feature).try(:details)
         [_(details[:name]), _(details[:description]) || _(details[:name])]
       end


### PR DESCRIPTION
The fratures tree under RBAC/roles displayed wrong node titles because of a typo in `set_attributes` made it `set_attribute` which can't handle the array as the return value in its block.

**Before:**
![Screenshot from 2019-07-12 12-25-07](https://user-images.githubusercontent.com/649130/61121717-2d1b5780-a4a0-11e9-8bc8-d1198a0f4bf0.png)

**After:**
![Screenshot from 2019-07-12 12-23-25](https://user-images.githubusercontent.com/649130/61121720-31477500-a4a0-11e9-865d-89d65ca0c583.png)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label bug, hammer/no, trees