### PR TITLE
Drop the count_only argument from TreeBuilder#get_tree_roots

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -204,7 +204,7 @@ class TreeBuilder
   end
 
   def x_get_tree_objects(parent, count_only, parents)
-    children_or_count = parent.nil? ? x_get_tree_roots(count_only) : x_get_tree_kids(parent, count_only, parents)
+    children_or_count = parent.nil? ? x_get_tree_roots : x_get_tree_kids(parent, count_only, parents)
     children_or_count || (count_only ? 0 : [])
   end
 

--- a/app/presenters/tree_builder_action.rb
+++ b/app/presenters/tree_builder_action.rb
@@ -14,7 +14,7 @@ class TreeBuilderAction < TreeBuilder
   end
 
   # level 1 - actions
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, MiqAction.all, :description)
+  def x_get_tree_roots
+    count_only_or_objects(false, MiqAction.all, :description)
   end
 end

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -16,8 +16,8 @@ class TreeBuilderAeClass < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, User.current_tenant.visible_domains)
+  def x_get_tree_roots
+    count_only_or_objects(false, User.current_tenant.visible_domains)
   end
 
   def x_get_tree_class_kids(object, count_only)

--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -12,7 +12,7 @@ class TreeBuilderAeCustomization < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, nil)
+  def x_get_tree_roots
+    count_only_or_objects(false, nil)
   end
 end

--- a/app/presenters/tree_builder_alert.rb
+++ b/app/presenters/tree_builder_alert.rb
@@ -14,7 +14,7 @@ class TreeBuilderAlert < TreeBuilder
   end
 
   # level 1 - alerts
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, MiqAlert.all, :description)
+  def x_get_tree_roots
+    count_only_or_objects(false, MiqAlert.all, :description)
   end
 end

--- a/app/presenters/tree_builder_alert_profile.rb
+++ b/app/presenters/tree_builder_alert_profile.rb
@@ -20,7 +20,7 @@ class TreeBuilderAlertProfile < TreeBuilder
   end
 
   # level 1 - * alert profiles
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = alert_profile_kinds.map do |db|
       # Set alert profile folder nodes to open so we pre-load all children
       open_node("xx-#{db}")
@@ -28,7 +28,7 @@ class TreeBuilderAlertProfile < TreeBuilder
       {:id => db, :text => text, :tip => text, :icon => db.constantize.decorate.fonticon}
     end
 
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   # level 2 - alert profiles

--- a/app/presenters/tree_builder_alert_profile_assign.rb
+++ b/app/presenters/tree_builder_alert_profile_assign.rb
@@ -6,7 +6,7 @@ class TreeBuilderAlertProfileAssign < TreeBuilder
     super(name, sandbox, build)
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     roots = ExtManagementSystem.assignable.each_with_object({}) do |ems, nodes|
       subtree = ems.children.flat_map(&:folders).each_with_object({}) do |folder, obj|
         obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE))
@@ -15,7 +15,7 @@ class TreeBuilderAlertProfileAssign < TreeBuilder
       nodes.merge!(ems => subtree) if subtree.any?
     end
 
-    count_only_or_objects(count_only, roots)
+    count_only_or_objects(false, roots)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -30,7 +30,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     obj = if @assign_to.blank? || @assign_to == "enterprise"
             []
           elsif @cat_tree
@@ -40,6 +40,6 @@ class TreeBuilderAlertProfileObj < TreeBuilder
           else
             @assign_to.camelize.constantize.all
           end
-    count_only_or_objects(count_only, obj.sort_by { |o| (o.name.presence || o.description).downcase })
+    count_only_or_objects(false, obj.sort_by { |o| (o.name.presence || o.description).downcase })
   end
 end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -8,8 +8,8 @@ class TreeBuilderAutomate < TreeBuilder
     {:full_ids => false, :lazy => true, :onclick => "miqOnClickAutomate"}
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, [MiqAeDomain.find_by(:id => @sb[:domain_id])])
+  def x_get_tree_roots
+    count_only_or_objects(false, [MiqAeDomain.find_by(:id => @sb[:domain_id])])
   end
 
   def override(node, object)

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -5,8 +5,8 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
     super.merge!(:onclick => "miqOnClickAutomateCatalog")
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, filter_ae_objects(User.current_tenant.visible_domains))
+  def x_get_tree_roots
+    count_only_or_objects(false, filter_ae_objects(User.current_tenant.visible_domains))
   end
 
   def override(node, object)

--- a/app/presenters/tree_builder_automate_simulation_results.rb
+++ b/app/presenters/tree_builder_automate_simulation_results.rb
@@ -14,7 +14,7 @@ class TreeBuilderAutomateSimulationResults < TreeBuilder
     {:full_ids => true}
   end
 
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     xml_children(MiqXml.load(@root).root)
   end
 

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -16,7 +16,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = []
     templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"), :match_via_descendants => ConfigurationScript)
 
@@ -24,7 +24,7 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
       objects.push(temp)
     end
 
-    count_only_or_objects(count_only, objects + FILTERS.values)
+    count_only_or_objects(false, objects + FILTERS.values)
   end
 
   def x_get_tree_cmat_kids(object, count_only)

--- a/app/presenters/tree_builder_automation_manager_providers.rb
+++ b/app/presenters/tree_builder_automation_manager_providers.rb
@@ -16,8 +16,8 @@ class TreeBuilderAutomationManagerProviders < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects_filtered(count_only, ManageIQ::Providers::AnsibleTower::AutomationManager, "name")
+  def x_get_tree_roots
+    count_only_or_objects_filtered(false, ManageIQ::Providers::AnsibleTower::AutomationManager, "name")
   end
 
   def x_get_tree_cmat_kids(object, count_only)

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -34,8 +34,8 @@ class TreeBuilderBelongsToHac < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, ExtManagementSystem.assignable)
+  def x_get_tree_roots
+    count_only_or_objects(false, ExtManagementSystem.assignable)
   end
 
   def x_get_provider_kids(parent, count_only)

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -18,7 +18,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     buttons = CustomButton.button_classes.map do |klass|
       name = target_class_name(klass)
 

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -41,9 +41,7 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
     count_only_or_objects(count_only, objects)
   end
 
-  def x_get_tree_roots(count_only)
-    return super + 1 if count_only
-
+  def x_get_tree_roots
     # FIXME: adding gettext here would break the tree_select for languages other than English
     super.unshift(ServiceTemplateCatalog.new(:name => 'Unassigned', :description => 'Unassigned Catalogs'))
   end

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -9,7 +9,7 @@ class TreeBuilderCatalogsClass < TreeBuilder
     super(id) || ServiceTemplateCatalog.new
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects_filtered(count_only, ServiceTemplateCatalog.all, "name")
+  def x_get_tree_roots
+    count_only_or_objects_filtered(false, ServiceTemplateCatalog.all, "name")
   end
 end

--- a/app/presenters/tree_builder_chargeback.rb
+++ b/app/presenters/tree_builder_chargeback.rb
@@ -6,9 +6,8 @@ class TreeBuilderChargeback < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     rate_types = ChargebackRate::VALID_CB_RATE_TYPES
-    return rate_types.length if count_only
 
     rate_types.map do |type|
       {

--- a/app/presenters/tree_builder_chargeback_reports.rb
+++ b/app/presenters/tree_builder_chargeback_reports.rb
@@ -13,25 +13,21 @@ class TreeBuilderChargebackReports < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     items = MiqReportResult.with_saved_chargeback_reports
                            .select_distinct_results
                            .group("miq_report_results.miq_report_id, miq_reports.name, miq_report_results.id, \
                                    miq_reports.id")
-    if count_only
-      items.length
-    else
-      objects = []
-      items.each_with_index do |item, idx|
-        objects.push(
-          :id   => "#{item.miq_report_id}-#{idx}",
-          :text => item.miq_report.name,
-          :icon => "fa fa-file-text-o",
-          :tip  => item.name
-        )
-      end
-      objects
+    objects = []
+    items.each_with_index do |item, idx|
+      objects.push(
+        :id   => "#{item.miq_report_id}-#{idx}",
+        :text => item.miq_report.name,
+        :icon => "fa fa-file-text-o",
+        :tip  => item.name
+      )
     end
+    objects
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -30,7 +30,7 @@ class TreeBuilderClusters < TreeBuilder
     end
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = @root[:clusters].map do |node|
       { :id         => node[:id].to_s,
         :text       => node[:name],
@@ -50,7 +50,7 @@ class TreeBuilderClusters < TreeBuilder
               :selectable => false}
       nodes.push(node)
     end
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -18,8 +18,8 @@ class TreeBuilderComplianceHistory < TreeBuilder
     {:full_ids => true}
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, @root.compliances.order("timestamp DESC").limit(10))
+  def x_get_tree_roots
+    count_only_or_objects(false, @root.compliances.order("timestamp DESC").limit(10))
   end
 
   def x_get_compliance_kids(parent, count_only)

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -19,7 +19,7 @@ class TreeBuilderCondition < TreeBuilder
   end
 
   # level 1 - host / vm
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     text_i18n = {:Host                => _("Host Conditions"),
                  :Vm                  => _("VM and Instance Conditions"),
                  :ContainerReplicator => _("Replicator Conditions"),
@@ -41,7 +41,7 @@ class TreeBuilderCondition < TreeBuilder
         :tip  => text
       }
     end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   # level 2 - conditions

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -16,8 +16,8 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects_filtered(count_only, ManageIQ::Providers::Foreman::ConfigurationManager, "name", :match_via_descendants => ConfiguredSystem)
+  def x_get_tree_roots
+    count_only_or_objects_filtered(false, ManageIQ::Providers::Foreman::ConfigurationManager, "name", :match_via_descendants => ConfiguredSystem)
   end
 
   def node_by_tree_id(id)

--- a/app/presenters/tree_builder_configured_systems.rb
+++ b/app/presenters/tree_builder_configured_systems.rb
@@ -12,9 +12,9 @@ class TreeBuilderConfiguredSystems < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = []
     objects.push(configured_systems)
-    count_only_or_objects(count_only, objects + FILTERS.values)
+    count_only_or_objects(false, objects + FILTERS.values)
   end
 end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -18,7 +18,7 @@ class TreeBuilderDatastores < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = @root.map do |node|
       children = []
       if @data[node[:id]].hosts.present?
@@ -42,7 +42,7 @@ class TreeBuilderDatastores < TreeBuilder
         :selectable => false,
         :nodes      => children }
     end
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_default_filters.rb
+++ b/app/presenters/tree_builder_default_filters.rb
@@ -43,7 +43,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     roots = @data.keys.map do |folder|
       {:id           => folder,
        :text         => folder,
@@ -52,7 +52,7 @@ class TreeBuilderDefaultFilters < TreeBuilder
        :selectable   => false,
        :hideCheckbox => true}
     end
-    count_only_or_objects(count_only, roots)
+    count_only_or_objects(false, roots)
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_event.rb
+++ b/app/presenters/tree_builder_event.rb
@@ -14,7 +14,7 @@ class TreeBuilderEvent < TreeBuilder
   end
 
   # level 1 - events
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, MiqPolicy.all_policy_events, :description)
+  def x_get_tree_roots
+    count_only_or_objects(false, MiqPolicy.all_policy_events, :description)
   end
 end

--- a/app/presenters/tree_builder_genealogy.rb
+++ b/app/presenters/tree_builder_genealogy.rb
@@ -47,9 +47,9 @@ class TreeBuilderGenealogy < TreeBuilder
     }.merge(vm_icon_image(object))
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     kids = @root.parent.present? ? [@root] : @root.children
-    count_only_or_objects(count_only, kids, :name)
+    count_only_or_objects(false, kids, :name)
   end
 
   def x_get_vm_or_template_kids(parent, count_only)

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -12,8 +12,8 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, GenericObjectDefinition.all, :name)
+  def x_get_tree_roots
+    count_only_or_objects(false, GenericObjectDefinition.all, :name)
   end
 
   def x_get_god_kids(object, count_only)

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -15,8 +15,8 @@ class TreeBuilderImages < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => TemplateCloud) +
-      count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Images"))
+  def x_get_tree_roots
+    count_only_or_objects_filtered(false, EmsCloud, "name", :match_via_descendants => TemplateCloud) +
+      count_only_or_objects(false, x_get_tree_arch_orph_nodes("Images"))
   end
 end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -24,9 +24,9 @@ class TreeBuilderInfraNetworking < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = Rbac.filtered(ManageIQ::Providers::Vmware::InfraManager.order("lower(name)"))
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   def x_get_tree_provider_kids(object, count_only)

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -14,9 +14,9 @@ class TreeBuilderInstances < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => VmCloud) +
-      count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Instances"))
+  def x_get_tree_roots
+    count_only_or_objects_filtered(false, EmsCloud, "name", :match_via_descendants => VmCloud) +
+      count_only_or_objects(false, x_get_tree_arch_orph_nodes("Instances"))
   end
 
   def x_get_tree_ems_kids(object, count_only)

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -15,8 +15,8 @@ class TreeBuilderIsoDatastores < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, IsoDatastore.all, "name")
+  def x_get_tree_roots
+    count_only_or_objects(false, IsoDatastore.all, "name")
   end
 
   def x_get_tree_iso_datastore_kids(object, count_only)

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -36,7 +36,7 @@ class TreeBuilderMenuRoles < TreeBuilder
   # parents to children. Therefore we include the children with the parent.
   # The :data key was chosen to avoid future conflicts with the :nodes key.
   #
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     branches = menus.map do |i|
       grandkids = i.last.kind_of?(Array) ? i.last : []
 
@@ -49,7 +49,7 @@ class TreeBuilderMenuRoles < TreeBuilder
       }
     end
 
-    count_only_or_objects(count_only, branches)
+    count_only_or_objects(false, branches)
   end
 
   # Referenced by has_kids_for, builds nodes from branch kids and grandkids

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -29,10 +29,8 @@ class TreeBuilderNetwork < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    kids = count_only ? 0 : []
-    kids = count_only_or_objects(count_only, @root.switches) unless @root.switches.empty?
-    kids
+  def x_get_tree_roots
+    @root.switches.empty? ? [] : count_only_or_objects(false, @root.switches)
   end
 
   def x_get_tree_switch_kids(parent, count_only)

--- a/app/presenters/tree_builder_ops.rb
+++ b/app/presenters/tree_builder_ops.rb
@@ -13,9 +13,9 @@ class TreeBuilderOps < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     region = MiqRegion.my_region
     objects = region.zones.visible.sort_by { |z| z.name.downcase }
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 end

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -20,7 +20,7 @@ class TreeBuilderOpsRbac < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     objects = []
     if ApplicationHelper.role_allows?(:feature => "rbac_user_view", :any => true)
       objects.push(:id => "u", :text => _("Users"), :icon => "pficon pficon-user", :tip => _("Users"))

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -18,7 +18,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
 
   private
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     top_nodes = Menu::Manager.items.select do |section|
       Vmdb::PermissionStores.instance.can?(section.id) && !section.kind_of?(Menu::Item)
     end
@@ -28,7 +28,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
         MiqProductFeature.obj_features[additional_feature][:feature]
     end
 
-    count_only_or_objects(count_only, top_nodes.compact)
+    count_only_or_objects(false, top_nodes.compact)
   end
 
   def x_get_tree_section_kids(parent, count_only = false)

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -18,7 +18,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     objects = [
       {:id => "sis", :text => _("Analysis Profiles"), :icon => "fa fa-search", :tip => _("Analysis Profiles")},
       {:id => "z", :text => _("Zones"), :icon => "pficon pficon-zone", :tip => _("Zones")}

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -16,9 +16,9 @@ class TreeBuilderOpsVmdb < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = Rbac.filtered(VmdbDatabase.my_database.try(:evm_tables).to_a).to_a
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects(false, objects, "name")
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -12,7 +12,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = [
       {:id   => 'otcfn',
        :tree => "otcfn_tree",
@@ -45,7 +45,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
        :icon => "pficon pficon-template",
        :tip  => _("vApp Templates")}
     ]
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -49,7 +49,7 @@ class TreeBuilderPolicy < TreeBuilder
   end
 
   # level 1 - compliance & control
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = []
     objects << {:id => "compliance", :text => _("Compliance Policies"), :icon => "pficon pficon-history", :tip => _("Compliance Policies")}
     objects << {:id => "control", :text => _("Control Policies"), :icon => "fa fa-shield", :tip => _("Control Policies")}
@@ -57,7 +57,7 @@ class TreeBuilderPolicy < TreeBuilder
     # Push folder node ids onto open_nodes array
     objects.each { |o| open_node("xx-#{o[:id]}") }
 
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   # level 2 & 3...

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -18,8 +18,8 @@ class TreeBuilderPolicyProfile < TreeBuilder
   end
 
   # level 1 - policy profiles
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, MiqPolicySet.all, :description)
+  def x_get_tree_roots
+    count_only_or_objects(false, MiqPolicySet.all, :description)
   end
 
   # level 2 - policies

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -40,7 +40,7 @@ class TreeBuilderPolicySimulation < TreeBuilder
     end
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = if @data.present?
               reject_na_nodes(@data).map do |node|
                 {:id         => node['id'],
@@ -53,7 +53,7 @@ class TreeBuilderPolicySimulation < TreeBuilder
             else
               [{:id => nil, :text => _("Items out of scope"), :icon => 'fa fa-ban', :selectable => false}]
             end
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def node_out_of_scope?(node)

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -110,8 +110,8 @@ class TreeBuilderPolicySimulationResults < TreeBuilder
      :selectable => false}
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, vm_nodes(@root[:results]))
+  def x_get_tree_roots
+    count_only_or_objects(false, vm_nodes(@root[:results]))
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -17,7 +17,7 @@ class TreeBuilderProtect < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = MiqPolicySet.all.sort_by { |profile| profile.description.downcase }.map do |profile|
       { :id         => "policy_profile_#{profile.id}",
         :text       => profile.description,
@@ -27,7 +27,7 @@ class TreeBuilderProtect < TreeBuilder
         :nodes      => profile.members,
         :selectable => false}
     end
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -13,7 +13,7 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = MiqDialog::DIALOG_TYPES.sort.collect do |typ|
       {
         :id   => "MiqDialog_#{typ[1]}",
@@ -22,7 +22,7 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
         :tip  => typ[0]
       }
     end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -14,22 +14,16 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    items = PxeImageType.all
-    if count_only
-      # add +1 for customization spec folder thats used to show system templates
-      items.size + 1
-    else
-      objects = []
-      objects.push(:id   => "xx-system",
-                   :text => _("Examples (read only)"),
-                   :icon => "pficon pficon-folder-close",
-                   :tip  => _("Examples (read only)"))
-      PxeImageType.all.sort.each do |item, _idx|
-        objects.push(:id => "xx-#{item.id}", :text => item.name, :icon => "pficon pficon-folder-close", :tip => item.name)
-      end
-      objects
+  def x_get_tree_roots
+    objects = []
+    objects.push(:id   => "xx-system",
+                 :text => _("Examples (read only)"),
+                 :icon => "pficon pficon-folder-close",
+                 :tip  => _("Examples (read only)"))
+    PxeImageType.all.sort.each do |item, _idx|
+      objects.push(:id => "xx-#{item.id}", :text => item.name, :icon => "pficon pficon-folder-close", :tip => item.name)
     end
+    objects
   end
 
   def get_pxe_image_id(nodes)

--- a/app/presenters/tree_builder_pxe_image_types.rb
+++ b/app/presenters/tree_builder_pxe_image_types.rb
@@ -13,7 +13,7 @@ class TreeBuilderPxeImageTypes < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, PxeImageType.all, "name")
+  def x_get_tree_roots
+    count_only_or_objects(false, PxeImageType.all, "name")
   end
 end

--- a/app/presenters/tree_builder_pxe_servers.rb
+++ b/app/presenters/tree_builder_pxe_servers.rb
@@ -15,8 +15,8 @@ class TreeBuilderPxeServers < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, PxeServer.all, "name")
+  def x_get_tree_roots
+    count_only_or_objects(false, PxeServer.all, "name")
   end
 
   def x_get_tree_pxe_server_kids(object, count_only)

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -15,13 +15,13 @@ class TreeBuilderReportDashboards < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = []
     default_ws = MiqWidgetSet.find_by(:name => 'default', :read_only => true)
     text = "#{default_ws.description} (#{default_ws.name})"
     objects.push(:id => default_ws.id.to_s, :text => text, :icon => 'fa fa-tachometer', :tip => text)
     objects.push(:id => 'g', :text => _('All Groups'), :icon => 'pficon pficon-folder-close', :tip => _('All Groups'))
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -14,7 +14,7 @@ class TreeBuilderReportExport < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = [
       {:id   => 'exportcustomreports',
        :text => _('Custom Reports'),
@@ -23,6 +23,6 @@ class TreeBuilderReportExport < TreeBuilder
        :text => _('Widgets'),
        :icon => 'fa fa-file-text-o'}
     ]
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 end

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -23,8 +23,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
   end
 
   # Get root node and all children report folders. (will call get_tree_custom_kids to get report details)
-  def x_get_tree_roots(count_only)
-    return @rpt_menu.size if count_only
+  def x_get_tree_roots
     @rpt_menu.each_with_index.each_with_object({}) do |(r, node_id), a|
       open_node("xx-#{node_id}")
 

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -19,9 +19,9 @@ class TreeBuilderReportRoles < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     user  = User.current_user
     roles = user.super_admin_user? ? MiqGroup.non_tenant_groups_in_my_region : [user.current_group]
-    count_only_or_objects(count_only, roles, 'name')
+    count_only_or_objects(false, roles, 'name')
   end
 end

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -13,7 +13,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     u = User.current_user
     user_groups = u.report_admin_user? ? nil : u.miq_groups
     having_report_results(user_groups).sort

--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -14,13 +14,13 @@ class TreeBuilderReportSchedules < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
                 # Super admins see all report schedules
                 MiqSchedule.where(:resource_type => 'MiqReport')
               else
                 MiqSchedule.where(:resource_type => 'MiqReport', :userid => User.current_user.userid)
               end
-    count_only_or_objects(count_only, objects, 'name')
+    count_only_or_objects(false, objects, 'name')
   end
 end

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -20,9 +20,9 @@ class TreeBuilderReportWidgets < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = WIDGET_TYPES.collect { |k, v| {:id => k, :text => _(v), :icon => 'pficon pficon-folder-close', :tip => _(v)} }
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -3,7 +3,7 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
 
   private
 
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     x_get_tree_miq_servers
   end
 

--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -21,7 +21,7 @@ class TreeBuilderSections < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = []
     group = nil
     @data.master_list.each_slice(3) do |section, _records, _fields|
@@ -48,7 +48,7 @@ class TreeBuilderSections < TreeBuilder
                          true
                        end
     end
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_tree_hash_kids(parent, count_only)

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -3,7 +3,7 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
 
   private
 
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     x_get_tree_server_roles
   end
 

--- a/app/presenters/tree_builder_service_catalog.rb
+++ b/app/presenters/tree_builder_service_catalog.rb
@@ -14,7 +14,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     includes = {:tenant => {}, :service_templates => {}}
     objects = Rbac.filtered(ServiceTemplateCatalog, :include_for_find => includes).sort_by { |o| o.name.downcase }
     filtered_objects = []
@@ -23,7 +23,7 @@ class TreeBuilderServiceCatalog < TreeBuilderCatalogsClass
       items = Rbac.filtered(object.service_templates, :named_scope => %i[displayed public_service_templates])
       filtered_objects.push(object) unless items.empty?
     end
-    count_only_or_objects(count_only, filtered_objects, 'name')
+    count_only_or_objects(false, filtered_objects, 'name')
   end
 
   def x_get_tree_stc_kids(object, count_only)

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -11,8 +11,8 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = Rbac.filtered(Dialog.all).sort_by { |a| a.label.downcase }
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 end

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -18,12 +18,12 @@ class TreeBuilderServices < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     objects = [
       services_root('asrv', _('Active Services'), _('Active Services')),
       services_root('rsrv', _('Retired Services'), _('Retired Services')),
     ]
-    count_only_or_objects(count_only, objects + FILTERS.values)
+    count_only_or_objects(false, objects + FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -25,9 +25,9 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     nodes = @data.miq_servers.select(&:is_a_proxy?).sort_by { |s| [s.name, s.id] }
-    count_only_or_objects(count_only, nodes)
+    count_only_or_objects(false, nodes)
   end
 
   def x_get_server_kids(parent, count_only = false)

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -43,9 +43,9 @@ class TreeBuilderSnapshots < TreeBuilder
     @tree_state.x_node_set(node[:key], @name)
   end
 
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     root_kid = @record.snapshots.present? ? @record.snapshots.find_all { |x| x.parent_id.nil? } : []
-    count_only_or_objects(count_only, root_kid)
+    count_only_or_objects(false, root_kid)
   end
 
   def x_get_tree_snapshot_kids(parent, count_only)

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -14,8 +14,8 @@ class TreeBuilderStorage < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, FILTERS.values)
+  def x_get_tree_roots
+    count_only_or_objects(false, FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -26,13 +26,8 @@ class TreeBuilderStorageAdapters < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    kids = count_only ? 0 : []
-    unless @root.hardware.storage_adapters.empty?
-      kids = count_only_or_objects(count_only, @root.hardware.storage_adapters)
-    end
-    kids.reverse unless count_only
-    kids
+  def x_get_tree_roots
+    @root.hardware.storage_adapters.empty? ? [] : @root.hardware.storage_adapters.reverse
   end
 
   def x_get_tree_guest_device_kids(parent, count_only = false)

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -11,8 +11,8 @@ class TreeBuilderStoragePod < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, EmsFolder.where(:type => 'StorageCluster'))
+  def x_get_tree_roots
+    count_only_or_objects(false, EmsFolder.where(:type => 'StorageCluster'))
   end
 
   def x_get_ems_folder_kids(object, count_only)

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -47,7 +47,7 @@ class TreeBuilderTenants < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(_count_only)
+  def x_get_tree_roots
     if ApplicationHelper.role_allows?(:feature => 'rbac_tenant_view')
       Tenant.with_current_tenant
     end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -25,10 +25,10 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   # Get root nodes count/array for explorer tree
-  def x_get_tree_roots(count_only)
+  def x_get_tree_roots
     ent = MiqEnterprise.my_enterprise
     objects = ent.miq_regions.sort_by { |a| a.description.downcase }
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(false, objects)
   end
 
   def x_get_tree_region_kids(object, count_only)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -16,11 +16,9 @@ class TreeBuilderVandt < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    roots = count_only_or_objects_filtered(count_only, EmsInfra, "name", :match_via_descendants => VmOrTemplate)
-    arch_orph = count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("VMs and Templates"))
-
-    return roots + arch_orph if count_only
+  def x_get_tree_roots
+    roots = count_only_or_objects_filtered(false, EmsInfra, "name", :match_via_descendants => VmOrTemplate)
+    arch_orph = count_only_or_objects(false, x_get_tree_arch_orph_nodes("VMs and Templates"))
 
     roots.each_with_object({}) do |ems, nodes|
       nodes.merge!(relationship_tree(ems))

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -20,8 +20,8 @@ class TreeBuilderVmsFilter < TreeBuilder
     }
   end
 
-  def x_get_tree_roots(count_only)
-    count_only_or_objects(count_only, FILTERS.values)
+  def x_get_tree_roots
+    count_only_or_objects(false, FILTERS.values)
   end
 
   def x_get_tree_custom_kids(object, count_only)

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -266,7 +266,7 @@ describe AutomationManagerController do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
     TreeBuilderAutomationManagerProviders.new(:automation_manager_providers_tree, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerProviders.new("root", {})
-    objects = tree_builder.send(:x_get_tree_roots, false)
+    objects = tree_builder.send(:x_get_tree_roots)
     expected_objects = [automation_manager1, automation_manager2, automation_manager3]
     expect(objects).to match_array(expected_objects)
   end
@@ -283,7 +283,7 @@ describe AutomationManagerController do
     user = login_as user_with_feature(%w(automation_manager_providers providers_accord automation_manager_configured_system automation_manager_configuration_scripts_accord))
     TreeBuilderAutomationManagerConfigurationScripts.new(:configuration_scripts_tree, controller.instance_variable_get(:@sb))
     tree_builder = TreeBuilderAutomationManagerConfigurationScripts.new("root", {})
-    objects = tree_builder.send(:x_get_tree_roots, false)
+    objects = tree_builder.send(:x_get_tree_roots)
     expect(objects).to include(@automation_manager1)
     expect(objects).to include(@automation_manager2)
   end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -294,7 +294,7 @@ describe ProviderForemanController do
 
   it "builds foreman child tree" do
     tree_builder = TreeBuilderConfigurationManager.new("root", controller.instance_variable_get(:@sb))
-    objects = tree_builder.send(:x_get_tree_roots, false)
+    objects = tree_builder.send(:x_get_tree_roots)
     expected_objects = [@config_mgr, @config_mgr2]
     expect(objects).to match_array(expected_objects)
   end

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -80,7 +80,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
-        s = subject.send(:x_get_tree_roots, false)
+        s = subject.send(:x_get_tree_roots)
         expect(s).to eq([tag1a, tag2a, tag3a].sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end
@@ -89,7 +89,7 @@ describe TreeBuilderAlertProfileObj do
       it 'returns all ExtManagementSystems except the Embedded Ansible when @assign_to=ext_management_system' do
         subject.instance_variable_set(:@cat_tree, nil)
         subject.instance_variable_set(:@assign_to, "ext_management_system")
-        expect(subject.send(:x_get_tree_roots, false)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+        expect(subject.send(:x_get_tree_roots)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
       end
     end
   end
@@ -106,7 +106,7 @@ describe TreeBuilderAlertProfileObj do
 
     describe '#x_get_tree_roots' do
       it 'sets first level nodes correctly' do
-        s = subject.send(:x_get_tree_roots, false)
+        s = subject.send(:x_get_tree_roots)
         expect(s).to eq(Tenant.all.sort_by { |o| (o.name.presence || o.description).downcase })
       end
     end

--- a/spec/presenters/tree_builder_belongs_to_hac_spec.rb
+++ b/spec/presenters/tree_builder_belongs_to_hac_spec.rb
@@ -87,7 +87,7 @@ describe TreeBuilderBelongsToHac do
 
   describe '#x_get_tree_roots' do
     it 'returns all ExtManagementSystems except the Embedded Ansible' do
-      expect(subject.send(:x_get_tree_roots, false)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
+      expect(subject.send(:x_get_tree_roots)).to eq(ExtManagementSystem.where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager"))
     end
   end
 

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -36,7 +36,7 @@ describe TreeBuilderClusters do
     end
 
     it 'set cluster nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots, false)
+      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
       expect(cluster_nodes.first).to eq(:id         => "1",
                                         :text       => "Name",
                                         :icon       => 'pficon pficon-cluster',
@@ -55,7 +55,7 @@ describe TreeBuilderClusters do
     end
 
     it 'sets non-cluster host nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots, false)
+      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
       non_cluster_host = @cluster_tree.send(:x_get_tree_hash_kids, cluster_nodes.last, false)
       expect(non_cluster_host).to eq([{:id         => "NonCluster_2",
                                        :text       => "Non Cluster Host",
@@ -67,7 +67,7 @@ describe TreeBuilderClusters do
     end
 
     it 'sets cluster hosts nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots, false)
+      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
       cluster_hosts = @cluster_tree.send(:x_get_tree_hash_kids, cluster_nodes.first, false)
       cluster_hosts_expected = @ho_enabled.map do |node|
         {:id         => "#{cluster_nodes.first[:id]}_#{node[:id]}",

--- a/spec/presenters/tree_builder_compliance_history_spec.rb
+++ b/spec/presenters/tree_builder_compliance_history_spec.rb
@@ -25,13 +25,13 @@ describe TreeBuilderComplianceHistory do
       expect(tree_options[:lazy]).not_to be_truthy
     end
     it 'returns Compliance as root kids' do
-      kids = @ch_tree.send(:x_get_tree_roots, false)
+      kids = @ch_tree.send(:x_get_tree_roots)
       kids.each do |kid|
         expect(kid).to be_a_kind_of(Compliance)
       end
     end
     it 'returns correctly ComplianceDetail nodes' do
-      parent = @ch_tree.send(:x_get_tree_roots, false).find { |x| x.compliance_details.present? }
+      parent = @ch_tree.send(:x_get_tree_roots).find { |x| x.compliance_details.present? }
       kids = @ch_tree.send(:x_get_compliance_kids, parent, false)
       expect(@ch_tree.send(:x_get_compliance_kids, parent, true)).to eq(2)
       kids.each do |kid|
@@ -39,7 +39,7 @@ describe TreeBuilderComplianceHistory do
       end
     end
     it 'returns empty node' do
-      parents = @ch_tree.send(:x_get_tree_roots, false)
+      parents = @ch_tree.send(:x_get_tree_roots)
       parent = parents.find { |x| x.compliance_details == [] }
       kid = @ch_tree.send(:x_get_compliance_kids, parent, false).first
       expect(kid).to eq(:id         => "#{parent.id}-nopol",
@@ -51,7 +51,7 @@ describe TreeBuilderComplianceHistory do
       expect(@ch_tree.send(:x_get_tree_custom_kids, kid, true)).to eq(0)
     end
     it 'returns Policy with multiple Conditions' do
-      grandparents = @ch_tree.send(:x_get_tree_roots, false)
+      grandparents = @ch_tree.send(:x_get_tree_roots)
       grandparent = grandparents.find { |x| x.compliance_details.present? }
       grandparent_id = "cm-#{grandparent.id}"
       parents = @ch_tree.send(:x_get_compliance_kids, grandparent, false)

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -25,13 +25,13 @@ describe TreeBuilderDatastores do
       expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
     end
     it 'sets Datastore node correctly' do
-      parent = @datastores_tree.send(:x_get_tree_roots, false)
+      parent = @datastores_tree.send(:x_get_tree_roots)
       expect(parent.first[:text]).to eq("<strong>Datastore</strong> [#{@datastore.first[:location]}]")
       expect(parent.first[:tip]).to eq("Datastore [#{@datastore.first[:location]}]")
       expect(parent.first[:icon]).to eq('fa fa-database')
     end
     it 'sets Host node correctly' do
-      parent = @datastores_tree.send(:x_get_tree_roots, false)
+      parent = @datastores_tree.send(:x_get_tree_roots)
       kids = @datastores_tree.send(:x_get_tree_hash_kids, parent.first, false)
       expect(kids.first[:text]).to eq(@host[:name])
       expect(kids.first[:tip]).to eq(@host[:name])

--- a/spec/presenters/tree_builder_default_filters_spec.rb
+++ b/spec/presenters/tree_builder_default_filters_spec.rb
@@ -70,7 +70,7 @@ describe TreeBuilderDefaultFilters do
     end
 
     it 'returns folders as root kids' do
-      kids = @default_filters_tree.send(:x_get_tree_roots, false)
+      kids = @default_filters_tree.send(:x_get_tree_roots)
       kids.each do |kid|
         expect(kid[:icon]).to eq('pficon pficon-folder-close')
         expect(kid[:hideCheckbox]).to eq(true)
@@ -80,7 +80,7 @@ describe TreeBuilderDefaultFilters do
 
     it 'returns filter or folder as folder kids' do
       data = @default_filters_tree.send(:prepare_data, @filters)
-      grandparents = @default_filters_tree.send(:x_get_tree_roots, false)
+      grandparents = @default_filters_tree.send(:x_get_tree_roots)
       grandparents.each do |grandparent|
         parents = @default_filters_tree.send(:x_get_tree_hash_kids, grandparent, false)
         parents.each do |parent|

--- a/spec/presenters/tree_builder_ems_folders_spec.rb
+++ b/spec/presenters/tree_builder_ems_folders_spec.rb
@@ -20,7 +20,7 @@ describe TreeBuilderEmsFolders do
   describe '#x_get_tree_roots' do
     context 'no ems folders with a single provider' do
       it 'returns with a no roots' do
-        expect(subject.send(:x_get_tree_roots, false).length).to eq(0)
+        expect(subject.send(:x_get_tree_roots).length).to eq(0)
       end
     end
 
@@ -36,7 +36,7 @@ describe TreeBuilderEmsFolders do
       end
 
       it 'returns with a single root' do
-        expect(subject.send(:x_get_tree_roots, false).length).to eq(1)
+        expect(subject.send(:x_get_tree_roots).length).to eq(1)
       end
     end
   end

--- a/spec/presenters/tree_builder_genealogy_spec.rb
+++ b/spec/presenters/tree_builder_genealogy_spec.rb
@@ -52,8 +52,7 @@ describe TreeBuilderGenealogy do
 
   describe '#x_get_tree_roots' do
     it 'returns tree roots correctly' do
-      expect(subject.send(:x_get_tree_roots, false)).to include(vm_with_kid, vm_without_kid)
-      expect(subject.send(:x_get_tree_roots, true)).to eq(2)
+      expect(subject.send(:x_get_tree_roots)).to include(vm_with_kid, vm_without_kid)
     end
   end
 

--- a/spec/presenters/tree_builder_images_spec.rb
+++ b/spec/presenters/tree_builder_images_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderImages do
 
   it 'sets providers nodes correctly' do
     allow(@images_tree).to receive(:role_allows?).and_return(true)
-    providers = @images_tree.send(:x_get_tree_roots, false)
+    providers = @images_tree.send(:x_get_tree_roots)
     expect(providers).to eq([@template_cloud_with_az.ext_management_system,
                              {:id              => "arch",
                               :text            => "<Archived>",

--- a/spec/presenters/tree_builder_instances_spec.rb
+++ b/spec/presenters/tree_builder_instances_spec.rb
@@ -36,7 +36,7 @@ describe TreeBuilderInstances do
 
   it 'sets providers nodes correctly' do
     allow(@instances_tree).to receive(:role_allows?).and_return(true)
-    providers = @instances_tree.send(:x_get_tree_roots, false)
+    providers = @instances_tree.send(:x_get_tree_roots)
 
     expect(providers).to eq([@vm_cloud_with_az.ext_management_system,
                              @vm_cloud_without_az.ext_management_system,
@@ -53,8 +53,8 @@ describe TreeBuilderInstances do
   end
 
   it 'sets availability zones correctly if vms are hidden' do
-    provider_with_az = @instances_tree.send(:x_get_tree_roots, false)[0] # provider with vm that has availability zone
-    provider_without_az = @instances_tree.send(:x_get_tree_roots, false)[1] # provider with vm that doesn't have availability zone
+    provider_with_az = @instances_tree.send(:x_get_tree_roots)[0] # provider with vm that has availability zone
+    provider_without_az = @instances_tree.send(:x_get_tree_roots)[1] # provider with vm that doesn't have availability zone
     allow(provider_with_az).to receive(:availability_zones) { [@vm_cloud_with_az.availability_zone] }
     az = @instances_tree.x_get_tree_ems_kids(provider_with_az, false)
     vm_without_az = @instances_tree.x_get_tree_ems_kids(provider_without_az, false)

--- a/spec/presenters/tree_builder_network_spec.rb
+++ b/spec/presenters/tree_builder_network_spec.rb
@@ -25,25 +25,25 @@ describe TreeBuilderNetwork do
     end
 
     it 'returns Switch as root child' do
-      kid = @network_tree.send(:x_get_tree_roots, false)
+      kid = @network_tree.send(:x_get_tree_roots)
       expect(kid.first).to be_a_kind_of(Switch)
     end
 
     it 'returns GuestDevice and Lan as Switch children' do
-      parent = @network_tree.send(:x_get_tree_roots, false).first
+      parent = @network_tree.send(:x_get_tree_roots).first
       kids = @network_tree.send(:x_get_tree_switch_kids, parent, false)
       expect(kids[0]).to be_a_kind_of(GuestDevice)
       expect(kids[1]).to be_a_kind_of(Lan)
     end
 
     it 'returns Vm as Lan child' do
-      parent = @network_tree.send(:x_get_tree_roots, false).first.lans.first
+      parent = @network_tree.send(:x_get_tree_roots).first.lans.first
       kid = @network_tree.send(:x_get_tree_lan_kids, parent, false)
       expect(kid.first).to be_a_kind_of(Vm)
     end
 
     it 'returns nothing as GuestDevice child' do
-      parent = @network_tree.send(:x_get_tree_roots, false).first.guest_devices.first
+      parent = @network_tree.send(:x_get_tree_roots).first.guest_devices.first
       number_of_kids = @network_tree.send(:x_get_tree_objects, parent, true, nil)
       expect(number_of_kids).to eq(0)
     end

--- a/spec/presenters/tree_builder_policy_simulation_results_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_results_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderPolicySimulationResults do
     end
 
     it 'sets vm nodes correctly' do
-      vms = @rsop_tree.send(:x_get_tree_roots, false)
+      vms = @rsop_tree.send(:x_get_tree_roots)
       original_vms = @data[:results].sort_by { |a| a[:name].downcase }
       vms.each_with_index do |vm, i|
         expect(vm[:text]).to eq("<strong>VM:</strong> #{original_vms[i][:name]}")
@@ -50,7 +50,7 @@ describe TreeBuilderPolicySimulationResults do
     end
 
     it 'sets profile nodes correctly' do
-      vms = @rsop_tree.send(:x_get_tree_roots, false)
+      vms = @rsop_tree.send(:x_get_tree_roots)
       original_vms = @data[:results].sort_by { |a| a[:name].downcase }
       profiles_one = @rsop_tree.send(:x_get_tree_hash_kids, vms.first, false)
       profiles_two = @rsop_tree.send(:x_get_tree_hash_kids, vms.last, false)
@@ -60,7 +60,7 @@ describe TreeBuilderPolicySimulationResults do
     end
 
     it 'sets policy nodes correctly' do
-      vms = @rsop_tree.send(:x_get_tree_roots, false)
+      vms = @rsop_tree.send(:x_get_tree_roots)
       original_vms = @data[:results].sort_by { |a| a[:name].downcase }
       profiles = @rsop_tree.send(:x_get_tree_hash_kids, vms.first, false)
       policies = @rsop_tree.send(:x_get_tree_hash_kids, profiles.first, false)
@@ -69,7 +69,7 @@ describe TreeBuilderPolicySimulationResults do
     end
 
     it 'sets condition and action nodes correctly' do
-      vms = @rsop_tree.send(:x_get_tree_roots, false)
+      vms = @rsop_tree.send(:x_get_tree_roots)
       original_vms = @data[:results].sort_by { |a| a[:name].downcase }
       profiles = @rsop_tree.send(:x_get_tree_hash_kids, vms.first, false)
       policies = @rsop_tree.send(:x_get_tree_hash_kids, profiles.first, false)

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -63,7 +63,7 @@ describe TreeBuilderPolicySimulation do
     end
 
     it 'sets Policy Profile node correctly' do
-      node = @policy_simulation_tree.send(:x_get_tree_roots, false).first
+      node = @policy_simulation_tree.send(:x_get_tree_roots).first
       expect(node[:text]).to eq("<strong>Policy Profile:</strong> #{@data.first['description']}")
       expect(node[:icon]).to eq("pficon pficon-ok")
       expect(node[:tip]).to eq(@data.first['description'])
@@ -71,7 +71,7 @@ describe TreeBuilderPolicySimulation do
     end
 
     it 'sets Policy nodes correctly' do
-      node = @policy_simulation_tree.send(:x_get_tree_roots, false).first
+      node = @policy_simulation_tree.send(:x_get_tree_roots).first
       kids = @policy_simulation_tree.send(:x_get_tree_hash_kids, node, false)
       expect(kids.first[:text]).to eq("<strong>Policy:</strong> #{@data.first['policies'].first['description']}")
       expect(kids.first[:icon]).to eq('fa fa-ban')
@@ -84,7 +84,7 @@ describe TreeBuilderPolicySimulation do
     end
 
     it 'sets Condition nodes correctly' do
-      root = @policy_simulation_tree.send(:x_get_tree_roots, false).first
+      root = @policy_simulation_tree.send(:x_get_tree_roots).first
       parent_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, root, false).first
       kid_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_one, false).first
       parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, root, false).last
@@ -98,7 +98,7 @@ describe TreeBuilderPolicySimulation do
     end
 
     it 'sets Condition nodes correctly' do
-      root = @policy_simulation_tree.send(:x_get_tree_roots, false).first
+      root = @policy_simulation_tree.send(:x_get_tree_roots).first
       grand_parent_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, root, false).first
       parent_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, grand_parent_one, false).first
       grand_parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, root, false).last
@@ -127,7 +127,7 @@ describe TreeBuilderPolicySimulation do
                                                                 :options   => @policy_options)
     end
     it 'sets Policy Profile node correctly if no data found' do
-      node = @policy_simulation_tree.send(:x_get_tree_roots, false).first
+      node = @policy_simulation_tree.send(:x_get_tree_roots).first
       expect(node[:text]).to eq("Items out of scope")
       expect(node[:icon]).to eq("fa fa-ban")
       expect(node[:selectable]).to eq(false)

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderProtect do
     end
 
     it 'sets roots correctly' do
-      roots = @protect_tree.send(:x_get_tree_roots, false)
+      roots = @protect_tree.send(:x_get_tree_roots)
       @roots.each_with_index do |root, i|
         expect(roots[i][:id]).to eq("policy_profile_#{root.id}")
         expect(roots[i][:icon]).to eq(root.active? ? "fa fa-shield" : "fa fa-inactive fa-shield")
@@ -52,7 +52,7 @@ describe TreeBuilderProtect do
     end
 
     it 'sets Policy ' do
-      roots = @protect_tree.send(:x_get_tree_roots, false)
+      roots = @protect_tree.send(:x_get_tree_roots)
       kids = @protect_tree.send(:x_get_tree_hash_kids, roots[0], false)
       expect(kids[0][:id]).to eq("policy_#{@kids[0].id}")
       expect(kids[0][:text]).to eq("<strong>#{ui_lookup(:model => @kids[0].towhat)} #{@kids[0].mode.capitalize}:</strong> #{@kids[0].description}".html_safe)

--- a/spec/presenters/tree_builder_report_widgets_spec.rb
+++ b/spec/presenters/tree_builder_report_widgets_spec.rb
@@ -6,7 +6,7 @@ describe TreeBuilderReportWidgets do
   end
 
   it "#x_get_tree_roots (private)" do
-    expect(subject.send(:x_get_tree_roots, false)).to match_array([
+    expect(subject.send(:x_get_tree_roots)).to match_array([
                                                                     {:id => "r",  :text => "Reports",   :icon => "pficon pficon-folder-close", :tip => "Reports"},
                                                                     {:id => "c",  :text => "Charts",    :icon => "pficon pficon-folder-close", :tip => "Charts"},
                                                                     {:id => "m",  :text => "Menus",     :icon => "pficon pficon-folder-close", :tip => "Menus"}

--- a/spec/presenters/tree_builder_resource_pools_spec.rb
+++ b/spec/presenters/tree_builder_resource_pools_spec.rb
@@ -20,7 +20,7 @@ describe TreeBuilderResourcePools do
   describe '#x_get_tree_roots' do
     context 'no ems folders with a single provider' do
       it 'returns with a no roots' do
-        expect(subject.send(:x_get_tree_roots, false).length).to eq(0)
+        expect(subject.send(:x_get_tree_roots).length).to eq(0)
       end
     end
 
@@ -36,7 +36,7 @@ describe TreeBuilderResourcePools do
       end
 
       it 'returns with a single root' do
-        expect(subject.send(:x_get_tree_roots, false).length).to eq(1)
+        expect(subject.send(:x_get_tree_roots).length).to eq(1)
       end
     end
   end

--- a/spec/presenters/tree_builder_roles_by_server_spec.rb
+++ b/spec/presenters/tree_builder_roles_by_server_spec.rb
@@ -40,7 +40,7 @@ describe TreeBuilderRolesByServer do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      server_nodes = @server_tree.send(:x_get_tree_roots)
       expect(server_nodes).to eq([@miq_server])
     end
 

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -69,7 +69,7 @@ describe TreeBuilderSections do
       expect(locals[:three_checks]).to eq(true)
     end
     it 'sets roots correctly' do
-      roots = @sections_tree.send(:x_get_tree_roots, false)
+      roots = @sections_tree.send(:x_get_tree_roots)
       expect(roots).to eq([{:id         => "group_Properties",
                             :text       => "Properties",
                             :tip        => "Properties",
@@ -80,7 +80,7 @@ describe TreeBuilderSections do
     end
 
     it 'sets children correctly' do
-      root = @sections_tree.send(:x_get_tree_roots, false).first
+      root = @sections_tree.send(:x_get_tree_roots).first
       kids = @sections_tree.send(:x_get_tree_hash_kids, root, false)
       expect(kids).to eq([{:id         => "group_Properties:_model_",
                            :text       => "Filesystem",

--- a/spec/presenters/tree_builder_servers_by_role_spec.rb
+++ b/spec/presenters/tree_builder_servers_by_role_spec.rb
@@ -42,7 +42,7 @@ describe TreeBuilderServersByRole do
     end
 
     it 'returns server nodes as root kids' do
-      server_nodes = @server_tree.send(:x_get_tree_roots, false)
+      server_nodes = @server_tree.send(:x_get_tree_roots)
       expect(server_nodes).to eq([@server_role])
     end
 

--- a/spec/presenters/tree_builder_service_catalog_spec.rb
+++ b/spec/presenters/tree_builder_service_catalog_spec.rb
@@ -25,7 +25,7 @@ describe TreeBuilderServiceCatalog do
   end
 
   it "#x_get_tree_roots" do
-    roots = @tree.send(:x_get_tree_roots, false)
+    roots = @tree.send(:x_get_tree_roots)
     expect(roots.first.name).to eq(@catalog.name)
   end
 

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -14,7 +14,7 @@ describe TreeBuilderServices do
 
   describe '#x_get_tree_roots' do
     it 'returns the four root nodes' do
-      root_nodes = subject.send(:x_get_tree_roots, false)
+      root_nodes = subject.send(:x_get_tree_roots)
 
       expect(root_nodes).to match [
         a_hash_including(:id => 'asrv'),

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -51,7 +51,7 @@ describe TreeBuilderSmartproxyAffinity do
       expect(locals[:three_checks]).to eq(true)
     end
     it 'sets roots correctly' do
-      roots = @smartproxy_affinity_tree.send(:x_get_tree_roots, false)
+      roots = @smartproxy_affinity_tree.send(:x_get_tree_roots)
       expect(roots).to eq([@svr1, @svr2])
     end
     it 'sets MiqServer kids correctly' do

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -34,14 +34,14 @@ describe TreeBuilderSnapshots do
     end
 
     it 'returns Snapshot as kids of root' do
-      snapshot_nodes = tree.send(:x_get_tree_roots, false)
+      snapshot_nodes = tree.send(:x_get_tree_roots)
       snapshot_nodes.each do |snapshot_node|
         expect(snapshot_node).to be_a_kind_of(Snapshot)
       end
     end
 
     it 'returns Snapshot as kids of Snapshot' do
-      snapshot_parent = tree.send(:x_get_tree_roots, false).first
+      snapshot_parent = tree.send(:x_get_tree_roots).first
       snapshot_nodes = tree.send(:x_get_tree_snapshot_kids, snapshot_parent, false)
       snapshot_nodes.each do |snapshot_node|
         expect(snapshot_node).to be_a_kind_of(Snapshot)

--- a/spec/presenters/tree_builder_storage_adapters_spec.rb
+++ b/spec/presenters/tree_builder_storage_adapters_spec.rb
@@ -26,12 +26,12 @@ describe TreeBuilderStorageAdapters do
     end
 
     it 'returns MiqScsiTarget as children of root' do
-      kids = @sa_tree.send(:x_get_tree_roots, false)
+      kids = @sa_tree.send(:x_get_tree_roots)
       expect(kids.first).to be_a_kind_of(MiqScsiTarget)
     end
 
     it 'returns MiqScsiLun as MiqScsiTarget children' do
-      parent = @sa_tree.send(:x_get_tree_roots, false).first
+      parent = @sa_tree.send(:x_get_tree_roots).first
       kids = @sa_tree.send(:x_get_tree_target_kids, parent, false)
       number_of_kids = @sa_tree.send(:x_get_tree_target_kids, parent, true)
       expect(kids.first).to be_a_kind_of(MiqScsiLun)
@@ -39,7 +39,7 @@ describe TreeBuilderStorageAdapters do
     end
 
     it 'returns nothing as MiqScsiLun children' do
-      root = @sa_tree.send(:x_get_tree_roots, false).first
+      root = @sa_tree.send(:x_get_tree_roots).first
       parent = @sa_tree.send(:x_get_tree_target_kids, root, false).first
       number_of_kids = @sa_tree.send(:x_get_tree_objects, parent, true, nil)
       kids = @sa_tree.send(:x_get_tree_objects, parent, false, nil)


### PR DESCRIPTION
This argument is always set to `false` as the root node is never lazy. So making our life easier by getting rid of this argument and all of this callsites. There will be additional code cleanup required in the individual methods, that will come in the future.

@miq-bot add_label refactoring, trees, ivanchuk/no, technical debt
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 
@miq-bot assign @mzazrivec 