### PR TITLE
Change toolbar delete buttons for Button and Button Group to use generic code

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -70,8 +70,8 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
       .catch(miqService.handleFailure);
   }
 
-  function postAction() {
-    var entityName = toolbar.entityName;
+  function postAction(response) {
+    var entityName = response.name;
     var saveMsg = sprintf(__('%s: "%s" was successfully deleted'), toolbar.entity, entityName);
     if (toolbar.redirectUrl) {
       miqService.redirectBack(saveMsg, 'success', toolbar.redirectUrl);

--- a/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition-toolbar.js
@@ -46,10 +46,6 @@ function genericObjectDefinitionToolbarController(API, miqService, $window) {
       });
     } else if (toolbar.action === 'delete' && currentRecordId) {
       deleteWithAPI('/api/generic_object_definitions/', currentRecordId);
-    } else if (toolbar.action === 'delete_custom_button_set' && currentRecordId) {
-      deleteWithAPI('/api/custom_button_sets/', currentRecordId);
-    } else if (toolbar.action === 'delete_custom_button' && currentRecordId) {
-      deleteWithAPI('/api/custom_buttons/', currentRecordId);
     }
   }
 

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
-  def data
+  def self.data(_record)
     nil
   end
 

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -14,6 +14,10 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
+  def data
+    nil
+  end
+
   def role_allows_feature?
     # for select buttons RBAC is checked only for nested buttons
     return true if self[:type] == :buttonSelect

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -14,8 +14,8 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
-  def self.data(_record)
-    nil
+  def data(data)
+    data
   end
 
   def role_allows_feature?

--- a/app/helpers/application_helper/button/generic_object_definition_button_button_delete.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_button_button_delete.rb
@@ -1,9 +1,5 @@
-class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonDelete < ApplicationHelper::Button::Basic
   needs :@record
-
-  def disabled?
-    !@record.custom_buttons.count.zero?
-  end
 
   def data(_data)
     {
@@ -12,10 +8,10 @@ class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete 
         :type       => 'delete',
         :controller => 'toolbarActions',
         :payload    => {
-          :entity       => "custom_button_sets",
+          :entity       => "custom_buttons",
           :redirect_url => "/generic_object_definition/",
           :name         => @record.name,
-          :labels       => { :single => _("Button Group") }
+          :labels       => { :single => _("Button") }
         }
       }
     }

--- a/app/helpers/application_helper/button/generic_object_definition_button_button_group_delete.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_button_button_group_delete.rb
@@ -5,18 +5,19 @@ class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete 
     @record.kind_of?(CustomButtonSet) && !@record.custom_buttons.count.zero?
   end
 
-  def data
-    {'function'      => 'sendDataWithRx',
-     'function-data' => {
+  def self.data(record)
+    {
+      'function'      => 'sendDataWithRx',
+     'function-data'  => {
        :type       => 'delete',
        :controller => 'toolbarActions',
-       :url        => "show_list",
        :payload    => {
-         :entity       => @record.class.model_name.plural,
+         :entity       => record.class.model_name.plural,
          :redirect_url => "/generic_object_definition/",
-         :name         => @record.name,
-         :labels       => { :single => @record.class.name }
+         :name         => record.name,
+         :labels       => { :single => record.class.name }
        }
-     }.to_json}
+     }
+    }
   end
 end

--- a/app/helpers/application_helper/button/generic_object_definition_button_button_group_delete.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_button_button_group_delete.rb
@@ -1,5 +1,22 @@
 class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete < ApplicationHelper::Button::Basic
+  needs :@record
+
   def disabled?
-    !@record.custom_buttons.count.zero?
+    @record.kind_of?(CustomButtonSet) && !@record.custom_buttons.count.zero?
+  end
+
+  def data
+    {'function'      => 'sendDataWithRx',
+     'function-data' => {
+       :type       => 'delete',
+       :controller => 'toolbarActions',
+       :url        => "show_list",
+       :payload    => {
+         :entity       => @record.class.model_name.plural,
+         :redirect_url => "/generic_object_definition/",
+         :name         => @record.name,
+         :labels       => { :single => @record.class.name }
+       }
+     }.to_json}
   end
 end

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
@@ -12,12 +12,11 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonCenter < Applicat
           :url => 'custom_button_edit',
         ),
         button(
-          :ab_button_delete,
+          :custom_button_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Button from Inventory'),
-          :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete_custom_button", "controller": "genericObjectDefinitionToolbarController", "entity": "Button"}'},
+          N_('Remove this Custom Button from Inventory'),
           :confirm => N_("Warning: This Button will be permanently removed!"),
+          :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete
         )
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
@@ -16,7 +16,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonCenter < Applicat
           'pficon pficon-delete fa-lg',
           N_('Remove this Custom Button from Inventory'),
           :confirm => N_("Warning: This Button will be permanently removed!"),
-          :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete
+          :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonDelete
         )
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
@@ -18,13 +18,11 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonGroupCenter < App
           :url => 'custom_button_new',
         ),
         button(
-          :ab_button_delete,
+          :custom_button_set_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Button Group from Inventory'),
-          :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete_custom_button_set", "controller": "genericObjectDefinitionToolbarController", "entity": "Button Group"}'},
+          N_('Remove this Custom Button Group from Inventory'),
+          :confirm => N_("Warning: This Custom Button Group will be permanently removed!"),
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete,
-          :confirm => N_("Warning: This Button Group will be permanently removed!"),
         ),
       ]
     )

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -112,7 +112,7 @@ class ApplicationHelper::ToolbarBuilder
   def apply_common_props(button, input)
     button.update(
       :color        => input[:color],
-      :data         => input[:data] || button.data,
+      :data         => input[:data] || (input[:klass].present? ? input[:klass].data(@record) : nil),
       :hidden       => button[:hidden] || !!input[:hidden],
       :icon         => input[:icon],
       :name         => button[:id],

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -112,7 +112,7 @@ class ApplicationHelper::ToolbarBuilder
   def apply_common_props(button, input)
     button.update(
       :color        => input[:color],
-      :data         => input[:data] || (input[:klass].present? ? input[:klass].data(@record) : nil),
+      :data         => button.data(input[:data]),
       :hidden       => button[:hidden] || !!input[:hidden],
       :icon         => input[:icon],
       :name         => button[:id],

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -112,7 +112,7 @@ class ApplicationHelper::ToolbarBuilder
   def apply_common_props(button, input)
     button.update(
       :color        => input[:color],
-      :data         => input[:data],
+      :data         => input[:data] || button.data,
       :hidden       => button[:hidden] || !!input[:hidden],
       :icon         => input[:icon],
       :name         => button[:id],

--- a/app/javascript/toolbar-actions/delete.js
+++ b/app/javascript/toolbar-actions/delete.js
@@ -23,12 +23,17 @@ export function generateMessages(results) {
   }, { false: 0, true: 0 });
 }
 
-export function APIDelete(entity, resources, labels) {
+export function APIDelete(entity, resources, labels = { single: '', multiple: '' }, redirectUrl, name) {
   API.post(`/api/${entity}`, {
     action: 'delete',
     resources,
   }).then((data) => {
-    showMessage(generateMessages(data.results), labels);
+    if (redirectUrl) {
+      miqFlashLater({ message: sprintf(__('%s: "%s" was successfully deleted'), labels.single, name) });
+      window.location.href = redirectUrl;
+    } else {
+      showMessage(generateMessages(data.results), labels);
+    };
     return data;
   });
 }
@@ -41,6 +46,6 @@ export function onDelete(data, resources) {
   if (data.customAction) {
     customActionDelete(data, resources);
   } else {
-    APIDelete(data.entity, resources, data.labels);
+    APIDelete(data.entity, resources, data.labels, data.redirect_url, data.name);
   }
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753388

Go to Automation -> Automate -> Generic Objects - > delete a custom button(with or without Custom Button Group it shouldn't matter)

Actual result:
There's an error popup and message for a sec.  See Before pic.

Expected result:
No error message/popup. See After pic.

According to the BZ it happens in 70%. 

This fix should work for all possible delete actions on Generic Object Definition page. 

Before:
<img width="1442" alt="Screenshot 2019-09-24 at 14 58 14" src="https://user-images.githubusercontent.com/9210860/65513594-cbce2680-dedb-11e9-85bd-32306e8c586e.png">
After:
![image](https://user-images.githubusercontent.com/9210860/65513630-e0122380-dedb-11e9-99f9-705fa3338a98.png)

@miq-bot add_label bug, generic objects, ivanchuk/yes, changelog/no, wip

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/6289