### PR TITLE
Fixed rubocop standard error warning in pxe_servers.rb

### DIFF
--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -188,7 +188,7 @@ module PxeController::PxeServers
   def pxe_server_async_cred_validation
     begin
       PxeServer.verify_depot_settings(params[:pxe])
-    rescue => bang
+    rescue StandardError => bang
       render :json => {:status => 'error', :message => _("Error during 'Validate': %{error_message}") % {:error_message => bang.message}}
     end
 


### PR DESCRIPTION
Follow up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/5614#issuecomment-515385838