### PR TITLE
Get record class while performing operations on VMs of chosen Cluster

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -264,7 +264,7 @@ module ApplicationController::CiProcessing
     when "ems_storage"
       params[:pressed].starts_with?("cloud_object_store_object") ? CloudObjectStoreObject : CloudObjectStoreContainer
     when "ems_cluster"
-      EmsCluster
+      %w[all_vms vms].include?(params[:display]) || params[:pressed].starts_with?('miq_template') ? VmOrTemplate : EmsCluster
     when "storage"
       %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : Storage
     else


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1732370

This PR fixes the same problem as it was fixed [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/5867).

After discussion with @skateman, we've decided to fix the problem the same way and later to refactor the code to avoid not very nice block of cases in `get_rec_cls` and adding extra conditions for each controller as it is in this PR. I've created an issue for this: https://github.com/ManageIQ/manageiq-ui-classic/issues/5924

---

**Before:**
![cluster_before](https://user-images.githubusercontent.com/13417815/62462282-4fdf1a00-b787-11e9-9ea5-326ad41ff406.png)

**After:**
![cluster_after](https://user-images.githubusercontent.com/13417815/62462152-eced8300-b786-11e9-8acf-f0a91e4bffb2.png)
