### PR TITLE
Show selected currency value consistent with a drop down on edit screen

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -506,7 +506,7 @@ class ChargebackController < ApplicationController
 
     # Select the currency of the first chargeback_rate_detail. All the chargeback_rate_details have the same currency
     @edit[:new][:currency] = rate_details[0].detail_currency.id
-    @edit[:new][:code_currency] = rate_details[0].detail_currency.code
+    @edit[:new][:code_currency] = "#{rate_details[0].detail_currency.symbol} [#{rate_details[0].detail_currency.full_name}]"
 
     rate_details.each_with_index do |detail, detail_index|
       temp = detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES)
@@ -560,7 +560,8 @@ class ChargebackController < ApplicationController
     @edit[:new][:description] = params[:description] if params[:description]
     if params[:currency]
       @edit[:new][:currency] = params[:currency].to_i
-      @edit[:new][:code_currency] = ChargebackRateDetailCurrency.find(params[:currency]).code
+      rate_detail_currency = ChargebackRateDetailCurrency.find(params[:currency])
+      @edit[:new][:code_currency] = "#{rate_detail_currency.symbol} [#{rate_detail_currency.full_name}]"
     end
     @edit[:new][:details].each_with_index do |detail, detail_index|
       %i[per_time per_unit sub_metric].each do |measure|


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740411

Core PR that fixes display of currency value on summary screen https://github.com/ManageIQ/manageiq/pull/19207

before
![before1](https://user-images.githubusercontent.com/3450808/63738913-727dc380-c859-11e9-9534-e8bc696aaec4.png)

after
![after1](https://user-images.githubusercontent.com/3450808/63738914-76114a80-c859-11e9-8793-b9f0a9e2d533.png)
