### PR TITLE
Add abandon changes popup to data driven forms components

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -311,6 +311,12 @@ function miqCheckForChanges() {
     return confirm(__('Abandon changes?'));
   }
 
+  var formValues = ManageIQ.redux.store.getState().formReducer;
+
+  if (formValues && !formValues.pristine) {
+    return confirm(__('Abandon changes?'));
+  }
+
   // use default browser reaction for onclick
   return true;
 }

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -75,6 +75,7 @@ ManageIQ.explorer.processReplaceMainDiv = function(data) {
   ManageIQ.explorer.updateRightCellText(data);
   ManageIQ.explorer.updatePartials(data);
   ManageIQ.explorer.setVisibility(data);
+  ManageIQ.explorer.resetReduxForms();
 };
 
 ManageIQ.explorer.processFlash = function(data) {
@@ -110,7 +111,6 @@ ManageIQ.explorer.updatePartials = function(data) {
       if (!miqDomElementExists(element)) {
         console.error('updatePartials: #' + element + ' does not exist in the DOM');
       }
-
       $('#' + element).html(content);
     });
   }
@@ -119,6 +119,12 @@ ManageIQ.explorer.updatePartials = function(data) {
 ManageIQ.explorer.reloadTrees = function(data) {
   if (_.isObject(data.reloadTrees)) {
     sendDataWithRx({reloadTrees: data.reloadTrees});
+  }
+};
+
+ManageIQ.explorer.resetReduxForms = function() {
+  if (ManageIQ.redux.store) {
+    ManageIQ.redux.store.dispatch({type: '@@data-driven-forms/reset'});
   }
 };
 
@@ -340,6 +346,8 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   } else {
     miqSparkleOff();
   }
+
+  ManageIQ.explorer.resetReduxForms();
 
   return null;
 };

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -35,6 +35,10 @@ class TaggingWrapper extends React.Component {
     this.loadState(this.props.tags);
   }
 
+  componentWillUnmount() {
+    this.props.reset();
+  }
+
   loadState = state => this.props.loadState(state);
   reset = () => this.props.reset();
   isLoaded = () => this.props.isLoaded();

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { Form } from 'patternfly-react';
 import FormRender, { Validators, layoutComponents } from '@data-driven-forms/react-form-renderer';
 import { layoutMapper } from '@data-driven-forms/pf3-component-mapper';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { setPristine } from '../miq-redux/form-reducer';
 import formFieldsMapper from './mappers/formsFieldsMapper';
 
 Validators.messages = {
@@ -16,7 +20,9 @@ const buttonLabels = {
   cancelLabel: __('Cancel'),
 };
 
-const MiqFormRenderer = ({ className, ...props }) => (
+const MiqFormRenderer = ({
+  className, setPristine, onStateUpdate, ...props
+}) => (
   <FormRender
     formFieldsMapper={formFieldsMapper}
     layoutMapper={{
@@ -27,6 +33,12 @@ const MiqFormRenderer = ({ className, ...props }) => (
       'pristine',
       'invalid',
     ]}
+    onStateUpdate={(formOptions) => {
+      setPristine(formOptions.pristine);
+      if (onStateUpdate) {
+        onStateUpdate(formOptions);
+      }
+    }}
     {...buttonLabels}
     {...props}
   />
@@ -34,10 +46,15 @@ const MiqFormRenderer = ({ className, ...props }) => (
 
 MiqFormRenderer.propTypes = {
   className: PropTypes.string,
+  onStateUpdate: PropTypes.func,
+  setPristine: PropTypes.func.isRequired,
 };
 
 MiqFormRenderer.defaultProps = {
   className: 'form-react',
+  onStateUpdate: undefined,
 };
 
-export default MiqFormRenderer;
+const mapDispatchToProps = dispatch => bindActionCreators({ setPristine }, dispatch);
+
+export default connect(null, mapDispatchToProps)(MiqFormRenderer);

--- a/app/javascript/miq-redux/form-reducer.js
+++ b/app/javascript/miq-redux/form-reducer.js
@@ -1,0 +1,17 @@
+export const SET_PRISTINE = '@@data-driven-forms/set-pristine';
+
+export const setPristine = pristine => ({
+  type: SET_PRISTINE,
+  payload: {
+    pristine,
+  },
+});
+
+export const reducer = (state = { pristine: true }, action) => {
+  switch (action.type) {
+    case SET_PRISTINE:
+      return { ...state, pristine: action.payload.pristine };
+    default:
+      return state;
+  }
+};

--- a/app/javascript/miq-redux/form-reducer.js
+++ b/app/javascript/miq-redux/form-reducer.js
@@ -1,4 +1,5 @@
 export const SET_PRISTINE = '@@data-driven-forms/set-pristine';
+export const RESET = '@@data-driven-forms/reset';
 
 export const setPristine = pristine => ({
   type: SET_PRISTINE,
@@ -7,10 +8,12 @@ export const setPristine = pristine => ({
   },
 });
 
-export const reducer = (state = { pristine: true }, action) => {
+export const reducer = (state = {}, action) => {
   switch (action.type) {
     case SET_PRISTINE:
       return { ...state, pristine: action.payload.pristine };
+    case RESET:
+      return {};
     default:
       return state;
   }

--- a/app/javascript/miq-redux/store.js
+++ b/app/javascript/miq-redux/store.js
@@ -3,6 +3,8 @@ import createReducer from './reducer';
 import createMiddlewares from './middleware';
 import { history } from '../miq-component/react-history.js';
 
+import { reducer as formReducer } from './form-reducer';
+
 const initialState = {};
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -17,7 +19,9 @@ const initializeStore = () => {
   /**
    * storage for all future reducers
    */
-  store.asyncReducers = {};
+  store.asyncReducers = {
+    formReducer,
+  };
 
   /**
    * @param {Object} reducers object where key is the name of reducer and value reducer function

--- a/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
+++ b/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 import ImportDatastoreViaGit from '../../components/automate-import-export-form/import-datastore-via-git';
 import '../helpers/addFlash';
+import { mount, shallow } from '../helpers/mountForm';
 
 describe('Import datastore via git component', () => {
   /**

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -4,14 +4,13 @@ exports[`Catalog form component should render add variant form 1`] = `
 <div
   className="container-fluid"
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Add",
       }
     }
     canReset={false}
-    className="form-react"
     onCancel={[Function]}
     onReset={[Function]}
     onSubmit={[Function]}
@@ -85,14 +84,13 @@ exports[`Catalog form component should render edit variant form 1`] = `
 <div
   className="container-fluid"
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Save",
       }
     }
     canReset={true}
-    className="form-react"
     initialValues={
       Object {
         "description": "This is a DROGO!",

--- a/app/javascript/spec/catalog-form/catalog-form.spec.js
+++ b/app/javascript/spec/catalog-form/catalog-form.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 import CatalogForm from '../../components/catalog-form/catalog-form';
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import '../helpers/addFlash';
+import { mount, shallow } from '../helpers/mountForm';
 
 describe('Catalog form component', () => {
   let submitSpyMiqSparkleOn;
@@ -58,7 +58,7 @@ describe('Catalog form component', () => {
 
   it('should render add variant form', (done) => {
     fetchMock.getOnce(urlFreeTemplates, { resources });
-    const wrapper = shallow(<CatalogForm />);
+    const wrapper = shallow(<CatalogForm />).dive();
 
     setImmediate(() => {
       wrapper.update();
@@ -70,7 +70,7 @@ describe('Catalog form component', () => {
   it('should render edit variant form', (done) => {
     fetchMock.getOnce(urlFreeTemplates, { resources })
       .getOnce(urlTemplates, assignedResources);
-    const wrapper = shallow(<CatalogForm catalogId="1001" />);
+    const wrapper = shallow(<CatalogForm catalogId="1001" />).dive();
 
     setImmediate(() => {
       wrapper.update();
@@ -103,7 +103,7 @@ describe('Catalog form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().isLoaded).toBe(true);
+      expect(wrapper.children().state().isLoaded).toBe(true);
       expect(submitSpyMiqSparkleOff).toHaveBeenCalled();
       done();
     });
@@ -121,12 +121,12 @@ describe('Catalog form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().initialValues).toEqual({
+      expect(wrapper.children().state().initialValues).toEqual({
         name: 'DROGO',
         description: 'This is a DROGO!',
         service_templates: rightValues,
       });
-      expect(wrapper.state().originalRightValues).toEqual(originalRightValues);
+      expect(wrapper.children().state().originalRightValues).toEqual(originalRightValues);
       expect(submitSpyMiqSparkleOff).toHaveBeenCalled();
       done();
     });
@@ -138,7 +138,7 @@ describe('Catalog form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      const spy = jest.spyOn(wrapper.instance(), 'submitValues');
+      const spy = jest.spyOn(wrapper.children().instance(), 'submitValues');
       const button = wrapper.find('button').first();
       button.simulate('click');
       expect(spy).toHaveBeenCalledTimes(0);
@@ -159,7 +159,7 @@ describe('Catalog form component', () => {
         { key: 'http://localhost:3000/api/service_templates/44', label: 'template 44' },
       ],
     };
-    wrapper.instance().submitValues(values).then(() => {
+    wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(urlCreate)).toBe(true);
       expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit?button=add');
       done();
@@ -178,7 +178,7 @@ describe('Catalog form component', () => {
     fetchMock.postOnce(urlCreate, returnObject);
 
     const wrapper = mount(<CatalogForm />);
-    const spyHandleError = jest.spyOn(wrapper.instance(), 'handleError');
+    const spyHandleError = jest.spyOn(wrapper.children().instance(), 'handleError');
 
     expect(spyHandleError).not.toHaveBeenCalled();
 
@@ -190,7 +190,7 @@ describe('Catalog form component', () => {
       ],
     };
 
-    return wrapper.instance().submitValues(values).then(() => {
+    return wrapper.children().instance().submitValues(values).then(() => {
       expect(spyHandleError).toHaveBeenCalledWith(expect.objectContaining({ data: returnObject.body, status: returnObject.status }));
       done();
     });
@@ -210,9 +210,9 @@ describe('Catalog form component', () => {
     fetchMock.postOnce(apiBase, returnObject);
 
     const wrapper = mount(<CatalogForm catalogId="1001" />);
-    const spyHandleError = jest.spyOn(wrapper.instance(), 'handleError');
+    const spyHandleError = jest.spyOn(wrapper.children().instance(), 'handleError');
 
-    wrapper.instance().setState({ originalRightValues: [] });
+    wrapper.children().instance().setState({ originalRightValues: [] });
 
     expect(spyHandleError).not.toHaveBeenCalled();
 
@@ -222,7 +222,7 @@ describe('Catalog form component', () => {
       service_templates: [],
     };
 
-    return wrapper.instance().submitValues(values).then(() => {
+    return wrapper.children().instance().submitValues(values).then(() => {
       expect(spyHandleError).toHaveBeenCalledWith(expect.objectContaining({ data: returnObject.body, status: returnObject.status }));
       done();
     });
@@ -245,9 +245,9 @@ describe('Catalog form component', () => {
       ],
     };
 
-    wrapper.instance().setState({ originalRightValues });
+    wrapper.children().instance().setState({ originalRightValues });
 
-    wrapper.instance().submitValues(values).then(() => {
+    wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(apiBase)).toBe(true);
       expect(fetchMock.called(`${apiBase}/service_templates`)).toBe(true);
       expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save');
@@ -270,9 +270,9 @@ describe('Catalog form component', () => {
       service_templates: rightValues,
     };
 
-    wrapper.instance().setState({ originalRightValues });
+    wrapper.children().instance().setState({ originalRightValues });
 
-    wrapper.instance().submitValues(values).then(() => {
+    wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(apiBase)).toBe(true);
       expect(fetchMock.called(`${apiBase}/service_templates`)).toBe(false);
       expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save');
@@ -287,7 +287,7 @@ describe('Catalog form component', () => {
       };
       const wrapper = mount(<CatalogForm catalogId="1001" />);
 
-      expect(wrapper.instance().handleError(error)).toEqual(error.data.error.message);
+      expect(wrapper.children().instance().handleError(error)).toEqual(error.data.error.message);
     });
 
     it('should parse duplicate name error', () => {
@@ -296,7 +296,7 @@ describe('Catalog form component', () => {
       };
       const wrapper = mount(<CatalogForm catalogId="1001" />);
 
-      expect(wrapper.instance().handleError(error)).toEqual(__('Name has already been taken'));
+      expect(wrapper.children().instance().handleError(error)).toEqual(__('Name has already been taken'));
     });
   });
 });

--- a/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
+++ b/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
@@ -6,14 +6,13 @@ exports[`Cloud Network form component should render edit variant 1`] = `
   componentClass="div"
   fluid={true}
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Save",
       }
     }
     canReset={true}
-    className="form-react"
     initialValues={
       Object {
         "cidr": null,
@@ -310,14 +309,13 @@ exports[`Cloud Network form component should render form 1`] = `
   componentClass="div"
   fluid={true}
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Add",
       }
     }
     canReset={false}
-    className="form-react"
     initialValues={
       Object {
         "enabled": true,

--- a/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
+++ b/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
@@ -1,20 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cloud tenant form component should render adding form variant 1`] = `
-<div
-  className="container-fluid"
+<Grid
+  bsClass="container"
+  componentClass="div"
+  fluid={true}
 >
   <h3>
     Basic Information
   </h3>
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Add",
       }
     }
     canReset={false}
-    className="form-react"
     onCancel={[Function]}
     onReset={[Function]}
     onSubmit={[Function]}
@@ -68,24 +69,25 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
       }
     }
   />
-</div>
+</Grid>
 `;
 
 exports[`Cloud tenant form component should render editing form variant 1`] = `
-<div
-  className="container-fluid"
+<Grid
+  bsClass="container"
+  componentClass="div"
+  fluid={true}
 >
   <h3>
     Edit Cloud Tenant
   </h3>
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Save",
       }
     }
     canReset={true}
-    className="form-react"
     onCancel={[Function]}
     onReset={[Function]}
     onSubmit={[Function]}
@@ -108,5 +110,5 @@ exports[`Cloud tenant form component should render editing form variant 1`] = `
       }
     }
   />
-</div>
+</Grid>
 `;

--- a/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
+++ b/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 import CloudTenantForm from '../../components/cloud-tenant-form/cloud-tenant-form';
+import { mount, shallow } from '../helpers/mountForm';
 
 require('../helpers/miqSparkle.js');
 require('../helpers/miqAjaxButton.js');

--- a/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
+++ b/app/javascript/spec/copy-catalog-form/copy-catalog-form.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import CopyCatalogForm from '../../components/copy-catalog-form/copy-catalog-form';
 
 import '../helpers/miqAjaxButton';
 import MiqFormRenderer from '../../forms/data-driven-form';
+import { mount } from '../helpers/mountForm';
 
 describe('Copy catalog form', () => {
   let initialProps;

--- a/app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
+++ b/app/javascript/spec/copy-dashboard-form/copy-dashboard-form.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import CopyDashboardForm from '../../components/copy-dashboard-form/copy-dashboard-form';
 
@@ -7,6 +6,7 @@ import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import * as handleFailure from '../../helpers/handle-failure';
+import { mount } from '../helpers/mountForm';
 
 describe('Copy Dashboard form', () => {
   let initialProps;
@@ -118,7 +118,7 @@ describe('Copy Dashboard form', () => {
 
     setTimeout(() => {
       wrapper.update();
-      const { form } = wrapper.find(MiqFormRenderer).children().children().instance();
+      const { form } = wrapper.find(MiqFormRenderer).children().children().children().instance();
       expect(fetchMock.calls()).toHaveLength(3);
 
       form.batch(() => {

--- a/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
+++ b/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
@@ -6,13 +6,12 @@ exports[`Flavor form component should render form 1`] = `
   componentClass="div"
   fluid={true}
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
         "submitLabel": "Add",
       }
     }
-    className="form-react"
     initialValues={
       Object {
         "ems_id": 1,

--- a/app/javascript/spec/flavor-form/flavor-form.spec.js
+++ b/app/javascript/spec/flavor-form/flavor-form.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 import FlavorForm from '../../components/flavor-form/flavor-form';
@@ -8,7 +7,7 @@ import '../helpers/mockAsyncRequest';
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import '../helpers/miqFlashLater';
-import { wrap } from 'module';
+import { mount, shallow } from '../helpers/mountForm';
 
 jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
 
@@ -44,7 +43,7 @@ describe('Flavor form component', () => {
     fetchMock
       .mock('/flavor/ems_list', emsList)
       .mock('/flavor/cloud_tenants', cloudTenants);
-    const wrapper = shallow(<FlavorForm />);
+    const wrapper = shallow(<FlavorForm />).dive();
     setImmediate(() => {
       wrapper.update();
       expect(toJson(wrapper)).toMatchSnapshot();
@@ -82,16 +81,16 @@ describe('Flavor form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().initialValues).toEqual({
+      expect(wrapper.children().state().initialValues).toEqual({
         ems_id: 1,
         is_public: true,
         rxtx_factor: '1.0',
       });
-      expect(wrapper.state().emsList).toEqual([
+      expect(wrapper.children().state().emsList).toEqual([
         { name: 'name1', id: 1 },
         { name: 'name2', id: 2 },
       ]);
-      expect(wrapper.state().cloudTenants).toEqual([
+      expect(wrapper.children().state().cloudTenants).toEqual([
         { label: 'name3', value: 3 },
         { label: 'name4', value: 4 },
       ]);
@@ -106,7 +105,7 @@ describe('Flavor form component', () => {
       .mock('/flavor/cloud_tenants', cloudTenants);
 
     const wrapper = mount(<FlavorForm />);
-    const spy = jest.spyOn(wrapper.instance(), 'submitValues');
+    const spy = jest.spyOn(wrapper.children().instance(), 'submitValues');
 
     setImmediate(() => {
       wrapper.update();
@@ -123,9 +122,9 @@ describe('Flavor form component', () => {
       .mock('/flavor/cloud_tenants', cloudTenants);
 
     const wrapper = mount(<FlavorForm />);
-    wrapper.instance().submitValues = jest.fn();
+    wrapper.children().instance().submitValues = jest.fn();
 
-    const spySubmit = jest.spyOn(wrapper.instance(), 'submitValues');
+    const spySubmit = jest.spyOn(wrapper.children().instance(), 'submitValues');
 
     setImmediate(() => {
       wrapper.update();
@@ -169,7 +168,7 @@ describe('Flavor form component', () => {
 
   it('nonError sends right message', () => {
     const wrapper = mount(<FlavorForm />);
-    wrapper.instance().nonError('Flavor1');
+    wrapper.children().instance().nonError('Flavor1');
     expect(miqRedirectBack).toHaveBeenCalledWith(
       __('Add of Flavor "Flavor1" was successfully initialized.'),
       'success',
@@ -179,7 +178,7 @@ describe('Flavor form component', () => {
 
   it('onError sends right message', () => {
     const wrapper = mount(<FlavorForm />);
-    wrapper.instance().onError({
+    wrapper.children().instance().onError({
       results: [
         {
           message: 'Name too short!',
@@ -203,8 +202,8 @@ describe('Flavor form component', () => {
         }],
       };
       const wrapper = mount(<FlavorForm />);
-      const spyOnError = jest.spyOn(wrapper.instance(), 'onError');
-      wrapper.instance().getBack(response, 'Flavor1');
+      const spyOnError = jest.spyOn(wrapper.children().instance(), 'onError');
+      wrapper.children().instance().getBack(response, 'Flavor1');
       expect(spyOnError).toHaveBeenCalledWith(response, 'Flavor1');
     });
 
@@ -216,8 +215,8 @@ describe('Flavor form component', () => {
         }],
       };
       const wrapper = mount(<FlavorForm />);
-      const spyNonError = jest.spyOn(wrapper.instance(), 'nonError');
-      wrapper.instance().getBack(response, 'Flavor1');
+      const spyNonError = jest.spyOn(wrapper.children().instance(), 'nonError');
+      wrapper.children().instance().getBack(response, 'Flavor1');
       expect(spyNonError).toHaveBeenCalledWith('Flavor1');
     });
   });
@@ -230,18 +229,18 @@ describe('Flavor form component', () => {
     fetchMock
       .getOnce('flavor/cloud_tenants', cloudTenants);
     const wrapper = mount(<FlavorForm />);
-    const spyGetBack = jest.spyOn(wrapper.instance(), 'getBack');
+    const spyGetBack = jest.spyOn(wrapper.children().instance(), 'getBack');
     const values = {
       name: 'Some name',
       ems_id: '1',
     };
-    wrapper.instance().setState({
+    wrapper.children().instance().setState({
       is_public: true,
       emsList: [
         { id: 1, name: 'EmsName' },
       ],
     });
-    wrapper.instance().submitValues(values).then(() => {
+    wrapper.children().instance().submitValues(values).then(() => {
       expect(spyGetBack).toHaveBeenCalled();
       done();
     });

--- a/app/javascript/spec/forms/data-driven-form.spec.js
+++ b/app/javascript/spec/forms/data-driven-form.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import { layoutMapper } from '@data-driven-forms/pf3-component-mapper';
+
+import formFieldsMapper from '../../forms/mappers/formsFieldsMapper';
+import DataDrivenForm from '../../forms/data-driven-form';
+
+describe('DataDrivenForm', () => {
+  let initialProps;
+  let schema;
+  let onSubmit;
+
+  beforeEach(() => {
+    onSubmit = jest.fn();
+    schema = {
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'name',
+      }],
+    };
+    initialProps = {
+      layoutMapper,
+      formFieldsMapper,
+      schema,
+      onSubmit,
+    };
+  });
+
+  afterEach(() => {
+    onSubmit.mockReset();
+  });
+
+  it('should render correctly', () => {
+    const wrapper = mount(<DataDrivenForm {...initialProps} store={ManageIQ.redux.store} />);
+    expect(wrapper.find('form')).toHaveLength(1);
+    expect(wrapper.find('input')).toHaveLength(1);
+  });
+
+  it('should set pristine in reducer when changing state', () => {
+    const wrapper = mount(<DataDrivenForm {...initialProps} store={ManageIQ.redux.store} />);
+    wrapper.find('input').first().simulate('change', { target: { value: 'changed-value' } });
+
+    expect(ManageIQ.redux.store.getState().formReducer.pristine).toEqual(false);
+
+    wrapper.find('input').first().simulate('change', { target: { value: '' } });
+
+    expect(ManageIQ.redux.store.getState().formReducer.pristine).toEqual(true);
+  });
+});

--- a/app/javascript/spec/helpers/mountForm.jsx
+++ b/app/javascript/spec/helpers/mountForm.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { mount as enzymeMount, shallow as enzymeShallow } from 'enzyme';
+
+export const mount = children => enzymeMount(
+  <Provider store={ManageIQ.redux.store}>
+    { children }
+  </Provider>,
+);
+
+export const shallow = children => enzymeShallow(
+  <Provider store={ManageIQ.redux.store}>
+    { children }
+  </Provider>,
+);

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
+import { mount } from '../helpers/mountForm';
 import OpsTenantForm from '../../components/ops-tenant-form/ops-tenant-form';
 import MiqFormRenderer from '../../forms/data-driven-form';
 

--- a/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
+++ b/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 
 import '../helpers/addFlash';
 import '../helpers/miqFlashLater';
 import '../helpers/miqSparkle';
 import '../helpers/sprintf';
+import { mount } from '../helpers/mountForm';
 
 import CodeEditor from '../../components/code-editor';
 import OrcherstrationTemplateForm from '../../components/orchestration-template/orcherstration-template-form';

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PxeServersForm should render correctly 1`] = `
-<div
-  className="container-fluid"
+<Grid
+  bsClass="container"
+  componentClass="div"
+  fluid={true}
 >
-  <MiqFormRenderer
+  <Connect(MiqFormRenderer)
     canReset={false}
-    className="form-react"
     initialValues={Object {}}
     onCancel={[Function]}
     onSubmit={[Function]}
@@ -140,5 +141,5 @@ exports[`PxeServersForm should render correctly 1`] = `
       }
     }
   />
-</div>
+</Grid>
 `;

--- a/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
+++ b/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
 
@@ -8,6 +7,7 @@ import '../helpers/miqFlashLater';
 import '../helpers/sprintf';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import PxeServersForm from '../../components/pxe-servers-form/pxe-server-form';
+import { mount, shallow } from '../helpers/mountForm';
 
 describe('PxeServersForm', () => {
   let initialProps;
@@ -53,7 +53,7 @@ describe('PxeServersForm', () => {
       .postOnce('/api/pxe_servers', {});
 
     const wrapper = mount(<PxeServersForm {...initialProps} />);
-    const { form } = wrapper.find(MiqFormRenderer).children().children().instance();
+    const { form } = wrapper.find(MiqFormRenderer).children().children().children().instance();
     /**
      * pause validation so we dont need async mocks
      */

--- a/app/javascript/spec/service-dialog-from-form/service-dialog-from-form.spec.js
+++ b/app/javascript/spec/service-dialog-from-form/service-dialog-from-form.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 
 import '../helpers/addFlash';
 import '../helpers/miqFlashLater';
 import '../helpers/miqSparkle';
 import '../helpers/sprintf';
+import { mount } from '../helpers/mountForm';
 
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 

--- a/app/javascript/spec/service-form/service-form.spec.js
+++ b/app/javascript/spec/service-form/service-form.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import FormRender from '@data-driven-forms/react-form-renderer';
 import ServiceForm from '../../components/service-form';
+import { mount } from '../helpers/mountForm';
 
 require('../helpers/addFlash.js');
 require('../helpers/miqSparkle.js');
@@ -38,7 +38,7 @@ describe('Service form component', () => {
     expect(fetchMock.lastUrl()).toEqual('/service/service_form_fields/3');
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().initialValues).toEqual({ foo: 'bar' });
+      expect(wrapper.children().state().initialValues).toEqual({ foo: 'bar' });
       done();
     });
   });

--- a/app/javascript/spec/set-ownership-form/set-ownership-form.spec.js
+++ b/app/javascript/spec/set-ownership-form/set-ownership-form.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import FormRenderer from '@data-driven-forms/react-form-renderer';
 import SetOwnershipForm from '../../components/set-ownership-form';
@@ -7,6 +6,7 @@ import createSchema from '../../components/set-ownership-form/ownership-form.sch
 import '../helpers/miqAjaxButton';
 import '../helpers/miqSparkle';
 import '../helpers/addFlash';
+import { mount } from '../helpers/mountForm';
 
 describe('Set ownership form component', () => {
   let initialProps;

--- a/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
+++ b/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import VmServerRelationShipForm from '../../components/vm-server-relationship-form';
 import '../helpers/miqAjaxButton';
+import { mount } from '../helpers/mountForm';
 
 describe('Vm server relationship form component', () => {
   const miqAjaxButtonSpy = jest.spyOn(window, 'miqAjaxButton');
@@ -52,7 +52,7 @@ describe('Vm server relationship form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().initialValues).toEqual({
+      expect(wrapper.children().state().initialValues).toEqual({
         serverId: undefined,
       });
       done();
@@ -67,7 +67,7 @@ describe('Vm server relationship form component', () => {
 
     setImmediate(() => {
       wrapper.update();
-      expect(wrapper.state().initialValues).toEqual({
+      expect(wrapper.children().state().initialValues).toEqual({
         serverId: '/api/servers/13',
       });
       done();
@@ -77,7 +77,7 @@ describe('Vm server relationship form component', () => {
   it('should not submit values when form is not valid', (done) => {
     fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
     const wrapper = mount(<VmServerRelationShipForm {...props} />);
-    const spy = jest.spyOn(wrapper.instance(), 'onSubmit');
+    const spy = jest.spyOn(wrapper.children().instance(), 'onSubmit');
 
     setImmediate(() => {
       wrapper.update();
@@ -97,7 +97,7 @@ describe('Vm server relationship form component', () => {
     const values = {
       serverId: '/api/servers/16',
     };
-    wrapper.instance().onSubmit(values).then(() => {
+    wrapper.children().instance().onSubmit(values).then(() => {
       expect(miqAjaxButtonSpy).toHaveBeenCalledWith('/vm_or_template/evm_relationship_update/10?button=save');
       expect(fetchMock.called('/api/vms/10',
         {

--- a/app/javascript/spec/workers-form/workers-form.spec.js
+++ b/app/javascript/spec/workers-form/workers-form.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import WorkersForm from '../../components/workers-form/workers-form';
 
@@ -8,6 +7,7 @@ import '../helpers/addFlash';
 import '../helpers/sprintf';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import Dualgroup from '../../components/dual-group';
+import { mount } from '../helpers/mountForm';
 
 describe('Workers form', () => {
   let initialProps;
@@ -153,7 +153,8 @@ describe('Workers form', () => {
       expect(submitSpyMiqSparkleOff).toHaveBeenCalled();
       expect(fetchMock.called(baseUrl)).toBe(true);
       expect(fetchMock.calls()).toHaveLength(1);
-      const { form } = wrapper.find(MiqFormRenderer).children().children().instance();
+      const { form } = wrapper.find(MiqFormRenderer).children().children().children()
+        .instance();
       expect(form.getState().values).toEqual(expectedValues);
       done();
     });
@@ -169,7 +170,8 @@ describe('Workers form', () => {
 
     setImmediate(() => {
       wrapper.update();
-      const { form } = wrapper.find(MiqFormRenderer).children().children().instance();
+      const { form } = wrapper.find(MiqFormRenderer).children().children().children()
+        .instance();
       expect(fetchMock.calls()).toHaveLength(1);
 
       form.change('smart_proxy_worker.count', 1);

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -31,3 +31,10 @@ document.body.createTextRange = () => ({
       right: 0,
     };
   }});
+
+// configure Redux store
+
+import initializeStore from '../app/javascript/miq-redux/store';
+
+ManageIQ.redux.store = initializeStore();
+ManageIQ.redux.store.injectReducers();


### PR DESCRIPTION
Part of https://bugzilla.redhat.com/show_bug.cgi?id=1725927

**Description**

DDF components are missing a option to tell the Abandon changes popup to show up. This PR connects all Data driven forms to redux and store pristine of the form in its store.

The same thing should be done for Tag component.

**Before**

![image](https://user-images.githubusercontent.com/32869456/64795218-05b73880-d57e-11e9-886c-54cff5de12e0.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/64795041-bd981600-d57d-11e9-9443-e08b4a63ba8e.png)

@miq-bot add_label bug, ivanchuk/yes, react