### PR TITLE
Correctly catch & handle API errors when creating orchestration template

### DIFF
--- a/app/javascript/components/orchestration-template/orcherstration-template-form.js
+++ b/app/javascript/components/orchestration-template/orcherstration-template-form.js
@@ -8,13 +8,17 @@ import MiqFormRenderer from '../../forms/data-driven-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import orchestrationFormSchema from './orchestration-template-form.schema';
 
-const submitNewTemplate = (values, message) => API.post('/api/orchestration_templates', values)
+const submitNewTemplate = (values, message) => API.post('/api/orchestration_templates', values, {skipErrors: [400, 500]})
   .then(() => miqRedirectBack(message, 'success', '/catalog/explorer'))
-  .catch(() => miqSparkleOff());
+  .catch((apiResult) => {
+    add_flash(apiResult.data.error.message, 'error');
+    miqSparkleOff()});
 
-const updateTemplate = (values, message, otId) => API.patch(`/api/orchestration_templates/${otId}`, values)
+const updateTemplate = (values, message, otId) => API.patch(`/api/orchestration_templates/${otId}`, values, {skipErrors: [400, 500]})
   .then(() => miqRedirectBack(message, 'success', '/catalog/explorer'))
-  .catch(() => miqSparkleOff());
+  .catch((apiResult) => {
+    add_flash(apiResult.data.error.message, 'error');
+    miqSparkleOff()});
 
 const copyTemplate = (values, message, otId) => API.post(`/api/orchestration_templates/${otId}`, {
   action: 'copy',


### PR DESCRIPTION
1. create an orchestration template
2. create another orchestration template with exactly the same content

Without this fix, a modal window showing an odd looking api error would be shown.

With this fix, a nice flash message with an error is rendered.

https://bugzilla.redhat.com/show_bug.cgi?id=1745884