### PR TITLE
Do not use hash nodes for MiqReport records in Saved Reports 🌳

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -423,7 +423,6 @@ class ReportController < ApplicationController
 
   def determine_xx_node_info
     case x_active_tree
-    when :savedreports_tree then saved_reports_get_node_info
     when :db_tree           then db_get_node_info
     when :reports_tree      then reports_get_node_info
     when :widgets_tree      then widget_get_node_info
@@ -531,6 +530,7 @@ class ReportController < ApplicationController
     when "root" then determine_root_node_info
     when "g"    then determine_g_node_info(nodeid)
     when "xx"   then determine_xx_node_info
+    when "rep"  then saved_reports_get_node_info
     when "rr"   then determine_rr_node_info
     when "msc"  then determine_msc_node_info(nodeid)
     end

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -16,14 +16,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   def x_get_tree_roots(_count_only)
     u = User.current_user
     user_groups = u.report_admin_user? ? nil : u.miq_groups
-    having_report_results(user_groups).pluck(:name, :id).sort.map do |name, id|
-      {:id => id.to_i.to_s, :text => name, :icon => 'fa fa-file-text-o', :tip => name}
-    end
-  end
-
-  def x_get_tree_custom_kids(object, count_only)
-    scope = MiqReportResult.with_current_user_groups_and_report(object[:id].split('-').last)
-    count_only ? 1 : scope.order("last_run_on DESC").includes(:miq_task).to_a
+    having_report_results(user_groups).sort
   end
 
   # Scope on reports that have report results.

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -28,7 +28,7 @@ describe TreeBuilderReportSavedReports do
           saved_reports_in_tree = tree.tree_nodes.first[:nodes]
 
           displayed_report_ids = saved_reports_in_tree.map do |saved_report|
-            saved_report[:key].gsub("xx-", "")
+            saved_report[:key].gsub("rep-", "")
           end
 
           # logged User1 can see report with Group1
@@ -36,12 +36,12 @@ describe TreeBuilderReportSavedReports do
         end
       end
 
-      describe "#x_get_tree_custom_kids" do
+      describe "#x_get_tree_r_kids" do
         it "is allowed to see report results created under Group1 for User2(with current group Group2)" do
           report_result = MiqReportResult.first
 
           tree = TreeBuilderReportSavedReports.new('savedreports_tree', {})
-          tree_report_results = tree.send(:x_get_tree_custom_kids, {:id => @rpt.id.to_s}, false)
+          tree_report_results = tree.send(:x_get_tree_r_kids, @rpt, false)
 
           expect(tree_report_results).to include(report_result)
         end


### PR DESCRIPTION
Hash nodes are evil as we can work much better with nodes that are mapped from objects. In the `Saved Reports` under `Overview -> Reports` the explorer tree unnecessarily uses hash nodes for `MiqReport` records. I had to tweak the `get_node_info` a little so it can handle the new prefix, but as it is a prefix that has not been used in the tree before, it should be safe.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5620
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label hammer/no, ivanchuk/no, trees, refactoring, technical debt