### PR TITLE
Add formatting to report data filter display.

### DIFF
--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -8,12 +8,29 @@ import {
   Paginator,
   PAGINATION_VIEW,
   sortableHeaderCellFormatter,
-  tableCellFormatter,
   Table,
   TABLE_SORT_DIRECTION,
+  TableCell,
 } from 'patternfly-react';
 
 import { API } from '../http_api';
+
+const cellFormatter = value => (
+  <TableCell className={value.style_class}>
+    {value.value}
+  </TableCell>
+);
+
+cellFormatter.propTypes = {
+  value: PropTypes.shape({
+    value: PropTypes.node,
+    style_class: PropTypes.string,
+  }),
+};
+
+cellFormatter.defaultProps = {
+  value: null,
+};
 
 const makeColumn = (name, label, index) => ({
   property: name,
@@ -30,7 +47,7 @@ const makeColumn = (name, label, index) => ({
     props: {
       index: 1,
     },
-    formatters: [tableCellFormatter],
+    formatters: [cellFormatter],
   },
 });
 
@@ -126,6 +143,7 @@ const fetchReportPage = (dispatch, reportResultId, sortingColumns, pagination, f
     : '';
 
   API.get(`/api/results/${reportResultId}?\
+expand_value_format=true&\
 hash_attribute=result_set&\
 sort_by=${sortBy}&sort_order=${sortDirection}&\
 limit=${limit}&offset=${offset}${filterString}`).then((data) => {

--- a/app/javascript/spec/report-data-table.spec.js
+++ b/app/javascript/spec/report-data-table.spec.js
@@ -29,6 +29,7 @@ describe('<ReportDataTable />', () => {
     const limit = 20;
     const offset = 0;
     const url = `/api/results/${initialProps.reportResultId}?\
+expand_value_format=true&\
 hash_attribute=result_set&\
 sort_by=${sortBy}&sort_order=${sortDirection}&\
 limit=${limit}&offset=${offset}`;


### PR DESCRIPTION
Add styling to report data filter display.

After:
![report-style-2019-08-02_11-19](https://user-images.githubusercontent.com/51095/62359616-7860dd00-b517-11e9-92c9-62ee8a487886.png)

Requires: https://github.com/ManageIQ/manageiq/pull/18938 (merged)