### PR TITLE
Allow returning back to the previous controller, after clicking on Back button and to cancel policy sim properly

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/policy_simulation.rb
+++ b/app/controllers/mixins/actions/vm_actions/policy_simulation.rb
@@ -20,7 +20,7 @@ module Mixins
             @refresh_partial = "layouts/flash_msg"
           else
             session[:tag_items] = records   # Set the array of tag items
-            session[:tag_db] = model_for_vm(records.first) # Remember the DB
+            session[:tag_db] = VmOrTemplate # Remember the DB
             if @explorer
               @edit ||= {}
               @edit[:explorer] = true       # Since no @edit, create @edit and save explorer to use while building url for vms in policy sim grid

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -164,7 +164,7 @@
           :class   => "btn btn-default",
           :alt     => t,
           :title   => t,
-          :onclick => "miqAjaxButton('#{url_for_only_path(:action => action, :continue => true)}');")
+          :onclick => "miqAjaxButton('#{url_for_only_path(:controller => controller_for_vm(model_for_vm(@record)), :action => action, :continue => true)}');")
       - elsif %w(drift policy_sim).include?(@sb[:action])
         -# Button to cancel policy simulation/drift and return to latest tree node
         = button_tag(t = _('Cancel'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3006,7 +3006,6 @@ Rails.application.routes.draw do
         launch_html5_console
         launch_vmrc_console
         perf_chart_chooser
-        policies
         protect
         retire
         right_size_print

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -226,9 +226,9 @@ describe VmInfraController do
 
   it 'policy simulation has no clickable quadicons' do
     expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
-      :model_name                     => 'ManageIQ::Providers::InfraManager::Vm',
+      :model_name                     => 'VmOrTemplate',
       :report_data_additional_options => {
-        :model     => 'ManageIQ::Providers::InfraManager::Vm',
+        :model     => "VmOrTemplate",
         :clickable => false
       }
     )

--- a/spec/views/layouts/_x_edit_buttons.html.haml_spec.rb
+++ b/spec/views/layouts/_x_edit_buttons.html.haml_spec.rb
@@ -1,0 +1,14 @@
+describe 'layouts/_x_edit_buttons.html.haml' do
+  context 'policy simulation' do
+    let(:record) { FactoryBot.create(:vm_infra) }
+
+    before { assign(:record, record) }
+
+    it 'renders Back button with proper onclick' do
+      render :partial => 'layouts/x_edit_buttons',
+             :locals  => {:record_id => record.id,
+                          :params    => {:action => 'policies'}}
+      expect(response).to include('title="Back" onclick="miqAjaxButton(&#39;/vm_infra/policy_sim?continue=true&#39;);">')
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1717495

When clicking on quadion of a VM or Template while running policy simulation, the actual controller was changed to `VmOrTemplate`. After clicking on _Back_ button, it remained the same. This was causing unexpected behavior later in the next steps, many variables not set properly, not able to cancel policy sim properly... To prevent this controller's 'change' https://github.com/ManageIQ/manageiq-ui-classic/pull/5580 was created. 

The solution worked well except the case that user chose some items from the list which were both VMs AND Templates, for policy sim, in _Compute > Infra > Virtual Machines > **VMs & Templates**_ accordion. The problem was missing quadicon(s) of Template in policy simulation.

So little bit different approach  is good to implement: going 'back' to the previous controller after clicking on _Back_ button (instead of the same controller all the time). So I specified the controller name for getting proper url for `onclick` for appropriate _Back_ button. By using `model_for_vm` method we get a proper model of the `@record`, and with `controller_for_vm` we get a proper controller name.

---

**Before:**
![polsim_before](https://user-images.githubusercontent.com/13417815/61532700-ed69e800-aa2a-11e9-8d60-76f565637e6e.png)

**After:**
![polsim_after](https://user-images.githubusercontent.com/13417815/61532909-a4666380-aa2b-11e9-989c-3d6cc2360a21.png)
