### PR TITLE
Prevent login redirect with ?timeout during logout

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1718,6 +1718,10 @@ var fontIconChar = _.memoize(function(klass) {
 });
 
 function redirectLogin(msg) {
+  if (ManageIQ.logoutInProgress) {
+    return; // prevent double redirect after pressing the Logout button
+  }
+
   add_flash(msg, 'warning');
   window.document.location.href = '/dashboard/login?timeout=true';
 }

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -48,6 +48,7 @@ if (!window.ManageIQ) {
     i18n: {
       mark_translated_strings: false,
     },
+    logoutInProgress: false,  // prevent redirectLogin *during* logout
     mouse: {
       x: null, // mouse X coordinate for popup menu
       y: null, // mouse Y coordinate for popup menu

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -46,7 +46,7 @@
                   = _(menu_item.name)
       %li.divider
       %li
-        %a{:href => "/dashboard/logout", :onclick => 'return miqCheckForChanges()', :title => _("Click to Logout")}
+        %a{:href => "/dashboard/logout", :onclick => 'ManageIQ.logoutInProgress = true; return miqCheckForChanges()', :title => _("Click to Logout")}
           = _('Logout')
 
 - else


### PR DESCRIPTION
When logging out via the Logout button,
when there are multiple HTTP requests happening,
the logout can cause API requests to fail with a 401 before the browser redirects to the login screen,
causing the response handler to call redirectLogin, to redirec to the login screen with a "session timed out" message.

We should not be claiming a timeout *during* logout, adding a check for that.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741283
