### PR TITLE
Support node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "^1.13.3",
     "@data-driven-forms/react-form-renderer": "^1.13.3",
-    "@manageiq/react-ui-components": "~0.11.37",
+    "@manageiq/react-ui-components": "~0.11.38",
     "@manageiq/ui-components": "~1.3.0",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
@@ -131,7 +131,7 @@
     "jest-cli": "^22.0.0",
     "js-yaml": "~3.13.1",
     "ng-annotate-loader": "~0.6.1",
-    "node-sass": "~4.9.3",
+    "node-sass": "~4.12.0",
     "path-complete-extname": "~0.1.0",
     "postcss-loader": "~2.1.5",
     "postcss-smart-import": "~0.6.11",


### PR DESCRIPTION
Fixes #5589

The problem with node 12 was that we need a newer version of node-sass (4.12.0), and that there was no new version of fs-ext or ttembed-js which depends on it, but fortunately we could drop ttembed-js completely, in https://github.com/ManageIQ/react-ui-components/pull/141

So, this brings us to compatibility with node 12.

(@simaishi should we ivanchuk/yes this? Any change we will need to build ivanchuk with node 12 at some point?)
