### PR TITLE
Sort vlans in reconfigure network adapters

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -227,7 +227,7 @@ module Mixins
           Rbac.filtered(Lan.where("switch_id IN (?)", switch_ids)).each do |lan|
             vlan_options << lan.name
           end
-          vlan_options
+          vlan_options.sort
         end
 
         def get_iso_options(vm)


### PR DESCRIPTION
When I add or edit a vlan in Reconfigure Network Adapter, the results are unorganized. I suggest to sort these vlans alphabetically for clarity.