### PR TITLE
Optimization - html title for saved reports

### DIFF
--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -65,7 +65,7 @@ class OptimizationController < ApplicationController
   def show
     @record = find_record_with_rbac(MiqReportResult, params[:id])
     @report = find_record_with_rbac(MiqReport, params[:report_id] || @record.miq_report_id)
-    @title = @record.name
+    @right_cell_text, @title = ReportController::SavedReports.saved_report_title(@record)
   end
 
   def queue_report

--- a/spec/controllers/optimization_controller_spec.rb
+++ b/spec/controllers/optimization_controller_spec.rb
@@ -108,14 +108,14 @@ describe OptimizationController do
       end
 
       it "uses saved report name for title" do
-        expect(controller.title).to eq(saved.name)
+        expect(controller.title).to match(/Saved Report.*saved/)
       end
 
       it "sets breadcrumbs right" do
-        expect(controller.data_for_breadcrumbs.pluck(:title)).to eq(['Overview',
-                                                                     'Optimization',
-                                                                     report.name,
-                                                                     saved.name])
+        expect(controller.data_for_breadcrumbs.pluck(:title)).to match(['Overview',
+                                                                        'Optimization',
+                                                                        report.name,
+                                                                        a_string_matching(/Saved Report.*saved/)])
       end
 
       context "even if report.name and saved.name match" do
@@ -127,10 +127,10 @@ describe OptimizationController do
         end
 
         it "sets breadcrumbs right" do
-          expect(controller.data_for_breadcrumbs.pluck(:title)).to eq(['Overview',
-                                                                       'Optimization',
-                                                                       report.name,
-                                                                       saved.name])
+          expect(controller.data_for_breadcrumbs.pluck(:title)).to match(['Overview',
+                                                                          'Optimization',
+                                                                          report.name,
+                                                                          a_string_matching(/Saved Report/)])
         end
 
         it "links to both parents" do


### PR DESCRIPTION
Overview > Optimization - click on a report with results, click on a report result

similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/6035 and https://github.com/ManageIQ/manageiq-ui-classic/pull/6076,

this is the 3rd place we're showing saved reports in, all should have consistent titles :).

Before:

![before](https://user-images.githubusercontent.com/289743/63516521-90a39680-c4dc-11e9-8bad-0e469fb62504.png)


After:

![after](https://user-images.githubusercontent.com/289743/63516524-926d5a00-c4dc-11e9-9986-88a04aa63171.png)

Cc @martinpovolny 