### PR TITLE
Disable <Choose a Role> option to prevent error while adding Group

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -69,9 +69,11 @@
             %i.ff.ff-user-role{params}
             = link_to(@group.miq_user_role.name, "#", params)
         - else
+          - disabled_item = ["<Choose a Role>", nil]
+          - selected_item = @edit[:new][:role] || disabled_item
           = select_tag('group_role',
-              options_for_select(@edit[:roles].sort, @edit[:new][:role]),
-              :class  => "selectpicker")
+                       options_for_select(@edit[:roles], :selected => selected_item, :disabled => disabled_item),
+                       :class => "selectpicker")
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent("group_role", "#{combo_url}")

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -82,5 +82,14 @@ describe 'ops/_rbac_group_details.html.haml' do
       expect(rendered).not_to have_selector('input#lookup')
       expect(rendered).not_to include('Look up External Authentication Groups')
     end
+
+    context 'choosing Role from the drop down while adding Group' do
+      before { view.instance_variable_set(:@edit, :ldap_groups_by_user => [], :new => {}, :roles => {'<Choose a Role>' => nil}, :projects_tenants => []) }
+
+      it 'disables Choose a Role option' do
+        render :partial => 'ops/rbac_group_details'
+        expect(rendered).to include('<option selected="selected" disabled="disabled" value="">&lt;Choose a Role&gt;</option>')
+      end
+    end
   end
 end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1730402

Unexpected error occurs if we choose _< Choose a Role >_ option in the drop down for specifying some Role while adding a new Group (after we had some Role already chosen). With disabling this option, we prevent occurring errors and we also bring more consistency because it is not possible to choose _<Choose a Project/Tenant>_ option, too, for specifying a Project or Tenant.

With disabling _<Choose a Role>_ option, we also prevent saving group with _<Choose a Role>_ in the drop down.

Note:
Name, Role and Project or Tenant are required to specify for adding new Group.

---

**Before:**
![role_before](https://user-images.githubusercontent.com/13417815/62374994-86c1ef80-b53d-11e9-81f9-ab07741f62c7.png)

**After:**
![role_after](https://user-images.githubusercontent.com/13417815/62374837-20d56800-b53d-11e9-972c-248250971eae.png)
