### PR TITLE
Select active snapshot instead of the last one in the snapshots 🌳

### DIFF
--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -23,18 +23,24 @@ class TreeBuilderSnapshots < TreeBuilder
     }
   end
 
-  # The tree name is the same for any snapshot tree, so it doesn't make sense to
-  # load the selected node from the session. This method always selects the last
-  # node in the tree.
+  # The tree name is the same for any snapshot tree, so it doesn't make sense to load the selected
+  # node from the session. This method tries to find the active snapshot based on its suffix.
+  # FIXME: deciding based on the string is not ideal, it should be evaluated on the node object instead
   def active_node_set(tree_nodes)
-    # Find the last node
     stack = [tree_nodes.last]
     while stack.any?
       node = stack.pop
+      # If the node's text has an active suffix, return with it
+      if node.try(:[], :text).try(:ends_with?, " (#{_('Active')})")
+        active = node
+        break
+      end
+
       stack.push(node[:nodes].last) if node[:nodes].try(:any?)
     end
     # Set it as the active node in the tree state
-    @tree_state.x_node_set(node[:key], @name)
+    # If no active snapshot has been found, return with the last node
+    @tree_state.x_node_set(active.try(:[], :key) || node[:key], @name)
   end
 
   def x_get_tree_roots(count_only)


### PR DESCRIPTION
In the snapshots tree for VMs the last tree node is not always the active snapshot. Therefore, I had to alter the logic of the selected node evaluation to select the active snapshot instead of the last one. It's testing the node's text for the `(Active)` suffix, which is not ideal. However, this is a fix to be backported and a more cleaner change would require a lot of risky changes in the codebase.

@miq-bot add_reviewer @h-kataria 
@miq-bot add_label bug, trees, ivanchuk/yes
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1745065