### PR TITLE
Fix error when canceling addition of new schedule

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -36,7 +36,7 @@ module OpsController::Settings::Schedules
     assert_privileges("schedule_edit")
     case params[:button]
     when "cancel"
-      @schedule = MiqSchedule.find(params[:id])
+      @schedule = MiqSchedule.find_by(:id => params[:id])
       if !@schedule || @schedule.id.blank?
         add_flash(_("Add of new Schedule was cancelled by the user"))
       else


### PR DESCRIPTION
1. Under Settings, add a new schedule
2. Cancel the addition (i.e. no save)

The following error will show in rails console:
```
FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqSchedule with 'id'=new
~/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.1.7/lib/active_record/core.rb:189:in `find'
manageiq-ui-classic/app/controllers/ops_controller/settings/schedules.rb:39:in `schedule_edit'
...
```