### PR TITLE
Do not use hash nodes for PxeImageType in Customization Templates 🌳

### DIFF
--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -1,4 +1,5 @@
 class TreeBuilderPxeCustomizationTemplates < TreeBuilder
+  has_kids_for PxeImageType, %i[x_get_tree_pxe_image_type_kids]
   private
 
   def tree_init_options
@@ -21,7 +22,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
                  :icon => "pficon pficon-folder-close",
                  :tip  => _("Examples (read only)"))
     PxeImageType.all.sort.each do |item, _idx|
-      objects.push(:id => "xx-#{item.id}", :text => item.name, :icon => "pficon pficon-folder-close", :tip => item.name)
+      objects.push(item)
     end
     objects
   end
@@ -30,18 +31,14 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
     nodes.length >= 3 ? nodes[2] : nodes[1]
   end
 
-  # Handle custom tree nodes (object is a Hash)
+  def x_get_tree_pxe_image_type_kids(object, count_only)
+    objects = CustomizationTemplate.where(:pxe_image_type_id => object.id)
+    count_only_or_objects(count_only, objects, "name")
+  end
+
+  # Handle custom tree nodes (object is the Examples folder)
   def x_get_tree_custom_kids(object, count_only)
-    nodes = object[:full_id] ? object[:full_id].split('-') : object[:id].split('-')
-    pxe_img_id = if nodes[1] == "system" || nodes[2] == "system"
-                   # root node was clicked or if folder node was clicked
-                   # System templates
-                   nil
-                 else
-                   # root node was clicked or if folder node was clicked
-                   get_pxe_image_id(nodes)
-                 end
-    objects = CustomizationTemplate.where(:pxe_image_type_id => pxe_img_id)
+    objects = CustomizationTemplate.where(:pxe_image_type_id => nil)
     count_only_or_objects(count_only, objects, "name")
   end
 end


### PR DESCRIPTION
Next step in getting rid of hash nodes, it's in Infra -> PXE -> Customization Templates. It displays the icon for `PxeImageType` from the decorator instead of the folder, but this icon might be not the most descriptive. I can create an override to change it back to a folder or we can come up with a new icon in the decorator with @epwinchell.

**Before:**
![Screenshot from 2019-09-09 18-20-45](https://user-images.githubusercontent.com/649130/64548260-926bb780-d32e-11e9-9ca9-da690272a9b8.png)

**After:**
![Screenshot from 2019-09-09 18-19-59](https://user-images.githubusercontent.com/649130/64548268-98619880-d32e-11e9-8ed8-850dcae4a7ce.png)


@miq-bot add_label trees, technical debt, ivanchuk/no
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @ZitaNemeckova  
@miq-bot add_reviewer @martinpovolny 