### PR TITLE
Add the configuration toolbar button on Ansible/Templates screen

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -440,7 +440,7 @@ class AutomationManagerController < ApplicationController
 
   def configscript_service_dialog
     assert_privileges("automation_manager_configuration_script_service_dialog")
-    cs = ConfigurationScript.find_by(:id => params[:id])
+    cs = ConfigurationScript.find_by(:id => params[:id] || params[:miq_grid_checks])
     @edit = {:rec_id => cs.id}
     @in_a_form = true
     @right_cell_text = _("Adding a new Service Dialog from \"%{name}\"") % {:name => cs.name}

--- a/app/helpers/application_helper/toolbar/configuration_scripts_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_scripts_center.rb
@@ -1,3 +1,22 @@
 class ApplicationHelper::Toolbar::ConfigurationScriptsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configuration_script_vmdb', [
+    select(
+      :configuration_script_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :configscript_service_dialog,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Create Service Dialog from this Template'),
+          t,
+          :onwhen => '1',
+          :send_checked => true
+        ),
+      ]
+    )
+  ])
+
   include ApplicationHelper::Toolbar::ConfigurationScripts::PolicyMixin
 end

--- a/app/helpers/application_helper/toolbar/x_configuration_scripts_center.rb
+++ b/app/helpers/application_helper/toolbar/x_configuration_scripts_center.rb
@@ -1,3 +1,22 @@
 class ApplicationHelper::Toolbar::XConfigurationScriptsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configuration_script_vmdb', [
+    select(
+      :configuration_script_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :configscript_service_dialog,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Create Service Dialog from this Template'),
+          t,
+          :onwhen => '1',
+          :send_checked => true
+        ),
+      ]
+    )
+  ])
+
   include ApplicationHelper::Toolbar::ConfigurationScripts::PolicyMixin
 end


### PR DESCRIPTION
This is one of the explorer-nonexplorer screens, so there are two toolbars depending on some kind of :spaghetti: :sparkles: magic :sparkles: and both of them can be rendered. This is an awful fix and the whole screen/toolbar selection should be refactored.

**Before:**
![Screenshot from 2019-08-08 14-20-31](https://user-images.githubusercontent.com/649130/62702677-b3678280-b9e7-11e9-9a82-987a485aa830.png)

**After:**
![Screenshot from 2019-08-09 17-14-09](https://user-images.githubusercontent.com/649130/62789402-24329b80-bac9-11e9-9f0b-0e6e44ea2430.png)

@miq-bot add_label bug
@miq-bot assign @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1382635