### PR TITLE
Fix typo in chargeback breadcrumbs options

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -970,7 +970,7 @@ class ChargebackController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Overview")},
-        {:title => _("Chargebacks")},
+        {:title => _("Chargeback")},
       ],
     }
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1740408

**Description**
There is a typo in Chargeback breadcrumbs options

@miq-bot add_label bug, ivanchuk/yes, breadcrumbs
