### PR TITLE
Show item's description when edit/copy in Requests

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -544,6 +544,10 @@ class MiqRequestController < ApplicationController
     session[:prov_options] = @options if @options
   end
 
+  def gtl_url
+    "/show"
+  end
+
   def breadcrumbs_options
     if @layout == "miq_request_ae" || @record&.type == "AutomationRequest"
       {
@@ -559,6 +563,7 @@ class MiqRequestController < ApplicationController
           {:title => _("Services")},
           {:title => _("Requests"), :url => controller_url},
         ],
+        :record_info  => (MiqRequest.find(params[:req_id]) if params[:req_id]),
         :record_title => :description,
       }
     end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -511,4 +511,17 @@ describe MiqRequestController do
     [{"=" => {"value" => user1.id, "field" => "MiqRequest-requester_id"}},
      {"=" => {"value" => user2.id, "field" => "MiqRequest-requester_id"}}]
   end
+
+  describe "breadcrumbs_options" do
+    let(:miq_request) do
+      FactoryBot.create(:miq_provision_request, :with_approval, :description => 'Description of request')
+    end
+
+    it "returns item's breadcrumb on action page" do
+      controller.params = {:req_id => miq_request.id} # simulate action with id (edit, copy, etc.)
+      allow(controller).to receive(:not_show_page?).and_return(true) # simulate page with item's breadcrumb
+
+      expect(controller.send(:data_for_breadcrumbs).last).to include(:title => miq_request.description)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726741

**Description**

Breadcrumb with item description was missing on Edit/Copy pages.

**Steps to Reproduce:**
1. Create provision service that needs approval, order it (A standard lifecycle provisioning request that exceeds default quotas (number of vms > 1) will need to be approved, and can then be edited.)

_Compute > Cloud > Instances > Lifecycle > provision requests...._

2. View request details, edit request
3. Note breadcrumb

**Expected results**

The breadcrumb includes: Services > Requests > Provision from [<temp>] to [<vm>] > Edit VM Provision

**Before**
![image](https://user-images.githubusercontent.com/32869456/61363245-f5d3ee80-a883-11e9-94be-96ef16359bf7.png)

**After**
![image](https://user-images.githubusercontent.com/32869456/61363155-cb823100-a883-11e9-9355-dd1d5f803256.png)

@miq-bot add_label hammer/no, changelog/no, breadcrumbs, requests

