### PR TITLE
Allow comparing Hosts and VMs/Instances displayed as a nested list

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -891,8 +891,6 @@ module ApplicationController::CiProcessing
       "image"
     elsif pressed.starts_with?("instance_")
       "instance"
-    elsif pressed.starts_with?("vm_")
-      "vm"
     elsif pressed.starts_with?("miq_template_")
       "miq_template"
     elsif pressed.starts_with?("orchestration_stack_")

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -37,6 +37,8 @@ class CloudNetworkController < ApplicationController
     when "custom_button"
       custom_buttons
       return
+    when 'instance_compare'
+      return comparemiq
     when "instance_tag"
       return tag("VmOrTemplate")
     when "network_router_tag"

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -29,12 +29,14 @@ class CloudSubnetController < ApplicationController
       delete_subnets
     when "cloud_subnet_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id)
+    when "cloud_subnet_new"
+      javascript_redirect(:action => "new")
     when "custom_button"
       custom_buttons
+    when 'instance_compare'
+      comparemiq
     else
-      if params[:pressed] == "cloud_subnet_new"
-        javascript_redirect(:action => "new")
-      elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
+      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
       else
         render_flash

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -27,6 +27,8 @@ class NetworkRouterController < ApplicationController
       return tag("CloudSubnet")
     when "custom_button"
       custom_buttons
+    when 'instance_compare'
+      comparemiq
     when "instance_tag"
       return tag("VmOrTemplate")
     when "network_router_add_interface"

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -26,6 +26,8 @@ class SecurityGroupController < ApplicationController
     case params[:pressed]
     when "instance_tag"
       return tag("VmOrTemplate")
+    when 'instance_compare'
+      comparemiq
     when "network_port_tag"
       return tag("NetworkPort")
     when "security_group_tag"
@@ -34,12 +36,12 @@ class SecurityGroupController < ApplicationController
       delete_security_groups
     when "security_group_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id(params))
+    when 'security_group_new'
+      javascript_redirect(:action => "new")
     when "custom_button"
       custom_buttons
     else
-      if params[:pressed] == "security_group_new"
-        javascript_redirect(:action => "new")
-      elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
+      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
       else
         render_flash

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -77,14 +77,26 @@ class StorageController < ApplicationController
                                      "guest_",
                                      "host_")
 
-      scanhosts if params[:pressed] == "host_scan"
-      analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"
-      check_compliance_hosts if params[:pressed] == "host_check_compliance"
-      refreshhosts if params[:pressed] == "host_refresh"
-      tag(Host) if params[:pressed] == "host_tag"
-      assign_policies(Host) if params[:pressed] == "host_protect"
-      edit_record if params[:pressed] == "host_edit"
-      deletehosts if params[:pressed] == "host_delete"
+      case params[:pressed]
+      when 'host_analyze_check_compliance'
+        analyze_check_compliance_hosts
+      when 'host_check_compliance'
+        check_compliance_hosts
+      when 'host_compare'
+        comparemiq
+      when 'host_delete'
+        deletehosts
+      when 'host_edit'
+        edit_record
+      when 'host_protect'
+        assign_policies(Host)
+      when 'host_refresh'
+        refreshhosts
+      when 'host_scan'
+        scanhosts
+      when 'host_tag'
+        tag(Host)
+      end
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons
@@ -93,7 +105,7 @@ class StorageController < ApplicationController
       else
         process_vm_buttons(pfx)
         return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
-                   "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_protect", "#{pfx}_retire",
+                   'host_compare', "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_protect", "#{pfx}_retire",
                    "#{pfx}_ownership", "#{pfx}_right_size", "#{pfx}_reconfigure"].include?(params[:pressed]) &&
                   @flash_array.nil? # Tag screen is showing, so return
 
@@ -126,7 +138,7 @@ class StorageController < ApplicationController
     elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else
-      javascript_flash
+      javascript_flash unless performed?
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1716,7 +1716,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         create
@@ -1724,6 +1725,7 @@ Rails.application.routes.draw do
         form_field_changed
         quick_search
         listnav_search_selected
+        sections_field_changed
         show
         show_list
         tag_edit_form_field_changed
@@ -1732,6 +1734,7 @@ Rails.application.routes.draw do
         wait_for_task
       ) +
         adv_search_post +
+        compare_post +
         save_post +
         exp_post +
         dialog_runner_post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1625,7 +1625,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         create
@@ -1641,6 +1642,7 @@ Rails.application.routes.draw do
         wait_for_task
       ) +
         adv_search_post +
+        compare_post +
         save_post +
         exp_post +
         dialog_runner_post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2794,7 +2794,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         listnav_search_selected
@@ -2808,6 +2809,7 @@ Rails.application.routes.draw do
         quick_search
       ) +
                adv_search_post +
+               compare_post +
                exp_post +
                save_post
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -539,7 +539,8 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         tag_edit_form_field_changed
-      ),
+      ) +
+        compare_get,
       :post => %w(
         attach_volume
         detach_volume
@@ -552,13 +553,19 @@ Rails.application.routes.draw do
         form_field_changed
         listnav_search_selected
         quick_search
+        sections_field_changed
         show
         show_list
         tagging_edit
         tag_edit_form_field_changed
         update
         wait_for_task
-      ) + adv_search_post + exp_post + save_post + dialog_runner_post
+      ) +
+        adv_search_post +
+        compare_post +
+        dialog_runner_post +
+        exp_post +
+        save_post
     },
 
     :cloud_volume_snapshot    => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1684,7 +1684,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         button
         create
@@ -1692,6 +1693,7 @@ Rails.application.routes.draw do
         form_field_changed
         listnav_search_selected
         quick_search
+        sections_field_changed
         show
         show_list
         tag_edit_form_field_changed
@@ -1700,6 +1702,7 @@ Rails.application.routes.draw do
         wait_for_task
       ) +
         adv_search_post +
+        compare_post +
         save_post +
         exp_post +
         dialog_runner_post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1791,7 +1791,8 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-      ),
+      ) +
+        compare_get,
       :post => %w(
         add_interface
         add_interface_select
@@ -1811,6 +1812,7 @@ Rails.application.routes.draw do
         wait_for_task
       ) +
         adv_search_post +
+        compare_post +
         save_post +
         exp_post +
         dialog_runner_post

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -260,6 +260,15 @@ describe CloudNetworkController do
         controller.send(:button)
       end
     end
+
+    context 'comparing Instances displayed in a nested list of Cloud Network' do
+      let(:params) { {:pressed => 'instance_compare'} }
+
+      it 'calls comparemiq method for comparing Instances' do
+        expect(controller).to receive(:comparemiq)
+        controller.send(:button)
+      end
+    end
   end
 
   describe "#delete_networks" do

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -235,6 +235,28 @@ describe CloudSubnetController do
     end
   end
 
+  describe '#button' do
+    before { controller.params = params }
+
+    context 'comparing Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_compare'} }
+
+      it 'calls comparemiq to compare Instances' do
+        expect(controller).to receive(:comparemiq)
+        controller.send(:button)
+      end
+    end
+
+    context 'adding new Cloud Subnet' do
+      let(:params) { {:pressed => 'cloud_subnet_new'} }
+
+      it 'redirects to action new' do
+        expect(controller).to receive(:javascript_redirect).with(:action => 'new')
+        controller.send(:button)
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :cloud_subnet_openstack
 
   include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google amazon)

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,8 +1,9 @@
 describe NetworkRouterController do
   include_examples :shared_examples_for_network_router_controller, %w(openstack azure google amazon)
 
-  context "#tags_edit" do
+  describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       @ct = FactoryBot.create(:network_router, :name => "router-01")
@@ -101,57 +102,53 @@ describe NetworkRouterController do
       @router = FactoryBot.create(:network_router_openstack)
     end
 
-    context "#create" do
-      let(:task_options) do
-        {
-          :action => "creating Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "creating Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
 
-      let(:cloud_tenant) do
-        FactoryBot.create(:cloud_tenant)
-      end
+    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant) }
 
-      let(:queue_options) do
-        {
-          :class_name  => @ems.class.name,
-          :method_name => 'create_network_router',
-          :instance_id => @ems.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{
-            :name            => 'test',
-            :admin_state_up  => 'true',
-            :ems_id          => @ems.id.to_s,
-            :cloud_subnet_id => '',
-            :cloud_tenant    => cloud_tenant
-          }]
-        }
-      end
+    let(:queue_options) do
+      {
+        :class_name  => @ems.class.name,
+        :method_name => 'create_network_router',
+        :instance_id => @ems.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => @ems.my_zone,
+        :args        => [{
+          :name            => 'test',
+          :admin_state_up  => 'true',
+          :ems_id          => @ems.id.to_s,
+          :cloud_subnet_id => '',
+          :cloud_tenant    => cloud_tenant
+        }]
+      }
+    end
 
-      it "builds create screen" do
-        post :button, :params => { :pressed => "network_router_new", :format => :js }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds create screen" do
+      post :button, :params => { :pressed => "network_router_new", :format => :js }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :create, :params => {
-          :button           => 'add',
-          :controller       => 'network_router',
-          :format           => :js,
-          :name             => 'test',
-          :admin_state_up   => 'true',
-          :cloud_subnet_id  => '',
-          :cloud_tenant     => {:id => cloud_tenant.id},
-          :ems_id           => @ems.id,
-          :external_gateway => 'false',
-          :extra_attributes => '',
-          :id               => 'new'
-        }
-      end
+    it "queues the create action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :create, :params => {
+        :button           => 'add',
+        :controller       => 'network_router',
+        :format           => :js,
+        :name             => 'test',
+        :admin_state_up   => 'true',
+        :cloud_subnet_id  => '',
+        :cloud_tenant     => {:id => cloud_tenant.id},
+        :ems_id           => @ems.id,
+        :external_gateway => 'false',
+        :extra_attributes => '',
+        :id               => 'new'
+      }
     end
   end
 
@@ -164,45 +161,44 @@ describe NetworkRouterController do
                                    :ext_management_system => @ems)
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "updating Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => 'raw_update_network_router',
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => [{:name => "foo2", :external_gateway_info => {}}]
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "updating Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @router.class.name,
+        :method_name => 'raw_update_network_router',
+        :instance_id => @router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => @ems.my_zone,
+        :args        => [{:name => "foo2", :external_gateway_info => {}}]
+      }
+    end
 
-      it "builds edit screen" do
-        post :button, :params => { :pressed => "network_router_edit", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds edit screen" do
+      post :button, :params => { :pressed => "network_router_edit", :format => :js, :id => @router.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :update, :params => {
-          :button => "save",
-          :format => :js,
-          :id     => @router.id,
-          :name   => "foo2"
-        }
-      end
+    it "queues the update action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :update, :params => {
+        :button => "save",
+        :format => :js,
+        :id     => @router.id,
+        :name   => "foo2"
+      }
     end
   end
 
   describe "#delete_network_routers" do
     let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
     let(:router) { FactoryBot.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
+
     before do
       stub_user(:features => :all)
       setup_zone
@@ -210,6 +206,7 @@ describe NetworkRouterController do
       controller.instance_variable_set(:@lastaction, "show")
       controller.instance_variable_set(:@layout, "network_router")
     end
+
     it "it calls process_network_routers function" do
       expect(controller).to receive(:process_network_routers).with([NetworkRouter], "destroy")
 
@@ -227,38 +224,36 @@ describe NetworkRouterController do
       session[:network_router_lastaction] = 'show'
     end
 
-    context "#delete" do
-      let(:task_options) do
-        {
-          :action => "deleting Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => 'raw_delete_network_router',
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "deleting Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @router.class.name,
+        :method_name => 'raw_delete_network_router',
+        :instance_id => @router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => 'ems_operations',
+        :zone        => @ems.my_zone,
+        :args        => []
+      }
+    end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        controller.params = {:pressed => "network_router_delete",
-                             :id      => @router.id}
-        controller.instance_variable_set(:@lastaction, "show")
-        controller.instance_variable_set(:@layout, "network_router")
-        controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
-        expect(controller).to receive(:render)
-        controller.send(:button)
-        flash_messages = assigns(:flash_array)
-        expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Network Router.",
-                                           :level   => :success)
-      end
+    it "queues the delete action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      controller.params = {:pressed => "network_router_delete",
+                           :id      => @router.id}
+      controller.instance_variable_set(:@lastaction, "show")
+      controller.instance_variable_set(:@layout, "network_router")
+      controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
+      expect(controller).to receive(:render)
+      controller.send(:button)
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Network Router.",
+                                         :level   => :success)
     end
   end
 
@@ -271,85 +266,83 @@ describe NetworkRouterController do
       @subnet = FactoryBot.create(:cloud_subnet, :ext_management_system => @ems)
     end
 
-    context "#add_interface" do
-      let(:task_options) do
-        {
-          :action => "Adding Interface to Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => "raw_add_interface",
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@subnet.id]
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "Adding Interface to Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @router.class.name,
+        :method_name => "raw_add_interface",
+        :instance_id => @router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => @ems.my_zone,
+        :args        => [@subnet.id]
+      }
+    end
 
-      it "builds add interface screen" do
-        stub_user(:features => :all)
-        post :button, :params => { :pressed => "network_router_add_interface", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds add interface screen" do
+      stub_user(:features => :all)
+      post :button, :params => { :pressed => "network_router_add_interface", :format => :js, :id => @router.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it 'list subnet choices' do
-        stub_user(:features => :all)
+    it 'list subnet choices' do
+      stub_user(:features => :all)
+      allow(controller).to receive(:drop_breadcrumb)
+      controller.instance_variable_set(:@router, @router)
+      controller.params = {:id => @router.id}
+      controller.send(:add_interface_select)
+      subnet_choices = controller.instance_variable_get(:@subnet_choices)
+
+      expect(subnet_choices).to eq(@subnet.name => @subnet.id)
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    context 'with restricted user' do
+      let!(:subnet_2) { FactoryBot.create(:cloud_subnet, :ext_management_system => @ems) }
+      let(:user)    { FactoryBot.create(:user, :features => "network_router_add_interface") }
+      let(:tag)     { "/managed/environment/prod" }
+
+      before do
         allow(controller).to receive(:drop_breadcrumb)
         controller.instance_variable_set(:@router, @router)
         controller.params = {:id => @router.id}
+
+        @router.tag_with(tag, :ns => '')
+        subnet_2.tag_with(tag, :ns => '')
+
+        user.current_group.entitlement.tap do |entitlement|
+          entitlement.set_managed_filters([[tag]])
+          entitlement.save!
+        end
+        login_as user
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'list subnet choices' do
+        controller.instance_variable_set(:@router, @router)
+        controller.params = {:id => @router.id}
+
         controller.send(:add_interface_select)
         subnet_choices = controller.instance_variable_get(:@subnet_choices)
-
-        expect(subnet_choices).to eq(@subnet.name => @subnet.id)
+        expect(subnet_choices).to eq(subnet_2.name => subnet_2.id)
         expect(assigns(:flash_array)).to be_nil
       end
+    end
 
-      context 'with restricted user' do
-        let!(:subnet_2) { FactoryBot.create(:cloud_subnet, :ext_management_system => @ems) }
-        let(:user)    { FactoryBot.create(:user, :features => "network_router_add_interface") }
-        let(:tag)     { "/managed/environment/prod" }
-
-        before do
-          allow(controller).to receive(:drop_breadcrumb)
-          controller.instance_variable_set(:@router, @router)
-          controller.params = {:id => @router.id}
-
-          @router.tag_with(tag, :ns => '')
-          subnet_2.tag_with(tag, :ns => '')
-
-          user.current_group.entitlement.tap do |entitlement|
-            entitlement.set_managed_filters([[tag]])
-            entitlement.save!
-          end
-          login_as user
-          allow(controller).to receive(:current_user).and_return(user)
-        end
-
-        it 'list subnet choices' do
-          controller.instance_variable_set(:@router, @router)
-          controller.params = {:id => @router.id}
-
-          controller.send(:add_interface_select)
-          subnet_choices = controller.instance_variable_get(:@subnet_choices)
-          expect(subnet_choices).to eq(subnet_2.name => subnet_2.id)
-          expect(assigns(:flash_array)).to be_nil
-        end
-      end
-
-      it "queues the add interface action" do
-        stub_user(:features => :all)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :add_interface, :params => {
-          :button          => "add",
-          :format          => :js,
-          :id              => @router.id,
-          :cloud_subnet_id => @subnet.id
-        }
-      end
+    it "queues the add interface action" do
+      stub_user(:features => :all)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :add_interface, :params => {
+        :button          => "add",
+        :format          => :js,
+        :id              => @router.id,
+        :cloud_subnet_id => @subnet.id
+      }
     end
   end
 
@@ -363,46 +356,42 @@ describe NetworkRouterController do
       @subnet = FactoryBot.create(:cloud_subnet, :ext_management_system => @ems)
     end
 
-    context "#remove_interface" do
-      let(:task_options) do
-        {
-          :action => "Removing Interface from Network Router for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @router.class.name,
-          :method_name => "raw_remove_interface",
-          :instance_id => @router.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@subnet.id]
-        }
-      end
+    let(:task_options) do
+      {
+        :action => "Removing Interface from Network Router for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => @router.class.name,
+        :method_name => "raw_remove_interface",
+        :instance_id => @router.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => @ems.my_zone,
+        :args        => [@subnet.id]
+      }
+    end
 
-      it "builds remove interface screen" do
-        post :button, :params => { :pressed => "network_router_remove_interface", :format => :js, :id => @router.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
+    it "builds remove interface screen" do
+      post :button, :params => { :pressed => "network_router_remove_interface", :format => :js, :id => @router.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "queues the remove interface action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :remove_interface, :params => {
-          :button          => "remove",
-          :format          => :js,
-          :id              => @router.id,
-          :cloud_subnet_id => @subnet.id
-        }
-      end
+    it "queues the remove interface action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :remove_interface, :params => {
+        :button          => "remove",
+        :format          => :js,
+        :id              => @router.id,
+        :cloud_subnet_id => @subnet.id
+      }
     end
   end
 
   describe '#button' do
-    before do
-      controller.params = params
-    end
+    before { controller.params = params }
 
     context 'tagging instances from a list of instances, accessed from the details page of a network router' do
       let(:params) { {:pressed => "instance_tag"} }
@@ -428,6 +417,15 @@ describe NetworkRouterController do
       it 'calls tag method for tagging floating ips' do
         expect(controller).to receive(:tag).with("FloatingIp")
 
+        controller.send(:button)
+      end
+    end
+
+    context 'comparing Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_compare'} }
+
+      it 'calls comparemiq to compare Instances' do
+        expect(controller).to receive(:comparemiq)
         controller.send(:button)
       end
     end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -219,5 +219,23 @@ describe SecurityGroupController do
         controller.send(:button)
       end
     end
+
+    context 'comparing Instances displayed thru Security Group summary' do
+      let(:params) { {:pressed => 'instance_compare'} }
+
+      it 'calls comparemiq to compare Instances' do
+        expect(controller).to receive(:comparemiq)
+        controller.send(:button)
+      end
+    end
+
+    context 'creating Security Group' do
+      let(:params) { {:pressed => 'security_group_new'} }
+
+      it 'redirect to action new' do
+        expect(controller).to receive(:javascript_redirect).with(:action => 'new')
+        controller.send(:button)
+      end
+    end
   end
 end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -6,9 +6,12 @@ describe StorageController do
     2.times { st.all_miq_templates << FactoryBot.create(:miq_template) }
     st
   end
+
   before { stub_user(:features => :all) }
 
-  context "#button" do
+  describe "#button" do
+    before { allow(controller).to receive(:performed?) }
+
     it "when VM Right Size Recommendations is pressed" do
       controller.params = {:pressed => "vm_right_size"}
       expect(controller).to receive(:vm_right_size)
@@ -67,6 +70,13 @@ describe StorageController do
       expect(controller).to receive(:render)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+
+    it 'calls comparemiq for comparing Hosts' do
+      controller.params = {:pressed => "host_compare"}
+      expect(controller).to receive(:comparemiq)
+      controller.send(:button)
+      expect(controller.instance_variable_get(:@flash_array)).to be_nil
     end
 
     {"host_standby"  => "Enter Standby Mode",
@@ -284,7 +294,7 @@ describe StorageController do
       end
     end
 
-    context "#tree_select" do
+    describe "#tree_select" do
       before do
         storage
         storage_cluster
@@ -340,7 +350,7 @@ describe StorageController do
     end
   end
 
-  context "#tags_edit" do
+  describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1741122
**Related PR with more info:** https://github.com/ManageIQ/manageiq-ui-classic/pull/5876

It was not possible to compare VMs/Instances/Hosts displayed in a nested list due to missing routes and/or missing `comparemiq` method in some controllers. You clicked on "Compare Selected items" and nothing happened in the UI or error message about missing route appeared. 

Adding missing routes and `comparemiq` calls in appropriate controllers fixes the problem. I am also adding `unless performed?` to prevent multiple calls of `javascript_flash` method, for example in storage controller - this can happen for some operations because of [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L613) and [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/storage_controller.rb#L129).

Where I fixed comparing items:
a) _Compute > Infra > Datastores_ > choose some Datastore > Hosts (Relationships)
b) _Networks > Networks_ > choose some Network > Instances (Relationships)
c) _Networks > Subnets_ > choose some Subnet > Instances (Relationships)
d) _Storage > Block Storage > Volumes_ > choose some Volume > Instances (Relationships)
e) _Networks > Network Routers_ > choose some Router > Instances (Relationships)
f) _Compute > Infra > Resource Pools_ > choose some Pool > All/Direct VMs (Relationships)
g) _Networks > Security Groups_ > choose some Group > Instances (Relationships)

**Note:**
Missing _Cancel_ button to cancel Compare action will be added via another PR.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1733295 (fixed)

---

**Before:** (nothing happens in the UI)
![comp_host_before](https://user-images.githubusercontent.com/13417815/63778443-1496bd80-c8e5-11e9-97ad-ac120a0c1767.png)

**After:**
![host_comp](https://user-images.githubusercontent.com/13417815/63778449-1791ae00-c8e5-11e9-8a4e-9606348b4c78.png)

