### PR TITLE
Add 'Service ID' to Service detail page

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -8,7 +8,7 @@ module ServiceHelper::TextualSummary
   # Groups
 
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i[name description guid])
+    TextualGroup.new(_("Properties"), %i[name description id guid])
   end
 
   def textual_group_provisioning_results
@@ -100,6 +100,10 @@ module ServiceHelper::TextualSummary
   end
 
   # Items
+
+  def textual_id
+    {:label => _("Service ID"), :value => @record.id}
+  end
 
   def textual_guid
     {:label => _("Management Engine GUID"), :value => @record.guid}

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -110,7 +110,7 @@ describe ServiceHelper::TextualSummary do
     allow(self).to receive(:textual_miq_custom_attributes).and_return([])
   end
 
-  include_examples "textual_group", "Properties", %i(name description guid)
+  include_examples "textual_group", "Properties", %i(name description id guid)
 
   include_examples "textual_group", "Results", %i(status start_time finish_time elapsed_time owner), "provisioning_results"
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1630348/62629098-8a1cf880-b8fa-11e9-8fee-9b1bdc994294.png)

After:
![image](https://user-images.githubusercontent.com/1630348/62628762-f0ede200-b8f9-11e9-90c3-6d87781f8780.png)

@miq-bot add_labels enhancement, services

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1504293