### PR TITLE
Queue up schedule/s to run now

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -80,6 +80,7 @@ class OpsController < ApplicationController
     'schedule_delete'           => :schedule_delete,
     'schedule_enable'           => :schedule_enable,
     'schedule_disable'          => :schedule_disable,
+    'schedule_run_now'          => :schedule_run_now
   }.freeze
 
   def collect_current_logs

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -109,7 +109,7 @@ module ReportController::Schedules
             else
               _("The selected Schedules have been queued to run")
             end
-      add_flash(msg, :info, true)
+      add_flash(msg, :success, true)
     end
     get_node_info
     replace_right_cell


### PR DESCRIPTION
The functionality of schedule_run_now added.

It adds choose Schedule/s to the MiqQueue. After adding, flash messega appears and checked boxes are unchecked.
### RSpec
It tests adding 1 Schedule and multiple Schedules.
Simulate checking Schedule/s and expect correct flash message.
Then control if the Schedule/s are in MiqQueue
### Visual 
Before:
![image](https://user-images.githubusercontent.com/52449124/62299731-c7eecc80-b475-11e9-8be8-2a549d94e48d.png)

After:
![image](https://user-images.githubusercontent.com/52449124/62299582-7d6d5000-b475-11e9-89fc-384c54797485.png)

Is it okay like that? Can I start writing specs? @himdel 
 @lpichler 
