### PR TITLE
Report data: add display of active filter. Add empty state.

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -41,6 +41,7 @@ $login-container-details-border-color-rgba: rgba(0, 0, 0, 0.5);
 @import "dual_list";
 @import "codemirror_editor";
 @import "dynamic_prefix_form_input";
+@import "report-data-table";
 
 .login-pf #brand img { // sets size of brand.svg on login screen (upstream only)
   height: 38px;

--- a/app/assets/stylesheets/report-data-table.scss
+++ b/app/assets/stylesheets/report-data-table.scss
@@ -1,0 +1,10 @@
+.report-toolbar form:last-child {
+  margin-bottom: 10px;
+}
+
+.report-empty-state {
+  background: transparent;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+}

--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import * as resolve from 'table-resolver';
 import {
   customHeaderFormattersDefinition,
+  EmptyState,
   Filter,
+  Form,
   FormControl,
   Paginator,
   PAGINATION_VIEW,
@@ -51,10 +53,10 @@ const makeColumn = (name, label, index) => ({
   },
 });
 
-const makeFilterColumn = (name, label, _index) => ({
+const makeFilterColumn = (name, title, _index) => ({
   id: name,
-  title: label,
-  placeholder: sprintf(__('Filter by %s'), label),
+  title: title,
+  placeholder: sprintf(__('Filter by %s'), title),
   filterType: 'text',
 });
 
@@ -71,7 +73,7 @@ const sortColumnAndDirection = (sortingColumns) => {
 const parseReportColumns = reportData => reportData
   .report.col_order.map((item, index) => ({
     name: item,
-    label: reportData.report.headers[index],
+    title: reportData.report.headers[index],
   }));
 
 const parseReportRows = reportData => reportData
@@ -80,43 +82,48 @@ const parseReportRows = reportData => reportData
     ...item,
   }));
 
-const processLoadedData = (state, action) => {
+const reduceLoadedData = (state, action) => {
   const columns = parseReportColumns(action.data);
+
+  // Setting the initial filter field to the first one, if not yet set.
   const filter = { ...state.filter };
-  if (!filter.field) {
-    filter.field = columns[0] && columns[0].name;
+  if (!filter.field && columns[0]) {
+    filter.field = columns[0].name;
+    filter.title = columns[0].title;
   }
 
   return {
     ...state,
     loading: false,
-    filter,
     columns,
     rows: parseReportRows(action.data),
     total: action.data.count,
     sortingColumns: action.sortingColumns,
     pagination: action.pagination,
+    activeFilters: action.activeFilters,
+    filter
   };
 };
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case 'loadedData':
-      return processLoadedData(state, action);
-    case 'filterSelected':
+    case 'dataLoaded':
+      return reduceLoadedData(state, action);
+    case 'filterTypeSelected':
       return {
         ...state,
         filter: {
           string: state.filter && state.filter.string,
           field: action.field,
+          title: action.title,
         },
       };
     case 'filterTextUpdate':
       return {
         ...state,
         filter: {
+          ...state.filter,
           string: action.string,
-          field: state.filter && state.filter.field,
         },
       };
     default:
@@ -131,15 +138,22 @@ const initialState = {
   total: 0,
 };
 
-const fetchReportPage = (dispatch, reportResultId, sortingColumns, pagination, filter = {}) => {
+const filterToString = filter => (
+  filter && filter.field && filter.string
+    ? `&filter_column=${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
+    : ''
+);
+
+const fetchReportPage = (dispatch, reportResultId, sortingColumns, pagination, activeFilters = null) => {
   const { sortBy, sortDirection } = sortColumnAndDirection(sortingColumns);
   const limit = pagination.perPage;
   const offset = pagination.perPage * (pagination.page - 1);
 
   miqSparkleOn();
 
-  const filterString = (filter && filter.field && filter.string)
-    ? `&filter_column=${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
+  // for now, just one active filter
+  const filterString = activeFilters && activeFilters[0]
+    ? filterToString(activeFilters[0])
     : '';
 
   API.get(`/api/results/${reportResultId}?\
@@ -148,10 +162,11 @@ hash_attribute=result_set&\
 sort_by=${sortBy}&sort_order=${sortDirection}&\
 limit=${limit}&offset=${offset}${filterString}`).then((data) => {
     dispatch({
-      type: 'loadedData',
+      type: 'dataLoaded',
       data,
       sortingColumns,
       pagination,
+      activeFilters,
     });
 
     miqSparkleOff();
@@ -173,8 +188,48 @@ const ReportDataTable = (props) => {
 
   useEffect(() => fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, state.pagination), []);
 
-  const columns = state.columns.map((item, index) => makeColumn(item.name, item.label, index));
-  const filterColumns = state.columns.map((item, index) => makeFilterColumn(item.name, item.label, index));
+  const columns = state.columns.map((item, index) => makeColumn(item.name, item.title, index));
+  const filterColumns = state.columns.map((item, index) => makeFilterColumn(item.name, item.title, index));
+
+  // When clearing the filters, we just empty the activeFilters and
+  // keep the current filter setting.
+  const fetchNoFilters = () =>
+    fetchReportPage(
+      dispatch,
+      props.reportResultId,
+      state.sortingColumns,
+      state.pagination,
+      null,
+    );
+
+  // Until the API is available for multi-field filtereing there's only one filter,
+  // so removing a single filter removes all of them.
+  const renderActiveFilters = () => (
+    <React.Fragment>
+      <Filter.ActiveLabel>{__('Active Filters:')}</Filter.ActiveLabel>
+      <Filter.List>
+        {state.activeFilters.map(item => (
+          <Filter.Item
+            key={item.field}
+            onRemove={fetchNoFilters}
+            filterData={item}
+          >
+            {`${item.title}: ${item.string}`}
+          </Filter.Item>
+        ))}
+      </Filter.List>
+      <a
+        href="#"
+        onClick={(e) => {
+          fetchNoFilters();
+          e.preventDefault();
+        }}
+      >
+        {__('Clear All Filters')}
+      </a>
+    </React.Fragment>
+  );
+
 
   const setPage = page => fetchReportPage(
     dispatch,
@@ -184,20 +239,25 @@ const ReportDataTable = (props) => {
       ...state.pagination,
       page,
     },
-    state.filter,
+    state.activeFilters,
   );
 
-  const perPageSelect = (perPage, _e) => {
-    const newPagination = {
+  const perPageSelect = (perPage, _e) => fetchReportPage(
+    dispatch,
+    props.reportResultId,
+    state.sortingColumns,
+    {
       ...state.pagination,
-      perPage,
-      page: 1,
-    };
-    fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, newPagination, state.filter);
-  };
+      perPage, // When setting new page size,
+      page: 1, // go to page 1.
+    },
+    state.activeFilters,
+  );
 
-  const onSort = (e, column, sortDirection) => {
-    const newSortingColumns = {
+  const onSort = (e, column, sortDirection) => fetchReportPage(
+    dispatch,
+    props.reportResultId,
+    {
       [column.property]: {
         direction:
           sortDirection === TABLE_SORT_DIRECTION.ASC
@@ -205,14 +265,15 @@ const ReportDataTable = (props) => {
             : TABLE_SORT_DIRECTION.ASC,
         position: 0,
       },
-    };
-
-    fetchReportPage(dispatch, props.reportResultId, newSortingColumns, state.pagination, state.filter);
-  };
+    },
+    state.pagination,
+    state.activeFilters,
+  );
 
   const filterTypeSelected = field => dispatch({
-    type: 'filterSelected',
+    type: 'filterTypeSelected',
     field: field && field.id,
+    title: field && field.title,
   });
 
   const filterTextUpdate = event => dispatch({
@@ -222,12 +283,16 @@ const ReportDataTable = (props) => {
 
   const filterKeyPress = (keyEvent) => {
     if (keyEvent.key === 'Enter') {
-      // navigate to page 1 when searching
+      // Navigate to page 1 when searching.
       const newPagination = {
         ...state.pagination,
         page: 1,
       };
-      fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, newPagination, state.filter);
+      // The currently edited filter becomes the only one active filter.
+      const activeFilters = [{
+        ...state.filter,
+      }];
+      fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, newPagination, activeFilters);
       keyEvent.stopPropagation();
       keyEvent.preventDefault();
     }
@@ -238,54 +303,63 @@ const ReportDataTable = (props) => {
   return (
     <React.Fragment>
       <div className="row toolbar-pf table-view-pf-toolbar">
-        <form className="toolbar-pf-actions">
-          <div className="form-group toolbar-pf-filter">
-            <Filter>
-              <Filter.TypeSelector
-                filterTypes={filterColumns}
-                currentFilterType={filterColumn}
-                onFilterTypeSelected={filterTypeSelected}
-              />
-              <FormControl
-                type="text"
-                value={state.filter && state.filter.text}
-                placeholder={__('search text')}
-                onChange={filterTextUpdate}
-                onKeyPress={filterKeyPress}
-              />
-            </Filter>
-          </div>
+        <form className="col-xs-12 col-md-6">
+          <Form.InputGroup>
+            <Filter.TypeSelector
+              filterTypes={filterColumns}
+              currentFilterType={filterColumn}
+              onFilterTypeSelected={filterTypeSelected}
+            />
+            <FormControl
+              type="text"
+              value={state.filter && state.filter.text}
+              placeholder={__('search text')}
+              onChange={filterTextUpdate}
+              onKeyPress={filterKeyPress}
+            />
+          </Form.InputGroup>
         </form>
+        <div className="col-xs-12 toolbar-pf-results">
+          {state.activeFilters && state.activeFilters.length > 0
+            && renderActiveFilters()}
+        </div>
       </div>
-      <Table.PfProvider
-        striped
-        bordered
-        hover
-        dataTable
-        columns={columns}
-        components={{
-          header: {
-            // enables our custom header formatters extensions to reactabular
-            cell: cellProps => customHeaderFormattersDefinition({
-              cellProps,
-              columns,
-              sortingColumns: state.sortingColumns,
-              rows: state.rows,
-              onSort,
-            }),
-          },
-        }}
-      >
-        <Table.Header headerRows={resolve.headerRows({ columns })} />
-        <Table.Body rows={state.rows} rowKey="id" />
-      </Table.PfProvider>
-      <Paginator
-        viewType={PAGINATION_VIEW.TABLE}
-        pagination={state.pagination}
-        itemCount={state.total}
-        onPageSet={setPage}
-        onPerPageSelect={perPageSelect}
-      />
+      {state.total > 0 && (
+        <React.Fragment>
+          <Table.PfProvider
+            striped
+            bordered
+            hover
+            dataTable
+            columns={columns}
+            components={{
+              header: {
+                // Enables pf-react's custom header formatters extensions to reactabular.
+                cell: cellProps => customHeaderFormattersDefinition({
+                  cellProps,
+                  columns,
+                  sortingColumns: state.sortingColumns,
+                  rows: state.rows,
+                  onSort,
+                }),
+              },
+            }}
+          >
+            <Table.Header headerRows={resolve.headerRows({ columns })} />
+            <Table.Body rows={state.rows} rowKey="id" />
+          </Table.PfProvider>
+          <Paginator
+            viewType={PAGINATION_VIEW.TABLE}
+            pagination={state.pagination}
+            itemCount={state.total}
+            onPageSet={setPage}
+            onPerPageSelect={perPageSelect}
+          />
+        </React.Fragment>)}
+      {state.total === 0 && (
+        <EmptyState>
+          <EmptyState.Title>{ __('No records found.') }</EmptyState.Title>
+        </EmptyState>)}
     </React.Fragment>
   );
 };

--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -359,6 +359,7 @@ const ReportDataTable = (props) => {
         </React.Fragment>)}
       {state.total === 0 && (
         <EmptyState className="report-empty-state">
+          <EmptyState.Icon type="fa" name="search" />
           <EmptyState.Title>{ __('No records found') }</EmptyState.Title>
         </EmptyState>)}
     </React.Fragment>

--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -288,10 +288,11 @@ const ReportDataTable = (props) => {
         ...state.pagination,
         page: 1,
       };
-      // The currently edited filter becomes the only one active filter.
-      const activeFilters = [{
-        ...state.filter,
-      }];
+      const activeFilters = state.filter.string !== ''
+        // The currently edited filter becomes the only one active filter.
+        ? [{ ...state.filter }]
+        // Empty string means no filter.
+        : [];
       fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, newPagination, activeFilters);
       keyEvent.stopPropagation();
       keyEvent.preventDefault();
@@ -302,7 +303,7 @@ const ReportDataTable = (props) => {
 
   return (
     <React.Fragment>
-      <div className="row toolbar-pf table-view-pf-toolbar">
+      <div className="row toolbar-pf table-view-pf-toolbar report-toolbar">
         <form className="col-xs-12 col-md-6">
           <Form.InputGroup>
             <Filter.TypeSelector
@@ -319,10 +320,10 @@ const ReportDataTable = (props) => {
             />
           </Form.InputGroup>
         </form>
-        <div className="col-xs-12 toolbar-pf-results">
-          {state.activeFilters && state.activeFilters.length > 0
-            && renderActiveFilters()}
-        </div>
+        {state.activeFilters && state.activeFilters.length > 0 && (
+          <div className="col-xs-12 toolbar-pf-results">
+            {renderActiveFilters()}
+          </div>)}
       </div>
       {state.total > 0 && (
         <React.Fragment>
@@ -357,8 +358,8 @@ const ReportDataTable = (props) => {
           />
         </React.Fragment>)}
       {state.total === 0 && (
-        <EmptyState>
-          <EmptyState.Title>{ __('No records found.') }</EmptyState.Title>
+        <EmptyState className="report-empty-state">
+          <EmptyState.Title>{ __('No records found') }</EmptyState.Title>
         </EmptyState>)}
     </React.Fragment>
   );

--- a/app/javascript/spec/report-data-table.spec.js
+++ b/app/javascript/spec/report-data-table.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import { act } from 'react-test-renderer';
+import { EmptyState, Paginator, Table } from 'patternfly-react';
 
 import './helpers/mockAsyncRequest';
 import './helpers/miqSparkle';
@@ -23,30 +24,53 @@ describe('<ReportDataTable />', () => {
     fetchMock.reset();
   });
 
-  it('should fetch report data when instantiated', (done) => {
+  const requestUrl = () => {
     const sortBy = '';
     const sortDirection = '';
     const limit = 20;
     const offset = 0;
-    const url = `/api/results/${initialProps.reportResultId}?\
+    return `/api/results/${initialProps.reportResultId}?\
 expand_value_format=true&\
 hash_attribute=result_set&\
 sort_by=${sortBy}&sort_order=${sortDirection}&\
 limit=${limit}&offset=${offset}`;
+  };
 
-    fetchMock.getOnce(url, { report: { col_order: [] }, count: 0, result_set: [] });
+  it('should fetch and display report data when instantiated', (done) => {
+    fetchMock.getOnce(requestUrl(), { report: { col_order: [] }, count: 1, result_set: [{ foo: 'bar' }] });
 
     let wrapper;
-
     act(() => {
       wrapper = mount(<ReportDataTable {...initialProps} />);
     });
 
     setTimeout(() => {
+      wrapper.update();
+
       expect(fetchMock.calls()).toHaveLength(1);
       expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
-      expect(wrapper.find('table.table')).toHaveLength(1);
-      expect(wrapper.find('form.table-view-pf-pagination')).toHaveLength(1);
+      expect(wrapper.find(Table.PfProvider)).toHaveLength(1);
+      expect(wrapper.find(Paginator)).toHaveLength(1);
+      done();
+    });
+  });
+
+  it('should display empty state when there is no data', (done) => {
+    fetchMock.getOnce(requestUrl(), { report: { col_order: [] }, count: 0, result_set: [] });
+
+    let wrapper;
+    act(() => {
+      wrapper = mount(<ReportDataTable {...initialProps} />);
+    });
+
+    setTimeout(() => {
+      wrapper.update();
+
+      expect(fetchMock.calls()).toHaveLength(1);
+      expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
+      expect(wrapper.find(Table.PfProvider)).toHaveLength(0);
+      expect(wrapper.find(Paginator)).toHaveLength(0);
+      expect(wrapper.find(EmptyState)).toHaveLength(1);
       done();
     });
   });


### PR DESCRIPTION
The active filter display allows one click clearing of the filters as
requested by a BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1739264

The display of active filter is partly ready for the multi-criteria
filtering, once it's available in the API.

When there are no records, no grid and no paginator is displayed.
Instead an empty state component with a message is displayed.

https://bugzilla.redhat.com/show_bug.cgi?id=1740055

ping @himdel 

After:
![rep-fil-2-2019-08-14_21-42](https://user-images.githubusercontent.com/51095/63051037-aa414e80-bedc-11e9-8bf8-695801be8728.png)

![esfinal-2019-08-15_11-55](https://user-images.githubusercontent.com/51095/63087925-a1d82a80-bf53-11e9-8e48-f7a2b2b9b2d1.png)
