### PR TITLE
Fix onclick setting for VMs on host/networks🌳 extend it to templates

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -190,7 +190,7 @@ function miqOnClickSnapshots(id) {
 function miqOnClickHostNet(id) {
   var ids = id.split('|')[0].split('_'); // Break apart the node ids
   var nid = ids[ids.length - 1].split('-'); // Get the last part of the node id
-  DoNav('/vm/show/' + encodeURIComponent(nid[1]));
+  DoNav('/vm_or_template/show/' + encodeURIComponent(nid[1]));
 }
 
 // OnCheck handler for the belongs to drift/compare sections tree

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -3,7 +3,7 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
   def override(node, object)
-    node[:selectable] = false unless object.kind_of?(Vm)
+    node[:selectable] = object.kind_of?(::VmOrTemplate)
   end
 
   def initialize(name, sandbox, build = true, **params)


### PR DESCRIPTION
The `Vm` class is being resolved as `TreeNode::Vm` but during my code reload it has been properly resolved as `Vm`. The solution is to force it to the top-level by using the `::` prefix. Also the 🌳 can display templates as well, so I'm extending the behavior to the `VmOrTemplate` model and updating the URL for redirections.

See also: https://github.com/ManageIQ/manageiq-ui-classic/pull/5990

@miq-bot add_label bug, trees
@miq-bot add_reviewer @ZitaNemeckova 