### PR TITLE
Provider validate - don't attempt to directly connect from the UI

### DIFF
--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -80,19 +80,10 @@ module Mixins
         verify_ems.authentication_check(params[:cred_type], :save => false, :database => params[:metrics_database_name])
       end
 
-      def realtime_raw_connect(ems_type)
-        ems_type.raw_connect(*get_task_args(ems_type))
-        true
-      rescue => err
-        [false, err.message]
-      end
-
       def create_ems_button_validate
         @in_a_form = true
         ems_type = model.model_from_emstype(params[:emstype])
-        result, details = if %w[ems_cloud ems_infra].include?(params[:controller]) && session[:selected_roles].try(:include?, 'user_interface')
-                            realtime_raw_connect(ems_type)
-                          elsif %w[ems_cloud ems_infra].include?(params[:controller])
+        result, details = if %w[ems_cloud ems_infra].include?(params[:controller])
                             ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
                           else
                             realtime_authentication_check(ems_type.new)

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -326,10 +326,11 @@ describe EmsCloudController do
         controller.send(:create_ems_button_validate)
       end
 
-      it "does not queue the authentication check if it is a cloud provider with a ui role" do
+      it "does queue the authentication check even if it is a cloud provider with a ui role" do
         session[:selected_roles] = ['user_interface']
 
-        expect(mocked_class).to receive(:raw_connect)
+        expect(mocked_class).not_to receive(:raw_connect)
+        expect(mocked_class).to receive(:validate_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 


### PR DESCRIPTION
validation via the queue was added in https://github.com/ManageIQ/manageiq-ui-classic/issues/1580,
but explicitly left some cases to try connecting directly.

This is not really desirable as the UiWorker is not guaranteed to be able to do that in general.

@miq-bot add_label wip

we only talked about this with @agrare and @gprocunier on gitter [September 24, 2019 8:30 PM](https://gitter.im/ManageIQ/manageiq/ui?at=5d8a7cdda38dae3a63afba5a),
I have not actually tested this with any (or all) providers.