### PR TITLE
Use copy_params_if_present in vm_common, manager_controller_mixin and miq_request_methods

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -663,9 +663,8 @@ module ApplicationController::MiqRequestMethods
     id = params[:ou_id].gsub(/_-_/, ",") if params[:ou_id]
     @edit[:new][:ldap_ous] = id.match(/(.*)\,(.*)/)[1..2] if id # ou selected in a tree
 
+    copy_params_if_present(@edit[:new], params, %i[start_hour start_min])
     @edit[:new][:start_date]    = params[:miq_date_1] if params[:miq_date_1]
-    @edit[:new][:start_hour]    = params[:start_hour] if params[:start_hour]
-    @edit[:new][:start_min]     = params[:start_min] if params[:start_min]
     @edit[:new][:schedule_time] = Time.zone.parse("#{@edit[:new][:start_date]} #{@edit[:new][:start_hour]}:#{@edit[:new][:start_min]}")
 
     params.each do |key, _value|

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -138,10 +138,8 @@ module Mixins
     end
 
     def cs_edit_get_form_vars
-      @edit[:new][:name] = params[:name] if params[:name]
-      @edit[:new][:description] = params[:description] if params[:description]
+      copy_params_if_present(@edit[:new], params, %i[name description dialog_name])
       @edit[:new][:draft] = params[:draft] == "true" if params[:draft]
-      @edit[:new][:dialog_name] = params[:dialog_name] if params[:dialog_name]
     end
 
     def cs_form_field_changed

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1589,9 +1589,7 @@ module VmCommon
   # Get variables from edit form
   def get_form_vars
     @record = VmOrTemplate.find_by(:id => @edit[:vm_id])
-    @edit[:new][:custom_1] = params[:custom_1] if params[:custom_1]
-    @edit[:new][:description] = params[:description] if params[:description]
-    @edit[:new][:name] = params[:name] if params[:name]
+    copy_params_if_present(@edit[:new], params, %i[custom_1 description name])
     @edit[:new][:parent] = params[:chosen_parent].to_i if params[:chosen_parent]
     # if coming from explorer
     get_vm_child_selection if %w[allright left right].include?(params[:button])


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6105

We can use `copy_params_if_present` method in some more places/controllers and to improve functionality (remove `""` vs `nil` issues and bad response of _Add/Save_ buttons) or to simplify the code.

Related PRs/changes:
https://github.com/ManageIQ/manageiq-ui-classic/pull/6139
#5815
https://github.com/ManageIQ/manageiq-ui-classic/commit/d3c3878c7cde6f682c6e25928b7c90a4c01b664f#diff-956e46b33fb5307990c4e1a4b5fd86ccR1267
