### PR TITLE
Remove whitespace from attribute name

### DIFF
--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -9,7 +9,7 @@
                               "name"        => "instance_name",
                               "ng-options"  => "instance for instance in scheduleModel.instance_names",
                               "checkchange" => "",
-                              "miq-select " => true}
+                              "miq-select" => true}
 
     .form-group
       %label.col-md-2.control-label{"for" => "object_message"}


### PR DESCRIPTION
```
$ be rake locale:plugin:find[ManageIQ::UI::Classic]
** override_gem("manageiq-ui-classic", :path=>"/home/milan/src/manage-iq/manageiq-ui-classic") at /home/milan/src/manage-iq/manageiq/bundler.d/pry.rb:5
** Using session_store: ActionDispatch::Session::MemCacheStore
** ManageIQ master, codename: Ivanchuk
Error parsing /home/milan/src/manage-iq/manageiq-ui-classic/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
rake aborted!
Haml::InvalidAttributeNameError: Invalid attribute name 'miq-select ' was rendered
/home/milan/src/manage-iq/manageiq/lib/tasks/locale.rake:210:in `block (2 levels) in <top (required)>'
/home/milan/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/home/milan/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => gettext:po:update => gettext:po:ja:update => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.po => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.edit.po => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ManageIQ_UI_Classic.pot
(See full trace by running task with --trace)
```