### PR TITLE
[WIP] Storage - treat all_vms and all_miq_templates the same

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -17,10 +17,6 @@ class StorageController < ApplicationController
     %w[all_vms hosts all_miq_templates registered_vms unregistered_vms custom_button_events]
   end
 
-  def self.custom_display_method
-    %w[all_miq_templates]
-  end
-
   def display_all_miq_templates
     nested_list(MiqTemplate, :parent => @record, :association => "all_miq_templates")
   end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -428,7 +428,7 @@ class ApplicationHelper::ToolbarChooser
         return "template_clouds_center_tb"
       elsif @display == "instances"
         return "vm_clouds_center_tb"
-      elsif @display == "miq_templates"
+      elsif @display == "miq_templates" || @display == "all_miq_templates"
         return "template_infras_center_tb"
       elsif performance_layouts.include?(@layout) && @display == "performance"
         return "#{@explorer ? "x_" : ""}vm_performance_tb"


### PR DESCRIPTION
When viewing a Datastore detail screen, there are nested lists of vms and templates.

For vms, a toolbar is displayed,
for templates, it's not.

Showing the toolbar for templates as well.

(And removing `all_miq_templates` from `custom_display_method` because it's also in `display_methods` and that always wins.)