### PR TITLE
Empty virtual DOM on ManageIQ.explorer.updatePartials.

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -108,7 +108,11 @@ ManageIQ.explorer.updatePartials = function(data) {
       if (!miqDomElementExists(element)) {
         console.error('updatePartials: #' + element + ' does not exist in the DOM');
       }
-
+      /**
+       * Remove all children and unmount any React component that were mounted to any partial children
+       */
+      $('#' + element).empty();
+      ManageIQ.component.cleanVirtualDom();
       $('#' + element).html(content);
     });
   }


### PR DESCRIPTION
React components get sometimes orphaned and duplicated in virtual DOM when updating partials using miq_explorer. That can mess up global events like redux actions or component subscribed to RxJS messages.

It is caused by replacing react root element instead of deleting it in DOM. This change will empty the partial first and triggers the component unmount manually and then resumes the partial update. 