### PR TITLE
Fixed lost focus on code editor after first state update.

### DIFF
--- a/app/javascript/components/code-editor/index.js
+++ b/app/javascript/components/code-editor/index.js
@@ -29,10 +29,8 @@ const CodeEditor = ({
   ...props
 }) => {
   const [codeMode, setCodeMode] = useState(mode);
-  const [value, setValue] = useState();
   const [editor, setEditor] = useState();
   useEffect(() => {
-    setValue(props.value);
     if (editor) {
       editor.refresh();
     }
@@ -60,7 +58,7 @@ const CodeEditor = ({
         }}
         style={{ height: 'auto' }}
         onBeforeChange={(editor, _data, value) => {
-          setValue(value);
+          onChange(editor, _data, value);
         }}
         onChange={(editor, _data, value) => {
           onChange(editor, _data, value);
@@ -69,7 +67,6 @@ const CodeEditor = ({
           setEditor(editor);
         }}
         {...props}
-        value={value}
       />
     </div>
   );
@@ -86,33 +83,33 @@ CodeEditor.defaultProps = {
   modes: [],
 };
 
+const CodeGroup = ({
+  input: { value, onChange, name },
+  meta: { error },
+  formOptions: _formOptions,
+  label,
+  isRequired,
+  ...props
+}) => (
+  <FormGroup name={name} validationState={error && 'error'}>
+    <ControlLabel>
+      {isRequired ? <RequiredLabel label={label} /> : label }
+    </ControlLabel>
+    <CodeEditor
+      onChange={(_editor, _data, value) => onChange(value)}
+      value={value}
+      hasError={!!error}
+      {...props}
+    />
+    {error && <HelpBlock>{error}</HelpBlock>}
+  </FormGroup>
+);
+
 export const DataDrivenFormCodeEditor = ({
   FieldProvider,
   ...props
 }) => (
-  <FieldProvider {...props}>
-    {({
-      input: { value, onChange, name },
-      meta: { error },
-      formOptions: _formOptions,
-      label,
-      isRequired,
-      ...props
-    }) => (
-      <FormGroup name={name} validationState={error && 'error'}>
-        <ControlLabel>
-          {isRequired ? <RequiredLabel label={label} /> : label }
-        </ControlLabel>
-        <CodeEditor
-          onChange={(_editor, _data, value) => onChange(value)}
-          value={value}
-          hasError={!!error}
-          {...props}
-        />
-        {error && <HelpBlock>{error}</HelpBlock>}
-      </FormGroup>
-    )}
-  </FieldProvider>
+  <FieldProvider {...props} component={CodeGroup} />
 );
 
 export default CodeEditor;


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1754543

The issue here was with passing anonymous function to `FieldProvide`. It did not have any reference to it and was creating new instance of that component instead of updating its props. That caused loosing the focus of the field. By wrapping the children and naming the component the issue is fixed.

I also removed the value from state and let parent component handle it.