### PR TITLE
Broken endpoint fix for dialog from GO instance detail page

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -31,7 +31,12 @@ class ServiceController < ApplicationController
     display_options = {}
     ids = @lastaction == 'generic_object' ? @sb[:rec_id] : 'LIST'
     display_options[:display] = @display
-    display_options[:display_id] = params[:id]
+    display_options[:display_id] = if params[:miq_grid_checks]
+                                     params[:id]
+                                   else
+                                     # Determine related service ID for selected GO
+                                     @breadcrumbs.last[:url][/\/\d*\?/][1..-2]
+                                   end
     custom_buttons(ids, display_options)
   end
 


### PR DESCRIPTION
Description
----------------
Fixing broken endpoint for dialog from GenericObject(GO) detail page. As we can see from logs in BZ, endpoint url contains GO ID instead of related Service ID. In the case where there is no such a service with same ID as GO, you will get the error.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1729341

Steps for Testing/QA
-------------------------------
Steps are included in the BZ above
