### PR TITLE
React tree view with redux store

### DIFF
--- a/app/javascript/components/tree-view/hierarchical-tree-view.jsx
+++ b/app/javascript/components/tree-view/hierarchical-tree-view.jsx
@@ -1,53 +1,69 @@
 /* eslint camelcase: ["warn", {allow: ["bs_tree", "tree_name", "click_url", "check_url", "allow_reselect"]}] */
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Tree, { ActionTypes } from '@manageiq/react-ui-components/dist/wooden-tree';
+import Tree, {
+  Node,
+  defaultStore,
+  callBack,
+  ActionTypes,
+} from '@manageiq/react-ui-components/dist/wooden-tree';
 
 const convertData = data => Tree.convertHierarchicalTree(Tree.initHierarchicalTree(JSON.parse(data)));
 
 const HierarchicalTreeView = (props) => {
   const {
-    bs_tree, check_url, oncheck, checkboxes, allow_reselect,
+    tree_name,
+    bs_tree,
+    check_url,
+    oncheck,
+    checkboxes,
+    allow_reselect,
+    callBack,
   } = props;
-  const [tree, setTree] = useState(convertData(bs_tree));
 
-  const checked = (node, value) => {
-    const newNode = { ...node, state: { ...node.state, checked: value } };
-    if (oncheck) {
-      ManageIQ.tree.checkUrl = check_url;
-      window[oncheck](newNode);
-    }
-    return newNode;
-  };
+  const storeName = `tree_${tree_name}`;
+  const ConnectedNode = connect((store, ownProps) => ({ ...store[storeName][ownProps.nodeId] }))(Node);
+  const ReduxTree = connect(store => ({ data: { ...store[storeName] } }))(Tree);
 
-  const actionMapper = {
-    [ActionTypes.EXPANDED]: Tree.nodeExpanded,
-    [ActionTypes.CHECKED]: checked,
-    [ActionTypes.DISABLED]: Tree.nodeDisabled,
-    [ActionTypes.SELECTED]: Tree.nodeSelected,
-    [ActionTypes.CHILD_NODES]: Tree.nodeChildren,
-    [ActionTypes.LOADING]: Tree.nodeLoading,
-  };
+  /**
+   * After the component mounts adds a tree specific reducer to the store
+   */
+  useEffect(() => {
+    ManageIQ.redux.addReducer({ [storeName]: defaultStore });
+  }, []);
+
+  /**
+   * Populates the store from the prop by converting the supplied tree to
+   * the correct format and then dispatching it to the store.
+   */
+  useEffect(() => {
+    callBack('', ActionTypes.ADD_NODES, convertData(bs_tree));
+  }, [bs_tree]);
 
   const onDataChange = (commands) => {
-    let NewTree = { ...tree };
     commands.forEach((command) => {
-      NewTree = (command.type === ActionTypes.ADD_NODES)
-        ? Tree.addNodes(NewTree, command.value)
-        : Tree.nodeUpdater(NewTree, actionMapper[command.type](Tree.nodeSelector(NewTree, command.nodeId), command.value));
+      callBack(command.nodeId, command.type, command.value);
+
+      // On checkbox change call the supplied function with the node, if there is one.
+      if (command.type === ActionTypes.CHECKED && oncheck) {
+        const node = Tree.nodeSelector(ManageIQ.redux.store.getState()[storeName], command.nodeId);
+        ManageIQ.tree.checkUrl = check_url;
+        window[oncheck]({ ...node, state: { ...node.state, checked: command.value } });
+      }
     });
-    setTree(NewTree);
   };
 
   return (
-    <Tree
-      data={tree}
+    <ReduxTree
+      class="Tree"
       expandIcon="fa fa-fw fa-angle-right"
       collapseIcon="fa fa-fw fa-angle-down"
       loadingIcon="fa fa-fw fa-spinner fa-pulse"
       checkedIcon="fa fa-fw fa-check-square-o"
       uncheckedIcon="fa fa-fw fa-square-o"
       partiallyCheckedIcon="fa fa-fw fa-check-square"
+      connectedNode={ConnectedNode}
       checkable={checkboxes}
       showCheckbox={checkboxes}
       allowReselect={allow_reselect}
@@ -58,11 +74,13 @@ const HierarchicalTreeView = (props) => {
 };
 
 HierarchicalTreeView.propTypes = {
+  tree_name: PropTypes.string.isRequired,
   bs_tree: PropTypes.string.isRequired,
   checkboxes: PropTypes.bool,
   allow_reselect: PropTypes.bool,
   oncheck: PropTypes.string,
   check_url: PropTypes.string,
+  callBack: PropTypes.func.isRequired,
 };
 
 HierarchicalTreeView.defaultProps = {
@@ -72,4 +90,6 @@ HierarchicalTreeView.defaultProps = {
   check_url: '',
 };
 
-export default HierarchicalTreeView;
+const HierarchicalTreeViewConn = connect(null, { callBack })(HierarchicalTreeView);
+
+export default HierarchicalTreeViewConn;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import '@manageiq/react-ui-components/dist/tagging.css';
 import '@manageiq/react-ui-components/dist/quadicon.css';
+import '@manageiq/react-ui-components/dist/wooden-tree.css';
 import { TagGroup, TableListView, GenericGroup } from '@manageiq/react-ui-components/dist/textual_summary';
 import { TagView } from '@manageiq/react-ui-components/dist/tagging';
 import { Toolbar } from '@manageiq/react-ui-components/dist/toolbar';

--- a/app/javascript/spec/tree-view/tree-view.spec.js
+++ b/app/javascript/spec/tree-view/tree-view.spec.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mount } from '../helpers/mountForm';
+import { HierarchicalTreeView } from '../../components/tree-view';
+
+ManageIQ.redux.addReducer = ManageIQ.redux.store.injectReducers;
+
+describe('Tree View component', () => {
+  const props = {
+    allow_reselect: false,
+    bs_tree: JSON.stringify([
+      {
+        key: 'root',
+        text: 'Providers',
+        tooltip: '',
+        icon: 'pficon pficon-folder-open',
+        hideCheckbox: true,
+        class: 'no-cursor',
+        selectable: false,
+        state: { expanded: true },
+        nodes: [
+          {
+            key: 'e-38',
+            text: 'Amazon',
+            tooltip: 'Ems Cloud: Amazon',
+            image: '/assets/svg/vendor-ec2-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg',
+            selectable: true,
+            state: { checked: false, expanded: false },
+          },
+          {
+            key: 'e-40',
+            text: 'Amazon EBS Storage Manager',
+            tooltip: 'Provider: Amazon EBS Storage Manager',
+            image: '/assets/svg/vendor-ec2_ebs_storage-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg',
+            selectable: true,
+            state: { checked: false, expanded: false },
+          },
+          {
+            key: 'e-39',
+            text: 'Amazon Network Manager',
+            tooltip: 'Provider: Amazon Network Manager',
+            image: '/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg',
+            selectable: true,
+            state: { checked: false, expanded: false },
+          },
+          {
+            key: 'at-19',
+            text: 'Ansible Tower Automation Manager',
+            tooltip: 'Provider: Ansible Tower Automation Manager',
+            image: '/assets/svg/vendor-ansible-53cf0c18065b8e2c8b99cbde9dca3ac9245ec363b700af6e9fd2bc5b743c85a9.svg',
+            selectable: true,
+            state: { checked: false, expanded: false },
+          },
+          {
+            key: 'e-3',
+            text: 'Azure (East US)',
+            tooltip: 'Ems Cloud: Azure (East US)',
+            image: '/assets/svg/vendor-azure-9e2644144afcc98aa84451aee955851b15e6409a916d9054849b3a136a1f4887.svg',
+            selectable: true,
+            state: { checked: true, expanded: false },
+          },
+        ],
+      },
+    ]),
+    checkboxes: true,
+    tree_id: 'object_treebox',
+    tree_name: 'object_tree',
+  };
+
+  it('should mount to the correct redux store', () => {
+    mount(<HierarchicalTreeView {...props} />);
+    expect(ManageIQ.redux.store.getState().tree_object_tree).toBeTruthy();
+  });
+});


### PR DESCRIPTION
React tree view wrapper now uses the redux tree version with redux store. The name of the store is always the name of the rendered tree, so it shouldn't have problems with multiple trees rendered on the same page, as long as they have different names. 

This update also applies fixes on the tree: #6011 #6010 

Depends on: https://github.com/ManageIQ/react-ui-components/pull/153

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @skateman 
@miq-bot add_reviewer @himdel 