### PR TITLE
Use React component to create service dialog from ansible tower

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -401,13 +401,12 @@ module Mixins
     end
 
     def render_service_dialog_form
-      return if %w[cancel save].include?(params[:button])
       @in_a_form = true
       clear_flash_msg
       presenter = rendering_objects
       update_service_dialog_partials(presenter)
       rebuild_toolbars(false, presenter)
-      handle_bottom_cell(presenter)
+      handle_bottom_cell(presenter, true)
       presenter[:right_cell_text] = @right_cell_text
 
       render :json => presenter.for_render
@@ -445,10 +444,10 @@ module Mixins
       presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
     end
 
-    def handle_bottom_cell(presenter)
+    def handle_bottom_cell(presenter, hide_form_buttons = false)
       # Handle bottom cell
       if @pages || @in_a_form
-        if @pages && !@in_a_form
+        if (@pages && !@in_a_form) || hide_form_buttons
           presenter.hide(:form_buttons_div)
         elsif @in_a_form
           presenter.remove_paging.show(:form_buttons_div)

--- a/app/views/automation_manager/_configscript_service_dialog.html.haml
+++ b/app/views/automation_manager/_configscript_service_dialog.html.haml
@@ -1,17 +1,8 @@
 #form_div
   #basic_info_div
     = render :partial => "layouts/flash_msg"
-    - url = url_for_only_path(:action => "cs_form_field_changed", :id => @edit[:rec_id])
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _('Service Dialog Name')
-        .col-md-8
-          = text_field_tag("dialog_name",
-                           "",
-                           :autocomplete => 'off',
-                           :diabled => false,
-                           :class => "form-control",
-                           :maxlength => 255,
-                           "data-miq_observe" => {:interval => '.5',
-                                                  :url => url}.to_json)
+    = react('ServiceDialogFromForm', 
+            :templateId            => @edit[:rec_id],
+            :dialogClass           => "Dialog::AnsibleTowerJobTemplateDialogService",
+            :templateClass         => "ConfigurationScript",
+            :miqRedirectBackAdress => "/automation_manager/explorer")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,7 +193,6 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         tree_autoload
         tree_select
-        configscript_service_dialog_submit
         cs_form_field_changed
         users
         wait_for_task
@@ -2668,7 +2667,6 @@ Rails.application.routes.draw do
         tag_edit_form_field_changed
         tree_autoload
         tree_select
-        configscript_service_dialog_submit
         cs_form_field_changed
         users
         wait_for_task

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -618,22 +618,6 @@ describe AutomationManagerController do
       expect(response.status).to eq(200)
     end
 
-    it "displays the new dialog form with no reset button" do
-      post :x_button, :params => {:pressed => 'configscript_service_dialog', :id => @cs.id}
-      expect(response.status).to eq(200)
-      expect(response.body).to include('Save Changes')
-      expect(response.body).not_to include('Reset')
-    end
-
-    it "Service Dialog is created from an Ansible Tower Job Template" do
-      controller.params = {:button => "save", :id => @cs.id}
-      allow(controller).to receive(:replace_right_cell)
-      controller.send(:configscript_service_dialog_submit)
-      expect(assigns(:flash_array).first[:message]).to include("was successfully created")
-      expect(Dialog.where(:label => @dialog_label).first).not_to be_nil
-      expect(assigns(:edit)).to be_nil
-    end
-
     it "renders tagging editor for a job template system" do
       session[:tag_items] = [@cs.id]
       session[:assigned_filters] = []


### PR DESCRIPTION
~~Waiting for https://github.com/ManageIQ/manageiq-ui-classic/pull/5842~~ (merged)

**Description**

Use React component form for creating service dialog from ansible tower job template

`Automation` > `Ansible Tower` > `Explorer` > `Templates` > Select One > `Configuration` >` Create a service dialog
`

**Before**

![Screenshot from 2019-07-23 14-54-59](https://user-images.githubusercontent.com/32869456/61713876-db08ea80-ad59-11e9-9700-e7d10f99d9ff.png)

**After**

![Screenshot from 2019-07-23 14-52-49](https://user-images.githubusercontent.com/32869456/61713855-d3494600-ad59-11e9-9b05-f12d32165adf.png)


@miq-bot add_label hammer/no, react, changelog/no