### PR TITLE
Add option of copying tags

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,7 +114,7 @@ class CatalogController < ApplicationController
     record = find_record_with_rbac(ServiceTemplate, params[:id])
     message = nil
     if record.present?
-      saved = record.template_copy(params[:name])
+      saved = record.template_copy(params[:name], :copy_tags => params[:copy_tags])
     else
       saved = false
       message = _("Record not found.")

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -18,6 +18,7 @@ class CopyCatalogForm extends Component {
       schema: createSchema(),
       initialValues: {
         name: 'Copy of ' + this.props.originName,
+        copy_tags: false
       },
       isLoaded: true,
     }));
@@ -29,7 +30,7 @@ class CopyCatalogForm extends Component {
   };
 
   submitValues = (values) => {
-    http.post('/catalog/save_copy_catalog', { id: this.props.catalogId, name: values.name }, { skipErrors: [400] })
+    http.post('/catalog/save_copy_catalog', { id: this.props.catalogId, name: values.name, copy_tags: values.copy_tags }, { skipErrors: [400] })
       .then(() => miqAjaxButton('/catalog/servicetemplate_copy_saved'))
       .catch((error) => add_flash(this.handleError(error), 'error'));
   };

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.schema.js
@@ -27,6 +27,11 @@ function createSchema() {
       maxLength: 40,
       autoFocus: true,
       validateOnMount: true,
+    },
+    {
+      component: componentTypes.CHECKBOX,
+      name: 'copy_tags',
+      label: __('Copy Tags'),
     }];
   return { fields };
 }

--- a/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
+++ b/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import fetchMock from 'fetch-mock';
+import CopyCatalogForm from '../../components/copy-catalog-form/copy-catalog-form';
+
+import '../helpers/miqAjaxButton';
+import MiqFormRenderer from '../../forms/data-driven-form';
+
+describe('Copy catalog form', () => {
+  let initialProps;
+  let cancelUrl;
+  let copySavedUrl;
+  let spyMiqAjaxButton;
+
+  beforeEach(() => {
+    initialProps = {
+      catalogId: '10000000000000',
+      originName: 'Template1',
+    };
+
+    cancelUrl = `/catalog/servicetemplate_copy_cancel/${initialProps.catalogId}`;
+    copySavedUrl = '/catalog/servicetemplate_copy_saved';
+    spyMiqAjaxButton = jest.spyOn(window, 'miqAjaxButton');
+
+    fetchMock
+      .getOnce('/catalog/servicetemplates_names', { names: ['Template1', 'Template2'] });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('should render correctly and set initialValue', (done) => {
+    const wrapper = mount(<CopyCatalogForm {...initialProps} />);
+
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.find(MiqFormRenderer)).toHaveLength(1);
+      expect(wrapper.find('input[name="name"]').instance().value).toEqual('Copy of Template1');
+      expect(wrapper.find('input[name="copy_tags"]').instance().value).toEqual('false');
+
+      done();
+    });
+  });
+
+  it('should handle cancel', (done) => {
+    const wrapper = mount(<CopyCatalogForm {...initialProps} />);
+
+    setImmediate(() => {
+      wrapper.update();
+      wrapper.find('button').last().simulate('click'); // click on cancel
+      expect(spyMiqAjaxButton).toHaveBeenCalledWith(cancelUrl);
+      done();
+    });
+  });
+
+  it('should handle submit', (done) => {
+    const postData = '{"id":"10000000000000","name":"Copy of Template1","copy_tags":false}';
+    fetchMock
+      .postOnce('/catalog/save_copy_catalog', {})
+
+    const wrapper = mount(<CopyCatalogForm {...initialProps} />);
+
+    setTimeout(() => {
+
+      wrapper.update();
+      setTimeout(() => {
+        wrapper.find('button').first().simulate('click');
+        setImmediate(() => {
+          expect(spyMiqAjaxButton).toHaveBeenCalledWith(copySavedUrl);
+          expect(fetchMock.lastOptions().body).toEqual(postData);
+          done();
+        });
+      }, 1000);
+    }, 1000);
+  });
+
+  it('should handle submit with copy_tags checked', (done) => {
+    const postData = '{"id":"10000000000000","name":"Copy of Template1","copy_tags":true}';
+    const wrapper = mount(<CopyCatalogForm {...initialProps} />);
+    fetchMock
+      .postOnce('/catalog/save_copy_catalog', {})
+
+    setImmediate(() => {
+      wrapper.update();
+      const check_box = wrapper.find('input[name="copy_tags"]');
+      expect(check_box.instance().value).toEqual('false');
+      check_box.instance().checked = true;
+      check_box.simulate('change');
+
+      expect(check_box.instance().value).toEqual('true');
+
+      done();
+    });
+
+    setTimeout(() => {
+      setTimeout(() => {
+        wrapper.find('button').first().simulate('click');
+        setImmediate(() => {
+          expect(spyMiqAjaxButton).toHaveBeenCalledWith(copySavedUrl);
+          expect(fetchMock.lastOptions().body).toEqual(postData);
+          done();
+        });
+      }, 1000);
+    }, 1000);
+  });
+});


### PR DESCRIPTION
When catalog item is copied, the default behavior does
not copy tags. This PR adds an option of copying tags.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1740399
Depends on #19206

@miq-bot assign @h-kataria 
@miq-bot add_label enhancement, ivanchuk/yes, changelog/yes
@miq-bot add_reviewer @ZitaNemeckova 