### PR TITLE
Remove sandpaper styling around GTLs

### DIFF
--- a/app/assets/javascripts/controllers/report_data_controller.js
+++ b/app/assets/javascripts/controllers/report_data_controller.js
@@ -409,12 +409,10 @@
       return;
     }
 
-    angular.element(mainContent).removeClass('miq-sand-paper');
     angular.element(mainContent).removeClass('miq-list-content');
     angular.element(pagination).css('display', 'none');
 
     if (viewType === 'grid' || viewType === 'tile') {
-      angular.element(mainContent).addClass('miq-sand-paper');
       angular.element(pagination).css('display', 'block');
     } else if (viewType === 'list') {
       angular.element(mainContent).addClass('miq-list-content');

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -151,11 +151,6 @@ ManageIQ.explorer.focus = function(data) {
   }
 };
 
-ManageIQ.explorer.removeSand = function() {
-  var mainContent = $('#main-content');
-  mainContent.removeClass('miq-sand-paper');
-};
-
 ManageIQ.explorer.removePaging = function() {
   miqGtlSetExtraClasses();
 };
@@ -328,9 +323,6 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
     ManageIQ.explorer.lockSidebar(data.lockSidebar);
   }
 
-  if (data.removeSand) {
-    ManageIQ.explorer.removeSand();
-  }
   if (data.removePaging) {
     ManageIQ.explorer.removePaging();
   }

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -375,7 +375,6 @@ class AutomationManagerController < ApplicationController
   def update_partials(record_showing, presenter)
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
-      presenter.remove_sand
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "layouts/textual_groups_generic"])
     elsif @in_a_form
@@ -389,12 +388,10 @@ class AutomationManagerController < ApplicationController
       partial = 'form'
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])
     elsif valid_managed_group_record?(@inventory_group_record)
-      presenter.remove_sand
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "inventory_group",
                                     :locals  => {:controller => controller_name}])
     elsif valid_configuration_script_record?(@configuration_script_record)
-      presenter.remove_sand
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "configuration_script",
                                     :locals  => {:controller => controller_name}])

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -368,7 +368,6 @@ class ProviderForemanController < ApplicationController
     if record_showing && valid_configured_system_record?(@configured_system_record)
       get_tagdata(@record)
       presenter.hide(:form_buttons_div)
-      presenter.remove_sand
       presenter.update(:main_div, r[:partial => "layouts/textual_groups_generic"])
     elsif @in_a_form
       partial_locals = {:controller => controller_name}
@@ -382,7 +381,6 @@ class ProviderForemanController < ApplicationController
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])
     elsif valid_configuration_profile_record?(@configuration_profile_record)
       presenter.hide(:form_buttons_div)
-      presenter.remove_sand
       presenter.update(:main_div, r[:partial => "configuration_profile",
                                     :locals  => {:controller => controller_name}])
     else

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -441,7 +441,6 @@ class ServiceController < ApplicationController
         r[:partial => 'layouts/x_gtl', :locals => {:controller => "vm", :action_url => @lastaction}]
       elsif record_showing
         @selected_ids = [] # FIXME: hack to hide checkboxes
-        presenter.remove_sand
         r[:partial => "service/svcs_show", :locals => {:controller => "service"}]
       else
         r[:partial => "layouts/x_gtl"]

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -118,16 +118,6 @@ module ApplicationHelper::PageLayouts
     ].include?(controller.action_name)
   end
 
-  def miq_layout_center_div_no_listnav_class
-    if (!@in_a_form && (@lastaction == "show_dashboard" ||
-                        @layout == "monitor_alerts_overview")) ||
-        show_list_with_no_provider?
-      'miq-body'
-    else
-      ''
-    end
-  end
-
   def center_div_partial
     if layout_uses_listnav?
       "layouts/center_div_with_listnav"

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -78,15 +78,9 @@ class ExplorerPresenter
       :show_miq_buttons     => false,
       :load_chart           => nil,
       :open_window          => nil,
-      :remove_sand          => nil,
       :remove_paging        => nil,
       :rx                   => nil,
     }.update(options)
-  end
-
-  def remove_sand
-    @options[:remove_sand] = true
-    self
   end
 
   def remove_paging
@@ -309,7 +303,6 @@ class ExplorerPresenter
     data[:lockSidebar] = !!@options[:lock_sidebar]
     data[:chartData] = @options[:load_chart]
     data[:resetChanges] = !!@options[:reset_changes]
-    data[:removeSand] = !!@options[:remove_sand]
     data[:removePaging] = !!@options[:remove_paging]
     data[:resetOneTrans] = !!@options[:reset_one_trans]
     data[:focus] = @options[:focus]

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -8,7 +8,7 @@
         .row.toolbar-pf#toolbar
           .col-sm-12
             = render :partial => "layouts/angular/toolbar"
-      .row#main-content.miq-layout-center_div_no_listnav{:class => miq_layout_center_div_no_listnav_class }
+      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
         .col-md-12
         - if layout_uses_tabs?
           .col-md-12

--- a/app/views/service/explorer.html.haml
+++ b/app/views/service/explorer.html.haml
@@ -6,13 +6,6 @@
   -# Showing a specific Service
   #main_div
     = render :partial => "svcs_show", :locals => {:controller => "service"}
-    -# FIXME: remove sand-paper style hack when we resolve the div shared between
-    -# the GTL grid an details.
-    :javascript
-      setTimeout(function() {
-        var mainContent = $('#main-content');
-        mainContent.removeClass('miq-sand-paper');
-      });
 - else
   -# Showing a list of VMs
   #main_div


### PR DESCRIPTION
This PR removes all of the code added to ensure that the gray background used in Tile and Grid views was rendered correctly.

Depends on  https://github.com/ManageIQ/ui-components/pull/409
Issue: https://github.com/ManageIQ/ui-components/issues/406