### PR TITLE
Reorganize the TreeBuilder tree name mapping to the actual state

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -284,6 +284,10 @@ class TreeBuilder
     :export                          => "TreeBuilderReportExport",
     ## Timelines (TODO)
 
+    ## Utilization
+    ### Utilization
+    :utilization                     => "TreeBuilderUtilization",
+
     ## Chargeback
     ### Reports
     :cb_reports                      => "TreeBuilderChargebackReports",
@@ -359,11 +363,6 @@ class TreeBuilder
     ### Configured Systems
     :configuration_manager_cs_filter => "TreeBuilderConfigurationManagerConfiguredSystems",
 
-    # Automation
-    ## Automate
-    ### Generic Objects
-    :generic_object_definition       => "TreeBuilderConfigurationManager",
-
     # Control
     ## Explorer
     ### Policy Profiles
@@ -403,11 +402,8 @@ class TreeBuilder
     :ab                              => "TreeBuilderButtons",
     #### Import/Export
     :dialog_import_export            => "TreeBuilderAeCustomization",
-
-    # Optimize
-    ## Utilization
-    ### Utilization (TODO)
-    :utilization                     => "TreeBuilderUtilization",
+    ### Generic Objects
+    :generic_object_definition       => "TreeBuilderGenericObjectDefinition",
 
     # OPS (Configuration)
     ## Settings


### PR DESCRIPTION
The optimize menu item has been removed, from that the utilization has been moved to overview. The generic object definitions has been added into the wrong place and mapped to a treebuilder that has nothing to do with it. :hamster: 

@miq-bot add_label ivanchuk/no, trees, technical debt
@miq-bot add_reviewer @ZitaNemeckova 