### PR TITLE
Display flash messages for report that has no data available

### DIFF
--- a/app/views/report/_savedreports_list.html.haml
+++ b/app/views/report/_savedreports_list.html.haml
@@ -9,4 +9,7 @@
   - elsif x_node.split('-').length == 2 && @view
     = render :partial => 'layouts/x_gtl'
   - else
-    = render :partial => 'layouts/info_msg', :locals => {:message => _("Choose a Report from the menus on the left.")}
+    - if @flash_array
+      = render :partial => 'layouts/flash_msg'
+    - else
+      = render :partial => 'layouts/info_msg', :locals => {:message => _("Choose a Report from the menus on the left.")}


### PR DESCRIPTION
This is an ugly implementation of the solution and I'm not proud of it, however, without proper refactorings in the area, I cannot do better here :disappointed: 

We display either the flash messages or the original *choose a report* message based on the availability of the `@flash_array`.

**Before:**
![Screenshot from 2019-08-14 09-15-38](https://user-images.githubusercontent.com/649130/63001527-1a67ba00-be74-11e9-9452-e39fd6afb070.png)

**After:**
![Screenshot from 2019-08-14 09-14-41](https://user-images.githubusercontent.com/649130/63001494-03c16300-be74-11e9-8233-9bbb005b8a4a.png)


@miq-bot add_label bug, hammer/no, ivanchuk/yes,cloud intel/reporting

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740686