### PR TITLE
Fixed to show a warning flash message.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -922,9 +922,18 @@ class ApplicationController < ActionController::Base
   end
 
   def flash_errors?
-    Array(@flash_array).any? { |f| f[:level] == :error }
+    flash_error_or_warning(:error)
   end
   helper_method(:flash_errors?)
+
+  def flash_warnings?
+    flash_error_or_warning(:warning)
+  end
+  helper_method(:flash_warnings?)
+
+  def flash_error_or_warning(type)
+    Array(@flash_array).any? { |f| f[:level] == type }
+  end
 
   # Handle the breadcrumb array by either adding, or resetting to, the passed in breadcrumb
   # if replace = true, only add this bc if it was already there

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -359,7 +359,7 @@ class CloudVolumeController < ApplicationController
       show_list
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "cloud_volume"
-      @single_delete = true unless flash_errors?
+      @single_delete = true unless flash_errors? || flash_warnings?
     else
       drop_breadcrumb(:name => 'dummy', :url => " ") # missing a bc to get correctly back so here's a dummy
       flash_to_session

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -437,6 +437,30 @@ describe ApplicationController do
     end
   end
 
+  describe "#flash_errors?" do
+    it "returns true when errors are present in flash_array" do
+      controller.instance_variable_set(:@flash_array, [:message => "Error message", :level => :error])
+      expect(controller.send(:flash_errors?)).to be_truthy
+    end
+
+    it "returns false when there no errors are present in flash_array" do
+      controller.instance_variable_set(:@flash_array, [:message => "Foo message"])
+      expect(controller.send(:flash_errors?)).to be_falsey
+    end
+  end
+
+  describe "#flash_warnings?" do
+    it "returns true when errors are present in flash_array" do
+      controller.instance_variable_set(:@flash_array, [:message => "Warning message", :level => :warning])
+      expect(controller.send(:flash_warnings?)).to be_truthy
+    end
+
+    it "returns false when no warnings are present in flash_array" do
+      controller.instance_variable_set(:@flash_array, [:message => "Foo message"])
+      expect(controller.send(:flash_warnings?)).to be_falsey
+    end
+  end
+
   context "private methods" do
     describe "#process_params_model_view" do
       it "with options[:model_name]" do


### PR DESCRIPTION
When trying to delete a Cloud Volume that has instances attached to it from its summary view, need to stay on the summary screen and show warning flash message on the same screen. Previous code was redirecting to list view after pressing delete button even tho the Cloud Volume deletion was not successful and was showing warning flash message as green message.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1745989

In this case when deleting a single item from it's summary screen in absence of flash error message, code just assumes that delete was successful and redirects user to the list view. Made changes to check for warning message as well in the `@flash_array`

before
![before](https://user-images.githubusercontent.com/3450808/63810664-4878df80-c8f3-11e9-9489-5df8e50f2fcb.png)

after
![after](https://user-images.githubusercontent.com/3450808/63810277-5ed26b80-c8f2-11e9-955e-fe31a976af38.png)
