### PR TITLE
Add abandon changes popup to tagging pages

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -304,6 +304,13 @@ function miqCheckForChanges() {
              !miqDomElementExists('ignore_form_changes')) {
     return confirm(__('Abandon changes?'));
   }
+
+  var taggingStore = ManageIQ.redux.store.getState().tagging;
+
+  if (taggingStore && !_.isEqual(taggingStore.appState.assignedTags, taggingStore.initialState.assignedTags)) {
+    return confirm(__('Abandon changes?'));
+  }
+
   // use default browser reaction for onclick
   return true;
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -465,4 +465,55 @@ describe('miq_application.js', function() {
       });
     });
   });
+
+  describe('miqCheckForChanges', () => {
+    let tmpManageIQ;
+
+    beforeEach(() => {
+      tmpManageIQ = ManageIQ.redux.store.getState;
+    });
+
+    afterEach(() => {
+      ManageIQ.redux.store.getState = tmpManageIQ;
+    });
+
+    it('returns true by default', () => {
+      expect(miqCheckForChanges()).toEqual(true);
+    });
+
+    it('returns true if no changes in tagging', () => {
+      ManageIQ.redux.store.getState = () => ({
+        tagging: {
+          appState: {
+            assignedTags: [],
+          },
+          initialState: {
+            assignedTags: [],
+          },
+        },
+      });
+
+      expect(miqCheckForChanges()).toEqual(true);
+    });
+
+    it('returns value from confirm if there are changes in tagging', () => {
+      spyOn(window, 'confirm').and.returnValues(true, false);
+
+      ManageIQ.redux.store.getState = () => ({
+        tagging: {
+          appState: {
+            assignedTags: [{id: '1011531', description: 'description', values: [{id: '108', description: '2GB'}]}],
+          },
+          initialState: {
+            assignedTags: [],
+          },
+        },
+      });
+
+      expect(window.confirm).not.toHaveBeenCalled();
+      expect(miqCheckForChanges()).toEqual(true);
+      expect(window.confirm).toHaveBeenCalled();
+      expect(miqCheckForChanges()).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
Part of https://bugzilla.redhat.com/show_bug.cgi?id=1725927

**Description**

Tagging pages do not trigger the abandon changes popup, when leaving the page. 

- adds a condition which checks if values in tagging reducer are changed

**Before**

![taggingbefore](https://user-images.githubusercontent.com/32869456/64956438-ddd01980-d88a-11e9-893e-aacf0e18125e.gif)

**After**

![taggingafter](https://user-images.githubusercontent.com/32869456/64956398-c6912c00-d88a-11e9-8716-c354faeb1c1a.gif)

@miq-bot add_label bug, ivanchuk/yes, tagging

