### PR TITLE
Fix Policy breadcrumbs when coming from GTL page

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -74,7 +74,7 @@ module Mixins
       elsif floating_ip_address?(variable.first)
         title = variable.first[:address]
       else
-        title = variable.first[:name]
+        title = variable.first[:name] unless params[:miq_grid_checks] # do not show name if coming from GTL page
       end
       {:title => title} if title
     end

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -67,14 +67,15 @@ module Mixins
     def special_page_breadcrumb(variable)
       # breadcrumb_url = url(controller_url, notshow, variable.first[:id])
       # EMS has key instead of name
-      return unless variable
+      return if !variable || variable.count != 1
+
       if variable.first[:key]
         title = variable.first[:key]
       # FloatingIps do not have name
       elsif floating_ip_address?(variable.first)
         title = variable.first[:address]
       else
-        title = variable.first[:name] unless params[:miq_grid_checks] # do not show name if coming from GTL page
+        title = variable.first[:name]
       end
       {:title => title} if title
     end

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -66,6 +66,7 @@ describe Mixins::BreadcrumbsMixin do
     allow(mixin_explorer).to receive(:x_active_tree).and_return(:active_tree)
     allow(mixin_explorer).to receive(:gtl_url).and_return("/show")
     mixin_explorer.instance_variable_set(:@sb, {})
+    allow(mixin).to receive(:params).and_return({})
 
     allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
                                                                {:title => _("First Layer")},
@@ -207,6 +208,17 @@ describe Mixins::BreadcrumbsMixin do
     context "when no title" do
       before do
         mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}])
+      end
+
+      it "returns nil" do
+        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(nil)
+      end
+    end
+
+    context "when coming from GTL page" do
+      before do
+        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}])
+        allow(mixin).to receive(:params).and_return({:miq_grid_checks => "42"})
       end
 
       it "returns nil" do

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -66,7 +66,6 @@ describe Mixins::BreadcrumbsMixin do
     allow(mixin_explorer).to receive(:x_active_tree).and_return(:active_tree)
     allow(mixin_explorer).to receive(:gtl_url).and_return("/show")
     mixin_explorer.instance_variable_set(:@sb, {})
-    allow(mixin).to receive(:params).and_return({})
 
     allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
                                                                {:title => _("First Layer")},
@@ -215,10 +214,9 @@ describe Mixins::BreadcrumbsMixin do
       end
     end
 
-    context "when coming from GTL page" do
+    context "more than one item is selected in GTL page" do
       before do
-        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}])
-        allow(mixin).to receive(:params).and_return({:miq_grid_checks => "42"})
+        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}, {:id => "1984", :description => "thing"}])
       end
 
       it "returns nil" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1720714

How to reproduce:
Go Compute -> Infrastructure -> VMs -> check two or more VMs -> Policy -> Edit Tags/Policy Simulation/Manage Policies -> see breadcrumbs

Before:
<img width="1439" alt="Screenshot 2019-07-16 at 13 09 08" src="https://user-images.githubusercontent.com/9210860/61289952-ee9cda00-a7ca-11e9-8e62-28c2d9d9affc.png">

After:
<img width="1439" alt="Screenshot 2019-07-16 at 13 02 31" src="https://user-images.githubusercontent.com/9210860/61289626-06279300-a7ca-11e9-99aa-dab20ae1b2b7.png">

There's no change when doing the same from a VM Summary page.

Following [guides for breadcrumbs](https://github.com/ManageIQ/manageiq-ui-classic/wiki/Breadcrumbs) **Tagging/Ownership/etc.**

@miq-bot add_label bug, hammer/no

@rvsia please have a look, thanks :)
