### PR TITLE
Fix main_div double id withour getting rid of <div id=main_div>

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -242,35 +242,35 @@ class GenericObjectDefinitionController < ApplicationController
   def process_root_node(presenter)
     root_node_info
     process_show_list
-    presenter.replace(:main_div, r[:partial => 'list'])
+    presenter.update(:main_div, r[:partial => 'list'])
     presenter.show(:paging_div)
     [build_toolbar("gtl_view_tb"), build_toolbar("generic_object_definitions_center_tb")]
   end
 
   def process_god_node(presenter, node)
     god_node_info(node)
-    presenter.replace(:main_div, r[:partial => 'show_god'])
+    presenter.update(:main_div, r[:partial => 'show_god'])
     presenter.hide(:paging_div)
     [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_center_tb")]
   end
 
   def process_actions_node(presenter, node)
     actions_node_info(node)
-    presenter.replace(:main_div, r[:partial => 'show_actions'])
+    presenter.update(:main_div, r[:partial => 'show_actions'])
     presenter.hide(:paging_div)
     [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_actions_node_center_tb")]
   end
 
   def process_custom_button_group_node(presenter, node)
     custom_button_group_node_info(node)
-    presenter.replace(:main_div, r[:partial => 'show_custom_button_group'])
+    presenter.update(:main_div, r[:partial => 'show_custom_button_group'])
     presenter.hide(:paging_div)
     [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_button_group_center_tb")]
   end
 
   def process_custom_button_node(presenter, node)
     custom_button_node_info(node)
-    presenter.replace(:main_div, r[:partial => 'show_custom_button'])
+    presenter.update(:main_div, r[:partial => 'show_custom_button'])
     presenter.hide(:paging_div)
     [build_toolbar("x_summary_view_tb"), build_toolbar("generic_object_definition_button_center_tb")]
   end

--- a/app/views/generic_object_definition/_list.html.haml
+++ b/app/views/generic_object_definition/_list.html.haml
@@ -1,5 +1,4 @@
-#main_div
-  = render :partial => 'layouts/gtl'
+= render :partial => 'layouts/gtl'
 
 :javascript
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_actions.html.haml
+++ b/app/views/generic_object_definition/_show_actions.html.haml
@@ -1,26 +1,25 @@
-#main_div
-  = render :partial => "layouts/flash_msg"
-  - if @record.custom_button_sets.present?
-    %hr
-      %h3
-        = _('Button Groups')
-      %table.table.table-bordered.table-hover.table-striped
-        %thead
-          %th.table-view-pf-select
-          %th
-            = _('Text')
-          %th
-            = _('Hover Text')
-        %tbody
-          - @record.custom_button_sets.sort_by{ |group | group.name }.each do |obj|
-            %tr
-              %td.table-view-pf-select
-                %i{:class => obj.set_data[:button_icon], :style => obj.set_data.key?(:button_color) ? "color: #{obj.set_data[:button_color]};" : nil}
-              %td
-                = obj[:name]
-              %td
-                = obj[:description]
-  - if @record.custom_buttons.present?
-    = render :partial => 'table_button' , :locals => {:buttons =>  @record.custom_buttons.sort_by{ |button| button.name.downcase }}
+= render :partial => "layouts/flash_msg"
+- if @record.custom_button_sets.present?
+  %hr
+    %h3
+      = _('Button Groups')
+    %table.table.table-bordered.table-hover.table-striped
+      %thead
+        %th.table-view-pf-select
+        %th
+          = _('Text')
+        %th
+          = _('Hover Text')
+      %tbody
+        - @record.custom_button_sets.sort_by{ |group | group.name }.each do |obj|
+          %tr
+            %td.table-view-pf-select
+              %i{:class => obj.set_data[:button_icon], :style => obj.set_data.key?(:button_color) ? "color: #{obj.set_data[:button_color]};" : nil}
+            %td
+              = obj[:name]
+            %td
+              = obj[:description]
+- if @record.custom_buttons.present?
+  = render :partial => 'table_button' , :locals => {:buttons =>  @record.custom_buttons.sort_by{ |button| button.name.downcase }}
 :javascript
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_custom_button.html.haml
+++ b/app/views/generic_object_definition/_show_custom_button.html.haml
@@ -1,37 +1,36 @@
-#main_div
-  = render :partial => "layouts/flash_msg"
-  - if @record && @record.kind_of?(CustomButton)
-    -# don't need basic info box for Unassigned button group
-    %h3
-      = _('Basic Information')
-    .form-horizontal.static
-      .form-group
-        %label.control-label.col-md-2
-          = _('Text')
-        .col-md-8
-          = @record.name.split('|').first
-          - display = @record.options.key?(:display) ? @record.options[:display] : true
-          &nbsp;
-          .checkbox-inline
-            %label{:style => "font-weight: normal"}
-              = check_box_tag(display, true, display, :disabled => true)
-              = _('Display on Button')
+= render :partial => "layouts/flash_msg"
+- if @record && @record.kind_of?(CustomButton)
+  -# don't need basic info box for Unassigned button group
+  %h3
+    = _('Basic Information')
+  .form-horizontal.static
+    .form-group
+      %label.control-label.col-md-2
+        = _('Text')
+      .col-md-8
+        = @record.name.split('|').first
+        - display = @record.options.key?(:display) ? @record.options[:display] : true
+        &nbsp;
+        .checkbox-inline
+          %label{:style => "font-weight: normal"}
+            = check_box_tag(display, true, display, :disabled => true)
+            = _('Display on Button')
 
-      .form-group
-        %label.control-label.col-md-2
-          = _('Hover Text')
-        .col-md-8
-          = @record.description
-      .form-group
-        %label.control-label.col-md-2
-          = _('Image')
-        .col-md-8
-          %span{:class => @record.options[:button_icon], :style => @record.options.key?(:button_color) ? "color: #{@record.options[:button_color]};" : nil}
+    .form-group
+      %label.control-label.col-md-2
+        = _('Hover Text')
+      .col-md-8
+        = @record.description
+    .form-group
+      %label.control-label.col-md-2
+        = _('Image')
+      .col-md-8
+        %span{:class => @record.options[:button_icon], :style => @record.options.key?(:button_color) ? "color: #{@record.options[:button_color]};" : nil}
 
-    %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
-                                                                           'entity'       => _('Custom Button'),
-                                                                           'entity-name'  => @record.name,
-                                                                           'redirect-url' => "/generic_object_definition",}
+  %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
+                                                                         'entity'       => _('Custom Button'),
+                                                                         'entity-name'  => @record.name,
+                                                                         'redirect-url' => "/generic_object_definition",}
 :javascript
   miq_bootstrap('#generic_object_definition_show_form');
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_custom_button_group.html.haml
+++ b/app/views/generic_object_definition/_show_custom_button_group.html.haml
@@ -1,42 +1,41 @@
-#main_div
-  = render :partial => "layouts/flash_msg"
-  - if @record && @record.kind_of?(CustomButtonSet)
-    %h3
-      = _('Basic Information')
-    .form-horizontal.static
-      .form-group
-        %label.control-label.col-md-2
-          = _('Text')
-        .col-md-8
-          = @record.name.split('|').first
-          - display = @record.set_data.key?(:display) ? @record.set_data[:display] : true
-          &nbsp;
-          .checkbox-inline
-            %label{:style => "font-weight: normal"}
-              = check_box_tag(display, true, display, :disabled => true)
-              = _('Display on Button')
+= render :partial => "layouts/flash_msg"
+- if @record && @record.kind_of?(CustomButtonSet)
+  %h3
+    = _('Basic Information')
+  .form-horizontal.static
+    .form-group
+      %label.control-label.col-md-2
+        = _('Text')
+      .col-md-8
+        = @record.name.split('|').first
+        - display = @record.set_data.key?(:display) ? @record.set_data[:display] : true
+        &nbsp;
+        .checkbox-inline
+          %label{:style => "font-weight: normal"}
+            = check_box_tag(display, true, display, :disabled => true)
+            = _('Display on Button')
 
-      .form-group
-        %label.control-label.col-md-2
-          = _('Hover Text')
-        .col-md-8
-          = @record.description
-      .form-group
-        %label.control-label.col-md-2
-          = _('Image')
-        .col-md-8
-          %span{:class => @record.set_data[:button_icon], :style => @record.set_data.key?(:button_color) ? "color: #{@record.set_data[:button_color]};" : nil}
+    .form-group
+      %label.control-label.col-md-2
+        = _('Hover Text')
+      .col-md-8
+        = @record.description
+    .form-group
+      %label.control-label.col-md-2
+        = _('Image')
+      .col-md-8
+        %span{:class => @record.set_data[:button_icon], :style => @record.set_data.key?(:button_color) ? "color: #{@record.set_data[:button_color]};" : nil}
 
-      - if @record.custom_buttons.empty?
-        %hr
-          = render :partial => 'layouts/info_msg', :locals => {:message => _("No Buttons found.")}
-      - else
-        = render :partial => 'table_button', :locals => {:buttons => @record.set_data[:button_order].map{ |id| CustomButton.find_by(:id => id) }}
+    - if @record.custom_buttons.empty?
+      %hr
+        = render :partial => 'layouts/info_msg', :locals => {:message => _("No Buttons found.")}
+    - else
+      = render :partial => 'table_button', :locals => {:buttons => @record.set_data[:button_order].map{ |id| CustomButton.find_by(:id => id) }}
 
-      %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
-                                                                             'entity'       => _('Custom Button Group'),
-                                                                             'entity-name'  => @record.description,
-                                                                             'redirect-url' => "/generic_object_definition",}
+    %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
+                                                                           'entity'       => _('Custom Button Group'),
+                                                                           'entity-name'  => @record.description,
+                                                                           'redirect-url' => "/generic_object_definition",}
 :javascript
   miq_bootstrap('#generic_object_definition_show_form');
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/_show_god.html.haml
+++ b/app/views/generic_object_definition/_show_god.html.haml
@@ -1,22 +1,21 @@
-#main_div
-  - if %w(generic_objects).include?(@display)
-    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-  - else
-    = render :partial => 'layouts/textual_groups_generic'
+- if %w(generic_objects).include?(@display)
+  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+- else
+  = render :partial => 'layouts/textual_groups_generic'
 
-    - if @record.picture
-      %hr
-        %h3
-          = _('Custom Image')
-        .form-horizontal
-          .form-group
-            .col-md-9
-              %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
+  - if @record.picture
+    %hr
+      %h3
+        = _('Custom Image')
+      .form-horizontal
+        .form-group
+          .col-md-9
+            %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
 
-  %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
-                                                                         'entity'       => _('Generic Object Class'),
-                                                                         'entity-name'  => @record.name,
-                                                                         'redirect-url' => "/generic_object_definition",}
+%generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
+                                                                       'entity'       => _('Generic Object Class'),
+                                                                       'entity-name'  => @record.name,
+                                                                       'redirect-url' => "/generic_object_definition",}
 :javascript
   miq_bootstrap('#generic_object_definition_show_form');
   $('#searchbox').hide();

--- a/app/views/generic_object_definition/show.html.haml
+++ b/app/views/generic_object_definition/show.html.haml
@@ -1,1 +1,2 @@
-= render :partial => 'generic_object_definition/show_god'
+#main_div
+  = render :partial => 'generic_object_definition/show_god'

--- a/app/views/generic_object_definition/show_list.html.haml
+++ b/app/views/generic_object_definition/show_list.html.haml
@@ -1,1 +1,2 @@
-= render :partial => 'show_list'
+#main_div
+  = render :partial => 'show_list'


### PR DESCRIPTION
Based on https://github.com/ManageIQ/manageiq-ui-classic/pull/5931#issuecomment-518266538 here's a cleaner fix for my favourite controller.

Go to Automation -> Automate -> Generic Objects -> see console log -> try `document.getElementById("main_div")`

For all forms/pages of GOD there should be exactly one `<div id="main_div">...</div>`. 

Before:
![image](https://user-images.githubusercontent.com/9210860/62366162-72bec380-b526-11e9-8b73-3ec82decd4e5.png)
After:
No warnings 

@miq-bot add_label technical debt, changelog/no, ivanchuk/no

@miq-bot assign @himdel