### PR TITLE
Changed model name when showing list of Tower Templates.

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -223,7 +223,7 @@ class AutomationManagerController < ApplicationController
     when "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem", "ConfiguredSystem"
       configured_system_list(id, model)
     when "ConfigurationScript", "ConfigurationWorkflow"
-      configuration_scripts_list(id, model)
+      configuration_scripts_list(id, model == "ConfigurationScript" ? "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript" : model)
     when "MiqSearch"
       miq_search_node
     else
@@ -332,7 +332,7 @@ class AutomationManagerController < ApplicationController
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Configured Systems")
     elsif x_active_tree == :configuration_scripts_tree
-      options = {:model      => "ConfigurationScript",
+      options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
                  :gtl_dbname => "automation_manager_configuration_scripts"}
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Templates")

--- a/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScript.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScript.yaml
@@ -1,0 +1,82 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Ansible Tower Templates
+
+# Menu name
+name: Templates
+
+# Main DB table report is based on
+db: ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+
+# Columns to fetch from the main table
+cols:
+- name
+- type
+- description
+- created_at
+- updated_at
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- type
+- description
+- created_at
+- updated_at
+
+# Column titles, in order
+headers:
+- Name
+- Type
+- Description
+- Created On
+- Updated On
+
+
+col_formats:
+-
+- :model_name
+-
+-
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -428,7 +428,7 @@ describe AutomationManagerController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
       controller.params = {:id => "configuration_scripts"}
-      expect(controller).to receive(:get_view).with("ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
+      expect(controller).to receive(:get_view).with("ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
       controller.send(:accordion_select)
     end
   end


### PR DESCRIPTION
previously code was passing in model as `ConfigurationScript` that returns all Tower templates, Changed to use `ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript` so that embedded ansible templates are excluded from the list

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656734

before
![before](https://user-images.githubusercontent.com/3450808/62306367-bbf01400-b44f-11e9-9f23-e6a1d2d0b5de.png)

after
![after](https://user-images.githubusercontent.com/3450808/62306374-bf839b00-b44f-11e9-9886-bf1039e239cf.png)
