### PR TITLE
Drop the TreeBuilder.convert_bs_tree as it is no longer necessary

### DIFF
--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -10,11 +10,10 @@ module ApplicationController::TreeSupport
     tree_name = (params[:tree] || x_active_tree).to_sym
     tree_klass = x_tree(tree_name)[:klass_name]
 
-    nodes = TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
-                                             :klass_name => tree_klass,
-                                             :name       => tree_name,
-                                             :id         => id)
-    TreeBuilder.convert_bs_tree(nodes)
+    TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
+                                     :klass_name => tree_klass,
+                                     :name       => tree_name,
+                                     :id         => id)
   end
 
   def tree_exists?(tree_name)

--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -43,7 +43,7 @@ class TreeController < ApplicationController
     tree.reload!
 
     if node_id
-      TreeBuilder.convert_bs_tree(tree.x_get_child_nodes(node_id)).to_json
+      tree.x_get_child_nodes(node_id).to_json
     else
       tree.instance_variable_get(:@bs_tree)
     end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -98,18 +98,6 @@ class TreeBuilder
     open_nodes.push(id) unless open_nodes.include?(id)
   end
 
-  # FIXME: temporary conversion, needs to be moved into the generation
-  def self.convert_bs_tree(nodes)
-    return [] if nodes.nil?
-    nodes = [nodes] if nodes.kind_of?(Hash)
-    stack = nodes.dup
-    while stack.any?
-      node = stack.pop
-      stack += node[:nodes] if node.key?(:nodes)
-    end
-    nodes
-  end
-
   # Add child nodes to a tree below node 'id'
   def self.tree_add_child_nodes(sandbox:, klass_name:, name:, id:)
     tree = klass_name.constantize.new(name, sandbox, false)
@@ -119,9 +107,8 @@ class TreeBuilder
   private
 
   # Temporary method to append the no-cursor class to an already existing CSS class
-  # list. It is intended to be used in the override methods in order to get rid of
-  # the TreeBuilder.convert_bs_tree method. Eventually it should be removed after
-  # all the code from the override methods are moved into the TreeNode as a DSL.
+  # list. Eventually it should be removed after all the code from the override methods
+  # is moved into the TreeNode as a DSL.
   def append_no_cursor(klass)
     (klass || '').split(' ').push('no-cursor').join(' ')
   end
@@ -130,8 +117,7 @@ class TreeBuilder
     @tree_nodes = x_build_tree
     active_node_set(@tree_nodes)
     add_root_node(@tree_nodes) if respond_to?(:root_options, true)
-    # Convert the nodes to the Bootstrap Treeview format
-    @bs_tree = self.class.convert_bs_tree(@tree_nodes).to_json
+    @bs_tree = @tree_nodes.to_json
     @locals_for_render = set_locals_for_render
   end
 


### PR DESCRIPTION
After a couple of years, we're finally able to get rid of the "temporary" `convert_bs_tree` method that has been introduced into the `TreeBuilder` and `TreeNode` world to convert the tree from the old dynatree format into the new bootstrap treeview. All the conversions have been moved in previous PRs straight to the `TreeNode` attribute definitions.

There's a tiny little catch with the `TreeBuilder#override` methods, where the same format is being used as well. These calls will be standardized on the `TreeNode` objects and the overriding eventually will happen before we convert the nodes into hash format.

@miq-bot add_label cleanup, technical debt, ivanchuk/no, trees
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @ZitaNemeckova 