### PR TITLE
Hide Tenant Name for Infra and Cloud providers in list views for non-admin users

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -12,6 +12,15 @@ class EmsCloudController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  # when methods are evaluated from this constant and return true that means: column is displayed
+  DISPLAY_GTL_METHODS = [
+    :user_super_admin?
+  ].freeze
+
+  def user_super_admin?
+    current_user.super_admin_user?
+  end
+
   def self.model
     ManageIQ::Providers::CloudManager
   end

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -11,6 +11,15 @@ class EmsInfraController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  # when methods are evaluated from this constant and return true that means: column is displayed
+  DISPLAY_GTL_METHODS = [
+    :user_super_admin?
+  ].freeze
+
+  def user_super_admin?
+    current_user.super_admin_user?
+  end
+
   def self.model
     ManageIQ::Providers::InfraManager
   end

--- a/product/views/ManageIQ_Providers_CloudManager.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager.yaml
@@ -73,6 +73,10 @@ headers:
 - Tenant
 - Region
 
+col_options:
+  tenant.name:
+    :display_method: user_super_admin?
+
 # Condition(s) string for the SQL query
 conditions:
 

--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -88,6 +88,10 @@ headers:
 - Tenant
 - Region
 
+col_options:
+  tenant.name:
+    :display_method: user_super_admin?
+
 # Condition(s) string for the SQL query
 conditions:
 


### PR DESCRIPTION
Non admin(=super-admin) logged:
👀 look on Tenant column.



before
CLOUD provider list
<img width="1459" alt="Screenshot 2019-07-12 at 14 17 49" src="https://user-images.githubusercontent.com/14937244/61127566-e7ff2180-a4af-11e9-9b1d-9d31b844ec4a.png">


INFRA provider list


<img width="1459" alt="Screenshot 2019-07-12 at 14 20 37" src="https://user-images.githubusercontent.com/14937244/61127680-43311400-a4b0-11e9-8dd5-6ea79aa94e0f.png">

**after**

CLOUD provider list
<img width="1453" alt="Screenshot 2019-07-12 at 14 16 51" src="https://user-images.githubusercontent.com/14937244/61127577-ec2b3f00-a4af-11e9-9253-13e39c962885.png">

INFRA provider list
<img width="1454" alt="Screenshot 2019-07-12 at 14 16 12" src="https://user-images.githubusercontent.com/14937244/61127581-edf50280-a4af-11e9-884e-18112529dff4.png">



# Links
hiding mechanism has been implemented and used here for service templates: 
https://github.com/ManageIQ/manageiq-ui-classic/pull/5616

https://bugzilla.redhat.com/show_bug.cgi?id=1678122


@miq-bot assign @himdel 

