### PR TITLE
Automate url open fixes

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -91,8 +91,8 @@ module ApplicationController::Buttons
   end
 
   # Provider, Service, User, Group, Tenant, Cloud Tenant, Generic Object
-  # TODO: test each
-  MODEL_WITH_OPEN_URL = %w[Provider Service User MiqGroup Tenant CloudTenant GenericObject Vm].freeze
+  # we need a "Provider" so adding an "ExtManagementSystem" to the list.
+  MODEL_WITH_OPEN_URL = %w[ExtManagementSystem Service User MiqGroup Tenant CloudTenant GenericObject Vm].freeze
 
   def automate_button_field_changed
     unless params[:target_class]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2839,6 +2839,7 @@ Rails.application.routes.draw do
         x_history
         x_show
         ownership_form_fields
+        wait_for_task
       ) +
                dialog_runner_post +
                adv_search_post +
@@ -3067,7 +3068,6 @@ Rails.application.routes.draw do
         ownership_update
         associate_floating_ip_vm
         disassociate_floating_ip_vm
-        wait_for_task
         ownership_form_fields
       ) +
                adv_search_post +


### PR DESCRIPTION
Fixes for:

https://bugzilla.redhat.com/show_bug.cgi?id=1550002

  * "Provider" is really an "ExtManagementSystem",
  * `wait_for_task` route missing in Service controller.

#### Tested automate code for "Provider":

~~For "Provider" testing also https://github.com/ManageIQ/manageiq/pull/19157 is needed.~~ (merged)

```
provider = $evm.root['ext_management_system']
provider.external_url = "https://www.redhat.com"
```

#### Tested automate code for "Service":
```
service = $evm.root['service']
service.external_url = "https://www.redhat.com"
```

#### Tested automate code for "CloudTenant":

```
t = $evm.root['cloud_tenant']
$evm.log(:info, "cloud_tenant: #{t.inspect}")
t.external_url = "https://www.redhat.com"
```

#### Tested automate code for "Tenant":

~~Requires automation engine PR: https://github.com/ManageIQ/manageiq-automation_engine/pull/350~~ (merged)

```
$evm.log(:info, $evm.root['vmdb_object_type'])
$evm.log(:info, "tenant_id: #{$evm.root['tenant_id']}")

# t = $evm.root['tenant'] # this will give the LOGGGED IN tenant, not the target object tenant
t = $evm.vmdb($evm.root['vmdb_object_type']).find_by(:id => $evm.root['tenant_id'])
$evm.log(:info, "tenant: #{t.inspect}")
t.external_url = "https://www.redhat.com"
```

### Notes:

How to access a number of objects: https://pemcg.gitbooks.io/introduction-to-cloudforms-automation/content/chapter6/evm_and_the_workspace.html

Note that `$evm.root['vmdb_object_type'] ` contains the class for all the objects.
However `$evm.root['target_object_ids']` is NOT set for the singular case (and thus is useless for this case). I am not aware of any generic way to get the ID of the target object in the singular case.

Note that a number of variables such as `$evm.root['vm']` or `$evm.root['user']` exist but they do NOT contain the target object in all cases.

The `$evm.root[...]` variables `user`, `group` and `tenant` contain the LOGGED IN user insted of the target object one.

For the case where User is the target class, `$evm.root['user_id']` is set with the ID of the target object.
