### PR TITLE
[HAMMER] Don't store Classification AR object in session

### DIFF
--- a/app/views/layouts/_tag_edit.html.haml
+++ b/app/views/layouts/_tag_edit.html.haml
@@ -15,7 +15,7 @@
             - if session[:assigned_filters].include?(cat_key.downcase)
               - @categories.delete(cat_key)
           = select_tag("tag_cat",
-            options_for_select(@categories, @edit[:cat].name),
+            options_for_select(@categories, @edit[:cat][:name]),
             "data-live-search"     => "true",
             "data-container"       => "body",
             "class"                => "selectpicker")


### PR DESCRIPTION
When you have 10000+ entries under single tag, object became too big to be stored in session and user get signed off. BZ said 1000 is enough to brake it, but for me it worked fine with 1000 entries.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1726313


Steps for Testing/QA [Optional]
-------------------------------

Have a Tag with 10000+ entries, try to tag a VM with one of those.
I have reproduce it with something like this in rails console (not very efficient, it took few minutes):
```
10000.times { |i| Classification.first.add_entry(:name => i.to_s, :description => i.to_s)}
```

@h-kataria 
