### PR TITLE
Remove :hide_special_item from breadcrumbs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2031,7 +2031,6 @@ class CatalogController < ApplicationController
         {:title => _("Services")},
         {:title => _("Catalogs")},
       ],
-      :hide_special_item => true,
     }
   end
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -51,7 +51,7 @@ module Mixins
 
         # On special page (tagitems, politems, etc.)
         if @tagitems || @politems || @ownershipitems || @retireitems
-          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems, true, options[:x_node])) unless options[:hide_special_item]
+          breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems, true, options[:x_node]))
           breadcrumbs.push(:title => right_cell_text)
         else
           # Ancestry parents breadcrumbs (only in services)


### PR DESCRIPTION
**Description**

Because of reworked breadcrumbs (https://github.com/ManageIQ/manageiq-ui-classic/pull/6073, https://github.com/ManageIQ/manageiq-ui-classic/pull/6193), this option is not needed anymore.

**How to test it**

1. `Services` > `Catalog` > `Catalog Items`
2. Select one
3. `Policy` > `Edit tags`
4. You will see breadcrumbs like ```Services Catalogs > Catalog Items > Create RDS Instance > Editing My Company Tags for "Service Catalog Items"```

@miq-bot add_label technical debt, ivanchuk/yes, breadcrumbs