### PR TITLE
Make the check against Satellite organization safe to fix RHSM issues

### DIFF
--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -218,7 +218,7 @@ module OpsController::Settings::RHN
   # fields are filled-in.
   def rhn_allow_save?
     obligatory_fields = %i[customer_password customer_userid server_url repo_name]
-    obligatory_fields << :customer_org if @edit[:organizations].length > 1
+    obligatory_fields << :customer_org if @edit[:organizations].try(:length).to_i > 1
     obligatory_fields << :proxy_address if @edit[:new][:use_proxy].to_i == 1
 
     obligatory_fields.find_all do |field|


### PR DESCRIPTION
When you try to add your credentials for *Red Hat Subscription Manager* under `Settings -> Region -> Red Hat Updates`, the workflow breaks on a type conversion error which has been introduced to support organization for *Satellite*. The fix is to use `try` and convert the data to number so the comparison never fails.

@miq-bot add_label bug, hammer/yes, ivanchuk/yes
@miq-bot add_reviewer @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1731962