### PR TITLE
 Refactor spec for hiding tenant column for non admin users

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1290,17 +1290,15 @@ describe CatalogController do
     end
   end
 
-  context "hiding columns" do
-    let(:user) { FactoryBot.create(:user) }
-
+  context "hiding tenant column for non admin user" do
     before do
       Tenant.seed
       EvmSpecHelper.local_miq_server
     end
 
-    let!(:service_template) { FactoryBot.create(:service_template, :description => 'XXX', :tenant => Tenant.root_tenant) }
+    let!(:record) { FactoryBot.create(:service_template, :description => 'XXX', :tenant => Tenant.root_tenant) }
 
-    let!(:report) do
+    let(:report) do
       FactoryGirl.create(:miq_report,
                          :name        => 'Catalog Items',
                          :db          => 'ServiceTemplate',
@@ -1311,40 +1309,6 @@ describe CatalogController do
                          :col_options => {"tenant.name" => {:display_method => :user_super_admin?}})
     end
 
-    it "renders show_list and does not include hidden column(hidden by display method)" do
-      allow(controller).to receive(:render)
-
-      login_as user
-
-      expect(controller).to receive(:get_db_view).and_return(report)
-      controller.send(:report_data)
-      view_hash = controller.send(:view_to_hash, assigns(:view))
-
-      headers = view_hash[:head].map { |x| x[:text] }.compact
-      expect(headers).to match_array(%w[Name Description Type])
-      expect(headers).not_to include('Tenant')
-
-      first_row_values = view_hash[:rows][0][:cells].map { |x| x[:text] }.compact
-      expect(first_row_values).to match_array([service_template.name, service_template.description, service_template.type_display])
-      expect(first_row_values).not_to include(service_template.tenant.name)
-    end
-
-    let(:user_admin) { FactoryBot.create(:user_admin) }
-
-    it "renders show_list and includes all columns" do
-      allow(controller).to receive(:render)
-
-      login_as user_admin
-
-      expect(controller).to receive(:get_db_view).and_return(report)
-      controller.send(:report_data)
-      view_hash = controller.send(:view_to_hash, assigns(:view))
-
-      headers = view_hash[:head].map { |x| x[:text] }.compact
-      expect(headers).to match_array(%w[Name Description Tenant Type])
-
-      first_row_values = view_hash[:rows][0][:cells].map { |x| x[:text] }.compact
-      expect(first_row_values).to match_array([service_template.name, service_template.description, service_template.tenant.name, service_template.type_display])
-    end
+    include_examples 'hiding tenant column for non admin user', :name => "Name", :description => "Description", :type_display => "Type"
   end
 end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -758,17 +758,15 @@ describe EmsCloudController do
 
   it_behaves_like "relationship table screen with GTL", nested_lists, :ems_amazon
 
-  context "hiding columns" do
-    let(:user) { FactoryBot.create(:user) }
-
+  context "hiding tenant column for non admin user" do
     before do
       Tenant.seed
       EvmSpecHelper.local_miq_server
     end
 
-    let!(:ems_cloud) { FactoryBot.create(:ems_cloud, :tenant => Tenant.root_tenant) }
+    let!(:record) { FactoryBot.create(:ems_cloud, :tenant => Tenant.root_tenant) }
 
-    let!(:report) do
+    let(:report) do
       FactoryGirl.create(:miq_report,
                          :name        => 'Cloud Providers',
                          :db          => 'EmsCloud',
@@ -780,40 +778,6 @@ describe EmsCloudController do
                          :include     => {"tenant" => {"columns" => ['name']}})
     end
 
-    it "renders show_list and does not include hidden column(hidden by display method)" do
-      allow(controller).to receive(:render)
-
-      login_as user
-
-      expect(controller).to receive(:get_db_view).and_return(report)
-      controller.send(:report_data)
-      view_hash = controller.send(:view_to_hash, assigns(:view))
-
-      headers = view_hash[:head].map { |x| x[:text] }.compact
-      expect(headers).to match_array(%w[Name Type])
-      expect(headers).not_to include('Tenant')
-
-      first_row_values = view_hash[:rows][0][:cells].map { |x| x[:text] }.compact
-      expect(first_row_values).to match_array([ems_cloud.name, ems_cloud.emstype_description])
-      expect(first_row_values).not_to include(ems_cloud.tenant.name)
-    end
-
-    let(:user_admin) { FactoryBot.create(:user_admin) }
-
-    it "renders show_list and includes all columns" do
-      allow(controller).to receive(:render)
-
-      login_as user_admin
-
-      expect(controller).to receive(:get_db_view).and_return(report)
-      controller.send(:report_data)
-      view_hash = controller.send(:view_to_hash, assigns(:view))
-
-      headers = view_hash[:head].map { |x| x[:text] }.compact
-      expect(headers).to match_array(%w[Name Type Tenant])
-
-      first_row_values = view_hash[:rows][0][:cells].map { |x| x[:text] }.compact
-      expect(first_row_values).to match_array([ems_cloud.name, ems_cloud.emstype_description, ems_cloud.tenant.name])
-    end
+    include_examples 'hiding tenant column for non admin user', :name => "Name", :emstype_description => "Type"
   end
 end

--- a/spec/shared/controllers/shared_examples_for_hiding_column_non_admin.rb
+++ b/spec/shared/controllers/shared_examples_for_hiding_column_non_admin.rb
@@ -1,0 +1,34 @@
+shared_examples 'hiding tenant column for non admin user' do |expected_result|
+  before do
+    allow(controller).to receive(:render)
+    login_as FactoryBot.create(user_type)
+  end
+
+  subject do
+    expect(controller).to receive(:get_db_view).and_return(report)
+    controller.send(:report_data)
+    controller.send(:view_to_hash, assigns(:view))
+  end
+
+  let(:first_row) { subject[:rows][0][:cells].map { |x| x[:text] }.compact }
+  let(:headers) { subject[:head].map { |x| x[:text] }.compact }
+  let(:result_array) { expected_result.keys.map { |column| record.send(column) } }
+
+  context "when not admin" do
+    let(:user_type) { :user }
+
+    it "renders show_list and does not include hidden column(hidden by display method)" do
+      expect(headers).to match_array(expected_result.values)
+      expect(first_row).to match_array(result_array)
+    end
+  end
+
+  context "when admin" do
+    let(:user_type) { :user_admin }
+
+    it "renders show_list and includes all columns" do
+      expect(headers).to match_array(expected_result.values + ['Tenant'])
+      expect(first_row).to match_array(result_array + [record.tenant.name])
+    end
+  end
+end


### PR DESCRIPTION
Similar parts of spec code refracted into the shared example. @lpichler 