### PR TITLE
Do not update breadcrumbs when ops/change_tab

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -625,7 +625,7 @@ class OpsController < ApplicationController
     extra_js_commands(presenter)
 
     presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
-    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
+    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs']) unless %w[change_tab].include?(action_name)
 
     render :json => presenter.for_render
   end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -364,8 +364,12 @@ describe OpsController do
         allow(controller).to receive(:check_privileges).and_return(true)
         allow(controller).to receive(:assert_privileges).and_return(true)
         seed_session_trees('ops', :settings_tree, 'root')
-        expect(controller).to receive(:render_to_string).with(any_args).exactly(4).times
+        expect(controller).to receive(:render_to_string).with(any_args).exactly(3).times
         post :change_tab, :params => {:tab_id => tab, :parent_tab_id => 'settings_tags'}
+      end
+
+      it "change_tab does not update breadcrumbs" do
+        expect(JSON.parse(response.body)["updatePartials"]).not_to include(:breadcrumbs)
       end
 
       it "Apply button remains disabled with flash errors" do


### PR DESCRIPTION
**Description**

Breadcrumbs are being generated when changing tabs in ops controller, that is unnecessary and it creates a redundant breadcrumb.

**Before**

![change_tab_before](https://user-images.githubusercontent.com/32869456/66638040-8700fa00-ec14-11e9-8638-dd32471f2421.gif)

**After**

![change_tab_after](https://user-images.githubusercontent.com/32869456/66637956-6042c380-ec14-11e9-9308-8cacd5da2e01.gif)

@miq-bot add_label bug, breadcrumbs