### PR TITLE
policy_sim - set @in_a_form to prevent adv_search_build

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -74,6 +74,9 @@ module ApplicationController::PolicySupport
 
   # Perform policy simulation for a set of objects
   def policy_sim(records = [])
+    # prevent adv_search_build on policy_sim screens
+    @in_a_form = true
+
     if request.xml_http_request? # Ajax request means in explorer
       @explorer = true
       @edit ||= {}


### PR DESCRIPTION
A policy simulation screen has a GTL with the list of affected entities.
When a policy simulation happens in an explorer screen, whenever `@explorer`=true and `@in_a_form`=false,
`get_view` calls `adv_search_build` to build advanced search.

Policy simulation should have no advanced search.

This can fail with an exception, when the `session[:adv_search]` hash has an entry for the model class
(but currently policy simulation seems to get `VmOrTemplate` whereas infra VMs get `ManageIQ::Providers::InfraManager::Vm`).

(That happens because when `adv_search_build` finds an entry, it assumes a corresponding entry in `@edit` exists, but `@edit` gets cleared for policy simulation.)

So, making sure `adv_search_build` never happens, by setting `@in_a_form` early, in `policy_sim`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1717483
