### PR TITLE
Allow to copy from 'read only' CodeMirror editor

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1184,6 +1184,7 @@ function miqInitCodemirror(options) {
     matchBrackets: true,
     theme: 'eclipse',
     readOnly: options.read_only ? 'nocursor' : false,
+    inputStyle: "contenteditable",
     viewportMargin: Infinity,
   });
 


### PR DESCRIPTION
Instead of [`readOnly`](https://codemirror.net/doc/manual.html#option_readOnly) option I'd prefer to use [`cursorBlinkRate`](https://codemirror.net/doc/manual.html#option_cursorBlinkRate) to disable cursor in 'read only' CodeMirror instance.

Setting `nocursor` for [`readOnly`](https://codemirror.net/doc/manual.html#option_readOnly) option makes it impossible to copy from CodeMirror, which is annoying (e.g. if you need to copy Automate methods) and it has been an issue before.

According to the CodeMirror manual, setting negative value for [`cursorBlinkRate`](https://codemirror.net/doc/manual.html#option_cursorBlinkRate) hides the cursor.

Therefore I'm setting either `-1` or `530` (default CodeMirror value) as possible values.

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/1758
* https://github.com/ManageIQ/manageiq-ui-classic/pull/5700

Steps for Testing/QA
-------------------------------

1. Services - Catalogs - Orchestration Templates
2. see a template detail screen

\- or -

1. go to Automation - Automate - Datastore
2. try to copy code of any method
