### PR TITLE
Operate with the TreeNode::Node in TreeBuilder#x_build_node

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -198,34 +198,25 @@ class TreeBuilder
     parents = pid.to_s.split('_')
 
     object, ancestry_kids = object_from_ancestry(object)
-    node = x_build_single_node(object, pid)
+    node = TreeNode.new(object, pid, self)
+    override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
 
     # A node should be also expanded in three cases:
     # - it has been already expanded in a previous session
     # - the open_all setting is present in the tree_init_options
     # - the node is set as active_node in the tree state
-    node[:state] ||= {}
-    node[:state][:expanded] ||= Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) ||
-                                !!@options[:open_all]                                              ||
-                                @tree_state.x_tree(@name)[:active_node] == node[:key]
+    node.expanded ||= Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node.key) ||
+                      !!@options[:open_all]                                            ||
+                      @tree_state.x_tree(@name)[:active_node] == node.key
 
-    if ancestry_kids || node[:state][:expanded] || !@options[:lazy]
-      kids = (ancestry_kids || x_get_tree_objects(object, false, parents)).map do |o|
-        x_build_node(o, node[:key])
+    if ancestry_kids || node.expanded || !@options[:lazy]
+      (ancestry_kids || x_get_tree_objects(object, false, parents)).each do |o|
+        node.nodes.push(x_build_node(o, node.key))
       end
-      node[:nodes] = kids unless kids.empty?
-    else
-      if x_get_tree_objects(object, true, parents) > 0
-        node[:lazyLoad] = true # set child flag if children exist
-      end
+    elsif x_get_tree_objects(object, true, parents).positive?
+      node.lazy = true # set child flag if children exist
     end
-    node
-  end
 
-  def x_build_single_node(object, pid)
-    node = TreeNode.new(object, pid, self)
-    override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
-    # FIXME: to_h is for backwards compatibility with hash-trees, it needs to be removed in the future
     node.to_h
   end
 

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -1,14 +1,14 @@
 module TreeNode
   class Node
-    attr_reader :tree
-
-    attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :klass, :selectable, :selected, :tooltip
+    attr_reader :nodes, :tree
     attr_writer :icon, :image
+    attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :lazy, :klass, :selectable, :selected, :tooltip
 
     def initialize(object, parent_id, tree)
       @object = object
       @parent_id = parent_id
       @tree = tree
+      @nodes = []
     end
 
     def text
@@ -57,6 +57,8 @@ module TreeNode
         :class          => [selectable ? nil : 'no-cursor'].push(klass).compact.join(' ').presence, # add no-cursor if not selectable
         :selectable     => selectable,
         :checkable      => checkable ? nil : false,
+        :lazyLoad       => lazy,
+        :nodes          => nodes.presence,
         :state          => {
           :checked  => checked,
           :expanded => expanded,


### PR DESCRIPTION
Added a readable `nodes` attribute to `TreeNode::Node#node` that is able to store the children of a given node. Also implemented the `lazy` attribute that transforms to the `lazyLoad` key when converting to hash. These two attributes allow us to directly modify the `TreeNode::Node` object in ˙TreeBuilder#x_build_node` and to get rid of `TreeBuilder#x_build_single_node`. Also the final conversion to hash can now happen as the very last thing.

@miq-bot add_label ivanchuk/no, trees, refactoring
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @romanblanco 