### PR TITLE
Mark the options argument in TreeBuilder methods unnecessary with _

### DIFF
--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -32,7 +32,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   end
 
   # level 2 - alert profiles
-  def x_get_tree_custom_kids(parent, count_only, options)
+  def x_get_tree_custom_kids(parent, count_only, _options)
     objects = MiqAlertSet.where(:mode => parent[:id].split('-'))
 
     count_only_or_objects(count_only, objects, :description)

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -41,7 +41,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
     count_only_or_objects_filtered(count_only, scripts, "name")
   end
 
-  def x_get_tree_custom_kids(object, count_only, options)
+  def x_get_tree_custom_kids(object, count_only, _options)
     objects = MiqSearch.where(:db => "ConfigurationScript").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -5,7 +5,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ExtManagementSystem, [:x_get_provider_kids]
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
-  def override(node, object, _pid, options)
+  def override(node, object, _pid, _options)
     node[:select] = if @assign_to
                       @selected_nodes&.include?("ResourcePool_#{object[:id]}")
                     else

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -45,7 +45,7 @@ class TreeBuilderCondition < TreeBuilder
   end
 
   # level 2 - conditions
-  def x_get_tree_custom_kids(parent, count_only, options)
+  def x_get_tree_custom_kids(parent, count_only, _options)
     towhat = parent[:id].camelize
     return super unless MiqPolicyController::UI_FOLDERS.collect(&:name).include?(towhat)
 

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -61,7 +61,7 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   # level 2 & 3...
-  def x_get_tree_custom_kids(parent, count_only, options)
+  def x_get_tree_custom_kids(parent, count_only, _options)
     # level 2 - host, vm, etc. under compliance/control
     if %w[compliance control].include?(parent[:id])
       mode = parent[:id]

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -24,7 +24,7 @@ class TreeBuilderReportDashboards < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, options)
+  def x_get_tree_custom_kids(object, count_only, _options)
     objects = []
     if object[:id].split('-').first == "g"
       objects = Rbac.filtered(MiqGroup.non_tenant_groups)

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -21,7 +21,7 @@ class TreeBuilderStorage < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, options)
+  def x_get_tree_custom_kids(object, count_only, _options)
     objects = MiqSearch.where(:db => "Storage").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end


### PR DESCRIPTION
The goal is to get rid of this variable completely, but the first step is to mark all of the occurrences so I can see where it is still being used.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, technical debt, hammer/no, ivanchuk/no