### PR TITLE
Using class that includes both Job and Workflow templates

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -223,7 +223,7 @@ class AutomationManagerController < ApplicationController
     when "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem", "ConfiguredSystem"
       configured_system_list(id, model)
     when "ConfigurationScript", "ConfigurationWorkflow"
-      configuration_scripts_list(id, model == "ConfigurationScript" ? "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript" : model)
+      configuration_scripts_list(id, model == "ConfigurationScript" ? "ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript" : model)
     when "MiqSearch"
       miq_search_node
     else
@@ -332,7 +332,7 @@ class AutomationManagerController < ApplicationController
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Configured Systems")
     elsif x_active_tree == :configuration_scripts_tree
-      options = {:model      => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
+      options = {:model      => "ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript",
                  :gtl_dbname => "automation_manager_configuration_scripts"}
       process_show_list(options)
       @right_cell_text = _("All Ansible Tower Templates")

--- a/product/views/ManageIQ_Providers_ExternalAutomationManager_ConfigurationScript.yaml
+++ b/product/views/ManageIQ_Providers_ExternalAutomationManager_ConfigurationScript.yaml
@@ -15,7 +15,7 @@ title: Ansible Tower Templates
 name: Templates
 
 # Main DB table report is based on
-db: ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
+db: ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript
 
 # Columns to fetch from the main table
 cols:

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -428,7 +428,7 @@ describe AutomationManagerController do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       allow(controller).to receive(:x_active_accord).and_return(:configuration_scripts)
       controller.params = {:id => "configuration_scripts"}
-      expect(controller).to receive(:get_view).with("ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
+      expect(controller).to receive(:get_view).with("ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript", :gtl_dbname => "automation_manager_configuration_scripts").and_call_original
       controller.send(:accordion_select)
     end
   end


### PR DESCRIPTION
Fixed class name that was changed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5925, previously made change was excluding Workflow Templates in UI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1747589

@tinaafitz pls review/verify.