### PR TITLE
Do not rely on the obsolete sandbox variable in ComplianceHistory🌳

### DIFF
--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -7,12 +7,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
   end
 
   def initialize(name, sandbox, build = true, **params)
-    sandbox[:ch_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
     @root = params[:root]
-    unless @root
-      model, id = TreeBuilder.extract_node_model_and_id(sandbox[:ch_root])
-      @root = model.constantize.find_by(:id => id)
-    end
     super(name, sandbox, build)
   end
 


### PR DESCRIPTION
Avaialble on any entity that has compliance (assignable policies) support through its summary screen. The tree is not lazy and it always comes in with a root node.

@miq-bot add_label technical debt, hammer/no, ivanchuk/no, trees, cleanup
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 