### PR TITLE
Fixed correct setting of record to get counts of relationships

### DIFF
--- a/app/controllers/cloud_tenant_dashboard_controller.rb
+++ b/app/controllers/cloud_tenant_dashboard_controller.rb
@@ -32,19 +32,19 @@ class CloudTenantDashboardController < ApplicationController
   private
 
   def collect_data
-    CloudTenantDashboardService.new(@tenant, self, EmsCloud).all_data
+    CloudTenantDashboardService.new(@tenant, self, CloudTenant).all_data
   end
 
   def recent_instances
-    CloudTenantDashboardService.new(@tenant, self, EmsCloud).recent_instances_data
+    CloudTenantDashboardService.new(@tenant, self, CloudTenant).recent_instances_data
   end
 
   def recent_images
-    CloudTenantDashboardService.new(@tenant, self, EmsCloud).recent_images_data
+    CloudTenantDashboardService.new(@tenant, self, CloudTenant).recent_images_data
   end
 
   def aggregate_status
-    CloudTenantDashboardService.new(@tenant, self, EmsCloud).aggregate_status_data
+    CloudTenantDashboardService.new(@tenant, self, CloudTenant).aggregate_status_data
   end
 
   def get_session_data

--- a/app/services/cloud_tenant_dashboard_service.rb
+++ b/app/services/cloud_tenant_dashboard_service.rb
@@ -1,11 +1,9 @@
-class CloudTenantDashboardService < EmsCloudDashboardService
+class CloudTenantDashboardService < DashboardService
   include Mixins::CheckedIdMixin
 
   def initialize(tenant, controller, klass)
-    @ems_id = tenant.ext_management_system.id
-    @ems = find_record_with_rbac(klass, @ems_id) if @ems_id.present?
-    @tenant_id = tenant.id
-    @conroller = controller
+    @record_id = tenant.id
+    @record = tenant
   end
 
   def attributes_data
@@ -47,7 +45,69 @@ class CloudTenantDashboardService < EmsCloudDashboardService
     format_data('cloud_tenant', attributes, attr_icon, attr_url, attr_hsh)
   end
 
-  def get_url(resource, _ems_id, attr_url)
-    "/#{resource}/show/#{@tenant_id}?display=#{attr_url}"
+  def get_url(resource, _record_id, attr_url)
+    "/#{resource}/show/#{@record_id}?display=#{attr_url}"
+  end
+
+  def get_icon(tenant)
+    fileicon = tenant.ext_management_system.decorate.try(:fileicon)
+    fileicon ? ActionController::Base.helpers.image_path(fileicon) : nil
+  end
+
+  def recent_images_data
+    recent_resources(MiqTemplate, _('Recent Images'), _('Images'))
+  end
+
+  def recent_instances_data
+    recent_resources(ManageIQ::Providers::CloudManager::Vm, _('Recent Instances'), _('Instances'))
+  end
+
+  def aggregate_status_data
+    {
+      :aggStatus => aggregate_status
+    }.compact
+  end
+
+  def aggregate_status
+    {
+      :status   => status_data,
+      :attrData => attributes_data,
+    }
+  end
+
+  def recent_resources(model, title, label)
+    all_resources = recent_records(model)
+    config = {
+      :title => title,
+      :label => label
+    }
+
+    data = if all_resources.blank?
+             {
+               :dataAvailable => false,
+               :config        => config
+             }
+           else
+             {
+               :dataAvailable => true,
+               :xData         => all_resources.keys,
+               :yData         => all_resources.values.map,
+               :config        => config
+             }
+           end
+    {
+      :recentResources => data
+    }.compact
+  end
+
+  def recent_records(model)
+    db_table     = model.arel_table
+    to_char_args = [db_table[:created_on], Arel::Nodes::SqlLiteral.new("'YYYY-MM-DD'")]
+    group_by_sql = Arel::Nodes::NamedFunction.new("to_char", to_char_args)
+
+    model.where(:ems_id => @record.ext_management_system.id)
+         .where(db_table[:created_on].gt(30.days.ago.utc))
+         .group(group_by_sql.to_sql)
+         .count
   end
 end

--- a/app/services/dashboard_service.rb
+++ b/app/services/dashboard_service.rb
@@ -54,4 +54,25 @@ class DashboardService
       end
     end
   end
+
+  def format_data(resource, attributes, attr_icon, attr_url, attr_hsh)
+    attr_data = []
+    attributes.each do |attr|
+      attr_data.push(
+        :id        => "#{attr_hsh[attr]}_#{@record_id}",
+        :iconClass => attr_icon[attr],
+        :title     => attr_hsh[attr],
+        :count     => @record.send(attr).count,
+        :href      => get_url(resource, @record_id, attr_url[attr])
+      )
+    end
+    attr_data
+  end
+
+  def status_data
+    {
+      :iconImage => get_icon(@record),
+      :largeIcon => true,
+    }
+  end
 end


### PR DESCRIPTION
- Fixed to use CloudTenant record to get counts of relationships for Cloud Tenant dashboard, prior to changes in this PR, code was using a Provider record to get counts and was also passing in an incorrect controller to the CloudTenantDashboardService module.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1731735
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1487178


before
![Screenshot from 2019-08-12 13-45-00](https://user-images.githubusercontent.com/3450808/62890058-a3fe7700-bd10-11e9-8e33-eceab0bdab7c.png)


after
![Screenshot from 2019-08-12 13-54-53](https://user-images.githubusercontent.com/3450808/62890065-a791fe00-bd10-11e9-9013-4e02922dbf45.png)
