### PR TITLE
Propagate parent model into GTLs on InfraNetwork switches 🖵 🐞

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -219,7 +219,7 @@ class InfraNetworkingController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => @host_record.switches.pluck(:id)}
+      options = {:model => "Switch", :named_scope => :shareable, :parent => @record}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
@@ -235,9 +235,7 @@ class InfraNetworkingController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      hosts = @cluster_record.hosts
-      switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
+      options = {:model => "Switch", :named_scope => :shareable, :parent => @record}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil
@@ -253,9 +251,7 @@ class InfraNetworkingController < ApplicationController
       self.x_node = "root"
       get_node_info("root")
     else
-      hosts = Host.where(:ems_id => @provider_record.id)
-      switch_ids = hosts.collect { |host| host.switches.pluck(:id) }
-      options = {:model => "Switch", :named_scope => :shareable, :selected_ids => switch_ids.flatten.uniq}
+      options = {:model => "Switch", :named_scope => :shareable, :parent => @record}
       process_show_list(options) if @show_list
       @showtype        = 'main'
       @pages           = nil

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -4,6 +4,10 @@ class TreeBuilderInfraNetworking < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
   has_kids_for EmsFolder, [:x_get_tree_folder_kids]
 
+  def override(node, object, _pid, _options)
+    node[:selectable] = false if object.kind_of?(Lan)
+  end
+
   private
 
   def tree_init_options


### PR DESCRIPTION
The GTL on the `Compute > Infrastructure -> Networking` displays the same switches all the time, doesn't matter which node you are selecting. The problem is that the `selected_ids` param is no longer propagated into the GTLs. Even if I would try to propagate it, an empty array would fall back to the current behavior (possibly because of a `compact` on the params somewhere). 

*The Right Way&trade;* is to send the parent record into the `options` passed further to the GTL and it will automagically call the `switches` method on it. Of course this requires to have the `switches` method on every model we're touching and it's [missing](https://github.com/ManageIQ/manageiq/pull/19076) from the `EmsCluster`.

Also found out that the `Lan` nodes under switches should not be clickable, we lost this functionality [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/5278).

@miq-bot add_label pending core, bug, compute/infrastructure, explorers, hammer/yes, ivanchuk/yes
@miq-bot add_reviewer @h-kataria 

Depends on: https://github.com/ManageIQ/manageiq/pull/19076
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726280