### PR TITLE
[WIP] Introduce the concept of the VirtualFolder AR-like object for 🌳🌳

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -278,7 +278,8 @@ module ApplicationController::Explorer
     kls = modelname.constantize
     return treenodeid if kls == Hash
 
-    unless kls.where(:id => rec_id).exists?
+    # FIXME: temporary hack to skip the refresh for deleted nodes if it's a VirtualFolder
+    unless kls == VirtualFolder || kls.where(:id => rec_id).exists?
       @replace_trees = [@sb[:active_accord]] # refresh trees
       self.x_node = "root"
       unless @report_deleted

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -503,6 +503,7 @@ class TreeBuilder
     "u"    => "User",
     "v"    => "Vm",
     "vap"  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate",
+    "vf"   => "VirtualFolder",
     "vnf"  => "ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate",
     "wi"   => "WindowsImage",
     "xx"   => "Hash", # For custom (non-CI) nodes, specific to each tree

--- a/app/presenters/tree_node/virtual_folder.rb
+++ b/app/presenters/tree_node/virtual_folder.rb
@@ -1,0 +1,7 @@
+module TreeNode
+  class VirtualFolder < Node
+    set_attribute(:id, &:id)
+    set_attribute(:text, &:title)
+    set_attribute(:tooltip, &:title)
+  end
+end

--- a/app/presenters/virtual_folder.rb
+++ b/app/presenters/virtual_folder.rb
@@ -1,0 +1,65 @@
+# Not all TreeNode objects can be mapped to database objects, some serve presentation purposes only. These nodes are
+# hardcoded in our codebase as hashes. The purpose of this VirtualFolder is to bridge together the non-persistent
+# nodes with the persistent ones by faking some ActiveRecord behavior.
+class VirtualFolder
+  extend ActiveModel::Naming
+
+  def self.base_class
+    self
+  end
+
+  def self.base_model
+    model_name
+  end
+
+  # Decorator support
+  if defined?(ManageIQ::Decorators::Engine)
+    extend MiqDecorator::Klass
+    include MiqDecorator::Instance
+  end
+
+  # We're using the singleton class as an ActiveRecord-like store for storing all instances of the VirtualFolder.
+  # The storage is a simple hash indexed by the ID of each VirtualFolder. If you try to create a new instance with
+  # an existing ID, the already existing object will be returned from the registry. This means that all folders
+  # require a unique ID upon creation.
+  class << self
+    def new(id, *params)
+      if exists?(id) # If the instance with the given ID already exists, return it.
+        find(id)
+      else # Otherwise create a new one and register it.
+        create(super(id, *params))
+      end
+    end
+
+    def create(folder)
+      registry[folder.id] = folder
+    end
+
+    def find(id)
+      registry[id]
+    end
+
+    def exists?(id)
+      registry.key?(id)
+    end
+
+    def delete(id)
+      @registry.delete(id)
+    end
+
+    private
+
+    def registry
+      @registry ||= {}
+    end
+  end
+
+  # These two attributes are always required for building the tree node
+  attr_reader :id, :title
+
+  def initialize(id, title, **node_overrides)
+    @id = id
+    @title = title
+    @node_overrides = node_overrides
+  end
+end

--- a/spec/presenters/tree_node/virtual_folder_spec.rb
+++ b/spec/presenters/tree_node/virtual_folder_spec.rb
@@ -1,0 +1,18 @@
+describe TreeNode::VirtualFolder do
+  # This ID has to be unique to not break other tests as we delete it
+  let(:folder_id) { "foo#{rand(512)}" }
+  after { VirtualFolder.delete(folder_id) }
+
+  subject { described_class.new(object, nil, nil) }
+  let(:object) { VirtualFolder.new(folder_id, "bar") }
+
+  include_examples 'TreeNode::Node#key prefix', 'vf-'
+  include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
+  include_examples 'TreeNode::Node#tooltip same as #text'
+
+  describe '#text' do
+    it 'returns the same as object title' do
+      expect(subject.tooltip).to eq(object.title)
+    end
+  end
+end

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -22,8 +22,8 @@ describe TreeNode do
     end
 
     TreeNode.constants.each do |type|
-      # We never instantiate MiqAeNode and Node in our codebase
-      next if %i[MiqAeNode Node Menu Root REXML].include?(type)
+      # We never instantiate some nodes in our codebase
+      next if %i[Menu MiqAeNode Node REXML Root VirtualFolder].include?(type)
 
       describe(type) do
         let(:klass) { type.to_s.constantize }

--- a/spec/presenters/virtual_folder_spec.rb
+++ b/spec/presenters/virtual_folder_spec.rb
@@ -1,0 +1,23 @@
+describe VirtualFolder do
+  # This ID has to be unique to not break other tests as we delete it
+  let(:folder_id) { "foo#{rand(512)}" }
+  after { VirtualFolder.delete(folder_id) }
+
+  describe '.new' do
+    subject { VirtualFolder.new(folder_id, "bar") }
+
+    context "no folders have been instantiated" do
+      it "creates a new VirtualFolder object" do
+        expect(subject).to be_an_instance_of(VirtualFolder)
+      end
+    end
+
+    context "folder with the same ID already exists" do
+      let!(:vf) { VirtualFolder.new(folder_id, "bar") }
+
+      it "returns the already existing VirtualFolder" do
+        expect(subject).to be(vf)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Most of our `TreeNode` classes are 1:1 mapped to database records, which makes the mapping reversible. However, we are excessively using `Hash` nodes for adding custom behavior and also for displaying nodes that aren't mapped to any persistent object. I'm constantly working on replacing the `Hash` nodes with pure record-mapped nodes where possible, but the non-persistent nodes will require a different approach. As most of these nodes are visualy represented as folders, I am naming this new concept the `VirtualFolder`.

The class implements a hybrid singleton/factory pattern with an in-memory persistence for all created instances. Every instance requires an ID and each of them can be instantiated only once. If someone tries to create an instance with an already existing ID, the class will return the already existing instance instead. This is achieved by storing all the possible instances in an internal hash indexed by the previously mentioned IDs.

Each `TreeBuilder` can define its own `VirtualFolder` instances as constants. This can be easily done for most of the `Hash` nodes that can not be 1:1 mapped to a database record. We can refer to these constants even without knowing their ID outside the `TreeBuilder` classes, so it's possible to use them in `get_node_info` for example.

As the class itself behaves like an `ActiveRecord` object, it is possible to call `find` on it, which is being used in `TreeBuilder#node_by_tree_id` and soon we can get rid of the fake partial `Hash` nodes created there. This opens up the possibility of a full reconstruction of the tree hierarchy from any node in any direction. I also defined a [decorator](https://github.com/ManageIQ/manageiq-decorators/pull/16) and a `TreeNode` so it's already possible to render this.

```ruby
class TreeBuilderServices < TreeBuilder
  has_kids_for Service, [:x_get_tree_nested_services]
  has_kids_for VirtualFolder, [:x_get_tree_virtual_kids]

  ACTIVE_SERVICES = VirtualFolder.new('asrv', _("Active Services"))
  RETIRED_SERVICES = VirtualFolder.new('rsrv', _("Retired Services"))
  # ...
  def x_get_tree_roots(count_only)
    objects = [
      ACTIVE_SERVICES, RETIRED_SERVICES,
      filter_root('global', _('Global Filters'), _('Global Shared Filters')),
      filter_root('my', _('My Filters'), _('My Personal Filters'))
    ]
    count_only_or_objects(count_only, objects)
  end
```

**Problem:**
The only single problem with this approach is that the `VirtualNode` instances are being created dynamically. This combined with the dynamic code loading can cause some non-deterministic behavior when searching for instances. This can only happen if we're trying to look up a node for a tree that has not been loaded yet. For example when jumping into a child node of a `TreeBuilder` that has been never loaded/constantized before. 

This is just a theoretical issue and we are might not affected at all. I still have to do some research about it, but if nothing works, I have three possible solutions:

**Solution 1:**
Jumping between accordions is not a problem, as all the trees are defined in the controller in advance and we are loading all of them. For the rest, we should just make sure to use the defined constants as mentioned above and it becomes safe.

**Solution 2:**
We can define the constants in the related controllers, or just simply make sure that the trees are always being loaded when dealing with that controller.

**Solution 3:**
As a very primitive fallback, we could force-load the trees when initializing the codebase:
```ruby
TreeBuilder::LEFT_TREE_CLASSES.each(&:constantize)
```

I know this idea is bold and has a lot of :sparkles: magic :sparkles: in it, but we definitely need a store where we can keep our nodes to be able to reconstruct the node path for our breadcrumbs. Also this would make our codebase much cleaner as we would not do any more string comparison when parsing node info.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @rvsia 
@miq-bot add_label enhancement, hammer/no, ivanchuk/no, trees

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5620