### PR TITLE
Hide Additional Tenants of Catalog Item if role does not allow displaying them

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -228,4 +228,5 @@
                           :title                 => _("Remove this Retirement Entry Point")) do
                   %i.pficon.pficon-close
             %span.input-group-addon{:style => "visibility:hidden"}
-    = render(:partial => "tenants_tree_show")
+    - if role_allows?(:feature => 'rbac_tenant_view')
+      = render(:partial => "tenants_tree_show")

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -122,11 +122,12 @@
             = _('Ownership Group')
           .col-md-9
             = h(@record.try(:miq_group).try(:name))
-        .form-group
-          %label.col-md-3.control-label
-            = _('Additional Tenants')
-          .col-md-8
-            = render(:partial => "shared/tree", :locals => {:tree => @tenants_tree, :name => @tenants_tree.name})
+        - if role_allows?(:feature => 'rbac_tenant_view')
+          .form-group
+            %label.col-md-3.control-label
+              = _('Additional Tenants')
+            .col-md-8
+              = render(:partial => "shared/tree", :locals => {:tree => @tenants_tree, :name => @tenants_tree.name})
         .form-group
           .col-md-9
             #tag_group

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -65,7 +65,8 @@
                   'ng-options'       => 'catalog as catalog.name for catalog in vm.catalogs',
                   "data-live-search" => "true",
                   'miq-select'        => true}
-      = render(:partial => "tenants_tree_show", :locals => {:angular => true})
+      - if role_allows?(:feature => 'rbac_tenant_view')
+        = render(:partial => "tenants_tree_show", :locals => {:angular => true})
 
       .form-group
         %label.col-md-2.control-label{"for" => "zone_id"}

--- a/spec/views/catalog/_form_basic_info.html.haml_spec.rb
+++ b/spec/views/catalog/_form_basic_info.html.haml_spec.rb
@@ -1,0 +1,30 @@
+describe 'catalog/_form_basic_info.html.haml' do
+  before { set_controller_for_view('catalog') }
+
+  context 'Additional Tenants tree' do
+    let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+
+    before do
+      allow(view).to receive(:hidden_div_if)
+      assign(:edit, :new => {:available_dialogs => {}})
+      assign(:available_catalogs, [])
+      assign(:zones, [])
+      assign(:tenants_tree, TreeBuilderTenants.new('tenants_tree', {}, true, :additional_tenants => [], :selectable => true))
+      login_as user
+    end
+
+    it 'renders Additional Tenants field with tree' do
+      render :partial => 'catalog/form_basic_info'
+      expect(response).to include('Additional Tenants')
+    end
+
+    context 'user does not have permission to see Tenants' do
+      let(:user) { FactoryBot.create(:user_with_group) }
+
+      it 'does not render Additional Tenants field with tree' do
+        render :partial => 'catalog/form_basic_info'
+        expect(response).not_to include('Additional Tenants')
+      end
+    end
+  end
+end

--- a/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_sandt_tree_show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "catalog/_sandt_tree_show.html.haml" do
-  let(:admin_user) { FactoryBot.create(:user_admin) }
-  let(:bundle)     { FactoryBot.create(:service_template, :service_type => "composite", :display => true, :tenant => tenant) }
-  let(:tenant)     { FactoryBot.create(:tenant) }
+  let(:user)   { FactoryBot.create(:user_admin) }
+  let(:bundle) { FactoryBot.create(:service_template, :service_type => "composite", :display => true, :tenant => tenant) }
+  let(:tenant) { FactoryBot.create(:tenant) }
 
   before do
     set_controller_for_view("catalog")
@@ -9,12 +9,28 @@ describe "catalog/_sandt_tree_show.html.haml" do
     assign(:record, bundle)
     assign(:sb, {})
     assign(:tenants_tree, TreeBuilderTenants.new('tenants_tree', {}, true, :additional_tenants => [], :selectable => false))
-    login_as admin_user
+    login_as user
   end
 
   it "Renders bundle summary screen" do
     render
     expect(rendered).to include(bundle.name)
     expect(rendered).to include(bundle.tenant.name)
+  end
+
+  context 'Additional Tenants' do
+    it 'renders Additional Tenants field with tree' do
+      render :partial => 'catalog/sandt_tree_show'
+      expect(response).to include('Additional Tenants')
+    end
+
+    context 'user does not have permission to see Tenants' do
+      let(:user) { FactoryBot.create(:user_with_group) }
+
+      it 'does not render Additional Tenants field with tree' do
+        render :partial => 'catalog/sandt_tree_show'
+        expect(response).not_to include('Additional Tenants')
+      end
+    end
   end
 end

--- a/spec/views/catalog/_st_angular_form.html.haml_spec.rb
+++ b/spec/views/catalog/_st_angular_form.html.haml_spec.rb
@@ -1,0 +1,29 @@
+describe "catalog/_st_angular_form.html.haml" do
+  before { set_controller_for_view('catalog') }
+
+  context 'Additional Tenants' do
+    let(:user) { FactoryBot.create(:user_admin, :userid => 'admin') }
+
+    before do
+      allow(view).to receive(:playbook_label)
+      assign(:edit, :new => {})
+      assign(:record, FactoryBot.create(:service_template))
+      assign(:tenants_tree, TreeBuilderTenants.new('tenants_tree', {}, true, :additional_tenants => [], :selectable => true))
+      login_as user
+    end
+
+    it 'renders Additional Tenants field with tree' do
+      render :partial => 'catalog/st_angular_form'
+      expect(response).to include('Additional Tenants')
+    end
+
+    context 'user does not have permission to see Tenants' do
+      let(:user) { FactoryBot.create(:user_with_group) }
+
+      it 'does not render Additional Tenants field with tree' do
+        render :partial => 'catalog/st_angular_form'
+        expect(response).not_to include('Additional Tenants')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1741075
Related RFE: https://github.com/ManageIQ/manageiq-ui-classic/pull/5445

User needs to have permission to see Tenants (_Configuration -> Access Control -> Tenants -> View_), and it means that also _Additional Tenants_  in Catalog Item details page (Additional Tenants are still Tenants). However, _Additional Tenants_ field was always present. So with this PR, I am hiding it if user's role doesn't have this permission.

---

Note:
If you are a super admin, you can see all Tenants in Additional Tenants tree, for Catalog Item.
If you log in as a user, you can see Tenants according to your role's permissions:
![catitem2](https://user-images.githubusercontent.com/13417815/63088299-d3052a80-bf54-11e9-9d55-7f52bbedf00b.png)

---

**Before:**
![catitem_before](https://user-images.githubusercontent.com/13417815/63088690-f2508780-bf55-11e9-85f2-6a537c38e477.png)

**After:**
No _Additional Tenants_ section in Catalog Item details page:
![catitem1](https://user-images.githubusercontent.com/13417815/63088258-b1a43e80-bf54-11e9-9593-98be9b54b548.png)
No _Additional Tenants_ section in Catalog Item editing page:
![catitem1_](https://user-images.githubusercontent.com/13417815/63088266-ba951000-bf54-11e9-8e6f-eeb01c3d721d.png)
