### PR TITLE
Extract a separate TreeNode::MiqAeDomain from TreeNode::MiqAeNamespace

### DIFF
--- a/app/presenters/tree_node/miq_ae_domain.rb
+++ b/app/presenters/tree_node/miq_ae_domain.rb
@@ -2,22 +2,7 @@ module TreeNode
   class MiqAeDomain < MiqAeNode
     include MiqAeClassHelper
 
-    set_attributes(:icon, :image) do
-      # Having a "flat" case here makes the code more readable
-      # rubocop:disable LiteralAsCondition
-      case true
-      when @object.git_enabled?
-        image = 'svg/ae_git_domain.svg'
-      when @object.name == MiqAeDatastore::MANAGEIQ_DOMAIN
-        icon = 'ff ff-manageiq'
-      when !@object.top_level_namespace
-        icon = 'fa fa-globe'
-      else
-        image = "svg/vendor-#{@object.top_level_namespace.downcase}.svg"
-      end
-      # rubocop:enable LiteralAsCondition
-      [icon, image]
-    end
+    set_attribute(:image) { @object.try(:decorate).try(:fileicon) }
 
     def text
       title = super

--- a/app/presenters/tree_node/miq_ae_domain.rb
+++ b/app/presenters/tree_node/miq_ae_domain.rb
@@ -1,0 +1,36 @@
+module TreeNode
+  class MiqAeDomain < MiqAeNode
+    include MiqAeClassHelper
+
+    set_attributes(:icon, :image) do
+      # Having a "flat" case here makes the code more readable
+      # rubocop:disable LiteralAsCondition
+      case true
+      when @object.git_enabled?
+        image = 'svg/ae_git_domain.svg'
+      when @object.name == MiqAeDatastore::MANAGEIQ_DOMAIN
+        icon = 'ff ff-manageiq'
+      when !@object.top_level_namespace
+        icon = 'fa fa-globe'
+      else
+        image = "svg/vendor-#{@object.top_level_namespace.downcase}.svg"
+      end
+      # rubocop:enable LiteralAsCondition
+      [icon, image]
+    end
+
+    def text
+      title = super
+      editable_domain = editable_domain?(@object)
+      enabled_domain  = @object.enabled
+
+      unless editable_domain && enabled_domain
+        title = add_read_only_suffix(title, editable_domain, enabled_domain)
+      end
+
+      title
+    end
+
+    set_attribute(:klass) { @object.enabled? ? nil : 'opacity' }
+  end
+end

--- a/app/presenters/tree_node/miq_ae_namespace.rb
+++ b/app/presenters/tree_node/miq_ae_namespace.rb
@@ -1,45 +1,4 @@
 module TreeNode
   class MiqAeNamespace < MiqAeNode
-    include MiqAeClassHelper
-
-    set_attributes(:icon, :image) do
-      # Having a "flat" case here makes the code more readable
-      # rubocop:disable LiteralAsCondition
-      case true
-      when !@object.domain?
-        icon = @object.decorate.fonticon
-      when @object.git_enabled?
-        image = 'svg/ae_git_domain.svg'
-      when @object.name == MiqAeDatastore::MANAGEIQ_DOMAIN
-        icon = 'ff ff-manageiq'
-      when !@object.top_level_namespace
-        icon = 'fa fa-globe'
-      else
-        image = "svg/vendor-#{@object.top_level_namespace.downcase}.svg"
-      end
-      # rubocop:enable LiteralAsCondition
-      [icon, image]
-    end
-
-    set_attribute(:klass) { @object.domain? && !@object.enabled? ? 'opacity' : nil }
-
-    def text
-      title = super
-      if @object.domain?
-        editable_domain = editable_domain?(@object)
-        enabled_domain  = @object.enabled
-
-        unless editable_domain && enabled_domain
-          title = add_read_only_suffix(title, editable_domain, enabled_domain)
-        end
-      end
-      title
-    end
-
-    private
-
-    def model
-      @object.domain? ? 'MiqAeDomain' : super
-    end
   end
 end

--- a/app/presenters/tree_node/miq_ae_node.rb
+++ b/app/presenters/tree_node/miq_ae_node.rb
@@ -1,15 +1,9 @@
 module TreeNode
   class MiqAeNode < Node
-    set_attribute(:tooltip) { "#{ui_lookup(:model => model)}: #{text}" }
+    set_attribute(:tooltip) { "#{ui_lookup(:model => @object.class.to_s)}: #{text}" }
 
     def text
       @object.display_name.blank? ? @object.name : "#{@object.display_name} (#{@object.name})"
-    end
-
-    private
-
-    def model
-      @object.class.to_s
     end
   end
 end

--- a/spec/presenters/tree_node/miq_ae_domain_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_domain_spec.rb
@@ -1,0 +1,41 @@
+describe TreeNode::MiqAeDomain do
+  before { login_as FactoryBot.create(:user_with_group) }
+  subject { described_class.new(object, nil, nil) }
+  let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1") }
+
+  describe '#title' do
+    it 'returns without any suffix' do
+      expect(subject.text).to eq('test1')
+    end
+  end
+
+  context 'disabled' do
+    let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1", :enabled => false) }
+
+    describe '#title' do
+      it 'returns disabled in the suffix' do
+        expect(subject.text).to eq('test1 (Disabled)')
+      end
+    end
+  end
+
+  context 'locked' do
+    let(:object) { FactoryBot.create(:miq_ae_system_domain_enabled, :name => "test1") }
+
+    describe '#title' do
+      it 'returns locked in the suffix' do
+        expect(subject.text).to eq('test1 (Locked)')
+      end
+    end
+  end
+
+  context 'locked & disabled' do
+    let(:object) { FactoryBot.create(:miq_ae_system_domain, :name => "test1") }
+
+    describe '#title' do
+      it 'returns both locked and disabled in the suffix' do
+        expect(subject.text).to eq('test1 (Locked & Disabled)')
+      end
+    end
+  end
+end

--- a/spec/presenters/tree_node/miq_ae_namespace_spec.rb
+++ b/spec/presenters/tree_node/miq_ae_namespace_spec.rb
@@ -1,53 +1,9 @@
 describe TreeNode::MiqAeNamespace do
-  before { login_as FactoryBot.create(:user_with_group) }
   subject { described_class.new(object, nil, nil) }
 
-  let(:object) do
-    domain = FactoryBot.create(:miq_ae_domain)
-    FactoryBot.create(:miq_ae_namespace, :parent => domain)
-  end
+  let(:object) { FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain)) }
 
   include_examples 'TreeNode::Node#key prefix', 'aen-'
   include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
   include_examples 'TreeNode::Node#tooltip prefix', 'Automate Namespace'
-
-  context 'MiqAeDomain' do
-    let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1") }
-
-    describe '#title' do
-      it 'returns without any suffix' do
-        expect(subject.text).to eq('test1')
-      end
-    end
-
-    context 'disabled' do
-      let(:object) { FactoryBot.create(:miq_ae_domain, :name => "test1", :enabled => false) }
-
-      describe '#title' do
-        it 'returns disabled in the suffix' do
-          expect(subject.text).to eq('test1 (Disabled)')
-        end
-      end
-    end
-
-    context 'locked' do
-      let(:object) { FactoryBot.create(:miq_ae_system_domain_enabled, :name => "test1") }
-
-      describe '#title' do
-        it 'returns locked in the suffix' do
-          expect(subject.text).to eq('test1 (Locked)')
-        end
-      end
-    end
-
-    context 'locked & disabled' do
-      let(:object) { FactoryBot.create(:miq_ae_system_domain, :name => "test1") }
-
-      describe '#title' do
-        it 'returns both locked and disabled in the suffix' do
-          expect(subject.text).to eq('test1 (Locked & Disabled)')
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
They are each other's STI children, so we can get rid of a bunch of conditional logic by creating a new 🌳node class. Also the icon/image logic has been extracted to a newly created decorator.

Depends on: https://github.com/ManageIQ/manageiq-decorators/pull/17
@miq-bot add_label pending core, ivanchuk/no, refactoring, trees
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @ZitaNemeckova 