### PR TITLE
Do not set the :expand attribute on tree roots as it is redundant

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -26,8 +26,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
       :tooltip      => "",
       :icon         => "pficon pficon-folder-open",
       :hideCheckbox => true,
-      :selectable   => false,
-      :expand       => true
+      :selectable   => false
     }
   end
 

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -68,7 +68,6 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       :icon       => "pficon pficon-folder-close",
       :text       => _(root_details[:name]),
       :tooltip    => _(root_details[:description]) || _(root_details[:name]),
-      :expand     => true,
       :selectable => false,
       :checkable  => @editable
     }

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -75,7 +75,6 @@ describe TreeBuilderAlertProfileObj do
         expect(res[:icon]).to eq("pficon pficon-folder-open")
         expect(res[:hideCheckbox]).to be_truthy
         expect(res[:selectable]).to be_falsey
-        expect(res[:expand]).to be_truthy
       end
     end
 


### PR DESCRIPTION
The root node is [always expanded](https://github.com/ManageIQ/manageiq-ui-classic/blob/c5b9371e779bca82dce927ae47fdb32e47719d7d/app/presenters/tree_builder.rb#L197) when set via `root_options`, so there's no need to set it explicitly expanded one more time. The alert profile assign tree and the RBAC role features tree were affected and cleaned up.

@miq-bot add_label cleanup, ivanchuk/no, trees
@miq-bot add_reviewer @romanblanco 
@miq-bot assign @mzazrivec 