### PR TITLE
Drop the node text override from AlertProfile assignment 🌳🌳

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,8 +8,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object)
-    node[:text] = (object.name.presence || object.description) unless object.kind_of?(MiddlewareServer)
-    node[:hideCheckbox] = false
     node[:select] = @selected.try(:include?, object.id)
   end
 


### PR DESCRIPTION
All the nodes have their own definition of `text`, so there's no need for overriding. You can find these :deciduous_tree: :deciduous_tree: under `Control -> Explorer -> Alert Profiles` when you try to edit the assignments of an existing alert profile. Also dropping the unnecessary `hideCheckbox` override as it's by default alwas `false`.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, ivanchuk/no, trees