### PR TITLE
Add title for clone_to_template edit action

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -228,13 +228,18 @@ module ApplicationController::MiqRequestMethods
         @edit[:explorer] = true if @explorer
         @tabactive = @edit[:new][:current_tab_key]
       end
-      drop_breadcrumb(:name => if params[:req_id]
-                                 _("Edit %{type}") % {:type => @edit[:prov_type]}
-                               else
-                                 _("Add %{type}") % {:type => @edit[:prov_type]}
-                               end,
-                      :url  => "/vm/provision")
+
+      title = if params[:prov_type] == "clone_to_template"
+                _('Publish Virtual Machine')
+              elsif params[:req_id]
+                _("Edit %{type}") % {:type => @edit[:prov_type]}
+              else
+                _("Add %{type}") % {:type => @edit[:prov_type]}
+              end
+
+      drop_breadcrumb(:name => title, :url => "/vm/provision")
       @in_a_form = true
+
       #     render :action=>"show"
     end
   end

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -524,4 +524,45 @@ describe MiqRequestController do
       expect(controller.send(:data_for_breadcrumbs).last).to include(:title => miq_request.description)
     end
   end
+
+  describe "#prov_edit" do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.local_miq_server
+    end
+
+    context "when request type is clone_to_template" do
+      let(:request) do
+        FactoryBot.create(:miq_provision_request, :with_approval, :request_type => "clone_to_vm")
+      end
+
+      it "returns header including Publish" do
+        get :prov_edit, :params => {:prov_id => request.id, :prov_type => "clone_to_template"}
+
+        expect(response.body).to include("Publish")
+        expect(response.body).to_not include("Add")
+      end
+    end
+
+    context "when no request type" do
+      let(:request) do
+        FactoryBot.create(:miq_provision_request, :with_approval)
+      end
+
+      it "returns header including Edit" do
+        get :prov_edit, :params => {:req_id => request.id}
+
+        expect(response.body).to include("Edit")
+        expect(response.body).to_not include("Add")
+      end
+    end
+
+    context "when no request type" do
+      it "returns header including Add" do
+        get :prov_edit
+
+        expect(response.body).to include("Add")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1733521

**Steps to Reproduce:**
1. Add a provider (tested with RHV43)
2. Compute -> Infrastructure -> Providers
3. Click on the provider
4. Click on the VMs
5. Select any VM by clicking on the checkbox
6. Lifecycle -> Publish selected VM to a Template

**Actual results:**
Breadcrumb has "Add VM Provision"

**Expected results:**
Breadcrumb has "Publish Virtual Machine"

**Description**

When request is type of `clone_to_template` it has set generic 'add' title and breadcrumbs take it.

**Before**

![image](https://user-images.githubusercontent.com/32869456/62049656-008d6c80-b210-11e9-81df-c64c06578210.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/62049524-bad0a400-b20f-11e9-9705-e0a5c75d682e.png)

@miq-bot add_label requests, ivanchuk/yes, compute/infrastructure, changelog/no