### PR TITLE
Fixed to set saveable state regardless of number of items selected.

### DIFF
--- a/app/assets/javascripts/components/retirement-form.js
+++ b/app/assets/javascripts/components/retirement-form.js
@@ -9,11 +9,11 @@ ManageIQ.angular.app.component('retirementForm', {
     vm.$onInit = function() {
       if (vm.objectIds.length === 1) {
         miqService.sparkleOn();
-        vm.saveable = miqService.saveable;
         $http.get('/' + ManageIQ.controller + '/retirement_info/' + vm.objectIds[0])
           .then(getRetirementInfoFormData)
           .catch(miqService.handleFailure);
       }
+      vm.saveable = miqService.saveable;
     };
 
     vm.select_options = [


### PR DESCRIPTION
Setting saveable state only when 1 item is selected for retirement was causing Save button to remain disabled when multiple items were selected for retirement.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1745984

before
![before](https://user-images.githubusercontent.com/3450808/63799314-dea00c00-c8d9-11e9-9a0b-fba8fbbbb6df.png)

after
![after](https://user-images.githubusercontent.com/3450808/63799308-dc3db200-c8d9-11e9-83c4-dddf9954ef74.png)
