### PR TITLE
Use copy_params_if_present in report, miq_policy and pxe controllers

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -422,20 +422,16 @@ Methods updated/added: %{method_stats}") % stat_options)
     if params[:readonly]
       @resolve[:new][:readonly] = (params[:readonly] != "1")
     end
-    @resolve[:new][:instance_name] = params[:instance_name] if params.key?(:instance_name)
-    @resolve[:new][:other_name] = params[:other_name] if params.key?(:other_name)
-    @resolve[:new][:object_message] = params[:object_message] if params.key?(:object_message)
-    @resolve[:new][:object_request] = params[:object_request] if params.key?(:object_request)
+
+    copy_params_if_present(@resolve[:new], params, %i[instance_name other_name object_message object_request target_class target_id])
+
     ApplicationController::AE_MAX_RESOLUTION_FIELDS.times do |i|
       f = ("attribute_" + (i + 1).to_s)
       v = ("value_" + (i + 1).to_s)
       @resolve[:new][:attrs][i][0] = params[f] if params[f.to_sym]
       @resolve[:new][:attrs][i][1] = params[v] if params[v.to_sym]
     end
-    @resolve[:new][:target_class] = params[:target_class] if params[:target_class]
-    #   @resolve[:new][:target_attr_name] = params[:target_attr_name] if params.has_key?(:target_attr_name)
     if params.key?(:target_class)
-      @resolve[:new][:target_class] = params[:target_class]
       targets = Rbac.filtered(params[:target_class]).select(:id, *columns_for_klass(params[:target_class])) if params[:target_class].present?
       unless targets.nil?
         @resolve[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
@@ -443,9 +439,7 @@ Methods updated/added: %{method_stats}") % stat_options)
       end
     end
     @resolve[:new][:target_id] = nil if params[:target_class] == ""
-    @resolve[:new][:target_id] = params[:target_id] if params.key?(:target_id)
-    @resolve[:button_text] = params[:button_text] if params.key?(:button_text)
-    @resolve[:button_number] = params[:button_number] if params.key?(:button_number)
+    copy_params_if_present(@resolve, params, %i[button_text button_number])
     @resolve[:throw_ready] = ready_to_throw
   end
 

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -85,19 +85,15 @@ module MiqPolicyController::MiqActions
     return unless load_edit("action_edit__#{params[:id]}", "replace_cell__explorer")
     @action = @edit[:action_id] ? MiqAction.find(@edit[:action_id]) : MiqAction.new
 
-    @edit[:new][:description] = params[:description].presence if params[:description]
-    @edit[:new][:options][:from] = params[:from].presence if params[:from]
-    @edit[:new][:options][:to] = params[:to].presence if params[:to]
+    copy_param_if_present(@edit[:new], params, %i[description])
+    copy_params_if_present(@edit[:new][:options], params, %i[from to parent_type attribute value hosts])
     @edit[:new][:options][:name] = params[:snapshot_name].presence if params[:snapshot_name]
     @edit[:new][:options][:age] = params[:snapshot_age].to_i if params.key?(:snapshot_age)
-    @edit[:new][:options][:parent_type] = params[:parent_type].presence if params[:parent_type]
     if params[:cpu_value]
       @edit[:new][:options][:value] = params[:cpu_value]
     elsif params[:memory_value]
       @edit[:new][:options][:value] = params[:memory_value]
     end
-    @edit[:new][:options][:attribute] = params[:attribute] if params[:attribute]
-    @edit[:new][:options][:value] = params[:value] if params[:value]
     @edit[:new][:options][:ae_message] = params[:object_message] if params.key?(:object_message)
     @edit[:new][:options][:ae_request] = params[:object_request] if params[:object_request]
     params.each do |var, val|
@@ -127,7 +123,6 @@ module MiqPolicyController::MiqActions
       update_playbook_variables(params)
     end
     @edit[:new][:options][:service_template_id] = params[:service_template_id].to_i if params[:service_template_id]
-    @edit[:new][:options][:hosts] = params[:hosts] if params[:hosts]
 
     # Note that the params[:tag] here is intentionally singular
     @edit[:new][:options][:tags] = params[:tag].present? ? [Classification.find(params[:tag]).tag.name] : nil if params[:tag]

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -176,15 +176,14 @@ class MiqTaskController < ApplicationController
   # Gather any changed options
   def tasks_change_options
     @edit = session[:edit]
+    copy_params_if_present(@edit[:opts], params, %i[user_choice state_choice])
     @edit[:opts][:zone] = params[:chosen_zone] if params[:chosen_zone]
-    @edit[:opts][:user_choice] = params[:user_choice] if params[:user_choice]
     @edit[:opts][:time_period] = params[:time_period].to_i if params[:time_period]
     @edit[:opts][:queued] = params[:queued] == "1" ? params[:queued] : nil if params[:queued]
     @edit[:opts][:ok] = params[:ok] == "1" ? params[:ok] : nil if params[:ok]
     @edit[:opts][:error] = params[:error] == "1" ? params[:error] : nil if params[:error]
     @edit[:opts][:warn] = params[:warn] == "1" ? params[:warn] : nil if params[:warn]
     @edit[:opts][:running] = params[:running] == "1" ? params[:running] : nil if params[:running]
-    @edit[:opts][:state_choice] = params[:state_choice] if params[:state_choice]
 
     render :update do |page|
       page << javascript_prologue

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -146,10 +146,8 @@ module PxeController::PxeCustomizationTemplates
   # Get variables from edit form
   def template_get_form_vars
     @ct = @edit[:ct_id] ? CustomizationTemplate.find(@edit[:ct_id]) : CustomizationTemplate.new
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:description] = params[:description] if params[:description]
+    copy_params_if_present(@edit[:new], params, %i[name description typ])
     @edit[:new][:img_type] = params[:img_typ] if params[:img_typ]
-    @edit[:new][:typ] = params[:typ] if params[:typ]
     @edit[:new][:script] = params[:script_data] if params[:script_data]
     @edit[:new][:script] = @edit[:new][:script] + "..." if !params[:name] && !params[:description] && !params[:img_typ] && !params[:script_data] && !params[:typ]
   end

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -127,8 +127,7 @@ module PxeController::PxeImageTypes
   # Get variables from edit form
   def pxe_image_type_get_form_vars
     @pxe_image_type = @edit[:pxe_id] ? PxeImageType.find(@edit[:pxe_id]) : PxeImageType.new
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:provision_type] = params[:provision_type] if params[:provision_type]
+    copy_params_if_present(@edit[:new], params, %i[name provision_type])
   end
 
   # Set form variables for edit

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -323,8 +323,8 @@ module ReportController::Dashboards
       db_move_cols_up if params[:button] == "up"
       db_move_cols_down if params[:button] == "down"
     else
-      @edit[:new][:name] = params[:name] if params[:name]
-      @edit[:new][:description] = params[:description] if params[:description]
+      copy_params_if_present(@edit[:new], params, %i[name description])
+
       if params[:locked]
         @edit[:new][:locked] = params[:locked].to_i == 1
       end

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -477,8 +477,7 @@ module ReportController::Menus
   end
 
   def menu_get_form_vars
-    @edit[:form_vars][:selected_reports] = params[:selected_reports] if params[:selected_reports]
-    @edit[:form_vars][:available_reports] = params[:available_reports] if params[:available_reports]
+    copy_params_if_present(@edit[:form_vars], params, %i[selected_reports available_reports])
     @edit[:temp_arr] = []
     id = session[:node_selected].split('__')
     selected = id[1].split(':')

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -478,13 +478,11 @@ module ReportController::Reports::Editor
   end
 
   def gfv_report_fields
-    @edit[:new][:pdf_page_size] = params[:pdf_page_size] if params[:pdf_page_size]
+    copy_params_if_present(@edit[:new], params, %i[pdf_page_size name title])
     if params[:chosen_queue_timeout]
       @edit[:new][:queue_timeout] = params[:chosen_queue_timeout].blank? ? nil : params[:chosen_queue_timeout].to_i
     end
     @edit[:new][:row_limit] = params[:row_limit].presence || ""
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:title] = params[:title] if params[:title]
   end
 
   def gfv_move_cols_buttons

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -356,8 +356,7 @@ module ReportController::Schedules
   # Get variables from edit form
   def schedule_get_form_vars
     @schedule = @edit[:sched_id] ? MiqSchedule.find(@edit[:sched_id]) : MiqSchedule.new(:userid => session[:userid])
-    @edit[:new][:name] = params[:name] if params[:name]
-    @edit[:new][:description] = params[:description] if params[:description]
+    copy_params_if_present(@edit[:new], params, %i[name description])
     @edit[:new][:enabled] = (params[:enabled] == "1") if params[:enabled]
     @edit[:new][:filter] = params[:filter_typ] if params[:filter_typ]
     @edit[:new][:subfilter] = params[:subfilter_typ] if params[:subfilter_typ]

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -17,7 +17,7 @@ describe MiqAeToolsController do
       expect(controller).to receive(:render)
       controller.params = {:target_class => '', :id => 'new'}
       controller.send(:form_field_changed)
-      expect(assigns(:resolve)[:new][:target_class]).to eq('')
+      expect(assigns(:resolve)[:new][:target_class]).to be_nil
       expect(assigns(:resolve)[:new][:target_id]).to eq(nil)
     end
 


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6105

This is another PR with use of `copy_params_if_present` method in some controllers.
With `copy_params_if_present`, we improve functionality (remove `""` vs `nil` issues and bad response of _Add/Save_ buttons) or we simplify the code.

Similar PRs/changes:
https://github.com/ManageIQ/manageiq-ui-classic/pull/6152
#6139
#5815
https://github.com/ManageIQ/manageiq-ui-classic/commit/d3c3878c7cde6f682c6e25928b7c90a4c01b664f#diff-956e46b33fb5307990c4e1a4b5fd86ccR1267