### PR TITLE
Send only string ids to Tagging

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -172,11 +172,11 @@ module ApplicationController::Tags
 
     @tags = cats.map do |cat|
       {
-        :id          => cat.id,
+        :id          => cat.id.to_s,
         :description => cat.description,
         :singleValue => cat.single_value,
         :values      => cat.entries.sort_by { |e| e[:description.downcase] }.map do |entry|
-          { :id => entry.id, :description => entry.description }
+          { :id => entry.id.to_s, :description => entry.description }
         end
       }
     end
@@ -184,13 +184,13 @@ module ApplicationController::Tags
     assigned_tags = assignments.uniq.map do |tag|
       {
         :description => tag.parent.description,
-        :id          => tag.parent.id,
+        :id          => tag.parent.id.to_s,
         :values      => assignments.select { |assignment| assignment.parent_id == tag.parent_id }.map do |assignment|
-          { :description => assignment.description, :id => assignment.id }
+          { :description => assignment.description, :id => assignment.id.to_s }
         end
       }
     end
-    @tags = {:tags => @tags, :assignedTags => assigned_tags, :affectedItems => @tagitems.map(&:id)}
+    @tags = {:tags => @tags, :assignedTags => assigned_tags, :affectedItems => @tagitems.map { |i| i.id.to_s } }
     @button_urls = {
       :save_url   => button_url(controller_path, @sb[:rec_id] || @edit[:object_ids][0], 'save'),
       :cancel_url => button_url(controller_path, @sb[:rec_id] || @edit[:object_ids][0], 'cancel')

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -906,11 +906,11 @@ module OpsController::OpsRbac
       cats.sort_by! { |t| t.description.try(:downcase) } # Get the categories, sort by description
       tags = cats.map do |cat|
         {
-          :id          => cat.id,
+          :id          => cat.id.to_s,
           :description => cat.description,
           :singleValue => false,
           :values      => cat.entries.sort_by { |e| e[:description.downcase] }.map do |entry|
-            { :id => entry.id, :description => entry.description }
+            { :id => entry.id.to_s, :description => entry.description }
           end
         }
       end
@@ -919,8 +919,8 @@ module OpsController::OpsRbac
       assigned_tags = Tag.where(:name => filters.flatten).map do |tag|
         {
           :description => tag.category.description,
-          :id          => tag.category.id,
-          :values      => [{:id => tag.classification.id, :description => tag.classification.description}]
+          :id          => tag.category.id.to_s,
+          :values      => [{:id => tag.classification.id.to_s, :description => tag.classification.description}]
         }
       end
 
@@ -935,7 +935,7 @@ module OpsController::OpsRbac
 
       assigned_tags.uniq! { |tag| tag[:id] }
       group_id = @group&.id
-      @tags = {:tags => tags, :assignedTags => assigned_tags, :affectedItems => [group_id]}
+      @tags = {:tags => tags, :assignedTags => assigned_tags, :affectedItems => [group_id.to_s]}
       @button_urls = {
         :save_url   => url_for_only_path(:action => "rbac_group_edit", :id => group_id, :button => "save"),
         :cancel_url => url_for_only_path(:action => "rbac_group_edit", :id => group_id, :button => "cancel")

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -21,8 +21,8 @@ const params = (type = 'default', state, tag = {}) => ({
 })[type]
 
 const onDelete = (type = 'default', params = [], deleted_element) => ({
-  provision: {...params, check: 0, ids_checked: params.ids_checked.filter(element => element !== deleted_element) },
-  default: params,
+  provision: () => ({...params, check: 0, ids_checked: params.ids_checked.filter(element => element !== deleted_element) }),
+  default: ()   => params,
 })[type]
 
 class TaggingWrapper extends React.Component {

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -103,7 +103,7 @@ TaggingWrapper.propTypes = {
         description: PropTypes.string.isRequired,
       }).isRequired).isRequired,
     })).isRequired,
-    affectedItems: PropTypes.arrayOf(PropTypes.number),
+    affectedItems: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/app/javascript/miq-redux/middleware.js
+++ b/app/javascript/miq-redux/middleware.js
@@ -9,7 +9,7 @@ export const taggingMiddleware = store => next => action => {
     if (type === 'UI-COMPONENTS_TAGGING_TOGGLE_TAG_VALUE_CHANGE') {
       $.post({url: meta.url, data: JSON.stringify(params), contentType: "application/json"})
     } else if (type === 'UI-COMPONENTS_TAGGING_DELETE_ASSIGNED_TAG') {
-      params = meta.onDelete(meta.type, params, tag.tagValue.id);
+      params = meta.onDelete(meta.type, params, tag.tagValue.id)();
       $.post({url: meta.url, data: JSON.stringify(params), contentType: "application/json"})
     }
   }

--- a/app/javascript/spec/miq-redux/middleware.spec.js
+++ b/app/javascript/spec/miq-redux/middleware.spec.js
@@ -17,7 +17,7 @@ const params = (type = 'default', state, tag = {}) => ({
   }
 })[type]
 
-const onDelete = (x, y, z) => ({...y, check: 0});
+const onDelete = (x, y, z) => (() => ({...y, check: 0}));
 
 it('passes the intercepted action to next', () => {
 


### PR DESCRIPTION
Send only string ids to Tagging. Due to the limitation of MAX_SAFE_INTEGER in JS  #1405, we need to consistently treat any database id as a string in JS.

In second commit I am fixing the issue with deleting on Group Tagging page.

Links [Optional]
----------------
https://github.com/ManageIQ/manageiq-ui-classic/issues/5946
#1405


Steps for Testing/QA
-------------------------------
#5946
