### PR TITLE
Remove additional deprecated Load Balancers code in UI

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -101,7 +101,6 @@ module Mixins
           hosts
           images
           instances
-          load_balancers
           middleware_deployments
           middleware_domains
           middleware_server_groups

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -357,10 +357,6 @@ module VmCommon
     show_association('network_ports', _('Ports'), :network_ports, NetworkPort)
   end
 
-  def load_balancers
-    show_association('load_balancers', _('Load Balancers'), :load_balancers, LoadBalancer)
-  end
-
   def snap
     assert_privileges(params[:pressed])
     @vm = @record = identify_record(params[:id], VmOrTemplate)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -415,7 +415,7 @@ class ApplicationHelper::ToolbarChooser
     # toolbar buttons on sub-screens
     to_display = %w[availability_zones cloud_networks cloud_object_store_containers cloud_subnets
                     cloud_tenants cloud_volumes ems_clusters flavors floating_ips host_aggregates hosts
-                    load_balancers network_ports network_routers orchestration_stacks resource_pools
+                    network_ports network_routers orchestration_stacks resource_pools
                     security_groups storages middleware_deployments
                     middleware_servers]
     to_display_center = %w[stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers guest_devices]

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -15,7 +15,7 @@ module EmsNetworkHelper::TextualSummary
       _("Relationships"),
       %i[
         parent_ems_cloud cloud_tenants cloud_networks cloud_subnets network_routers security_groups floating_ips
-        network_ports load_balancers custom_button_events
+        network_ports custom_button_events
       ]
     )
   end
@@ -82,10 +82,6 @@ module EmsNetworkHelper::TextualSummary
 
   def textual_network_ports
     textual_link(@record.network_ports, :label => _("Network Ports"))
-  end
-
-  def textual_load_balancers
-    textual_link(@record.load_balancers, :label => _("Load Balancers"))
   end
 
   def textual_cloud_networks

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -66,7 +66,7 @@ module VmHelper::TextualSummary
       %i[
         ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service genealogy
         cloud_network cloud_subnet orchestration_stack cloud_networks cloud_subnets network_routers security_groups
-        floating_ips network_ports load_balancers cloud_volumes custom_button_events
+        floating_ips network_ports cloud_volumes custom_button_events
       ]
     )
   end
@@ -403,19 +403,6 @@ module VmHelper::TextualSummary
       h[:title] = _("Show all Network Ports")
       h[:explorer] = true
       h[:link]  = url_for_only_path(:action => 'network_ports', :id => @record, :display => "network_ports")
-    end
-    h
-  end
-
-  def textual_load_balancers
-    return nil if @record.try(:load_balancers).nil?
-
-    num   = @record.number_of(:load_balancers)
-    h     = {:label => _('Load Balancers'), :icon => "ff ff-load-balancer", :value => num}
-    if num.positive? && role_allows?(:feature => "load_balancer_show_list")
-      h[:title] = _("Show all Load Balancers")
-      h[:explorer] = true
-      h[:link]  = url_for_only_path(:action => 'load_balancers', :id => @record, :display => "load_balancers")
     end
     h
   end

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -9,11 +9,6 @@ class NetworkTopologyService < TopologyService
         :floating_ips    => :writable_classification_tags,
         :cloud_tenant    => :writable_classification_tags,
         :security_groups => :writable_classification_tags,
-        :load_balancers  => %i[
-          writable_classification_tags
-          floating_ips
-          security_groups
-        ]
       ]
     ],
     :cloud_subnets      => [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3051,7 +3051,6 @@ Rails.application.routes.draw do
         floating_ips
         network_routers
         network_ports
-        load_balancers
         cloud_subnets
         cloud_networks
         cloud_volumes

--- a/spec/helpers/ems_network_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_network_helper/textual_summary_spec.rb
@@ -15,7 +15,6 @@ describe EmsNetworkHelper::TextualSummary do
     security_groups
     floating_ips
     network_ports
-    load_balancers
     custom_button_events
   )
 

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -82,7 +82,6 @@ describe VmHelper::TextualSummary do
     security_groups
     floating_ips
     network_ports
-    load_balancers
     cloud_volumes
     custom_button_events
   ), "vm_cloud_relationships"


### PR DESCRIPTION
Remove additional/remaining code for the display of Load Balancers in UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1672949

Screen shot showing Load Balancers relationships in Instance by Provider page prior to code removal:
![Instance by Provider showing Load Balancers prior to fix](https://user-images.githubusercontent.com/552686/61333262-417e8d80-a7db-11e9-995e-664caba6273f.png)

Screen shot post code fix sans Load Balancers relationship display in **Instance by Provider** page:
![Instance by Provider NOT showing Load Balancers post fix](https://user-images.githubusercontent.com/552686/61333316-6410a680-a7db-11e9-90da-19c2f7a401a3.png)

Screen shot post code fix sans Load Balancers relationship in **Network Manager** page:
![Network Manager NOT showing Load Balancers](https://user-images.githubusercontent.com/552686/61333378-95897200-a7db-11e9-8ef1-4c2c8a4374ee.png)


