### PR TITLE
Do not use the same 🌳🌳 for assignments for Alert Profiles and RBAC groups

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -198,10 +198,10 @@ module MiqPolicyController::AlertProfiles
   def alert_profile_build_obj_tree
     return nil if alert_profile_get_assign_to_objects_empty?
     if @assign[:new][:assign_to] == "ems_folder"
-      instantiate_tree("TreeBuilderBelongsToVat", :vat_tree,
+      instantiate_tree("TreeBuilderEmsFolders", :ems_folders_tree,
                        @assign[:new][:objects].collect { |f| "EmsFolder_#{f}" })
     elsif @assign[:new][:assign_to] == "resource_pool"
-      instantiate_tree("TreeBuilderBelongsToHac", :hac_tree,
+      instantiate_tree("TreeBuilderResourcePools", :resource_pools_tree,
                        @assign[:new][:objects].collect { |f| "ResourcePool_#{f}" })
     else
       instantiate_tree("TreeBuilderAlertProfileObj", :object_tree, @assign[:new][:objects])

--- a/app/presenters/tree_builder_alert_profile_assign.rb
+++ b/app/presenters/tree_builder_alert_profile_assign.rb
@@ -1,0 +1,29 @@
+class TreeBuilderAlertProfileAssign < TreeBuilder
+  def initialize(name, sandbox, build, **params)
+    @selected_nodes = params[:selected_nodes]
+    # need to remove tree info
+    TreeState.new(sandbox).remove_tree(name)
+    super(name, sandbox, build)
+  end
+
+  def x_get_tree_roots(count_only, _options)
+    roots = ExtManagementSystem.assignable.each_with_object({}) do |ems, nodes|
+      subtree = ems.children.flat_map(&:folders).each_with_object({}) do |folder, obj|
+        obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE))
+      end
+
+      nodes.merge!(ems => subtree) if subtree.any?
+    end
+
+    count_only_or_objects(count_only, roots)
+  end
+
+  def tree_init_options
+    {
+      :full_ids   => true,
+      :checkboxes => true,
+      :oncheck    => "miqOnCheckGeneric",
+      :check_url  => "/miq_policy/alert_profile_assign_changed/"
+    }
+  end
+end

--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -1,0 +1,24 @@
+class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
+  ANCESTRY_TYPE = EmsFolder
+
+  def override(node, object, _pid, _options)
+    node[:selectable] = false
+    if object.kind_of?(EmsFolder) && blue?(object)
+      node[:icon] = "pficon pficon-folder-close-blue"
+    else
+      node[:hideCheckbox] = true
+    end
+    node[:select] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+  end
+
+  private
+
+  def blue?(object)
+    return false if object.parent.blank?
+
+    object.parent.name == 'vm' &&
+      object.parent.parent.present? &&
+      object.parent.parent.kind_of?(Datacenter) ||
+      blue?(object.parent)
+  end
+end

--- a/app/presenters/tree_builder_resource_pools.rb
+++ b/app/presenters/tree_builder_resource_pools.rb
@@ -1,0 +1,10 @@
+class TreeBuilderResourcePools < TreeBuilderAlertProfileAssign
+  ANCESTRY_TYPE = ResourcePool
+
+  def override(node, object, _pid, _options)
+    node[:selectable] = false
+    node[:checkable] = true
+    node[:hideCheckbox] = true unless object.kind_of?(ResourcePool)
+    node[:select] = @selected_nodes&.include?("ResourcePool_#{object[:id]}")
+  end
+end

--- a/spec/presenters/tree_builder_ems_folders_spec.rb
+++ b/spec/presenters/tree_builder_ems_folders_spec.rb
@@ -1,0 +1,43 @@
+describe TreeBuilderEmsFolders do
+  before do
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
+    FactoryBot.create(:ems_google_network)
+  end
+
+  subject do
+    described_class.new(:ems_folders_tree, {:trees => {}}, false, :selected => {})
+  end
+
+  describe '#tree_init_options' do
+    it 'sets tree options correctly' do
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :checkboxes => true,
+                                                     :oncheck    => "miqOnCheckGeneric",
+                                                     :check_url  => "/miq_policy/alert_profile_assign_changed/")
+    end
+  end
+
+  describe '#x_get_tree_roots' do
+    context 'no ems folders with a single provider' do
+      it 'returns with a no roots' do
+        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(0)
+      end
+    end
+
+    context 'redhat provider with folders' do
+      let(:ems) { FactoryBot.create(:ems_redhat) }
+      let(:datacenter) { FactoryBot.create(:datacenter) }
+      let(:subfolder) { FactoryBot.create(:ems_folder, :name => 'vm') }
+
+      before do
+        datacenter.parent = ems
+        datacenter.with_relationship_type("ems_metadata") { datacenter.add_folder(subfolder) }
+        subfolder.with_relationship_type("ems_metadata") { subfolder.add_child(FactoryBot.create(:ems_folder)) }
+      end
+
+      it 'returns with a single root' do
+        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/presenters/tree_builder_resource_pools_spec.rb
+++ b/spec/presenters/tree_builder_resource_pools_spec.rb
@@ -1,0 +1,43 @@
+describe TreeBuilderResourcePools do
+  before do
+    login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
+    FactoryBot.create(:ems_google_network)
+  end
+
+  subject do
+    described_class.new(:resource_pools_tree, {:trees => {}}, false, :selected => {})
+  end
+
+  describe '#tree_init_options' do
+    it 'sets tree options correctly' do
+      expect(subject.send(:tree_init_options)).to eq(:full_ids   => true,
+                                                     :checkboxes => true,
+                                                     :oncheck    => "miqOnCheckGeneric",
+                                                     :check_url  => "/miq_policy/alert_profile_assign_changed/")
+    end
+  end
+
+  describe '#x_get_tree_roots' do
+    context 'no ems folders with a single provider' do
+      it 'returns with a no roots' do
+        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(0)
+      end
+    end
+
+    context 'redhat provider with folders' do
+      let(:ems) { FactoryBot.create(:ems_redhat) }
+      let(:datacenter) { FactoryBot.create(:datacenter) }
+      let(:subfolder) { FactoryBot.create(:ems_folder, :name => 'vm') }
+
+      before do
+        datacenter.parent = ems
+        datacenter.with_relationship_type("ems_metadata") { datacenter.add_folder(subfolder) }
+        subfolder.with_relationship_type("ems_metadata") { subfolder.add_child(FactoryBot.create(:resource_pool)) }
+      end
+
+      it 'returns with a single root' do
+        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The logic between the two behaviors in both `TreeBuilderBelongsTo` classes has been split up based on testing a parameter multiple times. This is an 🦛 antipattern 🦛 that caused a lot of :spaghetti: :spaghetti: and also in the Alert Profiles we do not need most of the rendered nodes like providers without any assignable items as children. We even had some checkboxes where it was not necessary.

The `TreeBuilderBelongsToHac` has been used for:
* assigning hosts and clusters when editing an RBAC group in access control (2nd tab)
* assigning resource pools to VM Alert Profiles in control/explorer (edit assignments)

The `TreeBuilderBelongsToVat` has been used for:
* assigning vms and templates when editing an RBAC group in access control (3rd tab)
* assigning ems folders to VM Alert Profiles in control/explorer (edit assignments)

As first I created a new `TreeBuilderAlertProfileAssign` that uses some :sparkles: ancestry :sparkles: magic :sparkles to build the hierarchical structure of just the required nodes. The type of the required nodes is being passed using a constant defined in the subclasses. The `override` methods are mostly copy-pasted and free of the testing against the `@assign_to` parameter. These new trees allowed me to get rid of the :spaghetti: :spaghetti: code from the old trees.

**Before:**
![Screenshot from 2019-08-06 14-25-46](https://user-images.githubusercontent.com/649130/62539696-204b1300-b856-11e9-8a72-c6d13386edfb.png)
![Screenshot from 2019-08-06 14-26-23](https://user-images.githubusercontent.com/649130/62539723-30fb8900-b856-11e9-8521-6f66929ea366.png)

**After:**
![Screenshot from 2019-08-06 14-09-09](https://user-images.githubusercontent.com/649130/62538744-d95c1e00-b853-11e9-9f1d-4174b9700f17.png)
![Screenshot from 2019-08-06 14-10-16](https://user-images.githubusercontent.com/649130/62538781-f133a200-b853-11e9-8105-d29c21720eb6.png)


@miq-bot add_label hammer/no, ivanchuk/no, refactoring, trees
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @epwinchell 
@miq-bot assign @martinpovolny 