### PR TITLE
Switch find_by_* to lookup_by_*

### DIFF
--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -30,7 +30,7 @@ module ApplicationController::CurrentUser
 
   def current_user
     if current_userid
-      @current_user ||= User.find_by_userid(current_userid).tap do |u|
+      @current_user ||= User.lookup_by_userid(current_userid).tap do |u|
         u.current_group_id = session[:group] if session[:group]
       end
     end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -823,7 +823,7 @@ module ApplicationController::MiqRequestMethods
       # FIXME: use selected_ids passed through get_view to replace all of
       # gtl_selected_records after Gaprindashvili
     end
-    @user = User.find_by_userid(@miq_request.stamped_by)
+    @user = User.lookup_by_userid(@miq_request.stamped_by)
   end
 
   # Set form variables for provision request

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -844,7 +844,7 @@ module ApplicationController::Performance
 
     charts = []
     chart_data = []
-    cat_desc = Classification.find_by_name(@perf_options[:cat]).description
+    cat_desc = Classification.lookup_by_name(@perf_options[:cat]).description
 
     layout_name = case @perf_options[:typ]
                   when "Hourly" then 'hourly_tag_charts'
@@ -1414,7 +1414,7 @@ module ApplicationController::Performance
   end
 
   def breadcrumb_tag(report, legend_index)
-    category = Classification.find_by_name(@perf_options[:cat]).description
+    category = Classification.lookup_by_name(@perf_options[:cat]).description
     group_by = report.extras[:group_by_tag_descriptions][legend_index]
     "#{category}:#{group_by}"
   end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -217,7 +217,7 @@ class MiqAeClassController < ApplicationController
         self.x_node = "#{selected_node[0]}-#{record.id}"
         parents.push(record)
       else
-        ns = MiqAeNamespace.find_by_fqname(nodes[0..i].join("/"))
+        ns = MiqAeNamespace.lookup_by_fqname(nodes[0..i].join("/"))
         parents.push(ns) if ns
       end
     end

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -398,7 +398,7 @@ module MiqPolicyController::MiqActions
     end
 
     if %w[inherit_parent_tags remove_tags].include?(@action.action_type)
-      @cats = Classification.find_by_names(@action.options[:cats]).pluck(:description).sort_by(&:downcase).join(" | ")
+      @cats = Classification.lookup_by_names(@action.options[:cats]).pluck(:description).sort_by(&:downcase).join(" | ")
     end
   end
 end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -177,7 +177,7 @@ module OpsController::Settings::LabelTagMapping
     cat_name = cat_prefix + Classification.sanitize_name(label_name.tr("/", ":"))
 
     # UI currently can't allow 2 mappings for same (entity, label).
-    if Classification.find_by_name(cat_name)
+    if Classification.lookup_by_name(cat_name)
       add_flash(_("Mapping for %{entity}, Label \"%{label}\" already exists") %
                   {:entity => entity_ui_name_or_all(entity), :label => label_name}, :error)
       javascript_flash

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -140,7 +140,7 @@ module OpsController::Settings::Tags
   def ce_new_cat
     ce_get_form_vars
     if params[:classification_name]
-      @cat = Classification.find_by_name(params["classification_name"])
+      @cat = Classification.lookup_by_name(params["classification_name"])
       ce_build_screen # Build the Classification Edit screen
       render :update do |page|
         page << javascript_prologue
@@ -236,7 +236,7 @@ module OpsController::Settings::Tags
   def ce_get_form_vars
     @edit = session[:edit]
     @cats = session[:config_cats]
-    @cat = Classification.find_by_name(session[:config_cat])
+    @cat = Classification.lookup_by_name(session[:config_cat])
     nil
   end
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1374,7 +1374,7 @@ module ReportController::Reports::Editor
   end
 
   def entries_hash(category_name)
-    cat = Classification.find_by_name(category_name)
+    cat = Classification.lookup_by_name(category_name)
     return {} unless cat
     cat.entries.each_with_object({}) { |e, h| h[e.name] = e.description }
   end

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -402,7 +402,7 @@ module ReportController::Schedules
       # rebuild hash to hold user's email along with name if user record was found for display, defined as hash so only email id can be sent from form to be deleted from array above
       @email_to = {}
       @edit[:new][:email][:to].each_with_index do |e, _e_idx|
-        u = User.find_by_email(e)
+        u = User.lookup_by_email(e)
         @email_to[e] = u ? "#{u.name} (#{e})" : e
       end
     end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -26,14 +26,14 @@ class UserValidationService
 
     if user[:new_password].present?
       begin
-        User.find_by_userid(user[:name]).change_password(user[:password], user[:new_password])
+        User.lookup_by_userid(user[:name]).change_password(user[:password], user[:new_password])
       rescue => bang
         return ValidateResult.new(:fail, "Error: " + bang.message)
       end
     end
 
     start_url = session[:start_url] # Hang on to the initial start URL
-    db_user = User.find_by_userid(user[:name])
+    db_user = User.lookup_by_userid(user[:name])
     session_reset
     feature = User.missing_user_features(db_user)
     if feature

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -41,7 +41,7 @@ describe ApplicationController do
     end
 
     describe 'perf_gen_tag_data_after_wait' do
-      it 'calls Classification.find_by_name and other specific methods' do
+      it 'calls Classification.lookup_by_name and other specific methods' do
         task = double(:task)
         allow(task).to receive_message_chain(:miq_report_result, :report_results)
         expect(task).to receive(:destroy)
@@ -50,7 +50,7 @@ describe ApplicationController do
 
         cat = double(:cat)
         allow(cat).to receive(:description)
-        expect(Classification).to receive(:find_by_name).with('cat').and_return(cat)
+        expect(Classification).to receive(:lookup_by_name).with('cat').and_return(cat)
 
         controller.instance_variable_set(:@sb, {})
         controller.instance_variable_set(:@perf_record, FactoryBot.create(:host))

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -343,7 +343,7 @@ describe ReportController do
           tag_cat = "department"
           controller.params = {:cb_tag_cat => tag_cat}
           cl_rec = FactoryBot.create(:classification, :name => "test_name", :description => "Test Description")
-          expect(Classification).to receive(:find_by_name).and_return([cl_rec])
+          expect(Classification).to receive(:lookup_by_name).and_return([cl_rec])
           controller.send(:gfv_chargeback)
           expect(assigns(:edit)[:new][:cb_tag_cat]).to eq(tag_cat)
           expect(assigns(:edit)[:cb_tags]).to be_a_kind_of(Hash)


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_*.
Switching the callers in this repo to the lookup_by_* methods.

Depend on https://github.com/ManageIQ/manageiq/pull/19313

@miq-bot add_label ivanchuk/no, refactoring
