### PR TITLE
Fix manager typo in menu breadcrumbs

### DIFF
--- a/app/controllers/ems_block_storage_controller.rb
+++ b/app/controllers/ems_block_storage_controller.rb
@@ -49,7 +49,7 @@ class EmsBlockStorageController < ApplicationController
       :breadcrumbs => [
         {:title => _("Storage")},
         {:title => _("Block Storage")},
-        {:url   => controller_url, :title => _("Network Managers")},
+        {:url   => controller_url, :title => _("Managers")},
       ],
     }
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1740843

**Description**

Typo in menu breadcrumbs title

(the last breadcrumb will be resolved by https://github.com/ManageIQ/manageiq-ui-classic/pull/5904 )

**Before**

![image](https://user-images.githubusercontent.com/32869456/63008878-bf3dc380-be83-11e9-935a-09de3035b6de.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/63008901-c9f85880-be83-11e9-9d80-7edb6cdc16c1.png)

@miq-bot add_label breadcrumbs, ivanchuk/no, storage, bug