### PR TITLE
Fix traceback in edit report preview

### DIFF
--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -49,11 +49,11 @@ module ReportController::Reports
         @edit[:tl_xml]            = nil
       end
       if !rpt.graph.nil? && rpt.graph[:type].present? # If graph present
-        @edit[:chart_data] = nil
-      else
         # FIXME: UNTESTED!!!
         rpt.to_chart(settings(:display, :reporttheme), false, MiqReport.graph_options) # Generate the chart
         @edit[:chart_data] = rpt.chart
+      else
+        @edit[:chart_data] = nil
       end
     end
     miq_task.destroy


### PR DESCRIPTION
This is to fix traceback caused by https://github.com/ManageIQ/manageiq-ui-classic/commit/b74c4a5af516b5b14260ca484b7050615f90a2ca#diff-a31349b4cac8623f48847e8d969ecbeaL53

1. Overeview ➛ Reports ➛ Reports ➛ Select a report  ➛ Edit that report ➛ Preview tab
2. Observe the following traceback in logs:
```
[----] F, [2019-09-11T13:50:40.491791 #7953:2b01517a57ec] FATAL -- : Error caught: [RuntimeError] Graph type not specified
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4de7acd5caeb/lib/report_formatter/chart_common.rb:16:in `build_document_header'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4de7acd5caeb/lib/report_formatter/c3.rb:56:in `build_document_header'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:598:in `maybe'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:584:in `block in execute_stages'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:583:in `each'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:583:in `execute_stages'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:574:in `_run_'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:520:in `run'
/opt/rh/cfme-gemset/bundler/gems/ruport-3727775479b0/lib/ruport/controller.rb:436:in `render'
/var/www/miq/vmdb/app/models/miq_report/formatters/graph.rb:13:in `to_chart'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4de7acd5caeb/app/controllers/report_controller/reports.rb:55:in `show_preview'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-4de7acd5caeb/app/controllers/application_controller/wait_for_task.rb:23:in `wait_for_task'

```
https://bugzilla.redhat.com/show_bug.cgi?id=1751328