### PR TITLE
Use the TreeBuilder#node_by_tree_id in compliance history 🌳

### DIFF
--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -54,8 +54,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
 
   def x_get_compliance_detail_kids(parent, count_only, parents)
     kids = []
-    model, id = TreeBuilder.extract_node_model_and_id(parents.first)
-    grandpa = model.constantize.find_by(:id => id)
+    grandpa = node_by_tree_id(parents.first)
     grandpa.compliance_details.order("miq_policy_desc, condition_desc").each do |node|
       next unless node.miq_policy_id == parent.miq_policy_id
       kids.push(get_policy_elm(parent, node))


### PR DESCRIPTION
Removing some duplicated code in :deciduous_tree: :deciduous_tree: for retrieving a record from a node's key.

@miq-bot add_label refactoring, trees, hammer/no, ivanchuk/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 