### PR TITLE
Add the selected accessor to TreeNode::Node and clean up its to_h

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -2,7 +2,7 @@ module TreeNode
   class Node
     attr_reader :tree
 
-    attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :klass, :selectable, :tooltip
+    attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :klass, :selectable, :selected, :tooltip
     attr_writer :icon, :image
 
     def initialize(object, parent_id, tree)
@@ -45,7 +45,7 @@ module TreeNode
     end
 
     def to_h
-      node = {
+      {
         :key            => key,
         :text           => escape(text),
         :tooltip        => escape(tooltip),
@@ -60,10 +60,9 @@ module TreeNode
         :state          => {
           :checked  => checked,
           :expanded => expanded,
+          :selected => selected
         }.compact
-      }
-
-      node.delete_if { |_, v| v.nil? }
+      }.compact
     end
 
     class << self


### PR DESCRIPTION
Missed this one from https://github.com/ManageIQ/manageiq-ui-classic/pull/6208, the change is harmless as the `selected` attribute is never being set yby the node itself. However, it will be significant when the `TreeBuilder#override` methods will [start](https://github.com/ManageIQ/manageiq-ui-classic/pull/6220) using it. Also the `delete_if` is no longer necessary in `to_h` as we have the `compact`. 

@miq-bot add_label enhancement, technical debt, ivanchuk/no, trees
@miq-bot add_reviewer @romanblanco 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @mzazrivec 