### PR TITLE
Clear modal after Applying advanced search

### DIFF
--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -27,7 +27,7 @@
                      :class   => "btn btn-primary",
                      :alt     => t = _("Apply the current filter"),
                      :title   => t,
-                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');")
+                     :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');$('#advsearchModal').modal('hide');")
       - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
         - if report_admin_user? || @edit[@expkey][:selected][:typ] == "user"
           - actual_filter = @edit[@expkey][:selected][:description]


### PR DESCRIPTION
When applying a boolean advanced search the modal is not hidden resulting in an unclickable screen.

Reproduced via:
Compute - Cloud - Instances - All Instances
Advanced search consisting of: Field: Instance : Active = "true"

@miq-bot add_labels bug, compute/cloud

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1725838