### PR TITLE
Use copy_params_if_present in cloud network/subnet and floating ip controllers

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -223,17 +223,12 @@ class CloudNetworkController < ApplicationController
     # Admin_state_Up is true by default
     params[:enabled] = false unless params[:enabled]
 
-    options[:name] = params[:name] if params[:name]
-    options[:ems_id] = params[:ems_id] if params[:ems_id]
+    copy_params_if_present(options, params, %i[name ems_id qos_policy_id provider_network_type provider_physical_network provider_segmentation_id])
     options[:admin_state_up] = switch_to_bol(params[:enabled])
     options[:shared] = switch_to_bol(params[:shared])
     options[:external_facing] = switch_to_bol(params[:external_facing])
     # TODO: uncomment once form contains this field
     # options[:port_security_enabled] = params[:port_security_enabled] if params[:port_security_enabled]
-    options[:qos_policy_id] = params[:qos_policy_id] if params[:qos_policy_id]
-    options[:provider_network_type] = params[:provider_network_type] if params[:provider_network_type].present?
-    options[:provider_physical_network] = params[:provider_physical_network] if params[:provider_physical_network]
-    options[:provider_segmentation_id] = params[:provider_segmentation_id] if params[:provider_segmentation_id]
     cloud_tenant = find_record_with_rbac(CloudTenant, params[:cloud_tenant][:id]) if params[:cloud_tenant][:id]
     options[:tenant_id] = cloud_tenant.ems_ref
     options

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -282,25 +282,15 @@ class CloudSubnetController < ApplicationController
     params[:network_protocol] ||= "ipv4"
     params[:dhcp_enabled] ||= false
     options = {}
-    options[:name] = params[:name] if params[:name]
-    options[:ems_id] = params[:ems_id] if params[:ems_id]
-    options[:cidr] = params[:cidr] if params[:cidr]
+    copy_params_if_present(options, params, %i[name ems_id cidr network_id availability_zone_id ipv6_router_advertisement_mode ipv6_address_mode network_group_id parent_cloud_subnet_id])
     # Provider to automatically assign gateway address unless provided
     if params[:gateway]
       options[:gateway_ip] = params[:gateway].presence
     end
     options[:ip_version] = params[:network_protocol] =~ /4/ ? 4 : 6
     options[:cloud_tenant] = find_record_with_rbac(CloudTenant, params[:cloud_tenant][:id]) if params.fetch_path(:cloud_tenant, :id)
-    options[:network_id] = params[:network_id] if params[:network_id]
     options[:enable_dhcp] = params[:dhcp_enabled]
     # TODO: Add dns_nameservers, allocation_pools, host_routes
-    options[:availability_zone_id] = params[:availability_zone_id] if params[:availability_zone_id]
-    if params[:ipv6_router_advertisement_mode]
-      options[:ipv6_router_advertisement_mode] = params[:ipv6_router_advertisement_mode]
-    end
-    options[:ipv6_address_mode] = params[:ipv6_address_mode] if params[:ipv6_address_mode]
-    options[:network_group_id] = params[:network_group_id] if params[:network_group_id]
-    options[:parent_cloud_subnet_id] = params[:parent_cloud_subnet_id] if params[:parent_cloud_subnet_id]
     options[:allocation_pools] = parse_allocation_pools(params[:allocation_pools]) if params[:allocation_pools].present?
     options[:dns_nameservers] = parse_dns_nameservers(params[:dns_nameservers]) if params[:dns_nameservers].present?
     options[:host_routes] = parse_host_routes(params[:host_routes]) if params[:host_routes].present?

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -186,10 +186,8 @@ class FloatingIpController < ApplicationController
 
   def form_params
     options = {}
+    copy_params_if_present(options, params, %i[address cloud_network_id cloud_tenant_id])
     options[:ems_id] = params[:ems_id] if params[:ems_id] && params[:ems_id] != 'new'
-    options[:address] = params[:address] if params[:address]
-    options[:cloud_network_id] = params[:cloud_network_id] if params[:cloud_network_id]
-    options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
     if params[:network_port] && params[:network_port][:ems_ref]
       options[:network_port_ems_ref] = params[:network_port][:ems_ref]
     end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6105

We can use new `copy_params_if_present` method in many places in the code and to improve functionality (remove `""` vs `nil` issues and bad response of `Add/Save` buttons), to simplify the code.

**Related PRs/changes:**
https://github.com/ManageIQ/manageiq-ui-classic/pull/5815
https://github.com/ManageIQ/manageiq-ui-classic/pull/5472/commits/d3c3878c7cde6f682c6e25928b7c90a4c01b664f#diff-956e46b33fb5307990c4e1a4b5fd86ccR1267

