### PR TITLE
Removed antipatterns from the spec for BreadcrumbsMixin

### DIFF
--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -1,248 +1,249 @@
 describe Mixins::BreadcrumbsMixin do
-  # dummy for a tree
-
-  class Tree
-    attr_reader :name, :bs_tree
-
-    def initialize(name, tree)
-      @name = name
-      @bs_tree = tree
-    end
-  end
-
-  # dummies for a controller using Mixin
-
-  class TestMixinExplorer < ApplicationController
-    include Mixins::BreadcrumbsMixin
-
-    def features
-      [
-        {
-          :role_any => true,
-          :name     => :utilization_tree,
-          :title    => _("Active Tree")
-        },
-        {
-          :role_any => true,
-          :name     => :old_dialog_tree,
-          :title    => _("Dialog Tree")
-        },
-        {
-          :role_any => true,
-          :name     => :tree,
-          :title    => _("Tree")
-        }
-      ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
-    end
-
-    def build_tree
-      Tree.new(:active_tree, "[{\"key\":\"root\",\"text\":\"All Dialogs\", \"nodes\":[{\"key\":\"xx-1\",\"text\":\"Item1\"},{\"key\":\"xx-2\",\"text\":\"Item2\"}]}]")
-    end
-  end
-
-  class TestMixin < ApplicationController
+  class BreadcrumbsTestController < ActionController::Base
     include Mixins::BreadcrumbsMixin
   end
 
-  let(:mixin_explorer) { TestMixinExplorer.new }
-  let(:mixin) { TestMixin.new }
-  let(:controller_url) { 'testmixin' }
-  let(:features) { {:title => "Active Tree", :name => :utilization_tree} }
-  let(:breadcrumbs) do
-    [
-      {:title => _("First Layer")},
-      {:title => _("Second Layer")},
-    ]
+  subject { BreadcrumbsTestController.new }
+
+  let(:tree) { TreeBuilderUtilization.new(:utilization_tree, {}, false) }
+  let(:breadcrumbs_options) do
+    {
+      :breadcrumbs => [
+        {:title => _("First Layer")},
+        {:title => _("Second Layer")},
+      ]
+    }
   end
 
   before do
-    allow(mixin_explorer).to receive(:controller_name).and_return("testmixin")
-    allow(mixin_explorer).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
-                                                                        {:title => _("First Layer")},
-                                                                        {:title => _("Second Layer")},
-                                                                      ])
-    allow(mixin_explorer).to receive(:x_node).and_return("xx-1")
-    allow(mixin_explorer).to receive(:x_active_accord).and_return(:utilization_tree)
-    allow(mixin_explorer).to receive(:x_active_tree).and_return(:active_tree)
-    allow(mixin_explorer).to receive(:gtl_url).and_return("/show")
-    mixin_explorer.instance_variable_set(:@sb, {})
-
-    allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs => [
-                                                               {:title => _("First Layer")},
-                                                               {:title => _("Second Layer")},
-                                                             ])
-    allow(mixin).to receive(:controller_name).and_return("testmixin")
-    allow(mixin).to receive(:gtl_url).and_return("/show")
-    mixin.instance_variable_set(:@sb, {})
+    allow(subject).to receive(:breadcrumbs_options).and_return(breadcrumbs_options)
   end
 
-  describe "#url" do
-    it "returns url" do
-      expect(mixin_explorer.url('ems', 'show', 'node')).to eq("/ems/show/node")
+  context 'mixin loaded into an explorer controller' do
+    before do
+      subject.instance_variable_set(:@sb, :explorer => true)
+
+      allow(subject).to receive(:features).and_return([
+        {
+          :role_any => true,
+          :name     => :utilization,
+          :title    => _("Utilization")
+        },
+        {
+          :role_any => true,
+          :name     => :old_dialogs,
+          :title    => _("Dialogs")
+        }
+      ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) })
+
+      allow(subject).to receive(:x_active_accord).and_return(:utilization)
+      allow(subject).to receive(:x_active_tree).and_return(:utilization_tree)
+
+      allow(ApplicationHelper).to receive(:role_allows?).and_return(true)
     end
-  end
 
-  describe "#accord_name" do
-    context 'when features contains the tree' do
-      it "returns name" do
-        expect(mixin_explorer.accord_name).to eq(features[:name])
+    describe "#url" do
+      it "returns url" do
+        expect(subject.url('ems', 'show', 'node')).to eq("/ems/show/node")
       end
     end
 
-    context 'when features do not contains the tree' do
-      it "returns nil" do
-        allow(mixin_explorer).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin_explorer.accord_name).to be(nil)
-      end
-    end
-  end
-
-  describe "#accord_title" do
-    context 'when features contains the tree' do
-      it "returns title" do
-        expect(mixin_explorer.accord_title).to eq(features[:title])
-      end
-    end
-
-    context 'when features do not contains the tree' do
-      it "returns nil" do
-        allow(mixin_explorer).to receive(:x_active_accord).and_return(:not_tree)
-        expect(mixin_explorer.accord_title).to be(nil)
-      end
-    end
-  end
-
-  describe "#build_breadcrumbs_from_tree" do
-    it "returns breadcrumbs" do
-      expect(mixin_explorer.build_breadcrumbs_from_tree).to eq([
-                                                                 {:title => "All Dialogs", :key => "root"},
-                                                                 {:title => "Item1", :key => "xx-1"}
-                                                               ])
-    end
-  end
-
-  describe "#data_for_breadcrumbs" do
-    context "when no explorer controller" do
-      it "creates breadcrumbs" do
-        expect(mixin.data_for_breadcrumbs).to eq([{:title=>"First Layer"}, {:title=>"Second Layer"}])
+    describe "#accord_name" do
+      context 'when features contains the tree' do
+        it "returns name" do
+          expect(subject.accord_name).to eq(:utilization)
+        end
       end
 
-      context "when record_info set" do
-        let(:some_record) { {:id => "1234", :some_name => "record_info_title"} }
+      context 'when features do not contains the tree' do
+        before { allow(subject).to receive(:x_active_accord).and_return(:not_tree) }
 
-        it "creates breadcrumbs" do
-          allow(mixin).to receive(:breadcrumbs_options).and_return(:breadcrumbs  => [
-                                                                     {:title => _("First Layer")},
-                                                                     {:title => _("Second Layer")},
-                                                                   ],
-                                                                   :record_info  => some_record,
-                                                                   :record_title => :some_name)
-
-          expect(mixin.data_for_breadcrumbs).to eq([{:title => "First Layer"},
-                                                    {:title => "Second Layer"},
-                                                    {:title => "record_info_title", :url => "/testmixin/show/1234"}])
+        it "returns nil" do
+          expect(subject.accord_name).to be(nil)
         end
       end
     end
 
-    context "when explorer controller" do
-      before do
-        mixin_explorer.instance_variable_set(:@right_cell_text, "Right text")
-        mixin_explorer.instance_variable_set(:@sb, :explorer => true)
+    describe "#accord_title" do
+      context 'when features contains the tree' do
+        it "returns title" do
+          expect(subject.accord_title).to eq("Utilization")
+        end
       end
 
+      context 'when features do not contains the tree' do
+        before { allow(subject).to receive(:x_active_accord).and_return(:not_tree) }
+
+        it "returns nil" do
+          expect(subject.accord_title).to be(nil)
+        end
+      end
+    end
+
+    context 'build tree' do
+      before do
+        allow(subject).to receive(:x_node).and_return("xx-1")
+        allow(TreeBuilderUtilization).to receive(:new).and_return(tree)
+        allow(tree).to receive(:bs_tree).and_return(
+          [
+            {
+              :key   => 'root',
+              :text  => 'Root Node',
+              :nodes => [
+                {:key => 'xx-1', :text => 'Item 1'},
+                {:key => 'xx-2', :text => 'Item 2'}
+              ]
+
+            }
+          ].to_json
+        )
+      end
+
+      describe "#build_breadcrumbs_from_tree" do
+        it "returns breadcrumbs" do
+          expect(subject.build_breadcrumbs_from_tree).to eq(
+            [
+              {:title => "Root Node", :key => "root"},
+              {:title => "Item 1", :key => "xx-1"}
+            ]
+          )
+        end
+      end
+
+      describe "#data_for_breadcrumbs" do
+        it "creates breadcrumbs" do
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+              {:title => "Utilization", :key => "utilization_accord", :action => "accordion_select"},
+              {:title => "Root Node", :key => "root"},
+              {:title => "Item 1", :key => "xx-1"}
+            ]
+          )
+        end
+      end
+
+      describe "#ancestry_parents" do
+        let(:service_1) { FactoryBot.create(:service) }
+        let(:service_2) { FactoryBot.create(:service, :parent => service_1) }
+        let(:service_3) { FactoryBot.create(:service, :parent => service_2) }
+
+        it "creates one level nested breadcrumbs" do
+          expect(Service).to receive(:find).and_return(service_1)
+          expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service_1.id}")
+
+          expect(subject.ancestry_parents(Service, service_2, :name)).to eq(
+            [
+              {:title => service_1.name, :key => "xx-#{service_1.id}"}
+            ]
+          )
+        end
+
+        it "creates two level nested breadcrumbs" do
+          expect(Service).to receive(:find).and_return(service_2, service_1)
+          expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service_2.id}", "xx-#{service_1.id}")
+
+          expect(subject.ancestry_parents(Service, service_3, :name)).to eq(
+            [
+              {:title => service_1.name, :key => "xx-#{service_1.id}"},
+              {:title => service_2.name, :key => "xx-#{service_2.id}"},
+            ]
+          )
+        end
+      end
+    end
+  end
+
+  context 'mixin loaded into a non-explorer controller' do
+    describe '#data_for_breadcrumbs' do
       it "creates breadcrumbs" do
-        expect(mixin_explorer.data_for_breadcrumbs).to eq([{:title => "First Layer"},
-                                                           {:title => "Second Layer"},
-                                                           {:title => "Active Tree", :key => "utilization_tree_accord", :action => "accordion_select"},
-                                                           {:title => "All Dialogs", :key => "root"},
-                                                           {:title => "Item1", :key => "xx-1"}])
-      end
-    end
-  end
-
-  describe "#special_page_breadcrumb" do
-    before do
-      mixin.send(:breadcrumbs_options)
-    end
-
-    context "when ems controller" do
-      before do
-        mixin.instance_variable_set(:@tagitems, [{:key => "ems", :id => "id"}])
-        allow(mixin).to receive(:controller_name).and_return("ems")
-      end
-
-      it "create breadcrumbs" do
-        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(
-          :title => "ems"
+        expect(subject.data_for_breadcrumbs).to eq(
+          [
+            {:title=>"First Layer"},
+            {:title=>"Second Layer"}
+          ]
         )
       end
+
+      context "record_info set" do
+        let(:breadcrumbs_options) do
+          {
+            :breadcrumbs  => [
+              {:title => _("First Layer")},
+              {:title => _("Second Layer")},
+            ],
+            :record_info  => {
+              :id        => 1234,
+              :some_name => "record_info_title"
+            },
+            :record_title => :some_name
+          }
+        end
+
+        it "creates breadcrumbs" do
+          allow(subject).to receive(:gtl_url).and_return("/show")
+
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+              {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"}
+            ]
+          )
+        end
+      end
     end
 
-    context "when floating_ips controller" do
+    describe "#special_page_breadcrumb" do
+      let(:controller_name) { 'test' }
+
       before do
-        mixin.instance_variable_set(:@tagitems, [{ :id => "1", :address => "172.0.0.1"}])
-        allow(mixin).to receive(:controller_name).and_return("floating_ips")
+        subject.send(:breadcrumbs_options)
+        allow(subject).to receive(:controller_name).and_return(controller_name)
       end
 
-      it "create breadcrumbs" do
-        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(
-          :title => "172.0.0.1"
-        )
-      end
-    end
+      context "ems controller" do
+        let(:tagitems) { [{:key => "ems", :id => "id"}] }
+        let(:controller_name) { 'ems' }
 
-    context "when others controller" do
-      before do
-        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :name => "item"}])
+        it "creates breadcrumbs" do
+          expect(subject.special_page_breadcrumb(tagitems)).to eq(:title => "ems")
+        end
       end
 
-      it "create breadcrumbs" do
-        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(
-          :title => "item"
-        )
-      end
-    end
+      context "floating_ips controller" do
+        let(:tagitems) { [{ :id => "1", :address => "127.0.0.1"}] }
+        let(:controller_name) { 'floating_ips' }
 
-    context "when no title" do
-      before do
-        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}])
+        it "creates breadcrumbs" do
+          expect(subject.special_page_breadcrumb(tagitems)).to eq(:title => "127.0.0.1")
+        end
       end
 
-      it "returns nil" do
-        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(nil)
-      end
-    end
+      context "other controllers" do
+        let(:tagitems) { [{:id => "1789", :name => "item"}] }
 
-    context "more than one item is selected in GTL page" do
-      before do
-        mixin.instance_variable_set(:@tagitems, [{:id => "1789", :description => "item"}, {:id => "1984", :description => "thing"}])
+        it "creates breadcrumbs" do
+          expect(subject.special_page_breadcrumb(tagitems)).to eq(:title => "item")
+        end
       end
 
-      it "returns nil" do
-        expect(mixin.special_page_breadcrumb(mixin.instance_variable_get(:@tagitems))).to eq(nil)
+      context "no title" do
+        let(:tagitems) { [{:id => "1789", :description => "item"}] }
+
+        it "returns nil" do
+          expect(subject.special_page_breadcrumb(tagitems)).to eq(nil)
+        end
       end
-    end
-  end
 
-  describe "#ancestry_parents" do
-    let(:service1) { FactoryBot.create(:service, :ancestry => nil) }
-    let(:service2) { FactoryBot.create(:service, :ancestry => service1.id) }
-    let(:service3) { FactoryBot.create(:service, :ancestry => service2.id) }
+      context "more than one item is selected" do
+        let(:tagitems) { [{:id => "1789", :description => "item"}, {:id => "1984", :description => "thing"}] }
 
-    it "creates one level nested breadcrumbs" do
-      expect(Service).to receive(:find).and_return(service1)
-      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service1.id}")
-      expect(mixin.ancestry_parents(Service, service2, :name)).to eq([{:title => service1.name, :key => "xx-#{service1.id}"}])
-    end
-
-    it "creates two level nested breadcrumbs" do
-      expect(Service).to receive(:find).and_return(service2, service1)
-      expect(TreeBuilder).to receive(:build_node_id).and_return("xx-#{service2.id}", "xx-#{service1.id}")
-      expect(mixin.ancestry_parents(Service, service3, :name)).to eq([
-                                                                       {:title => service1.name, :key => "xx-#{service1.id}"},
-                                                                       {:title => service2.name, :key => "xx-#{service2.id}"},
-                                                                     ])
+        it "returns nil" do
+          expect(subject.special_page_breadcrumb(tagitems)).to eq(nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Specs for `BreadcrumbsMixin` make super hard to work on https://github.com/ManageIQ/manageiq-ui-classic/pull/5889, so I decided to clean up all the antipatterns:
* method (re)definitions for mocking
* unnecessary variable alterations instead of contexts `mixin` and `mixin_explorer`
* unnecessary mocks and variables
* confusing naming in the features hash
* wrongly used tree definition
* presence of `when` in `context`

@miq-bot add_reviewer @rvsia 
@miq-bot add_label ivanchuk/no, hammer/no, test, technical debt