### PR TITLE
Don't use string interpolation inside gettext strings

### DIFF
--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -67,7 +67,7 @@ class EmsPhysicalInfraController < ApplicationController
   # +/ems_physical_infra/change_password/<id>+
   def change_password
     @record = find_record_with_rbac(model, params[:id])
-    @title = _("Change Password for Physical Infrasctructure Provider '#{@record.name}'")
+    @title = _("Change Password for Physical Infrasctructure Provider '%{provider_name}'") % {:provider_name => @record.name}
     @in_a_form = true # to show the page on all content frame
   end
 

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -31,7 +31,7 @@ module OpsController::Settings::Upload
         add_flash(_("%{image} \"%{name}\" uploaded") % {:image => text, :name => field[:logo].original_filename})
       end
     else
-      add_flash(_("Use the Choose file button to locate .#{type} image file"), :error)
+      add_flash(_("Use the Choose file button to locate .%{image_type} image file") % {:image_type => type}, :error)
     end
     flash_to_session
     redirect_to(:action => 'explorer')

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -211,7 +211,7 @@ class SecurityGroupController < ApplicationController
     td = session[:security_group][:task]
     task = MiqTask.find(td[:id])
     if MiqTask.status_ok?(task.status)
-      add_flash(_("#{td[:resource]} #{td[:action]}d"))
+      add_flash("#{td[:resource]} #{td[:action]}d")
     else
       add_flash(_("Unable to %{action} %{resource}: %{details}") % {
         :action   => td[:action],


### PR DESCRIPTION
We must not use string interpolation with `#{}` in gettext strings: http://manageiq.org/docs/guides/i18n#string-interpolation

Strings that come out of string interpolation with `#{}` are in fact new strings, which are not present in the catalog. We must use `%{}` instead.