### PR TITLE
Build the selected node key from the session stored model in RBS 🌳🐞

### DIFF
--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -8,7 +8,7 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
   end
 
   def override(node, _object)
-    if @sb[:diag_selected_id] && node[:key] == "svr-#{@sb[:diag_selected_id]}"
+    if @sb[:diag_selected_id] && node[:key] == "#{self.class.get_prefix_for_model(@sb[:diag_selected_model]) || 'svr'}-#{@sb[:diag_selected_id]}"
       node[:highlighted] = true
     end
   end


### PR DESCRIPTION
The node highlighting in the `TreeBuilderRolesByServer` went a little off after some refactoring because the model has not been calculated into the selected node's prefix generation. Therefore, only servers could be highlighted after a tree reload. If there was no server with the same ID as the role, no node has been selected after suspending/resuming a server role.

This code is :spaghetti: bad :spaghetti: and I am working on a followup refactoring PR, but it touches too many pieces of session, so it takes me some time to make right all the wrongs. For more info about the reproducing, please see the BZ.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @h-kataria 
@miq-bot add_label bug, hammer/no, ivanchuk/yes, trees

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734393