### PR TITLE
Fixed issues with 'Back' button on right size screen

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -514,7 +514,8 @@ module VmCommon
     @rightsize = true
     @in_a_form = true
     if params[:button] == "back"
-      javascript_prologue(previous_breadcrumb_url)
+      javascript_prologue
+      javascript_redirect(previous_breadcrumb_url)
     end
     if !@explorer && params[:button] != "back"
       drop_breadcrumb(:name => _("Right Size VM '%{name}''") % {:name => @record.name}, :url => "/vm/right_size")

--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -220,5 +220,5 @@
         :alt     => t,
         :title   => t,
         :onclick => "miqAjaxButton('#{url_for_only_path(:action => "right_size",
-                                              :id     => @record_id,
+                                              :id     => @record.id,
                                               :button => "back")}');")

--- a/spec/controllers/vm_controller_spec.rb
+++ b/spec/controllers/vm_controller_spec.rb
@@ -20,4 +20,26 @@ describe VmController do
       expect(response).to render_template('vm_common/_live_migrate')
     end
   end
+
+  describe "#right_size" do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+    before do
+      stub_user(:features => :all)
+    end
+
+    it "when back button is pressed, it redirects back to previous screen" do
+      breadcrumbs = [
+        {:name => "Foo", :url => "/ems_infra/show_list"},
+        {:name => "Bar", :url => "/ems_infra/1?display=vms"},
+        {:name => "Right Size", :url => "/vm/right_size"}
+      ]
+      controller.instance_variable_set(:@breadcrumbs, breadcrumbs)
+      page = double('page')
+      allow(page).to receive(:<<).with(any_args)
+      expect(page).to receive(:redirect_to).with("/ems_infra/1?display=vms")
+      expect(controller).to receive(:render).with(:update).and_yield(page)
+      controller.params = {:id => vm.id, :button => 'back'}
+      controller.send(:right_size)
+    end
+  end
 end


### PR DESCRIPTION
Multiple issues fixed with back button on non-explorer version of VM Right Size recommendations screen

- fixed a typo it should be `@record.id`
- fixed call to javascript_prologue, method does not expect argument
- added code to redirect back to previous screen when back button is pressed

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1733207

Note: This is only an issue when drilling down to list of VMs thru relationships and selecting a VM from a list view to view it's right size recommendations.

Please review @hstastna @skateman 