### PR TITLE
Optimization - don't deduplicate breadcrumbs when report definition and saved report have the same name

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -12,10 +12,7 @@ module Mixins
       options[:show_header] ||= false
       options[:not_tree] ||= false
       options[:hide_title] ||= false
-      options[:no_magic] ||= false
       breadcrumbs = options[:breadcrumbs] || []
-
-      return breadcrumbs.compact if options[:no_magic]
 
       # Different methods for controller with explorers and for non-explorers controllers
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -12,7 +12,10 @@ module Mixins
       options[:show_header] ||= false
       options[:not_tree] ||= false
       options[:hide_title] ||= false
+      options[:no_magic] ||= false
       breadcrumbs = options[:breadcrumbs] || []
+
+      return breadcrumbs.compact if options[:no_magic]
 
       # Different methods for controller with explorers and for non-explorers controllers
 

--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -27,10 +27,14 @@ class OptimizationController < ApplicationController
         bc_optimization,
         bc_report,
         {:title => @title},
-      ].compact,
-      :no_magic => true,
+      ],
     }
   end
+
+  def data_for_breadcrumbs
+    breadcrumbs_options[:breadcrumbs].compact
+  end
+  helper_method :data_for_breadcrumbs
 
   # show optimization when in saved reports or report results
   def bc_optimization

--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -26,7 +26,9 @@ class OptimizationController < ApplicationController
         {:title => _('Overview')},
         bc_optimization,
         bc_report,
+        {:title => @title},
       ].compact,
+      :no_magic => true,
     }
   end
 

--- a/spec/controllers/optimization_controller_spec.rb
+++ b/spec/controllers/optimization_controller_spec.rb
@@ -117,6 +117,29 @@ describe OptimizationController do
                                                                      report.name,
                                                                      saved.name])
       end
+
+      context "even if report.name and saved.name match" do
+        let(:saved) do
+          result.tap do |rr|
+            rr.name = report.name
+            rr.save
+          end
+        end
+
+        it "sets breadcrumbs right" do
+          expect(controller.data_for_breadcrumbs.pluck(:title)).to eq(['Overview',
+                                                                       'Optimization',
+                                                                       report.name,
+                                                                       saved.name])
+        end
+
+        it "links to both parents" do
+          expect(controller.data_for_breadcrumbs.pluck(:url)).to eq([nil,
+                                                                     '/optimization/show_list',
+                                                                     "/optimization/show_list/#{report.id}",
+                                                                     nil])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Breadcrumbs deduplicate breadcrumbs with identical titles,
but for Optimization, the "saved reports under report" can have the same title as the "saved report detail" screen,
because the names of the saved reports are generated from the name of the report definition.

Adding a (failing) spec to make sure these don't get deduplicated in those conditions.
And overridden `data_for_breadcrumbs` with a version that just returns the defined breadcrumbs 

Cc @rvsia 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741203