### PR TITLE
Report cleanup

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -431,18 +431,7 @@ class ReportController < ApplicationController
   end
 
   def determine_rr_node_info
-    nodes = x_node.split('-')
-    show_saved_report
-    @record = MiqReportResult.for_user(current_user).find(nodes.last)
-    title_format_args ={
-      :name      => ERB::Util.html_escape(@record.name),
-      :timestamp => format_timezone(@record.created_on, Time.zone, "gt")
-    }
-    @title_for_breadcrumbs = _("Saved Report \"%{name} - %{timestamp}\"") % title_format_args
-    @right_cell_text = (
-      '<h1>%{name}</h1><h4>%{timestamp}</h4><div style="margin-top: 20px"/>' %
-      title_format_args
-    ).html_safe
+    show_saved_report(determine_report_result_id('savedreports'))
     @right_cell_div = "savedreports_list"
   end
 
@@ -504,10 +493,12 @@ class ReportController < ApplicationController
       end
       get_all_reps(nodes[4])
 
-    elsif nodes.length == 6
-      @sb[:last_saved_id] = x_node
+    elsif nodes.length == 6 # Report result selected.
       @sb[:miq_report_id] = nil
-      show_saved
+      report = show_saved_report(determine_report_result_id('report'))
+      if report.blank?
+        self.x_active_tree = :reports_tree
+      end
     end
 
     @right_cell_div ||= "report_list"

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1326,10 +1326,10 @@ describe ReportController do
           controller.params = {:id => report_result_id,
                                :controller => "report",
                                :action => "explorer"}
-          controller.instance_variable_set(:@sb, :last_savedreports_id => nil)
+          controller.instance_variable_set(:@sb, {})
           controller.instance_variable_set(:@settings, :perpage => { :reports => 20 })
           allow(controller).to receive(:get_all_reps)
-          controller.send(:show_saved_report)
+          controller.send(:show_saved_report, report_result_id)
 
           fetched_report_result_id = controller.instance_variable_get(:@report_result_id)
           expect(fetched_report_result_id).to eq(@rpt.miq_report_results.first.id)


### PR DESCRIPTION
I noticed that the new nice titles for reports where only available under the report results tree.

Looking into that I found 2 code paths doing basically the same.

By unifying those 2 there are now the same titles in both places (under both trees).

### After:
![rep-tit-2019-08-21_20-04](https://user-images.githubusercontent.com/51095/63456308-e7fb2580-c44e-11e9-8088-845c87cfee85.png)
