### PR TITLE
Travis after_install - log manageiq commit

### DIFF
--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -1,3 +1,5 @@
+(cd spec/manageiq ; git log -1 --oneline)
+
 if [ "$TEST_SUITE" = "spec:compile" ]; then
   # Collapse Travis output https://github.com/travis-ci/travis-ci/issues/2158
   echo "travis_fold:start:GEMFILE_LOCK"


### PR DESCRIPTION
`bin/setup` clones manageiq head to `spec/manageiq`,
but you can't tell which commit from the logs after.

Adding next to the lockfile output.

![after](https://user-images.githubusercontent.com/289743/64119892-667a9000-cd8a-11e9-9f38-7201134e9d15.png)
