### PR TITLE
Make items on the Ownership screen not clickable

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -102,7 +102,7 @@ module Mixins
           @groups = {} # Create new entries hash (2nd pulldown)
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
           @edit[:object_ids] = @ownershipitems
-          @view = get_db_view(klass == VmOrTemplate ? Vm : klass) # Instantiate the MIQ Report view object
+          @view = get_db_view(klass == VmOrTemplate ? Vm : klass, :clickable => false) # Instantiate the MIQ Report view object
           @view.table = ReportFormatter::Converter.records2table(@ownershipitems, @view.cols + ['id'])
           session[:edit] = @edit
         end

--- a/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
@@ -1,0 +1,25 @@
+describe Mixins::Actions::VmActions::Ownership do
+  describe '#build_ownership_info' do
+    context 'setting ownership of Catalog Item' do
+      let(:user_role) { FactoryBot.create(:miq_user_role) }
+      let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
+      let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
+      let(:controller) { CatalogController.new }
+      let(:cat_item) { FactoryBot.create(:service_template) }
+
+      before do
+        EvmSpecHelper.local_miq_server
+        login_as user
+        allow(controller).to receive(:find_records_with_rbac).and_return([cat_item])
+        allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
+        allow(controller).to receive(:session).and_return(:userid => user.userid)
+        controller.params = {:controller => 'catalog'}
+      end
+
+      it 'makes quadicons in Affected Items section not clickable' do
+        controller.send(:build_ownership_info, [cat_item.id])
+        expect(controller.instance_variable_get(:@report_data_additional_options)[:clickable]).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1741109

This PR makes items (VMs, Catalog Items, ...) on the Ownership screen not clickable to prevent interruption of setting ownership other than clicking on _Cancel_. The reason is achieving better consistency, for example while managing policies or policy simulation of VMs: there is also _Affected Items_ section (same as for setting ownership) and items (quadicons) there are NOT clickable (or some info is displayed after clicking on them also with _Back_ button so the operation is not interrupted).

---

**Before:** After clicking on the quadicon, setting ownership is over and textual summary of a chosen item is displayed
![ownership_before](https://user-images.githubusercontent.com/13417815/64111953-34672f00-cd86-11e9-82d5-ea5f96ac6b15.png)

**After:** Quadicon is not clickable, user can cancel the operation normally by clicking on _Cancel_ button
![ownership_after](https://user-images.githubusercontent.com/13417815/64112240-2239c080-cd87-11e9-8327-a5a94d60b07e.png)


