### PR TITLE
Drop the obsolete options argument from TreeBuilder#x_get_tree_roots

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -224,8 +224,8 @@ class TreeBuilder
     end
   end
 
-  def x_get_tree_objects(parent, options, count_only, parents)
-    children_or_count = parent.nil? ? x_get_tree_roots(count_only, options) : x_get_tree_kids(parent, count_only, parents)
+  def x_get_tree_objects(parent, _options, count_only, parents)
+    children_or_count = parent.nil? ? x_get_tree_roots(count_only) : x_get_tree_kids(parent, count_only, parents)
     children_or_count || (count_only ? 0 : [])
   end
 

--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -14,7 +14,7 @@ class TreeBuilderAction < TreeBuilder
   end
 
   # level 1 - actions
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, MiqAction.all, :description)
   end
 end

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -16,7 +16,7 @@ class TreeBuilderAeClass < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, User.current_tenant.visible_domains)
   end
 

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -12,7 +12,7 @@ class TreeBuilderAeCustomization < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, nil)
   end
 end

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -14,7 +14,7 @@ class TreeBuilderAlert < TreeBuilder
   end
 
   # level 1 - alerts
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, MiqAlert.all, :description)
   end
 end

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -20,7 +20,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   end
 
   # level 1 - * alert profiles
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = alert_profile_kinds.map do |db|
       # Set alert profile folder nodes to open so we pre-load all children
       open_node("xx-#{db}")

--- a/app/presenters/tree_builder_alert_profile_assign.rb
+++ b/app/presenters/tree_builder_alert_profile_assign.rb
@@ -6,7 +6,7 @@ class TreeBuilderAlertProfileAssign < TreeBuilder
     super(name, sandbox, build)
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     roots = ExtManagementSystem.assignable.each_with_object({}) do |ems, nodes|
       subtree = ems.children.flat_map(&:folders).each_with_object({}) do |folder, obj|
         obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE))

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -32,7 +32,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     obj = if @assign_to.blank? || @assign_to == "enterprise"
             []
           elsif @cat_tree

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -8,7 +8,7 @@ class TreeBuilderAutomate < TreeBuilder
     {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, [MiqAeDomain.find_by(:id => @sb[:domain_id])])
   end
 

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -5,7 +5,7 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
     super.merge!(:onclick => "miqOnClickAutomateCatalog")
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, filter_ae_objects(User.current_tenant.visible_domains))
   end
 

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -13,7 +13,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
     {:full_ids => true}
   end
 
-  def x_get_tree_roots(_count_only = false, _options = {})
+  def x_get_tree_roots(_count_only)
     objects = []
     xml = MiqXml.load(@root).root
     xml.each_element do |el|

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -15,7 +15,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = []
     templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"), :match_via_descendants => ConfigurationScript)
 

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -16,7 +16,7 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects_filtered(count_only, ManageIQ::Providers::AnsibleTower::AutomationManager, "name")
   end
 

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -32,7 +32,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, ExtManagementSystem.assignable)
   end
 

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -18,7 +18,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     buttons = CustomButton.button_classes.map do |klass|
       name = target_class_name(klass)
 

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -48,7 +48,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     return super + 1 if count_only
 
     # FIXME: adding gettext here would break the tree_select for languages other than English

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -9,7 +9,7 @@ class TreeBuilderCatalogsClass < TreeBuilder
     super(id) || ServiceTemplateCatalog.new
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
   end
 end

--- a/app/presenters/tree_builder_chargeback.rb
+++ b/app/presenters/tree_builder_chargeback.rb
@@ -6,7 +6,7 @@ class TreeBuilderChargeback < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     rate_types = ChargebackRate::VALID_CB_RATE_TYPES
     return rate_types.length if count_only
 

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -13,7 +13,7 @@ class TreeBuilderChargebackReports < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     items = MiqReportResult.with_saved_chargeback_reports
                            .select_distinct_results
                            .group("miq_report_results.miq_report_id, miq_reports.name, miq_report_results.id, \

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -30,7 +30,7 @@ class TreeBuilderClusters < TreeBuilder
     end
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     nodes = @root[:clusters].map do |node|
       { :id         => node[:id].to_s,
         :text       => node[:name],

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -22,7 +22,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
     {:full_ids => true}
   end
 
-  def x_get_tree_roots(count_only = false, _options = {})
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, @root.compliances.order("timestamp DESC").limit(10))
   end
 

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -19,7 +19,7 @@ class TreeBuilderCondition < TreeBuilder
   end
 
   # level 1 - host / vm
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     text_i18n = {:Host                => _("Host Conditions"),
                  :Vm                  => _("VM and Instance Conditions"),
                  :ContainerReplicator => _("Replicator Conditions"),

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -16,7 +16,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = []
     objects.push(:id            => "fr",
                  :tree          => "fr_tree",

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -28,7 +28,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = []
     objects.push(configured_systems)
     objects.push(:id         => "global",

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -18,7 +18,7 @@ class TreeBuilderDatastores < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     nodes = @root.map do |node|
       children = []
       if @data[node[:id]].hosts.present?

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -43,7 +43,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     roots = @data.keys.map do |folder|
       {:id           => folder,
        :text         => folder,

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -14,7 +14,7 @@ class TreeBuilderEvent < TreeBuilder
   end
 
   # level 1 - events
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, MiqPolicy.all_policy_events, :description)
   end
 end

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -47,7 +47,7 @@ class TreeBuilderGenealogy < TreeBuilder
     }.merge(vm_icon_image(object))
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     kids = @root.parent.present? ? [@root] : @root.children
     count_only_or_objects(count_only, kids, :name)
   end

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -13,7 +13,7 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, GenericObjectDefinition.all, :name)
   end
 

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -15,7 +15,7 @@ class TreeBuilderImages < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => TemplateCloud) +
       count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Images"))
   end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -21,7 +21,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = Rbac.filtered(ManageIQ::Providers::Vmware::InfraManager.order("lower(name)"))
     count_only_or_objects(count_only, objects)
   end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -14,7 +14,7 @@ class TreeBuilderInstances < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => VmCloud) +
       count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Instances"))
   end

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -15,7 +15,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, IsoDatastore.all, "name")
   end
 

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -36,7 +36,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   # parents to children. Therefore we include the children with the parent.
   # The :data key was chosen to avoid future conflicts with the :nodes key.
   #
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     branches = menus.map do |i|
       grandkids = i.last.kind_of?(Array) ? i.last : []
 

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -31,7 +31,7 @@ class TreeBuilderNetwork < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     kids = count_only ? 0 : []
     kids = count_only_or_objects(count_only, @root.switches) unless @root.switches.empty?
     kids

--- a/app/presenters/tree_builder_ops.rb
+++ b/app/presenters/tree_builder_ops.rb
@@ -13,7 +13,7 @@ class TreeBuilderOps < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     region = MiqRegion.my_region
     objects = region.zones.visible.sort_by { |z| z.name.downcase }
     count_only_or_objects(count_only, objects)

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -20,7 +20,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     objects = []
     if ApplicationHelper.role_allows?(:feature => "rbac_user_view", :any => true)
       objects.push(:id => "u", :text => _("Users"), :icon => "pficon pficon-user", :tip => _("Users"))

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -18,7 +18,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   private
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     top_nodes = Menu::Manager.items.select do |section|
       Vmdb::PermissionStores.instance.can?(section.id) && !section.kind_of?(Menu::Item)
     end

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -18,7 +18,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     objects = [
       {:id => "sis", :text => _("Analysis Profiles"), :icon => "fa fa-search", :tip => _("Analysis Profiles")},
       {:id => "z", :text => _("Zones"), :icon => "pficon pficon-zone", :tip => _("Zones")}

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -16,7 +16,7 @@ class TreeBuilderOpsVmdb < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = Rbac.filtered(VmdbDatabase.my_database.try(:evm_tables).to_a).to_a
     count_only_or_objects(count_only, objects, "name")
   end

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -12,7 +12,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     nodes = [
       {:id   => 'otcfn',
        :tree => "otcfn_tree",

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -49,7 +49,7 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   # level 1 - compliance & control
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = []
     objects << {:id => "compliance", :text => _("Compliance Policies"), :icon => "pficon pficon-history", :tip => _("Compliance Policies")}
     objects << {:id => "control", :text => _("Control Policies"), :icon => "fa fa-shield", :tip => _("Control Policies")}

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -18,7 +18,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
   end
 
   # level 1 - policy profiles
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, MiqPolicySet.all, :description)
   end
 

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -40,7 +40,7 @@ class TreeBuilderPolicySimulation < TreeBuilder
     end
   end
 
-  def x_get_tree_roots(count_only = false, _options = {})
+  def x_get_tree_roots(count_only)
     nodes = if @data.present?
               reject_na_nodes(@data).map do |node|
                 {:id         => node['id'],

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -110,7 +110,7 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
      :selectable => false}
   end
 
-  def x_get_tree_roots(count_only = false, _options = nil)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, vm_nodes(@root[:results]))
   end
 

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -17,7 +17,7 @@ class TreeBuilderProtect < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     nodes = MiqPolicySet.all.sort_by { |profile| profile.description.downcase }.map do |profile|
       { :id         => "policy_profile_#{profile.id}",
         :text       => profile.description,

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -13,7 +13,7 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = MiqDialog::DIALOG_TYPES.sort.collect do |typ|
       {
         :id   => "MiqDialog_#{typ[1]}",

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -14,7 +14,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     items = PxeImageType.all
     if count_only
       # add +1 for customization spec folder thats used to show system templates

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -13,7 +13,7 @@ class TreeBuilderPxeImageTypes < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, PxeImageType.all, "name")
   end
 end

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -15,7 +15,7 @@ class TreeBuilderPxeServers < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     count_only_or_objects(count_only, PxeServer.all, "name")
   end
 

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -15,7 +15,7 @@ class TreeBuilderReportDashboards < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = []
     default_ws = MiqWidgetSet.find_by(:name => 'default', :read_only => true)
     text = "#{default_ws.description} (#{default_ws.name})"

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -14,7 +14,7 @@ class TreeBuilderReportExport < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     nodes = [
       {:id   => 'exportcustomreports',
        :text => _('Custom Reports'),

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -23,7 +23,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   # Get root node and all children report folders. (will call get_tree_custom_kids to get report details)
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     return @rpt_menu.size if count_only
     @rpt_menu.each_with_index.each_with_object({}) do |(r, node_id), a|
       open_node("xx-#{node_id}")

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -19,7 +19,7 @@ class TreeBuilderReportRoles < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     user  = User.current_user
     roles = user.super_admin_user? ? MiqGroup.non_tenant_groups_in_my_region : [user.current_group]
     count_only_or_objects(count_only, roles, 'name')

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -13,7 +13,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     u = User.current_user
     user_groups = u.report_admin_user? ? nil : u.miq_groups
     having_report_results(user_groups).pluck(:name, :id).sort.map do |name, id|

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -14,7 +14,7 @@ class TreeBuilderReportSchedules < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
                 # Super admins see all report schedules
                 MiqSchedule.where(:resource_type => 'MiqReport')

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -20,7 +20,7 @@ class TreeBuilderReportWidgets < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = WIDGET_TYPES.collect { |k, v| {:id => k, :text => _(v), :icon => 'pficon pficon-folder-close', :tip => _(v)} }
     count_only_or_objects(count_only, objects)
   end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -3,7 +3,7 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
 
   private
 
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     x_get_tree_miq_servers
   end
 

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -21,7 +21,7 @@ class TreeBuilderSections < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     nodes = []
     group = nil
     @data.master_list.each_slice(3) do |section, _records, _fields|

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -3,7 +3,7 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
 
   private
 
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     x_get_tree_server_roles
   end
 

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -14,7 +14,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     includes = {:tenant => {}, :service_templates => {}}
     objects = Rbac.filtered(ServiceTemplateCatalog, :include_for_find => includes).sort_by { |o| o.name.downcase }
     filtered_objects = []

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -11,7 +11,7 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = Rbac.filtered(Dialog.all).sort_by { |a| a.label.downcase }
     count_only_or_objects(count_only, objects)
   end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -25,7 +25,7 @@ class TreeBuilderServices < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects = [
       services_root('asrv', _('Active Services'),  _('Active Services')),
       services_root('rsrv', _('Retired Services'), _('Retired Services')),

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -24,7 +24,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     nodes = @data.miq_servers.select(&:is_a_proxy?).sort_by { |s| [s.name, s.id] }
     count_only_or_objects(count_only, nodes)
   end

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -37,7 +37,7 @@ class TreeBuilderSnapshots < TreeBuilder
     @tree_state.x_node_set(node[:key], @name)
   end
 
-  def x_get_tree_roots(count_only = false, _options = {})
+  def x_get_tree_roots(count_only)
     root_kid = @record.snapshots.present? ? @record.snapshots.find_all { |x| x.parent_id.nil? } : []
     open_node("sn-#{root_kid.first.id}") if root_kid.present?
     count_only_or_objects(count_only, root_kid)

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -12,7 +12,7 @@ class TreeBuilderStorage < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects =
       [
         {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -22,7 +22,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only)
     kids = count_only ? 0 : []
     unless @root.hardware.storage_adapters.empty?
       kids = count_only_or_objects(count_only, @root.hardware.storage_adapters)

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -13,7 +13,7 @@ class TreeBuilderStoragePod < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     items = EmsFolder.where(:type => 'StorageCluster')
     if count_only
       items.size

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -47,7 +47,7 @@ class TreeBuilderTenants < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(_count_only, _options)
+  def x_get_tree_roots(_count_only)
     if ApplicationHelper.role_allows?(:feature => 'rbac_tenant_view')
       Tenant.with_current_tenant
     end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -22,7 +22,7 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     ent = MiqEnterprise.my_enterprise
     objects = ent.miq_regions.sort_by { |a| a.description.downcase }
     count_only_or_objects(count_only, objects)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -15,7 +15,7 @@ class TreeBuilderVandt < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, options)
+  def x_get_tree_roots(count_only)
     objects = count_only_or_objects_filtered(count_only, EmsInfra, "name", :match_via_descendants => VmOrTemplate)
     objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree } unless count_only
     root_nodes = count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("VMs and Templates"))

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -18,7 +18,7 @@ class TreeBuilderVmsFilter < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only, _options)
+  def x_get_tree_roots(count_only)
     objects =
       [
         {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -266,7 +266,7 @@ describe AutomationManagerController do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
     TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerProviders.new("root", {})
-    objects = tree_builder.send(:x_get_tree_roots, false, {})
+    objects = tree_builder.send(:x_get_tree_roots, false)
     expected_objects = [automation_manager1, automation_manager2, automation_manager3]
     expect(objects).to match_array(expected_objects)
   end
@@ -283,7 +283,7 @@ describe AutomationManagerController do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", {})
-    objects = tree_builder.send(:x_get_tree_roots, false, {})
+    objects = tree_builder.send(:x_get_tree_roots, false)
     expect(objects).to include(@automation_manager1)
     expect(objects).to include(@automation_manager2)
   end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -81,7 +81,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
-        s = subject.send(:x_get_tree_roots, false, nil)
+        s = subject.send(:x_get_tree_roots, false)
         expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end
@@ -90,7 +90,7 @@ describe TreeBuilderAlertProfileObj do
       it 'returns all ExtManagementSystems except the Embedded Ansible when @assign_to=ext_management_system' do
         subject.instance_variable_set(:@cat_tree, nil)
         subject.instance_variable_set(:@assign_to, "ext_management_system")
-        expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+        expect(subject.send(:x_get_tree_roots, false)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
       end
     end
   end
@@ -107,7 +107,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
-        s = subject.send(:x_get_tree_roots, false, nil)
+        s = subject.send(:x_get_tree_roots, false)
         expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -87,7 +87,7 @@ describe TreeBuilderBelongsToHac do
 
   describe '#x_get_tree_roots' do
     it 'returns all ExtManagementSystems except the Embedded Ansible' do
-      expect(subject.send(:x_get_tree_roots, false, nil)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+      expect(subject.send(:x_get_tree_roots, false)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
     end
   end
 

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -25,13 +25,13 @@ describe TreeBuilderDatastores do
       expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
     end
     it 'sets Datastore node correctly' do
-      parent = @datastores_tree.send(:x_get_tree_roots, false, nil)
+      parent = @datastores_tree.send(:x_get_tree_roots, false)
       expect(parent.first[:text]).to eq("<strong>Datastore</strong> [#{@datastore.first[:location]}]")
       expect(parent.first[:tip]).to eq("Datastore [#{@datastore.first[:location]}]")
       expect(parent.first[:icon]).to eq('fa fa-database')
     end
     it 'sets Host node correctly' do
-      parent = @datastores_tree.send(:x_get_tree_roots, false, nil)
+      parent = @datastores_tree.send(:x_get_tree_roots, false)
       kids = @datastores_tree.send(:x_get_tree_hash_kids, parent.first, false)
       expect(kids.first[:text]).to eq(@host[:name])
       expect(kids.first[:tip]).to eq(@host[:name])

--- a/spec/presenters/tree_builder_ems_folders_spec.rb
+++ b/spec/presenters/tree_builder_ems_folders_spec.rb
@@ -20,7 +20,7 @@ describe TreeBuilderEmsFolders do
   describe '#x_get_tree_roots' do
     context 'no ems folders with a single provider' do
       it 'returns with a no roots' do
-        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(0)
+        expect(subject.send(:x_get_tree_roots, false).length).to eq(0)
       end
     end
 
@@ -36,7 +36,7 @@ describe TreeBuilderEmsFolders do
       end
 
       it 'returns with a single root' do
-        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(1)
+        expect(subject.send(:x_get_tree_roots, false).length).to eq(1)
       end
     end
   end

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -52,8 +52,8 @@ describe TreeBuilderGenealogy do
 
   describe '#x_get_tree_roots' do
     it 'returns tree roots correctly' do
-      expect(subject.send(:x_get_tree_roots, false, {})).to include(vm_with_kid, vm_without_kid)
-      expect(subject.send(:x_get_tree_roots, true, {})).to eq(2)
+      expect(subject.send(:x_get_tree_roots, false)).to include(vm_with_kid, vm_without_kid)
+      expect(subject.send(:x_get_tree_roots, true)).to eq(2)
     end
   end
 

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderImages do
 
   it 'sets providers nodes correctly' do
     allow(@images_tree).to receive(:role_allows?).and_return(true)
-    providers = @images_tree.x_get_tree_roots(false, nil)
+    providers = @images_tree.send(:x_get_tree_roots, false)
     expect(providers).to eq([@template_cloud_with_az.ext_management_system,
                              {:id              => "arch",
                               :text            => "<Archived>",

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -36,7 +36,7 @@ describe TreeBuilderInstances do
 
   it 'sets providers nodes correctly' do
     allow(@instances_tree).to receive(:role_allows?).and_return(true)
-    providers = @instances_tree.x_get_tree_roots(false, nil)
+    providers = @instances_tree.send(:x_get_tree_roots, false)
 
     expect(providers).to eq([@vm_cloud_with_az.ext_management_system,
                              @vm_cloud_without_az.ext_management_system,
@@ -53,8 +53,8 @@ describe TreeBuilderInstances do
   end
 
   it 'sets availability zones correctly if vms are hidden' do
-    provider_with_az = @instances_tree.x_get_tree_roots(false, nil)[0] # provider with vm that has availability zone
-    provider_without_az = @instances_tree.x_get_tree_roots(false, nil)[1] # provider with vm that doesn't have availability zone
+    provider_with_az = @instances_tree.send(:x_get_tree_roots, false)[0] # provider with vm that has availability zone
+    provider_without_az = @instances_tree.send(:x_get_tree_roots, false)[1] # provider with vm that doesn't have availability zone
     allow(provider_with_az).to receive(:availability_zones) { [@vm_cloud_with_az.availability_zone] }
     az = @instances_tree.x_get_tree_ems_kids(provider_with_az, false)
     vm_without_az = @instances_tree.x_get_tree_ems_kids(provider_without_az, false)

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -6,11 +6,11 @@ describe TreeBuilderReportWidgets do
   end
 
   it "#x_get_tree_roots (private)" do
-    expect(subject.send(:x_get_tree_roots, false, nil)).to match_array([
-                                                                         {:id => "r",  :text => "Reports",   :icon => "pficon pficon-folder-close", :tip => "Reports"},
-                                                                         {:id => "c",  :text => "Charts",    :icon => "pficon pficon-folder-close", :tip => "Charts"},
-                                                                         {:id => "m",  :text => "Menus",     :icon => "pficon pficon-folder-close", :tip => "Menus"}
-                                                                       ])
+    expect(subject.send(:x_get_tree_roots, false)).to match_array([
+                                                                    {:id => "r",  :text => "Reports",   :icon => "pficon pficon-folder-close", :tip => "Reports"},
+                                                                    {:id => "c",  :text => "Charts",    :icon => "pficon pficon-folder-close", :tip => "Charts"},
+                                                                    {:id => "m",  :text => "Menus",     :icon => "pficon pficon-folder-close", :tip => "Menus"}
+                                                                  ])
   end
 
   it "#x_get_tree_custom_kids (private)" do

--- a/spec/presenters/tree_builder_resource_pools_spec.rb
+++ b/spec/presenters/tree_builder_resource_pools_spec.rb
@@ -20,7 +20,7 @@ describe TreeBuilderResourcePools do
   describe '#x_get_tree_roots' do
     context 'no ems folders with a single provider' do
       it 'returns with a no roots' do
-        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(0)
+        expect(subject.send(:x_get_tree_roots, false).length).to eq(0)
       end
     end
 
@@ -36,7 +36,7 @@ describe TreeBuilderResourcePools do
       end
 
       it 'returns with a single root' do
-        expect(subject.send(:x_get_tree_roots, false, {}).length).to eq(1)
+        expect(subject.send(:x_get_tree_roots, false).length).to eq(1)
       end
     end
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderRolesByServer do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false, {})
+      server_nodes = @server_tree.send(:x_get_tree_roots, false)
       expect(server_nodes).to eq([@miq_server])
     end
 

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -42,7 +42,7 @@ describe TreeBuilderServersByRole do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false, {})
+      server_nodes = @server_tree.send(:x_get_tree_roots, false)
       expect(server_nodes).to eq([@server_role])
     end
 

--- a/spec/presenters/tree_builder_service_catalog_spec.rb
+++ b/spec/presenters/tree_builder_service_catalog_spec.rb
@@ -25,7 +25,7 @@ describe TreeBuilderServiceCatalog do
   end
 
   it "#x_get_tree_roots" do
-    roots = @tree.send(:x_get_tree_roots, false, {})
+    roots = @tree.send(:x_get_tree_roots, false)
     expect(roots.first.name).to eq(@catalog.name)
   end
 

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderServices do
 
   describe '#x_get_tree_roots' do
     it 'returns the four root nodes' do
-      root_nodes = subject.send(:x_get_tree_roots, false, {})
+      root_nodes = subject.send(:x_get_tree_roots, false)
 
       expect(root_nodes).to match [
         a_hash_including(:id => 'asrv'),


### PR DESCRIPTION
As we're no longer using the `options` anywhere, it's safe to remove this argument from all the `x_get_tree_roots` method signatures.

@miq-bot add_label cleanup, hammer/no, ivanchuk/no, refactoring, trees
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 