### PR TITLE
Fix Chargeback tree for report

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -310,7 +310,7 @@ class TreeBuilder
 
   def count_only_or_objects(count_only, objects, sort_by = nil)
     if count_only
-      objects.size
+      objects.respond_to?(:order) ? objects.except(:order).size : objects.size
     elsif sort_by.kind_of?(Proc)
       objects.sort_by(&sort_by)
     elsif sort_by

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -40,6 +40,6 @@ class TreeBuilderChargebackReports < TreeBuilder
                              .select(:id, :miq_report_id, :name, :last_run_on, :miq_task_id)
                              .order(:last_run_on => :desc)
 
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -162,6 +162,10 @@ describe TreeBuilder do
 
       expect(builder.count_only_or_objects(false, 1..5, ->(i) { [i % 2, i] })).to eq([2, 4, 1, 3, 5])
     end
+
+    it 'counts collections with order' do
+      expect(builder.count_only_or_objects(true, VmOrTemplate.distinct.order("lower(vms.name)"))).to eq(0)
+    end
   end
 
   context "#open_node" do


### PR DESCRIPTION
### Problem
`count_only_or_object` currently works with ordered query:

Typically, when the order is passed into `count_only_or_object` as the 3rd param,
the order is not passed to the count queries. So it works.

But when the order is part of the query itself, it becomes part of the count
query, and this causes problems. (aka blows up)

### solution

The fix is to remove the order from the count query. The value returned is the
same, but the query is faster and has fewer problems.

`responds_to?` is used to keep working when arrays are passed in.


https://bugzilla.redhat.com/show_bug.cgi?id=1726790