### PR TITLE
Call miqCheckForChanges in breadcrumbs

### DIFF
--- a/app/javascript/components/breadcrumbs/index.js
+++ b/app/javascript/components/breadcrumbs/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import { unescape } from 'lodash';
 
+import { onClickTree, onClick } from './on-click-functions';
+
 const parsedText = text => unescape(text).replace(/<[/]{0,1}strong>/g, '');
 
 class Breadcrumbs extends Component {
@@ -10,14 +12,14 @@ class Breadcrumbs extends Component {
     const {
       items, controllerName,
     } = this.props;
-    return items.filter((item, index) => index !== (items.length - 1)).map((item, index) => {
+    return items.filter((_item, index) => index !== (items.length - 1)).map((item, index) => {
       const text = parsedText(item.title);
       if ((item.url || item.key) && !item.action) {
         if (item.key) {
           return (
             <Breadcrumb.Item
               key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
-              onClick={() => sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, key: item.key } })}
+              onClick={() => onClickTree(controllerName, item)}
             >
               {text}
             </Breadcrumb.Item>
@@ -27,6 +29,7 @@ class Breadcrumbs extends Component {
           <Breadcrumb.Item
             key={item.url || index}
             href={item.url}
+            onClick={e => onClick(e, item.url)}
           >
             {text}
           </Breadcrumb.Item>
@@ -38,7 +41,7 @@ class Breadcrumbs extends Component {
 
   render() {
     const {
-      items, title, controllerName, ...rest
+      items, title, controllerName, ...rest // eslint-disable-line no-unused-vars
     } = this.props;
 
     return (

--- a/app/javascript/components/breadcrumbs/on-click-functions.js
+++ b/app/javascript/components/breadcrumbs/on-click-functions.js
@@ -1,0 +1,10 @@
+export const onClickTree = (controllerName, item) => (
+  window.miqCheckForChanges()
+    ? sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, key: item.key } }) : null
+);
+
+export const onClick = (e) => {
+  if (!window.miqCheckForChanges()) {
+    e.preventDefault();
+  }
+};

--- a/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
+++ b/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
@@ -55,6 +55,7 @@ exports[`Breadcrumbs component is correctly rendered 1`] = `
           active={false}
           href="/providers"
           key="/providers"
+          onClick={[Function]}
         >
           <li
             className=""
@@ -62,6 +63,7 @@ exports[`Breadcrumbs component is correctly rendered 1`] = `
             <SafeAnchor
               componentClass="a"
               href="/providers"
+              onClick={[Function]}
             >
               <a
                 href="/providers"

--- a/app/javascript/spec/breadcrumbs/breadcrumbs.spec.js
+++ b/app/javascript/spec/breadcrumbs/breadcrumbs.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+
+import * as clickFunctions from '../../components/breadcrumbs/on-click-functions';
 import Breadcrumbs from '../../components/breadcrumbs';
 
 describe('Breadcrumbs component', () => {
@@ -18,5 +20,39 @@ describe('Breadcrumbs component', () => {
   it('is correctly rendered', () => {
     const wrapper = mount(<Breadcrumbs {...props} />);
     expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('clicked on breadcrumb in tree', () => {
+    clickFunctions.onClickTree = jest.fn();
+
+    const initialProps = {
+      ...props,
+      items: [
+        { key: 'xx-11', title: 'Item 11' },
+        { title: 'Header' },
+      ],
+    };
+    const wrapper = mount(<Breadcrumbs {...initialProps} />);
+
+    wrapper.find('a').first().simulate('click');
+
+    expect(clickFunctions.onClickTree).toHaveBeenCalledWith(initialProps.controllerName, initialProps.items[0]);
+  });
+
+  it('clicked on breadcrumb', () => {
+    clickFunctions.onClick = jest.fn();
+
+    const initialProps = {
+      ...props,
+      items: [
+        { url: 'xx-11', title: 'Item 11' },
+        { title: 'Header' },
+      ],
+    };
+    const wrapper = mount(<Breadcrumbs {...initialProps} />);
+
+    wrapper.find('a').first().simulate('click');
+
+    expect(clickFunctions.onClick).toHaveBeenCalledWith(expect.any(Object), initialProps.items[0].url);
   });
 });

--- a/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
+++ b/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
@@ -1,0 +1,52 @@
+import { onClickTree, onClick } from '../../components/breadcrumbs/on-click-functions';
+
+describe('Breadcrumbs onClick functions', () => {
+  describe('onClick', () => {
+    it('calls e.prevent default', () => {
+      const mockFn = jest.fn();
+      window.miqCheckForChanges = jest.fn(() => false);
+
+      onClick({ preventDefault: mockFn }, '/url');
+
+      expect(mockFn).toHaveBeenCalled();
+      expect(window.miqCheckForChanges).toHaveBeenCalled();
+
+      window.miqCheckForChanges.mockClear();
+    });
+
+    it('change location', () => {
+      const mockFn = jest.fn();
+      window.miqCheckForChanges = () => true;
+
+      onClick({ preventDefault: mockFn }, '/url');
+
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onClickTree', () => {
+    it('returns null if no changes', () => {
+      window.miqCheckForChanges = () => false;
+      jest.spyOn(window, 'sendDataWithRx');
+
+      const result = onClickTree();
+
+      expect(result).toEqual(null);
+      expect(window.sendDataWithRx).not.toHaveBeenCalled();
+    });
+
+    it('calls rxjs', () => {
+      window.miqCheckForChanges = () => true;
+      jest.spyOn(window, 'sendDataWithRx');
+
+      onClickTree('pxe', { key: 'xx-11' });
+
+      expect(window.sendDataWithRx).toHaveBeenCalledWith({
+        breadcrumbSelect: {
+          key: 'xx-11',
+          path: '/pxe/tree_select',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1725927

**Description**

- adds miqCheckForChanges in breadcrumbs

**Steps to test:**
1. Go to any form (not DDF)
2. Change something
3. Click on breadcrumbs

**Before**

![image](https://user-images.githubusercontent.com/32869456/62946233-9b757180-bde0-11e9-8972-818e72302265.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/62946267-aaf4ba80-bde0-11e9-812f-a30695665ff0.png)

@miq-bot add_label bug, breadcrumbs, changelog/yes, ivanchuk/no

@miq-bot add_reviewer @Hyperkid123 