### PR TITLE
Hide Copy Widget for non-SuperAdmin users

### DIFF
--- a/app/helpers/application_helper/button/miq_widget_set_copy.rb
+++ b/app/helpers/application_helper/button/miq_widget_set_copy.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqWidgetSetCopy < ApplicationHelper::Button::Basic
+  def visible?
+    User.current_user.super_admin_user?
+  end
+end

--- a/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
@@ -16,7 +16,8 @@ class ApplicationHelper::Toolbar::MiqWidgetSetCenter < ApplicationHelper::Toolba
           'pficon pficon-edit fa-lg',
           N_('Select a single Dashboard to copy'),
           N_('Copy Selected Dashboard'),
-          :send_checked => true
+          :send_checked => true,
+          :klass        => ApplicationHelper::Button::MiqWidgetSetCopy
         ),
         button(
           :db_delete,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1314875

- Log in as a user that has no SuperAdmin rights but can see Overview -> Reports
- Go to Overview -> Reports -> Dashboards-> select one -> Configuration -> Copy Selected Dashboard

**Before:**
<img width="1665" alt="Screenshot 2019-08-20 at 13 06 52" src="https://user-images.githubusercontent.com/9210860/63342316-6ec6da00-c34b-11e9-9357-0f8b26134534.png">
*After clicking*
<img width="1655" alt="Screenshot 2019-08-20 at 13 07 03" src="https://user-images.githubusercontent.com/9210860/63342315-6ec6da00-c34b-11e9-818c-044942801f60.png">

**After:**
<img width="1145" alt="Screenshot 2019-08-21 at 11 06 33" src="https://user-images.githubusercontent.com/9210860/63418669-c88adb00-c403-11e9-8fa2-5864dae8fdd8.png">


@miq-bot add_label bug, ivanchuk/yes, blocker
