### PR TITLE
Fix load tags with multiple values in one category

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -181,7 +181,7 @@ module ApplicationController::Tags
       }
     end
 
-    assigned_tags = assignments.uniq.map do |tag|
+    assigned_tags = assignments.uniq(&:parent_id).map do |tag|
       {
         :description => tag.parent.description,
         :id          => tag.parent.id,


### PR DESCRIPTION
When you select multiple values from on category, save it and load it again. Category is there multiple times. I have no idea how could nobody (especially me) notice this earlier. Since last changes in this area was quite a long time ago.

Screenshots
----------------
Before:
![Screenshot from 2019-08-06 12-54-21](https://user-images.githubusercontent.com/9535558/62534425-6a79c780-b849-11e9-8a03-8512722ffc7c.png)

After:
![Screenshot from 2019-08-06 12-52-19](https://user-images.githubusercontent.com/9535558/62534428-6d74b800-b849-11e9-94b7-60c8d473af52.png)

Links [Optional]
----------------

* http://documentation.for/library/that/I/am/adding
* [PR relevant issue or pull_request](#123)

Steps for Testing/QA [Optional]
-------------------------------
Compute -> Infra -> VMs -> Policy -> Edit Tags -> Add multiple values to single category -> Save -> Edit again
