### PR TITLE
Remove report names from group settings hash when reports are deleted

### DIFF
--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -19,6 +19,21 @@ describe ReportController, "::Reports" do
       expect(MiqReport.find_by(:id => report.id)).to be_nil
     end
 
+    it "deletes the report name from the group settings hash" do
+      report = FactoryBot.create(:miq_report, :rpt_type => "Custom", :miq_group => user.current_group)
+      report.miq_group.update(:settings => {"report_menus" => [["foo", [["bar", [report.name]]]]]})
+      session['sandboxes'] = {
+        controller.controller_name => { :active_tree => 'report_1',
+                                        :trees       => {'report_1' => {:active_node => "xx-0_xx-0-0_rep-#{report.id}"}}}
+      }
+
+      get :x_button, :params => { :id => report.id, :pressed => 'miq_report_delete' }
+      report.miq_group.reload
+      expect(response.status).to eq(200)
+      expect(MiqReport.find_by(:id => report.id)).to be_nil
+      expect(report.miq_group.settings).to eq("report_menus" => [["foo", [["bar", []]]]])
+    end
+
     it "cant delete default reports" do
       FactoryBot.create(:miq_report)
       report = FactoryBot.create(:miq_report, :rpt_type => "Default")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1731017

At the moment, deleting a report doesn't delete the report name from the settings hash of the group. 

This shouldn't be in the UI, any of it, but refactoring a [five level deep nested hash of settings](https://github.com/ManageIQ/manageiq-ui-classic/pull/5950/files#diff-a31349b4cac8623f48847e8d969ecbeaL199) is not a hill I'm willing to die on. So instead this. @jrafanie helped me with it and I know he'd like to review this. It's still bad. Just consistently bad. 