### PR TITLE
NetworkRouter form_params should get tenant id from nested hash

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -402,8 +402,8 @@ class NetworkRouterController < ApplicationController
     end
 
     options[:cloud_network_id].gsub!(/number:/, '') if options[:cloud_network_id]
-    if params[:cloud_tenant_id]
-      options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant_id])
+    if params.fetch_path(:cloud_tenant, :id)
+      options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params.fetch_path(:cloud_tenant, :id))
     end
     options
   end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -125,7 +125,8 @@ describe NetworkRouterController do
             :name            => 'test',
             :admin_state_up  => 'true',
             :ems_id          => @ems.id.to_s,
-            :cloud_subnet_id => ''
+            :cloud_subnet_id => '',
+            :cloud_tenant    => cloud_tenant
           }]
         }
       end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724114

The NetworkRouter form was updated quite some time ago to submit the cloud tenant id as an `id` key in a `cloud_tenant` object rather than as a field named `cloud_tenant_id`. This updates the NetworkRouterController's `form_params` method to reflect that.