### PR TITLE
Automate import - use format.json, not format.js when doing render :json

### DIFF
--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -154,7 +154,7 @@ var Automate = {
       postData = postData.concat(serialized);
 
       $.post('import_automate_datastore', postData, function(data) {
-        var flashMessage = JSON.parse(data)[0];
+        var flashMessage = data[0];
         if (flashMessage.level === 'error') {
           showErrorMessage(flashMessage.message);
         } else {
@@ -196,7 +196,7 @@ var Automate = {
       $('.domain-tree').empty();
 
       $.post('cancel_import', $('#import-form').serialize(), function(data) {
-        var flashMessage = JSON.parse(data)[0];
+        var flashMessage = data[0];
         showSuccessMessage(flashMessage.message);
 
         $('.import-or-export').show();

--- a/app/assets/javascripts/git_import.js
+++ b/app/assets/javascripts/git_import.js
@@ -10,13 +10,12 @@ var GitImport = {
       clearMessages();
 
       $.post('retrieve_git_datastore', $('#retrieve-git-datastore-form').serialize(), function(data) {
-        var parsedData = JSON.parse(data);
-        var messages = parsedData.message;
+        var messages = data.message;
         if (messages && messages.level === 'error') {
           showErrorMessage(messages.message);
           miqSparkleOff();
         } else {
-          GitImport.pollForGitTaskCompletion(parsedData);
+          GitImport.pollForGitTaskCompletion(data);
         }
       });
     });
@@ -24,11 +23,10 @@ var GitImport = {
 
   pollForGitTaskCompletion: function(gitData) {
     $.get('check_git_task', gitData, function(data) {
-      var parsedData = JSON.parse(data);
-      if (parsedData.state) {
+      if (data.state) {
         setTimeout(GitImport.pollForGitTaskCompletion, GitImport.TASK_POLL_TIMEOUT, gitData);
       } else {
-        GitImport.gitTaskCompleted(parsedData);
+        GitImport.gitTaskCompleted(data);
       }
     });
   },

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -122,7 +122,7 @@ class MiqAeToolsController < ApplicationController
     add_flash(_("Datastore import was cancelled or is finished"), :info)
 
     respond_to do |format|
-      format.js { render :json => @flash_array.to_json, :status => 200 }
+      format.json { render :json => @flash_array.to_json, :status => 200 }
     end
   end
 
@@ -136,7 +136,7 @@ class MiqAeToolsController < ApplicationController
     end
 
     respond_to do |format|
-      format.js { render :json => @flash_array.to_json, :status => 200 }
+      format.json { render :json => @flash_array.to_json, :status => 200 }
     end
   end
 
@@ -177,7 +177,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
     end
 
     respond_to do |format|
-      format.js { render :json => @flash_array.to_json, :status => 200 }
+      format.json { render :json => @flash_array.to_json, :status => 200 }
     end
   end
 
@@ -232,7 +232,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
     end
 
     respond_to do |format|
-      format.js { render :json => response_json.to_json, :status => 200 }
+      format.json { render :json => response_json.to_json, :status => 200 }
     end
   end
 
@@ -266,7 +266,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
            end
 
     respond_to do |format|
-      format.js { render :json => json.to_json, :status => 200 }
+      format.json { render :json => json.to_json, :status => 200 }
     end
   end
 

--- a/spec/javascripts/git_import_spec.js
+++ b/spec/javascripts/git_import_spec.js
@@ -42,7 +42,7 @@ describe('GitImport', function() {
           spyOn(window, 'showErrorMessage');
           spyOn(window, 'miqSparkleOff');
 
-          retrieveGitDatastoreCallback('{"message": {"message": "the message", "level": "error"}}');
+          retrieveGitDatastoreCallback({"message": {"message": "the message", "level": "error"}});
         });
 
         it('shows error messages', function() {
@@ -57,7 +57,7 @@ describe('GitImport', function() {
       describe('when there are are no "error" level messages', function() {
         beforeEach(function() {
           spyOn(GitImport, 'pollForGitTaskCompletion');
-          retrieveGitDatastoreCallback('{"message": {"message": "the message"}}');
+          retrieveGitDatastoreCallback({"message": {"message": "the message"}});
         });
 
         it('polls for task completion', function() {
@@ -88,7 +88,7 @@ describe('GitImport', function() {
         });
 
         it('sets a timeout to call itself', function() {
-          checkGitTaskCallback('{"state": "still doing stuff"}');
+          checkGitTaskCallback({"state": "still doing stuff"});
           expect(window.setTimeout).toHaveBeenCalledWith(GitImport.pollForGitTaskCompletion, 1500, 'the data');
         });
       });
@@ -99,7 +99,7 @@ describe('GitImport', function() {
         });
 
         it('calls gitTaskCompleted with the parsed data', function() {
-          checkGitTaskCallback('{"parsed": "data"}');
+          checkGitTaskCallback({"parsed": "data"});
           expect(GitImport.gitTaskCompleted).toHaveBeenCalledWith({'parsed': 'data'});
         });
       });


### PR DESCRIPTION
this affects the Content-Type, which in turn affects how the response is parsed client side

for `format.js`, the response is parsed as javascript, and must contain the `throw "error"` thing
for `format.json`, the response is parsed as json, so no need to `JSON.parse`

Fixes a surprising "Uncaught SyntaxError: Unexpected token import",
when datastore import succeeds, because we were trying to eval "Datastore import" as javascript.
(Automation > Automate > Import / Export, import a zip, "fails" on the Commit step, *after* successfully importing)

Cc @eclarizio 