### PR TITLE
Fixed container provider custom button dialog redirect.

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -66,6 +66,8 @@ class DialogLocalService
           "/ems_block_storage"
         when "SwiftManager"
           "/ems_object_storage"
+        when "ContainerManager"
+          "/ems_container/#{obj.id}"
         else
           "/ems_infra"
         end


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1732489

After submit/cancel container provider dialog triggered with custom button, user was redirected to infra provider screen. He should have been redirected back from where the dialog was open (container provider detail)

### Cause
- missing branch for `ContainerManager` class

### Changes
- added extra case for `ContainerManager` class in `determine_api_endpoints` method.