### PR TITLE
Update datepicker when start date changed

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -176,6 +176,7 @@ module ReportController::Schedules
                                          end
       end
       page << "$('#miq_date_1').val('#{@edit[:new][:timer].start_date}');"
+      page << "$('#miq_date_1').datepicker('update');"
 
       changed = (@edit[:new] != @edit[:current])
       if changed != session[:changed]


### PR DESCRIPTION
1. Create a new report schedule
2. Choose some starting date in the future
3. Change `Run` between `Hourly` and something else
4. Watch the start date changing to either today or tomorrow
5. Open the datepicker (by clicking on the input field)

Without this fix, the datepicker would not reflect the change of the starting date.

https://bugzilla.redhat.com/show_bug.cgi?id=1729882