### PR TITLE
Improve volume attachment user experience

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -22,7 +22,12 @@ class CloudVolumeController < ApplicationController
       delete_volumes
       return false
     when 'cloud_volume_attach'
-      javascript_redirect(:action => 'attach', :id => checked_item_id)
+      volume = find_record_with_rbac(CloudVolume, checked_item_id)
+      if !volume.is_available?(:attach_volume) || volume.status != "available"
+        render_flash(_("Cloud Volume \"%{volume_name}\" is not available to be attached to any Instances") % {:volume_name => volume.name}, :error)
+      else
+        javascript_redirect(:action => 'attach', :id => checked_item_id)
+      end
     when 'cloud_volume_detach'
       volume = find_record_with_rbac(CloudVolume, checked_item_id)
       if volume.attachments.empty?

--- a/app/helpers/application_helper/button/volume_attach.rb
+++ b/app/helpers/application_helper/button/volume_attach.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::VolumeAttach < ApplicationHelper::Button::Basic
+  def disabled?
+    if !@record.is_available?(:attach_volume)
+      @error_message = @record.is_available_now_error_message(:attach_volume)
+    elsif @record.status != "available"
+      @error_message = _("Cloud Volume \"%{name}\" is not available to be attached to any Instances") % {:name => @record.name}
+    end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_center.rb
@@ -41,7 +41,7 @@ class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar
                        'pficon pficon-volume fa-lg',
                        t = N_('Attach this Cloud Volume to an Instance'),
                        t,
-                       :klass        => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+                       :klass        => ApplicationHelper::Button::VolumeAttach,
                        :options      => {:feature => :attach_volume},
                        :url_parms    => 'main_div',
                        :send_checked => true,

--- a/spec/helpers/application_helper/buttons/volume_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_attach_spec.rb
@@ -1,0 +1,67 @@
+describe ApplicationHelper::Button::VolumeAttach do
+  describe '#disabled?' do
+    it "when the attach action is available and the volume.status is available then the button is enabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true, :status => 'available')}, {}
+      )
+      expect(button.disabled?).to be false
+    end
+
+    it "when the attach action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {},
+        {"record" => object_double(CloudVolume.new, :is_available?                  => false,
+                                                    :status                         => 'available',
+                                                    :is_available_now_error_message => "unavailable")}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+
+    it "when the volume.status is not available then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(CloudVolume.new, :is_available? => true,
+                                                                      :status        => 'in-use',
+                                                                      :name          => 'TestVolume')}, {}
+      )
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the attach action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => false, :status => 'available', :is_available_now_error_message => "unavailable"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("unavailable")
+    end
+
+    it "when the volume.status is not available then the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => true, :status => 'in-use', :name => "TestVolume"
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to eq("Cloud Volume \"TestVolume\" is not available to be attached to any Instances")
+    end
+
+    it "when the volume.status is available and the attach action is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context, {}, {"record" => object_double(
+          CloudVolume.new, :is_available? => true, :status => 'available'
+        )}, {}
+      )
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the Cloud Volume detail toolbar so that the Attach Volume button accounts for the volume status and greys out for unavailable volumes. It also fixes the Cloud Volume list toolbar so that selecting an unavailable volume flashes a message rather than continuing on to the attachment form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653062