### PR TITLE
Handle network managers in the dialog local service

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -60,6 +60,8 @@ class DialogLocalService
         case class_name
         when "CloudManager"
           "/ems_cloud"
+        when "NetworkManager"
+          "/ems_networks"
         when "CinderManager"
           "/ems_block_storage"
         when "SwiftManager"

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -79,6 +79,13 @@ describe DialogLocalService do
                        "cloud_network", "CloudNetwork", "cloud_networks", "/cloud_network"
     end
 
+    context "when the object is a NetworkManager" do
+      let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager, :id => 123) }
+
+      include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_networks"
+    end
+
     context "when the object is a private CloudNetwork" do
       let(:obj) { double(:class => ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private, :id => 123) }
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",


### PR DESCRIPTION
Just like it says on the tin. 


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732436
@miq-bot add_label hammer/no, bug
@miq-bot add_reviewer @eclarizio 
@miq-bot add_reviewer @tinaafitz 

Yes I know, it needs refactoring desperately. 

Network manager managing, it me. 