### PR TITLE
Drop the pid/options arguments from AssignTo trees' override 🐞

### DIFF
--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -1,7 +1,7 @@
 class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
   ANCESTRY_TYPE = EmsFolder
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:selectable] = false
     if object.kind_of?(EmsFolder) && blue?(object)
       node[:icon] = "pficon pficon-folder-close-blue"

--- a/app/presenters/tree_builder_resource_pools.rb
+++ b/app/presenters/tree_builder_resource_pools.rb
@@ -1,7 +1,7 @@
 class TreeBuilderResourcePools < TreeBuilderAlertProfileAssign
   ANCESTRY_TYPE = ResourcePool
 
-  def override(node, object, _pid, _options)
+  def override(node, object)
     node[:selectable] = false
     node[:checkable] = true
     node[:hideCheckbox] = true unless object.kind_of?(ResourcePool)


### PR DESCRIPTION
When you try to assign a vm alert profile to a resource pool or a folder, it fails with the following error:
```
Error caught: [ArgumentError] wrong number of arguments (given 2, expected 4)
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder_resource_pools.rb:4:in `override'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:274:in `x_build_single_node'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:240:in `x_build_node'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:280:in `x_build_node_tree'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:200:in `block in x_build_tree'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:195:in `each'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:195:in `map'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:195:in `x_build_tree'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:135:in `build_tree'
..ManageIQ/manageiq-ui-classic/app/presenters/tree_builder.rb:22:in `initialize'
```

![Screenshot from 2019-08-08 09-48-55](https://user-images.githubusercontent.com/649130/62684814-c5cec580-b9c1-11e9-807e-5090ab421ec5.png)

This is because I missed the 2 arguments in the rebase https://github.com/ManageIQ/manageiq-ui-classic/pull/5945 against https://github.com/ManageIQ/manageiq-ui-classic/pull/5940 so fixing it now :hammer: 

@miq-bot add_reviewer @brumik 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 
@miq-bot add_label bug, hammer/no, ivanchuk/no, changelog/no, trees