### PR TITLE
Firmware toolbar - don't use arrow functions in non-compiled JS

### DIFF
--- a/app/helpers/application_helper/toolbar/firmware_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registries_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistriesCenter < ApplicationHelper::
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         N_('Refresh'),
-        :data => { 'function' => '() => window.location.reload()' }
+        :data => { 'function' => 'window.location.reload' }
       ),
     ]
   )

--- a/app/helpers/application_helper/toolbar/firmware_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registries_center.rb
@@ -7,7 +7,8 @@ class ApplicationHelper::Toolbar::FirmwareRegistriesCenter < ApplicationHelper::
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         N_('Refresh'),
-        :data => { 'function' => 'window.location.reload' }
+        # needs the function because reload can't be called with different this
+        :data => { 'function' => 'function() { window.location.reload(); }' }
       ),
     ]
   )

--- a/app/helpers/application_helper/toolbar/firmware_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registry_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistryCenter < ApplicationHelper::To
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         N_('Refresh'),
-        :data => { 'function' => '() => window.location.reload()' }
+        :data => { 'function' => 'window.location.reload' }
       )
     ]
   )

--- a/app/helpers/application_helper/toolbar/firmware_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registry_center.rb
@@ -7,7 +7,8 @@ class ApplicationHelper::Toolbar::FirmwareRegistryCenter < ApplicationHelper::To
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         N_('Refresh'),
-        :data => { 'function' => 'window.location.reload' }
+        # needs the function because reload can't be called with different this
+        :data => { 'function' => 'function() { window.location.reload(); }' }
       )
     ]
   )


### PR DESCRIPTION
JS generated by ruby does not get compiled by webpack,
so toolbars using an arrow function will only work in browsers supporting arrow functions.

Introduced in #5929 , adding ivanchuk/yes.
Cc @miha-plesko 