### PR TITLE
Refresh trees after deleting catalog custom icon

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -471,7 +471,7 @@ class CatalogController < ApplicationController
     params[:id] = x_build_node_id(@record)  # Get the tree node id
     add_flash(msg, err == true ? :error : nil)
     respond_to do |format|
-      format.js { replace_right_cell }
+      format.js { replace_right_cell(:replace_trees => trees_to_replace(%i[sandt svccat stcat])) }
       format.html do # HTML, send error screen
         explorer
       end


### PR DESCRIPTION
Custom icon formerly stuck around until the trees were refreshed, forcing a tree reload when deleting the custom icon corrected in a more timely fashion. 

Before:
![image](https://user-images.githubusercontent.com/1630348/63791061-9fb58a80-c8c8-11e9-889c-bdcee81dd9ad.png)

After:
![image](https://user-images.githubusercontent.com/1630348/63790874-39306c80-c8c8-11e9-98c7-3d32685f4a4e.png)

@miq-bot add_labels bug, services

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1728197