### PR TITLE
Circling back and removing compliance join for all

### DIFF
--- a/product/views/InstanceOrImage.yaml
+++ b/product/views/InstanceOrImage.yaml
@@ -38,7 +38,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -39,7 +39,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
@@ -40,7 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :tags: {}
 

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
@@ -40,7 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :tags: {}
 

--- a/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
@@ -45,7 +45,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :tags: {}
 

--- a/product/views/ManageIQ_Providers_InfraManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Template.yaml
@@ -42,7 +42,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
@@ -43,7 +43,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/MiqTemplate-all_miq_templates.yaml
+++ b/product/views/MiqTemplate-all_miq_templates.yaml
@@ -37,7 +37,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/ProvisionInfraTemplates.yaml
+++ b/product/views/ProvisionInfraTemplates.yaml
@@ -37,7 +37,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/Vm.yaml
+++ b/product/views/Vm.yaml
@@ -34,7 +34,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/VmOrTemplate-all_orphaned.yaml
+++ b/product/views/VmOrTemplate-all_orphaned.yaml
@@ -38,7 +38,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}

--- a/product/views/VmOrTemplate-all_vms_and_templates.yaml
+++ b/product/views/VmOrTemplate-all_vms_and_templates.yaml
@@ -40,7 +40,6 @@ include:
 # Included tables and columns for query performance
 include_for_find:
   :snapshots: {}
-  :compliances: {}
   :operating_system: {}
   :hardware: {}
   :tags: {}


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-ui-classic/pull/5919

having `include_for_find: :compliances` forces a join
and too many records are coming back.

We removed a few of these in https://github.com/ManageIQ/manageiq-ui-classic/pull/5919, but this PR circles back and removes them from the other views, too.

https://bugzilla.redhat.com/show_bug.cgi?id=1733351