### PR TITLE
Replace x_build_node_tree with x_build_node in TreeBuilder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -45,7 +45,7 @@ class TreeBuilder
     open_node(id)
 
     x_get_tree_objects(object, false, parents).map do |o|
-      x_build_node_tree(o, id)
+      x_build_node(o, id)
     end
   end
 
@@ -188,7 +188,7 @@ class TreeBuilder
       if child.kind_of?(Hash) && child.key?(:text) && child.key?(:key) && child.key?(:image)
         child
       else
-        x_build_node_tree(child, nil)
+        x_build_node(child, nil)
       end
     end
 
@@ -258,11 +258,6 @@ class TreeBuilder
     node = TreeNode.new(object, pid, self).to_h
     override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
     node
-  end
-
-  # Called with object, tree node parent id
-  def x_build_node_tree(object, pid)
-    x_build_node(object, pid)
   end
 
   # Handle custom tree nodes (object is a Hash)


### PR DESCRIPTION
As I was cleaning up the `TreeBuilder`, the `x_build_node_tree` method became just a simple wrapper around `x_build_node`. Therefore it is safe to rename & remove :scissors: :fire: :toilet: :droplet: 

@miq-bot assign @mzazrivec 
@miq-bot add_label cleanup, ivanchuk/no, trees