### PR TITLE
Remove Load Balancer button from Network Topology page

### DIFF
--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -39,10 +39,6 @@
         %label
           %i.fa.fa-tag
           = _("Tags")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "LoadBalancer"}
-        %label
-          %i.ff.ff-load-balancer
-          = _("Load Balancer")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1798,31 +1798,6 @@ Rails.application.routes.draw do
         dialog_runner_post
     },
 
-    :load_balancer             => {
-      :get  => %w(
-        dialog_load
-        download_data
-        download_summary_pdf
-        index
-        show
-        show_list
-        tagging_edit
-      ),
-      :post => %w(
-        button
-        quick_search
-        show
-        show_list
-        listnav_search_selected
-        tag_edit_form_field_changed
-        tagging_edit
-      ) +
-        adv_search_post +
-        save_post +
-        exp_post +
-        dialog_runner_post
-    },
-
     :flavor                   => {
       # FIXME: Change tagging_edit to POST only; We need to remove the redirects
       # in app/controllers/application_controller/tags.rb#tag that are used in


### PR DESCRIPTION
Remove Load Balancer link/button from the Network Topology page.

https://bugzilla.redhat.com/show_bug.cgi?id=1672949

Screen shot prior to code fix:
![Topology with Load Balancer button prior to code fix](https://user-images.githubusercontent.com/552686/62243794-e760f900-b392-11e9-99d8-1c48dcd23db9.png)

Screen shot post code fix:
![Topology with no Load Balancer button post fix](https://user-images.githubusercontent.com/552686/62243827-f5167e80-b392-11e9-8850-9db3eda1e0cb.png)


