### PR TITLE
Clean up the building of my/global filters in TreeBuilders that contain them

### DIFF
--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -1,4 +1,5 @@
 class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
+  include TreeBuilderFiltersMixin
   has_kids_for ManageIQ::Providers::AnsibleTower::AutomationManager, [:x_get_tree_cmat_kids]
 
   private
@@ -23,17 +24,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
       objects.push(temp)
     end
 
-    objects.push(:id         => "global",
-                 :text       => _("Global Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :tip        => _("Global Shared Filters"),
-                 :selectable => false)
-    objects.push(:id         => "my",
-                 :text       => _("My Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :tip        => _("My Personal Filters"),
-                 :selectable => false)
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, objects + FILTERS.values)
   end
 
   def x_get_tree_cmat_kids(object, count_only)

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -33,7 +33,6 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only)
-    objects = MiqSearch.where(:db => "ConfigurationScript").filters_by_type(object[:id])
-    count_only_or_objects(count_only, objects, 'description')
+    count_only_or_filter_kids("ConfigurationScript", object, count_only)
   end
 end

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -8,25 +8,7 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only)
-    count_only_or_objects(count_only, x_get_search_results(object))
-  end
-
-  def x_get_search_results(object)
-    case object[:id]
-    when "global" # Global filters
-      x_get_global_filter_search_results
-    when "my"     # My filters
-      x_get_my_filter_search_results
-    end
-  end
-
-  def x_get_global_filter_search_results
-    MiqSearch.where(:db => @root_class).visible_to_all.sort_by { |a| a.description.downcase }
-  end
-
-  def x_get_my_filter_search_results
-    MiqSearch.where(:db => @root_class, :search_type => "user", :search_key => User.current_user.userid)
-             .sort_by { |a| a.description.downcase }
+    count_only_or_filter_kids(@root_class, object, count_only)
   end
 
   # Get root nodes count/array for explorer tree

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -1,4 +1,6 @@
 class TreeBuilderConfiguredSystems < TreeBuilder
+  include TreeBuilderFiltersMixin
+
   private
 
   def tree_init_options
@@ -31,16 +33,6 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   def x_get_tree_roots(count_only)
     objects = []
     objects.push(configured_systems)
-    objects.push(:id         => "global",
-                 :text       => _("Global Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :tip        => _("Global Shared Filters"),
-                 :selectable => false)
-    objects.push(:id         => "my",
-                 :text       => _("My Filters"),
-                 :icon       => "pficon pficon-folder-close",
-                 :tip        => _("My Personal Filters"),
-                 :selectable => false)
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, objects + FILTERS.values)
   end
 end

--- a/app/presenters/tree_builder_filters_mixin.rb
+++ b/app/presenters/tree_builder_filters_mixin.rb
@@ -19,4 +19,14 @@ module TreeBuilderFiltersMixin
     'global' => GLOBAL_FILTERS,
     'my'     => MY_FILTERS
   }.freeze
+
+  private
+
+  def count_only_or_filter_kids(klass, object, count_only)
+    # Do not try to load filters with invalid types
+    return unless FILTERS.key?(object.try(:[], :id))
+
+    objects = MiqSearch.where(:db => klass).filters_by_type(object[:id])
+    count_only_or_objects(count_only, objects, 'description')
+  end
 end

--- a/app/presenters/tree_builder_filters_mixin.rb
+++ b/app/presenters/tree_builder_filters_mixin.rb
@@ -1,0 +1,22 @@
+module TreeBuilderFiltersMixin
+  GLOBAL_FILTERS = {
+    :id         => "global",
+    :text       => _("Global Filters"),
+    :icon       => "pficon pficon-folder-close",
+    :tip        => _("Global Shared Filters"),
+    :selectable => false
+  }.freeze
+
+  MY_FILTERS = {
+    :id         => "my",
+    :text       => _("My Filters"),
+    :icon       => "pficon pficon-folder-close",
+    :tip        => _("My Personal Filters"),
+    :selectable => false
+  }.freeze
+
+  FILTERS = {
+    'global' => GLOBAL_FILTERS,
+    'my'     => MY_FILTERS
+  }.freeze
+end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -1,4 +1,5 @@
 class TreeBuilderServices < TreeBuilder
+  include TreeBuilderFiltersMixin
   has_kids_for Service, [:x_get_tree_nested_services]
 
   private
@@ -16,19 +17,13 @@ class TreeBuilderServices < TreeBuilder
     }
   end
 
-  def filter_root(id, name, tip)
-    services_root(id, name, tip).update(:selectable => false)
-  end
-
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only)
     objects = [
       services_root('asrv', _('Active Services'), _('Active Services')),
       services_root('rsrv', _('Retired Services'), _('Retired Services')),
-      filter_root('global', _('Global Filters'), _('Global Shared Filters')),
-      filter_root('my', _('My Filters'), _('My Personal Filters'))
     ]
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, objects + FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -29,8 +29,7 @@ class TreeBuilderServices < TreeBuilder
   def x_get_tree_custom_kids(object, count_only)
     case object[:id]
     when 'my', 'global'
-      # Get My Filters and Global Filters
-      count_only_or_objects(count_only, x_get_search_results(object))
+      count_only_or_filter_kids("Service", object, count_only)
     when 'asrv', 'rsrv'
       retired = object[:id] != 'asrv'
       # Cache the tree data to speed up child (count) retrieval
@@ -72,23 +71,5 @@ class TreeBuilderServices < TreeBuilder
       hash.find { |_, value| found = deep_find(value, key) }
       found
     end
-  end
-
-  def x_get_search_results(object)
-    case object[:id]
-    when "global" # Global filters
-      x_get_global_filter_search_results
-    when "my"     # My filters
-      x_get_my_filter_search_results
-    end
-  end
-
-  def x_get_global_filter_search_results
-    MiqSearch.where(:db => "Service").visible_to_all.sort_by { |a| a.description.downcase }
-  end
-
-  def x_get_my_filter_search_results
-    MiqSearch.where(:db => "Service", :search_type => "user", :search_key => User.current_user.userid)
-             .sort_by { |a| a.description.downcase }
   end
 end

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -19,7 +19,6 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only)
-    objects = MiqSearch.where(:db => "Storage").filters_by_type(object[:id])
-    count_only_or_objects(count_only, objects, 'description')
+    count_only_or_filter_kids("Storage", object, count_only)
   end
 end

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -1,4 +1,6 @@
 class TreeBuilderStorage < TreeBuilder
+  include TreeBuilderFiltersMixin
+
   private
 
   def tree_init_options
@@ -13,12 +15,7 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_roots(count_only)
-    objects =
-      [
-        {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},
-        {:id => "my",     :text => _("My Filters"),     :icon => "pficon pficon-folder-close", :tip => _("My Personal Filters"),   :selectable => false}
-      ]
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -25,7 +25,6 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only)
-    objects = MiqSearch.where(:db => @root_class).filters_by_type(object[:id])
-    count_only_or_objects(count_only, objects, 'description')
+    count_only_or_filter_kids(@root_class, object, count_only)
   end
 end

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -1,4 +1,6 @@
 class TreeBuilderVmsFilter < TreeBuilder
+  include TreeBuilderFiltersMixin
+
   def initialize(*args)
     @root_class ||= 'ManageIQ::Providers::InfraManager::Vm'
     super(*args)
@@ -19,12 +21,7 @@ class TreeBuilderVmsFilter < TreeBuilder
   end
 
   def x_get_tree_roots(count_only)
-    objects =
-      [
-        {:id => "global", :text => _("Global Filters"), :icon => "pficon pficon-folder-close", :tip => _("Global Shared Filters"), :selectable => false},
-        {:id => "my",     :text => _("My Filters"),     :icon => "pficon pficon-folder-close", :tip => _("My Personal Filters"),   :selectable => false}
-      ]
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)


### PR DESCRIPTION
I pulled out the definition of filters into constants and built a hash from this constant. I know that the hash seems an overkill in the current codebase (as we're calling just `#values` on it), but it will be useful when reverse building tree hierarchies for breadcrumbs. I also created a new method for fetching the child nodes and now we're using it across all the trees.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5620

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label hammer/no, ivanchuk/no, refactoring, trees