### PR TITLE
Make the Datastore Clusters 🌳  non-lazy as always loads its 🧒🧒

### DIFF
--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -1,9 +1,7 @@
 class TreeBuilderStoragePod < TreeBuilder
-  private
+  has_kids_for EmsFolder, %i[x_get_ems_folder_kids]
 
-  def tree_init_options
-    {:lazy => true}
-  end
+  private
 
   def root_options
     {
@@ -14,25 +12,10 @@ class TreeBuilderStoragePod < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only)
-    items = EmsFolder.where(:type => 'StorageCluster')
-    if count_only
-      items.size
-    else
-      items.map do |item|
-        {
-          :id            => item[:id],
-          :tree          => "dsc_tree",
-          :text          => item[:name],
-          :icon          => "pficon pficon-folder-close",
-          :tip           => item[:description],
-          :load_children => true
-        }
-      end
-    end
+    count_only_or_objects(count_only, EmsFolder.where(:type => 'StorageCluster'))
   end
 
-  def x_get_tree_custom_kids(object, count_only)
-    objects = EmsFolder.find_by(:id => object[:id])&.storages
-    count_only_or_objects(count_only, objects || [], "name")
+  def x_get_ems_folder_kids(object, count_only)
+    count_only_or_objects(count_only, object.try(:storages) || [], "name")
   end
 end

--- a/app/views/storage/_storage_pod_folders.html.haml
+++ b/app/views/storage/_storage_pod_folders.html.haml
@@ -5,7 +5,7 @@
       %tbody
         - @folders.each do |f|
           %tr{:title => _("View '%{name}' Cluster") % {:name => f.name},
-            :onclick => "miqTreeActivateNode('storage_pod_tree', 'xx-#{f.id}');"}
+            :onclick => "miqTreeActivateNode('storage_pod_tree', 'f-#{f.id}');"}
             %td.table-view-pf-select
               %i.pficon.pficon-folder-close
             %td


### PR DESCRIPTION
The 🌳 under `Infrastructure -> Datastores -> Datastore Clusters` is lazy and it has `EmsFolder` records converted to `Hash` so the `load_children` attribute can be set on them. I'm removing this complexity by making the tree non-lazy :hammer_and_wrench:

Note that there are no clusters in the DB we're using for development, you need to add the vc60 provider to test this.

@miq-bot add_label refactoring, hammer/no, ivanchuk/no, trees
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot assign @mzazrivec 