### PR TITLE
user_input_filter - don't send Cancel on Apply

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -984,6 +984,7 @@ function miqQsEnterEscape(e) {
   if (keycode === 13) {
     if ($('#apply_button').is(':visible')) {
       miqAjaxButton('quick_search?button=apply');
+      $('#quicksearchbox').modal('hide');
     }
   }
 

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -342,6 +342,8 @@ module ApplicationController::Filter
     exp_remove_tokens(@edit[:adv_search_applied][:qs_exp])
     session[:adv_search] ||= {}
     session[:adv_search][@edit[@expkey][:exp_model]] = copy_hash(@edit) # Save by model name in settings
+
+    # FIXME: this should really do $('#quicksearchbox').modal('hide'); ; for now, Apply closes the modal JS side
     if @edit[:in_explorer]
       replace_right_cell
     else

--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -103,10 +103,10 @@
                          :button => "apply"},
                         :class                 => "btn btn-primary",
                         :alt                   => t = _("Apply the current filter (Enter)"),
+                        "data-dismiss"         => "modal",
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true,
                         :remote                => true,
-                        "data-dismiss"         => "modal",
                         "data-method"          => :post,
                         :id                    => "apply_button",
                         :title                 => t)
@@ -125,7 +125,12 @@
       if (miqDomElementExists('value_1')) $('#value_1').focus();
     })
     $('#quicksearchbox').off("click");
-    $('#quicksearchbox').on('click', '[data-dismiss="modal"]', function() {
+    $('#quicksearchbox').on('click', '[data-dismiss="modal"]', function(event) {
+      if (event && event.target && event.target.id == 'apply_button') {
+        // don't cancel on Apply, but still close the modal
+        return true;
+      }
+
       miqJqueryRequest("quick_search?button=cancel", {beforeSend: true});
       return true;
     });


### PR DESCRIPTION
Go to Advanced search in an explorer controller (Compute > Infrastructure > VMs, accordion VMs),
add a filter which uses user input (say, VM power state == user input),
apply the filter,
(watch the Network tab,)
click Apply on the user input modal (after filling something in).

Before: you'll see requests to both quick_search?button=apply and quick_search?button=cancel.
After: no cancel, just apply

---

Since #3444 (which fixed the user input filter modal to hide after Apply, closing https://github.com/ManageIQ/manageiq-ui-classic/issues/499):

* clicking the apply button triggers a ?button=apply request
* but, thanks to data-dismiss="modal", it also closes the modal
* BUT, closing the modal this way triggers a ?button=cancel request

Thus, clicking apply triggers apply & cancel, in random order.
(Which sometimes works and sometimes doesn't.)

---

Ideally, we should not be using data-dismiss on the Apply button,
but using `$('#quicksearchbox').modal('hide')` in `quick_search_apply_click`, same as in `quick_search_cancel_click`.

The problem with that is that this would involve changing every single `replace_right_cell`, or somehow amending their output after the fact.

So, leaving the data-dismiss mechanism as is, but:

* explicitly adding code to not send the ?button=cancel request when the Apply button was clicked
* explicitly triggering hiding the modal when enter was clicked in the form (previously it would just apply)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1715550

Cc @hstastna 