### PR TITLE
Make Automate Domains and Providers clickable from the list displayed through Tenant's Relationships

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -93,6 +93,18 @@ class AutomationManagerController < ApplicationController
     generic_x_show
   end
 
+  # Display provider through Tenant's textual summary
+  def show
+    @explorer = true
+    @lastaction = 'explorer'
+
+    build_accordions_and_trees
+
+    self.x_node = "at-#{params[:id]}"
+    @record = ExtManagementSystem.find_by(:id => params[:id])
+    generic_x_show
+  end
+
   def tree_record
     @record = case x_active_tree
               when :automation_manager_providers_tree then automation_manager_providers_tree_rec

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -83,6 +83,18 @@ class MiqAeClassController < ApplicationController
     render :layout => "application"
   end
 
+  # Display any Automate Domain through Tenant's textual summary
+  def show
+    @sb[:action] = nil
+    @explorer = true
+    build_accordions_and_trees
+
+    self.x_node = "aen-#{params[:id]}"
+    get_node_info(x_node)
+
+    render :layout => 'application'
+  end
+
   def set_right_cell_text(id, rec = nil)
     nodes = id.split('-')
     case nodes[0]

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -56,8 +56,7 @@ class OpsController < ApplicationController
       :breadcrumb_title => _('Automate Domains'),
       :association      => :nested_ae_namespaces,
       :parent           => @record,
-      :no_checkboxes    => true,
-      :clickable        => false
+      :no_checkboxes    => true
     )
   end
 

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -45,8 +45,7 @@ class OpsController < ApplicationController
       :breadcrumb_title => _('Providers'),
       :association      => :nested_providers,
       :parent           => @record,
-      :no_checkboxes    => true,
-      :clickable        => false
+      :no_checkboxes    => true
     )
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -101,6 +101,19 @@ class ProviderForemanController < ApplicationController
     end
   end
 
+  # Display provider through Tenant's textual summary
+  def show
+    @explorer = true
+    @lastaction = "explorer"
+
+    build_accordions_and_trees
+
+    params[:action] = 'tree-select'
+    provider_node(params[:id], ExtManagementSystem.find_by(:id => params[:id]).type)
+
+    render :layout => "application"
+  end
+
   def x_show
     tree_record unless unassigned_configuration_profile?(params[:id])
 

--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -13,7 +13,12 @@ class RestfulRedirectController < ApplicationController
         elsif %w[ManageIQ::Providers::EmbeddedAnsible::AutomationManager].include?(record.type)
           redirect_to(:controller => 'ansible_playbook', :action => 'show_list')
         else
-          redirect_to(polymorphic_path(record))
+          begin
+            redirect_to(polymorphic_path(record))
+          rescue NoMethodError
+            flash_to_session(_("Cannot redirect to \"%{record}\" provider.") % {:record => record.name}, :error)
+            redirect_to(:controller => 'ops', :action => 'explorer')
+          end
         end
       else
         handle_missing_record

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -324,8 +324,17 @@ module ApplicationHelper
           return url_for_only_path(:action => action) + "/" # In explorer, don't jump to other controllers
         end
       else
-        controller = "vm_cloud" if controller == "template_cloud"
-        controller = "vm_infra" if controller == "template_infra"
+        controller = case controller
+                     when 'template_cloud'
+                       'vm_cloud'
+                     when 'template_infra'
+                       'vm_infra'
+                     when 'miq_ae_domain'
+                       'miq_ae_class'
+                     else
+                       controller
+                     end
+
         return url_for_only_path(:controller => controller, :action => action, :id => nil) + "/"
       end
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -335,6 +335,8 @@ module ApplicationHelper
                        controller
                      end
 
+        return url_for_only_path(:controller => 'restful_redirect', :model => 'ExtManagementSystem') if controller == 'ext_management_system'
+
         return url_for_only_path(:controller => controller, :action => action, :id => nil) + "/"
       end
     else

--- a/app/views/miq_ae_class/show.html.haml
+++ b/app/views/miq_ae_class/show.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  = render :partial => "all_tabs"
+
+-# To include MyCodeMirror JS and CSS files
+= render :partial => "/layouts/my_code_mirror", :locals => {:text_area_id => "miq_none", :mode => "ruby"}

--- a/app/views/provider_foreman/show.html.haml
+++ b/app/views/provider_foreman/show.html.haml
@@ -1,0 +1,4 @@
+= render(:partial => 'shared/provider_paused', :locals => {:record => @record})
+
+#main_div
+  = render(:partial => 'layouts/x_gtl')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2081,6 +2081,7 @@ Rails.application.routes.draw do
         explorer
         method_form_fields
         namespace
+        show
       ),
       :post => %w(
         add_update_method

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -95,9 +95,7 @@ describe AutomationManagerController do
   end
 
   context "asserts correct privileges" do
-    before do
-      login_as user_with_feature %w(automation_manager_provider_tag)
-    end
+    before { login_as user_with_feature %w[automation_manager_provider_tag] }
 
     it "should raise an error for feature that user has no access to" do
       expect { controller.send(:assert_privileges, "automation_manager_add_provider") }
@@ -126,10 +124,8 @@ describe AutomationManagerController do
     expect(assigns(:flash_array).first[:message]).to include("has already been taken")
   end
 
-  context "#edit" do
-    before do
-      stub_user(:features => :all)
-    end
+  describe "#edit" do
+    before { stub_user(:features => :all) }
 
     it "renders the edit page when the manager id is supplied" do
       post :edit, :params => { :id => @automation_manager1.id }
@@ -170,7 +166,7 @@ describe AutomationManagerController do
     end
   end
 
-  context "#refresh" do
+  describe "#refresh" do
     before do
       stub_user(:features => :all)
       allow(controller).to receive(:x_node).and_return("root")
@@ -197,10 +193,8 @@ describe AutomationManagerController do
     end
   end
 
-  context "#delete" do
-    before do
-      stub_user(:features => :all)
-    end
+  describe "#delete" do
+    before { stub_user(:features => :all) }
 
     it "deletes the provider when the manager id is supplied" do
       allow(controller).to receive(:replace_right_cell)
@@ -239,6 +233,7 @@ describe AutomationManagerController do
       allow(controller).to receive(:current_page).and_return(1)
       controller.send(:build_accordions_and_trees)
     end
+
     it "renders right cell text for root node" do
       controller.send(:get_node_info, "root")
       right_cell_text = controller.instance_variable_get(:@right_cell_text)
@@ -248,9 +243,7 @@ describe AutomationManagerController do
     context 'searching text' do
       let(:search) { "some_text" }
 
-      before do
-        controller.instance_variable_set(:@search_text, search)
-      end
+      before { controller.instance_variable_set(:@search_text, search) }
 
       it 'updates right cell text according to search text' do
         controller.send(:get_node_info, "root")
@@ -510,6 +503,7 @@ describe AutomationManagerController do
       login_as user_with_feature(%w(automation_manager_providers automation_manager_cs_filter_accord automation_manager_configuration_scripts_accord))
       controller.instance_variable_set(:@right_cell_text, nil)
     end
+
     render_views
 
     it 'can render details for a job template' do
@@ -567,7 +561,7 @@ describe AutomationManagerController do
     end
   end
 
-  context "#build_credentials" do
+  describe "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "userid",
                            :default_password => "password2"}
@@ -589,6 +583,7 @@ describe AutomationManagerController do
       @user = user_with_feature %w(automation_manager_providers automation_manager_configured_system)
       login_as @user
     end
+
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [tags]}
       allow(@user).to receive(:get_filters).and_return(user_filters)
@@ -598,7 +593,7 @@ describe AutomationManagerController do
     end
   end
 
-  context "#configscript_service_dialog" do
+  describe "#configscript_service_dialog" do
     before do
       stub_user(:features => :all)
       @cs = FactoryBot.create(:ansible_configuration_script)
@@ -631,8 +626,9 @@ describe AutomationManagerController do
     end
   end
 
-  context "#tags_edit" do
+  describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       allow(@ans_configured_system).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
@@ -671,6 +667,19 @@ describe AutomationManagerController do
       post :tagging_edit, :params => {:button => "save", :format => :js, :id => @ans_configured_system.id, :data => get_tags_json([@tag1, @tag2])}
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
+    end
+  end
+
+  describe '#show' do
+    before { controller.params = {:id => @automation_manager1.id} }
+
+    it 'displays Automation Manager provider through Tenants textual summary' do
+      expect(controller).to receive(:build_accordions_and_trees)
+      expect(controller).to receive(:generic_x_show)
+      controller.send(:show)
+      expect(controller.instance_variable_get(:@explorer)).to be(true)
+      expect(controller.instance_variable_get(:@record)).to eq(@automation_manager1)
+      expect(controller.x_node).to eq("at-#{controller.params[:id]}")
     end
   end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -1,5 +1,5 @@
 describe MiqAeClassController do
-  context "#set_record_vars" do
+  describe "#set_record_vars" do
     it "Namespace remains unchanged when a class is edited" do
       ns = FactoryBot.create(:miq_ae_namespace)
       cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
@@ -16,7 +16,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#set_right_cell_text" do
+  describe "#set_right_cell_text" do
     it "check if correct namespace_path is being set" do
       ns = FactoryBot.create(:miq_ae_namespace)
       cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
@@ -33,7 +33,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#domain_lock" do
+  describe "#domain_lock" do
     it "Marks domain as locked/readonly" do
       stub_user(:features => :all)
       ns = FactoryBot.create(:miq_ae_domain_enabled)
@@ -45,7 +45,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#domain_unlock" do
+  describe "#domain_unlock" do
     it "Marks domain as unlocked/editable" do
       stub_user(:features => :all)
       ns = FactoryBot.create(:miq_ae_domain_disabled)
@@ -57,7 +57,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#domains_priority_edit" do
+  describe "#domains_priority_edit" do
     it "sets priority of domains" do
       stub_user(:features => :all)
       FactoryBot.create(:miq_ae_domain, :name => "test1", :parent => nil, :priority => 1)
@@ -82,7 +82,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#copy_objects" do
+  describe "#copy_objects" do
     it "do not replace left side explorer tree when copy form is loaded initially" do
       stub_user(:features => :all)
       d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
@@ -279,7 +279,7 @@ describe MiqAeClassController do
       allow(MiqAeDomain).to receive(:find_by_name).with("another_fqname2").and_return(miq_ae_domain2)
     end
 
-    context "#node_info" do
+    describe "#node_info" do
       it "collect namespace info" do
         stub_user(:features => :all)
         d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1")
@@ -295,7 +295,7 @@ describe MiqAeClassController do
       end
     end
 
-    context "#get_instance_node_info" do
+    describe "#get_instance_node_info" do
       context "when record does not exist" do
         it "sets active node back to root" do
           id = %w(aei some_id)
@@ -328,7 +328,7 @@ describe MiqAeClassController do
       end
     end
 
-    context "#get_class_node_info" do
+    describe "#get_class_node_info" do
       context "when record does not exist" do
         it "sets active node back to root" do
           id = %w(aec some_id)
@@ -360,7 +360,7 @@ describe MiqAeClassController do
       end
     end
 
-    context "#get_method_node_info" do
+    describe "#get_method_node_info" do
       context "when record does not exist" do
         it "sets active node back to root" do
           id = %w(aem some_id)
@@ -395,7 +395,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#delete_domain" do
+  describe "#delete_domain" do
     let(:domain1) { FactoryBot.create(:miq_ae_system_domain_enabled) }
     let(:domain2) { FactoryBot.create(:miq_ae_domain_enabled) }
     let(:domain3) { FactoryBot.create(:miq_ae_git_domain) }
@@ -423,7 +423,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#ae_class_validation" do
+  describe "#ae_class_validation" do
     before do
       stub_user(:features => :all)
       ns = FactoryBot.create(:miq_ae_namespace)
@@ -665,7 +665,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#copy_objects_edit_screen" do
+  describe "#copy_objects_edit_screen" do
     it "sets only current tenant's domains to be displayed in To Domain pull down" do
       FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
       FactoryBot.create(:miq_ae_domain, :tenant => FactoryBot.create(:tenant))
@@ -676,7 +676,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#delete_namespaces_or_classes" do
+  describe "#delete_namespaces_or_classes" do
     before do
       stub_user(:features => :all)
       domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
@@ -717,7 +717,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#update_namespace" do
+  describe "#update_namespace" do
     before do
       stub_user(:features => :all)
       domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
@@ -760,7 +760,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#deleteclasses" do
+  describe "#deleteclasses" do
     before do
       stub_user(:features => :all)
       domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
@@ -783,7 +783,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#set_field_vars" do
+  describe "#set_field_vars" do
     it "sets priority of new schema fields" do
       ns = FactoryBot.create(:miq_ae_namespace)
       cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
@@ -811,7 +811,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#fields_seq_field_changed" do
+  describe "#fields_seq_field_changed" do
     before do
       ns = FactoryBot.create(:miq_ae_namespace, :name => 'foo')
       @cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
@@ -848,7 +848,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#replace_right_cell" do
+  describe "#replace_right_cell" do
     before do
       ns = FactoryBot.create(:miq_ae_namespace)
       cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id)
@@ -906,7 +906,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#open_parent_nodes" do
+  describe "#open_parent_nodes" do
     it "returns parent nodes hash for newly added item in tree" do
       ns = FactoryBot.create(:miq_ae_namespace)
       cls = FactoryBot.create(:miq_ae_class, :namespace_id => ns.id, :name => "foo_cls")
@@ -949,7 +949,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#deleteinstances" do
+  describe "#deleteinstances" do
     before do
       stub_user(:features => :all)
       domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
@@ -984,7 +984,7 @@ describe MiqAeClassController do
     end
   end
 
-  context "#deletemethods" do
+  describe "#deletemethods" do
     before do
       stub_user(:features => :all)
       domain = FactoryBot.create(:miq_ae_domain, :tenant => Tenant.seed)
@@ -1055,6 +1055,23 @@ describe MiqAeClassController do
     it 'wraps ids in parentheses and joins them with pipes' do
       allow(MiqAeMethod).to receive(:get_homonymic_across_domains).and_return([one, two, three])
       expect(controller.send(:embedded_method_regex, 'foo')).to eq("(1)|(2)|(3)")
+    end
+  end
+
+  describe '#show' do
+    let(:ae_domain) { FactoryBot.create(:miq_ae_domain) }
+
+    before do
+      controller.instance_variable_set(:@sb, {})
+      controller.params = {:id => ae_domain.id}
+    end
+
+    it 'calls build_accordions_and_trees, get_node_info and sets @explorer' do
+      expect(controller).to receive(:get_node_info).with("aen-#{ae_domain.id}")
+      expect(controller).to receive(:build_accordions_and_trees)
+      expect(controller).to receive(:render).with(:layout => 'application')
+      controller.send(:show)
+      expect(controller.instance_variable_get(:@explorer)).to be(true)
     end
   end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -574,8 +574,7 @@ describe OpsController do
           :breadcrumb_title => _('Automate Domains'),
           :association      => :nested_ae_namespaces,
           :parent           => record,
-          :no_checkboxes    => true,
-          :clickable        => false
+          :no_checkboxes    => true
         }
       end
 

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -557,8 +557,7 @@ describe OpsController do
           :breadcrumb_title => _('Providers'),
           :association      => :nested_providers,
           :parent           => record,
-          :no_checkboxes    => true,
-          :clickable        => false
+          :no_checkboxes    => true
         }
       end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -100,9 +100,7 @@ describe ProviderForemanController do
   end
 
   context "asserts correct privileges" do
-    before do
-      login_as user_with_feature %w(configured_system_provision)
-    end
+    before { login_as user_with_feature %w[configured_system_provision] }
 
     it "should not raise an error for feature that user has access to" do
       expect { controller.send(:assert_privileges, "configured_system_provision") }.not_to raise_error
@@ -148,10 +146,8 @@ describe ProviderForemanController do
     expect(assigns(:flash_array).last[:message]).to include("Name has already been taken")
   end
 
-  context "#edit" do
-    before do
-      stub_user(:features => :all)
-    end
+  describe "#edit" do
+    before { stub_user(:features => :all) }
 
     it "renders the edit page when the configuration manager id is supplied" do
       post :edit, :params => { :id => @config_mgr.id }
@@ -205,7 +201,7 @@ describe ProviderForemanController do
     end
   end
 
-  context "#refresh" do
+  describe "#refresh" do
     before do
       stub_user(:features => :all)
       allow(controller).to receive(:x_node).and_return("root")
@@ -232,10 +228,8 @@ describe ProviderForemanController do
     end
   end
 
-  context "#delete" do
-    before do
-      stub_user(:features => :all)
-    end
+  describe "#delete" do
+    before { stub_user(:features => :all) }
 
     it "deletes the provider when the configuration manager id is supplied" do
       allow(controller).to receive(:replace_right_cell)
@@ -593,7 +587,7 @@ describe ProviderForemanController do
     end
   end
 
-  context "#build_credentials" do
+  describe "#build_credentials" do
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "userid",
                            :default_password => "password2"}
@@ -611,9 +605,8 @@ describe ProviderForemanController do
   end
 
   context "when user with specific tag settings logs in" do
-    before do
-      login_as user_with_feature %w(providers_accord configured_systems_filter_accord)
-    end
+    before { login_as user_with_feature %w[providers_accord configured_systems_filter_accord] }
+
     it "builds foreman tree with no nodes after rbac filtering" do
       user_filters = {'belongs' => [], 'managed' => [tags]}
       allow_any_instance_of(User).to receive(:get_filters).and_return(user_filters)
@@ -649,8 +642,9 @@ describe ProviderForemanController do
     end
   end
 
-  context "#tags_edit" do
+  describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       allow(@configured_system).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
@@ -726,6 +720,21 @@ describe ProviderForemanController do
         controller.send(:get_node_info, "root")
         expect(controller.instance_variable_get(:@right_cell_text)).to eq(" (Names with \"#{search}\")")
       end
+    end
+  end
+
+  describe '#show' do
+    let!(:foreman) { FactoryBot.create(:configuration_manager) }
+
+    before { controller.params = {:id => foreman.id} }
+
+    it 'displays Satellite provider through Tenants textual summary' do
+      expect(controller).to receive(:provider_node).with(controller.params[:id], 'ManageIQ::Providers::Foreman::ConfigurationManager')
+      expect(controller).to receive(:build_accordions_and_trees)
+      expect(controller).to receive(:render).with(:layout => 'application')
+      controller.send(:show)
+      expect(controller.instance_variable_get(:@explorer)).to be(true)
+      expect(controller.params[:action]).to eq('tree-select')
     end
   end
 

--- a/spec/controllers/restful_redirect_controller_spec.rb
+++ b/spec/controllers/restful_redirect_controller_spec.rb
@@ -43,5 +43,25 @@ describe RestfulRedirectController do
       get :index, :params => { :model => "VmOrTemplate", :id => vm_cloud.id }
       expect(response).to redirect_to(:controller => "vm_cloud", :action => "show", :id => vm_cloud.id)
     end
+
+    it 'redirects to provider_foreman controller' do
+      foreman = FactoryBot.create(:configuration_manager)
+      get :index, :params => {:model => "ExtManagementSystem/#{foreman.id}"}
+      expect(response).to redirect_to(:controller => 'provider_foreman', :action => 'show', :id => foreman.id)
+    end
+
+    it 'redirects to automation_manager controller' do
+      automation_provider = FactoryBot.create(:provider_ansible_tower)
+      manager = ManageIQ::Providers::AnsibleTower::AutomationManager.find_by(:provider_id => automation_provider.id)
+      get :index, :params => {:model => "ExtManagementSystem/#{manager.id}"}
+      expect(response).to redirect_to(:controller => 'automation_manager', :action => 'show', :id => manager.id)
+    end
+
+    it 'redirects to ansible_playbook controller' do
+      embedded_ansible = FactoryBot.create(:provider_embedded_ansible)
+      manager = ManageIQ::Providers::EmbeddedAnsible::AutomationManager.find_by(:provider_id => embedded_ansible.id)
+      get :index, :params => {:model => "ExtManagementSystem/#{manager.id}"}
+      expect(response).to redirect_to(:controller => 'ansible_playbook', :action => 'show_list')
+    end
   end
 end

--- a/spec/controllers/restful_redirect_controller_spec.rb
+++ b/spec/controllers/restful_redirect_controller_spec.rb
@@ -63,5 +63,13 @@ describe RestfulRedirectController do
       get :index, :params => {:model => "ExtManagementSystem/#{manager.id}"}
       expect(response).to redirect_to(:controller => 'ansible_playbook', :action => 'show_list')
     end
+
+    it 'redirects to ops controller and displays flash message that it cannot redirect to the selected provider' do
+      embedded_ansible = FactoryBot.create(:provider_embedded_ansible)
+      allow(ExtManagementSystem).to receive(:find_by).and_return(embedded_ansible)
+      get :index, :params => {:model => "ExtManagementSystem/#{embedded_ansible.id}"}
+      expect(response).to redirect_to(:controller => 'ops', :action => 'explorer')
+      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Cannot redirect to \"#{embedded_ansible.name}\" provider.", :level => :error}])
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,9 +1,7 @@
 describe ApplicationHelper do
-  before do
-    login_as FactoryBot.create(:user, :features => "none")
-  end
+  before { login_as FactoryBot.create(:user, :features => "none") }
 
-  context "build_toolbar" do
+  describe "#build_toolbar" do
     it 'should substitute dynamic function values' do
       req        = ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=foo'
       menu_info  = helper.build_toolbar 'storages_center_tb'
@@ -38,6 +36,7 @@ describe ApplicationHelper do
 
   describe "#role_allows?" do
     let(:features) { MiqProductFeature.find_all_by_identifier("everything") }
+
     before do
       EvmSpecHelper.seed_specific_product_features("miq_report", "service")
       @user = login_as FactoryBot.create(:user, :features => features)
@@ -150,9 +149,7 @@ describe ApplicationHelper do
     end
 
     context "when formatting flash message for VM or Templates class" do
-      before do
-        @klass = VmOrTemplate
-      end
+      before { @klass = VmOrTemplate }
 
       it "with one Instance" do
         record_ids = [@record_1.id]
@@ -201,9 +198,7 @@ describe ApplicationHelper do
     end
 
     context "when formatting flash message for Non VM or Templates class" do
-      before do
-        @klass = Service
-      end
+      before { @klass = Service }
 
       it "with one Service" do
         record_ids = [@record_1.id]
@@ -224,9 +219,7 @@ describe ApplicationHelper do
     end
 
     context "when with @vm" do
-      before do
-        @vm = FactoryBot.create(:vm_vmware)
-      end
+      before { @vm = FactoryBot.create(:vm_vmware) }
 
       ["Account", "User", "Group", "Patch", "GuestApplication"].each do |d|
         it "and db = #{d}" do
@@ -309,9 +302,7 @@ describe ApplicationHelper do
     end
 
     context "when with ConditionSet" do
-      before do
-        @db = "ConditionSet"
-      end
+      before { @db = "ConditionSet" }
 
       it "and @explorer" do
         @explorer = true
@@ -493,6 +484,7 @@ describe ApplicationHelper do
 
   describe "#field_to_col" do
     subject { helper.field_to_col(field) }
+
     context "when field likes 'Vm.hardware.disks-size'" do
       let(:field) { "Vm.hardware.disks-size" }
       it { is_expected.to eq("disks.size") }
@@ -514,7 +506,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#is_browser?" do
+  describe "#is_browser?" do
     it "when browser's name is in the list" do
       allow_any_instance_of(ActionController::TestSession)
         .to receive(:fetch_path).with(:browser, :name).and_return('safari')
@@ -528,7 +520,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#is_browser_os?" do
+  describe "#is_browser_os?" do
     it "when browser's OS is in the list" do
       allow_any_instance_of(ActionController::TestSession)
         .to receive(:fetch_path).with(:browser, :os).and_return('windows')
@@ -542,7 +534,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#browser_info" do
+  describe "#browser_info" do
     it "preserves the case" do
       type = :a_type
       allow_any_instance_of(ActionController::TestSession)
@@ -602,6 +594,7 @@ describe ApplicationHelper do
 
   describe "#javascript_for_miq_button_visibility" do
     subject { helper.javascript_for_miq_button_visibility(display) }
+
     context "when display == true" do
       let(:display) { true }
       it { is_expected.to eq("miqButtons('show');") }
@@ -613,7 +606,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#javascript_reload_toolbars" do
+  describe "#javascript_reload_toolbars" do
     subject { helper.javascript_reload_toolbars }
 
     it "returns javascript to reload toolbar" do
@@ -622,7 +615,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#set_edit_timer_from_schedule" do
+  describe "#set_edit_timer_from_schedule" do
     before do
       @edit = {:tz => 'Eastern Time (US & Canada)', :new => {}}
       @interval = '3'
@@ -634,7 +627,7 @@ describe ApplicationHelper do
       @schedule = double(:run_at => @run_at)
     end
 
-    describe "when schedule.run_at == nil" do
+    context "when schedule.run_at == nil" do
       it "sets defaults" do
         schedule = double(:run_at => nil)
         helper.set_edit_timer_from_schedule schedule
@@ -646,7 +639,7 @@ describe ApplicationHelper do
       end
     end
 
-    describe "when schedule.run_at != nil" do
+    context "when schedule.run_at != nil" do
       it "sets values as monthly" do
         @run_at[:interval][:unit] = 'monthly'
         helper.set_edit_timer_from_schedule @schedule
@@ -701,7 +694,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#perf_parent?" do
+  describe "#perf_parent?" do
     it "when model == 'VmOrTemplate' and typ == 'realtime'" do
       @perf_options = {:model => 'VmOrTemplate', :typ => 'realtime'}
       expect(helper.perf_parent?).to be_falsey
@@ -728,7 +721,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#model_report_type" do
+  describe "#model_report_type" do
     it "when model == nil" do
       expect(helper.model_report_type(nil)).to be_falsey
     end
@@ -780,7 +773,7 @@ describe ApplicationHelper do
       expect(@sb[:trees][:svcs_tree][:active_node]).to eq('')
     end
 
-    context "#x_node" do
+    describe "#x_node" do
       it "without tree param" do
         @sb[:trees][:svcs_tree] = {:active_node => 'root'}
         expect(helper.x_node).to eq('root')
@@ -801,7 +794,7 @@ describe ApplicationHelper do
       end
     end
 
-    context "#x_tree" do
+    describe "#x_tree" do
       it "without tree param" do
         @sb[:trees][:vm_filter_tree] = {:tree => :vm_filter_tree}
 
@@ -833,7 +826,7 @@ describe ApplicationHelper do
       expect(helper.x_active_tree).to eq(:vm_filter_tree)
     end
 
-    context "#x_tree_init" do
+    describe "#x_tree_init" do
       it "does not replace existing trees" do
         helper.x_tree_init(:svcs_tree, :xxx, "XXX")
 
@@ -871,7 +864,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#title_for_cluster_record" do
+  describe "#title_for_cluster_record" do
     before do
       @ems1 = FactoryBot.create(:ems_vmware)
       @ems2 = FactoryBot.create(:ems_openstack_infra)
@@ -892,7 +885,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#title_for_host_record" do
+  describe "#title_for_host_record" do
     it "returns 'Host' for non-openstack host" do
       host = FactoryBot.create(:host_vmware, :ext_management_system => FactoryBot.create(:ems_vmware))
 
@@ -906,7 +899,7 @@ describe ApplicationHelper do
     end
   end
 
-  context "#tree_with_advanced_search?" do
+  describe "#tree_with_advanced_search?" do
     it 'should return true for explorer trees with advanced search' do
       controller.instance_variable_set(:@sb,
                                        :active_tree => :vms_instances_filter_tree,
@@ -1026,9 +1019,7 @@ describe ApplicationHelper do
   end
 
   describe "#display_adv_search?" do
-    before do
-      controller.instance_variable_set(:@layout, layout)
-    end
+    before { controller.instance_variable_set(:@layout, layout) }
 
     subject { helper.display_adv_search? }
 
@@ -1062,6 +1053,7 @@ describe ApplicationHelper do
 
     context 'active tab' do
       let(:active) { true }
+
       it 'renders an active accordion' do
         expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\"><h4 class=\"panel-title\"><a data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" class=\"panel-collapse collapse in\"><div class=\"panel-body\">content</div></div></div>")
       end
@@ -1069,6 +1061,7 @@ describe ApplicationHelper do
 
     context 'inactive tab' do
       let(:active) { false }
+
       it 'renders an active accordion' do
         expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\"><h4 class=\"panel-title\"><a data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"collapsed\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" class=\"panel-collapse collapse \"><div class=\"panel-body\">content</div></div></div>")
       end
@@ -1296,6 +1289,19 @@ describe ApplicationHelper do
 
       it "false if provider paused" do
         expect(subject).to be_falsey
+      end
+    end
+  end
+
+  describe '#view_to_url' do
+    before { allow(helper).to receive(:url_for_only_path).and_call_original }
+
+    context 'displaying Automate Domain through Tenant summary' do
+      let(:view) { MiqReport.new(:db => 'MiqAeDomain') }
+
+      it 'sets controller to miq_ae_class and returns proper url' do
+        expect(helper).to receive(:url_for_only_path).with(:controller => 'miq_ae_class', :action => 'show', :id => nil)
+        helper.view_to_url(view)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1304,5 +1304,14 @@ describe ApplicationHelper do
         helper.view_to_url(view)
       end
     end
+
+    context 'displaying Provider through Tenant summary' do
+      let(:view) { MiqReport.new(:db => 'ExtManagementSystem') }
+
+      it 'sets controller to restful_redirect and returns proper url' do
+        expect(helper).to receive(:url_for_only_path).with(:controller => 'restful_redirect', :model => 'ExtManagementSystem')
+        helper.view_to_url(view)
+      end
+    end
   end
 end

--- a/spec/views/miq_ae_class/show.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/show.html.haml_spec.rb
@@ -1,0 +1,14 @@
+describe "miq_ae_class/show.html.haml" do
+  let(:ae_domain) { FactoryBot.create(:miq_ae_domain) }
+
+  before do
+    allow(view).to receive(:x_node).and_return("aen-#{ae_domain.id}")
+    assign(:sb, :active_tab => 'details')
+    assign(:records, [])
+  end
+
+  it 'renders partial all_tabs' do
+    render
+    expect(response).to include("<div id='ae_tabs'>", "<div id='ns_details_div'>", 'miqInitCodemirror({"text_area_id":"miq_none"')
+  end
+end

--- a/spec/views/provider_foreman/show.html.haml_spec.rb
+++ b/spec/views/provider_foreman/show.html.haml_spec.rb
@@ -1,0 +1,13 @@
+describe 'provider_foreman/show.html.haml' do
+  helper(GtlHelper)
+
+  let(:foreman) { FactoryBot.create(:configuration_manager) }
+
+  before { assign(:record, foreman) }
+
+  it 'renders show template' do
+    expect(view).to receive(:render_gtl_outer)
+    render
+    expect(view).to render_template(:partial => 'shared/provider_paused', :locals => {:record => foreman})
+  end
+end


### PR DESCRIPTION
**RFE:** https://bugzilla.redhat.com/show_bug.cgi?id=1678124
**Depends on:** https://github.com/ManageIQ/manageiq-ui-classic/pull/5675 (merged)
Tracking issue: ManageIQ/manageiq#18734

---

This is a continuation of an RFE about converting Tenants details page to textual summary and adding _Relationships_ with _Services, Automate Domains_ and _Providers_. Specifically, this PR **makes Automate Domains and Providers clickable from the list** displayed thru Relationships table of Tenant's textual summary. After clicking on any Automate Domain or a Provider, we are redirected to the appropriate controller and details about the selected item are displayed.

For Automate Domains, I had to add new `show` method to `miq_ae_class` controller and to add a condition in application helper for choosing the right controller (instead of unnecessary creating `miq_ae_domain` controller). I also had to add missing template `app/views/miq_ae_class/show.html.haml` to make it work.

---

**TODO:**
- [x] make Automate Domains in the list (displayed thru Relationships table of Tenant's textual summary) clickable
- [x] make most of the common Providers clickable
- [x] make all the Satellite Providers clickable
 (but the whole rendered page does not work well - that's another [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1752480), unrelated to this PR)
- [x] solve clicking on Ansible Tower Providers
- [x] solve clicking on Embedded Ansible
  (redirect to _Automate -> Ansible -> Playbooks (Embedded Ansible)_)
- [x] make sure that clicking on all possible kinds of providers will work, with proper redirect,
  or at least, it will not :bomb:
- [x] specs

---

Automate Domains are finally clickable:
![aedomain_click](https://user-images.githubusercontent.com/13417815/64193180-85f1e580-ce7c-11e9-8847-808a81706d13.png)

Clicking on individual Satellite provider in the list of _Providers_ related to the selected Tenant displays the provider and its Configuration Profiles:
![foreman_provider_show](https://user-images.githubusercontent.com/13417815/64878571-1934d300-d654-11e9-9a2f-33ea4dc05e3d.png)

After clicking on some provider in the list, which is not common or is unknown, flash message is displayed and we are redirected to the Tenant's textual summary:
![provider-no-click](https://user-images.githubusercontent.com/13417815/65674025-31412500-e04c-11e9-83ff-9df857d58e45.png)

---

_Note:_
Normally, we can access Automate Domains in _Automation -> Automate -> Explorer_.
