### PR TITLE
Drop the laziness of the Foreman/Ansible configured systems 🌳🌳

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_automation_manager_configured_systems.rb
@@ -15,11 +15,10 @@ class TreeBuilderAutomationManagerConfiguredSystems < TreeBuilderConfiguredSyste
 
   def configured_systems
     {
-      :id            => "csa",
-      :text          => t = _("Ansible Tower Configured Systems"),
-      :icon          => "pficon pficon-folder-close",
-      :tip           => t,
-      :load_children => true
+      :id   => "csa",
+      :text => t = _("Ansible Tower Configured Systems"),
+      :icon => "pficon pficon-folder-close",
+      :tip  => t
     }
   end
 end

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -15,11 +15,10 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilderConfiguredSy
 
   def configured_systems
     {
-      :id            => "csf",
-      :text          => t = _("%{name} Configured Systems") % {:name => ui_lookup(:ui_title => 'foreman')},
-      :icon          => "pficon pficon-folder-close",
-      :tip           => t,
-      :load_children => true
+      :id   => "csf",
+      :text => t = _("%{name} Configured Systems") % {:name => ui_lookup(:ui_title => 'foreman')},
+      :icon => "pficon pficon-folder-close",
+      :tip  => t
     }
   end
 end

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -2,7 +2,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   private
 
   def tree_init_options
-    {:lazy => true, :allow_reselect => true}
+    {:allow_reselect => true}
   end
 
   def x_get_tree_custom_kids(object, count_only)


### PR DESCRIPTION
There's no need for the (probably copy-pasted) lazy-loading setting for `Configured Systems` trees in Automation/Ansible Tower and Configuration/Management. The trees are just 2 levels deep and no additional data is being loaded.

@miq-bot add_label hammer/no, ivanchuk/no, trees, technical debt
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 