### PR TITLE
Replace implicit TreeNode::Node methods with accessors/writers

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -2,6 +2,9 @@ module TreeNode
   class Node
     attr_reader :tree
 
+    attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :klass, :selectable, :tooltip
+    attr_writer :icon, :image
+
     def initialize(object, parent_id, tree)
       @object = object
       @parent_id = parent_id
@@ -12,48 +15,12 @@ module TreeNode
       @object.name
     end
 
-    def tooltip
-      nil
-    end
-
     def image
-      @object.try(:decorate).try(:fileicon)
+      @image || @object.try(:decorate).try(:fileicon)
     end
 
     def icon
-      @object.try(:decorate).try(:fonticon)
-    end
-
-    def icon_background
-      nil
-    end
-
-    def klass
-      nil
-    end
-
-    def selectable
-      true
-    end
-
-    def checked
-      nil
-    end
-
-    def color
-      nil
-    end
-
-    def checkable
-      true
-    end
-
-    def expanded
-      false
-    end
-
-    def hide_checkbox
-      nil
+      @icon || @object.try(:decorate).try(:fonticon)
     end
 
     def key
@@ -120,8 +87,6 @@ module TreeNode
 
           result
         end
-
-        equals_method(attribute)
       end
 
       def set_attributes(*attributes, &block)
@@ -139,16 +104,12 @@ module TreeNode
 
             result
           end
-
-          equals_method(attribute)
-        end
-      end
-
-      def equals_method(attribute)
-        define_method("#{attribute}=".to_sym) do |result|
-          instance_variable_set("@#{attribute}".to_sym, result)
         end
       end
     end
+
+    set_attribute(:selectable, true)
+    set_attribute(:checkable, true)
+    set_attribute(:expanded, false)
   end
 end


### PR DESCRIPTION
Instead of the dynamically defined accessor methods inside `set_attribute`, we can define them statically with `attr_accessor`. As the `icon` and `image` attributes have implicit dynamic values, their reader method has to stay custom and the `attr_writer` can be used instead of an explicit writer method. After this change the methods can be dropped and if they contain a static value, they can be moved into `set_attribute` calls.

This allows us to use these writer methods in the `TreeBuilder#override` definitions in the future when we are no longer dealing with hashes when overriding.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label ivanchuk/no, refactoring, trees, enhancement