### PR TITLE
Add offending Vm/Container Node/... to All Alerts Overview

### DIFF
--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -90,7 +90,7 @@
                   %th
                     = _("User")
                   %th
-                    = _("Offending %{type}" % {:type => "{{$parent.$parent.item.hostType}}"})
+                    = _("Offending %{type}" % {:type => "{{$parent.$parent.item.hostType.split('::').pop()}}"})
                   %th
                     = _("Note")
               %tbody

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -90,7 +90,7 @@
                   %th
                     = _("User")
                   %th
-                    = _("Offending %{type}" % {:type => "{{$parent.$parent.item.hostType.split('::').pop()}}"})
+                    = _("Offending %{type}") % {:type => "{{$parent.$parent.item.hostType.split('::').pop()}}"}
                   %th
                     = _("Note")
               %tbody
@@ -111,9 +111,7 @@
                              "tooltip-popup-delay" => "1000"}
                       {{state.username}}
                   %td
-                    .no-wrap{"uib-tooltip" => "{{}}",
-                             "tooltip-placement" => "top",
-                             "tooltip-popup-delay" => "1000"}
+                    %a{"ng-href" => '{{$parent.$parent.item.hostImg == $parent.$parent.item.objectTypeImg ? $parent.$parent.item.objectLink : $parent.$parent.item.hostLink}}'}
                       {{$parent.$parent.item.hostName}}
                   %td
                     .no-wrap{"uib-tooltip" => "{{state.comment}}",

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -79,6 +79,7 @@
                 %col.fixed-col
                 %col.fixed-col
                 %col.fixed-col
+                %col.fixed-col
                 %col.grow-col
               %thead
                 %tr
@@ -88,6 +89,8 @@
                     = _("Action")
                   %th
                     = _("User")
+                  %th
+                    = _("Offending %{type}" % {:type => "{{$parent.$parent.item.hostType}}"})
                   %th
                     = _("Note")
               %tbody
@@ -107,6 +110,11 @@
                              "tooltip-placement" => "top",
                              "tooltip-popup-delay" => "1000"}
                       {{state.username}}
+                  %td
+                    .no-wrap{"uib-tooltip" => "{{}}",
+                             "tooltip-placement" => "top",
+                             "tooltip-popup-delay" => "1000"}
+                      {{$parent.$parent.item.hostName}}
                   %td
                     .no-wrap{"uib-tooltip" => "{{state.comment}}",
                              "tooltip-placement" => "top",


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653427

Adding info about offending VM/ContainerNode/... to All Alerts Overview

Go to Monitor -> Alerts -> All Alerts

Before:
<img width="1438" alt="Screenshot 2019-08-05 at 13 46 36" src="https://user-images.githubusercontent.com/9210860/62462349-7bfa9b00-b787-11e9-992b-8757b733e64a.png">


After:
<img width="1440" alt="Screenshot 2019-08-05 at 13 42 25" src="https://user-images.githubusercontent.com/9210860/62462136-e3641b00-b786-11e9-9ca3-a63927235f91.png">

@miq-bot add_label enhancement, ivanchuk/yes, wip
