### PR TITLE
Removed gettext changing value for Analysis Profiles

### DIFF
--- a/app/views/ops/_ap_form_set.html.haml
+++ b/app/views/ops/_ap_form_set.html.haml
@@ -14,7 +14,7 @@
             - keyvalue.each do |k, v|
               - checked = @selected.include? k if @selected
               .col-md-4{:align => "left", :nowrap => "", :valign => "top"}
-                = check_box_tag("check_#{k}", _(v), checked,
+                = check_box_tag("check_#{k}", v, checked,
                   "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true,
                   "data-miq_observe_checkbox" => {:url => url}.to_json)
                 = _(v)


### PR DESCRIPTION
We don't want to pass translated labels as a value for `check_box_tag`

To get the partial rendered, go to:

1. Configuration (top) - Settings - Analysis Profiles
2. Add / Edit VM Analysis Profile

/cc @martinpovolny 