### PR TITLE
Drop the unnecessary _pid and _options args from TreeBuilder#override

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -271,7 +271,7 @@ class TreeBuilder
   def x_build_single_node(object, pid, options)
     # FIXME: to_h is for backwards compatibility with hash-trees, it needs to be removed in the future
     node = TreeNode.new(object, pid, options, self).to_h
-    override(node, object, pid, options) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
+    override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
     node
   end
 

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -7,7 +7,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     super(name, sandbox, build, **params)
   end
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:text] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
     node[:hideCheckbox] = false
     node[:select] = @selected.try(:include?, object.id)

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -12,7 +12,7 @@ class TreeBuilderAutomate < TreeBuilder
     count_only_or_objects(count_only, [MiqAeDomain.find_by(:id => @sb[:domain_id])])
   end
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:selectable] = false if object.kind_of?(MiqAeNamespace) && object.domain?
   end
 

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -9,7 +9,7 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
     count_only_or_objects(count_only, filter_ae_objects(User.current_tenant.visible_domains))
   end
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     # Only the instance items should be clickable when selecting a catalog item entry point
     node[:selectable] = false unless object.kind_of?(MiqAeInstance)
   end

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,5 +1,5 @@
 class TreeBuilderAutomateEntrypoint < TreeBuilderAutomateCatalog
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node.delete(:selectable)
     node[:fqname] = object.fqname if object.try(:fqname)
   end

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -5,7 +5,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ExtManagementSystem, [:x_get_provider_kids]
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:select] = if @assign_to
                       @selected_nodes&.include?("ResourcePool_#{object[:id]}")
                     else

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -7,7 +7,7 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
       blue?(object.parent)
   end
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:selectable] = false
     node[:checkable] = @edit.present? || @assign_to.present?
 

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -2,7 +2,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
   has_kids_for Compliance, [:x_get_compliance_kids]
   has_kids_for ComplianceDetail, %i[x_get_compliance_detail_kids parents]
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     node[:selectable] = false
   end
 

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -4,7 +4,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
   has_kids_for EmsFolder, [:x_get_tree_folder_kids]
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:selectable] = false if object.kind_of?(Lan)
   end
 

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -2,7 +2,7 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Lan, [:x_get_tree_lan_kids]
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     node[:selectable] = false # if node[:image].nil? || !node[:image].include?('svg/currentstate-')
   end
 

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -7,7 +7,7 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
     x_get_tree_miq_servers
   end
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
       node[:highlighted] = true
     end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -7,7 +7,7 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
     x_get_tree_server_roles
   end
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
       node[:highlighted] = true
     end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -9,7 +9,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
 
   private
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     node[:selectable] = false
   end
 

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -57,7 +57,7 @@ class TreeBuilderTenants < TreeBuilder
     count_only_or_objects(count_only, object.children, 'name')
   end
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:select] = @additional_tenants.try(:include?, object)
     node[:checkable] = @selectable
   end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -9,7 +9,7 @@ class TreeBuilderUtilization < TreeBuilder
     {:lazy => true}
   end
 
-  def override(node, _object, _pid, _options)
+  def override(node, _object)
     node[:selectable] = node[:key].split('-')[1].split('_')[0] != 'folder'
   end
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -53,16 +53,16 @@ describe TreeBuilderAlertProfileObj do
       let(:node) { {} }
 
       it 'sets node1' do
-        subject.send(:override, node, tag1a, nil, nil)
+        subject.send(:override, node, tag1a)
         expect(node[:hideCheckbox]).to be_falsey
         expect(node[:select]).to be_truthy
       end
       it 'sets node2' do
-        subject.send(:override, node, tag2a, nil, nil)
+        subject.send(:override, node, tag2a)
         expect(node[:select]).to be_truthy
       end
       it 'sets node3' do
-        subject.send(:override, node, tag3a, nil, nil)
+        subject.send(:override, node, tag3a)
         expect(node[:select]).to be_falsey
       end
     end


### PR DESCRIPTION
Sorry for the early :alarm_clock: PR, I can't :sleeping: and I'm creative :smiley: 

This is removing the two arguments from the `override` methods as they are no longer used in any of them.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, hammer/no, ivanchuk/no, trees