### PR TITLE
Add error message output for git domain refresh.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1713,9 +1713,12 @@ class MiqAeClassController < ApplicationController
 
   def refresh_git_domain
     if params[:button] == "save"
-      git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
-
-      add_flash(_("Successfully refreshed!"), :info)
+      begin
+        git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
+        add_flash(_("Successfully refreshed!"), :info)
+      rescue MiqException::Error => err
+        add_flash(err.message, :error)
+      end
     else
       add_flash(_("Git based refresh canceled"), :info)
     end


### PR DESCRIPTION
Description
-----------------
Fixing the silent UI errors for automate domain git refresh. If the automate domain at git is invalid, there is no error message output and no redirection from tag/branch choose page bellow. 

![Screenshot from 2019-08-29 18-20-37](https://user-images.githubusercontent.com/19405716/63957990-c242d180-ca89-11e9-9459-49373cbad384.png)

New error message output:
-----------------
![Screenshot from 2019-08-29 18-20-24](https://user-images.githubusercontent.com/19405716/63957996-c5d65880-ca89-11e9-8b34-e94a1fbed69b.png)

Links
----------------

* related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1696396

Steps for Testing/QA
-------------------------------

* Steps are included in the BZ above.
