### PR TITLE
Refactor get_rec_cls to get proper record class for various items

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -222,7 +222,7 @@ module ApplicationController::CiProcessing
   def process_cloud_object_storage_buttons(pressed)
     assert_privileges(pressed)
 
-    klass = get_rec_cls
+    klass = record_class
     task = pressed.sub("#{klass.name.underscore.to_sym}_", "")
 
     return tag(klass) if task == "tag"
@@ -247,33 +247,12 @@ module ApplicationController::CiProcessing
     process_objects(items.ids.sort, method, display_name)
   end
 
-  def get_rec_cls
-    # FIXME: the specs for ci_processing rely on setting (and testing) request.parameters['controller'].
-    # That is wrong and needs to be fixed.
-    case request.parameters["controller"] || controller_name
-    when "miq_template"
-      MiqTemplate
-    when "orchestration_stack"
-      params[:display] == "instances" ? VmOrTemplate : OrchestrationStack
-    when "service"
-      Service
-    when "cloud_object_store_container"
-      params[:pressed].starts_with?("cloud_object_store_object") ? CloudObjectStoreObject : CloudObjectStoreContainer
-    when "cloud_object_store_object"
-      CloudObjectStoreObject
-    when "ems_storage"
-      params[:pressed].starts_with?("cloud_object_store_object") ? CloudObjectStoreObject : CloudObjectStoreContainer
-    when "ems_cluster"
-      %w[all_vms vms].include?(params[:display]) || params[:pressed].starts_with?('miq_template') ? VmOrTemplate : EmsCluster
-    when "storage"
-      %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : Storage
-    else
-      VmOrTemplate
-    end
+  def record_class
+    VmOrTemplate
   end
 
   def process_objects(objs, task, display_name = nil)
-    klass = get_rec_cls
+    klass = record_class
     klass_str = klass.to_s
 
     assert_rbac(klass, objs)
@@ -608,7 +587,7 @@ module ApplicationController::CiProcessing
   #                 on a record
   #   options     - other optional parameters
   def generic_button_operation(action, action_name, operation, options = {})
-    records = find_records_with_rbac(get_rec_cls, checked_or_params)
+    records = find_records_with_rbac(record_class, checked_or_params)
     if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
         :text       => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},

--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -119,6 +119,10 @@ class CloudObjectStoreContainerController < ApplicationController
 
   private
 
+  def record_class
+    params[:pressed].starts_with?('cloud_object_store_object') ? CloudObjectStoreObject : CloudObjectStoreContainer
+  end
+
   def retrieve_provider_regions
     managers = ManageIQ::Providers::CloudManager.supported_subclasses.select(&:supports_regions?)
     managers.each_with_object({}) do |manager, provider_regions|

--- a/app/controllers/cloud_object_store_object_controller.rb
+++ b/app/controllers/cloud_object_store_object_controller.rb
@@ -29,6 +29,10 @@ class CloudObjectStoreObjectController < ApplicationController
 
   private
 
+  def record_class
+    CloudObjectStoreObject
+  end
+
   def textual_group_list
     [%i[properties relationships], %i[tags]]
   end

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -95,6 +95,10 @@ class EmsClusterController < ApplicationController
 
   private
 
+  def record_class
+    %w[all_vms vms].include?(params[:display]) || params[:pressed].starts_with?('miq_template') ? VmOrTemplate : EmsCluster
+  end
+
   def textual_group_list
     [
       %i[relationships],

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -224,6 +224,19 @@ class EmsInfraController < ApplicationController
 
   private
 
+  def record_class
+    case params[:pressed]
+    when /^ems_cluster/
+      EmsCluster
+    when /^orchestration_stack/
+      OrchestrationStack
+    when /^storage/
+      Storage
+    else
+      VmOrTemplate
+    end
+  end
+
   ############################
   # Special EmsCloud link builder for restful routes
   def show_link(ems, options = {})

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -73,6 +73,10 @@ class EmsStorageController < ApplicationController
 
   private
 
+  def record_class
+    params[:pressed].starts_with?('cloud_object_store_object') ? CloudObjectStoreObject : CloudObjectStoreContainer
+  end
+
   def textual_group_list
     [
       %i[properties status],

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -380,6 +380,17 @@ class HostController < ApplicationController
 
   private
 
+  def record_class
+    case params[:display] || @display
+    when 'storages'
+      Storage
+    when 'vms', 'miq_templates'
+      VmOrTemplate
+    else
+      Host
+    end
+  end
+
   def textual_group_list
     [
       %i[properties relationships],

--- a/app/controllers/miq_template_controller.rb
+++ b/app/controllers/miq_template_controller.rb
@@ -18,6 +18,10 @@ class MiqTemplateController < ApplicationController
 
   private
 
+  def record_class
+    MiqTemplate
+  end
+
   def get_session_data
     @title          = _("Templates")
     @layout         = session[:miq_template_type] ? session[:miq_template_type] : "miq_template"

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -146,6 +146,10 @@ class OrchestrationStackController < ApplicationController
 
   private
 
+  def record_class
+    params[:display] == 'instances' ? VmOrTemplate : OrchestrationStack
+  end
+
   def textual_group_list
     [%i[properties lifecycle relationships], %i[tags]]
   end

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -64,6 +64,10 @@ class ResourcePoolController < ApplicationController
 
   private
 
+  def record_class
+    %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : ResourcePool
+  end
+
   def textual_group_list
     [%i[properties relationships], %i[configuration smart_management]]
   end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -204,6 +204,10 @@ class ServiceController < ApplicationController
 
   private
 
+  def record_class
+    Service
+  end
+
   def sanitize_output(stdout)
     htm = stdout.gsub('"', '\"')
 

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -469,6 +469,10 @@ class StorageController < ApplicationController
 
   private
 
+  def record_class
+    %w[all_vms vms].include?(params[:display]) ? VmOrTemplate : Storage
+  end
+
   def session_reset
     if @record
       session[:edit] = @edit = nil

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -87,7 +87,7 @@ module VmCommon
   end
 
   def show_timeline
-    db = get_rec_cls
+    db = record_class
     @display = "timeline"
     session[:tl_record_id] = params[:id] if params[:id]
     @record = find_record_with_rbac(db, session[:tl_record_id])

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -148,480 +148,431 @@ describe ApplicationController do
   end
 
   context "Delete object store container" do
+    let(:container1) { FactoryBot.create(:cloud_object_store_container) }
+    let(:container2) { FactoryBot.create(:cloud_object_store_container) }
+
     before do
       allow(controller).to receive(:assert_rbac).and_return(nil)
       allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
-    end
-
-    let :container1 do
-      FactoryBot.create(:cloud_object_store_container)
-    end
-
-    let :container2 do
-      FactoryBot.create(:cloud_object_store_container)
+      controller.params[:pressed] = "cloud_object_store_container_delete"
     end
 
     context "from list view" do
-      before do
-        controller.params[:pressed] = "cloud_object_store_container_delete"
-        request.parameters["controller"] = "ems_storage"
-        controller.instance_variable_set(:@display, "cloud_object_store_containers")
-      end
+      describe EmsStorageController do
+        before { controller.instance_variable_set(:@display, "cloud_object_store_containers") }
 
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreContainer)
-      end
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreContainer)
+        end
 
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreContainer,
-          'delete'
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-      end
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreContainer,
+            'delete'
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+        end
 
-      it "invokes process_objects" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        expect(controller).to receive(:process_objects).with(
-          [container1.id, container2.id],
-          'cloud_object_store_container_delete',
-          'Delete'
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'delete')
-      end
+        it "invokes process_objects" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          expect(controller).to receive(:process_objects).with(
+            [container1.id, container2.id],
+            'cloud_object_store_container_delete',
+            'Delete'
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'delete')
+        end
 
-      it "invokes process_tasks on container class" do
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container1.id, container2.id],
-          :task   => 'cloud_object_store_container_delete',
-          :userid => anything
-        )
-        controller.send(:process_objects, [container1.id, container2.id], 'cloud_object_store_container_delete',
-                        'delete')
-      end
+        it "invokes process_tasks on container class" do
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id, container2.id],
+            :task   => 'cloud_object_store_container_delete',
+            :userid => anything
+          )
+          controller.send(:process_objects, [container1.id, container2.id], 'cloud_object_store_container_delete',
+                          'delete')
+        end
 
-      it "invokes process_tasks overall (when selected)" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container1.id, container2.id],
-          :task   => 'cloud_object_store_container_delete',
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-      end
+        it "invokes process_tasks overall (when selected)" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id, container2.id],
+            :task   => 'cloud_object_store_container_delete',
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+        end
 
-      it "raises an error when nothing selected" do
-        controller.params[:miq_grid_checks] = ''
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
-      end
+        it "raises an error when nothing selected" do
+          controller.params[:miq_grid_checks] = ''
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
+        end
 
-      it "flash - task not supported" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Delete does not apply to at least one of the selected items"
-        )
+        it "flash - task not supported" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete does not apply to at least one of the selected items"
+          )
+        end
       end
     end
 
     context "from details view" do
-      before do
-        allow(controller).to receive(:show_list).and_return(nil)
-        controller.params[:pressed] = "cloud_object_store_container_delete"
-        request.parameters["controller"] = "cloud_object_store_container"
-      end
+      describe CloudObjectStoreContainerController do
+        before { allow(controller).to receive(:show_list).and_return(nil) }
 
-      let :container do
-        FactoryBot.create(:cloud_object_store_container)
-      end
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreContainer)
+        end
 
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreContainer)
-      end
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreContainer,
+            'delete'
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+        end
 
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreContainer,
-          'delete'
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-      end
+        it "invokes process_objects" do
+          controller.params[:id] = container1.id
+          expect(controller).to receive(:process_objects).with(
+            [container1.id],
+            'cloud_object_store_container_delete',
+            'Delete'
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'delete')
+        end
 
-      it "invokes process_objects" do
-        controller.params[:id] = container.id
-        expect(controller).to receive(:process_objects).with(
-          [container.id],
-          'cloud_object_store_container_delete',
-          'Delete'
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'delete')
-      end
+        it "invokes process_tasks on container class" do
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id],
+            :task   => 'cloud_object_store_container_delete',
+            :userid => anything
+          )
+          controller.send(:process_objects, [container1.id], 'cloud_object_store_container_delete', 'delete')
+        end
 
-      it "invokes process_tasks on container class" do
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container.id],
-          :task   => 'cloud_object_store_container_delete',
-          :userid => anything
-        )
-        controller.send(:process_objects, [container.id], 'cloud_object_store_container_delete', 'delete')
-      end
+        it "invokes process_tasks overall" do
+          controller.params[:id] = container1.id
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id],
+            :task   => 'cloud_object_store_container_delete',
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+        end
 
-      it "invokes process_tasks overall" do
-        controller.params[:id] = container.id
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container.id],
-          :task   => 'cloud_object_store_container_delete',
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-      end
+        it "flash - container no longer exists" do
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
+        end
 
-      it "flash - container no longer exists" do
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete") }.to raise_error("Can't access records without an id")
-      end
-
-      it "flash - task not supported" do
-        controller.params[:id] = container.id
-        allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Delete does not apply to this item"
-        )
+        it "flash - task not supported" do
+          controller.params[:id] = container1.id
+          allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete does not apply to this item"
+          )
+        end
       end
     end
   end
 
   context "Delete object store object" do
+    let(:object1) { FactoryBot.create(:cloud_object_store_object) }
+    let(:object2) { FactoryBot.create(:cloud_object_store_object) }
+
     before do
       allow(controller).to receive(:assert_rbac).and_return(nil)
       allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
-    end
-
-    let :object1 do
-      FactoryBot.create(:cloud_object_store_object)
-    end
-
-    let :object2 do
-      FactoryBot.create(:cloud_object_store_object)
-    end
-
-    context "from list view" do
-      before do
-        controller.params[:pressed] = "cloud_object_store_object_delete"
-        request.parameters["controller"] = "cloud_object_store_container"
-        controller.instance_variable_set(:@display, "cloud_object_store_objects")
-      end
-
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreObject)
-      end
-
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreObject,
-          "delete"
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      end
-
-      it "invokes process_objects" do
-        controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
-        expect(controller).to receive(:process_objects).with(
-          [object1.id, object2.id],
-          "cloud_object_store_object_delete",
-          "Delete"
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreObject, "delete")
-      end
-
-      it "invokes process_tasks on container class" do
-        controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
-        expect(CloudObjectStoreObject).to receive(:process_tasks).with(
-          :ids    => [object1.id, object2.id],
-          :task   => "cloud_object_store_object_delete",
-          :userid => anything
-        )
-        controller.send(:process_objects, [object1.id, object2.id], "cloud_object_store_object_delete", "delete")
-      end
-
-      it "invokes process_tasks overall (when selected)" do
-        controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
-        expect(CloudObjectStoreObject).to receive(:process_tasks).with(
-          :ids    => [object1.id, object2.id],
-          :task   => "cloud_object_store_object_delete",
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      end
-
-      it "does not invoke process_tasks overall when nothing selected" do
-        controller.params[:miq_grid_checks] = ""
-        expect(CloudObjectStoreObject).not_to receive(:process_tasks)
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
-      end
-
-      it "flash - nothing selected" do
-        controller.params[:miq_grid_checks] = ""
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
-      end
-
-      it "flash - task not supported" do
-        controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
-        allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Delete does not apply to at least one of the selected items"
-        )
-      end
-    end
-
-    context "from details view" do
-      before do
-        allow(controller).to receive(:show_list).and_return(nil)
-        controller.params[:pressed] = "cloud_object_store_object_delete"
-        request.parameters["controller"] = "cloud_object_store_object"
-      end
-
-      let :object do
-        FactoryBot.create(:cloud_object_store_object)
-      end
-
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreObject)
-      end
-
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreObject,
-          "delete"
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      end
-
-      it "invokes process_objects" do
-        controller.params[:id] = object.id.to_s
-        expect(controller).to receive(:process_objects).with(
-          [object.id],
-          "cloud_object_store_object_delete",
-          "Delete"
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreObject, "delete")
-      end
-
-      it "invokes process_tasks on object class" do
-        controller.params[:id] = object.id.to_s
-        expect(CloudObjectStoreObject).to receive(:process_tasks).with(
-          :ids    => [object.id.to_s],
-          :task   => "cloud_object_store_object_delete",
-          :userid => anything
-        )
-        controller.send(:process_objects, [object.id.to_s], "cloud_object_store_object_delete", "delete")
-      end
-
-      it "invokes process_tasks overall" do
-        controller.params[:id] = object.id.to_s
-        expect(CloudObjectStoreObject).to receive(:process_tasks).with(
-          :ids    => [object.id],
-          :task   => "cloud_object_store_object_delete",
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      end
-
-      it "flash - container no longer exists" do
-        object.destroy
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
-      end
-
-      it "flash - task not supported" do
-        controller.params[:id] = object.id.to_s
-        allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Delete does not apply to this item"
-        )
-      end
-    end
-  end
-
-  context "Delete object store object" do
-    let :object1 do
-      FactoryBot.create(:cloud_object_store_object)
-    end
-
-    before do
-      allow(controller).to receive(:assert_rbac).and_return(nil)
       controller.params[:pressed] = "cloud_object_store_object_delete"
-      controller.params[:miq_grid_checks] = object1.id.to_s
-      request.parameters["controller"] = "cloud_object_store_container"
-      controller.instance_variable_set(:@display, "cloud_object_store_objects")
     end
 
-    it "invokes delete for a selected CloudObjectStoreObject" do
-      allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
-      controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      expect(assigns(:flash_array).first[:message]).to include(
-        "Delete initiated for 1 Cloud Object Store Object from the ManageIQ Database"
-      )
+    context "from list view" do
+      describe CloudObjectStoreContainerController do
+        before { controller.instance_variable_set(:@display, "cloud_object_store_objects") }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreObject)
+        end
+
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreObject,
+            "delete"
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+        end
+
+        it "invokes process_objects" do
+          controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
+          expect(controller).to receive(:process_objects).with(
+            [object1.id, object2.id],
+            "cloud_object_store_object_delete",
+            "Delete"
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreObject, "delete")
+        end
+
+        it "invokes process_tasks on container class" do
+          controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
+          expect(CloudObjectStoreObject).to receive(:process_tasks).with(
+            :ids    => [object1.id, object2.id],
+            :task   => "cloud_object_store_object_delete",
+            :userid => anything
+          )
+          controller.send(:process_objects, [object1.id, object2.id], "cloud_object_store_object_delete", "delete")
+        end
+
+        it "invokes process_tasks overall (when selected)" do
+          controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
+          expect(CloudObjectStoreObject).to receive(:process_tasks).with(
+            :ids    => [object1.id, object2.id],
+            :task   => "cloud_object_store_object_delete",
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+        end
+
+        it "invokes delete for a selected CloudObjectStoreObject" do
+          controller.params[:miq_grid_checks] = object1.id.to_s
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete initiated for 1 Cloud Object Store Object from the ManageIQ Database"
+          )
+        end
+
+        it "does not invoke process_tasks overall when nothing selected" do
+          controller.params[:miq_grid_checks] = ""
+          expect(CloudObjectStoreObject).not_to receive(:process_tasks)
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
+        end
+
+        it "flash - nothing selected" do
+          controller.params[:miq_grid_checks] = ""
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
+        end
+
+        it "flash - task not supported" do
+          controller.params[:miq_grid_checks] = "#{object1.id}, #{object2.id}"
+          allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete does not apply to at least one of the selected items"
+          )
+        end
+
+        it "flash - task not supported for one selected item" do
+          controller.params[:miq_grid_checks] = object1.id.to_s
+          allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete does not apply to this item"
+          )
+        end
+      end
     end
 
-    it "flash - task not supported" do
-      allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
-      controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
-      expect(assigns(:flash_array).first[:message]).to include(
-        "Delete does not apply to this item"
-      )
+    context "from details view" do
+      describe CloudObjectStoreObjectController do
+        before { allow(controller).to receive(:show_list).and_return(nil) }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreObject)
+        end
+
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreObject,
+            "delete"
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+        end
+
+        it "invokes process_objects" do
+          controller.params[:id] = object1.id.to_s
+          expect(controller).to receive(:process_objects).with(
+            [object1.id],
+            "cloud_object_store_object_delete",
+            "Delete"
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreObject, "delete")
+        end
+
+        it "invokes process_tasks on object class" do
+          controller.params[:id] = object1.id.to_s
+          expect(CloudObjectStoreObject).to receive(:process_tasks).with(
+            :ids    => [object1.id.to_s],
+            :task   => "cloud_object_store_object_delete",
+            :userid => anything
+          )
+          controller.send(:process_objects, [object1.id.to_s], "cloud_object_store_object_delete", "delete")
+        end
+
+        it "invokes process_tasks overall" do
+          controller.params[:id] = object1.id.to_s
+          expect(CloudObjectStoreObject).to receive(:process_tasks).with(
+            :ids    => [object1.id],
+            :task   => "cloud_object_store_object_delete",
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+        end
+
+        it "flash - container no longer exists" do
+          object1.destroy
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete") }.to raise_error("Can't access records without an id")
+        end
+
+        it "flash - task not supported" do
+          controller.params[:id] = object1.id.to_s
+          allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_object_delete")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Delete does not apply to this item"
+          )
+        end
+      end
     end
   end
 
   context "Clear object store container" do
+    let(:container1) { FactoryBot.create(:cloud_object_store_container) }
+    let(:container2) { FactoryBot.create(:cloud_object_store_container) }
+
     before do
       allow(controller).to receive(:assert_rbac).and_return(nil)
       allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
-    end
-
-    let :container1 do
-      FactoryBot.create(:cloud_object_store_container)
-    end
-
-    let :container2 do
-      FactoryBot.create(:cloud_object_store_container)
+      controller.params[:pressed] = "cloud_object_store_container_clear"
     end
 
     context "from list view" do
-      before do
-        controller.params[:pressed] = "cloud_object_store_container_clear"
-        request.parameters["controller"] = "ems_storage"
-        controller.instance_variable_set(:@display, "cloud_object_store_containers")
-      end
+      describe EmsStorageController do
+        before { controller.instance_variable_set(:@display, "cloud_object_store_containers") }
 
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreContainer)
-      end
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreContainer)
+        end
 
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreContainer,
-          'clear'
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-      end
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreContainer,
+            'clear'
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+        end
 
-      it "invokes process_objects" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        expect(controller).to receive(:process_objects).with(
-          [container1.id, container2.id],
-          'cloud_object_store_container_clear',
-          'Clear'
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'clear')
-      end
+        it "invokes process_objects" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          expect(controller).to receive(:process_objects).with(
+            [container1.id, container2.id],
+            'cloud_object_store_container_clear',
+            'Clear'
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'clear')
+        end
 
-      it "invokes process_tasks on container class" do
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container1.id, container2.id],
-          :task   => 'cloud_object_store_container_clear',
-          :userid => anything
-        )
-        controller.send(:process_objects, [container1.id, container2.id], 'cloud_object_store_container_clear',
-                        'clear')
-      end
+        it "invokes process_tasks on container class" do
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id, container2.id],
+            :task   => 'cloud_object_store_container_clear',
+            :userid => anything
+          )
+          controller.send(:process_objects, [container1.id, container2.id], 'cloud_object_store_container_clear',
+                          'clear')
+        end
 
-      it "invokes process_tasks overall (when selected)" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container1.id, container2.id],
-          :task   => 'cloud_object_store_container_clear',
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-      end
+        it "invokes process_tasks overall (when selected)" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id, container2.id],
+            :task   => 'cloud_object_store_container_clear',
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+        end
 
-      it "does not invoke process_tasks overall when nothing selected" do
-        controller.params[:miq_grid_checks] = ''
-        expect(CloudObjectStoreContainer).not_to receive(:process_tasks)
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
-      end
+        it "does not invoke process_tasks overall when nothing selected" do
+          controller.params[:miq_grid_checks] = ''
+          expect(CloudObjectStoreContainer).not_to receive(:process_tasks)
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
+        end
 
-      it "flash - nothing selected" do
-        controller.params[:miq_grid_checks] = ''
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
-      end
+        it "flash - nothing selected" do
+          controller.params[:miq_grid_checks] = ''
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
+        end
 
-      it "flash - task not supported" do
-        controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
-        allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Clear does not apply to at least one of the selected items"
-        )
+        it "flash - task not supported" do
+          controller.params[:miq_grid_checks] = "#{container1.id}, #{container2.id}"
+          allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Clear does not apply to at least one of the selected items"
+          )
+        end
       end
     end
 
     context "from details view" do
-      before do
-        allow(controller).to receive(:show_list).and_return(nil)
-        controller.params[:pressed] = "cloud_object_store_container_clear"
-        request.parameters["controller"] = "cloud_object_store_container"
-      end
+      describe CloudObjectStoreContainerController do
+        before { allow(controller).to receive(:show_list).and_return(nil) }
 
-      let :container do
-        FactoryBot.create(:cloud_object_store_container)
-      end
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(CloudObjectStoreContainer)
+        end
 
-      it "get_rec_cls" do
-        expect(controller.send(:get_rec_cls)).to eq(CloudObjectStoreContainer)
-      end
+        it "invokes cloud_object_store_button_operation" do
+          expect(controller).to receive(:cloud_object_store_button_operation).with(
+            CloudObjectStoreContainer,
+            'clear'
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+        end
 
-      it "invokes cloud_object_store_button_operation" do
-        expect(controller).to receive(:cloud_object_store_button_operation).with(
-          CloudObjectStoreContainer,
-          'clear'
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-      end
+        it "invokes process_objects" do
+          controller.params[:id] = container1.id
+          expect(controller).to receive(:process_objects).with(
+            [container1.id],
+            'cloud_object_store_container_clear',
+            'Clear'
+          )
+          controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'clear')
+        end
 
-      it "invokes process_objects" do
-        controller.params[:id] = container.id
-        expect(controller).to receive(:process_objects).with(
-          [container.id],
-          'cloud_object_store_container_clear',
-          'Clear'
-        )
-        controller.send(:cloud_object_store_button_operation, CloudObjectStoreContainer, 'clear')
-      end
+        it "invokes process_tasks on container class" do
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id],
+            :task   => 'cloud_object_store_container_clear',
+            :userid => anything
+          )
+          controller.send(:process_objects, [container1.id], 'cloud_object_store_container_clear', 'clear')
+        end
 
-      it "invokes process_tasks on container class" do
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container.id],
-          :task   => 'cloud_object_store_container_clear',
-          :userid => anything
-        )
-        controller.send(:process_objects, [container.id], 'cloud_object_store_container_clear', 'clear')
-      end
+        it "invokes process_tasks overall" do
+          controller.params[:id] = container1.id
+          expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
+            :ids    => [container1.id],
+            :task   => 'cloud_object_store_container_clear',
+            :userid => anything
+          )
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+        end
 
-      it "invokes process_tasks overall" do
-        controller.params[:id] = container.id
-        expect(CloudObjectStoreContainer).to receive(:process_tasks).with(
-          :ids    => [container.id],
-          :task   => 'cloud_object_store_container_clear',
-          :userid => anything
-        )
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-      end
+        it "flash - container no longer exists" do
+          expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
+        end
 
-      it "flash - container no longer exists" do
-        expect { controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear") }.to raise_error("Can't access records without an id")
-      end
-
-      it "flash - task not supported" do
-        controller.params[:id] = container.id
-        allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
-        controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
-        expect(assigns(:flash_array).first[:message]).to include(
-          "Clear does not apply to this item"
-        )
+        it "flash - task not supported" do
+          controller.params[:id] = container1.id
+          allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(false)
+          controller.send(:process_cloud_object_storage_buttons, "cloud_object_store_container_clear")
+          expect(assigns(:flash_array).first[:message]).to include(
+            "Clear does not apply to this item"
+          )
+        end
       end
     end
   end
@@ -672,28 +623,31 @@ describe ApplicationController do
   end
 
   context "Verify the reconfigurable flag for VMs" do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    before { controller.params = {:id => vm.id} }
+
+    subject { controller.send(:get_record, "vm") }
+
     it "Reconfigure VM action should be allowed only for a VM marked as reconfigurable" do
-      vm = FactoryBot.create(:vm_vmware)
-      controller.params = {:id => vm.id}
-      record = controller.send(:get_record, "vm")
-      action = :vm_reconfigure
       expect(controller).to receive(:render)
-      controller.send(action)
-      unless record.reconfigurable?
+      controller.send(:vm_reconfigure)
+      unless subject.reconfigurable?
         expect(controller.send(:flash_errors?)).to be_truthy
         expect(assigns(:flash_array).first[:message]).to include("does not apply")
       end
     end
-    it "Reconfigure VM action should not be allowed for a VM marked as reconfigurable" do
-      vm = FactoryBot.create(:vm_microsoft)
-      controller.params = {:id => vm.id}
-      record = controller.send(:get_record, "vm")
-      action = :vm_reconfigure
-      expect(controller).to receive(:render)
-      controller.send(action)
-      unless record.reconfigurable?
-        expect(controller.send(:flash_errors?)).to be_truthy
-        expect(assigns(:flash_array).first[:message]).to include("does not apply")
+
+    context 'Microsoft provider' do
+      let(:vm) { FactoryBot.create(:vm_microsoft) }
+
+      it "Reconfigure VM action should not be allowed for a VM marked as reconfigurable" do
+        expect(controller).to receive(:render)
+        controller.send(:vm_reconfigure)
+        unless subject.reconfigurable?
+          expect(controller.send(:flash_errors?)).to be_truthy
+          expect(assigns(:flash_array).first[:message]).to include("does not apply")
+        end
       end
     end
   end
@@ -703,6 +657,7 @@ describe ApplicationController do
 
     context "when a single is vm selected" do
       let(:supports_reconfigure_disks) { true }
+
       before do
         allow(vm).to receive(:supports_reconfigure_disks?).and_return(supports_reconfigure_disks)
         controller.instance_variable_set(:@reconfigitems, [vm])
@@ -713,8 +668,10 @@ describe ApplicationController do
           expect(controller.send(:supports_reconfigure_disks?)).to be_truthy
         end
       end
+
       context "when vm does not supports reconfiguring disks" do
         let(:supports_reconfigure_disks) { false }
+
         it "disables reconfigure disks" do
           expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
         end
@@ -723,6 +680,7 @@ describe ApplicationController do
 
     context "when multiple vms selected" do
       let(:vm1) { FactoryBot.create(:vm_redhat) }
+
       it "disables reconfigure disks" do
         controller.instance_variable_set(:@reconfigitems, [vm, vm1])
         expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
@@ -754,14 +712,14 @@ describe ApplicationController do
   end
 
   describe "#process_elements" do
+    let(:pxe) { FactoryBot.create(:pxe_server) }
+
     it "shows passed in display name in flash message" do
-      pxe = FactoryBot.create(:pxe_server)
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue', 'Refresh Relationships')
       expect(assigns(:flash_array).first[:message]).to include("Refresh Relationships successfully initiated")
     end
 
     it "shows task name in flash message when display name is not passed in" do
-      pxe = FactoryBot.create(:pxe_server)
       controller.send(:process_elements, [pxe.id], PxeServer, 'synchronize_advertised_images_queue')
       expect(assigns(:flash_array).first[:message])
         .to include("synchronize_advertised_images_queue successfully initiated")
@@ -783,11 +741,12 @@ describe ApplicationController do
   end
 
   describe "#get_record" do
+    let(:host) { FactoryBot.create(:host) }
+
+    before { controller.params = {:id => host.id} }
+
     it "use passed in db to set class for identify_record call" do
-      host = FactoryBot.create(:host)
-      controller.params = {:id => host.id}
-      record = controller.send(:get_record, "host")
-      expect(record).to be_a_kind_of(Host)
+      expect(controller.send(:get_record, "host")).to be_a_kind_of(Host)
     end
   end
 
@@ -877,14 +836,15 @@ describe HostController do
   end
 
   describe "#process_objects" do
-    it "returns array of object ids " do
-      vm1 = FactoryBot.create(:vm_vmware)
-      vm2 = FactoryBot.create(:vm_vmware)
-      vm3 = FactoryBot.create(:vm_vmware)
-      vms = [vm1.id, vm2.id, vm3.id]
-      controller.send(:process_objects, vms, 'refresh_ems', 'Refresh Provider')
-      flash_messages = assigns(:flash_array)
-      expect(flash_messages.first[:message]).to include "Refresh Provider initiated for #{vms.length} VMs"
+    let(:vm1) { FactoryBot.create(:vm_vmware) }
+    let(:vm2) { FactoryBot.create(:vm_vmware) }
+    let(:vm3) { FactoryBot.create(:vm_vmware) }
+
+    before { controller.params = {:display => 'vms'} }
+
+    it "returns array of object ids" do
+      controller.send(:process_objects, [vm1.id, vm2.id, vm3.id], 'refresh_ems', 'Refresh Provider')
+      expect(controller.instance_variable_get(:@flash_array).first[:message]).to include "Refresh Provider initiated for 3 VMs"
     end
   end
 
@@ -921,7 +881,7 @@ describe HostController do
     it "when the vm_or_template supports scan, returns false" do
       vm1 =  FactoryBot.create(:vm_microsoft)
       vm2 =  FactoryBot.create(:vm_vmware)
-      controller.params = {:miq_grid_checks => "#{vm1.id}, #{vm2.id}"}
+      controller.params = {:miq_grid_checks => "#{vm1.id}, #{vm2.id}", :display => 'vms'}
       controller.send(:generic_button_operation,
                       'scan',
                       "Smartstate Analysis",
@@ -934,7 +894,7 @@ describe HostController do
       vm = FactoryBot.create(:vm_vmware,
                               :ext_management_system => FactoryBot.create(:ems_openstack_infra),
                               :storage               => FactoryBot.create(:storage))
-      controller.params = {:miq_grid_checks => vm.id.to_s}
+      controller.params = {:miq_grid_checks => vm.id.to_s, :display => 'vms'}
       process_proc = controller.send(:vm_button_action)
       expect(process_proc).to receive(:call)
       controller.send(:generic_button_operation,
@@ -958,7 +918,7 @@ describe ServiceController do
       allow(user).to receive(:role_allows?).and_return(true)
     end
 
-    it "should continue to retire a service and does not render flash message 'xxx does not apply xxx' " do
+    it "should continue to retire a service and does not render flash message 'xxx does not apply xxx'" do
       service = FactoryBot.create(:service)
       template = FactoryBot.create(:template,
                                     :ext_management_system => FactoryBot.create(:ems_openstack_infra),
@@ -1094,6 +1054,7 @@ end
 describe EmsCloudController do
   describe "#delete_flavor" do
     let!(:flavor) { FactoryBot.create(:flavor) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       stub_user(:features => :all)
@@ -1114,9 +1075,7 @@ end
 
 describe VmInfraController do
   describe '#testable_action' do
-    before do
-      controller.params = {:controller => 'vm_infra'}
-    end
+    before { controller.params = {:controller => 'vm_infra'} }
 
     context 'power operations and vm infra controller' do
       %w(reboot_guest reset shutdown_guest start stop suspend).each do |op|

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -5,7 +5,7 @@ describe CloudObjectStoreContainerController do
     allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
   end
 
-  context "#tags_edit" do
+  describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
     before do
       allow(@container).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
@@ -135,10 +135,8 @@ describe CloudObjectStoreContainerController do
     end
   end
 
-  describe "create object store container" do
-    before do
-      stub_user(:features => :all)
-    end
+  context "create object store container" do
+    before { stub_user(:features => :all) }
 
     shared_examples "queue create container task" do
       let(:task_options) do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -1,7 +1,8 @@
 describe EmsInfraController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryBot.build(:zone) }
-  context "#button" do
+
+  describe "#button" do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
@@ -89,6 +90,40 @@ describe EmsInfraController do
       expect(controller).to receive(:vm_transform_mass)
       post :button, :params => {:pressed => "vm_transform_mass", :id => ems_infra.id, :format => :js}
       expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+
+    context 'operations on Clusters, Orchestration Stacks, Datastores of selected Provider' do
+      before do
+        controller.params = {:pressed => pressed}
+        controller.instance_variable_set(:@display, display)
+      end
+
+      context 'SSA on selected Clusters from a nested list' do
+        let(:pressed) { 'ems_cluster_scan' }
+        let(:display) { 'ems_clusters' }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(EmsCluster)
+        end
+      end
+
+      context 'retirement for Orchestration Stacks displayed in a nested list' do
+        let(:pressed) { 'orchestration_stack_retire_now' }
+        let(:display) { 'orchestration_stacks' }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(OrchestrationStack)
+        end
+      end
+
+      context 'SSA on selected Datastores from a nested list' do
+        let(:pressed) { 'storage_scan' }
+        let(:display) { 'storages' }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(Storage)
+        end
+      end
     end
   end
 
@@ -404,11 +439,12 @@ describe EmsInfraController do
     it { expect(response.status).to eq(200) }
   end
 
-  describe "breadcrumbs path on a 'show' page of an Infrastructure Provider accessed from Dashboard maintab" do
+  context "breadcrumbs path on a 'show' page of an Infrastructure Provider accessed from Dashboard maintab" do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
     end
+
     context "when previous breadcrumbs path contained 'Cloud Providers'" do
       it "shows 'Infrastructure Providers -> (Summary)' breadcrumb path" do
         ems = FactoryBot.create(:ems_vmware)
@@ -421,9 +457,8 @@ describe EmsInfraController do
   end
 
   describe "#build_credentials" do
-    before do
-      @ems = FactoryBot.create(:ems_openstack_infra)
-    end
+    before { @ems = FactoryBot.create(:ems_openstack_infra) }
+
     context "#build_credentials only contains credentials that it supports and has a username for in params" do
       let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
       let(:amqp_creds)    { {:userid => "amqp_userid",    :password => "amqp_password"} }
@@ -463,10 +498,8 @@ describe EmsInfraController do
     end
   end
 
-  describe "SCVMM - create, update, validate, cancel" do
-    before do
-      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
-    end
+  context "SCVMM - create, update, validate, cancel" do
+    before { login_as FactoryBot.create(:user, :features => %w[ems_infra_new ems_infra_edit]) }
 
     render_views
 
@@ -553,10 +586,8 @@ describe EmsInfraController do
     end
   end
 
-  describe "Openstack - create, update" do
-    before do
-      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
-    end
+  context "Openstack - create, update" do
+    before { login_as FactoryBot.create(:user, :features => %w[ems_infra_new ems_infra_edit]) }
 
     render_views
 
@@ -634,7 +665,7 @@ describe EmsInfraController do
     end
   end
 
-  describe "Redhat - create, update" do
+  context "Redhat - create, update" do
     before do
       login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
@@ -737,10 +768,8 @@ describe EmsInfraController do
     end
   end
 
-  describe "Kubevirt - update" do
-    before do
-      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
-    end
+  context "Kubevirt - update" do
+    before { login_as FactoryBot.create(:user, :features => %w[ems_infra_new ems_infra_edit]) }
 
     render_views
 
@@ -812,10 +841,8 @@ describe EmsInfraController do
     end
   end
 
-  describe "VMWare - create, update" do
-    before do
-      login_as FactoryBot.create(:user, :features => %w(ems_infra_new ems_infra_edit))
-    end
+  context "VMWare - create, update" do
+    before { login_as FactoryBot.create(:user, :features => %w[ems_infra_new ems_infra_edit]) }
 
     render_views
 

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -40,4 +40,17 @@ describe EmsStorageController do
       expect(assigns(:ems).id).to eq(ems_storage.id)
     end
   end
+
+  describe '#button' do
+    context 'tagging Cloud Object Store Container' do
+      before do
+        controller.params = {:pressed => 'cloud_object_store_container_tag'}
+        controller.instance_variable_set(:@display, 'cloud_object_store_containers')
+      end
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(CloudObjectStoreContainer)
+      end
+    end
+  end
 end

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -126,6 +126,10 @@ describe HostController do
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
+    it 'returns proper record class' do
+      expect(controller.send(:record_class)).to eq(Host)
+    end
+
     context 'provisioning VMS displayed through details page of a Host' do
       before do
         allow(controller).to receive(:process_vm_buttons)
@@ -140,6 +144,32 @@ describe HostController do
         controller.send(:prov_redirect)
         expect(controller).to receive(:render_or_redirect_partial).with('vm')
         controller.send(:button)
+      end
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(VmOrTemplate)
+      end
+    end
+
+    context 'SSA on Templates displayed through details page of a Host' do
+      before do
+        controller.params = {:pressed => 'miq_template_scan'}
+        controller.instance_variable_set(:@display, 'miq_templates')
+      end
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(VmOrTemplate)
+      end
+    end
+
+    context 'SSA on Datastores displayed through details page of a Host' do
+      before do
+        controller.params = {:pressed => 'storage_scan'}
+        controller.instance_variable_set(:@display, 'storages')
+      end
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(Storage)
       end
     end
   end

--- a/spec/controllers/miq_template_controller_spec.rb
+++ b/spec/controllers/miq_template_controller_spec.rb
@@ -1,0 +1,5 @@
+describe MiqTemplateController do
+  it 'returns proper record class' do
+    expect(controller.send(:record_class)).to eq(MiqTemplate)
+  end
+end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -1,9 +1,7 @@
 describe OrchestrationStackController do
   let!(:user) { stub_user(:features => :all) }
 
-  before do
-    EvmSpecHelper.create_guid_miq_server_zone
-  end
+  before { EvmSpecHelper.create_guid_miq_server_zone }
 
   render_views
 
@@ -227,6 +225,18 @@ describe OrchestrationStackController do
         expect(controller).to receive(:render).at_least(:once)
         post :button, :params => {:id => record.id, :pressed => "orchestration_stack_retire_now"}
         expect(controller.send(:flash_errors?)).not_to be_truthy
+      end
+    end
+
+    it 'returns proper record class' do
+      expect(controller.send(:record_class)).to eq(OrchestrationStack)
+    end
+
+    context 'Instances displayed through Relationships of Orchestration Stack' do
+      before { controller.params = {:display => 'instances'} }
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(VmOrTemplate)
       end
     end
   end

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -1,8 +1,6 @@
 describe ResourcePoolController do
-  context "#button" do
-    before do
-      controller.instance_variable_set(:@display, "vms")
-    end
+  describe "#button" do
+    before { controller.instance_variable_set(:@display, "vms") }
 
     it "when VM Right Size Recommendations is pressed" do
       controller.params = {:pressed => "vm_right_size"}
@@ -54,6 +52,20 @@ describe ResourcePoolController do
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    it 'returns proper record class' do
+      expect(controller.send(:record_class)).to eq(ResourcePool)
+    end
+
+    context 'VMs displayed through Relationships of a Resource Pool' do
+      %w[all_vms vms].each do |display|
+        before { controller.params = {:display => display} }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(VmOrTemplate)
+        end
+      end
+    end
   end
 
   describe "#show" do
@@ -76,6 +88,7 @@ describe ResourcePoolController do
 
     context "Direct VMs" do
       let(:url_params) { { :display => "vms" } }
+
       it "renders" do
         bypass_rescue
         expect(subject).to have_http_status(200)
@@ -84,6 +97,7 @@ describe ResourcePoolController do
 
     context "All VMs" do
       let(:url_params) { { :display => "all_vms" } }
+
       it "renders" do
         bypass_rescue
         expect(subject).to have_http_status(200)
@@ -92,6 +106,7 @@ describe ResourcePoolController do
 
     context "Nested Resource Pools" do
       let(:url_params) { { :display => "resource_pools"} }
+
       it "renders" do
         bypass_rescue
         expect(subject).to have_http_status(200)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -1,7 +1,5 @@
 describe ServiceController do
-  before do
-    stub_user(:features => :all)
-  end
+  before { stub_user(:features => :all) }
 
   let(:go_definition) do
     FactoryBot.create(:generic_object_definition, :properties => {:associations => {"vms" => "Vm", "services" => "Service"}})
@@ -111,10 +109,8 @@ describe ServiceController do
     end
   end
 
-  describe 'x_button' do
-    before do
-      ApplicationController.handle_exceptions = true
-    end
+  describe '#x_button' do
+    before { ApplicationController.handle_exceptions = true }
 
     describe 'corresponding methods are called for allowed actions' do
       ServiceController::SERVICE_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
@@ -236,6 +232,10 @@ describe ServiceController do
         expect(response.status).to eq(200)
         expect(response.body).to include('service/tagging_edit')
       end
+
+      it 'returns proper record class' do
+        expect(controller.send(:record_class)).to eq(Service)
+      end
     end
   end
 
@@ -340,9 +340,8 @@ describe ServiceController do
 
   context 'displaying a list of All Services' do
     describe '#tree_select' do
-      before do
-        allow(controller).to receive(:data_for_breadcrumbs).and_return([{:title => "title", :action => "action", :key => "key"}])
-      end
+      before { allow(controller).to receive(:data_for_breadcrumbs).and_return([{:title => "title", :action => "action", :key => "key"}]) }
+
       render_views
 
       let(:service_search) { FactoryBot.create(:miq_search, :description => 'a', :db => 'Service') }
@@ -396,9 +395,7 @@ describe ServiceController do
         context 'searching text' do
           let(:search) { "Service" }
 
-          before do
-            controller.instance_variable_set(:@search_text, search)
-          end
+          before { controller.instance_variable_set(:@search_text, search) }
 
           it 'updates right cell text properly' do
             controller.send(:get_node_info, "root")
@@ -446,7 +443,7 @@ describe ServiceController do
       end
     end
 
-    describe "helpers" do
+    context "helpers" do
       describe "generic_objects_list?" do
         it "returns true when user is in generic_objects section" do
           get :show, :params => { :id => service_with_go.id, :display => 'generic_objects'}

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -102,6 +102,20 @@ describe StorageController do
         expect(flash_messages.first[:level]).to eq(:success)
       end
     end
+
+    it 'returns proper record class' do
+      expect(controller.send(:record_class)).to eq(Storage)
+    end
+
+    context 'nested list of VMs' do
+      %w[all_vms vms].each do |display|
+        before { controller.params = {:display => display} }
+
+        it 'returns proper record class' do
+          expect(controller.send(:record_class)).to eq(VmOrTemplate)
+        end
+      end
+    end
   end
 
   context 'render_views' do

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -408,6 +408,17 @@ describe VmOrTemplateController do
     end
   end
 
+  describe '#show_timeline' do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    before { controller.params = {:id => vm.id} }
+
+    it 'gets proper record class and sets @record' do
+      controller.send(:show_timeline)
+      expect(controller.instance_variable_get(:@record)).to eq(vm)
+    end
+  end
+
   include_examples '#download_summary_pdf', :vm_cloud
   include_examples '#download_summary_pdf', :vm_infra
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/5924

We want to get rid of going through so many cases in `get_rec_cls` which is not very efficient. This PR addresses the solution. I've created a new method `record_class` which returns `VmOrTemplate` by default. No need to define this method in each controller.
I've also added some more special cases in some controllers in `record_class` which were missing in the original `get_rec_cls` method.

**Note:**
The following controllers need just the default `record_class` method:
- auth_key_pair_cloud
- availability_zone
- cloud_tenant
- cloud_volume
- ems_cloud
- flavor
- host_aggregate
- vm_cloud 
- vm_infra
- vm_or_template

Note2:
You will probably not be able to test some actions, scenarios because of various issues, for example:
https://github.com/ManageIQ/manageiq-ui-classic/issues/6338, https://github.com/ManageIQ/manageiq-ui-classic/issues/6309, https://github.com/ManageIQ/manageiq-ui-classic/issues/6241, ...

---

TODO:
- ~~make `record_class` methods private~~
- ~~call `super` in controllers instead of `VmOrTemplate`~~
- ~~remove unnecessary `record_class` (same as default) from some controllers~~
- ~~fix failing existing specs~~
- ~~check the remaining controllers~~
- ~~add new specs~~
