### PR TITLE
Don't modify original model value for form submission

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -39,11 +39,20 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
   $scope.saveClicked = function() {
     // remove existing subscriptions that have not changed before sending them up for save
-    var modified_subscriptions = $scope.pglogicalReplicationModel.subscriptions.slice();
-    modified_subscriptions.forEach(function(subscription, index, object) {
-      if (typeof subscription.id !== 'undefined' && subscription.remove !== true &&  !subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index])) {
-        object.splice(index, 1);
+    var modified_subscriptions = $scope.pglogicalReplicationModel.subscriptions.filter(function(subscription, index) {
+      if (! subscription.id) { // new
+        return true;
       }
+
+      if (subscription.remove) { // removed
+        return true;
+      }
+
+      if (subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index])) { // modified
+        return true;
+      }
+
+      return false;
     });
     pglogicalManageSubscriptionsButtonClicked('save', {
       'replication_type': $scope.pglogicalReplicationModel.replication_type,

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -39,14 +39,15 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
   $scope.saveClicked = function() {
     // remove existing subscriptions that have not changed before sending them up for save
-    $scope.pglogicalReplicationModel.subscriptions.forEach(function(subscription, index, object) {
+    var modified_subscriptions = $scope.pglogicalReplicationModel.subscriptions.slice();
+    modified_subscriptions.forEach(function(subscription, index, object) {
       if (typeof subscription.id !== 'undefined' && subscription.remove !== true &&  !subscriptionChanged(subscription, $scope.modelCopy.subscriptions[index])) {
         object.splice(index, 1);
       }
     });
     pglogicalManageSubscriptionsButtonClicked('save', {
       'replication_type': $scope.pglogicalReplicationModel.replication_type,
-      'subscriptions': $scope.pglogicalReplicationModel.subscriptions,
+      'subscriptions': modified_subscriptions,
     });
   };
 

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -149,14 +149,15 @@
             %td
               {{subscription.status}}
             %td{:class => "action-cell", "ng-show" => "showCancelDelete($index)"}
-              %button.btn.btn-default.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}= _('Cancel Delete')
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "cancelDelete($index)"}
+                = _('Cancel Delete')
 
-            %td{:class => "action-cell","ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
-              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}= _('Update')
-
-            %td{"ng-show" => "!showCancelDelete($index) && !pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
+            %td{:class => "action-cell","ng-show" => "!showCancelDelete($index) && (!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index))"}
+              %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "addInProgress()",  "ng-click" => "enableSubscriptionUpdate($index)"}
+                = _('Update')
+            %td{"ng-show" => "!pglogicalReplicationModel.updateEnabled || (pglogicalReplicationModel.updateEnabled && $index !== pglogicalReplicationModel.s_index)"}
               .dropdown.pull-right.dropdown-kebab-pf
-                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true"}
+                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true", "ng-disabled" => "showCancelDelete($index)"}
                   %span.fa.fa-ellipsis-v
                 %ul.dropdown-menu.dropdown-menu-right.3
                   %li
@@ -169,9 +170,9 @@
             %td{:class => "action-cell", "ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-disabled" => "!subscriptionValid()", "ng-click" => "addSubscription($index)"}= _('Accept')
 
-            %td{"ng-show" => "!showCancelDelete($index) && pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
+            %td{"ng-show" => "pglogicalReplicationModel.updateEnabled && $index === pglogicalReplicationModel.s_index"}
               .dropdown.pull-right.dropdown-kebab-pf
-                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true"}
+                %button.btn.btn-link.dropdown-toggle{"data-toggle" => "dropdown", "aria-haspopup" => "true", "ng-disabled" => "showCancelDelete($index)"}
                   %span.fa.fa-ellipsis-v
                 %ul.dropdown-menu.dropdown-menu-right.3
                   %li


### PR DESCRIPTION
1. Setup ManageIQ with one global region and multiple remote region appliances
2. Configuration ➛ Settings ➛ Select Global Region ➛ Replication

This PR contains several fixes:

1. Before submitting form with edited values, we need to remove non-edited (non-changed) items from the model so that we submit only things that changed. We cannot modify the orignal model though, since that would be reflected in the replication screen (i.e. the non-edited items would disappear from the screen after hitting Save).
2. Fix styling of `Cancel Delete` button
3. Disable kebab popup button when `Cancel Delete` button is active

https://bugzilla.redhat.com/show_bug.cgi?id=1726249