### PR TITLE
Allow loading of main.scss from outside this repository

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,5 +1,5 @@
 /*
- *= require ./main
+ *= require main
  *= require ./automate_import_export
  *= require ./dialog_fields
  *= require ./angular


### PR DESCRIPTION
If the `main.scss` file is required using a relative path (i.e. `./main.scss`), it's not possible to load it from outside the repository which breaks productization. This relative path has been [introduced](https://github.com/ManageIQ/manageiq-ui-classic/pull/5636/files#diff-fb7484bc2f56c263954da6fc44982eeaR2) for a better webpack support, but we have to go back to the old way.

Maybe for forcing to load using webpack, we should have a special preprocessor defined in sprockets. After 3 hours of debugging the asset pipeline I think I'm able to create it :laughing: 

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @himdel 
@miq-bot add_label bug, hammer/no

https://bugzilla.redhat.com/show_bug.cgi?id=1712933