### PR TITLE
Mark the Indexes node as expanded instead of altering it in 🌳state

### DIFF
--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -4,7 +4,7 @@ class TreeBuilderOpsVmdb < TreeBuilder
   private
 
   def tree_init_options
-    {:open_all => false, :lazy => true}
+    {:lazy => true}
   end
 
   def root_options
@@ -29,20 +29,16 @@ class TreeBuilderOpsVmdb < TreeBuilder
   end
 
   def x_get_tree_vmdb_table_kids(object, count_only)
-    if count_only
-      1 # each table has any index
-    else
-      # load this node expanded on autoload
-      open_node("xx-#{object.id}")
-      [
-        {
-          :id            => object.id.to_s,
-          :text          => _("Indexes"),
-          :icon          => "pficon pficon-folder-close",
-          :tip           => _("Indexes"),
-          :load_children => true
-        }
-      ]
-    end
+    return 1 if count_only # each table has one indexes subdir
+
+    [
+      {
+        :id     => object.id.to_s,
+        :text   => _("Indexes"),
+        :icon   => "pficon pficon-folder-close",
+        :tip    => _("Indexes"),
+        :expand => true # load this node expanded with its children
+      }
+    ]
   end
 end

--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -20,6 +20,8 @@ module TreeNode
 
     set_attribute(:tooltip) { @object[:tip] }
 
+    set_attribute(:expand) { @object[:expand] }
+
     set_attribute(:key) do
       if @object[:id] == "-Unassigned"
         "-Unassigned"


### PR DESCRIPTION
On the `OPS -> Database` screen each DB node in the left side tree has an `Indexes` node that contains all the node's indexes. This node is automatically expanded by altering the tree state using `open_node` and its children are preloaded using the `load_children` attribute. However, the exact same functionality can be achieved by setting the `expand` attribute which is much simpler and it might allow us to get rid of the `load_children` completely in the future.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 
@miq-bot add_label refactoring, hammer/no, ivanchuk/no, trees