### PR TITLE
Store the nodes as objects in the TreeBuilder instead of JSON

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -86,10 +86,12 @@ module Mixins
     def current_tree_path(tree, active_node, path = [])
       result = []
       result.replace(path)
-      result.push(:title => tree["text"], :key => tree["key"])
-      return result if tree["key"] == active_node
-      if tree.include?("nodes")
-        tree["nodes"].each do |node|
+      result.push(:title => tree[:text], :key => tree[:key])
+
+      return result if tree[:key] == active_node
+
+      if tree.include?(:nodes)
+        tree[:nodes].each do |node|
           value = current_tree_path(node, active_node, result)
           return value if value
         end
@@ -103,7 +105,7 @@ module Mixins
       tree = build_tree if node
 
       if tree.present?
-        JSON.parse(tree.bs_tree).each do |subtree|
+        tree.tree_nodes.each do |subtree|
           value = current_tree_path(subtree, node)
           breadcrumbs = value if value
         end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -16,7 +16,7 @@ class TreeBuilder
     @locals_for_render  = {}
     @name               = name.to_sym # includes _tree
     @options            = tree_init_options
-    @tree_nodes         = {}.to_json
+    @tree_nodes         = []
 
     add_to_sandbox
     build_tree if build
@@ -132,23 +132,17 @@ class TreeBuilder
 
   def build_tree
     # FIXME: we have the options -- no need to reload from @sb
-    tree_nodes = x_build_tree(@tree_state.x_tree(@name))
-    active_node_set(tree_nodes)
-    set_nodes(tree_nodes)
+    @tree_nodes = x_build_tree(@tree_state.x_tree(@name))
+    active_node_set(@tree_nodes)
+    add_root_node(@tree_nodes) if respond_to?(:root_options, true)
+    # Convert the nodes to the Bootstrap Treeview format
+    @bs_tree = self.class.convert_bs_tree(@tree_nodes).to_json
+    @locals_for_render = set_locals_for_render
   end
 
-  # Set active node to root if not set.
   # Subclass this method if active node on initial load is different than root node.
   def active_node_set(tree_nodes)
     @tree_state.x_node_set(tree_nodes.first[:key], @name) unless @tree_state.x_node(@name)
-  end
-
-  def set_nodes(nodes)
-    # Add the root node even if it is not set
-    add_root_node(nodes) if respond_to?(:root_options, true)
-    @bs_tree = self.class.convert_bs_tree(nodes).to_json
-    @tree_nodes = nodes.to_json
-    @locals_for_render = set_locals_for_render
   end
 
   def add_to_sandbox

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -1,6 +1,5 @@
 class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   has_kids_for ManageIQ::Providers::AnsibleTower::AutomationManager, [:x_get_tree_cmat_kids]
-  attr_reader :tree_nodes
 
   private
 

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -1,6 +1,4 @@
 class TreeBuilderConfiguredSystems < TreeBuilder
-  attr_reader :tree_nodes
-
   private
 
   def tree_init_options

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -592,8 +592,8 @@ describe AutomationManagerController do
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [tags]}
       allow(@user).to receive(:get_filters).and_return(user_filters)
-      tree_json = TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb)).tree_nodes
-      first_child = find_treenode_for_provider(automation_provider1, tree_json)
+      tree_objects = TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb)).tree_nodes
+      first_child = find_treenode_for_provider(automation_provider1, tree_objects)
       expect(first_child).to eq(nil)
     end
   end
@@ -674,10 +674,9 @@ describe AutomationManagerController do
     end
   end
 
-  def find_treenode_for_provider(provider, tree_json)
+  def find_treenode_for_provider(provider, tree)
     key = ems_key_for_provider(provider)
-    tree = JSON.parse(tree_json)
-    tree[0]['nodes']&.find { |c| c['key'] == key }
+    tree[0][:nodes]&.find { |c| c['key'] == key }
   end
 
   def ems_key_for_provider(provider)

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -84,7 +84,7 @@ describe Mixins::BreadcrumbsMixin do
       before do
         allow(subject).to receive(:x_node).and_return("xx-1")
         allow(TreeBuilderUtilization).to receive(:new).and_return(tree)
-        allow(tree).to receive(:bs_tree).and_return(
+        allow(tree).to receive(:tree_nodes).and_return(
           [
             {
               :key   => 'root',
@@ -95,7 +95,7 @@ describe Mixins::BreadcrumbsMixin do
               ]
 
             }
-          ].to_json
+          ]
         )
       end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -735,8 +735,7 @@ describe ProviderForemanController do
 
   def find_treenode_for_foreman_provider(tree, provider)
     key = ems_key_for_provider(provider)
-    tree_nodes = JSON.parse(tree.tree_nodes)
-    tree_nodes[0]['nodes'][0]['nodes']&.find { |c| c['key'] == key }
+    tree.tree_nodes[0][:nodes][0][:nodes]&.find { |c| c[:key] == key }
   end
 
   def ems_key_for_provider(provider)

--- a/spec/presenters/tree_builder_ae_class_spec.rb
+++ b/spec/presenters/tree_builder_ae_class_spec.rb
@@ -12,7 +12,7 @@ describe TreeBuilderAeClass do
 
     it "a tree without filter" do
       tree = TreeBuilderAeClass.new(:automate_tree, @sb)
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      domains = tree.tree_nodes.first[:nodes].collect { |h| h[:text] }
       expect(domains).to match_array %w(LUIGI MARIO)
     end
   end
@@ -29,7 +29,7 @@ describe TreeBuilderAeClass do
 
     it "should only return domains in a user's current tenant" do
       tree = TreeBuilderAeClass.new("ae_tree", {})
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      domains = tree.tree_nodes.first[:nodes].collect { |h| h[:text] }
       expect(domains).to match_array %w(test1)
       expect(domains).not_to include %w(test2)
     end
@@ -46,7 +46,7 @@ describe TreeBuilderAeClass do
 
     it "should return domains in correct order" do
       tree = TreeBuilderAeClass.new("ae_tree", {})
-      domains = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      domains = tree.tree_nodes.first[:nodes].collect { |h| h[:text] }
       expect(domains).to eq(%w(test2 test1))
     end
   end

--- a/spec/presenters/tree_builder_automate_catalog_spec.rb
+++ b/spec/presenters/tree_builder_automate_catalog_spec.rb
@@ -5,7 +5,7 @@ describe TreeBuilderAutomateCatalog do
     subject { described_class.new(:automate_tree, sb) }
 
     let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree} }
-    let(:domains) { JSON.parse(subject.tree_nodes).first['nodes'].collect { |h| h['text'] } }
+    let(:domains) { subject.tree_nodes.first[:nodes].collect { |h| h[:text] } }
 
     before do
       login_as FactoryBot.create(:user_with_group)

--- a/spec/presenters/tree_builder_automate_spec.rb
+++ b/spec/presenters/tree_builder_automate_spec.rb
@@ -8,7 +8,7 @@ describe TreeBuilderAutomate do
 
     let(:ae_model) { create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C') }
     let(:sb) { {:trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree, :domain_id => ae_model.id} }
-    let(:domains) { JSON.parse(subject.tree_nodes).first['nodes'].collect { |h| h['text'] } }
+    let(:domains) { subject.tree_nodes.first[:nodes].collect { |h| h[:text] } }
 
     it "creates a tree with the domains" do
       expect(domains).to match_array ['LUIGI']

--- a/spec/presenters/tree_builder_chargeback_assignments_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_assignments_spec.rb
@@ -2,8 +2,8 @@ describe TreeBuilderChargebackAssignments do
   context "#x_get_tree_roots" do
     it "correctly renders storage and compute nodes when no rates are available" do
       tree = TreeBuilderChargebackAssignments.new("cb_rates_tree", {})
-      keys = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
-      titles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
+      keys = tree.tree_nodes.first[:nodes].collect { |x| x[:text] }
+      titles = tree.tree_nodes.first[:nodes].collect { |x| x[:text] }
       rates = ChargebackRate.all
 
       expect(rates).to be_empty

--- a/spec/presenters/tree_builder_chargeback_rates_spec.rb
+++ b/spec/presenters/tree_builder_chargeback_rates_spec.rb
@@ -2,8 +2,8 @@ describe TreeBuilderChargebackRates do
   context "#x_get_tree_roots" do
     it "correctly renders storage and compute nodes when no rates are available" do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
-      keys = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['key'] }
-      titles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |x| x['text'] }
+      keys = tree.tree_nodes.first[:nodes].collect { |x| x[:key] }
+      titles = tree.tree_nodes.first[:nodes].collect { |x| x[:text] }
       rates = ChargebackRate.all
 
       expect(rates).to be_empty

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -16,71 +16,71 @@ describe TreeBuilderMenuRoles do
   end
 
   let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", sandbox, true, :role_choice => "cloud-execs") }
-  let(:tree_hash) { JSON.parse(instance.tree_nodes) }
+  let(:tree_hash) { instance.tree_nodes }
 
   describe "root node" do
     subject { tree_hash.first }
 
     it 'has the correct key' do
-      expect(subject["key"]).not_to be_nil
-      expect(subject["key"]).to eq "xx-b__Report Menus for cloud-execs"
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-b__Report Menus for cloud-execs"
     end
 
     it 'has the correct title' do
-      expect(subject["text"]).to eq "Top Level"
+      expect(subject[:text]).to eq "Top Level"
     end
 
     it 'has children' do
-      expect(subject["nodes"]).not_to be_empty
+      expect(subject[:nodes]).not_to be_empty
     end
   end
 
   describe "1st level folder" do
-    subject { tree_hash.first["nodes"].first }
+    subject { tree_hash.first[:nodes].first }
 
     it 'has the correct key' do
-      expect(subject["key"]).not_to be_nil
-      expect(subject["key"]).to eq "xx-p__Configuration Management"
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-p__Configuration Management"
     end
 
     it 'has children' do
-      expect(subject["nodes"]).not_to be_empty
+      expect(subject[:nodes]).not_to be_empty
     end
   end
 
   describe "2nd level folder" do
-    subject { tree_hash.first["nodes"].first["nodes"].first }
+    subject { tree_hash.first[:nodes].first[:nodes].first }
 
     it 'has the correct key' do
-      expect(subject["key"]).not_to be_nil
-      expect(subject["key"]).to eq "xx-s__Configuration Management:Virtual Machines"
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-s__Configuration Management:Virtual Machines"
     end
 
     it 'has a key with parent name and colon' do
-      expect(subject["key"]).to match(/Configuration\sManagement:/)
+      expect(subject[:key]).to match(/Configuration\sManagement:/)
     end
 
     it 'has children' do
-      expect(subject["nodes"]).not_to be_empty
+      expect(subject[:nodes]).not_to be_empty
     end
   end
 
   describe "report leaf node" do
     subject do
-      tree_hash.first["nodes"].first["nodes"].first["nodes"].first
+      tree_hash.first[:nodes].first[:nodes].first[:nodes].first
     end
 
     it 'has the correct key' do
-      expect(subject["key"]).not_to be_nil
-      expect(subject["key"]).to eq "xx-VMs with Free Space > 50% by Department"
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-VMs with Free Space > 50% by Department"
     end
 
     it 'is not clickable' do
-      expect(subject["selectable"]).to eq false
+      expect(subject[:selectable]).to eq false
     end
 
     it 'has no children' do
-      expect(subject["nodes"]).to be_nil
+      expect(subject[:nodes]).to be_nil
     end
   end
 

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -6,8 +6,8 @@ describe TreeBuilderOpsRbac do
 
   describe ".new" do
     def assert_tree_nodes(expected)
-      tree_json  = TreeBuilderOpsRbac.new("rbac_tree", {}).tree_nodes
-      tree_nodes = JSON.parse(tree_json).first['nodes'].collect { |h| h['text'] }
+      tree_obj = TreeBuilderOpsRbac.new("rbac_tree", {}).tree_nodes
+      tree_nodes = tree_obj.first[:nodes].collect { |h| h[:text] }
       expect(tree_nodes).to match_array expected
     end
 

--- a/spec/presenters/tree_builder_report_roles_spec.rb
+++ b/spec/presenters/tree_builder_report_roles_spec.rb
@@ -8,7 +8,7 @@ describe TreeBuilderReportRoles do
 
     it "gets roles/group for the specified user" do
       tree = TreeBuilderReportRoles.new("roles_tree", {})
-      roles = JSON.parse(tree.tree_nodes).first['nodes'].collect { |h| h['text'] }
+      roles = tree.tree_nodes.first[:nodes].collect { |h| h[:text] }
       expect(roles).to eq([@group.description])
     end
   end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -25,10 +25,10 @@ describe TreeBuilderReportSavedReports do
           # there is calling of x_get_tree_roots
           tree = TreeBuilderReportSavedReports.new('savedreports_tree', {})
 
-          saved_reports_in_tree = JSON.parse(tree.tree_nodes).first['nodes']
+          saved_reports_in_tree = tree.tree_nodes.first[:nodes]
 
           displayed_report_ids = saved_reports_in_tree.map do |saved_report|
-            saved_report["key"].gsub("xx-", "")
+            saved_report[:key].gsub("xx-", "")
           end
 
           # logged User1 can see report with Group1

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -71,7 +71,7 @@ describe TreeBuilder do
       tree = TreeBuilderChargebackRates.new("cb_rates_tree", {})
       tree.instance_eval { @tree_nodes = "{}" }
       tree.reload!
-      expect(tree.tree_nodes).not_to eq("{}")
+      expect(tree.tree_nodes).not_to eq({})
     end
   end
 
@@ -88,7 +88,7 @@ describe TreeBuilder do
     end
 
     it "descendants can set their own root_options" do
-      expect(tree.tree_nodes).to match(/"text":\s*"Foo"/)
+      expect(tree.tree_nodes.to_json).to match(/"text":\s*"Foo"/)
     end
   end
 


### PR DESCRIPTION
The `TreeBuilder` stores the nodes both as legacy dynatree JSON and as bs-treeview compatible JSON. The first one is used by tests only, so I'm dropping it and using its instance variable for storing the nodes as objects. This way we can avoid the unnecessary JSON parsing in specs and when building breadcrumbs.

@miq-bot add_reviewer @rvsia 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label refactoring, trees, hammer/no, ivanchuk/no, changelog/yes