### PR TITLE
Remove Host Discover and Add buttons

### DIFF
--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -24,7 +24,6 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     $scope.formId = hostFormId;
     $scope.validateClicked = miqService.validateWithAjax;
     $scope.formFieldsUrl = $attrs.formFieldsUrl;
-    $scope.createUrl = $attrs.createUrl;
     $scope.updateUrl = $attrs.updateUrl;
     $scope.model = 'hostModel';
     ManageIQ.angular.scope = $scope;
@@ -64,18 +63,10 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     $scope.currentTab = id;
   };
 
-  $scope.addClicked = function() {
-    miqService.sparkleOn();
-    var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);
-  };
-
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
     var url;
-    if (hostFormId === 'new') {
-      url = $scope.createUrl + 'new?button=cancel';
-    } else if (hostFormId.split(',').length === 1) {
+    if (hostFormId.split(',').length === 1) {
       url = $scope.updateUrl + hostFormId + '?button=cancel';
     } else if (hostFormId.split(',').length > 1) {
       url = $scope.updateUrl + '?button=cancel';

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -135,7 +135,11 @@ class HostController < ApplicationController
       @title = _("Info/Settings")
     else # if editing credentials for multi host
       @title = _("Credentials/Settings")
-      @host = find_record_with_rbac(Host, params[:selected_host])
+      @host = if params[:selected_host]
+                find_record_with_rbac(Host, params[:selected_host])
+              else
+                Host.new
+              end
       @changed = true
       @showlinks = true
       @in_a_form = true

--- a/app/controllers/mixins/actions/host_actions/discover.rb
+++ b/app/controllers/mixins/actions/host_actions/discover.rb
@@ -13,9 +13,7 @@ module Mixins
             return
           end
           @userid = @password = @verify = @client_id = @client_key = @azure_tenant_id = @subscription = ''
-          if session[:type] == "hosts"
-            @discover_type = Host.host_discovery_types
-          elsif session[:type] == "ems"
+          if session[:type] == "ems"
             discover_type(request.parameters[:controller])
           else
             @discover_type = ExtManagementSystem.ems_infra_discovery_types

--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -72,22 +72,7 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :confirm      => N_("Provide selected items?"),
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::HostIntrospectProvide),
-        button(
-          :host_discover,
-          'fa fa-search fa-lg',
-          t = N_('Discover items'),
-          t,
-          :url       => "/discover",
-          :url_parms => "?discover_type=hosts",
-          :klass     => ApplicationHelper::Button::ButtonNewDiscover),
         separator,
-        button(
-          :host_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New item'),
-          t,
-          :url   => "/new",
-          :klass => ApplicationHelper::Button::ButtonNewDiscover),
         button(
           :host_edit,
           'pficon pficon-edit fa-lg',

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -5,7 +5,6 @@
                  "ng-controller"   => "hostFormController",
                  'ng-cloak'        => '',
                  "form-fields-url" => "/#{controller_name}/host_form_fields/",
-                 "create-url"      => "/#{controller_name}/create/",
                  "update-url"      => "/#{controller_name}/update/",
                  "novalidate"      => true}
     = render :partial => "layouts/flash_msg"
@@ -40,6 +39,7 @@
                                     "checkchange" => ""}
                 %span.help-block{"ng-show" => "angularForm.hostname.$error.miqrequired"}
                   = _("Required")
+
             .form-group{"ng-class" => "{'has-error': angularForm.user_assigned_os.$invalid}", "ng-hide" => "hostModel.operating_system"}
               %label.col-md-2.control-label
                 = _("Host platform")
@@ -104,5 +104,5 @@
               = render :partial => 'layouts/gtl'
 
 :javascript
-  ManageIQ.angular.app.value('hostFormId', '#{(@host.id || (session[:host_items] && session[:host_items].join(","))) || "new"}');
+  ManageIQ.angular.app.value('hostFormId', '#{(@host.id || (session[:host_items] && session[:host_items].join(",")))}');
   miq_bootstrap('#form_div');

--- a/app/views/host/discover.html.haml
+++ b/app/views/host/discover.html.haml
@@ -1,1 +1,0 @@
-= render :partial => "layouts/discover"

--- a/app/views/host/new.html.haml
+++ b/app/views/host/new.html.haml
@@ -1,1 +1,0 @@
-= render :partial => 'form'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -70,13 +70,13 @@ describe ApplicationController do
 
   describe "#assert_privileges" do
     before do
-      EvmSpecHelper.seed_specific_product_features("host_new", "host_edit", "perf_reload")
-      feature = MiqProductFeature.find_all_by_identifier(["host_new"])
+      EvmSpecHelper.seed_specific_product_features("host_compare", "host_edit", "perf_reload")
+      feature = MiqProductFeature.find_all_by_identifier(["host_compare"])
       login_as FactoryBot.create(:user, :features => feature)
     end
 
     it "should not raise an error for feature that user has access to" do
-      expect { controller.send(:assert_privileges, "host_new") }.not_to raise_error
+      expect { controller.send(:assert_privileges, "host_compare") }.not_to raise_error
     end
 
     it "should raise an error for feature that user does not have access to" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -145,48 +145,6 @@ describe HostController do
     end
   end
 
-  describe "#create" do
-    it "can create a host with custom id and no host name" do
-      stub_user(:features => :all)
-      controller.instance_variable_set(:@breadcrumbs, [])
-
-      controller.instance_variable_set(
-        :@_params,
-        :button   => "add",
-        :id       => "new",
-        :name     => 'foobar',
-        :hostname => nil,
-        :custom_1 => 'bar'
-      )
-
-      expect_any_instance_of(Host).to receive(:save).and_call_original
-      expect(controller).to receive(:render)
-      controller.send(:create)
-      expect(response.status).to eq(200)
-    end
-
-    it "doesn't crash when trying to validate a new host" do
-      stub_user(:features => :all)
-      controller.instance_variable_set(:@breadcrumbs, [])
-      controller.new
-
-      controller.instance_variable_set(
-        :@_params,
-        :button           => "validate",
-        :type             => "default",
-        :id               => "new",
-        :name             => 'foobar',
-        :hostname         => '127.0.0.1',
-        :default_userid   => "abc",
-        :default_password => "def",
-        :user_assigned_os => "linux_generic"
-      )
-      expect(controller).to receive(:render)
-      controller.send(:create)
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe "#set_record_vars" do
     it "strips leading/trailing whitespace from hostname/ipaddress when adding infra host" do
       stub_user(:features => :all)
@@ -426,19 +384,6 @@ describe HostController do
       expect(controller.send(:set_credentials, mocked_host, :validate)).to include(:default => default_creds,
                                                                                    :ws      => ws_creds,
                                                                                    :ipmi    => ipmi_creds)
-    end
-  end
-
-  describe "#render pages" do
-    render_views
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-    end
-    it "renders a new page with ng-required condition set to false for password" do
-      get :new
-      expect(response.status).to eq(200)
-      expect(response.body).to include("name='default_password' ng-disabled='!vm.showVerify(&#39;default_userid&#39;)' ng-model='$parent.hostModel.default_password' ng-required='false'")
     end
   end
 

--- a/spec/javascripts/controllers/host/host_form_controller_spec.js
+++ b/spec/javascripts/controllers/host/host_form_controller_spec.js
@@ -29,7 +29,6 @@ describe('hostFormController', function() {
       $controller = _$controller_('hostFormController', {
         $scope: $scope,
         $attrs: {'formFieldsUrl': '/host/host_form_fields/',
-                 'createUrl': '/host/create/',
                  'updateUrl': '/host/update/'},
         hostFormId: 'new',
         miqService: miqService
@@ -42,35 +41,6 @@ describe('hostFormController', function() {
     });
 
     describe('initialization', function() {
-      describe('when the hostFormId is new', function() {
-        it('sets the name to blank', function () {
-          expect($scope.hostModel.name).toEqual('');
-        });
-        it('sets the hostname to blank', function () {
-          expect($scope.hostModel.hostname).toEqual('');
-        });
-
-        it('sets the custom identifier to blank', function() {
-          expect($scope.hostModel.user_assigned_os).toEqual('');
-        });
-
-        it('sets the custom identifier to blank', function() {
-          expect($scope.hostModel.custom_1).toEqual('');
-        });
-
-        it('sets the MAC address to blank', function() {
-          expect($scope.hostModel.mac_address).toEqual('');
-        });
-
-        it('sets the IPMI Address to blank', function() {
-          expect($scope.hostModel.ipmi_address).toEqual('');
-        });
-
-        it('sets the validate id to null', function() {
-          expect($scope.hostModel.validate_id).toEqual(null);
-        });
-      });
-
       describe('when the hostFormId is an Id', function() {
         var hostFormResponse = {
           name: 'aaa',
@@ -91,7 +61,6 @@ describe('hostFormController', function() {
 
             $controller = _$controller_('hostFormController', {$scope: $scope,
                                                                $attrs: {'formFieldsUrl': '/host/host_form_fields/',
-                                                                        'createUrl': '/host/create/',
                                                                         'updateUrl': '/host/update/'},
                                                                hostFormId: '12345'});
             $httpBackend.flush();
@@ -172,27 +141,6 @@ describe('hostFormController', function() {
 
     it('turns the spinner on once', function() {
       expect(miqService.sparkleOn.calls.count()).toBe(1);
-    });
-
-    it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/host/update/new?button=save', true);
-    });
-  });
-
-  describe('#addClicked', function() {
-    beforeEach(function() {
-      $scope.angularForm = {
-        $setPristine: function (value){}
-      };
-      $scope.addClicked();
-    });
-
-    it('turns the spinner on via the miqService', function() {
-      expect(miqService.sparkleOn).toHaveBeenCalled();
-    });
-
-    it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('create/new?button=add', true);
     });
   });
 


### PR DESCRIPTION
Removes the Discover and Add buttons from the Hosts screen. 

Related PRs:
https://github.com/ManageIQ/manageiq/pull/19116 (removes related user roles)
https://github.com/ManageIQ/manageiq/pull/19107

@miq-bot add_labels bug, compute/infrastructure

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1733294