### PR TITLE
Fix automate/simulation breadcrumbs

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -463,8 +463,9 @@ Methods updated/added: %{method_stats}") % stat_options)
       :breadcrumbs => [
         {:title => _("Automation")},
         {:title => _("Automate")},
-        action_name == "resolve" ? {:title => _("Automate")} : nil,
-      ].compact
+        action_name == "resolve" ? {:title => _("Simulation")} : nil,
+      ].compact,
+      :hide_title  => action_name == "resolve",
     }
   end
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -11,6 +11,7 @@ module Mixins
       options[:record_title] ||= :name
       options[:show_header] ||= false
       options[:not_tree] ||= false
+      options[:hide_title] ||= false
       breadcrumbs = options[:breadcrumbs] || []
 
       # Different methods for controller with explorers and for non-explorers controllers
@@ -23,7 +24,7 @@ module Mixins
         breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))
 
         # Append title breadcrumb if they exist and not same as previous breadcrumb (eg "Editing name")
-        if @title && @title != breadcrumbs.compact.last.try(:[], :title)
+        if @title && @title != breadcrumbs.compact.last.try(:[], :title) && !options[:hide_title]
           breadcrumbs.push(:title => @title)
         end
       else

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -545,4 +545,27 @@ describe MiqAeToolsController do
       end
     end
   end
+
+  describe "breadcrumbs" do
+    it "shows 'simulation' on resolve screen" do
+      get :resolve
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[2]).to eq("Simulation")
+      expect(controller.data_for_breadcrumbs.pluck(:title)[3]).to eq(nil) # no additional title
+    end
+
+    it "shows 'import / export' on import_export screen" do
+      get :import_export
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[2]).to eq("Import / Export")
+      expect(controller.data_for_breadcrumbs.pluck(:title)[3]).to eq(nil) # no additional title
+    end
+
+    it "shows 'log' on log screen" do
+      get :log
+
+      expect(controller.data_for_breadcrumbs.pluck(:title)[2]).to eq("Log")
+      expect(controller.data_for_breadcrumbs.pluck(:title)[3]).to eq(nil) # no additional title
+    end
+  end
 end

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -202,8 +202,24 @@ describe Mixins::BreadcrumbsMixin do
           }
         end
 
-        it "creates breadcrumbs" do
+        before do
+          subject.instance_variable_set(:@title, "Title")
           allow(subject).to receive(:gtl_url).and_return("/show")
+        end
+
+        it "creates breadcrumbs" do
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+              {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"},
+              {:title => "Title"}
+            ]
+          )
+        end
+
+        it "creates breadcrumbs with :hide_title set" do
+          breadcrumbs_options[:hide_title] = true
 
           expect(subject.data_for_breadcrumbs).to eq(
             [


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1740761

**Description**

- Automate  .... log, import/export, simulation are one controller. It makes some issues to get a correct path in the simulation page.
- Also added an option for controllers to control when to show `@title` breadcrumb in non-explorer screens

**Before**


![image](https://user-images.githubusercontent.com/32869456/63086633-96cfcb00-bf50-11e9-99c1-ac30a93b3c59.png)

**After**

Simulation

![image](https://user-images.githubusercontent.com/32869456/63086487-43f61380-bf50-11e9-8aad-79d36a48a195.png)


@miq-bot add_label bug, ivanchuk/yes, breadcrumbs, automation/automate, changelog/yes