### PR TITLE
Make editing schedule with EVM Group/Tenant type work

### DIFF
--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -19,10 +19,7 @@ module OpsController::Settings::AutomateSchedules
 
   def fetch_target_ids
     if params[:target_class] && params[:target_class] != 'null'
-      targets = Rbac.filtered(params[:target_class]).select(:id, *columns_for_klass(params[:target_class]))
-      if targets.present?
-        targets = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
-      end
+      targets = targets_from_class(params[:target_class])
     end
 
     render :json => {
@@ -47,10 +44,7 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:target_classes] = {}
     CustomButton.button_classes.each { |db| automate_request[:target_classes][db] = ui_lookup(:model => db) }
     automate_request[:target_classes] = Array(automate_request[:target_classes].invert).sort
-    if automate_request[:target_class]
-      targets = Rbac.filtered(automate_request[:target_class]).select(:id, :name)
-      automate_request[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
-    end
+    automate_request[:targets] = targets_from_class(automate_request[:target_class]) if automate_request[:target_class]
     automate_request[:target_id]      = filter[:ui][:ui_object][:target_id] || ""
     automate_request[:ui_attrs]       = filter[:ui][:ui_attrs] || []
 
@@ -73,5 +67,10 @@ module OpsController::Settings::AutomateSchedules
                         :ui_object => {}},
        :parameters => {}}
     end
+  end
+
+  def targets_from_class(klass)
+    targets = Rbac.filtered(klass).select(:id, *columns_for_klass(klass))
+    targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
   end
 end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1730750

While editing an existing _Schedule_ (_Configuration > Settings > Schedules_) with **_EVM Group_** or **_Tenant_** _Object Attribute Type_ , internal server error occurred. This PR fixes it.

**Details:**
For _EVM Group_, there is only `description` column, instead of `name`:
```
=> [----] I, [2019-07-17T15:56:35.346480 #19795:2ad8f888c54c]  INFO -- : Started GET "/ops/schedule_form_fields/121" for ::1 at 2019-07-17 15:56:35 +0200
[----] I, [2019-07-17T15:56:35.402769 #19795:2ad8f888c54c]  INFO -- : Processing by OpsController#schedule_form_fields as HTML
[----] I, [2019-07-17T15:56:35.402952 #19795:2ad8f888c54c]  INFO -- :   Parameters: {"id"=>"121"}
[----] F, [2019-07-17T15:56:35.841908 #19795:2ad8f888c54c] FATAL -- : Error caught: [ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column "name" does not exist
LINE 1: SELECT "miq_groups"."id", "name" FROM "miq_groups"
                                  ^
: SELECT "miq_groups"."id", "name" FROM "miq_groups"
```
For _Tenant_, there is a different problem: we are missing `use_config_for_attributes` attribute.
```
[----] I, [2019-07-17T18:10:07.284516 #25163:2ad562fb009c]  INFO -- : Started GET "/ops/schedule_form_fields/119" for ::1 at 2019-07-17 18:10:07 +0200
[----] I, [2019-07-17T18:10:07.325345 #25163:2ad562fb009c]  INFO -- : Processing by OpsController#schedule_form_fields as HTML
[----] I, [2019-07-17T18:10:07.325499 #25163:2ad562fb009c]  INFO -- :   Parameters: {"id"=>"119"}
[----] F, [2019-07-17T18:10:07.876950 #25163:2ad562fb009c] FATAL -- : Error caught: [ActiveModel::MissingAttributeError] missing attribute: use_config_for_attributes
```
Using an existing `columns_for_klass` method instead of just `:name` ([here](https://github.com/ManageIQ/manageiq-ui-classic/pull/5826/commits/f2c1ca5c765b10374811a46c0401e7ea57c5353f#diff-9a556bfb1df365bedf4c86405cb30811L51)) 'we' search for proper columns (according to the Object Attribute Type) so then `targets` are properly set.
I created a new method `targets_from_class` for setting targets, to prevent having the same code in more places. Maybe this method could be somewhere else and used by different controllers. If you have an idea, let me know.

---

**Before:**
![before_schedule](https://user-images.githubusercontent.com/13417815/61392084-5da72b00-a8be-11e9-82fa-cd6d4b25d0e7.png)

**After:**
![after_schedule](https://user-images.githubusercontent.com/13417815/61391872-f2f5ef80-a8bd-11e9-855e-067d0c1fe505.png)

