### PR TITLE
[IVANCHUK] Added a nil check.

### DIFF
--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -8,7 +8,7 @@
   - groups_opts = [["<#{_("Don't change")}>", 'dont-change'], ["<#{_('No User Group')}>", '']]
   - user_group = ''
 - else
-  - user_group = MiqGroup.find_by(:id => @group).tenant_group? ? @group : ''
+  - user_group = MiqGroup.find_by(:id => @group)&.tenant_group? ? @group : ''
   - groups_opts =  [["<#{_('No User Group')}>", user_group]]
 - groups_opts += @groups.sort
 


### PR DESCRIPTION
This fixes a `undefined method `tenant_group?' for nil:NilClass` error when selected KeyPair's group didnt exist

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1747179

@mzazrivec pls review, this issue does not exist on upstream. It has been fixe don upstream by changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/5863