### PR TITLE
Fix typo in PXE breadcrumbs_options

### DIFF
--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -272,7 +272,7 @@ class PxeController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Infrastructure")},
-        {:title => _("Networking")},
+        {:title => _("PXE")},
       ],
     }
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1740405

Another BZ, another typo

`Networking` should be `PXE`

@miq-bot add_label bug, breadcrumbs, ivanchuk/yes