### PR TITLE
Fix ArgumentError with set_custom_button_dialog_presenter

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -293,7 +293,7 @@ class InfraNetworkingController < ApplicationController
     end
 
     if action_type == "dialog_form_button_pressed"
-      presenter = set_custom_button_dialog_presenter
+      presenter = set_custom_button_dialog_presenter(options)
       render :json => presenter.for_render
       return
     end


### PR DESCRIPTION
This BZ didn't have a 'needinfo' on it for me so it kinda slipped through the cracks until I was directly notified by Dennis. This simple change should at least get past the `ArgumentError` that the BZ reports, but I currently don't have a full stable environment to test if the options sent in would be correct or not for actually displaying the dialog. @himdel Can you take a look please?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685555

~@miq-bot add_reviewer @himdel @h-kataria~ 
@miq-bot assign @h-kataria 
@miq-bot add_label bug, ivanchuk/yes