### PR TITLE
Drop the unused options argument from TreeBuilder#x_get_tree_objects

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -44,7 +44,7 @@ class TreeBuilder
     # Save node as open
     open_node(id)
 
-    x_get_tree_objects(object, @tree_state.x_tree(@name), false, parents).map do |o|
+    x_get_tree_objects(object, false, parents).map do |o|
       x_build_node_tree(o, id, @tree_state.x_tree(@name))
     end
   end
@@ -192,7 +192,7 @@ class TreeBuilder
   # :full_ids               # stack parent id on top of each node id
   # :lazy                   # set if tree is lazy
   def x_build_tree(options)
-    nodes = x_get_tree_objects(nil, options, false, []).map do |child|
+    nodes = x_get_tree_objects(nil, false, []).map do |child|
       # already a node? FIXME: make a class for node
       if child.kind_of?(Hash) && child.key?(:text) && child.key?(:key) && child.key?(:image)
         child
@@ -224,7 +224,7 @@ class TreeBuilder
     end
   end
 
-  def x_get_tree_objects(parent, _options, count_only, parents)
+  def x_get_tree_objects(parent, count_only, parents)
     children_or_count = parent.nil? ? x_get_tree_roots(count_only) : x_get_tree_kids(parent, count_only, parents)
     children_or_count || (count_only ? 0 : [])
   end
@@ -256,12 +256,12 @@ class TreeBuilder
                       @tree_state.x_tree(@name)[:active_node] == node[:key]
     if ancestry_kids || load_children || node[:expand] || !@options[:lazy]
 
-      kids = (ancestry_kids || x_get_tree_objects(object, options, false, parents)).map do |o|
+      kids = (ancestry_kids || x_get_tree_objects(object, false, parents)).map do |o|
         x_build_node(o, node[:key], options)
       end
       node[:nodes] = kids unless kids.empty?
     else
-      if x_get_tree_objects(object, options, true, parents) > 0
+      if x_get_tree_objects(object, true, parents) > 0
         node[:lazyLoad] = true # set child flag if children exist
       end
     end

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -274,7 +274,7 @@ describe AutomationManagerController do
   it "constructs the ansible tower inventory tree node" do
     TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerProviders.new("root", {})
-    objects = tree_builder.send(:x_get_tree_objects, @inventory_group, nil, false, nil)
+    objects = tree_builder.send(:x_get_tree_objects, @inventory_group, false, nil)
     expected_objects = [@ans_configured_system, @ans_configured_system2a]
     expect(objects).to match_array(expected_objects)
   end

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -44,7 +44,7 @@ describe TreeBuilderNetwork do
 
     it 'returns nothing as GuestDevice child' do
       parent = @network_tree.send(:x_get_tree_roots, false).first.guest_devices.first
-      number_of_kids = @network_tree.send(:x_get_tree_objects, parent, {}, true, nil)
+      number_of_kids = @network_tree.send(:x_get_tree_objects, parent, true, nil)
       expect(number_of_kids).to eq(0)
     end
   end

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -41,8 +41,8 @@ describe TreeBuilderStorageAdapters do
     it 'returns nothing as MiqScsiLun children' do
       root = @sa_tree.send(:x_get_tree_roots, false).first
       parent = @sa_tree.send(:x_get_tree_target_kids, root, false).first
-      number_of_kids = @sa_tree.send(:x_get_tree_objects, parent, {}, true, nil)
-      kids = @sa_tree.send(:x_get_tree_objects, parent, {}, false, nil)
+      number_of_kids = @sa_tree.send(:x_get_tree_objects, parent, true, nil)
+      kids = @sa_tree.send(:x_get_tree_objects, parent, false, nil)
       expect(number_of_kids).to eq(0)
       expect(kids).to eq([])
     end


### PR DESCRIPTION
This argument is no longer necessary and has been marked as unused anyway, so deleting it.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label hammer/no, ivanchuk/no, cleanup, technical debt, trees