### PR TITLE
[HAMMER] Add spec:jest, spec:javascript and spec:compile back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ env:
   - TEST_SUITE=spec:javascript
   - TEST_SUITE=spec:compile
   - TEST_SUITE=spec:jest
-matrix:
-  exclude:
-  - rvm: 2.4.6
-    env: TEST_SUITE=spec:javascript
-  - rvm: 2.4.6
-    env: TEST_SUITE=spec:compile
-  - rvm: 2.4.6
-    env: TEST_SUITE=spec:jest
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh
 before_script: bundle exec rake $TEST_SUITE:setup


### PR DESCRIPTION
broken in https://github.com/ManageIQ/manageiq-ui-classic/pull/5408
dropping the last version should have dropped the excludes too.

Since then, we've been only running `spec` on hammer, no JS tests.

Adding back :).

Cc @juliancheal @simaishi @mzazrivec 
(similar fix for ivanchuk in https://github.com/ManageIQ/manageiq-ui-classic/pull/5882)