### PR TITLE
Do not require password verification for RHN subscription

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -802,8 +802,7 @@ class OpsController < ApplicationController
     i = 0
     @edit[:new].each_key do |k|
       if @edit[:new][k] != @edit[:current][k]
-        if k.to_s.ends_with?("password2", "verify") # do nothing
-        elsif k.to_s.ends_with?("password", "_pwd") # Asterisk out password fields
+        if k.to_s.ends_with?("password", "_pwd") # Asterisk out password fields
           msg = "%{message} %{key}:[*] to [*]" % {:message => msg, :key => k.to_s}
         else
           msg += ", " if i.positive?

--- a/app/views/layouts/_auth_credentials2.html.haml
+++ b/app/views/layouts/_auth_credentials2.html.haml
@@ -8,7 +8,7 @@
 - prefix ||= ''
 - pfx = prefix.blank? ? '' : prefix + '_'
 - default_labels = {:user     => _('Login'),
-                    :password => _('Change Password / Confirm Password'),
+                    :password => _('Password'),
                     :title    => _('Validate the credentials')}
 - labels = defined?(labels) && labels.present? ? default_labels.update(labels) : default_labels
 - validate_note ||= nil
@@ -26,17 +26,11 @@
 .form-group
   %label.col-md-2.control-label
     = labels[:password]
-  .col-md-4
+  .col-md-8
     = password_field_tag("#{pfx}password", '',
                          :maxlength         => 50,
                          :class             => "form-control",
                          :placeholder       => placeholder_if_present(@edit[:new]["#{pfx}password".to_sym]),
-                         'data-miq_observe' => observe_url_json)
-  .col-md-4
-    = password_field_tag("#{pfx}password2", '',
-                         :maxlength         => 50,
-                         :class             => "form-control",
-                         :placeholder       => placeholder_if_present(@edit[:new]["#{pfx}password2".to_sym]),
                          'data-miq_observe' => observe_url_json)
 - if validate
   .form-group


### PR DESCRIPTION
There's no need to enter the password twice, because it's not a password setting, but a login. Also the identity of the two fields isn't even being checked.

**Before:**
![Screenshot from 2019-08-14 09-37-35](https://user-images.githubusercontent.com/649130/63002857-2e60eb00-be77-11e9-989a-035ba3b91c51.png)

**After:**
![Screenshot from 2019-08-14 09-35-16](https://user-images.githubusercontent.com/649130/63002725-dd50f700-be76-11e9-8e7c-ac80d60aa9cb.png)

@miq-bot add_label bug, technical debt, hammer/no, ivanchuk/yes

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740696