### PR TITLE
Automate method editing bugz

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -506,6 +506,7 @@ class MiqAeClassController < ApplicationController
     if playbook_style_location?(@ae_method.location)
       # these variants are implemented in Angular
       angular_form_specific_data
+      @right_cell_text = _("Editing Automate Method \"%{name}\"") % {:name => @ae_method.name}
     else
       # other variants are implemented server side
       set_method_form_vars

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -33,7 +33,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_playbook_id.$invalid}",
                 "ng-if" => "#{ng_model}.location!=='playbook'"}
       %label.col-md-3.control-label{"for" => "#{ng_model}.ansible_template_id"}
-        = playbook_label(@edit[:new][:location])
+        = playbook_label(@ae_method.try(:location) || @edit[:new][:location])
       .col-md-9
         %select{"ng-model"    => "#{ng_model}.ansible_template",
                 "name"        => "#{ng_model}_ansible_template_id",


### PR DESCRIPTION
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1678150
https://bugzilla.redhat.com/show_bug.cgi?id=1729999

also fixes a regression when editing automate methods:

```
[----] I, [2019-07-22T13:02:30.442810 #23250:57bee40]  INFO -- :   Rendered /home/martin/Projects/manageiq-ui-classic/app/views/miq_ae_class/_all_tabs.html.haml (235.7ms)                                         
[----] F, [2019-07-22T13:02:30.444149 #23250:57bee40] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `[]' for nil:NilClass                                                               
/home/martin/Projects/manageiq-ui-classic/app/views/layouts/angular/_ansible_form_options_angular.html.haml:36:in `__home_martin__rojects_manageiq_ui_classic_app_views_layouts_angular__ansible_form_options_angul
ar_html_haml__664314731155744517_69949740029940'                                                                                                                                                                  
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/template.rb:157:in `block in render'                                                                                                      
/home/martin/.rvm/gems/ruby-2.5.5/gems/activesupport-5.1.7/lib/active_support/notifications.rb:168:in `instrument'                                                                                                
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/template.rb:352:in `instrument_render_template'                                                                                           
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/template.rb:155:in `render'                                                                                                               
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/partial_renderer.rb:342:in `block in render_partial'                                                                              
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'                                                                                 
/home/martin/.rvm/gems/ruby-2.5.5/gems/activesupport-5.1.7/lib/active_support/notifications.rb:166:in `block in instrument'
/home/martin/.rvm/gems/ruby-2.5.5/gems/activesupport-5.1.7/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/martin/.rvm/gems/ruby-2.5.5/gems/activesupport-5.1.7/lib/active_support/notifications.rb:166:in `instrument'     
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/partial_renderer.rb:331:in `render_partial'         
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/partial_renderer.rb:310:in `render'             
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/renderer.rb:47:in `render_partial'        
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/renderer/renderer.rb:21:in `render'                                                                                                       
/home/martin/.rvm/gems/ruby-2.5.5/gems/actionview-5.1.7/lib/action_view/helpers/rendering_helper.rb:31:in `render'                                                                                                
/home/martin/Projects/manageiq-ui-classic/app/views/miq_ae_class/_angular_method_form.html.haml:51:in `__home_martin__rojects_manageiq_ui_classic_app_views_miq_ae_class__angular_method_form_html_haml__4544691709
638769177_72572040'    
```