### PR TITLE
Fixed API endpoint for GO object custom button dialogs.

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -31,7 +31,8 @@ class ServiceController < ApplicationController
     display_options = {}
     ids = @lastaction == 'generic_object' ? @sb[:rec_id] : 'LIST'
     display_options[:display] = @display
-    display_options[:display_id] = params[:id]
+    display_options[:record_id] = @sb['trees']['svcs_tree']['active_node'].split('-').last
+    display_options[:display_id] = params[:id] if @lastaction == 'generic_object'
     custom_buttons(ids, display_options)
   end
 

--- a/app/services/dialog_local_service.rb
+++ b/app/services/dialog_local_service.rb
@@ -48,8 +48,9 @@ class DialogLocalService
       cancel_endpoint = display_options[:cancel_endpoint] || "/vm_or_template/explorer"
     when /GenericObject/
       api_collection_name = "generic_objects"
-      cancel_endpoint = if !display_options.empty? && display_options[:display_id]
-                          "/service/show/#{display_options[:display_id]}?display=generic_objects"
+      cancel_endpoint = if !display_options.empty? && display_options[:record_id]
+                          god_url = "/service/show/#{display_options[:record_id]}?display=generic_objects"
+                          display_options[:display_id] ? "#{god_url}&generic_object_id=#{display_options[:display_id]}" : god_url
                         else
                           "/service/explorer"
                         end


### PR DESCRIPTION
Need to pass in correct parent record id and generic_object id to build endpoint url correctly when pressing a GO custom button from list view or details view.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1729341

In favor of https://github.com/ManageIQ/manageiq-ui-classic/pull/6049

@tinaafitz @pkomanek please review/test. Please test pressing custom button from List view and details view.