### PR TITLE
Remove the obsolete TreeBuilder#count_only_or_many_objects ✂️✂️

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -251,23 +251,6 @@ class TreeBuilder
     count_only ? 0 : []
   end
 
-  # count_only_or_objects but for many sets of objects
-  # count_only will short circuit the sizes
-  # the last parameter is a required sort_by (which is typically 'name')
-  #
-  # Passing a lambda around a collection will delay loading the collection.
-  # Especially useful when the collection downloads a lot of data.
-  def count_only_or_many_objects(count_only, *collections)
-    sort_by = collections.pop
-
-    if count_only
-      collections.detect { |objects| !resolve_object_lambdas(count_only, objects).empty? } ? 1 : 0
-    else
-      collections.map! { |objects| resolve_object_lambdas(count_only, objects) }
-      collections.flat_map { |objects| count_only_or_objects(count_only, objects, sort_by) }
-    end
-  end
-
   def count_only_or_objects(count_only, objects, sort_by = nil)
     if count_only
       objects.respond_to?(:order) ? objects.except(:order).size : objects.size
@@ -291,16 +274,6 @@ class TreeBuilder
       ViewHelper.concat(title)
     end
   end
-
-  def resolve_object_lambdas(count_only, objects)
-    if objects.respond_to?(:call)
-      # works with a no-param lambda OR a lambda that requests the count_only
-      objects.arity == 1 ? objects.call(count_only) : objects.call
-    else
-      objects
-    end
-  end
-  private :resolve_object_lambdas
 
   LEFT_TREE_CLASSES = {
     # Overview


### PR DESCRIPTION
This method is no longer being used anywhere, so :scissors: :toilet: :fire: also removing the `resolve_object_lambdas` as it is being used only in this method.

@miq-bot add_label cleanup, ivanchuk/no, trees
@miq-bot assign @mzazrivec 
