### PR TITLE
Remove unnecessary validation before clicking on Add/Save while adding/editing a Group or Role

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -670,6 +670,7 @@ module OpsController::OpsRbac
     when :group then
       record = @edit[:group_id] ? MiqGroup.find_by(:id => @edit[:group_id]) : MiqGroup.new
       validated = rbac_group_validate?
+      rbac_group_set_record_description_role(record) # Set new Description, Role and Tenant for a new Group
       rbac_group_set_record_vars(record) if validated
     when :role  then
       record = @edit[:role_id] ? MiqUserRole.find_by(:id => @edit[:role_id]) : MiqUserRole.new
@@ -1216,10 +1217,6 @@ module OpsController::OpsRbac
 
   # Set group record variables to new values
   def rbac_group_set_record_vars(group)
-    role = MiqUserRole.find(@edit[:new][:role])
-    group.description = @edit[:new][:description]
-    group.miq_user_role = role
-    group.tenant = Tenant.find(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]
     if @edit[:new][:use_filter_expression]
       @edit[:new][:filters].clear
     else
@@ -1228,6 +1225,13 @@ module OpsController::OpsRbac
     end
 
     rbac_group_set_filters(group) # Go set the filters for the group
+  end
+
+  # Set group record variables such as Description, Role and Tenant to new values
+  def rbac_group_set_record_description_role(group)
+    group.description = @edit[:new][:description]
+    group.miq_user_role = MiqUserRole.find(@edit[:new][:role]) if @edit[:new][:role]
+    group.tenant = Tenant.find(@edit[:new][:group_tenant]) if @edit[:new][:group_tenant]
   end
 
   # Set filters in the group record from the @edit[:new] hash values
@@ -1400,7 +1404,7 @@ module OpsController::OpsRbac
     @assigned_filters = [] if @edit[:new][:filters].empty? || @edit[:new][:use_filter_expression]
     @filter_expression = [] if @edit[:new][:filter_expression].empty? || @edit[:new][:use_filter_expression] == false
     if @edit[:new][:role].nil? || @edit[:new][:role] == ""
-      add_flash(_("A User Group must be assigned a Role"), :error)
+      add_flash(_("A Role must be assigned to this Group"), :error)
       return false
     end
     true

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -756,17 +756,7 @@ module OpsController::OpsRbac
 
     @edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i) if rec_type == "user"
 
-    bad = case rec_type
-          when 'group'
-            @edit[:new].values_at(:role, :group_tenant, :description).any?(&:blank?)
-          when 'role'
-            @edit[:new][:name].blank?
-          else
-            false
-          end
-
-    # We need to consider also bad variable, for proper response of Add button
-    session[:changed] = changed = @edit[:new] != @edit[:current] && !bad
+    session[:changed] = changed = @edit[:new] != @edit[:current]
 
     render :update do |page|
       page << javascript_prologue
@@ -775,7 +765,6 @@ module OpsController::OpsRbac
           page.replace("flash_msg_div", :partial => "layouts/flash_msg") if @refresh_div == "column_lists"
           page.replace(@refresh_div, :partial => @refresh_partial)
         end
-        bad = false
       else
         # only do following for user (adding/editing a user)
         if x_node.split("-").first == "u" || x_node == "xx-u"

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -727,13 +727,13 @@ describe OpsController do
         let(:params) { {:id => "new", :group_tenant => tenant.id.to_s} }
         let(:edit) { {:new => {:role => 1}} }
 
-        it 'sets session[:changed] to false while filling in role and tenant' do
+        it 'sets session[:changed] to true while filling in role and tenant' do
           controller.send(:rbac_field_changed, rec_type)
-          expect(controller.session[:changed]).to be(false)
+          expect(controller.session[:changed]).to be(true)
         end
 
-        context 'filling in all the required info' do
-          let(:edit) { {:new => {:role => 1, :description => 'new_group'}} }
+        context 'filling in description' do
+          let(:edit) { {:new => {:description => 'new_group'}} }
 
           it 'sets session[:changed] to true' do
             controller.send(:rbac_field_changed, rec_type)

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -806,4 +806,23 @@ describe OpsController do
       end
     end
   end
+
+  describe '#rbac_edit_save_or_add' do
+    context 'adding new Group' do
+      before do
+        allow(controller).to receive(:load_edit).and_return(true)
+        allow(controller).to receive(:render_flash)
+        controller.instance_variable_set(:@edit, :new => {:description           => 'Description',
+                                                          :filters               => {},
+                                                          :filter_expression     => {'???' => '???'},
+                                                          :use_filter_expression => false})
+        controller.params = {:button => 'add'}
+      end
+
+      it 'sets @flash_array properly if user forgot to choose a Role for a Group' do
+        controller.send(:rbac_edit_save_or_add, 'group')
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'A Role must be assigned to this Group', :level => :error}])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR removes unnecessary code related to **adding/editing a Group or Role** because in older fields like in our cases and validation is usually provided AFTER clicking on _Add/Save_ button - the same as in other screens => more consistency. _Add/Save_ button respond now on any changes, and not also on the information if all the required fields are set.

This PR also fixes displaying extra flash message (_Description can't be blank_) which accidentally appears if we fill in only Description and click on _Add_ button, while adding new Group. Caused by: https://github.com/ManageIQ/manageiq-ui-classic/pull/3164 The solution is setting Description, Role and/or Tenant (if it was chosen) even if `rbac_group_validate?` was not `true`. This issue is reproducible after applying the first commit of this PR (removing 'bad' variable).

**More:**
Related PR where we were dealing with the same issue: https://github.com/ManageIQ/manageiq-ui-classic/pull/5972#issuecomment-528855107
Older PR which was adding `bad` variable: https://github.com/ManageIQ/manageiq/pull/4566

**After:**
![group_add-after](https://user-images.githubusercontent.com/13417815/64534694-309f5380-d316-11e9-94e3-ace71d37d0e7.png)

**Note:**
Choosing Project/Tenant is not required. If user is signed it, its Tenant is chosen by default. See:
https://github.com/ManageIQ/manageiq/blob/33a3327b395700ce245f9f770b4277e0ce08d2c2/app/models/mixins/tenancy_mixin.rb#L16