### PR TITLE
Fix breadcrumbs in control section

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1135,9 +1135,16 @@ class MiqPolicyController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Control")},
-        action_name == "rsop" ? {:title => _("Simulation")} : {:title => _("Explorer")},
+        menu_breadcrumb,
       ].compact,
+      :not_tree    => %w[rsop export log].include?(action_name)
     }
+  end
+
+  def menu_breadcrumb
+    return nil if %w[export log].include?(action_name)
+
+    {:title => action_name == 'rsop' ? _('Simulation') : _('Explorer')}
   end
 
   def build_tree

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -10,11 +10,12 @@ module Mixins
       options[:record_info] ||= (@record || {})
       options[:record_title] ||= :name
       options[:show_header] ||= false
+      options[:not_tree] ||= false
       breadcrumbs = options[:breadcrumbs] || []
 
       # Different methods for controller with explorers and for non-explorers controllers
 
-      if !features?
+      if !features? || options[:not_tree]
         # Append breadcrumb from @record item (eg "Openstack") when on some action page (not show, display)
         breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title])) if not_show_page?
 

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -365,4 +365,32 @@ describe MiqPolicyController do
       expect(policy.conditions).to eq([])
     end
   end
+
+  describe "breadcrumbs" do
+    before { EvmSpecHelper.local_miq_server }
+
+    it "shows 'explorer' on explorer screen" do
+      get :explorer
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[1]).to eq("Explorer")
+    end
+
+    it "shows 'simulation' on rsop screen" do
+      get :rsop
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[1]).to eq("Simulation")
+    end
+
+    it "shows 'import / export' on export screen" do
+      get :export
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[1]).to eq("Import / Export")
+    end
+
+    it "shows 'log' on log screen" do
+      get :log
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[1]).to eq("Log")
+    end
+  end
 end

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -152,6 +152,27 @@ describe Mixins::BreadcrumbsMixin do
           )
         end
       end
+
+      context "not_tree set" do
+        let(:breadcrumbs_options) do
+          {
+            :breadcrumbs => [
+              {:title => _("First Layer")},
+              {:title => _("Second Layer")},
+            ],
+            :not_tree    => true
+          }
+        end
+
+        it "creates breadcrumbs with no tree section" do
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+            ]
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1740290

Bad breadcrumbs on non-explorer control pages

**Description**
- fixes breadcrumbs in control section (all pages are one controller and the controller is using features for generating trees...)
- also adds a new option to breadcrumb mixin how to manually disable tree branch

**Before**

export

![image](https://user-images.githubusercontent.com/32869456/63007591-37ef5080-be81-11e9-97a1-246427490c27.png)

log

![image](https://user-images.githubusercontent.com/32869456/63007609-40e02200-be81-11e9-84e9-6f696e0bea33.png)

**After**

export

![image](https://user-images.githubusercontent.com/32869456/62951934-222f4c00-bdeb-11e9-89d5-ea84939a4ecd.png)

log

![image](https://user-images.githubusercontent.com/32869456/62951992-37a47600-bdeb-11e9-848a-976b9a006869.png)


TODO
- [x] more tests

@miq-bot add_label bug, breadcrumbs, ivanchuk/yes, control