### PR TITLE
Removed `Tenant` column from list view.

### DIFF
--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -35,9 +35,6 @@ include:
   service_template_catalog:
     columns:
     - name
-  tenant:
-    columns:
-    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -47,7 +44,6 @@ include_for_find:
 col_order:
 - name
 - description
-- tenant.name
 - type_display
 - prov_type
 - display
@@ -59,7 +55,6 @@ col_order:
 headers:
 - Name
 - Description
-- Tenant
 - Type
 - Item Type
 - Display in Catalog


### PR DESCRIPTION
Due to enhancement made in https://github.com/ManageIQ/manageiq-ui-classic/pull/5445 , Now list of tenant can be lot of tenant names and may not fit properly on the list view, so removing the column from list view as this information is available in a nice tree view on the details view of a Catalog Item.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740172

before
![before](https://user-images.githubusercontent.com/3450808/62891004-a6fa6700-bd12-11e9-813f-da77fe48def9.png)

after
![after](https://user-images.githubusercontent.com/3450808/62891014-aa8dee00-bd12-11e9-863e-fa18fce39352.png)
