### PR TITLE
Fix missing whitespace

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -332,7 +332,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def create_related_custom_buttons(record, item)
-    item.custom_buttons.select{ |cb| cb.parent.present? }.collect { |cb| create_raw_custom_button_hash(cb, record) }
+    item.custom_buttons.select { |cb| cb.parent.present? }.collect { |cb| create_raw_custom_button_hash(cb, record) }
   end
 
   def record_to_service_buttons(record)


### PR DESCRIPTION
Fixing linter error from https://github.com/ManageIQ/manageiq-ui-classic/pull/6053

@miq-bot add_label ivanchuk/no, cleanup
