### PR TITLE
Do not show custom buttons of children of GO/ServiceTemplate in toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -332,7 +332,7 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def create_related_custom_buttons(record, item)
-    item.custom_buttons.collect { |cb| create_raw_custom_button_hash(cb, record) }
+    item.direct_custom_buttons.collect { |cb| create_raw_custom_button_hash(cb, record) }
   end
 
   def record_to_service_buttons(record)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744440

Steps to Reproduce:
1. In Automate -> Automation -> Customization -> create an unassigned button for Services 
2. In Services -> Catalogs -> Catalog Items -> create a Catalog Item with custom button(s) or custom button group with button(s)
3. Go to Services -> Service Catalogs -> Order a created Catalog Item
4. Go to Services -> My Services and click on the ordered Service
5. See buttons in the toolbar

Before:
<img width="1659" alt="Screenshot 2019-08-22 at 14 36 49" src="https://user-images.githubusercontent.com/9210860/63515084-4d502480-c4ea-11e9-86a5-893dbe52d341.png">
*`Unassigned` button belongs to `Service`*

After:
<img width="1668" alt="Screenshot 2019-08-22 at 14 34 58" src="https://user-images.githubusercontent.com/9210860/63514974-111cc400-c4ea-11e9-942a-a4d9883777b1.png">

@miq-bot add_label bug, services