### PR TITLE
Fix display of Container Project Compliance Policies

### DIFF
--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -7,6 +7,7 @@
                     "Container Group Compliance"         => _("Pod Compliance Policies"),
                     "Container Node Compliance"          => _("Container Node Compliance Policies"),
                     "Container Image Compliance"         => _("Container Image Compliance Policies"),
+                    "Container Project Compliance"       => _("Container Project Compliance Policies"),
                     "Ext Management System Compliance"   => _("Provider Compliance Policies"),
                     "Physical Server Compliance"         => _("Physical Infrastructure Compliance Policies"),
                     "Host Control"                       => _("Host Control Policies"),


### PR DESCRIPTION
Fix display of missing name for Container Policy Compliance. 

https://bugzilla.redhat.com/show_bug.cgi?id=1728740

Screen shot prior to code fix:
![Container Project Compliance policies name missing prior to code fix](https://user-images.githubusercontent.com/552686/62329086-c0c1c180-b469-11e9-9643-b7debc5bfb75.png)

Screen shot showing name displayed post code fix:
![Container Project Compliance policies name post fix](https://user-images.githubusercontent.com/552686/62329110-cf0fdd80-b469-11e9-9894-1d5429e2c74e.png)

