### PR TITLE
Switch the clickability between networks and storage trees

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -190,22 +190,7 @@ function miqOnClickSnapshots(id) {
 function miqOnClickHostNet(id) {
   var ids = id.split('|')[0].split('_'); // Break apart the node ids
   var nid = ids[ids.length - 1].split('-'); // Get the last part of the node id
-  switch (nid[0]) {
-    case 'v':
-      DoNav('/vm/show/' + encodeURIComponent(nid[1]));
-      break;
-    case 'h':
-      DoNav('/host/show/' + encodeURIComponent(nid[1]));
-      break;
-    case 'c':
-      DoNav('/ems_cluster/show/' + encodeURIComponent(nid[1]));
-      break;
-    case 'rp':
-      DoNav('/resource_pool/show/' + encodeURIComponent(nid[1]));
-      break;
-    default:
-      break;
-  }
+  DoNav('/vm/show/' + encodeURIComponent(nid[1]));
 }
 
 // OnCheck handler for the belongs to drift/compare sections tree

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -2,8 +2,8 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Lan, [:x_get_tree_lan_kids]
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
-  def override(node, _object)
-    node[:selectable] = false # if node[:image].nil? || !node[:image].include?('svg/currentstate-')
+  def override(node, object)
+    node[:selectable] = false unless object.kind_of?(Vm)
   end
 
   def initialize(name, sandbox, build = true, **params)

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -8,10 +8,14 @@ class TreeBuilderStorageAdapters < TreeBuilder
     super(name, sandbox, build)
   end
 
+  def override(node, _object)
+    node[:selectable] = false
+  end
+
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true, :onclick => "miqOnClickHostNet"}
+    {:full_ids => true, :lazy => true}
   end
 
   def root_options


### PR DESCRIPTION
Under a host's summary screen, there's a tree for the network devices and the storage adapters. They have been both using the same JS function to handle clicks. However, there was some mistakenly commented code in the networks tree that allowed only VMs to be clickable. As the code was commented out, none of the nodes were actually clickable, making the JS function to be never called. On the other hand, the JS function handling the clicks doesn't know how to deal with the nodes in the storage trees. 

Based on these facts, my proposal is to make the storage tree not clickable at all and make the VMs clickable on the networks tree.

@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label bug, trees, hammer/no, ivanchuk/no