### PR TITLE
Fix browser tabs for My/All Tasks text display in runtime language

### DIFF
--- a/app/helpers/application_helper/title.rb
+++ b/app/helpers/application_helper/title.rb
@@ -90,6 +90,10 @@ module ApplicationHelper
         _("Virtual Machines")
       when "vm_or_template"
         _("Workloads")
+      when "all_tasks"
+        _("All Tasks")
+      when "my_tasks"
+        _("My Tasks")
 
       # Specific titles for groups of layouts
       when /^miq_ae_/


### PR DESCRIPTION
Fix code to display text for My Tasks/All Tasks browser tabs in runtime language.

https://bugzilla.redhat.com/show_bug.cgi?id=1740777

Screen shot in Japanese runtime showing text in English prior to code fix, for All Tasks:
<img width="863" alt="Browser tab All Tasks text in English prior to code fix" src="https://user-images.githubusercontent.com/552686/62981497-3b7dcb80-bdde-11e9-9762-2c0ced5958d9.png">

Screen shot in Japanese runtime showing text in English prior to code fix, for My Tasks:
<img width="912" alt="Browser tab My Tasks text in English prior to code fix" src="https://user-images.githubusercontent.com/552686/62981632-9a434500-bdde-11e9-814a-fe2de033b2fe.png">

Screen shot post code fix for Japanese language runtime, for All Tasks:
<img width="883" alt="Browser tab All Tasks text in Japanese post code fix" src="https://user-images.githubusercontent.com/552686/62981564-5b14f400-bdde-11e9-99db-7cb7f9e9e8cd.png">

Screen shot post code fix for Japanese language runtime, for My Tasks:
<img width="902" alt="Browser tab My Tasks text in Japanese post code fix" src="https://user-images.githubusercontent.com/552686/62981690-c6f75c80-bdde-11e9-966b-beac9297aa4d.png">


Screen shot post code fix for Chinese language runtime
<img width="753" alt="Browser tab My Tasks text in Chinese post code fix" src="https://user-images.githubusercontent.com/552686/62981577-6700b600-bdde-11e9-8730-155f8f539d11.png">

Screen shot post code fix for French language runtime:
<img width="772" alt="Browser tab My Tasks text in French post code fix" src="https://user-images.githubusercontent.com/552686/62981600-767fff00-bdde-11e9-9e36-b76fc2b78b77.png">


