### PR TITLE
Consume the URL for VMRC from the task result instead of building it

### DIFF
--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -6,7 +6,7 @@
     :javascript
       // INITIALIZE
       $(document).ready(function(){
-        window.location.href = "#{j(vmrc_uri.to_s)}";
+        window.location.href = "#{j(remote_url.to_s)}";
         setTimeout(function () { window.close(); }, 8000);
       });
 


### PR DESCRIPTION
This is a side-advantage of implementing [the URL building in the provider](https://github.com/ManageIQ/manageiq-providers-vmware/pull/429) for [VMRC support in SUI](https://github.com/ManageIQ/manageiq/issues/18718). The `build_vmrc_uri` and the rest of the params are no longer necessary as the URL is being shipped in the task result.

@miq-bot add_label pending/core, technical debt, cleanup, hammer/no
@miq-bot add_reviewer @mzazrivec 

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/429