### PR TITLE
Set typ of tab before checking privilegies

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -461,8 +461,11 @@ class MiqRequestController < ApplicationController
   end
 
   def rbac_feature_id(feature_id)
-    return feature_id unless %w[ae host].include?(session[:request_tab])
-    "#{session[:request_tab]}_#{feature_id}"
+    # set this to be used to identify which Requests subtab was clicked
+    @request_tab = params[:typ] || session[:request_tab] if @request_tab.nil?
+    return feature_id unless %w[ae host].include?(@request_tab)
+
+    "#{@request_tab}_#{feature_id}"
   end
 
   # Delete all selected or single displayed action(s)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746386

Create a Role that has Automate/Requests checked in feature tree but NOT  Services/Request. Create a group with this Role. Create a User with this group. Switch to this user. Go to Automation -> Automate -> Requests.
Before:
<img width="1650" alt="Screenshot 2019-09-05 at 16 00 32" src="https://user-images.githubusercontent.com/9210860/64348915-4fd87100-cff6-11e9-8e16-733b1e2a06d1.png">

After:
<img width="1661" alt="Screenshot 2019-09-05 at 15 55 30" src="https://user-images.githubusercontent.com/9210860/64348623-c9239400-cff5-11e9-871f-ed7088e76fec.png">

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/4752 . After that change it never went through `index` (that is always allowed because `miq_request_index` is not a feature) sets `@request_tab` correctly before another `check_privileges`. The tab (`?typ=host`) that would have the same problem was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/4169 .

@miq-bot add_label wip, bug, blocker