### PR TITLE
Get proper record class while performing operations on Managed VMs of a chosen Datastore

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -266,7 +266,7 @@ module ApplicationController::CiProcessing
     when "ems_cluster"
       EmsCluster
     when "storage"
-      Storage
+      %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : Storage
     else
       VmOrTemplate
     end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1729953

For operations like _Refresh Relationships and Power States_,  _Perform SSA_, _Extract Running Processes_, and some others (Power operations, some others on VMs displayed as a nested list), error encountered:
```
[----] F, [2019-07-24T17:14:26.520402 #24911:2ac557646cc4] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Can't access selected records
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/mixins/checked_id_mixin.rb:60:in `find_records_with_rbac'
```
Selected VMs are not accessible. This is because of getting wrong record class (`Storage`) in `get_rec_cls` method while identifying selected records [here](https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L611). Choosing the proper class according to what is actually displayed, solves the problem.

The problem was created by some refactoring, especially by adding `storage` case [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/4076/commits/d9538094d83b026f7a0ac03ed69f33475682d3d8#diff-44003ee313a78ab3e3b556618f7085ffR319). Without this case, `get_rec_cls` returned [the proper class name](https://github.com/ManageIQ/manageiq-ui-classic/pull/4076/commits/d9538094d83b026f7a0ac03ed69f33475682d3d8#diff-44003ee313a78ab3e3b556618f7085ffR322). The problem is present since adding that change which did not count with the cases when `params[:display]` is set. This logic is missing. But we need that change which was added, too. So we need to add an extra condition for `params[:display]`, similar as it is [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/5867/commits/21e06346084b2c562d91fba3456f360f6c164a0b#diff-44003ee313a78ab3e3b556618f7085ffR257), to fix the problem.

**Before:**
![refresh_before](https://user-images.githubusercontent.com/13417815/61805735-9e5ef100-ae36-11e9-9775-8e0323b1d66f.png)

**After:**
![refresh_after](https://user-images.githubusercontent.com/13417815/61805506-2f819800-ae36-11e9-9d5b-ca361e1b8981.png)
