### PR TITLE
Do not append title to breadcrumbs on show_list pages

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -263,8 +263,7 @@ class CloudNetworkController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Networks")},
-        {:title => _("Networks")},
-        {:url   => controller_url, :title => _("Cloud Networks")},
+        {:title => _("Networks"), :url => controller_url},
       ],
       :record_info => @network,
     }

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -137,8 +137,7 @@ class CloudObjectStoreContainerController < ApplicationController
       :breadcrumbs  => [
         {:title => _("Storage")},
         {:title => _("Object Storage")},
-        {:title => _("Object Store Containers")},
-        {:url   => controller_url, :title => _("Cloud Object Store Containers")},
+        {:title => _("Object Store Containers"), :url => controller_url},
       ],
       :record_info  => @record,
       :record_title => :key,

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -39,8 +39,7 @@ class CloudObjectStoreObjectController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Object Storage")},
-        {:title => _("Object Store Objects")},
-        {:url   => controller_url, :title => _("Cloud Object Store Objects")},
+        {:title => _("Object Store Objects"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -330,8 +330,7 @@ class CloudSubnetController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Networks")},
-        {:title => _("Subnets")},
-        {:url   => controller_url, :title => _("Cloud Subnets")},
+        {:title => _("Subnets"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -257,8 +257,7 @@ class CloudTenantController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Clouds")},
-        {:title => _("Tenants")},
-        {:url   => controller_url, :title => _("Cloud Tenants")},
+        {:title => _("Tenants"), :url => controller_url},
       ],
       :record_info => @tenant,
     }.compact

--- a/app/controllers/cloud_volume_backup_controller.rb
+++ b/app/controllers/cloud_volume_backup_controller.rb
@@ -115,8 +115,7 @@ class CloudVolumeBackupController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Block Storage")},
-        {:title => _("Volume Backups")},
-        {:url   => controller_url, :title => _("Cloud Volume Backups")},
+        {:title => _("Volume Backups"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -620,8 +620,7 @@ class CloudVolumeController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Block Storage")},
-        {:title => _("Volumes")},
-        {:url   => controller_url, :title => _("Cloud Volumes")},
+        {:title => _("Volumes"), :url => controller_url},
       ],
       :record_info => @volume,
     }.compact

--- a/app/controllers/cloud_volume_snapshot_controller.rb
+++ b/app/controllers/cloud_volume_snapshot_controller.rb
@@ -80,8 +80,7 @@ class CloudVolumeSnapshotController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Block Storage")},
-        {:title => _("Volume Snapshots")},
-        {:url   => controller_url, :title => _("Cloud Volume Snapshots")},
+        {:title => _("Volume Snapshots"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/cloud_volume_type_controller.rb
+++ b/app/controllers/cloud_volume_type_controller.rb
@@ -22,8 +22,7 @@ class CloudVolumeTypeController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Block Storage")},
-        {:title => _("Volume Types")},
-        {:url   => controller_url, :title => _("Cloud Volume Types")},
+        {:title => _("Volume Types"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -64,8 +64,7 @@ class ConfigurationJobController < ApplicationController
       :breadcrumbs => [
         {:title => _("Automation")},
         {:title => _("Ansible Tower")},
-        {:title => _("Jobs")},
-        {:url   => controller_url, :title => _("Ansible Tower Jobs")},
+        {:title => _("Jobs"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -111,8 +111,7 @@ class ContainerDashboardController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Overview")},
-        {:url   => controller_url, :title => _("Container Dashboard")},
+        {:title => _("Overview"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -30,8 +30,7 @@ class ContainerGroupController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Pods")},
-        {:url   => controller_url, :title => _("Container Pods")},
+        {:title => _("Pods"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -50,8 +50,7 @@ class ContainerImageController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Images")},
-        {:url   => controller_url, :title => _("Container Images")},
+        {:title => _("Images"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_image_registry_controller.rb
+++ b/app/controllers/container_image_registry_controller.rb
@@ -21,8 +21,7 @@ class ContainerImageRegistryController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Image Registries")},
-        {:url   => controller_url, :title => _("Container Image Registries")},
+        {:title => _("Image Registries"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -49,8 +49,7 @@ class ContainerNodeController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Nodes")},
-        {:url   => controller_url, :title => _("Container Nodes")},
+        {:title => _("Nodes"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -25,8 +25,7 @@ class ContainerProjectController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Projects")},
-        {:url   => controller_url, :title => _("Container Projects")},
+        {:title => _("Projects"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_replicator_controller.rb
+++ b/app/controllers/container_replicator_controller.rb
@@ -21,8 +21,7 @@ class ContainerReplicatorController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Replicators")},
-        {:url   => controller_url, :title => _("Container Replicators")},
+        {:title => _("Replicators"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_route_controller.rb
+++ b/app/controllers/container_route_controller.rb
@@ -19,8 +19,7 @@ class ContainerRouteController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Routes")},
-        {:url   => controller_url, :title => _("Container Routes")},
+        {:title => _("Routes"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_service_controller.rb
+++ b/app/controllers/container_service_controller.rb
@@ -21,8 +21,7 @@ class ContainerServiceController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Services")},
-        {:url   => controller_url, :title => _("Container Services")},
+        {:title => _("Services"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/container_template_controller.rb
+++ b/app/controllers/container_template_controller.rb
@@ -19,8 +19,7 @@ class ContainerTemplateController < ApplicationController
       :breadcrumbs  => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Templates")},
-        {:url   => controller_url, :title => _("Container Templates")},
+        {:title => _("Templates"), :url => controller_url},
       ],
       :record_info  => (action_name == "service_dialog_from_ct" ? {:title => params["id"], :id => params["id"]} : nil),
       :record_title => :title,

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -123,8 +123,7 @@ class EmsCloudController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Clouds")},
-        {:title => _("Providers")},
-        {:url   => controller_url, :title => _("Cloud Providers")},
+        {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -152,8 +152,7 @@ class EmsContainerController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Providers")},
-        {:url   => controller_url, :title => _("Container Providers")},
+        {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -335,8 +335,7 @@ class EmsInfraController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Infrastructure")},
-        {:title => _("Providers")},
-        {:url   => controller_url, :title => _("Infrastructure Providers")},
+        {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -47,8 +47,7 @@ class EmsNetworkController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Networks")},
-        {:title => _("Providers")},
-        {:url   => controller_url, :title => _("Network Managers")},
+        {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/ems_object_storage_controller.rb
+++ b/app/controllers/ems_object_storage_controller.rb
@@ -48,8 +48,7 @@ class EmsObjectStorageController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Object Storage")},
-        {:title => _("Managers")},
-        {:url   => controller_url, :title => _("Object Storage Managers")},
+        {:title => _("Managers"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -89,8 +89,7 @@ class EmsPhysicalInfraController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Providers")},
-        {:url   => controller_url, :title => _("Physical Infrastructure Providers")},
+        {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,
     }.compact

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -24,7 +24,8 @@ module Mixins
         breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))
 
         # Append title breadcrumb if they exist and not same as previous breadcrumb (eg "Editing name")
-        if @title && @title != breadcrumbs.compact.last.try(:[], :title) && !options[:hide_title]
+        # Also do not append when user is on show_list page, the menu title is used instead of it
+        if @title && !same_as_last_breadcrumb?(breadcrumbs, @title) && !show_list_page? && !options[:hide_title]
           breadcrumbs.push(:title => @title)
         end
       else
@@ -152,6 +153,20 @@ module Mixins
     # User is not on show page
     def not_show_page?
       (action_name == "show" && params["display"] && !%w[dashboard main].include?(params["display"])) || (action_name != "show")
+    end
+
+    # User is on show_list page
+    # A lot of pages has different header than last item in menu
+    # The last item in menu is an abbreviation of the header
+    # So, breadcrumbs should contain only the abbreviation
+    def show_list_page?
+      action_name == "show_list"
+    end
+
+    # Checks if the title is same as the last item in breadcrumbs
+    # If so, then there is no reason to append the title to breadcrumbs
+    def same_as_last_breadcrumb?(breadcrumbs, title)
+      title == breadcrumbs.compact.last.try(:[], :title)
     end
 
     # Controls on tagging screen if the tagged item is floating_ip

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -248,8 +248,7 @@ class OrchestrationStackController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Clouds")},
-        {:title => _("Stacks")},
-        {:url   => controller_url, :title => _("Orchestration Stacks")},
+        {:title => _("Stacks"), :url => controller_url},
       ],
       :record_info => (
         unless @retireitems.nil? || @retireitems.length != 1

--- a/app/controllers/persistent_volume_controller.rb
+++ b/app/controllers/persistent_volume_controller.rb
@@ -23,8 +23,7 @@ class PersistentVolumeController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Volumes")},
-        {:url   => controller_url, :title => _("Persistent Volumes")},
+        {:title => _("Volumes"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -37,8 +37,7 @@ class PhysicalChassisController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Chassis")},
-        {:url   => controller_url, :title => _("Physical Chassis")},
+        {:title => _("Chassis"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/physical_rack_controller.rb
+++ b/app/controllers/physical_rack_controller.rb
@@ -51,8 +51,7 @@ class PhysicalRackController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Racks")},
-        {:url   => controller_url, :title => _("Physical Racks")},
+        {:title => _("Racks"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -138,8 +138,7 @@ class PhysicalServerController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Servers")},
-        {:url   => controller_url, :title => _("Physical Servers")},
+        {:title => _("Servers"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -41,8 +41,7 @@ class PhysicalStorageController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Storages")},
-        {:url   => controller_url, :title => _("Physical Storages")},
+        {:title => _("Storages"), :url => controller_url},
       ],
     }
   end

--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -50,8 +50,7 @@ class PhysicalSwitchController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Physical Infrastructure")},
-        {:title => _("Switches")},
-        {:url   => controller_url, :title => _("Physical Switches")},
+        {:title => _("Switches"), :url => controller_url},
       ],
     }
   end

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -230,6 +230,52 @@ describe Mixins::BreadcrumbsMixin do
           )
         end
       end
+
+      it "not contain header on show_list page" do
+        allow(subject).to receive(:action_name).and_return("show_list")
+        subject.instance_variable_set(:@title, "Do not show me")
+
+        expect(subject.data_for_breadcrumbs).to eq(
+          [
+            {:title=>"First Layer"},
+            {:title=>"Second Layer"}
+          ]
+        )
+      end
+
+      it "contain header on not show_list page" do
+        allow(subject).to receive(:action_name).and_return("edot")
+        subject.instance_variable_set(:@title, "Do show me")
+
+        expect(subject.data_for_breadcrumbs).to eq(
+          [
+            {:title=>"First Layer"},
+            {:title=>"Second Layer"},
+            {:title=>"Do show me"}
+          ]
+        )
+      end
+    end
+
+    describe "#same_as_last_breadcrumb?" do
+      let(:breadcrumbs) do
+        [
+          {:title=>"controller"},
+          {:title=>"header"}
+        ]
+      end
+
+      it "returns true if header is same as last breadcrumb" do
+        expect(subject.send(:same_as_last_breadcrumb?, breadcrumbs, "header")).to eq(true)
+      end
+
+      it "returns false if header is not same as last breadcrumb" do
+        expect(subject.send(:same_as_last_breadcrumb?, breadcrumbs, "different header")).to eq(false)
+      end
+
+      it "returns false if header is same as last breadcrumb but it in the breadcrumbs on different place" do
+        expect(subject.send(:same_as_last_breadcrumb?, breadcrumbs, "controller")).to eq(false)
+      end
     end
 
     describe "#special_page_breadcrumb" do


### PR DESCRIPTION
closes https://github.com/ManageIQ/manageiq-ui-classic/issues/5361

**Description**

When a header on the show_list page and a title in the menu are not the same, only the menu title is used.

**Before** 

![image](https://user-images.githubusercontent.com/32869456/62126224-7c022300-b2cf-11e9-8708-cde4e768fc73.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/62126189-6ee53400-b2cf-11e9-95f4-7fbc70502d06.png)


@miq-bot add_label changelog/yes, ivanchuk/no, breadcrumbs