### PR TITLE
Drop the unnecessary ISO images hash folder from the ISO tree

### DIFF
--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -268,7 +268,7 @@ module PxeController::IsoDatastores
     else
       @right_cell_div = "iso_datastore_details"
       nodes = treenodeid.split("-")
-      if (nodes[0] == "isd" && nodes.length == 2) || (["isd_xx"].include?(nodes[1]) && nodes.length == 3)
+      if nodes[0] == "isd" && nodes.length == 2
         # on iso_datastore node OR folder node is selected
         @record = @isd = IsoDatastore.find(nodes.last)
         @right_cell_text = _("ISO Datastore \"%{name}\"") % {:name => @isd.name}

--- a/app/presenters/tree_builder_iso_datastores.rb
+++ b/app/presenters/tree_builder_iso_datastores.rb
@@ -20,30 +20,6 @@ class TreeBuilderIsoDatastores < TreeBuilder
   end
 
   def x_get_tree_iso_datastore_kids(object, count_only)
-    iso_images = object.iso_images
-    if count_only
-      open_node("xx-isd_xx-#{object.id}")
-      iso_images.size
-    else
-      objects = []
-      unless iso_images.empty?
-        open_node("isd_xx-#{object.id}")
-        objects.push(
-          :id   => "isd_xx-#{object.id}",
-          :text => _("ISO Images"),
-          :icon => "pficon pficon-folder-close",
-          :tip  => _("ISO Images")
-        )
-      end
-      objects
-    end
-  end
-
-  def x_get_tree_custom_kids(object, count_only)
-    nodes = (object[:full_id] || object[:id]).split('_')
-    isd = IsoDatastore.find_by(:id => nodes.last.split('-').last)
-    # Iso Datastore node was clicked OR folder nodes was clicked
-    objects = isd.iso_images if nodes[0].end_with?("isd")
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects(count_only, object.iso_images, "name")
   end
 end


### PR DESCRIPTION
Analogously with the other trees, getting rid of redundant nodes. In the ISO datastore tree I think there's no need for the ISO images folder that has not siblings and only the ISO images as children. Also there's no extra functionality when it is selected, it just displays the same info as the datastore parent. The icon is being replaced to represent the ISO image much better in https://github.com/ManageIQ/manageiq-decorators/pull/19

**Before:**
![Screenshot from 2019-09-09 15-04-28](https://user-images.githubusercontent.com/649130/64533371-9ccc8800-d313-11e9-8410-60c13d84a909.png)

**After:**
![Screenshot from 2019-09-09 15-01-15](https://user-images.githubusercontent.com/649130/64533373-9fc77880-d313-11e9-8fc8-e3fc1ac26455.png)

@terezanovotna can you please take a look

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label ivanchuk/no, technical debt, trees, ux/review