### PR TITLE
Include fqname in automate 🌳nodes globally instead of overriding

### DIFF
--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,7 +1,6 @@
 class TreeBuilderAutomateEntrypoint < TreeBuilderAutomateCatalog
-  def override(node, object)
+  def override(node, _object)
     node.delete(:selectable)
-    node[:fqname] = object.fqname if object.try(:fqname)
   end
 
   def root_options

--- a/app/presenters/tree_node/miq_ae_node.rb
+++ b/app/presenters/tree_node/miq_ae_node.rb
@@ -1,9 +1,14 @@
 module TreeNode
   class MiqAeNode < Node
     set_attribute(:tooltip) { "#{ui_lookup(:model => @object.class.to_s)}: #{text}" }
+    set_attribute(:fqname) { @object.try(:fqname) }
 
     def text
       @object.display_name.blank? ? @object.name : "#{@object.display_name} (#{@object.name})"
+    end
+
+    def to_h
+      fqname ? super.merge(:fqname => fqname) : super
     end
   end
 end

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -940,6 +940,7 @@ describe MiqAeClassController do
             :icon       => "ff ff-class",
             :selectable => true,
             :lazyLoad   => true,
+            :fqname     => cls.fqname,
             :state      => {:expanded => false},
           }
         ]


### PR DESCRIPTION
I'm trying to clean up our `TreeBuilder#override` methods a little and this is bothering me a lot. The fqname is a crucial part of any automate node and I'd rather set it globally. 

@miq-bot add_reviewer @romanblanco 
@miq-bot add_label refactoring, technical debt, ivancuk/no, automation/automate

This affects the entry point selection in the dialog editor and also the embedded method selection in the automate explorer so I'd like to ask @romanblanco and @pkomanek to test it thoroughly.