### PR TITLE
Allow Display in Catalog to stay checked for Catalog Bundle

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1257,7 +1257,7 @@ class CatalogController < ApplicationController
   def get_form_vars
     copy_params_if_present(@edit[:new], params, %i[st_prov_type name description provision_cost catalog_id dialog_id generic_subtype long_description zone_id price retire_fqname reconfigure_fqname fqname])
 
-    @edit[:new][:display] = params[:display] == "1"
+    @edit[:new][:display] = params[:display] == "1" if params[:display] # @edit[:new][:display] should't be changed if params[:display] is not set
     # saving it in @edit as well, to use it later because prov_set_form_vars resets @edit[:new]
     @edit[:st_prov_type] = @edit[:new][:st_prov_type]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1232,6 +1232,18 @@ describe CatalogController do
         end
       end
     end
+
+    context 'adding a Resource while adding/editing Catalog Bundle' do
+      before do
+        controller.params = {:resource_id => '123'}
+        controller.instance_variable_set(:@edit, :new => {:display => true, :tenant_ids => []})
+      end
+
+      it 'remains @edit[:new][:display] to be set to true' do
+        controller.send(:get_form_vars)
+        expect(controller.instance_variable_get(:@edit)[:new][:display]).to be(true)
+      end
+    end
   end
 
   describe '#identify_catalog' do


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1743492
Bug introduced in: https://github.com/ManageIQ/manageiq-ui-classic/pull/5472

This PR adds necessary condition to catalog controller which was removed recently.
`if params[:display]` is needed because after checking _Display in Catalog_ checkbox and then adding a Resource in _Resources_ tab, while adding/editing some _Catalog Bundle_, `params[:display]` is set to `nil` (obviously, because we did not make any change about displaying in Catalog, we just added some Resource) but `@edit[:new][:display] = params[:display] == "1"` is executed anyway - and this leads to the unwanted behavior: `@edit[:new][:display]` is reset from `true` to `false` - and this leads to the fact that _Display in Catalog_ checkbox becomes unchecked.

**After:**
Going back to _Basic Info_ tab, after adding a Resource in _Resources_ tab: checkbox remains checked
![display_after1](https://user-images.githubusercontent.com/13417815/63444396-d017a780-c436-11e9-9265-d2b01dde99fa.png)
Displaying saved Catalog Bundle:
![display_after2](https://user-images.githubusercontent.com/13417815/63444400-d1e16b00-c436-11e9-8b33-c936cb4baa51.png)


