### PR TITLE
Expand the snapshots 🌳 with open_all instead of changing its state

### DIFF
--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -11,7 +11,13 @@ class TreeBuilderSnapshots < TreeBuilder
   private
 
   def tree_init_options
-    {:full_ids => true, :lazy => true, :onclick => 'miqOnClickSnapshots', :silent_activate => true}
+    {
+      :full_ids        => true,
+      :lazy            => true,
+      :onclick         => 'miqOnClickSnapshots',
+      :silent_activate => true,
+      :open_all        => true
+    }
   end
 
   def root_options
@@ -39,29 +45,11 @@ class TreeBuilderSnapshots < TreeBuilder
 
   def x_get_tree_roots(count_only)
     root_kid = @record.snapshots.present? ? @record.snapshots.find_all { |x| x.parent_id.nil? } : []
-    open_node("sn-#{root_kid.first.id}") if root_kid.present?
     count_only_or_objects(count_only, root_kid)
-  end
-
-  def parent_id(id)
-    Snapshot.find(id).parent_id
-  end
-
-  def id(kid_id)
-    id = kid_id
-    while parent_id(kid_id).present?
-      kid_id = parent_id(kid_id)
-      id = "#{kid_id}_sn-#{id}"
-    end
-    "sn-#{id}"
   end
 
   def x_get_tree_snapshot_kids(parent, count_only)
     kids = parent.children.presence || []
-    if kids.present?
-      id = id(kids.first.id)
-      open_node(id)
-    end
     count_only_or_objects(count_only, kids)
   end
 end


### PR DESCRIPTION
We don't need to manipulate the tree state in the snapshots tree for opening all nodes as there's already an `:open_all` option that expands the whole tree. Thanks to this I can :scissors: :fire: some lines of code.

@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_label ivanchuk/no, trees, cleanup