### PR TITLE
Small refactoring in ops rbac

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1068,14 +1068,13 @@ module OpsController::OpsRbac
       move_cols_up   if params[:button] == "up"
       move_cols_down if params[:button] == "down"
     else
-      @edit[:new][:ldap_groups_user] = params[:ldap_groups_user]  if params[:ldap_groups_user]
-      @edit[:new][:description]      = params[:description]       if params[:description]
+      copy_params_if_present(@edit[:new], params, %i[ldap_groups_user description user user_id])
 
       if params[:group_role]
         if valid_role?(new_role_id = params[:group_role].to_i)
           @edit[:new][:role] = new_role_id
         else
-          raise "Invalid group selected."
+          raise "Invalid role selected."
         end
       end
 
@@ -1088,8 +1087,6 @@ module OpsController::OpsRbac
       end
 
       @edit[:new][:lookup]           = (params[:lookup] == "1")   if params[:lookup]
-      @edit[:new][:user]             = params[:user]              if params[:user]
-      @edit[:new][:user_id]          = params[:user_id]           if params[:user_id]
       @edit[:new][:user_pwd]         = params[:password]          if params[:password]
     end
 

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1006,13 +1006,11 @@ module OpsController::OpsRbac
 
   # Get variables from user edit form
   def rbac_user_get_form_vars
-    @edit[:new][:name] = params[:name].presence if params[:name]
+    copy_params_if_present(@edit[:new], params, %i[name password verify])
+
     @edit[:new][:userid] = params[:userid].strip.presence if params[:userid]
     @edit[:new][:email] = params[:email].strip.presence if params[:email]
     @edit[:new][:group] = params[:chosen_group] if params[:chosen_group]
-
-    @edit[:new][:password] = params[:password].presence if params[:password]
-    @edit[:new][:verify] = params[:verify].presence if params[:verify] # Confirm Password form
   end
 
   # Set user record variables to new values

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -169,9 +169,7 @@ module OpsController::Settings::LabelTagMapping
   # Get variables from label_tag_mapping edit form
   def lt_map_get_form_vars
     @lt_map = @edit[:lt_map]
-    @edit[:new][:entity] = params[:entity] if params[:entity]
-    @edit[:new][:label_name] = params[:label_name] if params[:label_name]
-    @edit[:new][:category] = params[:category] if params[:category]
+    copy_params_if_present(@edit[:new], params, %i[entity label_name category])
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -286,8 +286,7 @@ module OpsController::Settings::Tags
   # Get variables from category edit form
   def category_get_form_vars
     @category = @edit[:category]
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:description] = params[:description] if params[:description]
+    copy_params_if_present(@edit[:new], params, %i[name description example_text])
     #   if params[:show] == "1"
     #     @edit[:new][:show] = true
     #   elsif params[:show] == "null"
@@ -295,7 +294,6 @@ module OpsController::Settings::Tags
     #   end
     @edit[:new][:show] = (params[:show] == 'true') if params[:show]
     @edit[:new][:perf_by_tag] = (params[:perf_by_tag] == "true") if params[:perf_by_tag]
-    @edit[:new][:example_text] = params[:example_text] if params[:example_text]
     #   if !@edit[:new][:name].blank? && !Classification.find_by_name(@edit[:new][:name]) && params[:button] != "add" && params[:single_value]
     #     @edit[:new][:single_value] = (params[:single_value] == "1")
     #   end

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -144,13 +144,9 @@ module OpsController::Settings::Zones
   # Get variables from zone edit form
   def zone_get_form_vars
     @zone = @edit[:zone_id] ? Zone.find(@edit[:zone_id]) : Zone.new
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:description] = params[:description] if params[:description]
-    @edit[:new][:proxy_server_ip] = params[:proxy_server_ip] if params[:proxy_server_ip]
+
+    copy_params_if_present(@edit[:new], params, %i[name description proxy_server_ip userid password verify])
     @edit[:new][:concurrent_vm_scans] = params[:max_scans].to_i if params[:max_scans]
-    @edit[:new][:userid] = params[:userid] if params[:userid]
-    @edit[:new][:password] = params[:password] if params[:password]
-    @edit[:new][:verify] = params[:verify] if params[:verify]
 
     settings_get_form_vars_sync_ntp
     set_verify_status

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -700,6 +700,18 @@ describe OpsController do
         controller.send(:rbac_field_changed, rec_type)
         expect(subject.count).to eq(2)
       end
+
+      context 'deleting name and/or password from the form while adding user' do
+        let(:params) { {:name => '', :id => 'new', :password => '', :verify => ''} }
+        let(:edit) { {:new => {:name => 'new_user', :password => 'passw', :verify => 'passw'}, :current => edit_curr } }
+        let(:edit_curr) { {:name => nil, :group => [], :password => nil, :verify => nil} }
+
+        it 'sets @edit[:new] and changed variable properly' do
+          controller.send(:rbac_field_changed, rec_type)
+          expect(controller.instance_variable_get(:@edit)[:new]).to eq(edit_curr)
+          expect(session[:changed]).to be(false)
+        end
+      end
     end
 
     context 'adding a new group' do


### PR DESCRIPTION
**Depends on:** (merged)
https://github.com/ManageIQ/manageiq-ui-classic/pull/5472

This PR is simply updated solution from https://github.com/ManageIQ/manageiq-ui-classic/pull/3771. The problem there was that `""` vs `nil` was not the same value so then `changed` variable was set wrong (especially when writing something in the field and then deleting it all), and _Add_ button was not responding properly to the changes made in the fields while adding a new User.

No need to use `copy_params_if_present` for `params[:chosen_group]` because `""` vs `nil` issue is already solved in other place.

Using `copy_params_if_present` also in `rbac_group_get_form_vars` also simplifies the code little bit.
