### PR TITLE
 Fix resizer blocking paginator elements

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -552,7 +552,7 @@ miq-quadicon > .single-wrapper {
       border: 0;
       height: 44px;
       margin: 0;
-      padding: 3px 0 0 0;
+      padding: 3px 0 0 10px;
     }
   }
 }


### PR DESCRIPTION
This PR fixes a problem where the screen resizer was blocking the "select all" checkbox (and possibly other  elements) in the paging bar.

https://bugzilla.redhat.com/show_bug.cgi?id=1729894

Old
<img width="375" alt="Screen Shot 2019-07-25 at 10 05 42 AM" src="https://user-images.githubusercontent.com/1287144/61884101-9ac87a00-aec9-11e9-9fd7-618a99448b50.png">

New
<img width="335" alt="Screen Shot 2019-07-25 at 10 36 43 AM" src="https://user-images.githubusercontent.com/1287144/61884054-82585f80-aec9-11e9-908e-b8b60dd81e28.png">



