### PR TITLE
Adding global filters only possible by (super)admin

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -48,7 +48,7 @@ module ApplicationController::AdvancedSearch
       add_flash(_("Search Name is required"), :error) if params[:button] == 'saveit'
       false
     else
-      s = @edit[@expkey].build_search(@edit[:new_search_name], @edit[:search_type], session[:userid])
+      s = @edit[@expkey].build_search(@edit[:new_search_name], current_user.admin_user? || current_user.super_admin_user? ? @edit[:search_type] : nil, session[:userid])
       s.filter = MiqExpression.new(@edit[:new][@expkey]) # Set the new expression
       if s.save
         add_flash(_("%{model} search \"%{name}\" was saved") %


### PR DESCRIPTION
Our tenants are able to add global filters for VM's by loading a global filter (which is already added by an admin) in the 'advanced search ' tab, then editing and saving it. The fact that other tenants can see these filters obviously shouldn't be possible. I think the adding of global filters should only be able for admin and super admin users. The proposed change might not be the most elegant one, but fixes the described bug.