### PR TITLE
Do not highlight Action node when deleting last Button Group

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -227,6 +227,7 @@ module ApplicationController::Buttons
       return
     end
     custom_button_set = CustomButtonSet.find(params[:id])
+    service_template = ServiceTemplate.find { |template| template.custom_button_sets.include?(custom_button_set) }
     description = custom_button_set.description
     audit = {:event => "custom_button_set_record_delete", :message => "[#{custom_button_set.description}] Record deleted", :target_id => custom_button_set.id, :target_class => "CustomButtonSet", :userid => session[:userid]}
 
@@ -238,6 +239,7 @@ module ApplicationController::Buttons
       add_flash(_("Button Group \"%{name}\": Delete successful") % {:name => description})
       id = x_node.split('_')
       id.pop
+      id.pop if x_active_tree == :sandt_tree && service_template.custom_button_sets.empty? && service_template.direct_custom_buttons.empty? # if CustomButtonSet/CustomButton was last one skip Action button that no longer exists
       self.x_node = id.join("_")
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
       replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687289

Go to Services -> Catalogs -> Catalog Items -> have a Catalog Item with just one Button Group -> delete it

Before:
<img width="1433" alt="Screenshot 2019-08-12 at 11 49 16" src="https://user-images.githubusercontent.com/9210860/62857213-545f8180-bcf7-11e9-93b8-28edcf67b3d3.png">

After:
<img width="1429" alt="Screenshot 2019-08-09 at 15 20 42" src="https://user-images.githubusercontent.com/9210860/62856220-99ce7f80-bcf4-11e9-9813-19de06ef5b65.png">

@miq-bot add_label bug, ivanchuk/yes, hammer/yes

@miq-bot add_reviewer @romanblanco 