### PR TITLE
Replaced add_root_node logic with a TreeNode::Root object

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -116,7 +116,6 @@ class TreeBuilder
   def build_tree
     @tree_nodes = x_build_tree
     active_node_set(@tree_nodes)
-    add_root_node(@tree_nodes) if respond_to?(:root_options, true)
     @bs_tree = @tree_nodes.to_json
     @locals_for_render = set_locals_for_render
   end
@@ -134,15 +133,6 @@ class TreeBuilder
         :open_nodes => []
       )
     )
-  end
-
-  def add_root_node(nodes)
-    root = nodes.first.merge!(%i[text tooltip].each_with_object(root_options) { |key, hsh| hsh[key] = ERB::Util.html_escape(hsh[key]) })
-    if root[:image]
-      root[:image] = ActionController::Base.helpers.image_path(root[:image])
-    else
-      root[:icon] ||= 'pficon pficon-folder-close' # Fall back to the folder fonticon
-    end
   end
 
   def group_id
@@ -180,7 +170,7 @@ class TreeBuilder
 
     return nodes unless respond_to?(:root_options, true)
 
-    [{:key => 'root', :nodes => nodes, :state => {:expanded => true}}]
+    [TreeNode::Root.new(root_options, nil, self).to_h.merge(:nodes => nodes)]
   end
 
   # determine if this is an ancestry node, and return the approperiate object

--- a/app/presenters/tree_node/root.rb
+++ b/app/presenters/tree_node/root.rb
@@ -1,0 +1,8 @@
+module TreeNode
+  class Root < TreeNode::Hash
+    set_attribute(:key) { @object[:key] || 'root' }
+    set_attribute(:icon) { @object[:icon] || 'pficon pficon-folder-close' }
+    set_attribute(:expanded) { true }
+    set_attribute(:tooltip) { @object[:tooltip] }
+  end
+end

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -43,10 +43,11 @@ describe TreeBuilder do
                                'state'      => { 'expanded' => true },
                                'selectable' => true,
                                'text'       => "Storage"}],
-                'state'   => { 'expanded' => true },
-                'text'    => "Rates",
-                'tooltip' => "Rates",
-                'icon'    => 'pficon pficon-folder-close'}]
+                'state'      => { 'expanded' => true },
+                'text'       => "Rates",
+                'tooltip'    => "Rates",
+                'selectable' => true,
+                'icon'       => 'pficon pficon-folder-close'}]
       tree.locals_for_render.key?(:bs_tree)
       expect(JSON.parse(tree.locals_for_render[:bs_tree])).to eq(nodes)
     end

--- a/spec/presenters/tree_node/root.rb
+++ b/spec/presenters/tree_node/root.rb
@@ -1,0 +1,10 @@
+describe TreeNode::Root do
+  subject { described_class.new(object, nil, nil) }
+  let(:object) { {} }
+
+  include_examples 'TreeNode::Node#icon', 'pficon pficon-folder-close'
+
+  describe '#key' do
+    it { expect(subject.key).to eq('root') }
+  end
+end

--- a/spec/presenters/tree_node_spec.rb
+++ b/spec/presenters/tree_node_spec.rb
@@ -23,7 +23,7 @@ describe TreeNode do
 
     TreeNode.constants.each do |type|
       # We never instantiate MiqAeNode and Node in our codebase
-      next if %i[MiqAeNode Node Menu REXML].include?(type)
+      next if %i[MiqAeNode Node Menu Root REXML].include?(type)
 
       describe(type) do
         let(:klass) { type.to_s.constantize }


### PR DESCRIPTION
The logic responsible for adding a root node when necessary has been in two places. First when we build the tree, we create an empty root node if the `root_options` method is defined. Then after the tree is built, we call the `add_root_node` which overrides this empty node with options from the `root_options` method. 

Instead of this :spaghetti: I created a `TreeNode::Root` class which is inherited from `TreeNode::Hash` but this might [change](https://github.com/ManageIQ/manageiq-ui-classic/pull/6092) in the future. This makes the `add_root_node` method obsolete as it is being instantiated with `root_options`.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label refactoring, ivanchuk/no, trees