### PR TITLE
Add Back button to policy simulation page for non-explorer

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -98,6 +98,8 @@ module ApplicationController::PolicySupport
         @refresh_partial = "layouts/policy_sim"
         replace_right_cell(:refresh_breadcrumbs => false)
       end
+    else
+      session[:edit] = @edit
     end
   end
 

--- a/app/views/vm_common/_policies.html.haml
+++ b/app/views/vm_common/_policies.html.haml
@@ -12,3 +12,12 @@
 
   = _('* Items in <font color="red"><i>red italics</i></font> do not change the outcome of the scope or expression.').html_safe
 
+- unless @explorer
+  #buttons{:align => 'right'}
+    -# Go back to policy simulation screen
+    = link_to(_('Back'),
+              {:action => 'policy_sim', :continue => true, :controller => 'vm'},
+               :class  => 'btn btn-default',
+               :alt    => t = _('Back'),
+               :title  => t,
+               :method => :post)

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -66,4 +66,20 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#policy_sim' do
+    let(:vm) { FactoryBot.create(:vm_infra) }
+
+    before do
+      allow(controller).to receive(:drop_breadcrumb)
+      allow(controller).to receive(:session).and_return(:tag_db => VmOrTemplate, :tag_items => [vm])
+      allow(controller).to receive(:vm_or_instance).and_return('vm_infra')
+      controller.params = {:action => 'policy_sim', :continue => true, :controller => 'vm'}
+    end
+
+    it 'sets session[:edit] when going back to policy simulation, in non-explorer screen' do
+      controller.send(:policy_sim)
+      expect(controller.session).to include(:edit => {:pol_items => [vm]})
+    end
+  end
 end

--- a/spec/views/vm_common/_policies.html.haml_spec.rb
+++ b/spec/views/vm_common/_policies.html.haml_spec.rb
@@ -1,0 +1,13 @@
+describe 'vm_common/_policies.html.haml' do
+  before do
+    assign(:policy_options, :out_of_scope => true, :passed => true, :failed => true)
+    assign(:policy_simulation_tree, TreeBuilderPolicySimulation.new(:policy_simulation_tree, {}, true))
+    assign(:record, FactoryBot.create(:vm_infra))
+    set_controller_for_view('vm_or_template')
+  end
+
+  it 'renders Back button for non explorer screens' do
+    render :partial => 'vm_common/policies'
+    expect(response).to include('<a class="btn btn-default" alt="Back" title="Back" rel="nofollow" data-method="post" href="/vm/policy_sim?continue=true">Back</a>')
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1704395

_Back_ button was missing in policy simulation screen while checking details of selected item. This is related only to non-explorer screens, for example for list of VMs displayed thru provider's details page. For explorer ones, the button was there (see [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_x_edit_buttons.html.haml#L163)).

I am also adding another change `session[:edit] = @edit`. First, `@edit` with details of policy simulation is set in `policy_sim_build_screen` [method](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/policy_support.rb#L218) and then forgotten, for non-explorer screens. This caused problems with rendering the selected item's info later, also with clicking on a selected item (quadicon). `session[:edit] = @edit` needs to be set after `policy_sim_build_screen` is called.

The fix works also for nested list of Instances.

---

**After:**
![back-after](https://user-images.githubusercontent.com/13417815/63704394-41869a00-c82b-11e9-943d-530884ea4d7a.png)
