### PR TITLE
The dialog ems_network endpoint is wrong

### DIFF
--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -61,7 +61,7 @@ class DialogLocalService
         when "CloudManager"
           "/ems_cloud"
         when "NetworkManager"
-          "/ems_networks"
+          "/ems_network"
         when "CinderManager"
           "/ems_block_storage"
         when "SwiftManager"

--- a/spec/services/dialog_local_service_spec.rb
+++ b/spec/services/dialog_local_service_spec.rb
@@ -83,7 +83,7 @@ describe DialogLocalService do
       let(:obj) { double(:class => ManageIQ::Providers::Amazon::NetworkManager, :id => 123) }
 
       include_examples "DialogLocalService#determine_dialog_locals_for_custom_button return value",
-                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_networks"
+                       "ext_management_system", "ExtManagementSystem", "providers", "/ems_network"
     end
 
     context "when the object is a private CloudNetwork" do


### PR DESCRIPTION
The ems_network endpoint is singular. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732436

@miq-bot add_label bug, ivanchuk/yes
@martinpovolny sorry, my mistake

