### PR TITLE
Allow Tagging for Floating Ip from CloudNetwork/NetworkRouter

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -41,6 +41,8 @@ class CloudNetworkController < ApplicationController
       return tag("VmOrTemplate")
     when "network_router_tag"
       return tag("NetworkRouter")
+    when "floating_ip_tag"
+      return tag("FloatingIp")
     end
   end
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -42,6 +42,8 @@ class NetworkRouterController < ApplicationController
       javascript_redirect(:action => "remove_interface_select", :id => checked_item_id)
     when "network_router_tag"
       return tag("NetworkRouter")
+    when "floating_ip_tag"
+      return tag("FloatingIp")
     else
       render_flash
     end

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -250,6 +250,16 @@ describe CloudNetworkController do
         controller.send(:button)
       end
     end
+
+    context 'tagging floating ips from a list of floating ips, accessed from the details page of a network' do
+      let(:params) { {:pressed => "floating_ip_tag"} }
+
+      it 'calls tag method for tagging floating ips' do
+        expect(controller).to receive(:tag).with("FloatingIp")
+
+        controller.send(:button)
+      end
+    end
   end
 
   describe "#delete_networks" do

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -421,5 +421,15 @@ describe NetworkRouterController do
         controller.send(:button)
       end
     end
+
+    context 'tagging floating ips from a list of floating ips, accessed from the details page of a network router' do
+      let(:params) { {:pressed => "floating_ip_tag"} }
+
+      it 'calls tag method for tagging floating ips' do
+        expect(controller).to receive(:tag).with("FloatingIp")
+
+        controller.send(:button)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740891

Go to Networks > Network Routers > click the router > click Floating IPs > select an IP > Policy > Edit Tags

Go to Networks > Cloud Network > click the network > click Floating IPs > select an IP > Policy > Edit Tags

Notes:
Network with Floating Ips `ext` or find one in console ` CloudNetwork.find{ |cn| cn.floating_ips.present? }`
Network Router with Floating Ips `kocsisrouter` or find one in console `NetworkRouter.find{ |cn| cn.floating_ips.present? }`

Before:
Nothing happens
After:
Tagging screen for Floating Ip appears

@miq-bot add_label bug, tagging, ivanchuk/yes, changelog/no

cc @hstastna 