### PR TITLE
Add !important to our no-cursor CSS rule to override patternfly

### DIFF
--- a/app/assets/stylesheets/miq_tree.scss
+++ b/app/assets/stylesheets/miq_tree.scss
@@ -13,7 +13,7 @@
     }
 
     &.no-cursor {
-      cursor: default;
+      cursor: default !important;
     }
   }
 }


### PR DESCRIPTION
Patternfly added an `!important` on their cursor setting for trees https://github.com/patternfly/patternfly/pull/462#issuecomment-518554588 and we have to fight the fire with more fire, so we're adding an `!important` as well to override the setting for the `no-cursor` class. Even though I don't like the idea of having `!important` in our codebase, there's no other option :disappointed: 

You can see this in action in the `Services -> My Services` tree on the `Global Filters` and `My Filters` nodes.

@miq-bot add_label bug, trees
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @romanblanco 