### PR TITLE
[WIP] Make Add/Save button response properly while adding/editing Zone

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -806,6 +806,8 @@ module OpsController::Settings::Common
       field = "ntp_server_#{field_num}"
       next unless params.key?(field)
       @edit[:new][:ntp][field] = params[field]
+      # remove unnecessary key from @edit[:new][:ntp] if there is no change
+      @edit[:new][:ntp].except!(*field) if params[field] == @edit[:new][:ntp][:server][field_num - 1]
     end
   end
 

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -83,8 +83,11 @@ module OpsController::Settings::Zones
   # AJAX driven routine to check for changes in ANY field on the user form
   def zone_field_changed
     return unless load_edit("zone_edit__#{params[:id]}", "replace_cell__explorer")
+
     zone_get_form_vars
-    @changed = (@edit[:new] != @edit[:current])
+    bad = @edit[:new][:name].blank? || @edit[:new][:description].blank? # need to check if required fields (Name and Description) are filled in
+    session[:changed] = @changed = @edit[:new] != @edit[:current] && !bad
+
     render :update do |page|
       page << javascript_prologue
       if @refresh_div
@@ -95,12 +98,7 @@ module OpsController::Settings::Zones
       # checking to see if password/verify pwd fields either both have value or are both blank
       password_fields_changed = !(@edit[:new][:password].blank? ^ @edit[:new][:verify].blank?)
 
-      if @changed != session[:changed]
-        session[:changed] = @changed
-        page << javascript_for_miq_button_visibility(@changed && password_fields_changed)
-      else
-        page << javascript_for_miq_button_visibility(password_fields_changed)
-      end
+      page << javascript_for_miq_button_visibility(@changed && password_fields_changed)
     end
   end
 

--- a/spec/controllers/ops_controller/settings/zones_spec.rb
+++ b/spec/controllers/ops_controller/settings/zones_spec.rb
@@ -1,0 +1,52 @@
+describe OpsController do
+  describe '#zone_field_changed' do
+    let(:edit) { {:new => {}, :current => {}} }
+    let(:params) { {:id => 'new'} }
+
+    before do
+      allow(controller).to receive(:load_edit).and_return(true)
+      allow(controller).to receive(:render).and_return(true)
+      controller.instance_variable_set(:@_params, params)
+      controller.instance_variable_set(:@edit, edit)
+      login_as FactoryBot.create(:user_admin)
+    end
+
+    it 'sets session[:changed] to false if name and/or description is missing' do
+      controller.send(:zone_field_changed)
+      expect(controller.session[:changed]).to eq(false)
+    end
+
+    context 'adding new Zone' do
+      let(:edit) { {:new => {:name => 'zone_name'}, :current => {}} }
+      let(:params) { {:id => 'new', :description => 'zone_description'} }
+
+      it 'sets session[:changed] to true if it is possible to save new Zone' do
+        controller.send(:zone_field_changed)
+        expect(controller.session[:changed]).to eq(true)
+      end
+    end
+
+    context 'editing an existing Zone' do
+      let(:edit) { {:new => {:name => zone.name, :description => zone.description}, :current => {:name => zone.name, :description => zone.description}} }
+      let(:params) { {:userid => 'user_id'} }
+      let(:zone) { FactoryBot.create(:zone) }
+
+      it 'sets session[:changed] to true if there is any change and required fields are filled in' do
+        controller.send(:zone_field_changed)
+        expect(controller.session[:changed]).to eq(true)
+      end
+
+      context 'missing Verify Password if Password filled in' do
+        let(:params) { {:password => 'pwd'} }
+
+        subject { controller.instance_variable_get(:@edit)[:new] }
+
+        it 'sets session[:changed] to false' do
+          controller.send(:zone_field_changed)
+          password_fields_changed = !(subject[:password].blank? ^ subject[:verify].blank?)
+          expect(controller.session[:changed] && password_fields_changed).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1730067

With this PR, _Save_ and _Add_ button will respond properly on any changes, while adding/editing a Zone. The buttons will also respond on filling in required fields - _Name_ and _Description_: if Name or Description misses, the button will become disabled (see [this](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Inconsistencies_adding_Zone?expand=1#diff-46d9c2a2602cc981686abc11859bed16R88)) - I used the same approach as it is used for example [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L761). The buttons will respond properly also on changes in _NTP Servers_ zone.

Core of the problem was, as in many other places in MIQ, `""` vs `nil` values and wrong setting `changed` variable or `session[:changed]` (due to the difference between `@edit[:new]` and `@edit[:current]`). Using `copy_param_if_present` we prevent these problems and also we simplify the code little bit.

**Before:**(after deleting everything from Name and Description, Add button is enabled!)
![zone_before](https://user-images.githubusercontent.com/13417815/62707837-6937ce80-b9f2-11e9-8499-c12672b4bed5.png)

**After:**(Add button is disabled which is right)
![zone_after](https://user-images.githubusercontent.com/13417815/62707390-8d46e000-b9f1-11e9-929a-742ae1ba23c3.png)
