### PR TITLE
Make service edit description field not required

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -135,7 +135,7 @@ class ServiceController < ApplicationController
     case params[:button]
     when "cancel"
       service = find_record_with_rbac(Service, params[:id])
-      add_flash(_("Edit of Service \"%{name}\" was cancelled by the user") % {:name => service.description})
+      add_flash(_("Edit of Service \"%{name}\" was cancelled by the user") % {:name => service.name})
       replace_right_cell
     when "save", "add"
       service = find_record_with_rbac(Service, params[:id])

--- a/app/javascript/components/service-form/service-form.schema.js
+++ b/app/javascript/components/service-form/service-form.schema.js
@@ -17,9 +17,6 @@ function createSchema(maxNameLen, maxDescLen) {
       label: __('Description'),
       validateOnMount: true,
       autoFocus: true,
-      validate: [{
-        type: 'required-validator',
-      }],
     }],
   };
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746367

Steps to Reproduce:
1. Create any Catalog Item and assign it to some Catalog
2. Order it
3. Go to Services->My Services
4. Choose Configuration->Edit this Service
5. Click Cancel button
Before:
![before2](https://user-images.githubusercontent.com/52415358/65233352-f6327500-dad2-11e9-9c39-72fbd49862c8.png)

![before1](https://user-images.githubusercontent.com/52415358/65233213-c1beb900-dad2-11e9-8528-869a131280bd.png)


After:
![Screenshot from 2019-09-19 11-37-49](https://user-images.githubusercontent.com/52415358/65232779-0433c600-dad2-11e9-94e3-6892b090d139.png)
![bz-canceldva](https://user-images.githubusercontent.com/52415358/65669760-6c3f5a80-e044-11e9-9d42-8421a3a2a857.png)

