### PR TITLE
Generalized check for accordion in params when selecting (saved)reports

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -2,7 +2,7 @@ module ReportController::SavedReports
   extend ActiveSupport::Concern
 
   def show_saved
-    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report"
+    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report" && !accordion_select?(params[:id])
     fetch_saved_report(@sb[:last_saved_id])
     if @report.blank? # if report was nil. reset active tree back to report tree, and keep active node report to be same
       self.x_active_tree = :reports_tree
@@ -10,7 +10,7 @@ module ReportController::SavedReports
   end
 
   def show_saved_report
-    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && params[:id] != "savedreports"
+    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && params[:id] != 'savedreports' && !accordion_select?(params[:id])
     fetch_saved_report(@sb[:last_savedreports_id])
   end
 
@@ -133,5 +133,11 @@ module ReportController::SavedReports
     @current_page = @pages[:current] unless @pages.nil? # save the current page number
     session["#{x_active_tree}_sortcol".to_sym] = @sortcol
     session["#{x_active_tree}_sortdir".to_sym] = @sortdir
+  end
+
+  private
+
+  def accordion_select?(param)
+    param.to_s.ends_with?('accord')
   end
 end

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -2,7 +2,7 @@ module ReportController::SavedReports
   extend ActiveSupport::Concern
 
   def show_saved
-    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report" && !params[:id].to_s.start_with?("savedreports")
+    @sb[:last_saved_id] = params[:id] if params[:id] && params[:id] != "report"
     fetch_saved_report(@sb[:last_saved_id])
     if @report.blank? # if report was nil. reset active tree back to report tree, and keep active node report to be same
       self.x_active_tree = :reports_tree

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -10,7 +10,7 @@ module ReportController::SavedReports
   end
 
   def show_saved_report
-    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && !params[:id].to_s.start_with?("savedreports")
+    @sb[:last_savedreports_id] = params[:id].to_s.split('-').last if params[:id] && params[:id] != "savedreports"
     fetch_saved_report(@sb[:last_savedreports_id])
   end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1525,4 +1525,20 @@ describe ReportController do
       end
     end
   end
+
+  context 'saved reports' do
+    describe '#accordion_select?' do
+      subject { controller.send(:accordion_select?, param) }
+
+      context 'an accord' do
+        let(:param) { "foo_accord" }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'a number' do
+        let(:param) { "1234" }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1338,13 +1338,6 @@ describe ReportController do
           fetched_report.id = @rpt.id # Reports serialized into the report column don't have ids
           expect(fetched_report).to eq(@rpt)
         end
-
-        it "doesn't set the report id upon an accordion change" do
-          controller.params = {:id => "savedreports_accord"}
-          controller.instance_variable_set(:@sb, :last_savedreports_id => 123)
-          expect(controller).to receive(:fetch_saved_report).with(123)
-          controller.send(:show_saved_report)
-        end
       end
     end
   end


### PR DESCRIPTION
QE kept coming up with new and new edge cases after https://github.com/ManageIQ/manageiq-ui-classic/pull/5803 and https://github.com/ManageIQ/manageiq-ui-classic/pull/5779 and I had to come up with a more general solution for testing the existence of an accordion switch in `params[:id]`. I went directly to the source and asked QE to test all the edge cases on an appliance that has this fix.

Of course *The Right Way&trade;* would be to not use the same param for both selecting a node and loading an accordion. I will look into the possibilities of how can we split these two params up as we have in on other explorers.

@miq-bot assign @h-kataria 
@miq-bot add_label bug, hammer/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724209