### PR TITLE
Fix breadcrumbs on service/generic_objects

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -524,11 +524,20 @@ class ServiceController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Services")},
-        {:title => _("My services")},
+        {:title => _("My services"), :url => (url_for(:action => 'explorer', :controller => controller_name) if generic_objects_list?)},
       ],
-      :record_info => @service,
+      :record_info => (hide_record_info? ? {} : @service),
       :ancestry    => Service,
+      :not_tree    => generic_objects_list?,
     }
+  end
+
+  def generic_objects_list?
+    params[:display] == 'generic_objects'
+  end
+
+  def hide_record_info?
+    generic_objects_list? && !params[:generic_object_id]
   end
 
   menu_section :svc

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -1,7 +1,6 @@
 describe ServiceController do
   before do
     stub_user(:features => :all)
-    allow(controller).to receive(:data_for_breadcrumbs).and_return({})
   end
 
   let(:go_definition) do
@@ -430,6 +429,50 @@ describe ServiceController do
         controller.send(:get_node_info, 'xx-rsrv')
         expect(controller.session[:edit]).to be_nil
         expect(controller.session[:adv_search]["Service"]).to be_nil
+      end
+    end
+  end
+
+  describe "breadcrumbs" do
+    context "generic_objects" do
+      before { get :show, :params => { :id => service_with_go.id, :display => 'generic_objects'} }
+
+      it "contains url to all services" do
+        expect(controller.data_for_breadcrumbs.find { |x| x[:title] == 'My services' }[:url]).to end_with('service/explorer')
+      end
+
+      it "contains breadcrumbs with item" do
+        expect(controller.data_for_breadcrumbs.find { |x| x[:title].include?(service_with_go.name) }).to be_truthy
+      end
+    end
+
+    describe "helpers" do
+      describe "generic_objects_list?" do
+        it "returns true when user is in generic_objects section" do
+          get :show, :params => { :id => service_with_go.id, :display => 'generic_objects'}
+
+          expect(controller.send(:generic_objects_list?)).to eq(true)
+        end
+
+        it "returns true when user is not in generic_objects section" do
+          get :show, :params => { :id => service_with_go.id }
+
+          expect(controller.send(:generic_objects_list?)).to eq(false)
+        end
+      end
+
+      describe "hide_record_info?" do
+        it "returns false when user is in detail of generic_object" do
+          get :show, :params => { :id => service_with_go.id, :display => 'generic_objects', :generic_object_id => '10101'}
+
+          expect(controller.send(:hide_record_info?)).to eq(false)
+        end
+
+        it "returns true when user is not in detail of generic_object" do
+          get :show, :params => { :id => service_with_go.id, :display => 'generic_objects' }
+
+          expect(controller.send(:hide_record_info?)).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741050

**Steps to Reproduce:**
1. Create a Generic object associated with services
2. Navigate to Service > My Services > Generic [Instance] 
3. breadcrumb will show like `Services > My services > Services> Active Services > service_22`
4. Click on Active Services


**Actual results:**
Link is broken unable to navigate with breadcrumb


**Expected results:**
it should nav to all active services.


**Description**
- Explorer controller behaves like non-explorer when service is going to `generic_objects instances` list

**Before**

![generic_objects_beforeoriginal](https://user-images.githubusercontent.com/32869456/65511359-506a7600-ded7-11e9-842b-169b8fbdab59.gif)

**After**

![generic_objects_after](https://user-images.githubusercontent.com/32869456/65513273-48143a00-dedb-11e9-9b7b-52e20a8e7334.gif)

@miq-bot add_label bug, ivanchuk/yes, breadcrumbs, services