### PR TITLE
Fix nilClass error

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -232,6 +232,7 @@ module Mixins
 
         def get_iso_options(vm)
           iso_options = []
+          return iso_options unless vm&.host&.storages
 
           datastore_ids = vm.host.storages.pluck(:id)
           # determine available iso files for the datastores

--- a/spec/controllers/mixins/actions/vm_actions/reconfigure_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/reconfigure_spec.rb
@@ -11,6 +11,12 @@ describe Mixins::Actions::VmActions::Reconfigure do
     context 'populate list of Host files' do
       let(:controller) { VmInfraController.new }
 
+      it "gets empty list when VM's has no host" do
+        @vm.host = nil
+        storage_list = controller.send(:get_iso_options, @vm)
+        expect(storage_list.count).to be(0)
+      end
+
       it "gets list of VM's host storages that have iso files" do
         @host.storages << @datastore
         storage_list = controller.send(:get_iso_options, @vm)


### PR DESCRIPTION
Added nil check to fix `undefined method `storages' for nil:NilClass` error

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1743529

To recreate: try to reconfigure an archived VM