### PR TITLE
Do not show unassigned buttons in My Service page

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -332,7 +332,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def create_related_custom_buttons(record, item)
-    item.custom_buttons.collect { |cb| create_raw_custom_button_hash(cb, record) }
+    item.custom_buttons.select{ |cb| cb.parent.present? }.collect { |cb| create_raw_custom_button_hash(cb, record) }
   end
 
   def record_to_service_buttons(record)


### PR DESCRIPTION
Make sure you have a `Service` that has a `ServiceTemplate`/`Generic Object` with Unassigned `Custom Button(s)`.

Go to Services -> My Services -> click on that `Service` -> see buttons in toolbar

Before: There are some unassigned buttons
<img width="905" alt="Screenshot 2019-08-19 at 13 58 54" src="https://user-images.githubusercontent.com/9210860/63263652-8178da80-c289-11e9-94af-2a3cd966e93c.png">

After: Only `CustomButtonSet(s)` are in toolbar
<img width="889" alt="Screenshot 2019-08-19 at 13 58 02" src="https://user-images.githubusercontent.com/9210860/63263661-863d8e80-c289-11e9-8535-7b9413e1572d.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1709870

TODO: Fix it in SUI as well.

Cc: @himdel @h-kataria 