### PR TITLE
Eliminate Indexes hash node in Ops/Database 🌳

### DIFF
--- a/app/controllers/ops_controller/db.rb
+++ b/app/controllers/ops_controller/db.rb
@@ -108,16 +108,9 @@ module OpsController::Db
       @tab_text = _("Tables")
     elsif @sb[:active_tab] == "db_indexes" || params[:action] == "x_show" # if table is selected
       nodes = x_node.split('-')
-      if nodes.first == "xx"
-        tb = VmdbTableEvm.find(nodes.last)
-        @indexes = get_indexes(tb)
-        @right_cell_text = _("Indexes for VMDB Table \"%{name}\"") % {:name => tb.name}
-        @tab_text = "%{table_name} Indexes" % {:table_name => tb.name}
-      else
-        @vmdb_index = VmdbIndex.find(nodes.last)
-        @right_cell_text = _("VMDB Index \"%{name}\"") % {:name => @vmdb_index.name}
-        @tab_text = @vmdb_index.name
-      end
+      @vmdb_index = VmdbIndex.find(nodes.last)
+      @right_cell_text = _("VMDB Index \"%{name}\"") % {:name => @vmdb_index.name}
+      @tab_text = @vmdb_index.name
     elsif @sb[:active_tab] == "db_utilization"
       @record = VmdbTable.find(x_node.split('-').last)
       perf_gen_init_options # Initialize perf chart options, charts will be generated async
@@ -132,11 +125,6 @@ module OpsController::Db
       @right_cell_text = _("VMDB Table \"%{name}\"") % {:name => @table.name}
       @tab_text = @table.name
     end
-  end
-
-  def get_indexes(tb)
-    return [] unless tb.kind_of?(VmdbTableEvm)
-    tb.vmdb_indexes.sort_by(&:name)
   end
 
   def db_refresh

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -22,23 +22,8 @@ class TreeBuilderOpsVmdb < TreeBuilder
   end
 
   # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only)
-    vmdb_table_id = object[:id].split("|").last.split('-').last
-    vmdb_indexes  = VmdbIndex.includes(:vmdb_table).where(:vmdb_tables => {:type => 'VmdbTableEvm', :id => vmdb_table_id})
-    count_only_or_objects(count_only, vmdb_indexes, "name")
-  end
-
   def x_get_tree_vmdb_table_kids(object, count_only)
-    return 1 if count_only # each table has one indexes subdir
-
-    [
-      {
-        :id     => object.id.to_s,
-        :text   => _("Indexes"),
-        :icon   => "pficon pficon-folder-close",
-        :tip    => _("Indexes"),
-        :expand => true # load this node expanded with its children
-      }
-    ]
+    vmdb_indexes = VmdbIndex.includes(:vmdb_table).where(:vmdb_tables => {:type => 'VmdbTableEvm', :id => object.id})
+    count_only_or_objects(count_only, vmdb_indexes, "name")
   end
 end


### PR DESCRIPTION
Resolves https://github.com/ManageIQ/manageiq-ui-classic/issues/6082 by dropping the `Indexes` hash node. You can access this tree by selecting the `Database` accordion under OPS.

**Before:**
![Screenshot from 2019-08-22 13-36-42](https://user-images.githubusercontent.com/649130/63515417-1cbcba80-c4eb-11e9-9736-9dfc05192241.png)

**After:**
![Screenshot from 2019-08-22 13-39-21](https://user-images.githubusercontent.com/649130/63515421-1fb7ab00-c4eb-11e9-8e89-3e9d3c9460fc.png)

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label ux/review, hammer/no, ivanchuk/no, trees, cleanup