### PR TITLE
Filters header renamed to Global Filters

### DIFF
--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -6,7 +6,7 @@
     - unless @def_searches.blank?
       - if @panels["#{@view.db}_def_searches"].nil?
         - @panels["#{@view.db}_def_searches"] = true
-      = miq_accordion_panel(_("Filters"), true, "#{@view.db}_def_searches") do
+      = miq_accordion_panel(_("Global Filters"), true, "#{@view.db}_def_searches") do
         %ul.nav.nav-pills.nav-stacked
           - @def_searches.each do |search|
             - li_class = ""


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1429540 
 header "Filters" renamed to "Global Filters"
Before:
![image](https://user-images.githubusercontent.com/52449124/62137851-ebcfd800-b2e6-11e9-9ff7-e52f298b12c7.png)

After:
![image](https://user-images.githubusercontent.com/52449124/62138098-5e40b800-b2e7-11e9-8885-58c72a0bf912.png)


