### PR TITLE
Adjust spec for TreeNode::PxeImageType after the decorator icon change

### DIFF
--- a/spec/presenters/tree_node/pxe_image_type_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_type_spec.rb
@@ -3,5 +3,5 @@ describe TreeNode::PxeImageType do
   let(:object) { FactoryBot.create(:pxe_image_type) }
 
   include_examples 'TreeNode::Node#key prefix', 'pit-'
-  include_examples 'TreeNode::Node#icon', 'ff ff-network-card'
+  include_examples 'TreeNode::Node#icon', 'pficon pficon-image'
 end


### PR DESCRIPTION
Fixing travis after https://github.com/ManageIQ/manageiq-decorators/pull/20

@miq-bot add_reviewer @epwinchell 
@miq-bot assign @h-kataria 
@miq-bot add_label tests, ivanchuk/no