### PR TITLE
Remove some legacy 🌳node conversion code for CSS classes and lazy loading

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -106,7 +106,6 @@ class TreeBuilder
     while stack.any?
       node = stack.pop
       stack += node[:nodes] if node.key?(:nodes)
-      node[:lazyLoad] = node.delete(:isLazy) if node.key?(:isLazy)
       node[:state] ||= {}
       node[:state][:expanded] = node.delete(:expand) if node.key?(:expand)
       node[:state][:checked] = node.delete(:select) if node.key?(:select)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -109,9 +109,7 @@ class TreeBuilder
       node[:state] ||= {}
       node[:state][:expanded] = node.delete(:expand) if node.key?(:expand)
       node[:state][:checked] = node.delete(:select) if node.key?(:select)
-      node[:class] = ''
-      node[:class] = node.delete(:addClass) if node.key?(:addClass) && !node[:addClass].nil?
-      node[:class] = node[:class].split(' ').push('no-cursor').join(' ') if node[:selectable] == false
+      node[:class] = (node[:class] || '').split(' ').push('no-cursor').join(' ') if node[:selectable] == false
     end
     nodes
   end

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -87,7 +87,7 @@ module TreeNode
         :iconColor      => color,
         :expand         => expand,
         :hideCheckbox   => hide_checkbox,
-        :addClass       => klass,
+        :class          => klass,
         :selectable     => selectable,
         :select         => selected,
         :checkable      => checkable ? nil : false,

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -119,8 +119,7 @@ describe ReportController do
                    :icon       => 'fa fa-file-text-o',
                    :tooltip    => widget.name,
                    :state      => {:expanded => false},
-                   :selectable => true,
-                   :class      => ""}]
+                   :selectable => true}]
       expect(nodes).to eq(expected)
     end
   end

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -941,7 +941,6 @@ describe MiqAeClassController do
             :selectable => true,
             :lazyLoad   => true,
             :state      => {:expanded => false},
-            :class      => "",
           }
         ]
       }

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -55,17 +55,14 @@ describe TreeBuilderRolesByServer do
                                   'iconBackground' => '#3F9C35',
                                   'text'           => "<strong>Role: SmartProxy</strong> (primary, active, PID=)",
                                   'state'          => {'expanded' => true},
-                                  'selectable'     => true,
-                                  'class'          => ''},
+                                  'selectable'     => true},
                                  {'key'            => "asr-#{@assigned_server_role2.id}",
                                   'icon'           => 'pficon pficon-on',
                                   'iconBackground' => '#3F9C35',
                                   'text'           => "<strong>Role: SmartProxy</strong> (secondary, active, PID=)",
                                   'state'          => {'expanded' => true},
-                                  'selectable'     => true,
-                                  'class'          => ''},],
-                'state'      => {'expanded' => true, 'selected' => true},
-                'class'      => ''}]
+                                  'selectable'     => true}],
+                'state'      => {'expanded' => true, 'selected' => true}}]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end
   end

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -58,16 +58,14 @@ describe TreeBuilderServersByRole do
                                   'text'           => "<strong>Server: smartproxy [#{@assigned_server_role1.id}]</strong> (primary, available, PID=)",
                                   'state'          => { 'expanded' => true },
                                   'selectable'     => true,
-                                  'class'          => 'red', },
+                                  'class'          => 'red'},
                                  {'key'            => "asr-#{@assigned_server_role2.id}",
                                   'icon'           => 'pficon pficon-on',
                                   'iconBackground' => '#3F9C35',
                                   'text'           => "<strong>Server: smartproxy [#{@assigned_server_role2.id}]</strong> (secondary, active, PID=)",
                                   'state'          => { 'expanded' => true },
-                                  'selectable'     => true,
-                                  'class'          => ''}],
-                'state'      => { 'expanded' => true, "selected" => true},
-                'class'      => '' }]
+                                  'selectable'     => true}],
+                'state'      => { 'expanded' => true, "selected" => true}}]
       expect(JSON.parse(@server_tree.locals_for_render[:bs_tree])).to eq(nodes)
     end
   end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -36,19 +36,16 @@ describe TreeBuilder do
                                'icon'       => "pficon pficon-cpu",
                                'state'      => { 'expanded' => true },
                                'text'       => "Compute",
-                               'selectable' => true,
-                               'class'      => ''},
+                               'selectable' => true},
                               {'key'        => "xx-Storage",
                                'tooltip'    => "Storage",
                                'icon'       => "fa fa-hdd-o",
                                'state'      => { 'expanded' => true },
                                'selectable' => true,
-                               'text'       => "Storage",
-                               'class'      => ''}],
+                               'text'       => "Storage"}],
                 'state'   => { 'expanded' => true },
                 'text'    => "Rates",
                 'tooltip' => "Rates",
-                'class'   => '',
                 'icon'    => 'pficon pficon-folder-close'}]
       tree.locals_for_render.key?(:bs_tree)
       expect(JSON.parse(tree.locals_for_render[:bs_tree])).to eq(nodes)


### PR DESCRIPTION
Lazy loading is being set using the `:lazyLoad` attribute on a single place in `TreeBuilder#x_build_node`. The legacy `:isLazy` attribute is no longer used, so it's safe to drop it from the `convert_bs_tree` method.

The `addClass` attribute has been used only on a single place in `TreeNode#to_h` and then converted to `:class` in `convert_bs_tree`. Instead of this conversion, we can set it directly, which lets us delete a few extra lines from the conversion code.

@miq-bot add_label ivanchuk/no, trees, refactoring, cleanup
@miq-bot add_reviewer @ZitaNemeckova 