### PR TITLE
Update ui-components to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@data-driven-forms/pf3-component-mapper": "^1.13.3",
     "@data-driven-forms/react-form-renderer": "^1.13.3",
     "@manageiq/react-ui-components": "~0.11.35",
-    "@manageiq/ui-components": "~1.2.10",
+    "@manageiq/ui-components": "~1.3.0",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",


### PR DESCRIPTION
Changing version to 1.3.0 now that ivanchuk is cut, 1.2.* will be ivanchuk from now on.

Also, since 1.2.10:

https://github.com/ManageIQ/ui-components/pull/405
https://github.com/ManageIQ/ui-components/pull/407
https://github.com/ManageIQ/ui-components/pull/408
https://github.com/ManageIQ/ui-components/pull/409
https://github.com/ManageIQ/ui-components/pull/404