### PR TITLE
Do not rely on the obsolete sandbox variable in Networks 🌳

### DIFF
--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -7,12 +7,7 @@ class TreeBuilderNetwork < TreeBuilder
   end
 
   def initialize(name, sandbox, build = true, **params)
-    sandbox[:network_root] = TreeBuilder.build_node_id(params[:root]) if params[:root]
     @root = params[:root]
-    unless @root
-      model, id = TreeBuilder.extract_node_model_and_id(sandbox[:network_root])
-      @root = model.constantize.find_by(:id => id)
-    end
     super(name, sandbox, build)
   end
 


### PR DESCRIPTION
The tree is accessible from the Infra -> Hosts summary screen. This variable is not being used anywhere else, not even during lazyloading.

@miq-bot add_label trees, technical debt, hammer/no, ivanchuk/no, cleanup
@miq-bot add_reviewer @ZitaNemeckova
@miq-bot assign @mzazrivec