### PR TITLE
Drop the unnecessary sandbox variable in storage adapters 🌳✂️✂️

### DIFF
--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -3,8 +3,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
   has_kids_for MiqScsiTarget, [:x_get_tree_target_kids]
 
   def initialize(name, sandbox, build = true, **params)
-    sandbox[:sa_root] = params[:root] if params[:root]
-    @root = sandbox[:sa_root]
+    @root = params[:root]
     super(name, sandbox, build)
   end
 


### PR DESCRIPTION
The tree is accessible from the `Infra -> Hosts` summary screen. This variable is not being used anywhere else, not even during lazyloading.

@miq-bot add_label trees, technical debt, hammer/no, ivanchuk/no
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 