### PR TITLE
Service - use x_node instead of accessing tree internals via @sb

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -31,7 +31,7 @@ class ServiceController < ApplicationController
     display_options = {}
     ids = @lastaction == 'generic_object' ? @sb[:rec_id] : 'LIST'
     display_options[:display] = @display
-    display_options[:record_id] = @sb['trees']['svcs_tree']['active_node'].split('-').last
+    display_options[:record_id] = parse_nodetype_and_id(x_node).last
     display_options[:display_id] = params[:id] if @lastaction == 'generic_object'
     custom_buttons(ids, display_options)
   end


### PR DESCRIPTION
comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/6052

Just a cosmetic detail, this should be doing exactly the same thing as before :)

Cc @h-kataria 