### PR TITLE
Throttle notification toast messages and display only 3 at most

### DIFF
--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -299,9 +299,13 @@ angular.module('ManageIQ').service('eventNotifications', ['$timeout', '$window',
     }
   };
 
-  this.showToast = function(notification, persist) {
+  var simpleShow = function(notification, persist) {
     var $this = this;
     notification.show = true;
+    // Remove the very first element of the array if it's too long
+    if (state.toastNotifications.length === 3) {
+      state.toastNotifications.shift();
+    }
     state.toastNotifications.push(notification);
     notifyObservers();
 
@@ -314,6 +318,16 @@ angular.module('ManageIQ').service('eventNotifications', ['$timeout', '$window',
           $this.removeToast(notification);
         }
       }, ManageIQ.angular.eventNotificationsData.toastDelay);
+    }
+  }.bind(this);
+
+  var throttledShow = _.throttle(simpleShow, 500);
+
+  this.showToast = function(notification, persist) {
+    if (state.toastNotifications.length < 3) {
+      simpleShow(notification, persist);
+    } else {
+      throttledShow(notification, persist);
     }
   };
 


### PR DESCRIPTION
When having a storm of notifications, they can take over a significant amount of the screen. This change throttles the amount of toasts by maximizing one toast in 0.5 second and also doesn't allow displaying more than 3 toasts by always removing the oldest one.

@miq-bot add_reviever @martinpovolny 
@miq-bot add_reviever @himdel 
@miq-bot add_label hammer/yes, ivanchuk/yes, bug, ux/review

@terezanovotna this will need some testing from you on a real setup with some fake notifications that can be created by:
```ruby
Notification.take(10).each { |n| n.dup.save; sleep 0.25 }
```

**Before:**
![before](https://user-images.githubusercontent.com/649130/65139904-ba81a780-da0d-11e9-93bf-fa027e8d7111.gif)

**After:**
![after](https://user-images.githubusercontent.com/649130/65139916-be152e80-da0d-11e9-9292-c21c19db7c3a.gif)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639473