### PR TITLE
[WIP] Dialog editor - show validation errors

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -7,6 +7,12 @@
     .row
       .col-md-12
         %form.form-horizontal
+          .alert.alert-danger{'ng-if' => 'vm.DialogValidation.invalid.message'}
+            %span.pficon.pficon-error-circle-o
+            %strong
+              {{vm.DialogValidation.invalid.description}}:
+              {{vm.DialogValidation.invalid.message}}
+
           %div{"pf-form-group" => "", "pf-label" => _("Dialog's name")}
             %input#name{"ng-model" => "vm.dialog.content[0].label",
               :type => "text",
@@ -17,14 +23,17 @@
             %textarea#description{"ng-model" => "vm.dialog.content[0].description",
               :title => _("Dialog's description")}
               {{ vm.dialog.content[0].description }}
+
     %dialog-editor{'tree-options' => 'vm.treeOptions'}
+
     .pull-right
-      %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
+      %button.btn.btn-primary{"ng-click"    => "vm.saveDialogDetails()",
                               "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) || vm.saveButtonDisabled",
-                              "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
-                              :type => "button"}= _("Save")
+                              :type         => "button"}
+        = _("Save")
       %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
-                              :type => "button"}= _("Cancel")
+                              :type      => "button"}
+        = _("Cancel")
 
 :javascript
   ManageIQ.angular.app.value('dialogIdAction', '#{ dialog_id_action.to_json }');


### PR DESCRIPTION
Right now, we never actually show dialog editor validation errors.
We're trying to show it on the submit button in ui-classic, but the button is disabled (and thus not rendering title) when validation fails.

So, moving to an explicit error div.

(related to https://bugzilla.redhat.com/show_bug.cgi?id=1729265 and https://github.com/ManageIQ/ui-components/pull/407 ; merge ui-components first)
