### PR TITLE
Select the features tree items when 'everything' is allowed

### DIFF
--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -12,7 +12,7 @@ module TreeNode
         parent_feature = ::MiqProductFeature.obj_features[::MiqProductFeature.feature_parent(@object.feature)][:feature]
 
         [parent_feature.identifier, @object.feature].any? do |item|
-          @tree.features.include?(item)
+          @tree.features.include?('everything') || @tree.features.include?(item)
         end
       end
     end

--- a/app/presenters/tree_node/miq_product_feature.rb
+++ b/app/presenters/tree_node/miq_product_feature.rb
@@ -3,7 +3,9 @@ module TreeNode
     set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.identifier}" }
     set_attribute(:text) { _(@object.name) }
     set_attribute(:tooltip) { _(@object.description) || _(@object.name) }
-    set_attribute(:selected) { @tree.features.include?(@object.identifier.sub(/_accords$/, '')) }
+    set_attribute(:selected) do
+      @tree.features.include?('everything') || @tree.features.include?(@object.identifier.sub(/_accords$/, ''))
+    end
 
     set_attribute(:icon) do
       case @object.feature_type


### PR DESCRIPTION
This is a regression possibly caused by the refactoring of the rbac features tree. Basically when all features are checked, there's no list of features, instead we use `everything` and the checked state of the nodes was not universal for this meta-feature.

@miq-bot add_label bug, ivanchuk/yes, hammer/no, trees, rbac
@miq-bot add_reviewer @ZitaNemeckova 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732576