### PR TITLE
Replace select attribute in tree nodes with the state/checked

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -108,7 +108,6 @@ class TreeBuilder
       stack += node[:nodes] if node.key?(:nodes)
       node[:state] ||= {}
       node[:state][:expanded] = node.delete(:expand) if node.key?(:expand)
-      node[:state][:checked] = node.delete(:select) if node.key?(:select)
       node[:class] = (node[:class] || '').split(' ').push('no-cursor').join(' ') if node[:selectable] == false
     end
     nodes

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,7 +8,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object)
-    node[:select] = @selected.try(:include?, object.id)
+    node[:state] ||= {}
+    node[:state][:checked] = @selected.try(:include?, object.id)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -6,7 +6,8 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
   def override(node, object)
-    node[:select] = @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
+    node[:state] ||= {}
+    node[:state][:checked] = @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
     node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
     node[:selectable] = false
     node[:checkable] = @edit.present?

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -8,7 +8,8 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
     else
       node[:hideCheckbox] = true
     end
-    node[:select] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+    node[:state] ||= {}
+    node[:state][:checked] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
   end
 
   def x_get_tree_datacenter_kids(parent, count_only)

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -36,7 +36,7 @@ class TreeBuilderClusters < TreeBuilder
         :text       => node[:name],
         :icon       => 'pficon pficon-cluster',
         :tip        => node[:name],
-        :select     => node[:capture],
+        :checked    => node[:capture],
         :nodes      => @data[node[:id]][:ho_enabled] + @data[node[:id]][:ho_disabled],
         :selectable => false}
     end
@@ -45,7 +45,7 @@ class TreeBuilderClusters < TreeBuilder
               :text       => _("Non-clustered Hosts"),
               :icon       => 'pficon pficon-container-node',
               :tip        => _("Non-clustered Hosts"),
-              :select     => non_cluster_selected,
+              :checked    => non_cluster_selected,
               :nodes      => @root[:non_cl_hosts],
               :selectable => false}
       nodes.push(node)
@@ -63,7 +63,7 @@ class TreeBuilderClusters < TreeBuilder
        :text       => node[:name],
        :tip        => _("Host: %{name}") % {:name => node[:name]},
        :icon       => 'pficon pficon-container-node',
-       :select     => node.kind_of?(Hash) ? node[:capture] : !value,
+       :checked    => node.kind_of?(Hash) ? node[:capture] : !value,
        :selectable => false,
        :nodes      => []}
     end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -38,7 +38,7 @@ class TreeBuilderDatastores < TreeBuilder
         :text       => text,
         :icon       => 'fa fa-database',
         :tip        => "#{node[:name]} [#{node[:location]}]",
-        :select     => node[:capture] == true,
+        :checked    => node[:capture] == true,
         :selectable => false,
         :nodes      => children }
     end

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -76,7 +76,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
                    :icon       => 'fa fa-filter',
                    :tip        => kid[:description],
                    :selectable => false,
-                   :select     => kid[:search_key] != "_hidden_"}
+                   :checked    => kid[:search_key] != "_hidden_"}
                 end
               end
     end

--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -8,6 +8,7 @@ class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
     else
       node[:hideCheckbox] = true
     end
-    node[:select] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+    node[:state] ||= {}
+    node[:state][:checked] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
   end
 end

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -23,7 +23,7 @@ class TreeBuilderProtect < TreeBuilder
         :text       => profile.description,
         :icon       => profile.active? ? "fa fa-shield" : "fa fa-inactive fa-shield",
         :tip        => profile.description,
-        :select     => @data[:new][profile.id] == @data[:pol_items].length,
+        :checked    => @data[:new][profile.id] == @data[:pol_items].length,
         :nodes      => profile.members,
         :selectable => false}
     end

--- a/app/presenters/tree_builder_resource_pools.rb
+++ b/app/presenters/tree_builder_resource_pools.rb
@@ -5,6 +5,7 @@ class TreeBuilderResourcePools < TreeBuilderAlertProfileAssign
     node[:selectable] = false
     node[:checkable] = true
     node[:hideCheckbox] = true unless object.kind_of?(ResourcePool)
-    node[:select] = @selected_nodes&.include?("ResourcePool_#{object[:id]}")
+    node[:state] ||= {}
+    node[:state][:checked] = @selected_nodes&.include?("ResourcePool_#{object[:id]}")
   end
 end

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -31,7 +31,7 @@ class TreeBuilderSections < TreeBuilder
                    :text       => section[:group] == "Categories" ? _("%{current_tenant} Tags") % {:current_tenant => @current_tenant} : _(section[:group]),
                    :tip        => _(section[:group]),
                    :image      => false,
-                   :select     => true,
+                   :checked    => true,
                    :selectable => false,
                    :nodes      => [section])
       else
@@ -40,13 +40,13 @@ class TreeBuilderSections < TreeBuilder
     end
     nodes.each do |node|
       checked = node[:nodes].count { |kid| @data.include[kid[:name]][:checked] } # number of checked kids
-      node[:select] = if checked.zero?
-                        false
-                      elsif checked < node[:nodes].size
-                        'undefined'
-                      else
-                        true
-                      end
+      node[:checked] = if checked.zero?
+                         false
+                       elsif checked < node[:nodes].size
+                         'undefined'
+                       else
+                         true
+                       end
     end
     count_only_or_objects(count_only, nodes)
   end
@@ -57,7 +57,7 @@ class TreeBuilderSections < TreeBuilder
        :text       => _(kid[:header]),
        :tip        => _(kid[:header]),
        :image      => false,
-       :select     => @data.include[kid[:name]][:checked],
+       :checked    => @data.include[kid[:name]][:checked],
        :selectable => false,
        :nodes      => []}
     end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -48,7 +48,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
       {:id              => "#{parent[:id]}_#{kid.id}",
        :icon            => parent[:icon],
        :text            => kid.name,
-       :select          => affinities.include?(kid.id),
+       :checked         => affinities.include?(kid.id),
        :selectable      => false,
        :nodes           => [],
        :smartproxy_kind => parent[:smartproxy_kind]}

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -58,7 +58,8 @@ class TreeBuilderTenants < TreeBuilder
   end
 
   def override(node, object)
-    node[:select] = @additional_tenants.try(:include?, object)
+    node[:state] ||= {}
+    node[:state][:checked] = @additional_tenants.try(:include?, object)
     node[:checkable] = @selectable
   end
 end

--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -12,7 +12,7 @@ module TreeNode
 
     set_attribute(:hide_checkbox) { @object.key?(:hideCheckbox) && @object[:hideCheckbox] ? true : nil }
 
-    set_attribute(:selected) { @object.key?(:select) && @object[:select] ? true : nil }
+    set_attribute(:selected) { @object.key?(:checked) && @object[:checked] ? true : nil }
 
     set_attribute(:klass) { @object.key?(:addClass) ? @object[:addClass] : nil }
 

--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -12,7 +12,7 @@ module TreeNode
 
     set_attribute(:hide_checkbox) { @object.key?(:hideCheckbox) && @object[:hideCheckbox] ? true : nil }
 
-    set_attribute(:selected) { @object.key?(:checked) && @object[:checked] ? true : nil }
+    set_attribute(:checked) { @object.key?(:checked) && @object[:checked] ? true : nil }
 
     set_attribute(:klass) { @object.key?(:addClass) ? @object[:addClass] : nil }
 

--- a/app/presenters/tree_node/menu/item.rb
+++ b/app/presenters/tree_node/menu/item.rb
@@ -8,7 +8,7 @@ module TreeNode
         [_(details[:name]), _(details[:description]) || _(details[:name])]
       end
 
-      set_attribute(:selected) do
+      set_attribute(:checked) do
         parent_feature = ::MiqProductFeature.obj_features[::MiqProductFeature.feature_parent(@object.feature)][:feature]
 
         [parent_feature.identifier, @object.feature].any? do |item|

--- a/app/presenters/tree_node/miq_product_feature.rb
+++ b/app/presenters/tree_node/miq_product_feature.rb
@@ -3,7 +3,7 @@ module TreeNode
     set_attribute(:key) { "#{@tree.node_id_prefix}__#{@object.identifier}" }
     set_attribute(:text) { _(@object.name) }
     set_attribute(:tooltip) { _(@object.description) || _(@object.name) }
-    set_attribute(:selected) do
+    set_attribute(:checked) do
       @tree.features.include?('everything') || @tree.features.include?(@object.identifier.sub(/_accords$/, ''))
     end
 

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -36,7 +36,7 @@ module TreeNode
       true
     end
 
-    def selected
+    def checked
       nil
     end
 
@@ -89,7 +89,7 @@ module TreeNode
         :hideCheckbox   => hide_checkbox,
         :class          => klass,
         :selectable     => selectable,
-        :select         => selected,
+        :select         => checked,
         :checkable      => checkable ? nil : false,
       }
 

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -89,7 +89,9 @@ module TreeNode
         :hideCheckbox   => hide_checkbox,
         :class          => klass,
         :selectable     => selectable,
-        :select         => checked,
+        :state          => {
+          :checked => checked
+        }.compact,
         :checkable      => checkable ? nil : false,
       }
 

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -55,15 +55,15 @@ describe TreeBuilderAlertProfileObj do
       it 'sets node1' do
         subject.send(:override, node, tag1a)
         expect(node[:hideCheckbox]).to be_falsey
-        expect(node[:select]).to be_truthy
+        expect(node[:state][:checked]).to be_truthy
       end
       it 'sets node2' do
         subject.send(:override, node, tag2a)
-        expect(node[:select]).to be_truthy
+        expect(node[:state][:checked]).to be_truthy
       end
       it 'sets node3' do
         subject.send(:override, node, tag3a)
-        expect(node[:select]).to be_falsey
+        expect(node[:state][:checked]).to be_falsey
       end
     end
 

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -41,7 +41,7 @@ describe TreeBuilderClusters do
                                         :text       => "Name",
                                         :icon       => 'pficon pficon-cluster',
                                         :tip        => "Name",
-                                        :select     => 'unsure',
+                                        :checked    => 'unsure',
                                         :selectable => false,
                                         :nodes      => @ho_enabled + @ho_disabled)
       # non-cluster-node
@@ -49,7 +49,7 @@ describe TreeBuilderClusters do
                                        :text       => "Non-clustered Hosts",
                                        :icon       => 'pficon pficon-container-node',
                                        :tip        => "Non-clustered Hosts",
-                                       :select     => true,
+                                       :checked    => true,
                                        :selectable => false,
                                        :nodes      => @non_cluster_hosts)
     end
@@ -61,7 +61,7 @@ describe TreeBuilderClusters do
                                        :text       => "Non Cluster Host",
                                        :tip        => "Host: Non Cluster Host",
                                        :icon       => 'pficon pficon-container-node',
-                                       :select     => true,
+                                       :checked    => true,
                                        :selectable => false,
                                        :nodes      => []}])
     end
@@ -74,7 +74,7 @@ describe TreeBuilderClusters do
          :text       => node[:name],
          :tip        => "Host: %{name}" % {:name => node[:name]},
          :icon       => 'pficon pficon-container-node',
-         :select     => true,
+         :checked    => true,
          :selectable => false,
          :nodes      => []}
       end
@@ -83,7 +83,7 @@ describe TreeBuilderClusters do
          :text       => node[:name],
          :tip        => "Host: %{name}" % {:name => node[:name]},
          :icon       => 'pficon pficon-container-node',
-         :select     => false,
+         :checked    => false,
          :selectable => false,
          :nodes      => []}
       end

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -95,14 +95,14 @@ describe TreeBuilderDefaultFilters do
               grandkids = @default_filters_tree.send(:x_get_tree_hash_kids, kid, false)
               grandkids.each_with_index do |grandkid, index|
                 expect(grandkid[:icon]).to eq('fa fa-filter')
-                expect(grandkid[:select]).to eq(offsprings[kid[:text]][index][:search_key] != "_hidden_")
+                expect(grandkid[:checked]).to eq(offsprings[kid[:text]][index][:search_key] != "_hidden_")
               end
             end
           else
             kids = @default_filters_tree.send(:x_get_tree_hash_kids, parent, false)
             kids.each_with_index do |kid, index|
               expect(kid[:icon]).to eq('fa fa-filter')
-              expect(kid[:select]).to eq(offsprings[index][:search_key] != "_hidden_")
+              expect(kid[:checked]).to eq(offsprings[index][:search_key] != "_hidden_")
             end
           end
         end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -46,7 +46,7 @@ describe TreeBuilderProtect do
         expect(roots[i][:icon]).to eq(root.active? ? "fa fa-shield" : "fa fa-inactive fa-shield")
         expect(roots[i][:text]).to eq(root.description)
         expect(roots[i][:nodes]).to eq(root.members)
-        expect(roots[i][:select]).to eq(@edit[:new].keys.include?(root.id))
+        expect(roots[i][:checked]).to eq(@edit[:new].key?(root.id))
       end
       expect(roots.size).to eq(3)
     end

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -74,7 +74,7 @@ describe TreeBuilderSections do
                             :text       => "Properties",
                             :tip        => "Properties",
                             :image      => false,
-                            :select     => true,
+                            :checked    => true,
                             :selectable => false,
                             :nodes      => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
     end
@@ -87,7 +87,7 @@ describe TreeBuilderSections do
                            :tip        => "Filesystem",
                            :image      => false,
                            :selectable => false,
-                           :select     => true,
+                           :checked    => true,
                            :nodes      => []}])
     end
   end

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -102,7 +102,7 @@ describe TreeBuilderSmartproxyAffinity do
           expect(kids[i][:text]).to eq(kid.name)
           expect(kids[i][:id]).to eq("#{parent[:id]}_#{kid.id}")
           expect(kids[i][:nodes]).to eq([])
-          expect(kids[i][:select]).to eq(parent[:parent].send("vm_scan_#{parent[:smartproxy_kind]}_affinity").collect(&:id).include?(kid.id))
+          expect(kids[i][:checked]).to eq(parent[:parent].send("vm_scan_#{parent[:smartproxy_kind]}_affinity").collect(&:id).include?(kid.id))
         end
       end
     end


### PR DESCRIPTION
There was a naming issue with the `select` and `selected` attributes in `TreeNode` as they have been used for setting the checkbox. So to make things right first, I'm renaming it to `checked` to make a little more sense. Then I'm moving the conversion of the `checked` attribute from `TreeBuilder.convert_bs_tree` to the `TreeNode#to_h` so we can get rid of one more line from this evil method.

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label ivanchuk/no, trees, cleanup, technical debt