### PR TITLE
Avoid calling render multiple times for Power operations on Instances of a Key Pair

### DIFF
--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -85,7 +85,7 @@ module Mixins
       elsif @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div
       else
-        render_flash
+        render_flash unless performed?
       end
     end
   end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6234

This PR fixes error while performing Power operations on Instances of a key Pair (see the issue).

In `handle_vm_buttons` method, called in `button` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/generic_button_mixin.rb#L56), `process_vm_buttons` is [called](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/generic_button_mixin.rb#L9). And if we chose _Start_ operation on a selected Instance, `startvms` is [called](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L932), obviously. In this method, `generic_button_operation` is called. If the selected feature/operation is not supported on a chosen record, it may end up [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L613) - by calling `javascript_redirect`. But.. we still continue in the `button` method till [this line](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/generic_button_mixin.rb#L88). Oh no! Should I call `javascript_flash` or `render_flash`?! (DoubleRenderError...) Adding `unless performed?` to `render_flash` fixes this issue perfectly.

**Before:**
![start_before](https://user-images.githubusercontent.com/13417815/65601988-67769a00-dfa3-11e9-83ac-ee0e5d1dad49.png)

**After:**
![start-after](https://user-images.githubusercontent.com/13417815/65601462-6abd5600-dfa2-11e9-8053-2efc68784f7e.png)
