### PR TITLE
Display tag  better with missing category in report editor

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1399,7 +1399,7 @@ module ReportController::Reports::Editor
       tag = nf.first.split(':')
       if nf.first.include?("Managed :")
         entry = MiqExpression.reporting_available_fields(@edit[:new][:model], @edit[:new][:perf_interval]).find { |a| a.last == nf.last }
-        nf[0] = entry ? entry.first : "#{tag} (Category not found)"
+        nf[0] = entry ? entry.first : "#{tag.last.strip} (Category not found)"
       end
     end
 


### PR DESCRIPTION
before

![before2](https://user-images.githubusercontent.com/14937244/64879075-636a8400-d655-11e9-95d5-259f74ed81fe.png)

after
![after2](https://user-images.githubusercontent.com/14937244/64879072-61a0c080-d655-11e9-8f68-0df3d059ab47.png)



@miq-bot assign @mzazrivec 

@miq-bot add_label bug