### PR TITLE
Determine if EmsFolder is a blue folder using a model method

### DIFF
--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -1,17 +1,9 @@
 class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
-  def blue?(object)
-    return false if object.parent.blank?
-    object.parent.name == 'vm' &&
-      object.parent.parent.present? &&
-      object.parent.parent.kind_of?(Datacenter) ||
-      blue?(object.parent)
-  end
-
   def override(node, object)
     node[:selectable] = false
     node[:checkable] = @edit.present? || @assign_to.present?
 
-    if object.kind_of?(EmsFolder) && blue?(object)
+    if object.kind_of?(EmsFolder) && object.vm_folder?
       node[:icon] = "pficon pficon-folder-close-blue"
     else
       node[:hideCheckbox] = true

--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -3,22 +3,11 @@ class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
 
   def override(node, object)
     node[:selectable] = false
-    if object.kind_of?(EmsFolder) && blue?(object)
+    if object.kind_of?(EmsFolder) && object.vm_folder?
       node[:icon] = "pficon pficon-folder-close-blue"
     else
       node[:hideCheckbox] = true
     end
     node[:select] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
-  end
-
-  private
-
-  def blue?(object)
-    return false if object.parent.blank?
-
-    object.parent.name == 'vm' &&
-      object.parent.parent.present? &&
-      object.parent.parent.kind_of?(Datacenter) ||
-      blue?(object.parent)
   end
 end


### PR DESCRIPTION
We were determining the blueness of a VMware folder via a recursive method and it was a little ineffective. Thanks to @agrare now we can use a [direct call](https://github.com/ManageIQ/manageiq/pull/19112) on the `EmsFolder` record. There are two trees that use this feature:
* Settings -> RBAC -> Group -> Last tab
* Control -> Explorer -> Alert Profiles -> VM alert profile -> Edit Assignments -> Select folder

![](https://media.giphy.com/media/ljSSxlYrMA7ss/giphy.gif)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label technical debt, trees, hammer/no, ivanchuk/no
@miq-bot assign @mzazrivec 