### PR TITLE
Remove delimiter for Request ID

### DIFF
--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -9,7 +9,7 @@
       %label.control-label.col-md-2
         = _("Request ID")
       .col-md-8
-        = h(number_with_delimiter(@miq_request.id))
+        = h(@miq_request.id)
     .form-group
       %label.control-label.col-md-2
         = _("Status")


### PR DESCRIPTION
If used, Request ID is copied to be used to search, in such case, we don't want to include delimiters

Steps for Testing/QA
-------------------------------

1. Order a service
2. Go to Requests

