### PR TITLE
Add missing routes to compare managed VMs of a Datastore

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1302,7 +1302,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+               compare_get,
       :post => %w(
         new
         button
@@ -1329,6 +1330,7 @@ Rails.application.routes.draw do
         open_admin_ui_done
       ) +
                adv_search_post +
+               compare_post +
                dialog_runner_post +
                discover_get_post +
                exp_post +
@@ -2865,7 +2867,8 @@ Rails.application.routes.draw do
         vm_ram_files
         vm_misc_files
         x_show
-      ),
+      ) +
+               compare_get,
       :post => %w(
         accordion_select
         button
@@ -2898,6 +2901,7 @@ Rails.application.routes.draw do
         x_show
       ) +
                adv_search_post +
+               compare_post +
                dialog_runner_post +
                exp_post +
                save_post +


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1733120

This PR adds missing routes to enable ability to compare Managed VMs of a Datastore (selected VMs, displayed in a nested list from Relationships table of a chosen Datastore).

**Note:**
missing _Cancel_ button will be fixed via https://bugzilla.redhat.com/show_bug.cgi?id=1733295

**Before:**
![compare_no_route](https://user-images.githubusercontent.com/13417815/61890457-c4a09180-af07-11e9-80f6-0dd433f97a47.png)

**Actually:**
![compare_vms](https://user-images.githubusercontent.com/13417815/61890035-e8afa300-af06-11e9-96ed-72c0998b35b6.png)
