### PR TITLE
Add titles for editor of service dialogs

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -139,6 +139,7 @@ class MiqAeCustomizationController < ApplicationController
               else
                 Dialog.new
               end
+    @title = @record.id ? _("Editing %{name} Service Dialog") % {:name => @record.name} : _("Add a new Dialog")
   end
 
   def tree_select

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -540,4 +540,22 @@ describe MiqAeCustomizationController do
       controller.send(:replace_right_cell, :replace_trees => %i(ab old_dialogs dialogs))
     end
   end
+
+  describe "#editor" do
+    let(:dialog) { FactoryBot.create(:dialog) }
+
+    it "sets title correctly when adding" do
+      controller.send(:editor)
+
+      expect(controller.instance_variable_get(:@title)).to include("Add a new Dialog")
+    end
+
+    it "sets title correctly when editing" do
+      controller.params = {:id => dialog.id}
+      controller.send(:editor)
+
+      expect(controller.instance_variable_get(:@title)).to include("Editing")
+      expect(controller.instance_variable_get(:@title)).to include(dialog.name)
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741241

**Description**

Service dialog editor do not have specific titles, so they cannot be displayed in the breadcrumbs.

This PR only adds titles, https://github.com/ManageIQ/manageiq-ui-classic/pull/6073 will show them in breadcrumbs.

**Before**

Edit/Add
![image](https://user-images.githubusercontent.com/32869456/63516182-cf414d00-c4ec-11e9-88b2-81d77fa02dc8.png)



**After**
Add

![image](https://user-images.githubusercontent.com/32869456/63516055-84bfd080-c4ec-11e9-88f6-7332de3d8645.png)

Editing

![image](https://user-images.githubusercontent.com/32869456/63516041-796ca500-c4ec-11e9-906a-cc2092747358.png)



@miq-bot add_label bug, ivanchuk/yes, changelog/yes