### PR TITLE
Call TreeBuilder#override on TreeNode objects instead of hashes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -106,13 +106,6 @@ class TreeBuilder
 
   private
 
-  # Temporary method to append the no-cursor class to an already existing CSS class
-  # list. Eventually it should be removed after all the code from the override methods
-  # is moved into the TreeNode as a DSL.
-  def append_no_cursor(klass)
-    (klass || '').split(' ').push('no-cursor').join(' ')
-  end
-
   def build_tree
     @tree_nodes = x_build_tree
     active_node_set(@tree_nodes)
@@ -230,10 +223,10 @@ class TreeBuilder
   end
 
   def x_build_single_node(object, pid)
-    # FIXME: to_h is for backwards compatibility with hash-trees, it needs to be removed in the future
-    node = TreeNode.new(object, pid, self).to_h
+    node = TreeNode.new(object, pid, self)
     override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
-    node
+    # FIXME: to_h is for backwards compatibility with hash-trees, it needs to be removed in the future
+    node.to_h
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -8,8 +8,7 @@ class TreeBuilderAlertProfileObj < TreeBuilder
   end
 
   def override(node, object)
-    node[:state] ||= {}
-    node[:state][:checked] = @selected.try(:include?, object.id)
+    node.checked = @selected.try(:include?, object.id)
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -13,10 +13,7 @@ class TreeBuilderAutomate < TreeBuilder
   end
 
   def override(node, object)
-    if object.kind_of?(MiqAeNamespace) && object.domain?
-      node[:selectable] = false
-      node[:class] = append_no_cursor(node[:class])
-    end
+    node.selectable = false if object.kind_of?(MiqAeNamespace) && object.domain?
   end
 
   def x_get_tree_class_kids(object, count_only)

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -11,10 +11,7 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
 
   def override(node, object)
     # Only the instance items should be clickable when selecting a catalog item entry point
-    unless object.kind_of?(MiqAeInstance)
-      node[:selectable] = false
-      node[:class] = append_no_cursor(node[:class])
-    end
+    node.selectable = false unless object.kind_of?(MiqAeInstance)
   end
 
   def x_get_tree_ns_kids(object, count_only)

--- a/app/presenters/tree_builder_automate_entrypoint.rb
+++ b/app/presenters/tree_builder_automate_entrypoint.rb
@@ -1,6 +1,6 @@
 class TreeBuilderAutomateEntrypoint < TreeBuilderAutomateCatalog
   def override(node, _object)
-    node.delete(:selectable)
+    node.selectable = nil
   end
 
   def root_options

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -6,12 +6,10 @@ class TreeBuilderBelongsToHac < TreeBuilder
   has_kids_for ResourcePool, [:x_get_resource_pool_kids]
 
   def override(node, object)
-    node[:state] ||= {}
-    node[:state][:checked] = @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
-    node[:hideCheckbox] = true if object.kind_of?(Host) && object.ems_cluster_id.present?
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
-    node[:checkable] = @edit.present?
+    node.checked = @selected_nodes&.include?("#{object.class.name}_#{object[:id]}")
+    node.hide_checkbox = true if object.kind_of?(Host) && object.ems_cluster_id.present?
+    node.selectable = false
+    node.checkable = @edit.present?
   end
 
   def initialize(name, sandbox, build, **params)

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -1,16 +1,14 @@
 class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
   def override(node, object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
-    node[:checkable] = @edit.present? || @assign_to.present?
+    node.selectable = false
+    node.checkable = @edit.present? || @assign_to.present?
 
     if object.kind_of?(EmsFolder) && object.vm_folder?
-      node[:icon] = "pficon pficon-folder-close-blue"
+      node.icon = "pficon pficon-folder-close-blue"
     else
-      node[:hideCheckbox] = true
+      node.hide_checkbox = true
     end
-    node[:state] ||= {}
-    node[:state][:checked] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+    node.checked = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
   end
 
   def x_get_tree_datacenter_kids(parent, count_only)

--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -3,8 +3,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
   has_kids_for ComplianceDetail, %i[x_get_compliance_detail_kids parents]
 
   def override(node, _object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
+    node.selectable = false
   end
 
   def initialize(name, sandbox, build = true, **params)

--- a/app/presenters/tree_builder_ems_folders.rb
+++ b/app/presenters/tree_builder_ems_folders.rb
@@ -2,14 +2,12 @@ class TreeBuilderEmsFolders < TreeBuilderAlertProfileAssign
   ANCESTRY_TYPE = EmsFolder
 
   def override(node, object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
+    node.selectable = false
     if object.kind_of?(EmsFolder) && object.vm_folder?
-      node[:icon] = "pficon pficon-folder-close-blue"
+      node.icon = "pficon pficon-folder-close-blue"
     else
-      node[:hideCheckbox] = true
+      node.hide_checkbox = true
     end
-    node[:state] ||= {}
-    node[:state][:checked] = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+    node.checked = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
   end
 end

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -5,10 +5,7 @@ class TreeBuilderInfraNetworking < TreeBuilder
   has_kids_for EmsFolder, [:x_get_tree_folder_kids]
 
   def override(node, object)
-    if object.kind_of?(Lan)
-      node[:selectable] = false
-      node[:class] = append_no_cursor(node[:class])
-    end
+    node.selectable = false if object.kind_of?(Lan)
   end
 
   private

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -3,10 +3,7 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
   def override(node, object)
-    unless object.kind_of?(::VmOrTemplate)
-      node[:selectable] = false
-      node[:class] = append_no_cursor(node[:class])
-    end
+    node.selectable = false unless object.kind_of?(::VmOrTemplate)
   end
 
   def initialize(name, sandbox, build = true, **params)

--- a/app/presenters/tree_builder_resource_pools.rb
+++ b/app/presenters/tree_builder_resource_pools.rb
@@ -2,11 +2,9 @@ class TreeBuilderResourcePools < TreeBuilderAlertProfileAssign
   ANCESTRY_TYPE = ResourcePool
 
   def override(node, object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
-    node[:checkable] = true
-    node[:hideCheckbox] = true unless object.kind_of?(ResourcePool)
-    node[:state] ||= {}
-    node[:state][:checked] = @selected_nodes&.include?("ResourcePool_#{object[:id]}")
+    node.selectable = false
+    node.checkable = true
+    node.hide_checkbox = true unless object.kind_of?(ResourcePool)
+    node.checked = @selected_nodes&.include?("ResourcePool_#{object[:id]}")
   end
 end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -8,9 +8,8 @@ class TreeBuilderRolesByServer < TreeBuilderDiagnostics
   end
 
   def override(node, _object)
-    if @sb[:diag_selected_id] && node[:key] == "#{self.class.get_prefix_for_model(@sb[:diag_selected_model]) || 'svr'}-#{@sb[:diag_selected_id]}"
-      node[:state] ||= {}
-      node[:state][:selected] = true
+    if @sb[:diag_selected_id] && node.key == "#{self.class.get_prefix_for_model(@sb[:diag_selected_model]) || 'svr'}-#{@sb[:diag_selected_id]}"
+      node.selected = true
     end
   end
 

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -8,9 +8,8 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
   end
 
   def override(node, _object)
-    if @sb[:diag_selected_id] && node[:key] == "role-#{@sb[:diag_selected_id]}"
-      node[:state] ||= {}
-      node[:state][:selected] = true
+    if @sb[:diag_selected_id] && node.key == "role-#{@sb[:diag_selected_id]}"
+      node.selected = true
     end
   end
 

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -10,8 +10,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   private
 
   def override(node, _object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
+    node.selectable = false
   end
 
   def tree_init_options

--- a/app/presenters/tree_builder_storage_adapters.rb
+++ b/app/presenters/tree_builder_storage_adapters.rb
@@ -8,8 +8,7 @@ class TreeBuilderStorageAdapters < TreeBuilder
   end
 
   def override(node, _object)
-    node[:selectable] = false
-    node[:class] = append_no_cursor(node[:class])
+    node.selectable = false
   end
 
   private

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -58,8 +58,7 @@ class TreeBuilderTenants < TreeBuilder
   end
 
   def override(node, object)
-    node[:state] ||= {}
-    node[:state][:checked] = @additional_tenants.try(:include?, object)
-    node[:checkable] = @selectable
+    node.checked = @additional_tenants.try(:include?, object)
+    node.checkable = @selectable
   end
 end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -10,10 +10,7 @@ class TreeBuilderUtilization < TreeBuilder
   end
 
   def override(node, _object)
-    if node[:key].split('-')[1].split('_')[0] == 'folder'
-      node[:selectable] = false
-      node[:class] = append_no_cursor(node[:class])
-    end
+    node.selectable = false if node.key.split('-')[1].split('_')[0] == 'folder'
   end
 
   def root_options

--- a/spec/presenters/tree_builder_alert_profile_obj_spec.rb
+++ b/spec/presenters/tree_builder_alert_profile_obj_spec.rb
@@ -50,20 +50,20 @@ describe TreeBuilderAlertProfileObj do
     end
 
     describe '#override' do
-      let(:node) { {} }
+      let(:node) { TreeNode.new({}) }
 
       it 'sets node1' do
         subject.send(:override, node, tag1a)
-        expect(node[:hideCheckbox]).to be_falsey
-        expect(node[:state][:checked]).to be_truthy
+        expect(node.to_h[:hideCheckbox]).to be_falsey
+        expect(node.to_h[:state][:checked]).to be_truthy
       end
       it 'sets node2' do
         subject.send(:override, node, tag2a)
-        expect(node[:state][:checked]).to be_truthy
+        expect(node.to_h[:state][:checked]).to be_truthy
       end
       it 'sets node3' do
         subject.send(:override, node, tag3a)
-        expect(node[:state][:checked]).to be_falsey
+        expect(node.to_h[:state][:checked]).to be_falsey
       end
     end
 


### PR DESCRIPTION
There's a controversial `TreeBuilder#override` method that is intended to change nodes after they are being built. This method has been called from `TreeBuilder#x_build_single_node` on individual hashes that come out from `TreeNode::Node#to_h`.

The final result of the `x_build_single_node` has been not changed, so the method still produces the same output. However, the `override` method is now being called on the `TreeNode::Node` object directly and it is being converted to a hash AFTER this. This allows us to have a cleaner dataflow and eventually the hash conversion can be pushed up to the highest level, leaving us with a pure object tree.

As the `override` happened after the conversion, the resulted node had to comply with the JSON specification of the tree. This forced us to reimplement features from the `TreeNode::Node#to_h`, such as lazy-initializing the `state` hash appending the extra `no-cursor` class to non-selectable nodes. These safeguards are no longer necessary and they have been removed.

@miq-bot add_label refactoring, trees, ivanchuk/no
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @ZitaNemeckova 