### PR TITLE
Dialog copy - remove ids pointing to the original dialog 

### DIFF
--- a/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
+++ b/app/assets/javascripts/controllers/dialog_editor/dialog_editor_controller.js
@@ -75,12 +75,28 @@ ManageIQ.angular.app.controller('dialogEditorController', ['$window', 'miqServic
       });
     }
 
+    function clearOriginalIds(dialog) {
+      _.forEach(dialog.dialog_tabs, function(tab) {
+        _.forEach(tab.dialog_groups, function(group) {
+          _.forEach(group.dialog_fields, function(field) {
+            delete field.dialog_group_id;
+          });
+          delete group.dialog_tab_id;
+        });
+        delete tab.dialog_id;
+      });
+      delete dialog.id;
+    }
+
     translateResponderNamesToIds(dialog.content[0]);
 
     if (requestDialogAction() === 'copy') {
       // gettext left out intentionally
       // the label will be rendered to all users in all locales as it was saved
       dialog.label = dialog.content[0].label = "Copy of " + dialog.label;
+
+      // otherwise we attempt to create tabs referencing the original dialog, etc.
+      clearOriginalIds(dialog.content[0]);
     }
 
     DialogEditor.setData(dialog);


### PR DESCRIPTION
When copying a dialog, we load the original, allow the user to change it, and save that data as a new dialog.

But, the API just saves the fields, groups and tabs, then saves the dialog, and only after that updates those tabs to point to the new dialog. No transactions.
Which means that when dialog validation fails, all the copied tabs still point to the original dialog, leading to duplicate tabs appearing in the original.

This does not fix the API bug or attempt to wrap it in a transaction,
this just makes sure the UI won't send any obsolete ids when copying,
thus limiting the impact of the API bug to extra unused tabs remaining in the db.
(And created https://github.com/ManageIQ/manageiq-api/issues/630.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1713100