### PR TITLE
Fix missing name of deleted GOD Button/ButtonGroup

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -70,8 +70,8 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
       .catch(miqService.handleFailure);
   }
 
-  function postAction(response) {
-    var entityName = response.name;
+  function postAction() {
+    var entityName = toolbar.entityName;
     var saveMsg = sprintf(__('%s:"%s" was successfully deleted'), toolbar.entity, entityName);
     if (toolbar.redirectUrl) {
       miqService.redirectBack(saveMsg, 'success', toolbar.redirectUrl);

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -72,7 +72,7 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
 
   function postAction() {
     var entityName = toolbar.entityName;
-    var saveMsg = sprintf(__('%s:"%s" was successfully deleted'), toolbar.entity, entityName);
+    var saveMsg = sprintf(__('%s: "%s" was successfully deleted'), toolbar.entity, entityName);
     if (toolbar.redirectUrl) {
       miqService.redirectBack(saveMsg, 'success', toolbar.redirectUrl);
     } else {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744478
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753289

Go to Automation -> Automate -> Generic Objects -> delete a custom button (delete a custom button group to make sure it works as well)

Before:
![image](https://user-images.githubusercontent.com/9210860/65244013-e83c1e80-dae9-11e9-8c4d-e83d22c04477.png)
or
<img width="1090" alt="Screenshot 2019-09-23 at 15 45 02" src="https://user-images.githubusercontent.com/9210860/65431048-2488bb00-de19-11e9-870a-476972671e55.png">


After:
<img width="1070" alt="Screenshot 2019-09-19 at 14 26 16" src="https://user-images.githubusercontent.com/9210860/65243823-76fc6b80-dae9-11e9-88c4-08dd7f1db936.png">


if you see 404 error during deleting it's related to this https://bugzilla.redhat.com/show_bug.cgi?id=1753388 and will be fixed in separated PR #6230 .

@miq-bot add_lable wip, bug, generic objects, ivanchuk/yes