### PR TITLE
Switch to Advanced tab when only error is "Request is required"

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -836,8 +836,6 @@ module ApplicationController::Buttons
 
     add_flash(_("Button Hover Text is required"), :error) if button_hash[:description].blank?
 
-    add_flash(_("Starting Process is required"), :error) if ab_button_name(button_hash).blank?
-
     if button_hash[:visibility_typ] == "role" && button_hash[:roles].blank?
       add_flash(_("At least one Role must be selected"), :error)
     end
@@ -852,11 +850,14 @@ module ApplicationController::Buttons
 
     validate_playbook_button(button_hash) if button_hash[:button_type] == "ansible_playbook"
 
+    if ab_button_name(button_hash).blank?
+      add_flash(_("Starting Process is required"), :error)
+      @switch_tab = true if @flash_array.length == 1
+    end
+
     if button_hash[:object_request].blank?
       add_flash(_("Request is required"), :error)
-      if @flash_array.length == 1
-        @switch_tab = true
-      end
+      @switch_tab = true if @flash_array.length == 1
     end
 
     !flash_errors?

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -517,7 +517,15 @@ module ApplicationController::Buttons
       drop_breadcrumb(:name => _("Edit of Button"), :url => "/miq_ae_customization/button_edit")
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
-      javascript_flash
+      if @switch_tab
+        render :update do |page|
+          page << javascript_prologue
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "document.querySelector(\"#ab_advanced_tab_tab > a\").click();"
+        end
+      else
+        javascript_flash
+      end
       return
     end
 
@@ -586,7 +594,15 @@ module ApplicationController::Buttons
       drop_breadcrumb(:name => _("Edit of Button"), :url => "/miq_ae_customization/button_edit")
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
-      javascript_flash
+      if @switch_tab
+        render :update do |page|
+          page << javascript_prologue
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "document.querySelector(\"#ab_advanced_tab_tab > a\").click();"
+        end
+      else
+        javascript_flash
+      end
       return
     end
 
@@ -822,8 +838,6 @@ module ApplicationController::Buttons
 
     add_flash(_("Starting Process is required"), :error) if ab_button_name(button_hash).blank?
 
-    add_flash(_("Request is required"), :error) if button_hash[:object_request].blank?
-
     if button_hash[:visibility_typ] == "role" && button_hash[:roles].blank?
       add_flash(_("At least one Role must be selected"), :error)
     end
@@ -837,6 +851,13 @@ module ApplicationController::Buttons
     end
 
     validate_playbook_button(button_hash) if button_hash[:button_type] == "ansible_playbook"
+
+    if button_hash[:object_request].blank?
+      add_flash(_("Request is required"), :error)
+      if @flash_array.length == 1
+        @switch_tab = true
+      end
+    end
 
     !flash_errors?
   end

--- a/app/views/shared/buttons/_ab_advanced_form.html.haml
+++ b/app/views/shared/buttons/_ab_advanced_form.html.haml
@@ -1,5 +1,5 @@
 - url = url_for_only_path(:action => 'automate_button_field_changed')
-#ab_form
+#ab_advanced_form
   %h3
     = _('Advanced Options')
   - if @edit[:new][:display_for] == "single"

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -304,8 +304,8 @@ describe ApplicationController do
                  :open_url       => true,
                  :display_for    => :list}
       }
-      flash_errors = [{:message => "Starting Process is required", :level => :error},
-                      {:message => 'URL can be opened only by buttons for a single entity', :level => :error}]
+      flash_errors = [{:message => 'URL can be opened only by buttons for a single entity', :level => :error},
+                      {:message => "Starting Process is required", :level => :error},]
 
       controller.send(:button_valid?, edit[:new])
       expect(assigns(:flash_array)).to match(flash_errors)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1717843

Go to Automation -> Automate -> Customization -> Buttons -> Configuration -> Add/Edit a Button -> make sure Request in Advanced tab is empty and Text, Hover Text, Icon in Options are set -> click Add/Save

First commit fixes the bug, other commits just clean around a bit.

Before:
<img width="1075" alt="Screenshot 2019-07-25 at 14 13 34" src="https://user-images.githubusercontent.com/9210860/61873728-f35a4000-aee6-11e9-9061-f7c4b70cbbd9.png">

After:
<img width="1074" alt="Screenshot 2019-07-25 at 14 13 16" src="https://user-images.githubusercontent.com/9210860/61873722-ee958c00-aee6-11e9-8069-b182c36253db.png">

@miq-bot add_label bug, automation/automate, ivanchuk/yes, hammer/yes

@h-kataria please have a look, thanks :)
