### PR TITLE
Drop the obsolete :full_ids from x_build_node_id in CatalogController

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -266,8 +266,8 @@ module ApplicationController::Explorer
     tagging_edit_tags_save_and_replace_right_cell
   end
 
-  def x_build_node_id(object, options = {})
-    TreeNode.new(object, nil, options).key
+  def x_build_node_id(object)
+    TreeNode.new(object, nil, {}).key
   end
 
   # FIXME: move partly to Tree once Trees are made from TreeBuilder

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -340,7 +340,7 @@ class CatalogController < ApplicationController
       identify_catalog(params[:id])
       @record ||= ServiceTemplateCatalog.find(params[:id])
     end
-    params[:id] = x_build_node_id(@record, x_tree(x_active_tree)) # Get the tree node id
+    params[:id] = x_build_node_id(@record) # Get the tree node id
     tree_select
   end
 
@@ -1779,7 +1779,7 @@ class CatalogController < ApplicationController
            x_tree[:open_nodes].include?(parents.last[:id])
       parents.reverse_each do |p|
         next if p.nil?
-        p_node = x_build_node_id(p, :full_ids => true)
+        p_node = x_build_node_id(p)
         unless x_tree[:open_nodes].include?(p_node)
           x_tree[:open_nodes].push(p_node)
           existing_node = p_node


### PR DESCRIPTION
The only place the param would be used is `TreeNode#key`, but there is an extra conditional next to it which is always `nil` when calling `x_build_node`. After cleaning this param up, the second argument is no longer necessary.

```ruby
"#{@options[:full_ids] && @parent_id.present? ? "#{@parent_id}_" : ''}#{prefix}-#{cid}"
```

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label cleanup, hammer/no, ivanchuk/no, trees