### PR TITLE
user_input_filter: Don't autofocus selects

### DIFF
--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -121,9 +121,10 @@
                       :title        => t)
 :javascript
   $(function(){
-    $('#quicksearchbox').on('shown.bs.modal', function () {
-      if (miqDomElementExists('value_1')) $('#value_1').focus();
-    })
+    $('#quicksearchbox').on('shown.bs.modal', function() {
+      // autofocus, but not a select as focusing hidden select breaks pf-select
+      $('#value_1').not('select').focus();
+    });
     $('#quicksearchbox').off("click");
     $('#quicksearchbox').on('click', '[data-dismiss="modal"]', function(event) {
       if (event && event.target && event.target.id == 'apply_button') {


### PR DESCRIPTION
Compute > Infra > VMs > VMs accordion,
add an advanced search like "VM.active" "=" "\<user input\>" - the field needs to be a boolean,
try to use it.

Before: there would be a Choose / True / False select, but chosing anything would just show Choose
Now: you should be able to chose a value.

(And field types other than bool should still have the input autofocused.)

--- 

The user input filter autofocuses the first input element,

but pf-select hides the select element and creates its own div.
That div never changes the text inside when chosing options, if the original select is focused.

Making sure we don't autofocus select elements.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5896
https://bugzilla.redhat.com/show_bug.cgi?id=1677258