### PR TITLE
Show key value pairs on request partial for dropdowns

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -28,7 +28,14 @@
       = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
 
     - when "DialogFieldDropDownList"
-      = h(field.value || "<None>")
+      - val = h(field.value)
+      - if val.present?
+        - if field.multiselect?
+          = val.split(',').map { |v| {v => field.values.to_h[v]} }
+        - else
+          = [val, field.values.to_h[field.value]]
+      - else
+        = "<None>"
 
     - when 'DialogFieldTagControl'
       - value = wf.value(field.name) || '' # it returns in format Clasification::id


### PR DESCRIPTION
In the request partial we only show the dropdown values and I have a bug about also showing their keys.

@eclarizio please review

@miq-bot add_label enhancement

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663046

now:
![Screen Shot 2019-09-10 at 11 37 53 AM](https://user-images.githubusercontent.com/16326669/64628479-782dea00-d3bf-11e9-921c-b3441d394532.png)


and here's what it looks like without a value: 
![Screen Shot 2019-09-10 at 11 47 12 AM](https://user-images.githubusercontent.com/16326669/64629209-c7284f00-d3c0-11e9-9238-0d819e2517df.png)


