### PR TITLE
Catalog item removal modal: disable delete button if API data incomplete

### DIFF
--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -67,7 +67,11 @@ class RemoveCatalogItemModal extends React.Component {
          name:         catalogItem.name,
          service_type: catalogItem.service_type, // 'atomic' or 'composite'
          services:     catalogItem.services})))
-      .then(data => this.setState({data}));
+      .then(data => this.setState({data}))
+      .then(() => this.props.dispatch({
+        type: 'FormButtons.saveable',
+        payload: true
+      }));
 
     // Buttons setup
     this.props.dispatch({
@@ -81,10 +85,6 @@ class RemoveCatalogItemModal extends React.Component {
     this.props.dispatch({
       type: "FormButtons.customLabel",
       payload: __('Delete'),
-    });
-    this.props.dispatch({
-      type: 'FormButtons.saveable',
-      payload: true
     });
   }
 

--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Modal } from 'patternfly-react';
+import { Modal, Spinner } from 'patternfly-react';
 import { API } from '../http_api';
 
 const parseApiError = (error) => {
@@ -51,7 +51,8 @@ class RemoveCatalogItemModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      data: []
+      data: [],
+      loaded: false
     };
   }
 
@@ -67,7 +68,7 @@ class RemoveCatalogItemModal extends React.Component {
          name:         catalogItem.name,
          service_type: catalogItem.service_type, // 'atomic' or 'composite'
          services:     catalogItem.services})))
-      .then(data => this.setState({data}))
+      .then(data => this.setState({data: data, loaded: true}))
       .then(() => this.props.dispatch({
         type: 'FormButtons.saveable',
         payload: true
@@ -126,15 +127,24 @@ class RemoveCatalogItemModal extends React.Component {
       }
     };
 
+    const renderSpinner = (spinnerOn) => {
+      if (spinnerOn) {
+        return <Spinner loading size="lg" />;
+      }
+    };
+
     return (
       <Modal.Body className="warning-modal-body">
+        {renderSpinner(!this.state.loaded)}
         {usedServicesMessage(this.state.data)}
-        <div>
-           <h4>{confirmationMessage(this.state.data)}</h4>
-           {this.state.data.map(item => (
-             <ul key={item.id}><h4><strong>{item.name}</strong></h4></ul>
-           ))}
-        </div>
+        {this.state.loaded &&
+          <div>
+             <h4>{confirmationMessage(this.state.data)}</h4>
+             {this.state.data.map(item => (
+               <ul key={item.id}><h4><strong>{item.name}</strong></h4></ul>
+             ))}
+          </div>
+        }
       </Modal.Body>
     );
   }

--- a/app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
+++ b/app/javascript/spec/remove-catalog-item-modal/remove-catalog-item-modal.spec.js
@@ -41,7 +41,7 @@ describe('RemoveCatalogItemModal', () => {
 
     setImmediate(() => {
       component.update();
-      expect(component.childAt(0).state()).toEqual({data: [apiResponse1]});
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1], loaded: true});
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('RemoveCatalogItemModal', () => {
 
     setImmediate(() => {
       component.update();
-      expect(component.childAt(0).state()).toEqual({data: [apiResponse1, apiResponse2]});
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1, apiResponse2], loaded: true});
       done();
     });
   });


### PR DESCRIPTION
1. Go to catalog items, have many of them available
2. Select all of them at once (or at lest 5-6 items)
3. Hit delete catalog items

Previously, the rendered modal would have delete button initialy enabled. Hitting the delete button before the modal would be filled by data would not delete anything at all, it would just show spinner indefinitely.

With this fix in place, the delete button will be enabled only after the API data is fetched and the modal is filled with appropriate data. The modal will also render a spinner before the data is
completely loaded.

https://bugzilla.redhat.com/show_bug.cgi?id=1713399

@himdel 