### PR TITLE
Pass the conditional class to the About Modal instead of HTML body

### DIFF
--- a/app/assets/stylesheets/about_modal_background.scss
+++ b/app/assets/stylesheets/about_modal_background.scss
@@ -7,7 +7,7 @@
   background-image: image-url($modal-about-pf-bg-img);
 }
 
-body.whitelabel {
+.modal-dialog.whitelabel {
   .about-modal-pf {
     background-image: image-url($img-bg-login-whitelabel);
     background-size: 100% 100%;

--- a/app/javascript/components/miq-about-modal.jsx
+++ b/app/javascript/components/miq-about-modal.jsx
@@ -77,6 +77,7 @@ class MiqAboutModal extends React.Component {
 
     return (
       <AboutModal
+        dialogClassName={this.props.dialogClassName}
         show={this.props.show}
         onHide={this.props.hideModal}
         productTitle={`${data.product_info.name_full} ${data.server_info.release}`}
@@ -111,6 +112,7 @@ class MiqAboutModal extends React.Component {
 }
 
 MiqAboutModal.propTypes = {
+  dialogClassName: PropTypes.string,
   show: PropTypes.bool,
   data: PropTypes.shape({
     product_info: PropTypes.shape({
@@ -129,6 +131,7 @@ MiqAboutModal.propTypes = {
 };
 
 MiqAboutModal.defaultProps = {
+  dialogClassName: undefined,
   show: false,
   data: undefined,
 };

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,4 +1,4 @@
-= react 'MiqAboutModal'
+= react 'MiqAboutModal', :dialogClassName => Settings.server.custom_login_logo ? 'whitelabel' : ''
 %nav.navbar.navbar-pf-vertical#notification-app{'ng-controller' => "headerController as vm"}
   .navbar-header
     %button{:type => "button", :class => "navbar-toggle"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,7 @@
       :javascript
         miqInitNotifications();
 
-  %body{:onload => 'miqOnLoad();', 'data-controller' => controller_name, :class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
+  %body{:onload => 'miqOnLoad();', 'data-controller' => controller_name}
     = render :partial => "layouts/header"
     = render :partial => "layouts/content"
     = render :partial => 'layouts/footer'


### PR DESCRIPTION
This way we don't have to hack the document's body, but we can pass a class directly to the about modal to show a custom background image. There is be no visual change, just lower semantical complexity of the HTML layout.

Resolves https://github.com/patternfly/patternfly-react/issues/2185
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @epwinchell 
@miq-bot add_label technical debt, hammer/no, ivanchuk/no, react