### PR TITLE
AzureStack orchestration template provisioning

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,11 +50,12 @@ class CatalogController < ApplicationController
   }.freeze
 
   ORCHESTRATION_TEMPLATES_NODES = {
-    'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate'    => "otcfn",
-    'ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate' => "othot",
-    'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate'     => "otazu",
-    'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate'          => "otvnf",
-    'ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate'    => "otvap"
+    'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate'     => "otcfn",
+    'ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate'  => "othot",
+    'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate'      => "otazu",
+    'ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate' => "otazs",
+    'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate'           => "otvnf",
+    'ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate'     => "otvap"
   }.freeze
 
   # when methods are evaluated from this constant and return true that means: column is displayed
@@ -1684,7 +1685,7 @@ class CatalogController < ApplicationController
         get_node_info_handle_simple_leaf_node(id)
       elsif x_node == "root"
         get_node_info_handle_root_node
-      elsif %w[xx-otcfn xx-othot xx-otazu xx-otvnf xx-otvap].include?(x_node)
+      elsif %w[xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap].include?(x_node)
         get_node_info_handle_ot_folder_nodes
       elsif x_active_tree == :stcat_tree
         get_node_info_handle_leaf_node_stcat(id)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -212,7 +212,7 @@ class ApplicationHelper::ToolbarChooser
         "services_center_tb"
       end
     elsif x_active_tree == :ot_tree
-      if %w[root xx-otcfn xx-othot xx-otazu xx-otvnf xx-otvap].include?(x_node)
+      if %w[root xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap].include?(x_node)
         "orchestration_templates_center_tb"
       else
         "orchestration_template_center_tb"

--- a/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
+++ b/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
@@ -14,6 +14,9 @@ const templateTypeOptions = [{
   label: 'Microsoft Azure',
   value: 'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate',
 }, {
+  label: 'Microsoft AzureStack',
+  value: 'ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate',
+}, {
   label: 'VNF',
   value: 'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate',
 }, {

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -509,6 +509,7 @@ class TreeBuilder
     "asr"  => "AssignedServerRole",
     "az"   => "AvailabilityZone",
     "azu"  => "ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate",
+    "azs"  => "ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate",
     "at"   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
     "cl"   => "Classification",
     "cf"   => "ConfigurationScript",

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -29,6 +29,11 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
        :text => _("Azure Templates"),
        :icon => "pficon pficon-template",
        :tip  => _("Azure Templates")},
+      {:id   => 'otazs',
+       :tree => "otazs_tree",
+       :text => _("AzureStack Templates"),
+       :icon => "pficon pficon-template",
+       :tip  => _("AzureStack Templates")},
       {:id   => 'otvnf',
        :tree => "otvnf_tree",
        :text => _("VNF Templates"),
@@ -48,6 +53,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "otcfn" => ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate,
       "othot" => ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate,
       "otazu" => ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate,
+      "otazs" => ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate,
       "otvnf" => ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate,
       "otvap" => ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate
     }

--- a/product/views/ManageIQ_Providers_AzureStack_CloudManager_OrchestrationTemplate.yaml
+++ b/product/views/ManageIQ_Providers_AzureStack_CloudManager_OrchestrationTemplate.yaml
@@ -1,0 +1,86 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: AzureStack Orchestration Templates
+
+# Menu name
+name: AzureStack Orchestration Template
+
+# Main DB table report is based on
+db: ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate
+
+# Columns to fetch from the main table
+cols:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Column titles, in order
+headers:
+- Name
+- Template Type
+- Draft
+- Description
+- Created On
+- Updated On
+
+col_formats:
+-
+- :model_name
+- :boolean_yes_no
+-
+-
+-
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -507,7 +507,7 @@ describe CatalogController do
       end
 
       it "Renders list of orchestration templates using correct GTL type" do
-        %w(root xx-otcfn xx-othot xx-otazu).each do |id|
+        %w[root xx-otcfn xx-othot xx-otazu xx-otazs].each do |id|
           post :tree_select, :params => { :id => id, :format => :js }
           expect(response).to have_http_status 200
           expect(response).to render_template('layouts/angular/_gtl')


### PR DESCRIPTION
With this commit we allow for yet another provider to perform OrchestrationStack template provisioning. The process is as follows:

- at `Services > Catalogs > Orchestration Templates` create a new   orchestration template of type "Azure Stack" and provide a   JSON specification

![image](https://user-images.githubusercontent.com/8102426/61536382-ce705380-aa34-11e9-8a87-f60665bda165.png)


- click on that new Orchestration Template and generate Dialog   out of it

![image](https://user-images.githubusercontent.com/8102426/61536453-f8c21100-aa34-11e9-8699-f22f88b11a70.png)

![image](https://user-images.githubusercontent.com/8102426/61536515-1e4f1a80-aa35-11e9-8fb3-55e8b8578e12.png)

- create Item of type "Orchestration" and connect it to Template   and Dialog

![image](https://user-images.githubusercontent.com/8102426/61536612-4e96b900-aa35-11e9-84cc-b5275f9738ff.png)

- as a user, order it. Doing so, user is offered to input parameters   as specified in JSON secification

![image](https://user-images.githubusercontent.com/8102426/61536660-6e2de180-aa35-11e9-8536-2dfe2416c221.png)

@miq-bot add_label enhancement
@miq-bot assign @himdel 

/cc @bzwei @agrare 