### PR TITLE
Needed to pass in `action` to fix form button display in form

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -58,7 +58,7 @@ module ApplicationController::Buttons
       @in_a_form = true
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
-      replace_right_cell(:nodetype => "group_reorder")
+      replace_right_cell(:nodetype => "group_reorder", :action => "group_reorder")
     end
   end
 


### PR DESCRIPTION
Catalog controller `replace_right_cell` method expects `action` to be passed in to display form buttons on reorder buttons form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744459

before
![before](https://user-images.githubusercontent.com/3450808/63537117-014db180-c4e3-11e9-939a-aa19b01b2120.png)

after
![after](https://user-images.githubusercontent.com/3450808/63537123-0448a200-c4e3-11e9-9090-84c16d89fb38.png)
