### PR TITLE
[WIP] Add a second redux store, without history

### DIFF
--- a/app/javascript/miq-redux/middleware.js
+++ b/app/javascript/miq-redux/middleware.js
@@ -18,8 +18,8 @@ export const taggingMiddleware = store => next => action => {
 }
 
 export default history => [
-  routerMiddleware(history),
-  taggingMiddleware,
+  history && routerMiddleware(history),
+  taggingMiddleware,  // FIXME: this should be added by tagging code, not globally
   thunk,
   promiseMiddleware(),
-];
+].filter(truthy => truthy);

--- a/app/javascript/miq-redux/store.js
+++ b/app/javascript/miq-redux/store.js
@@ -3,15 +3,13 @@ import createReducer from './reducer';
 import createMiddlewares from './middleware';
 import { history } from '../miq-component/react-history.js';
 
-const initialState = {};
-
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-const initializeStore = () => {
+const initializeStore = (initialState = {}, useHistory = true) => {
   const store = createStore(
-    createReducer({ history }),
+    createReducer(useHistory ? { history } : {}),
     initialState,
-    composeEnhancers(applyMiddleware(...createMiddlewares(history))),
+    composeEnhancers(applyMiddleware(...createMiddlewares(useHistory && history))),
   );
 
   /**
@@ -31,7 +29,7 @@ const initializeStore = () => {
      * replace current reducer with new function containing all new reducers
      * must be connected to router again
      */
-    store.replaceReducer(createReducer({ asyncReducers: store.asyncReducers, history }));
+    store.replaceReducer(createReducer({ asyncReducers: store.asyncReducers, history: useHistory ? history : null }));
     return store;
   };
   return store;

--- a/app/javascript/packs/application-common.js
+++ b/app/javascript/packs/application-common.js
@@ -32,6 +32,7 @@ ManageIQ.component = {
 };
 
 const store = initializeStore();
+const ephemeralStore = initializeStore({}, false);
 
 ManageIQ.redux = {
   store,
@@ -40,6 +41,11 @@ ManageIQ.redux = {
   ...createReduxRoutingActions(store),
   formButtonsActions: createFormButtonsActions(store),
   formButtonsActionTypes: { ...formButtonsActionTypes },
+  ephemeral: {
+    addReducer: ephemeralStore.injectReducers,
+    dispatch: ephemeralStore.dispatch,
+    store: ephemeralStore,
+  },
 };
 
 ManageIQ.angular.rxSubject = rxSubject;


### PR DESCRIPTION
the idea is to have a store that won't get synced
and it should probably ignore history

@skateman does this work for you?

(`ManageIQ.redux.ephemeral.store`, ``ManageIQ.redux.ephemeral.addReducer(...)`, `ManageIQ.redux.ephemeral.dispatch(...)`)