### PR TITLE
Amazon - support Assume Role ARN

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -76,6 +76,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       kubevirt_password: '',
       kubevirt_password_exists: false,
       default_url: '',
+      default_assume_role: '',
     };
 
     $scope.emsOptionsModel = {
@@ -158,6 +159,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.ssh_keypair_userid              = data.ssh_keypair_userid;
 
       $scope.emsCommonModel.service_account                 = data.service_account;
+      $scope.emsCommonModel.default_assume_role             = data.assume_role;
       $scope.emsCommonModel.azure_tenant_id                 = data.azure_tenant_id;
       $scope.emsCommonModel.keystone_v3_domain_id           = data.keystone_v3_domain_id;
       $scope.emsCommonModel.subscription                    = data.subscription;
@@ -637,6 +639,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         default_userid:            $scope.emsCommonModel.default_userid,
         default_password:          default_password,
         default_url:               $scope.emsCommonModel.default_url,
+        default_assume_role:       $scope.emsCommonModel.default_assume_role,
         realm:                     $scope.emsCommonModel.realm,
         azure_tenant_id:           $scope.emsCommonModel.azure_tenant_id,
         subscription:              $scope.emsCommonModel.subscription,

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -67,6 +67,22 @@
         .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'ec2'"}
           = render :partial => "layouts/angular-bootstrap/endpoints_for_url",
                                :locals => {:prefix => "default", :ng_model => "#{ng_model}"}
+          %div
+            .form-group{"ng-class" => "{'has-error': angularForm.default_assume_role.$invalid}"}
+              %label.col-md-2.control-label{"for" => "default_assume_role"}
+                = _("Assume role ARN")
+              .col-md-4
+                %input.form-control{"type"                    => "text",
+                                    "id"                      => "default_assume_role",
+                                    "ng-required"             => "false",
+                                    "ng-disabled"             => "false",
+                                    "name"                    => "default_assume_role",
+                                    "ng-model"                => "#{main_scope}.#{ng_model}.default_assume_role",
+                                    "checkchange"             => "",
+                                    "ng-trim"                 => false,
+                                    "detect_spaces"           => "",
+                                    "prefix"                  => "default",
+                                    "reset-validation-status" => "default_auth_status"}
           = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                  :locals  => {:ng_show                => true,
                                               :ng_model               => "#{ng_model}",

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -83,7 +83,8 @@ describe EmsCloudController do
           'ap-southeast-1',
           nil,
           true,
-          instance_of(URI::Generic)
+          instance_of(URI::Generic),
+          :assume_role => nil,
         ]),
         User.current_user.userid,
         zone.name
@@ -276,6 +277,7 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
       expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
+      expect(mocked_ems).to receive(:supports?).with(:assume_role).and_return(false)
       expect(controller.send(:build_credentials, mocked_ems, :validate)).to eq(:default => default_creds.merge!(:save => false), :amqp => amqp_creds.merge!(:save => false))
     end
 
@@ -287,6 +289,7 @@ describe EmsCloudController do
       expect(mocked_ems).to receive(:supports_authentication?).with(:amqp).and_return(true)
       expect(mocked_ems).to receive(:supports_authentication?).with(:oauth)
       expect(mocked_ems).to receive(:supports_authentication?).with(:auth_key)
+      expect(mocked_ems).to receive(:supports?).with(:assume_role).and_return(false)
       expect(controller.send(:build_credentials, mocked_ems, :validate)).to eq(:default => default_creds.merge!(:save => false), :amqp => amqp_creds.merge!(:save => false))
     end
   end

--- a/spec/controllers/mixins/ems_common/angular_spec.rb
+++ b/spec/controllers/mixins/ems_common/angular_spec.rb
@@ -222,9 +222,10 @@ describe Mixins::EmsCommon::Angular do
       before do
         @ems_cloud_controller = EmsCloudController.new
         @params = {
-          :default_userid   => "abc",
-          :default_password => "abc",
-          :default_url      => "http://abc.test/mypath"
+          :default_userid      => "abc",
+          :default_password    => "abc",
+          :default_url         => "http://abc.test/mypath",
+          :default_assume_role => "test_arn",
         }
         @ems = FactoryBot.create(:ems_amazon)
         allow(@ems).to receive(:to_s).and_return('ManageIQ::Providers::Amazon::CloudManager')
@@ -234,7 +235,16 @@ describe Mixins::EmsCommon::Angular do
         @params[:cred_type] = "default"
         @ems_cloud_controller.params = @params
 
-        expected_connect_options = ["abc", "v2:{XpADRTTI7f11hNT7AuDaKg==}", :EC2, nil, nil, true, URI.parse("http://abc.test/mypath")]
+        expected_connect_options = [
+          "abc",
+          "v2:{XpADRTTI7f11hNT7AuDaKg==}",
+          :EC2,
+          nil,
+          nil,
+          true,
+          URI.parse("http://abc.test/mypath"),
+          {:assume_role => "test_arn"},
+        ]
         expect(@ems_cloud_controller.send(:get_task_args, @ems)).to eq(expected_connect_options)
       end
     end

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -99,7 +99,8 @@ describe('emsCommonFormController', function() {
       openstack_infra_providers_exist: false,
       provider_region: "ap-southeast-2",
       default_userid: "default_user",
-      default_url: "http://host.test/abc"
+      default_url: "http://host.test/abc",
+      assume_role: 'arn:123',
     };
 
     beforeEach(inject(function(_$controller_) {
@@ -157,6 +158,10 @@ describe('emsCommonFormController', function() {
       expect($scope.emsCommonModel.default_url).toEqual("http://host.test/abc");
     });
 
+    it('sets default_assume_role', function() {
+      expect($scope.emsCommonModel.default_assume_role).toEqual("arn:123");
+    });
+
     it('sets the current tab to default', function() {
       expect($scope.currentTab).toEqual('default');
     });
@@ -164,7 +169,7 @@ describe('emsCommonFormController', function() {
     it('initializes $scope.postValidationModel with credential objects for only those providers that support validation', function () {
       $scope.postValidationModelRegistry('default');
       expect($scope.postValidationModel).toEqual(jasmine.objectContaining({
-        default: jasmine.objectContaining({provider_region: 'ap-southeast-2'}),
+        default: jasmine.objectContaining({provider_region: 'ap-southeast-2', default_assume_role: 'arn:123'}),
         console: jasmine.objectContaining({console_userid: undefined}),
         amqp: {},
         metrics: {},


### PR DESCRIPTION
Finishing work from https://github.com/ManageIQ/manageiq-ui-classic/pull/5621
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1631845

---

This is support PR for AWS Security Token Service's "[assume role](https://stackoverflow.com/a/50083442/4393476)" feature.

Basically, it's just a new field on form, and related validation and saving code changes.

![new_field](https://user-images.githubusercontent.com/289743/64542414-0e580680-d313-11e9-9709-28fcf662bf84.png)

Here is the primary PR with technical info: https://github.com/ManageIQ/manageiq-providers-amazon/pull/538
Related core repo PR: https://github.com/ManageIQ/manageiq/pull/18810

---

Changes since https://github.com/ManageIQ/manageiq-ui-classic/pull/5621:

* renamed `service_account` to `assume_role` to prevent collisions with GCE `service_account`,
* reordered commits to get rid of past experiments,
* added `{}` around hash in an array