### PR TITLE
Do not remember tab when downloading report from list view.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1671,7 +1671,7 @@ class ApplicationController < ActionController::Base
               request.headers['X-Angular-Request'].present?
 
     return if controller_name == 'dashboard' && %(iframe maintab cockpit_redirect).include?(action_name)
-    return if action_name == 'download_summary_pdf'
+    return if %(download_data download_summary_pdf).include?(action_name)
 
     remember_tab
   end


### PR DESCRIPTION
Extended change made in https://github.com/ManageIQ/manageiq-ui-classic/pull/4945

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1738664

