### PR TITLE
Raise flash message for blank dialog import 

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -47,6 +47,8 @@ class MiqAeCustomizationController < ApplicationController
         add_flash(_("Select Dialogs to import"), :info)
       rescue DialogImportValidator::ImportNonYamlError
         add_flash(_("Error: the file uploaded is not of the supported format"), :error)
+      rescue DialogImportValidator::BlankFileError
+        add_flash(_("Error: the uploaded file is blank"), :error)
       rescue DialogImportValidator::ParsedNonDialogYamlError
         add_flash(_("Error during upload: incorrect Dialog format, only service dialogs can be imported"), :error)
       rescue DialogFieldAssociationValidator::DialogFieldAssociationCircularReferenceError

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -314,6 +314,20 @@ describe MiqAeCustomizationController do
         end
       end
 
+      context "when the dialog importer raises a blank error" do
+        before do
+          allow(dialog_import_service).to receive(:store_for_import)
+            .and_raise(DialogImportValidator::BlankFileError)
+        end
+
+        it "redirects with an error message" do
+          post :upload_import_file, :params => params, :xhr => true
+          expect(controller.instance_variable_get(:@flash_array))
+            .to include(:message => "Error: the uploaded file is blank",
+                        :level   => :error)
+        end
+      end
+
       context "when the dialog importer raises an invalid dialog field type error" do
         before do
           allow(dialog_import_service).to receive(:store_for_import)


### PR DESCRIPTION
Uploading a blank file as a dialog import should raise a UI message. 
See https://github.com/ManageIQ/manageiq/pull/18951.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1720611
@miq-bot add_reviewer @eclarizio 
@tinaafitz 