### PR TITLE
Drop the unused options argument from TreeBuilder#x_get_custom_kids

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -281,7 +281,7 @@ class TreeBuilder
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(_object, count_only, _options)
+  def x_get_tree_custom_kids(_object, count_only)
     count_only ? 0 : []
   end
 

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -32,7 +32,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   end
 
   # level 2 - alert profiles
-  def x_get_tree_custom_kids(parent, count_only, _options)
+  def x_get_tree_custom_kids(parent, count_only)
     objects = MiqAlertSet.where(:mode => parent[:id].split('-'))
 
     count_only_or_objects(count_only, objects, :description)

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -41,7 +41,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
     count_only_or_objects_filtered(count_only, scripts, "name")
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = MiqSearch.where(:db => "ConfigurationScript").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -33,7 +33,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
     buttons.sort_by { |button| button[:text] }
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = object[:id].split('_')
     objects = CustomButtonSet.find_all_by_class_name(nodes[1])
     # add as first element of array

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -25,7 +25,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     # build node showing any button groups or buttons under selected CatalogItem
     @resolve ||= {}
     st = ServiceTemplate.find_by(:id => object[:id])

--- a/app/presenters/tree_builder_chargeback_rates.rb
+++ b/app/presenters/tree_builder_chargeback_rates.rb
@@ -9,7 +9,7 @@ class TreeBuilderChargebackRates < TreeBuilderChargeback
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = ChargebackRate.where(:rate_type => object[:id]).to_a
     count_only_or_objects(count_only, objects, "description")
   end

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -35,7 +35,7 @@ class TreeBuilderChargebackReports < TreeBuilder
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = MiqReportResult.with_saved_chargeback_reports(object[:id].split('-').first)
                              .select(:id, :miq_report_id, :name, :last_run_on, :miq_task_id)
                              .order(:last_run_on => :desc)

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -63,7 +63,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
     count_only_or_objects(count_only, kids)
   end
 
-  def x_get_tree_custom_kids(_parent, count_only, _options)
+  def x_get_tree_custom_kids(_parent, count_only)
     count_only ? 0 : []
   end
 end

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -45,7 +45,7 @@ class TreeBuilderCondition < TreeBuilder
   end
 
   # level 2 - conditions
-  def x_get_tree_custom_kids(parent, count_only, _options)
+  def x_get_tree_custom_kids(parent, count_only)
     towhat = parent[:id].camelize
     return super unless MiqPolicyController::UI_FOLDERS.collect(&:name).include?(towhat)
 

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -63,7 +63,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
     count_only_or_objects_filtered(count_only, configured_systems, "hostname")
   end
 
-  def x_get_tree_custom_kids(object_hash, count_only, _options)
+  def x_get_tree_custom_kids(object_hash, count_only)
     objects =
       case object_hash[:id]
       when "fr" then ManageIQ::Providers::Foreman::ConfigurationManager

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -5,7 +5,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
     {:lazy => true, :allow_reselect => true}
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     count_only_or_objects(count_only, x_get_search_results(object))
   end
 

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -39,7 +39,7 @@ class TreeBuilderIsoDatastores < TreeBuilder
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = (object[:full_id] || object[:id]).split('_')
     isd = IsoDatastore.find_by(:id => nodes.last.split('-').last)
     # Iso Datastore node was clicked OR folder nodes was clicked

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -37,7 +37,7 @@ class TreeBuilderOpsRbac < TreeBuilder
     objects
   end
 
-  def x_get_tree_custom_kids(object_hash, count_only, _options)
+  def x_get_tree_custom_kids(object_hash, count_only)
     objects =
       case object_hash[:id]
       when "u"  then Rbac.filtered(User.in_my_region)

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -28,7 +28,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     case object[:id]
     when "msc"
       objects = MiqSchedule.where("(prod_default != 'system' or prod_default is null) AND adhoc is null")

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -22,7 +22,7 @@ class TreeBuilderOpsVmdb < TreeBuilder
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     vmdb_table_id = object[:id].split("|").last.split('-').last
     vmdb_indexes  = VmdbIndex.includes(:vmdb_table).where(:vmdb_tables => {:type => 'VmdbTableEvm', :id => vmdb_table_id})
     count_only_or_objects(count_only, vmdb_indexes, "name")

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -48,7 +48,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
     count_only_or_objects(count_only, nodes)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     classes = {
       "otcfn" => ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate,
       "othot" => ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate,

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -61,7 +61,7 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   # level 2 & 3...
-  def x_get_tree_custom_kids(parent, count_only, _options)
+  def x_get_tree_custom_kids(parent, count_only)
     # level 2 - host, vm, etc. under compliance/control
     if %w[compliance control].include?(parent[:id])
       mode = parent[:id]

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -25,7 +25,7 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = MiqDialog.where(:dialog_type => object[:id].split('_').last).sort_by { |a| a.description.downcase }
     count_only_or_objects(count_only, objects)
   end

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -37,7 +37,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].split('-')
     pxe_img_id = if nodes[1] == "system" || nodes[2] == "system"
                    # root node was clicked or if folder node was clicked

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -46,7 +46,7 @@ class TreeBuilderPxeServers < TreeBuilder
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = (object[:full_id] || object[:id]).split('_')
     ps = PxeServer.find_by(:id => nodes.last.split('-').last)
     objects = if nodes[0].end_with?("pxe")

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -24,7 +24,7 @@ class TreeBuilderReportDashboards < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = []
     if object[:id].split('-').first == "g"
       objects = Rbac.filtered(MiqGroup.non_tenant_groups)

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -39,7 +39,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].to_s.split('-')
     parent_id = nodes[-2].split('_').first.to_i
     node_id = nodes.last.to_i

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -21,7 +21,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     scope = MiqReportResult.with_current_user_groups_and_report(object[:id].split('-').last)
     count_only ? 1 : scope.order("last_run_on DESC").includes(:miq_task).to_a
   end

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -25,7 +25,7 @@ class TreeBuilderReportWidgets < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     widgets = MiqWidget.where(:content_type => ReportController::Widgets::WIDGET_CONTENT_TYPE[object[:id].split('-').last])
     count_only_or_objects(count_only, widgets, 'title')
   end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -35,7 +35,7 @@ class TreeBuilderServices < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     case object[:id]
     when 'my', 'global'
       # Get My Filters and Global Filters

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -21,7 +21,7 @@ class TreeBuilderStorage < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = MiqSearch.where(:db => "Storage").filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -31,7 +31,7 @@ class TreeBuilderStoragePod < TreeBuilder
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = EmsFolder.find_by(:id => object[:id])&.storages
     count_only_or_objects(count_only, objects || [], "name")
   end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -51,7 +51,7 @@ class TreeBuilderUtilization < TreeBuilder
     end
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     nodes = object[:id].split('_')
     id = nodes.last.split('-').last
     if object_ems?(nodes, object)

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -27,7 +27,7 @@ class TreeBuilderVmsFilter < TreeBuilder
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_custom_kids(object, count_only, _options)
+  def x_get_tree_custom_kids(object, count_only)
     objects = MiqSearch.where(:db => @root_class).filters_by_type(object[:id])
     count_only_or_objects(count_only, objects, 'description')
   end

--- a/app/presenters/tree_kids.rb
+++ b/app/presenters/tree_kids.rb
@@ -7,7 +7,7 @@ module TreeKids
 
     def kids_generators
       @kids_generators ||= superclass.try(:kids_generators).try(:dup) || {
-        Hash => %i[x_get_tree_custom_kids options],
+        Hash => %i[x_get_tree_custom_kids],
       }
     end
   end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -294,7 +294,7 @@ describe ProviderForemanController do
 
   it "builds foreman child tree" do
     tree_builder = TreeBuilderConfigurationManager.new("root", controller.instance_variable_get(:@sb))
-    objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false, {})
+    objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false)
     expected_objects = [@config_mgr, @config_mgr2]
     expect(objects).to match_array(expected_objects)
   end

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -48,7 +48,7 @@ describe TreeBuilderComplianceHistory do
                         :icon       => "fa fa-ban",
                         :tip        => nil)
       expect(kid).to be_a_kind_of(Hash)
-      expect(@ch_tree.send(:x_get_tree_custom_kids, kid, true, {})).to eq(0)
+      expect(@ch_tree.send(:x_get_tree_custom_kids, kid, true)).to eq(0)
     end
     it 'returns Policy with multiple Conditions' do
       grandparents = @ch_tree.send(:x_get_tree_roots, false)

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -56,7 +56,7 @@ describe TreeBuilderOpsRbac do
 
     def x_get_tree_custom_kids_for_and_expect_objects(type_of_model, expected_objects)
       tree_builder = TreeBuilderOpsRbac.new("rbac_tree", {})
-      objects = tree_builder.send(:x_get_tree_custom_kids, {:id => type_of_model}, false, {})
+      objects = tree_builder.send(:x_get_tree_custom_kids, {:id => type_of_model}, false)
       expect(objects).to match_array(expected_objects)
     end
 

--- a/spec/presenters/tree_builder_report_dashboards_spec.rb
+++ b/spec/presenters/tree_builder_report_dashboards_spec.rb
@@ -25,7 +25,7 @@ describe TreeBuilderReportDashboards do
     it "is listing only user's groups, logged is self service user" do
       allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
       tree_builder = TreeBuilderReportDashboards.new("rbac_tree", {})
-      objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "g"}, false, :type => :db)
+      objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "g"}, false)
       expect(objects).to match_array([group])
     end
   end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -41,7 +41,7 @@ describe TreeBuilderReportSavedReports do
           report_result = MiqReportResult.first
 
           tree = TreeBuilderReportSavedReports.new('savedreports_tree', {})
-          tree_report_results = tree.send(:x_get_tree_custom_kids, {:id => @rpt.id.to_s}, false, {})
+          tree_report_results = tree.send(:x_get_tree_custom_kids, {:id => @rpt.id.to_s}, false)
 
           expect(tree_report_results).to include(report_result)
         end

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -18,6 +18,6 @@ describe TreeBuilderReportWidgets do
     widget2 = FactoryBot.create(:miq_widget)
     FactoryBot.create(:miq_widget, :content_type => "menu")
 
-    expect(subject.send(:x_get_tree_custom_kids, {:id => "-r"}, false, nil)).to match_array([widget1, widget2])
+    expect(subject.send(:x_get_tree_custom_kids, {:id => "-r"}, false)).to match_array([widget1, widget2])
   end
 end

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -27,12 +27,12 @@ describe TreeBuilderServices do
 
   describe '#x_get_tree_custom_kids' do
     it 'returns the root service node for active services' do
-      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'asrv'}, false, {})
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'asrv'}, false)
       expect(root_services).to match [root_srv]
     end
 
     it 'returns the retired child service node for retired services' do
-      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'rsrv'}, false, {})
+      root_services = subject.send(:x_get_tree_custom_kids, {:id => 'rsrv'}, false)
       expect(root_services).to match [reti_srv]
     end
   end


### PR DESCRIPTION
Well, yeah ... not used, no need for it ... chop chop :scissors: 

@miq-bot add_label cleanup, technical debt, hammer/no, ivanchuk/no, trees
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 