### PR TITLE
remove custom styling from svc dialog import/export

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,7 +11,6 @@
  *= require ./container_topology
  *= require ./physical_infra_topology
  *= require ./metrics
- *= require ./service_dialogs
  *= require ./remote_console
  *= require ./piecharts
 */

--- a/app/assets/stylesheets/service_dialogs.css
+++ b/app/assets/stylesheets/service_dialogs.css
@@ -1,6 +1,0 @@
-.service-dialog-export {
-  width: 400px;
-  min-width: 375px;
-  background-color: #fff;
-  border: 1px solid #999999;
-}

--- a/app/views/miq_ae_customization/_dialog_import_export.html.haml
+++ b/app/views/miq_ae_customization/_dialog_import_export.html.haml
@@ -35,17 +35,20 @@
   = form_tag('upload_import_file', :id => 'upload-service-dialogs', :remote => true) do
     .form-group
       .row
-        .col-md-4
-          = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
         .col-md-6
+          = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
+        .col-md-2
           = button_tag(_("Upload"), :id => "upload_service_dialog_import", :class => "btn btn-primary", :action => "submit")
 
   %hr
   %h3
     = _('Export')
-  = form_tag('export_service_dialogs', :method => :get) do
-    = select_tag("service_dialogs[]", options_for_select(@dialog_exports), :class => "service-dialog-export", :multiple => true)
-    = button_tag(_("Export"), :class => "btn btn-primary", :type => "submit")
+  = form_tag('export_service_dialogs', :method => :get, :class => "form-horizontal") do 
+    .form-group
+      .col-md-6
+        = select_tag("service_dialogs[]", options_for_select(@dialog_exports), :class => "form-control", :multiple => true)
+      .col-md-2
+        = button_tag(_("Export"), :class => "btn btn-primary", :type => "submit")
 
 :javascript
   $(function () {


### PR DESCRIPTION
This PR removes the unneeded custom styling  on the service dialog import/export screen

Old
<img width="591" alt="Screen Shot 2019-09-26 at 4 34 17 PM" src="https://user-images.githubusercontent.com/1287144/65725970-e3471400-e081-11e9-9cfe-457842a61641.png">

New
<img width="643" alt="Screen Shot 2019-09-26 at 4 32 54 PM" src="https://user-images.githubusercontent.com/1287144/65726016-0671c380-e082-11e9-9420-cb223dbf97a2.png">

