### PR TITLE
Override pf class for chart tooltip background

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -1096,3 +1096,7 @@ table.table-compressed tr td .piechart {
 .navbar-pf-vertical .nav .nav-item-iconic .fa {
   color: #fff;
 }
+
+table.c3-tooltip td {
+  background-color: #393f44;
+}


### PR DESCRIPTION
After updates in build process, patternfly styles are loaded earlier than c3 styles, that results in white text on white background -> broken tooltips. Adding more specific css class should fix this.

#### Screenshot
![Screenshot from 2019-07-19 10-12-23](https://user-images.githubusercontent.com/9535558/61520102-bfc27600-aa0d-11e9-8e9f-b5c33a50fa91.png)


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1729236

