### PR TITLE
Move text under Description to Chargeback Rate Details table

### DIFF
--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -5,8 +5,6 @@
   .form-group
     %label.col-md-2.control-label
       = _('Description')
-      %br
-      = _('(Column Name in Report)')
     .col-md-8
       %p.form-control-static
         = h(@record.description)
@@ -16,7 +14,10 @@
   %thead
     %tr
       %th{:rowspan => "2"}= _('Group')
-      %th{:rowspan => "2"}= _('Description')
+      %th{:rowspan => "2"}
+        = _('Description')
+        %br
+        = _('(Column Name in Report)')
       - if breakdown_present
         %th{:rowspan => '2'}= _('Sub Metric')
 


### PR DESCRIPTION
This PR moves the text as an explanation for a second column for _Rate Details_ table to the right place: under the _Description_, in the table.

**Where:**
_Overview > Chargeback > Rates_ accordion > click on some Rate and check the _Rate Details_ table

**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/5259
**Related PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/4596

---

**Before:**
![rate_table_before](https://user-images.githubusercontent.com/13417815/63838515-c386d800-c97d-11e9-944b-8109613cb4e2.png)

**After:**
![rate_table_after](https://user-images.githubusercontent.com/13417815/63838521-c681c880-c97d-11e9-913e-b7de9d0d6ce8.png)

**Note:**
While editing a rate, this text is already in the right place:
![rate_edit](https://user-images.githubusercontent.com/13417815/63838527-c8e42280-c97d-11e9-889f-5385976907b3.png)
