### PR TITLE
Do not call map unnecessarily on the OPS/settings SSL auth modes

### DIFF
--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -205,7 +205,7 @@
         = _("SSL Verify Mode")
       .col-md-8
         = select_tag('smtp_openssl_verify_mode',
-                      options_for_select(GenericMailer.openssl_verify_modes.collect { |m| [m.titleize, m] }, @edit[:new][:smtp][:openssl_verify_mode]),
+                      options_for_select(GenericMailer.openssl_verify_modes, @edit[:new][:smtp][:openssl_verify_mode]),
                       :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent('smtp_openssl_verify_mode', "#{url}")


### PR DESCRIPTION
@hstastna found out that the OPS/settings screen is broken with an `undefined method` exception. The reason is @bmclaughlin's https://github.com/ManageIQ/manageiq-ui-classic/pull/5763 that has been probably tested without https://github.com/ManageIQ/manageiq/pull/18956.

Dropping the `collect` (a.k.a. `map`) from the code fixes it :wink: :wrench: 

@miq-bot add_label bug, hammer/no
@miq-bot add_reviewer @hstastna 
@miq-bot add_reviewer @bmclaughlin 