### PR TITLE
Rename the "Cloud Intel" menu item to "Overview"

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -974,7 +974,7 @@ class ChargebackController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Cloud Intel")},
+        {:title => _("Overview")},
         {:title => _("Chargebacks")},
       ],
     }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -732,7 +732,7 @@ class DashboardController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Cloud Intel")},
+        {:title => _("Overview")},
         {:title => (action_name == "show" ? _("Dashboard") : _("Timelines"))},
       ],
     }

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -906,7 +906,7 @@ class ReportController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Cloud Intel")},
+        {:title => _("Overview")},
         {:title => _("Reports")},
       ],
     }

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -28,7 +28,7 @@ module Menu
       end
 
       def cloud_inteligence_menu_section
-        Menu::Section.new(:vi, N_("Cloud Intel"), 'fa fa-dashboard', [
+        Menu::Section.new(:vi, N_("Overview"), 'fa fa-dashboard', [
           Menu::Item.new('dashboard',  N_('Dashboard'),  'dashboard',  {:feature => 'dashboard_view'},           '/dashboard/show'),
           Menu::Item.new('report',     N_('Reports'),    'miq_report', {:feature => 'miq_report', :any => true}, '/report/explorer'),
           # Menu::Item.new('usage',    N_('Usage'),      'usage',      {:feature => 'usage'},                    '/report/usage/'), #  / Hiding usage for now - release 5.2

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -343,7 +343,7 @@ class TreeBuilder
   private :resolve_object_lambdas
 
   LEFT_TREE_CLASSES = {
-    # Cloud Intel
+    # Overview
     ## Reports
     ### Saved Reports
     :savedreports                    => "TreeBuilderReportSavedReports",

--- a/spec/presenters/menu/custom_loader_spec.rb
+++ b/spec/presenters/menu/custom_loader_spec.rb
@@ -19,7 +19,7 @@ describe Menu::CustomLoader do
     end
 
     it 'loads a custom menu item under an existing section' do
-      # create custom item placed in an existing section 'vi' (Cloud Intel)
+      # create custom item placed in an existing section 'vi' (Overview)
       described_class.register(
         Menu::Item.new('plug3', 'Plug Item', 'miq_report', {:feature => 'miq_report', :any => true}, '/demo', :default, :vi)
       )


### PR DESCRIPTION
By @terezanovotna's suggestion, we're renaming the menu item.

**Before:**
![Screenshot from 2019-07-15 10-31-13](https://user-images.githubusercontent.com/649130/61203793-b5416d00-a6eb-11e9-801a-3932256e95bb.png)

**Afer:**
![Screenshot from 2019-07-15 10-30-36](https://user-images.githubusercontent.com/649130/61203774-a9ee4180-a6eb-11e9-80f9-a00ed3af087a.png)


Resolves https://github.com/ManageIQ/manageiq-ui-classic/issues/5808
https://bugzilla.redhat.com/show_bug.cgi?id=1678196

@miq-bot add_reviewer @PanSpagetka 
@miq-bot add_label enhancement, hammer/no, ux/review