### PR TITLE
Revert "Do not show unassigned buttons"

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -332,7 +332,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def create_related_custom_buttons(record, item)
-    item.custom_buttons.select { |cb| cb.parent.present? }.collect { |cb| create_raw_custom_button_hash(cb, record) }
+    item.custom_buttons.collect { |cb| create_raw_custom_button_hash(cb, record) }
   end
 
   def record_to_service_buttons(record)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -316,6 +316,7 @@ class ApplicationHelper::ToolbarBuilder
         toolbar.button_group("custom_buttons_", buttons)
       end
     end
+    toolbar
   end
 
   def button_class_name(model)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -316,7 +316,6 @@ class ApplicationHelper::ToolbarBuilder
         toolbar.button_group("custom_buttons_", buttons)
       end
     end
-    toolbar
   end
 
   def button_class_name(model)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -165,7 +165,26 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
       it "#custom_button_add_related_buttons returns CustomButton without CustomButtonSet that applies to ServiceTemplate" do
         toolbar = Class.new(ApplicationHelper::Toolbar::Basic)
-        buttons_in_toolbar = toolbar_builder.custom_button_add_related_buttons(service.class, service, toolbar).definition["custom_buttons_"].buttons
+        toolbar_builder.custom_button_add_related_buttons(service.class, service, toolbar)
+        buttons_in_toolbar = toolbar.definition["custom_buttons_"].buttons
+        expect(buttons_in_toolbar.length).to eq(1)
+        expect(buttons_in_toolbar.first[:id]).to eq("custom__custom_#{@button[:id]}")
+      end
+    end
+
+    context "for GenericObject with GenericObjectDefinition" do
+      let(:generic_object_definition) { FactoryBot.create(:generic_object_definition) }
+      before do
+        allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
+        login_as user
+        @button = FactoryBot.create(:custom_button, :applies_to_class => "GenericObjectDefinition", :applies_to_id => generic_object_definition.id, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})
+        @goi = generic_object_definition.create_object(:name => "Test Load Balancer2")
+      end
+
+      it "#custom_button_add_related_buttons returns CustomButton without CustomButtonSet that applies to GenericObjectDefinition" do
+        toolbar = Class.new(ApplicationHelper::Toolbar::Basic)
+        toolbar_builder.custom_button_add_related_buttons(@goi.class, @goi, toolbar)
+        buttons_in_toolbar = toolbar.definition["custom_buttons_"].buttons
         expect(buttons_in_toolbar.length).to eq(1)
         expect(buttons_in_toolbar.first[:id]).to eq("custom__custom_#{@button[:id]}")
       end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -153,6 +153,23 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       it_behaves_like "no custom buttons"
       it_behaves_like "with custom buttons"
     end
+
+    context "for Service with ServiceTemplate" do
+      let(:service_template) { FactoryBot.create(:service_template) }
+      let!(:service)         { FactoryBot.create(:service, :service_template => service_template) }
+      before do
+        allow(MiqServer).to receive(:my_server) { FactoryBot.create(:miq_server) }
+        login_as user
+        @button = FactoryBot.create(:custom_button, :applies_to_class => "ServiceTemplate", :applies_to_id => service_template.id, :visibility => {:roles => ["_ALL_"]}, :options => {:button_icon => 'fa fa-star'})
+      end
+
+      it "#custom_button_add_related_buttons returns CustomButton without CustomButtonSet that applies to ServiceTemplate" do
+        toolbar = Class.new(ApplicationHelper::Toolbar::Basic)
+        buttons_in_toolbar = toolbar_builder.custom_button_add_related_buttons(service.class, service, toolbar).definition["custom_buttons_"].buttons
+        expect(buttons_in_toolbar.length).to eq(1)
+        expect(buttons_in_toolbar.first[:id]).to eq("custom__custom_#{@button[:id]}")
+      end
+    end
   end
 
   describe "#twostate_button_selected" do


### PR DESCRIPTION
This reverts commit f1c64661b9b27ade886f94bd7af81fd68f620068.

Because https://github.com/ManageIQ/manageiq-ui-classic/pull/6053 sounds ok but it's not. Correct behaviour described in https://github.com/ManageIQ/manageiq-ui-classic/issues/6062

@miq-bot add_label wip