### PR TITLE
Flatten the ConfigManagerProvider🌳 by dropping the single type

### DIFF
--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -17,14 +17,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only)
-    objects = []
-    objects.push(:id            => "fr",
-                 :tree          => "fr_tree",
-                 :text          => _("%{name} Providers") % {:name => ui_lookup(:ui_title => 'foreman')},
-                 :icon          => "pficon pficon-folder-close",
-                 :tip           => _("%{name} Providers") % {:name => ui_lookup(:ui_title => 'foreman')},
-                 :load_children => true)
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects_filtered(count_only, ManageIQ::Providers::Foreman::ConfigurationManager, "name", :match_via_descendants => ConfiguredSystem)
   end
 
   def node_by_tree_id(id)
@@ -61,13 +54,5 @@ class TreeBuilderConfigurationManager < TreeBuilder
     configured_systems = ConfiguredSystem.where(:configuration_profile_id => object[:id],
                                                 :manager_id               => object[:manager_id])
     count_only_or_objects_filtered(count_only, configured_systems, "hostname")
-  end
-
-  def x_get_tree_custom_kids(object_hash, count_only)
-    objects =
-      case object_hash[:id]
-      when "fr" then ManageIQ::Providers::Foreman::ConfigurationManager
-      end
-    count_only_or_objects_filtered(count_only, objects, "name", :match_via_descendants => ConfiguredSystem)
   end
 end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -294,7 +294,7 @@ describe ProviderForemanController do
 
   it "builds foreman child tree" do
     tree_builder = TreeBuilderConfigurationManager.new("root", controller.instance_variable_get(:@sb))
-    objects = tree_builder.send(:x_get_tree_custom_kids, {:id => "fr"}, false)
+    objects = tree_builder.send(:x_get_tree_roots, false)
     expected_objects = [@config_mgr, @config_mgr2]
     expect(objects).to match_array(expected_objects)
   end
@@ -731,7 +731,7 @@ describe ProviderForemanController do
 
   def find_treenode_for_foreman_provider(tree, provider)
     key = ems_key_for_provider(provider)
-    tree.tree_nodes[0][:nodes][0][:nodes]&.find { |c| c[:key] == key }
+    tree.tree_nodes[0][:nodes]&.find { |c| c[:key] == key }
   end
 
   def ems_key_for_provider(provider)


### PR DESCRIPTION
Under `Configuration -> Management -> Providers` the 🌳 has an unnecessary `Foreman Providers` node that remained after the extraction of Ansible Tower to `Automation`. The stuff on the right side doesn't really match what's written on that folder node. Also we have no other provider types in the area and even if we would have, we don't have this behavior elsewhere. So making it consistend and also getting rid of the `load_children` option.

**Before:**
![Screenshot from 2019-08-14 14-04-43](https://user-images.githubusercontent.com/649130/63019725-7d6d4700-be9c-11e9-9a9e-2c68e4bd4b98.png)

**After:**
![Screenshot from 2019-08-14 14-03-36](https://user-images.githubusercontent.com/649130/63019694-60387880-be9c-11e9-96f5-9b56bc8eecdb.png)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @epwinchell 
@miq-bot assign @mzazrivec 
@miq-bot add_label hammer/no, ivanchuk/no, ux/review, trees, technical debt, cleanup

@terezanovotna please take a look at the screenshots