### PR TITLE
Eliminate unnecessary hash nodes in the TreeBuilderReportDashboards

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -527,6 +527,7 @@ class ReportController < ApplicationController
     when "xx"   then determine_xx_node_info
     when "rep"  then saved_reports_get_node_info
     when "rr"   then determine_rr_node_info
+    when "ws"   then determine_xx_node_info
     when "msc"  then determine_msc_node_info(nodeid)
     end
 

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -257,7 +257,7 @@ module ReportController::Dashboards
   end
 
   def db_get_node_info
-    model, _, _ = TreeBuilder.extract_node_model_and_id(x_node)
+    model, rec_id, _ = TreeBuilder.extract_node_model_and_id(x_node)
     @sb[:nodes] = x_node.split('-')
     if @sb[:nodes].length == 1
       @default_ws = MiqWidgetSet.where_unique_on("default").where(:read_only => true).first
@@ -299,10 +299,10 @@ module ReportController::Dashboards
           @widgetsets.push(ws)
         end
       end
-    elsif model == "MiqWidgetSet" || (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")
+    elsif model == "MiqWidgetSet"
       # default dashboard nodes is selected or one under a specific group is selected
       # g = MiqGroup.find(@sb[:nodes][2])
-      @record = @dashboard = MiqWidgetSet.find(@sb[:nodes].last)
+      @record = @dashboard = MiqWidgetSet.find(rec_id)
       @right_cell_text = _("Dashboard \"%{name}\"") % {:name => "#{@dashboard.description} (#{@dashboard.name})"}
       @right_cell_div  = "db_list"
       @sb[:new] = {}

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -257,6 +257,7 @@ module ReportController::Dashboards
   end
 
   def db_get_node_info
+    model, _, _ = TreeBuilder.extract_node_model_and_id(x_node)
     @sb[:nodes] = x_node.split('-')
     if @sb[:nodes].length == 1
       @default_ws = MiqWidgetSet.where_unique_on("default").where(:read_only => true).first
@@ -298,8 +299,7 @@ module ReportController::Dashboards
           @widgetsets.push(ws)
         end
       end
-    elsif (@sb[:nodes].length == 4 && @sb[:nodes][1] == "g_g") ||
-          (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")
+    elsif model == "MiqWidgetSet" || (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")
       # default dashboard nodes is selected or one under a specific group is selected
       # g = MiqGroup.find(@sb[:nodes][2])
       @record = @dashboard = MiqWidgetSet.find(@sb[:nodes].last)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -515,6 +515,7 @@ class TreeBuilder
     "vap"  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate",
     "vnf"  => "ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate",
     "wi"   => "WindowsImage",
+    "ws"   => "MiqWidgetSet",
     "xx"   => "Hash", # For custom (non-CI) nodes, specific to each tree
     "z"    => "Zone"
   }.freeze

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -16,12 +16,12 @@ class TreeBuilderReportDashboards < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots
-    objects = []
-    default_ws = MiqWidgetSet.find_by(:name => 'default', :read_only => true)
-    text = "#{default_ws.description} (#{default_ws.name})"
-    objects.push(:id => default_ws.id.to_s, :text => text, :icon => 'fa fa-tachometer', :tip => text)
-    objects.push(:id => 'g', :text => _('All Groups'), :icon => 'pficon pficon-folder-close', :tip => _('All Groups'))
-    count_only_or_objects(false, objects)
+    [
+      MiqWidgetSet.default_dashboard,
+      {
+        :id => 'g', :text => _('All Groups'), :icon => 'pficon pficon-folder-close', :tip => _('All Groups')
+      }
+    ]
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_node/miq_widget_set.rb
+++ b/app/presenters/tree_node/miq_widget_set.rb
@@ -1,5 +1,12 @@
 module TreeNode
   class MiqWidgetSet < Node
-    set_attribute(:tooltip, &:name)
+    set_attributes(:text, :tooltip) do
+      if @object.read_only? && @object.name == "default" # Default dashboard
+        t = "#{@object.description} (#{@object.name})"
+        [t, t]
+      else
+        [@object.name, @object.name]
+      end
+    end
   end
 end

--- a/app/views/report/_db_list.html.haml
+++ b/app/views/report/_db_list.html.haml
@@ -51,7 +51,7 @@
                 %i.fa.fa-dashboard{:title => ws.description}
               %td
                 = "#{h(ws.description)} (#{h(ws.name)})"
-  - elsif ((@sb[:nodes].length == 4 && @sb[:nodes][1] == "g_g") || (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")) && !@in_a_form
+  - elsif @dashboard && !@in_a_form
     = render :partial => "layouts/flash_msg"
     = render :partial => "db_show", :locals => {:widget => @dashboard}
   - elsif @in_a_form

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -112,7 +112,7 @@ describe ReportController do
 
         MiqWidgetSet.seed
         widget_set = FactoryBot.create(:miq_widget_set, :group_id => user.current_group.id)
-        post :tree_select, :params => { :id => "xx-g_g-#{user.current_group.id}_-#{widget_set.id}", :format => :js, :accord => 'db' }
+        post :tree_select, :params => { :id => "xx-g_g-#{user.current_group.id}_ws-#{widget_set.id}", :format => :js, :accord => 'db' }
         expect(response).to render_template('report/_db_show')
       end
     end

--- a/spec/presenters/tree_node/miq_widget_set_spec.rb
+++ b/spec/presenters/tree_node/miq_widget_set_spec.rb
@@ -2,7 +2,7 @@ describe TreeNode::MiqWidgetSet do
   subject { described_class.new(object, nil, nil) }
   let(:object) { FactoryBot.create(:miq_widget_set, :name => 'foo') }
 
-  include_examples 'TreeNode::Node#key prefix', '-'
+  include_examples 'TreeNode::Node#key prefix', 'ws-'
   include_examples 'TreeNode::Node#icon', 'fa fa-tachometer'
   include_examples 'TreeNode::Node#tooltip same as #text'
 end


### PR DESCRIPTION
Except of the root node and the virtual folder for `All Groups` all nodes have a matchine record. First of all, the `MiqWidgetSet` prefix has been added to the `TreeBuilder::X_TREE_NODE_PREFIXES`. To avoid errors, the `get_node_info` logic has been altered accordingly. Then I was able to convert the default dashboard hash node to a mapped record node with some additional alterations in the `get_node_info`. 

The area in general is a big :spaghetti:, it relies a lot on the `@sb[:nodes]` and it would need additional refactoring, but that's out of the scope of my current work in https://github.com/ManageIQ/manageiq-ui-classic/issues/5620

Depends on: https://github.com/ManageIQ/manageiq/pull/19180
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label trees, refactoring, hammer/no, ivanchuk/no, pending core