### PR TITLE
Simplify TreeNode image definition by always using the decorators

### DIFF
--- a/app/presenters/tree_node/ext_management_system.rb
+++ b/app/presenters/tree_node/ext_management_system.rb
@@ -1,7 +1,5 @@
 module TreeNode
   class ExtManagementSystem < Node
-    set_attribute(:image) { @object.decorate.fileicon }
-
     set_attribute(:tooltip) do
       # # TODO: This should really leverage .base_model on an EMS
       prefix_model = case @object

--- a/app/presenters/tree_node/generic_object_definition.rb
+++ b/app/presenters/tree_node/generic_object_definition.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class GenericObjectDefinition < Node
-    set_attribute(:image) { @object.decorate.fileicon }
   end
 end

--- a/app/presenters/tree_node/miq_ae_domain.rb
+++ b/app/presenters/tree_node/miq_ae_domain.rb
@@ -2,8 +2,6 @@ module TreeNode
   class MiqAeDomain < MiqAeNode
     include MiqAeClassHelper
 
-    set_attribute(:image) { @object.try(:decorate).try(:fileicon) }
-
     def text
       title = super
       editable_domain = editable_domain?(@object)

--- a/app/presenters/tree_node/miq_ae_method.rb
+++ b/app/presenters/tree_node/miq_ae_method.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class MiqAeMethod < MiqAeNode
-    set_attribute(:image) { @object.try(:decorate).try(:fileicon) }
   end
 end

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -17,7 +17,7 @@ module TreeNode
     end
 
     def image
-      nil
+      @object.try(:decorate).try(:fileicon)
     end
 
     def icon

--- a/app/presenters/tree_node/service.rb
+++ b/app/presenters/tree_node/service.rb
@@ -1,12 +1,4 @@
 module TreeNode
   class Service < Node
-    set_attributes(:image, :icon) do
-      if @object.picture
-        image = @object.decorate.fileicon
-      else
-        icon = @object.decorate.fonticon
-      end
-      [image, icon]
-    end
   end
 end

--- a/app/presenters/tree_node/service_template.rb
+++ b/app/presenters/tree_node/service_template.rb
@@ -1,14 +1,5 @@
 module TreeNode
   class ServiceTemplate < Node
-    set_attributes(:image, :icon) do
-      if @object.picture
-        image = @object.decorate.fileicon
-      else
-        icon = @object.decorate.fonticon
-      end
-      [image, icon]
-    end
-
     set_attribute(:text) do
       if @object.tenant.ancestors.empty?
         @object.name

--- a/app/presenters/tree_node/windows_image.rb
+++ b/app/presenters/tree_node/windows_image.rb
@@ -1,5 +1,4 @@
 module TreeNode
   class WindowsImage < Node
-    set_attribute(:image) { @object.decorate.fileicon }
   end
 end


### PR DESCRIPTION
As we're always using decorators for setting the node images and they always have a higher priority than icons, we can simplify the codebase a little. The `TreeNode::Node` class already derived the `icon` attribute from the decorators, so I did the same for images.

Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/6093
@miq-bot add_label pending core, ivanchuk/no, trees, cleanup
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @epwinchell 