### PR TITLE
Fix tree breadcrumbs on explorer screen missing the tree

### DIFF
--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -19,12 +19,6 @@
         vm.updateTreeNode(payload.updateTreeNode);
         vm.$scope.$apply();
       }
-
-      if (payload.breadcrumbSelect) {
-        vm.nodeSelect({
-          key: payload.breadcrumbSelect.item.key, text: payload.breadcrumbSelect.item.title,
-        }, payload.breadcrumbSelect.path);
-      }
     });
 
     /**

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -74,11 +74,3 @@ function miq_bootstrap(selector, app) {
 
   return angular.bootstrap($(selector), [app], { strictDi: true });
 }
-
-function tree_action() {
-  listenToRx(function(payload) {
-    if (payload.breadcrumbSelect) {
-      window.location.href = "/generic_object_definition/show_list";
-    }
-  });
-}

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -292,12 +292,14 @@ class GenericObjectDefinitionController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs  => [
         {:title => _("Automation")},
         {:title => _("Automate")},
         {:title => _("Generic Objects")},
       ],
-      :record_info => @generic_object_definition,
+      :record_info  => @generic_object_definition,
+      :disable_tree => %w[new edit].include?(action_name),
+      :to_explorer  => 'show_list',
     }
   end
 

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -431,11 +431,13 @@ class MiqAeCustomizationController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs  => [
         {:title => _("Automation")},
         {:title => _("Automate")},
         {:title => _("Customization")},
       ],
+      :disable_tree => action_name == 'editor',
+      :to_explorer  => 'explorer',
     }
   end
 end

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -27,6 +27,7 @@ module Mixins
       options[:record_title] ||= :name
       options[:not_tree] ||= false
       options[:hide_title] ||= false
+      options[:disable_tree] ||= false
 
       breadcrumbs = options[:breadcrumbs] || []
 
@@ -99,6 +100,16 @@ module Mixins
           # i.e. editing, copying, adding, etc.
           extra_title = right_cell_text || @title
           breadcrumbs.push(:title => extra_title) if action_breadcrumb? && extra_title && title != extra_title
+        end
+
+        # disable_tree allows to remove all links from the tree
+        if options[:disable_tree]
+          filtered_breadcrumbs = breadcrumbs.compact.map { |item| {:title => item[:title]} }
+
+          # replace last clickable breadcrumb with link to explorer
+          filtered_breadcrumbs[-2][:to_explorer] = options[:to_explorer] if options[:to_explorer]
+
+          return filtered_breadcrumbs
         end
       end
       breadcrumbs << @tail_breadcrumb

--- a/app/javascript/components/breadcrumbs/index.js
+++ b/app/javascript/components/breadcrumbs/index.js
@@ -19,7 +19,7 @@ class Breadcrumbs extends Component {
           return (
             <Breadcrumb.Item
               key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
-              onClick={() => onClickTree(controllerName, item)}
+              onClick={e => onClickTree(e, controllerName, item)}
             >
               {text}
             </Breadcrumb.Item>

--- a/app/javascript/components/breadcrumbs/index.jsx
+++ b/app/javascript/components/breadcrumbs/index.jsx
@@ -3,23 +3,25 @@ import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import { unescape } from 'lodash';
 
-import { onClickTree, onClick } from './on-click-functions';
+import { onClickTree, onClick, onClickToExplorer } from './on-click-functions';
 
 const parsedText = text => unescape(text).replace(/<[/]{0,1}strong>/g, '');
 
 class Breadcrumbs extends Component {
   renderItems = () => {
-    const {
-      items, controllerName,
-    } = this.props;
+    const { items, controllerName } = this.props;
     return items.filter((_item, index) => index !== (items.length - 1)).map((item, index) => {
       const text = parsedText(item.title);
-      if ((item.url || item.key) && !item.action) {
-        if (item.key) {
+      if ((item.url || item.key || item.to_explorer) && !item.action) {
+        if (item.key || item.to_explorer) {
           return (
             <Breadcrumb.Item
               key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
-              onClick={e => onClickTree(e, controllerName, item)}
+              onClick={e =>
+                (item.to_explorer
+                  ? onClickToExplorer(e, controllerName, item.to_explorer)
+                  : onClickTree(e, controllerName, item))
+                }
             >
               {text}
             </Breadcrumb.Item>

--- a/app/javascript/components/breadcrumbs/on-click-functions.js
+++ b/app/javascript/components/breadcrumbs/on-click-functions.js
@@ -14,3 +14,12 @@ export const onClick = (e) => {
     e.preventDefault();
   }
 };
+
+export const onClickToExplorer = (e, controllerName, explorerLink) => {
+  if (window.miqCheckForChanges()) {
+    miqSparkleOn();
+    window.location.assign(`/${controllerName}/${explorerLink}`);
+  } else {
+    e.preventDefault();
+  }
+};

--- a/app/javascript/components/breadcrumbs/on-click-functions.js
+++ b/app/javascript/components/breadcrumbs/on-click-functions.js
@@ -1,7 +1,13 @@
-export const onClickTree = (controllerName, item) => (
-  window.miqCheckForChanges()
-    ? sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, item } }) : null
-);
+export const onClickTree = (e, controllerName, { key, title }) => {
+  if (window.miqCheckForChanges()) {
+    const id = encodeURIComponent(key.split('__')[0]);
+    const text = encodeURIComponent(title);
+    const url = `/${controllerName}/tree_select?id=${id}&text=${text}`;
+    miqAjax(url, null, { beforeSend: true });
+  } else {
+    e.preventDefault();
+  }
+};
 
 export const onClick = (e) => {
   if (!window.miqCheckForChanges()) {

--- a/app/javascript/spec/breadcrumbs/breadcrumbs.spec.js
+++ b/app/javascript/spec/breadcrumbs/breadcrumbs.spec.js
@@ -36,7 +36,7 @@ describe('Breadcrumbs component', () => {
 
     wrapper.find('a').first().simulate('click');
 
-    expect(clickFunctions.onClickTree).toHaveBeenCalledWith(initialProps.controllerName, initialProps.items[0]);
+    expect(clickFunctions.onClickTree).toHaveBeenCalledWith(expect.any(Object), initialProps.controllerName, initialProps.items[0]);
   });
 
   it('clicked on breadcrumb', () => {

--- a/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
+++ b/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
@@ -1,6 +1,7 @@
-import { onClickTree, onClick } from '../../components/breadcrumbs/on-click-functions';
+import { onClickTree, onClick, onClickToExplorer } from '../../components/breadcrumbs/on-click-functions';
 
 import '../helpers/miqAjax';
+import '../helpers/miqSparkle';
 
 describe('Breadcrumbs onClick functions', () => {
   let preventDefaultMock;
@@ -60,6 +61,26 @@ describe('Breadcrumbs onClick functions', () => {
 
       expect(spyMiqAjax).toHaveBeenCalledWith(`/pxe/tree_select?id=${item.key}&text=${item.title}`, null, { beforeSend: true });
       expect(preventDefaultMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onClickToExplorer', () => {
+    it('calls prevent default', () => {
+      window.miqCheckForChanges = () => false;
+
+      onClickToExplorer(event, 'pxe', 'explorer');
+
+      expect(preventDefaultMock).toHaveBeenCalled();
+    });
+
+    it('calls location assign', () => {
+      window.miqCheckForChanges = () => true;
+      window.location.assign = jest.fn();
+
+      onClickToExplorer(event, 'pxe', 'explorer');
+
+      expect(preventDefaultMock).not.toHaveBeenCalled();
+      expect(window.location.assign).toHaveBeenCalledWith('/pxe/explorer');
     });
   });
 });

--- a/app/javascript/spec/helpers/miqAjax.js
+++ b/app/javascript/spec/helpers/miqAjax.js
@@ -1,0 +1,1 @@
+window.miqAjax = () => {};

--- a/app/views/generic_object_definition/_generic_object_definition_form.html.haml
+++ b/app/views/generic_object_definition/_generic_object_definition_form.html.haml
@@ -7,4 +7,3 @@
 
 :javascript
   miq_bootstrap('generic-object-definition');
-  tree_action();

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -558,4 +558,18 @@ describe MiqAeCustomizationController do
       expect(controller.instance_variable_get(:@title)).to include(dialog.name)
     end
   end
+
+  describe "breadcrumbs" do
+    before { get :editor }
+
+    it "editor returns breadcrumbs with link to explorer" do
+      expect(controller.data_for_breadcrumbs[-2][:to_explorer]).to eq('explorer')
+    end
+
+    it "editor edit returns title as the last item" do
+      controller.instance_variable_set(:@sb, "action" => "dialog_new_create")
+
+      expect(controller.data_for_breadcrumbs[-1][:title]).to eq(controller.instance_variable_get(:@title))
+    end
+  end
 end

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -199,6 +199,37 @@ describe Mixins::BreadcrumbsMixin do
           )
         end
       end
+
+      context "disable_tree set" do
+        before do
+          breadcrumbs_options[:disable_tree] = true
+          subject.instance_variable_set(:@trees, [tree])
+        end
+
+        it "creates breadcrumbs with no tree links" do
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+              {:title => "Utilization"},
+              {:title => "Item 1"},
+            ]
+          )
+        end
+
+        it "creates breadcrumbs with link to explorer" do
+          breadcrumbs_options[:to_explorer] = 'explorer'
+
+          expect(subject.data_for_breadcrumbs).to eq(
+            [
+              {:title => "First Layer"},
+              {:title => "Second Layer"},
+              {:title => "Utilization", :to_explorer => 'explorer'},
+              {:title => "Item 1"},
+            ]
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740853

**Description** 

Refactoring
- removes RxJS for calling tree node select (I was trying if we can solve the nonfunctional link by calling this method, however we cannot call `tree_select` outside the explorer view.. :crying_cat_face: )
- fixes missing `x` in the name of the component

Adds options to `breadcrumbs_options`
- `:disable_tree` will disable links to tree nodes (use when the tree is not on the page, you cannot use its links)
- `:to_explorer` (need to be used together with `disable_tree`) which will add a link to explorer (which is set as this variable) to the `[-2]` item of breadcrumbs, so user can return to the explorer (service_dialog editing/creating, GOD editing/adding and probably some more place)


Problem: Tree links cannot be clicked outside the explorer view. (In this case, miq_ae_customization_controller is not consistent, it is an explorer controller, but editor action behaves like a non-explorer page.)

Solution: On specific pages tree links will lead to explorer page and re-render the whole page. (Basically it works like a back button, because the controller remembers the last visited item.)

**Before**


![miqaebefore](https://user-images.githubusercontent.com/32869456/66634092-a431ca80-ec0c-11e9-8b81-0962796acf03.gif)

**After**

![miqaeafter](https://user-images.githubusercontent.com/32869456/66633971-5a48e480-ec0c-11e9-943d-ed36100726a5.gif)

@miq-bot add_label bug, ivanchuk/yes, changelog/no, breadcrumbs