### PR TITLE
Remove tree path from breadcrumbs

### DIFF
--- a/app/assets/javascripts/controllers/tree_view_controller.js
+++ b/app/assets/javascripts/controllers/tree_view_controller.js
@@ -21,7 +21,9 @@
       }
 
       if (payload.breadcrumbSelect) {
-        vm.nodeSelect({key: payload.breadcrumbSelect.key}, payload.breadcrumbSelect.path);
+        vm.nodeSelect({
+          key: payload.breadcrumbSelect.item.key, text: payload.breadcrumbSelect.item.title,
+        }, payload.breadcrumbSelect.path);
       }
     });
 
@@ -103,7 +105,7 @@
     };
 
     vm.nodeSelect = function(node, path) {
-      var url = path + '?id=' + encodeURIComponent(node.key.split('__')[0]);
+      var url = path + '?id=' + encodeURIComponent(node.key.split('__')[0]) + '&text=' +  encodeURIComponent(node.text);
       miqJqueryRequest(url, {beforeSend: true});
     };
   };

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -449,13 +449,11 @@ class AutomationManagerController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs  => [
+      :breadcrumbs => [
         {:title => _("Automation")},
         {:title => _("Ansible Tower")},
         {:title => _("Explorer")},
       ],
-      :record_title => :hostname,
-      :show_header  => true,
     }
   end
 end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1133,11 +1133,12 @@ class MiqPolicyController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs  => [
         {:title => _("Control")},
         menu_breadcrumb,
       ].compact,
-      :not_tree    => %w[rsop export log].include?(action_name)
+      :not_tree     => %w[rsop export log].include?(action_name),
+      :record_title => :description,
     }
   end
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -6,6 +6,8 @@ module Mixins
 
     def self.included(c)
       c.helper_method(:data_for_breadcrumbs)
+      c.before_action(:x_node_text_from_session)
+      c.after_action(:x_node_text_save_to_session)
     end
 
     # Main method which creates all breadcrumbs and returns them (to view page which will parse them into breadcrumbs nav)
@@ -13,7 +15,6 @@ module Mixins
       options = breadcrumbs_options || {}
       options[:record_info] ||= (@record || {})
       options[:record_title] ||= :name
-      options[:show_header] ||= false
       options[:not_tree] ||= false
       options[:hide_title] ||= false
       breadcrumbs = options[:breadcrumbs] || []
@@ -33,33 +34,65 @@ module Mixins
           breadcrumbs.push(:title => @title)
         end
       else
+        self.x_node_text = params[:text] if action_name == "tree_select" # get text of the active node
+
         # Append breadcrumb from title of the accordion (eg "Policies")
-        breadcrumbs.push(:title => accord_title, :key => "#{accord_name}_accord", :action => "accordion_select") if accord_title
+        breadcrumbs.push(:title => accord_title, :key => "root") if accord_title
 
-        # Append breadcrumbs created from the tree (eg "All policies > Red Hat policies > Policy 1")
-        breadcrumbs_from_tree = build_breadcrumbs_from_tree
-        breadcrumbs.concat(breadcrumbs_from_tree)
-
-        if (options[:include_record] || breadcrumbs_from_tree.blank?) && options[:record_info].present? && options[:record_info][options[:record_title]] &&
-           !(@tagitems || @politems || @ownershipitems || @retireitems)
-          # Append breadcrumb created from record_info if included or if result from tree was empty (eg filters page)
-
-          # Ancestry parents breadcrumbs
+        # On special page (tagitems, politems, etc.)
+        if @tagitems || @politems || @ownershipitems || @retireitems
+          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems, true)) unless options[:hide_special_item]
+          breadcrumbs.push(:title => @right_cell_text)
+        else
+          # Ancestry parents breadcrumbs (only in services)
           breadcrumbs.concat(ancestry_parents(options[:ancestry], options[:record_info], options[:record_title])) if options[:ancestry]
 
-          breadcrumbs.push(:title => options[:record_info][options[:record_title]], :key => x_node_right_cell)
-          breadcrumbs.push(:title => title_for_breadcrumbs) if options[:show_header] && @right_cell_text
-        else
-          # Append breadcrumb from the title of right cell
-          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems)) unless options[:hide_special_item]
-          breadcrumbs.push(:title => title_for_breadcrumbs) if action_breadcrumb?
+          # Try to prepare TreeNode on every item outside the root
+          if x_node != 'root'
+            if options[:include_record] && options[:record_info].present?
+              # Include items (for trees, which does not have final nodes: VMs etc.)
+              node = TreeNode.new(options[:record_info])
+            else
+              # Try to create treenode from the x_node
+              model, model_id, _ = TreeBuilder.extract_node_model_and_id(x_node) if x_node
+              record = model.try(:constantize).try(:find, model_id)
+
+              node = TreeNode.new(record) if record
+            end
+          end
+
+          # Overrides: if x_root then show title_for_breadcrumbs
+          #
+          # Priority 1. Include record
+          #          2. TreeNode.text
+          #          3. Item from tree (if it's built)
+          #          4. Fallbacks (sent text, title of the record, title_for_breadcrumbs)
+
+          key = node ? node.key : x_node
+          title = if x_node == 'root'   # After switching accordion, there is no way how to get root text
+                    title_for_breadcrumbs
+                  elsif node            # Use node's text and key
+                    node.text
+                  elsif @trees.present? # Select a node when coming from different page (the tree is built)
+                    build_breadcrumb_from_tree.try(:[], :title)
+                  else                  # Last clicked tree node label
+                    @x_node_text.try(:[], x_active_tree)
+                  end
+
+          breadcrumbs.push(:title => title, :key => key) if title
+
+          # Append seperate action header breadcrumb when there is some action
+          # (User is not on show page)
+          # i.e. editing, copying, adding, etc.
+          extra_title = title_for_breadcrumbs || @title
+          breadcrumbs.push(:title => extra_title) if action_breadcrumb? && extra_title && title != extra_title
         end
       end
       breadcrumbs.compact
     end
 
     def action_breadcrumb?
-      @sb["action"] && @right_cell_text
+      @sb["action"]
     end
 
     def build_breadcrumbs_no_explorer(record_info, record_title)
@@ -71,7 +104,7 @@ module Mixins
 
     # TODO: Replace breadcrumb_url with url to right controller (database parameter to controller)
     # and add :url => breadcrumb_url parameter to return hash
-    def special_page_breadcrumb(variable)
+    def special_page_breadcrumb(variable, explorer = false)
       # breadcrumb_url = url(controller_url, notshow, variable.first[:id])
       # EMS has key instead of name
       return if !variable || variable.count != 1
@@ -84,48 +117,40 @@ module Mixins
       else
         title = variable.first[:name]
       end
-      {:title => title} if title
+      {:title => title, :key => (explorer ? x_node : nil)}.compact if title
     end
 
     # Explorer controller methods
 
-    # Get breadcrumbs from the current tree path
-    def current_tree_path(tree, active_node, path = [])
-      result = []
-      result.replace(path)
-      result.push(:title => tree[:text], :key => tree[:key])
-
-      return result if tree[:key] == active_node
+    # Get current item from the tree
+    def current_tree_item(tree)
+      return {:title => tree[:text], :key => tree[:key]} if tree[:key] == x_node
 
       if tree.include?(:nodes)
         tree[:nodes].each do |node|
-          value = current_tree_path(node, active_node, result)
+          value = current_tree_item(node)
           return value if value
         end
       end
       nil
     end
 
-    def build_breadcrumbs_from_tree
-      breadcrumbs = []
-      node = x_node
-      tree = build_tree if node
+    def build_breadcrumb_from_tree
+      breadcrumb = nil
 
-      if tree.present?
-        tree.tree_nodes.each do |subtree|
-          value = current_tree_path(subtree, node)
-          breadcrumbs = value if value
-        end
+      @trees.find { |tree| tree.name == x_active_tree }.tree_nodes.each do |subtree|
+        value = current_tree_item(subtree)
+        breadcrumb = value if value
       end
 
-      breadcrumbs
+      breadcrumb
     end
 
     # Build ancestry parents if user provides an ancestry key
     def ancestry_parents(parent_class, record, title)
       breadcrumbs = []
 
-      while record.ancestry
+      while record.try(:ancestry)
         record = parent_class.find(record.ancestry)
         breadcrumbs.push(:title => record[title], :key => TreeBuilder.build_node_id(record))
       end
@@ -135,18 +160,8 @@ module Mixins
 
     # Helper methods
 
-    def build_tree
-      allowed_features = ApplicationController::Feature.allowed_features(features)
-      # allow tree to load whole path to active_node with lazyload nodes (@sb[:trees][x_active_tree][:open_all] = true ?)
-      allowed_features.find { |f| f.tree_name == x_active_tree.to_s }.build_tree(@sb.deep_dup)
-    end
-
     def accord_title
       features.find { |f| f.accord_name == x_active_accord.to_s }.try(:title)
-    end
-
-    def accord_name
-      features.find { |f| f.accord_name == x_active_accord.to_s }.try(:name)
     end
 
     # Has controller features
@@ -195,6 +210,19 @@ module Mixins
     # return correct node to right cell
     def x_node_right_cell
       @sb[@sb[:active_accord]].presence || x_node
+    end
+
+    def x_node_text_from_session
+      @x_node_text = session[:x_node_text]
+    end
+
+    def x_node_text_save_to_session
+      session[:x_node_text] = @x_node_text
+    end
+
+    def x_node_text=(text)
+      @x_node_text ||= {}
+      @x_node_text[x_active_tree] = CGI.unescape(text) if text.present?
     end
   end
 end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -503,7 +503,6 @@ class ProviderForemanController < ApplicationController
         {:title => _("Management")},
       ],
       :record_title => :hostname,
-      :show_header  => @sb[:action],
     }
   end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -534,7 +534,6 @@ class ServiceController < ApplicationController
         {:title => _("Services")},
         {:title => _("My services")},
       ],
-      :show_header => @sb[:action],
       :record_info => @service,
       :ancestry    => Service,
     }

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -497,7 +497,6 @@ class StorageController < ApplicationController
         {:title => _("Infrastructure")},
         {:title => _("Datastores"), :url => File.join(controller_url, 'explorer')},
       ],
-      :include_record => true,
     }
   end
 

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -251,6 +251,7 @@ class VmCloudController < ApplicationController
         {:title => _("Instances")},
       ],
       :include_record => true,
+      :x_node         => x_node_right_cell
     }
   end
 

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -251,7 +251,6 @@ class VmCloudController < ApplicationController
         {:title => _("Instances")},
       ],
       :include_record => true,
-      :show_header    => @sb[:action],
     }
   end
 

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -81,7 +81,6 @@ class VmInfraController < ApplicationController
         {:title => _("Virtual Machines")},
       ],
       :include_record => true,
-      :show_header    => @sb[:action],
     }
   end
 

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -81,6 +81,7 @@ class VmInfraController < ApplicationController
         {:title => _("Virtual Machines")},
       ],
       :include_record => true,
+      :x_node         => x_node_right_cell
     }
   end
 

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -64,7 +64,6 @@ class VmOrTemplateController < ApplicationController
         {:title => _("Workloads")},
       ],
       :include_record => true,
-      :show_header    => @sb[:action],
     }
   end
 

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -64,6 +64,7 @@ class VmOrTemplateController < ApplicationController
         {:title => _("Workloads")},
       ],
       :include_record => true,
+      :x_node         => x_node_right_cell
     }
   end
 

--- a/app/javascript/components/breadcrumbs/on-click-functions.js
+++ b/app/javascript/components/breadcrumbs/on-click-functions.js
@@ -1,6 +1,6 @@
 export const onClickTree = (controllerName, item) => (
   window.miqCheckForChanges()
-    ? sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, key: item.key } }) : null
+    ? sendDataWithRx({ breadcrumbSelect: { path: `/${controllerName}/tree_select`, item } }) : null
 );
 
 export const onClick = (e) => {

--- a/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
+++ b/app/javascript/spec/breadcrumbs/on-click-functions.spec.js
@@ -39,11 +39,11 @@ describe('Breadcrumbs onClick functions', () => {
       window.miqCheckForChanges = () => true;
       jest.spyOn(window, 'sendDataWithRx');
 
-      onClickTree('pxe', { key: 'xx-11' });
+      onClickTree('pxe', { key: 'xx-11', title: 'My PXE Thing' });
 
       expect(window.sendDataWithRx).toHaveBeenCalledWith({
         breadcrumbSelect: {
-          key: 'xx-11',
+          item: { key: 'xx-11', title: 'My PXE Thing' },
           path: '/pxe/tree_select',
         },
       });

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -7,7 +7,6 @@ describe VmInfraController do
     stub_user(:features => :all)
 
     allow(controller).to receive(:protect_build_tree).and_return(nil)
-    allow(controller).to receive(:data_for_breadcrumbs).and_return({})
     controller.instance_variable_set(:@protect_tree, OpenStruct.new(:name => "name", :locals_for_render => {}))
 
     MiqRegion.seed
@@ -377,6 +376,14 @@ describe VmInfraController do
     post :x_button, :params => {:pressed => 'vm_migrate', :id => vm_vmware_migrateable.id}
     expect(response).to render_template('layouts/_x_edit_buttons')
     expect(response.status).to eq(200)
+  end
+
+  it "show item name in breadcrumbs when migrating" do
+    vm_vmware_migrateable = FactoryBot.create(:vm_vmware, :ems_id => 1, :storage_id => 1)
+    allow(controller).to receive(:x_node).and_return("v-#{vm_vmware_migrateable.id}")
+
+    post :x_button, :params => {:pressed => 'vm_migrate', :id => vm_vmware_migrateable.id}
+    expect(response.body).to include(vm_vmware_migrateable.name)
   end
 
   it 'can Publish selected VM' do


### PR DESCRIPTION
As we decided in https://github.com/ManageIQ/manageiq-ui-classic/issues/5620#issuecomment-522948905

This PR is onholding https://github.com/ManageIQ/manageiq-ui-classic/pull/5776, https://github.com/ManageIQ/manageiq-ui-classic/pull/6056

**Description**

- Removes the tree path from breadcrumbs
- Only selected item is shown
- Accordion serves as a link to root
- Removes all obsolete options for breadcrumbs

New breadcrumb structure

`[MENU]` > `[ACCORDION (root link)]` > `[ITEM (tree node text, name, etc.)]`

When some action

`[MENU]` > `[ACCORDION]` > `[ITEM]` >` [ACTION (right_cell_text, title)] `

**How it works**

1. First visit of the page

The tree is built, the selected node is found and its text is used.

2. Clicking in breadcrumbs/tree

`tree_select` receives ID of the node and TEXT, the text is used as a breadcrumb (see `x_node_text_set` )

3. Going to some action

Yeah, here it starts to be tricky. On Ruby side we cannot get the selected node (without built tree we don't know nothing => same problem as in the issue), so I saved the last text to the session. I know it's not a nice solution, but it's the way how to share variables across Rails application. I will welcome any other solution how to store and share this information!

4. Switching between visited trees

See 3. The last selected text for each tree is stored and used.

5. Switching between accordions

If user switches between accordions and the newly selected tree is not visited, `right_cell_text` is used as a text for breadcrumbs. Sometimes, there is a little variation between the node text and the `right_cell_text` ('All Dialogs' vs 'All service dialogs') but I don't think that is a serious issue)

@miq-bot ivanchuk/no, breadcrumbs

**IVANCHUK**

IVANCHUK would need a slightly different version (one line hast to be changed in the `breadcrumbs_mixin`, because the way how we are building trees was changed since then)

**Some screenshots**

![Screenshot from 2019-08-21 14-47-09](https://user-images.githubusercontent.com/32869456/63433204-09461c80-c423-11e9-8887-cbde57e96be9.png)
![Screenshot from 2019-08-21 14-47-02](https://user-images.githubusercontent.com/32869456/63433205-09461c80-c423-11e9-8e48-e9f821ee3014.png)
![Screenshot from 2019-08-21 14-51-03](https://user-images.githubusercontent.com/32869456/63433255-1f53dd00-c423-11e9-9eb6-9bf74029a563.png)
![Screenshot from 2019-08-21 14-50-56](https://user-images.githubusercontent.com/32869456/63433256-1f53dd00-c423-11e9-9529-1e1affe7cf52.png)

