### PR TITLE
Fix button sets order in tree

### DIFF
--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -24,7 +24,7 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
   end
 
   def x_get_actions_kids(object, count_only)
-    count_only_or_objects(count_only, object[:object].custom_button_sets + object[:object].custom_buttons, :name)
+    count_only_or_objects(count_only, object[:object].custom_button_sets.sort_by(&:name) + object[:object].custom_buttons)
   end
 
   def tree_init_options


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1665031

Go to Automation -> Automate -> Generic Objects ->  click Actions in a tree-> Add some custom button sets that start with UpperCase letter and some that start with LowerCase letter -> see different order in tree and GTL

Look at `annabelle` custom button set
Before:
<img width="1006" alt="Screenshot 2019-07-31 at 14 27 43" src="https://user-images.githubusercontent.com/9210860/62213323-ee900300-b3a2-11e9-9fbf-7bf325a88ba0.png">
After:
<img width="1012" alt="Screenshot 2019-07-31 at 14 26 50" src="https://user-images.githubusercontent.com/9210860/62213324-ee900300-b3a2-11e9-8b99-f86df1c31f5b.png">

@romanblanco please have a look, thanks

@miq-bot add_label hammer/yes, ivanchuc/yes, bug, generic objects