### PR TITLE
Catalog Item RHEV provision fix

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -28,8 +28,8 @@ module ApplicationController::MiqRequestMethods
       @record =
         if @edit[:new][:src_configured_system_ids].present?
           PhysicalServer.where(:id => @edit[:new][:src_configured_system_ids].first).first
-        elsif @edit[:new][:src_vm_id].first.present?
-          MiqTemplate.where(:id => @edit[:new][:src_vm_id].first).first
+        else
+          MiqTemplate.where(:id => @edit[:new][:src_vm_id].kind_of?(Array) ? @edit[:new][:src_vm_id].first : @edit[:new][:src_vm_id]).first
         end
       render :update do |page|
         page << javascript_prologue

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -31,10 +31,16 @@ module ApplicationController::MiqRequestMethods
         else
           MiqTemplate.where(:id => @edit[:new][:src_vm_id].kind_of?(Array) ? @edit[:new][:src_vm_id].first : @edit[:new][:src_vm_id]).first
         end
+
+      begin
+        all_dialogs = @edit[:wf].get_all_dialogs
+      rescue Exception
+        all_dialogs = []
+      end
+
       render :update do |page|
         page << javascript_prologue
         # Going thru all dialogs to see if model has set any of the dialog display to hide/ignore
-        all_dialogs = @edit[:wf].get_all_dialogs
         all_dialogs.each do |dialog_name, dialog|
           page << "miq_tabs_show_hide('#{dialog_name}_tab', #{dialog[:display] == :show});"
         end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -29,14 +29,10 @@ module ApplicationController::MiqRequestMethods
         if @edit[:new][:src_configured_system_ids].present?
           PhysicalServer.where(:id => @edit[:new][:src_configured_system_ids].first).first
         else
-          MiqTemplate.where(:id => @edit[:new][:src_vm_id].kind_of?(Array) ? @edit[:new][:src_vm_id].first : @edit[:new][:src_vm_id]).first
+          MiqTemplate.where(:id => Array(@edit[:new][:src_vm_id]).first)
         end
 
-      begin
-        all_dialogs = @edit[:wf].get_all_dialogs
-      rescue Exception
-        all_dialogs = []
-      end
+      all_dialogs = @edit[:wf].get_all_dialogs rescue []
 
       render :update do |page|
         page << javascript_prologue


### PR DESCRIPTION
First commit fixes issue I have encountered before I could get to the BZ itself. Problem is that `@edit[:new][:src_vm_id]` is very unsure about its identity. Sometimes it is array, sometimes it is integer, it depends...When it comes from `params` or it is stored in `session/@edit` after being loaded from `params` it is integer. However when it comes from `workflow` it is an Array `[id, name]` this is common pattern in workflows. Why we have two values associated under one key is beyond my understanding. 

Because different provisioning screen have slightly different interactions it is challenging to keep it together.  `@edit[:new]` is modified in workflow constructor `miq_request_methods.rb:989` that complicate things even more.

Second commit fixes the actual BZ.

Screenshot [Optional]
----------------
Before:
![name_catalog](https://user-images.githubusercontent.com/9535558/65152873-13126e00-da29-11e9-9c73-196d66562282.png)

After:
![Screenshot from 2019-09-18 15-28-47](https://user-images.githubusercontent.com/9535558/65152886-16a5f500-da29-11e9-84df-9250319f789a.png)


Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1729111

Steps for Testing/QA [Optional]
-------------------------------
Steps to Reproduce:

1. Go to Services > Catalogs > Catalog Items
2. Configuration > Add a New Catalog Item
3. For Catalog Item Type, choose Red Hat Virtualization
4. Fill in the name and click on Add button
5. Follow the flash messages, try to add the name,
   then also for example Name under Catalog tab, in Selected VM section
=> error during clicking on some name in the table,
   nothing happens in the UI!

NOTE: I am not very happy with these changes and I am open to suggestions how to make it better. But right now I don't see many options without need to disassemble the whole tractor(rozdelat cely traktor).