### PR TITLE
Credentials parameters need to be serialized

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -232,7 +232,7 @@ class HostController < ApplicationController
         render :update do |page|
           page << javascript_prologue
           new_url = url_for_only_path(:action => "update", :button => "validate", :type => params[:type], :remember_host => "true", :escape => false)
-          page << "if (confirm('#{_('The Host SSH key has changed, do you want to accept the new key?')}')) miqAjax('#{new_url}');"
+          page << "if (confirm('The Host SSH key has changed, do you want to accept the new key?')) miqAjax('#{new_url}', true);"
         end
         return
       rescue => bang

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -232,7 +232,7 @@ class HostController < ApplicationController
         render :update do |page|
           page << javascript_prologue
           new_url = url_for_only_path(:action => "update", :button => "validate", :type => params[:type], :remember_host => "true", :escape => false)
-          page << "if (confirm('The Host SSH key has changed, do you want to accept the new key?')) miqAjax('#{new_url}', true);"
+          page << "if (confirm('#{_('The Host SSH key has changed, do you want to accept the new key?')}')) miqAjax('#{new_url}', true);"
         end
         return
       rescue => bang


### PR DESCRIPTION
In case of a HostKeyMismatch with an host not previously validated
credentials should be serialized to be available for the second
credentials verification.

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1624700