### PR TITLE
Fixed call that build list of Storages to build Host file drop down

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -233,8 +233,8 @@ module Mixins
         def get_iso_options(vm)
           iso_options = []
 
-          datastore_ids = vm.storages.pluck(:id)
-          # determine available iso files for the datastaores
+          datastore_ids = vm.host.storages.pluck(:id)
+          # determine available iso files for the datastores
           Rbac.filtered(StorageFile.where("storage_id IN (?) and ext_name = 'iso'", datastore_ids)).each do |sf|
             iso_options << [sf.name, sf.name + ',' + sf.storage_id.to_s]
           end

--- a/spec/controllers/mixins/actions/vm_actions/reconfigure_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/reconfigure_spec.rb
@@ -1,0 +1,27 @@
+describe Mixins::Actions::VmActions::Reconfigure do
+  describe '#get_iso_options' do
+    before do
+      @host = FactoryBot.create(:host, :name =>'hostname1')
+      @datastore = FactoryBot.create(:storage, :name => 'storage_name')
+      @vm = FactoryBot.create(:vm_vmware, :host => @host)
+      FactoryBot.create(:storage_file, :storage_id => @datastore.id, :ext_name => 'iso', :base_name => "good-stuff.iso")
+      FactoryBot.create(:storage_file, :storage_id => 1, :ext_name => 'iso', :base_name => "some_other_storage.iso")
+    end
+
+    context 'populate list of Host files' do
+      let(:controller) { VmInfraController.new }
+
+      it "gets list of VM's host storages that have iso files" do
+        @host.storages << @datastore
+        storage_list = controller.send(:get_iso_options, @vm)
+        expect(storage_list.count).to be(1)
+      end
+
+      it "gets empty list for VM's storage" do
+        @vm.storages << @datastore
+        storage_list = controller.send(:get_iso_options, @vm)
+        expect(storage_list.count).to be(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3956, in commit 6df12d1079d09dd23fea2e1627b0ee3399d911ca code that builds Host file drop down was changed `vm.try(:available_iso_names)` was removed and new method `get_iso_options` was added to build the list. Changed to get all storages that the vm's host is attached to instead of all of the vm's storages

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1689369

before
![before](https://user-images.githubusercontent.com/3450808/62570697-ec73eb80-b85d-11e9-9523-65fbda16d11a.png)

after
![after](https://user-images.githubusercontent.com/3450808/62570576-d49c6780-b85d-11e9-9a46-00f0756f8e86.png)

cc @agrare 