### PR TITLE
Fix tagging for Edit Group and Provisioning screens

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -1000,7 +1000,6 @@ module ApplicationController::MiqRequestMethods
         :singleValue => cat[:single_value],
       }
     end
-
     assignments = Classification.find(vm_tags)
     assigned_tags = assignments.map do |tag|
       {

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1079,7 +1079,6 @@ module OpsController::OpsRbac
       @edit[:new][:lookup]           = (params[:lookup] == "1")   if params[:lookup]
       @edit[:new][:user_pwd]         = params[:password]          if params[:password]
     end
-
     if params[:check]                               # User checked/unchecked a tree node
       if params[:tree_typ] == "tags"                # MyCompany tag checked
         cat_name = Classification.find_by(:id => params[:cat]).name

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -8,13 +8,13 @@ import { http } from '../http_api';
 const params = (type = 'default', state, tag = {}) => ({
   provision: {
     id: "new",
-    ids_checked: [state.tagging.appState.assignedTags.map(t => t.values.map(val => val.id)).flat(), tag.tagValue.id].flat(),
+    ids_checked: [state.tagging.appState.assignedTags.map(t => t.values.map(val => val.id)).flat(), tag.tagValue.id || tag.tagValue[0].id].flat(),
     tree_typ: 'tags'
   },
   default: {
     id: state.tagging.appState.affectedItems[0] || "new",
     cat: tag.tagCategory.id,
-    val: tag.tagValue.id,
+    val: tag.tagValue.id || tag.tagValue[0].id,
     check: 1,
     tree_typ: 'tags'
   }
@@ -22,7 +22,7 @@ const params = (type = 'default', state, tag = {}) => ({
 
 const onDelete = (type = 'default', params = [], deleted_element) => ({
   provision: () => ({...params, check: 0, ids_checked: params.ids_checked.filter(element => element !== deleted_element) }),
-  default: ()   => params,
+  default: ()   => ({...params, check: "0"})
 })[type]
 
 class TaggingWrapper extends React.Component {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "~1.18.0",
     "@data-driven-forms/react-form-renderer": "~1.18.0",
-    "@manageiq/react-ui-components": "~0.11.48",
+    "@manageiq/react-ui-components": "~0.11.51",
     "@manageiq/ui-components": "~1.3.1",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",


### PR DESCRIPTION
Because of changes in https://github.com/ManageIQ/react-ui-components/pull/132 tagging wasn't working properly for Edit Group and Provisioning screens.



Links [Optional]
----------------
https://github.com/ManageIQ/react-ui-components/pull/132
https://github.com/ManageIQ/react-ui-components/pull/152 NEEDED TO BE MERGED FIRST
https://github.com/ManageIQ/manageiq-ui-classic/issues/5946

Steps for Testing/QA [Optional]
-------------------------------

Compute -> Cloud -> Instance -> Lifecycle -> Provision -> Purpose tab
Cog wheel in the right corner -> Access Control -> Groups -> Edit some group
