### PR TITLE
Set the node as selected using the state hash directly

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -107,10 +107,9 @@ class TreeBuilder
       node = stack.pop
       stack += node[:nodes] if node.key?(:nodes)
       node[:lazyLoad] = node.delete(:isLazy) if node.key?(:isLazy)
-      node[:state] = {}
+      node[:state] ||= {}
       node[:state][:expanded] = node.delete(:expand) if node.key?(:expand)
       node[:state][:checked] = node.delete(:select) if node.key?(:select)
-      node[:state][:selected] = node.delete(:highlighted) if node.key?(:highlighted)
       node[:class] = ''
       node[:class] = node.delete(:addClass) if node.key?(:addClass) && !node[:addClass].nil?
       node[:class] = node[:class].split(' ').push('no-cursor').join(' ') if node[:selectable] == false

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -9,7 +9,8 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
 
   def override(node, _object)
     if @sb[:diag_selected_id] && node[:key] == "#{self.class.get_prefix_for_model(@sb[:diag_selected_model]) || 'svr'}-#{@sb[:diag_selected_id]}"
-      node[:highlighted] = true
+      node[:state] ||= {}
+      node[:state][:selected] = true
     end
   end
 

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -9,7 +9,8 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
 
   def override(node, _object)
     if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
-      node[:highlighted] = true
+      node[:state] ||= {}
+      node[:state][:selected] = true
     end
   end
 


### PR DESCRIPTION
There are two trees setting the `highlighted` attribute in their `override` method. This attribute is being converted to the bootstrap-treeview format in `TreeBuilder.convert_bs_tree`. The trees are accessible under Ops/Diagnostics in the first two tabs when selecting a Zone. Instead of the conversion, we can set the value directly to the desired in these two places. 

@miq-bot add_label refactoring, ivanchuk/no, trees
@miq-bot add_reviewer @hstastna 
@miq-bot add_reviewer @romanblanco 