### PR TITLE
views: remove unneeded compliances join

### DIFF
--- a/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
@@ -33,7 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :tags: {}
 

--- a/product/views/MiqTemplate.yaml
+++ b/product/views/MiqTemplate.yaml
@@ -33,7 +33,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/ProvisionCloudTemplates.yaml
+++ b/product/views/ProvisionCloudTemplates.yaml
@@ -40,7 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/Vm-all_vms.yaml
+++ b/product/views/Vm-all_vms.yaml
@@ -38,7 +38,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/VmOrTemplate-all_archived.yaml
+++ b/product/views/VmOrTemplate-all_archived.yaml
@@ -38,7 +38,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}


### PR DESCRIPTION
For some databases, this brings back way too many records.

It is unnecessary. And if it were necessary, the includes would get added automatically anyway.

See also https://github.com/ManageIQ/manageiq-ui-classic/pull/5283

https://bugzilla.redhat.com/show_bug.cgi?id=1733351