### PR TITLE
Allow resetting changes while editing Zone's Password or Verify Password fields

### DIFF
--- a/spec/controllers/ops_controller/settings/zones_spec.rb
+++ b/spec/controllers/ops_controller/settings/zones_spec.rb
@@ -1,0 +1,33 @@
+describe OpsController do
+  before { login_as FactoryBot.create(:user_admin) }
+
+  describe '#zone_edit' do
+    before do
+      allow(controller).to receive(:javascript_flash)
+      allow(controller).to receive(:load_edit).and_return(true)
+      controller.instance_variable_set(:@edit, :zone_id => nil, :new => {:password => 'pwd'}, :current => {})
+      controller.params = {:button => 'add'}
+    end
+
+    it 'sets flash array according to the missing name, description and verify password' do
+      controller.send(:zone_edit)
+      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Name can't be blank",                              :level => :error},
+                                                                     {:message => "Description can't be blank",                       :level => :error},
+                                                                     {:message => "Password and Verify Password fields do not match", :level => :error}])
+    end
+  end
+
+  describe '#zone_field_changed' do
+    before do
+      allow(controller).to receive(:load_edit).and_return(true)
+      allow(controller).to receive(:render)
+      controller.instance_variable_set(:@edit, :zone_id => nil, :new => {}, :current => {})
+      controller.params = {:name => 'Zone', :password => 'pwd'}
+    end
+
+    it 'sets session[:changed] to true' do
+      controller.send(:zone_field_changed)
+      expect(session[:changed]).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1749834

This PR simply 'moves' validation of _Password_ and _Verify Password_ fields while editing Zone to be provided AFTER clicking on _Save_ button => more consistency with other screens.

This PR also allows us to be able to reset ANY change (while editing Zone), also changes in  _Password_ and _Verify Password_ fields - this was not possible because with [this](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16L96) and [this](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16L100) _Save_ and _Reset_ buttons were both disabled (if one of the two fields was not filled in and the other one was).

I've made some other changes in the code, for example [this change](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16R23) as condition [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16L21) will never be true, because `@edit[:new][:name]` will never be an empty string. It can be only `nil` or some non-empty string. The same with `@edit[:new][:description]`. Those conditions are, unfortunately, needed there, however validation will work good also without them. But the problem is that without them only one relevant flash message would be displayed, not all of them, if user clicks on _Save/Add_ and forgets to fill in more than one required fields or if he fills in Password and forgets about Verify Password field. This is why I had to add also [this](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16R30) change.

While playing with the code, I deleted [the next condition](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16R33) as it seemed to be unnecessary. However, I found that it is really needed there - to prevent rendering same flash messages twice. So I've added a comment there to make it more clear for the future.

I've also changed the flash messages little bit. Reason? More consistency. Try to remove those three conditions like [this](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Reset_changes_editing_Zone_pwd_verifypwd?expand=1#diff-46d9c2a2602cc981686abc11859bed16R23) from the file and see what happens.

**After:**
![zone_add](https://user-images.githubusercontent.com/13417815/65248747-fc384e00-daf2-11e9-9100-6cd35fa4e0a7.png)
![zone_reset](https://user-images.githubusercontent.com/13417815/65248757-fe9aa800-daf2-11e9-8322-02be1f09f241.png)

