### PR TITLE
Introduce breadcrumbs to utilization controller

### DIFF
--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -5,6 +5,7 @@ class UtilizationController < ApplicationController
   menu_section(:vi)
 
   include OptimizeHelper
+  include Mixins::BreadcrumbsMixin
 
   def index
     @explorer = true
@@ -224,6 +225,7 @@ class UtilizationController < ApplicationController
     presenter.set_visibility(@sb[:active_tab] == 'report', :toolbar)
 
     presenter.update(:main_div, r[:partial => 'utilization_tabs'])
+    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
     presenter[:right_cell_text] = @right_cell_text
     presenter[:build_calendar] = {
       :date_from => @sb[:options][:sdate],
@@ -242,5 +244,14 @@ class UtilizationController < ApplicationController
     @sb[:summary][:memory]&.each { |r| a.push("section" => _("Memory"), "item" => r[0], "value" => r[1]) }
     @sb[:summary][:storage]&.each { |r| a.push("section" => _("Disk"), "item" => r[0], "value" => r[1]) }
     a
+  end
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _("Overview")},
+        {:title => _("Utilization")},
+      ],
+    }
   end
 end

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -34,4 +34,12 @@ describe UtilizationController do
       end
     end
   end
+
+  describe "breadcrumbs" do
+    it "display breadcrumbs" do
+      get :index
+
+      expect(controller.data_for_breadcrumbs).to eq([{:title=>"Overview"}, {:title=>"Utilization"}])
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741188

**Description**

This controller was missing breadcrumbs.. because it doesn't work in my version, so I skipped it and I forgot to check it later. :disappointed: 

**Before**

![image](https://user-images.githubusercontent.com/32869456/63165435-bc7dd280-c02b-11e9-9532-4e93e8ed0120.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/63165326-63ae3a00-c02b-11e9-8056-f06fe1163c66.png)


@miq-bot add_label bug, ivanchuk/yes, breadcrumbs