### PR TITLE
Make Save button respond properly on changes in NTP Servers section while editing a Zone

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -806,6 +806,8 @@ module OpsController::Settings::Common
       field = "ntp_server_#{field_num}"
       next unless params.key?(field)
       @edit[:new][:ntp][field] = params[field]
+      # remove unnecessary key from @edit[:new][:ntp] if there is no change
+      @edit[:new][:ntp].except!(field) if params[field] == @edit[:new][:ntp][:server][field_num - 1]
     end
   end
 

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -47,10 +47,8 @@ describe OpsController do
         @edit = session[:edit]
       end
 
-      context "#smartproxy_affinity_field_changed" do
-        before do
-          expect(controller).to receive(:render)
-        end
+      describe "#smartproxy_affinity_field_changed" do
+        before { expect(controller).to receive(:render) }
 
         it "should select a host when checked" do
           controller.params = {:id => "xx-#{@svr1.id}__host_#{@host2.id}", :check => '1'}
@@ -115,7 +113,7 @@ describe OpsController do
         end
       end
 
-      context "#smartproxy_affinity_update" do
+      describe "#smartproxy_affinity_update" do
         it "updates the SmartProxy host affinities" do
           @svr1.vm_scan_host_affinity = []
           @svr2.vm_scan_host_affinity = []
@@ -138,8 +136,9 @@ describe OpsController do
       end
     end
 
-    context "#settings_update" do
+    describe "#settings_update" do
       let(:orgs) { [1] }
+
       before do
         session[:edit] = {
           :key           => "settings_rhn_edit__rhn_edit",
@@ -178,7 +177,7 @@ describe OpsController do
       end
     end
 
-    context "#settings_get_form_vars" do
+    describe "#settings_get_form_vars" do
       before do
         miq_server = FactoryBot.create(:miq_server)
         current = ::Settings.to_hash
@@ -207,6 +206,21 @@ describe OpsController do
                              :authentication_mode => 'ldap'}
         controller.send(:settings_get_form_vars)
         expect(assigns(:edit)[:new][:authentication][:ldap_role]).to eq(true)
+      end
+    end
+
+    describe '#settings_get_form_vars_sync_ntp' do
+      before do
+        controller.params = {'ntp_server_2' => '1'}
+        controller.instance_variable_set(:@edit, :current => {:ntp => {:server => ['0', '1', '2']}},
+                                                 :new     => {:ntp => {:server => ['0', '1', '2'], 'ntp_server_2' => ''}})
+      end
+
+      subject { controller.instance_variable_get(:@edit) }
+
+      it 'removes unnecessary key from @edit[:new][:ntp]' do
+        controller.send(:settings_get_form_vars_sync_ntp)
+        expect(subject[:new]).to eq(subject[:current])
       end
     end
 


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1749841

_Save_ button did not respond properly on changes in _NTP Servers_ section while editing an existing _Zone_. Let me explain the fix. [Here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/settings/common.rb#L20), the same as in other screens, values of `@edit[:new]` and `@edit[:current]` are crucial for detecting changes in the fields and response of _Add/Save_ buttons. In our case, we need to take care of `@edit[:new][:ntp]` and `@edit[:current][:ntp]`.
Beginning of editing a Zone: 
```
[18] pry(#<OpsController>)> @edit[:new][:ntp]
=> {:server=>["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]}
[19] pry(#<OpsController>)> @edit[:current][:ntp]
=> {:server=>["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]}
```
After we make some change and put it back, the result will look like this:
```
[6] pry(#<OpsController>)> @edit[:new][:ntp]
=> {:server=>["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"], "ntp_server_2"=>"1.pool.ntp.org"}
[7] pry(#<OpsController>)> @edit[:current][:ntp]
=> {:server=>["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"]}
```
We are adding something extra to `@edit[:new][:ntp]`. We always just add something, not remove. And this is core of the problem why _Save_ button remained always enabled if we touched anything in _NTP Servers_ section, no matter we really made a change or not.

So we need to remove unnecessary key `"ntp_server_2"` from `@edit[:new][:ntp]` to achieve proper response of _Save_ button. And as we can [see](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/settings/common.rb#L805) that the field/server numbers in the loop are from 1 to 3, we have to look at `field_num - 1`th item in the array of `@edit[:new][:ntp][:server]` to remove the right key from `@edit[:new][:ntp]` as the second position (_field_num == 2_) in array is in position 1, obviously.

**After:** (Save button becomes disabled after we put back the original values in fields in _NTP Servers_)
![ntp_after](https://user-images.githubusercontent.com/13417815/64443674-be8afc80-d0d2-11e9-8706-eab9d6683312.png)
