### PR TITLE
VmReconfigure: convert ActionController::Parameters to hash.

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -405,7 +405,7 @@ module Mixins
              params[params_key].each do |_key, p|
                p.transform_values! { |v| eval_if_bool_string(v) }
              end
-             options[options_key] = params[params_key].values
+             options[options_key] = params[params_key].values.map(&:to_unsafe_h)
            end
 
           if params[:id] && params[:id] != 'new'


### PR DESCRIPTION
Convert hash coming from params to notmal hash. Following Rails 5.1
upgrade.

https://bugzilla.redhat.com/show_bug.cgi?id=1740628

ping @h-kataria 