### PR TITLE
Use kind_of? instead of String comparison

### DIFF
--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -15,7 +15,7 @@ module EmsStorageHelper::TextualSummary
                        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
                        cloud_object_store_containers custom_button_events
       ]
-    relationships.push(:cloud_volume_types) if @record.type.include?("ManageIQ::Providers::StorageManager::CinderManager")
+    relationships.push(:cloud_volume_types) if @record.kind_of?(ManageIQ::Providers::StorageManager::CinderManager)
     TextualGroup.new(_("Relationships"), relationships)
   end
 


### PR DESCRIPTION
This way it catches ManageIQ::Providers::Openstack::StorageManager::CinderManager and ManageIQ::Providers::StorageManager::CinderManager. Not just the later.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650082

Storage -> Block Storage -> Managers -> click on non-Openstack storage provider or OpenStack Swift Provider
Before there's Cloud Volume Types in Relationships (last line):
![image](https://user-images.githubusercontent.com/9210860/56198164-ab4f9580-603a-11e9-8afb-44ee8321a458.png)
After there's no Cloud Volume Types in Relationships:
![image](https://user-images.githubusercontent.com/9210860/56198522-637d3e00-603b-11e9-8c15-3a0782d18f00.png)

For OpenStack Cinder Manager:
Before/After:
<img width="1070" alt="Screenshot 2019-09-10 at 09 34 47" src="https://user-images.githubusercontent.com/9210860/64593373-452f2a80-d3ae-11e9-8762-fac6e2483dfb.png">
*Zone is missing because this Provider was added via console and it's missing some stuff like a zone*

If you have no `CloudVolumeType` for OpenStack. Do this in console:
```
ems_id = ManageIQ::Providers::OpenStack::StorageManager::CinderManager.first.id
cvt = CloudVolumeType.create(:name => "name", :description => "description", :ems_id => ems_id)
cvt.save!
```

@miq-bot add_label bug, ivanchuk/yes

@himdel please have a look