### PR TITLE
Fixed JS snapshot test mismatch.

### DIFF
--- a/app/javascript/spec/forms/__snapshots__/input-with-dynamic-prefix.spec.js.snap
+++ b/app/javascript/spec/forms/__snapshots__/input-with-dynamic-prefix.spec.js.snap
@@ -15,7 +15,7 @@ exports[`DataDrivenInputWithPrefix should render correctly 1`] = `
   <div
     className="dynamic-prefix-input"
   >
-    <t
+    <Select
       id="dynamic-prefix-select-foo"
       input={
         Object {


### PR DESCRIPTION
- cause https://github.com/ManageIQ/manageiq-ui-classic/pull/5614
  - older PR had a snapshot with old dependency versions which is no longer mangling class/function names in minified build.