### PR TITLE
Sort Requester dropdown by label

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -378,7 +378,7 @@ class MiqRequestController < ApplicationController
 
     if approver?
       # list all requesters
-      [label_value_hash_with_all(requesters), 'all']
+      [label_value_hash_with_all(requesters).sort_by { |object| object[:label] }, 'all']
     elsif requesters.value?(current_user.name)
       # list just the current user
       [[{:value => current_user.id, :label => current_user.name}], current_user.id]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749953

Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3534

Steps to Reproduce:
1. go to Services -> Requests
2. click on the Requester dropdown

Before: NOT sorted alphabetically 
<img width="1423" alt="Screenshot 2019-09-18 at 10 53 47" src="https://user-images.githubusercontent.com/9210860/65133711-5eb22100-da03-11e9-8154-62cbc27a227c.png">

After: sorted alphabetically 
<img width="1207" alt="Screenshot 2019-09-18 at 11 46 50" src="https://user-images.githubusercontent.com/9210860/65137758-32e66980-da0a-11e9-9f1f-c4d05e8db928.png">


Note:
I boosted number of requesters by
```diff
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -368,7 +368,7 @@ class MiqRequestController < ApplicationController
 
   def requesters_in_30_days
     Rbac::Filterer.filtered(MiqRequest.where(:type       => MiqRequest::MODEL_REQUEST_TYPES[model_request_type_from_layout].keys,
-                                             :created_on => (30.days.ago.utc)..(Time.now.utc))).each_with_object({}) do |r, h|
+                                             :created_on => (3000.days.ago.utc)..(Time.now.utc))).each_with_object({}) do |r, h|
       h[r.requester_id] = requester_label(r)
     end
   end
```

@miq-bot add_label bug, ivanchuk/yes, hammer/yes

@miq-bot add_reviewer @romanblanco