### PR TITLE
Move the CSS class setting to TreeNode from the BS tree conversion

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -108,7 +108,6 @@ class TreeBuilder
       stack += node[:nodes] if node.key?(:nodes)
       node[:state] ||= {}
       node[:state][:expanded] = node.delete(:expand) if node.key?(:expand)
-      node[:class] = (node[:class] || '').split(' ').push('no-cursor').join(' ') if node[:selectable] == false
     end
     nodes
   end
@@ -120,6 +119,14 @@ class TreeBuilder
   end
 
   private
+
+  # Temporary method to append the no-cursor class to an already existing CSS class
+  # list. It is intended to be used in the override methods in order to get rid of
+  # the TreeBuilder.convert_bs_tree method. Eventually it should be removed after
+  # all the code from the override methods are moved into the TreeNode as a DSL.
+  def append_no_cursor(klass)
+    (klass || '').split(' ').push('no-cursor').join(' ')
+  end
 
   def build_tree
     @tree_nodes = x_build_tree

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -13,7 +13,10 @@ class TreeBuilderAutomate < TreeBuilder
   end
 
   def override(node, object)
-    node[:selectable] = false if object.kind_of?(MiqAeNamespace) && object.domain?
+    if object.kind_of?(MiqAeNamespace) && object.domain?
+      node[:selectable] = false
+      node[:class] = append_no_cursor(node[:class])
+    end
   end
 
   def x_get_tree_class_kids(object, count_only)

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -11,7 +11,10 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
 
   def override(node, object)
     # Only the instance items should be clickable when selecting a catalog item entry point
-    node[:selectable] = false unless object.kind_of?(MiqAeInstance)
+    unless object.kind_of?(MiqAeInstance)
+      node[:selectable] = false
+      node[:class] = append_no_cursor(node[:class])
+    end
   end
 
   def x_get_tree_ns_kids(object, count_only)

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -10,6 +10,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     node[:state][:checked] = @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
     node[:checkable] = @edit.present?
   end
 

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -1,6 +1,7 @@
 class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
   def override(node, object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
     node[:checkable] = @edit.present? || @assign_to.present?
 
     if object.kind_of?(EmsFolder) && object.vm_folder?

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -4,6 +4,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
 
   def override(node, _object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
   end
 
   def initialize(name, sandbox, build = true, **params)

--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -3,6 +3,7 @@ class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
 
   def override(node, object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
     if object.kind_of?(EmsFolder) && object.vm_folder?
       node[:icon] = "pficon pficon-folder-close-blue"
     else

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -5,7 +5,10 @@ class TreeBuilderInfraNetworking < TreeBuilder
   has_kids_for EmsFolder, [:x_get_tree_folder_kids]
 
   def override(node, object)
-    node[:selectable] = false if object.kind_of?(Lan)
+    if object.kind_of?(Lan)
+      node[:selectable] = false
+      node[:class] = append_no_cursor(node[:class])
+    end
   end
 
   private

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -3,7 +3,10 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
   def override(node, object)
-    node[:selectable] = object.kind_of?(::VmOrTemplate)
+    unless object.kind_of?(::VmOrTemplate)
+      node[:selectable] = false
+      node[:class] = append_no_cursor(node[:class])
+    end
   end
 
   def initialize(name, sandbox, build = true, **params)

--- a/app/presenters/tree_builder_resource_pools.rb
+++ b/app/presenters/tree_builder_resource_pools.rb
@@ -3,6 +3,7 @@ class TreeBuilderResourcePools < TreeBuilderAlertProfileAssign
 
   def override(node, object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
     node[:checkable] = true
     node[:hideCheckbox] = true unless object.kind_of?(ResourcePool)
     node[:state] ||= {}

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -11,6 +11,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
 
   def override(node, _object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -9,6 +9,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
 
   def override(node, _object)
     node[:selectable] = false
+    node[:class] = append_no_cursor(node[:class])
   end
 
   private

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -10,7 +10,10 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   def override(node, _object)
-    node[:selectable] = node[:key].split('-')[1].split('_')[0] != 'folder'
+    if node[:key].split('-')[1].split('_')[0] == 'folder'
+      node[:selectable] = false
+      node[:class] = append_no_cursor(node[:class])
+    end
   end
 
   def root_options

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -87,7 +87,7 @@ module TreeNode
         :iconColor      => color,
         :expand         => expand,
         :hideCheckbox   => hide_checkbox,
-        :class          => klass,
+        :class          => [selectable ? nil : 'no-cursor'].push(klass).compact.join(' ').presence, # add no-cursor if not selectable
         :selectable     => selectable,
         :state          => {
           :checked => checked


### PR DESCRIPTION
Moving the css class setting straight to the `TreeNode`, I'm trying to get rid of the `convert_bs_tree` method. The best to test is on the automate/explorer tree and the services tree's last 2 nodes.

As we're doing overrides to the `selectable` attribute after the node has been converted to hash, I had to add a method to explicitly set the `class` attribute in all affected `override` methods. It is just a temporary thing and shortly after the `convert_bs_tree` method is dropped, we can do the hash conversion of the trees AFTER we override stuff. 

@miq-bot add_reviewer @epwinchell 
@miq-bot assign @h-kataria 
@miq-bot add_label ivanchuk/no, trees, technical debt