### PR TITLE
Do not build the regex for embedded method when there's no fqname

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1676,7 +1676,7 @@ class MiqAeClassController < ApplicationController
 
   def embedded_methods_add
     submit_embedded_method(URI.unescape(params[:fqname]))
-    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname)
+    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname) if @edit[:ae_method_id]
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
@@ -1689,7 +1689,7 @@ class MiqAeClassController < ApplicationController
 
   def embedded_methods_remove
     @edit[:new][:embedded_methods].delete_at(params[:id].to_i)
-    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname)
+    @selectable_methods = embedded_method_regex(MiqAeMethod.find(@edit[:ae_method_id]).fqname) if @edit[:ae_method_id]
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue


### PR DESCRIPTION
When adding an inline method to an automate method, we're building a regular expression that prevents the inline method tree select to add the inline the same method as the current method being edited. However, this fails when a new automate method is being created as it has no fqname and we can't build the regular expression.

This causes not to render the list of selected methods in the editor. The fix is to not build the regex when the fqname is not available.

@miq-bot assign @martinpovolny 
@miq-bot add_label bug, hammer/yes, ivanchuk/yes, automation/automate

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1718495