### PR TITLE
Dialog Editor - show validation title when button is disabled

### DIFF
--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -25,6 +25,7 @@
                   'on-click'       => "vm.saveDialogDetails()",
                   'primary'        => 'true'}
       %miq-button{'name'     => _("Cancel"),
+                  'enabled'  => 'true',
                   'on-click' => "vm.dismissChanges()"}
 
 :javascript

--- a/app/views/miq_ae_customization/editor.html.haml
+++ b/app/views/miq_ae_customization/editor.html.haml
@@ -19,12 +19,13 @@
               {{ vm.dialog.content[0].description }}
     %dialog-editor{'tree-options' => 'vm.treeOptions'}
     .pull-right
-      %button.btn.btn-primary{"ng-click" => "vm.saveDialogDetails()",
-                              "ng-disabled" => "!vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) || vm.saveButtonDisabled",
-                              "ng-attr-title" => "{{vm.DialogValidation.invalid.message}}",
-                              :type => "button"}= _("Save")
-      %button.btn.btn-default{"ng-click" => "vm.dismissChanges()",
-                              :type => "button"}= _("Cancel")
+      %miq-button{'disabled-title' => "{{vm.DialogValidation.invalid.message}}",
+                  'enabled'        => 'vm.DialogValidation.dialogIsValid(vm.DialogEditor.data.content) && ! vm.saveButtonDisabled',
+                  'name'           => _("Save"),
+                  'on-click'       => "vm.saveDialogDetails()",
+                  'primary'        => 'true'}
+      %miq-button{'name'     => _("Cancel"),
+                  'on-click' => "vm.dismissChanges()"}
 
 :javascript
   ManageIQ.angular.app.value('dialogIdAction', '#{ dialog_id_action.to_json }');


### PR DESCRIPTION
this changes the dialog editor save/cancel buttons to use miq-button

the difference is that disabled buttons don't display title,
but non-enabled miq-buttons do display disabledTitle

(related to https://bugzilla.redhat.com/show_bug.cgi?id=1729265 )

Cc @romanblanco 

(the idea is - let's first make sure we display the message, and then we can deal with more explicit ways of displaying it, other than a tooltip, in https://github.com/ManageIQ/manageiq-ui-classic/pull/5922)