### PR TITLE
Fix missing flash message when adding first Container Provider 

### DIFF
--- a/app/views/ems_container/show_list.html.haml
+++ b/app/views/ems_container/show_list.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if Container.any?
+  - if ManageIQ::Providers::ContainerManager.any?
     = render :partial => 'layouts/gtl'
   - else
     = render :partial => 'layouts/empty',

--- a/app/views/layouts/_empty.html.haml
+++ b/app/views/layouts/_empty.html.haml
@@ -1,3 +1,4 @@
+= render :partial => "layouts/flash_msg"
 .blank-slate-pf{:style => 'border: 0'}
   .blank-slate-pf-icon
     %span.pficon.pficon-add-circle-o


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1713504

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5434

Go to Compute -> Containers-> Providers -> make sure you have no provider! -> add a new provider (see Bz for details) -> wait to be redirected back -> see there's no success/error message
Before:
<img width="1669" alt="Screenshot 2019-07-18 at 14 42 09" src="https://user-images.githubusercontent.com/9210860/61458206-41f95e80-a96a-11e9-8b7c-6dd68edb7fbb.png">

After:
<img width="1672" alt="Screenshot 2019-07-19 at 09 05 45" src="https://user-images.githubusercontent.com/9210860/61516246-ddd7a880-aa04-11e9-8a3d-c9c9f2a62497.png">


Go to Compute -> Containers-> Providers -> make sure you have no provider! -> Configuration -> Add a new Container Provider -> cancel -> see there's no "Canceled by user" message
Fixed for all providers.

Before:
<img width="1660" alt="Screenshot 2019-07-19 at 09 19 37" src="https://user-images.githubusercontent.com/9210860/61516958-66a31400-aa06-11e9-9cdc-1d8a137f73dd.png">


After:
<img width="1670" alt="Screenshot 2019-07-19 at 09 14 43" src="https://user-images.githubusercontent.com/9210860/61516838-188e1080-aa06-11e9-9e16-71461a7dc7f4.png">



@miq-bot add_label hammer/no, bug

cc: @romanblanco 