### PR TITLE
Adjust the test against accordion name in saved reports (part 2)

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -2,7 +2,7 @@ module ReportController::SavedReports
   extend ActiveSupport::Concern
 
   def show_saved
-    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report"
+    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report" && !params[:id].to_s.start_with?("savedreports")
     fetch_saved_report(@sb[:last_saved_id])
     if @report.blank? # if report was nil. reset active tree back to report tree, and keep active node report to be same
       self.x_active_tree = :reports_tree


### PR DESCRIPTION
Followup on https://github.com/ManageIQ/manageiq-ui-classic/pull/5779, somehow missed it.

@miq-bot add_label bug, hammer/no
@miq-bot assign @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724209