### PR TITLE
Timelines title

### DIFF
--- a/app/controllers/mixins/more_show_actions.rb
+++ b/app/controllers/mixins/more_show_actions.rb
@@ -7,7 +7,7 @@ module Mixins
       @lastaction = "show_timeline"
       @timeline = @timeline_filter = true
       tl_build_timeline # Create the timeline report
-      drop_breadcrumb(:name => _("Timelines"),
+      drop_breadcrumb(:name => _("Timelines for %{table} \"%{name}\"") % {:table => ui_lookup(:table => controller_name), :name => @record.name},
                       :url  => "/#{controller_name}/show/#{@record.id}" \
                                "?refresh=n&display=timeline")
     end

--- a/app/views/layouts/_tl_show.html.haml
+++ b/app/views/layouts/_tl_show.html.haml
@@ -3,6 +3,8 @@
   ManageIQ.calendar.calDateFrom = new Date(#{@tl_options.date.start});
   ManageIQ.calendar.calDateTo = new Date(#{@tl_options.date.end});
 
+%h1
+  = @title
 = render :partial => "layouts/flash_msg"
 = render :partial => "layouts/tl_options"
 = render :partial => 'layouts/tl_detail'

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -325,6 +325,11 @@ describe EmsInfraController do
         expect(ApplicationHelper::Toolbar::TimelineCenter).to receive(:definition).and_call_original
         subject
       end
+
+      it "contains timelines title" do
+        subject
+        expect(response.body).to include("Timelines for #{ui_lookup(:table => controller.controller_name)} &quot;#{@ems.name}&quot;")
+      end
     end
 
     context "render listnav partial" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732517

**Steps to Reproduce:**
1. Add infra provider
2. Navigate to Timelines page of the infra provider

**Actual results:**
No title on the page

**Expected results:**
Should be a title on the page

**Description**
- adds `@title` to timeline template
- sets specific `title` to be consistent with timelines in VM/instance controllers

**Before**

![image](https://user-images.githubusercontent.com/32869456/64330748-c9119d00-cfd1-11e9-85e7-443cd22305f8.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/64330733-c2832580-cfd1-11e9-8da9-a4c6af95cca1.png)

@miq-bot add_label bug, ivanchuk/yes, hammer/no, changelog/yes