### PR TITLE
Display tenant only from current region

### DIFF
--- a/app/helpers/report_helper/editor.rb
+++ b/app/helpers/report_helper/editor.rb
@@ -17,5 +17,8 @@ module ReportHelper::Editor
   def refresh_chargeback_filter_tab
     @edit[:cb_users] = Rbac::Filterer.filtered(User.in_my_region).each_with_object({}) { |u, h| h[u.userid] = u.name }
     @edit[:cb_tenant] = Rbac::Filterer.filtered(Tenant.in_my_region).each_with_object({}) { |t, h| h[t.id] = t.name }
+
+    tenant = Tenant.find_by(:id => @edit[:current][:cb_tenant_id])
+    @edit[:cb_tenant][tenant.id] = "#{tenant.name} (" + _('Region') + " #{tenant.miq_region.region})" if tenant && (tenant.miq_region&.region != MiqRegion.my_region_number)
   end
 end

--- a/app/helpers/report_helper/editor.rb
+++ b/app/helpers/report_helper/editor.rb
@@ -16,6 +16,6 @@ module ReportHelper::Editor
 
   def refresh_chargeback_filter_tab
     @edit[:cb_users] = Rbac::Filterer.filtered(User.in_my_region).each_with_object({}) { |u, h| h[u.userid] = u.name }
-    @edit[:cb_tenant] = Rbac::Filterer.filtered(Tenant).each_with_object({}) { |t, h| h[t.id] = t.name }
+    @edit[:cb_tenant] = Rbac::Filterer.filtered(Tenant.in_my_region).each_with_object({}) { |t, h| h[t.id] = t.name }
   end
 end


### PR DESCRIPTION

on multi region DB we are not displaying tenant from other regions.
(1) and this PR fixes this in report editor of chargeback in filter tab.

it is possible because you can import chargeback report from other region with tenant filter with the other region - (2) in this case I am displaying ten from other region with info about region.

**before**
![before](https://user-images.githubusercontent.com/14937244/64873685-ea196400-d649-11e9-8d74-eec9a1a0dfee.png)

**after**


![after](https://user-images.githubusercontent.com/14937244/64873691-ec7bbe00-d649-11e9-8f9e-0f3f914f2f53.png)


on pictures:

tenants from current region:
TENIS

tenants from other region (71): 
XXXXA
XXXXB
XXXXD


Links
-----

* related to https://bugzilla.redhat.com/show_bug.cgi?id=1750800


@miq-bot add_label bug
@miq-bot assign @mzazrivec 

cc @gtanzillo 