### PR TITLE
Remove the possibility to chose of quadicon/single quad in GTLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,7 +97,6 @@ class ApplicationController < ActionController::Base
 
   # Default UI settings
   DEFAULT_SETTINGS = {
-    :quadicons => Hash.new(true), # Show quad icons by resource type, true by default
     :views     => { # List view setting, by resource type
       :authkeypaircloud                                                       => "list",
       :availabilityzone                                                       => "list",

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -542,11 +542,6 @@ class ConfigurationController < ApplicationController
     @edit = session[:edit]
     case @tabform
     when "ui_1" # Visual Settings tab
-      view_context.allowed_quadicons.each_key do |key|
-        param = "quadicons_#{key}".to_sym
-        @edit[:new][:quadicons][key] = params[param] == "true" if params[param]
-      end
-
       @edit[:new][:perpage][:grid] = params[:perpage_grid].to_i if params[:perpage_grid]
       @edit[:new][:perpage][:tile] = params[:perpage_tile].to_i if params[:perpage_tile]
       @edit[:new][:perpage][:list] = params[:perpage_list].to_i if params[:perpage_list]

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,31 +1,3 @@
 module ConfigurationHelper
   include_concern 'ConfigurationViewHelper'
-
-  # Model class name comparison method that sorts provider models first
-  def compare_decorator_class(a, b)
-    if a.to_s.starts_with?('ManageIQ::Providers') == b.to_s.starts_with?('ManageIQ::Providers')
-      a.to_s <=> b.to_s
-    elsif a.to_s.starts_with?('ManageIQ::Providers')
-      -1
-    elsif b.to_s.starts_with?('ManageIQ::Providers')
-      1
-    end
-  end
-
-  # Returns with a hash of allowed quadicons for the current user
-  def allowed_quadicons
-    MiqDecorator.descendants # Get all the decorator classes
-                .select { |klass| klass.instance_methods(false).include?(:quadicon) } # Select only the decorators that define a quadicon
-                .sort(&method(:compare_decorator_class))
-                .map do |decorator|
-      # Get the model name by removing Decorator from the class name
-      klass = decorator.to_s.chomp('Decorator')
-      # Retrieve the related root feature node
-      feature = klass.constantize.model_name.singular_route_key.to_sym
-      # Just return nil if the feature is not allowed for the current user
-      next unless role_allows?(:feature => feature, :any => true)
-
-      [klass.demodulize.underscore.to_sym, ui_lookup(:model => klass)]
-    end.compact.to_h
-  end
 end

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -10,15 +10,7 @@
       .col-md-12.col-lg-6
         %fieldset
           %h3
-            = _('Grid/Tile Icons')
-          - allowed_quadicons.each do |key, name|
-            .form-group
-              %label.col-md-3.control-label
-                = _("Show %{title} Quadrants") % {:title => name}
-              .col-md-8
-                = check_box_tag("quadicons_#{key}", true, @edit[:new][:quadicons][key], :data => {:on_text => _('Yes'), :off_text => _('No')})
-              :javascript
-                miqInitBootstrapSwitch("quadicons_#{key}", "#{url}");
+            = _('Grid/Tile View')
           .form-group
             %label.col-md-3.control-label
               = _('Truncate Long Text')
@@ -30,7 +22,6 @@
                            :class => "selectpicker")
               :javascript
                 miqSelectPickerEvent('quad_truncate', '#{url}');
-
         %fieldset
           %h3
             = _('Start Page')
@@ -44,7 +35,6 @@
                            :class             => "selectpicker")
               :javascript
                 miqSelectPickerEvent('start_page', '#{url}');
-      .col-md-12.col-lg-6
         %fieldset
           %h3
             = _('Default Items Per Page')
@@ -61,6 +51,7 @@
                              :class => "selectpicker")
                 :javascript
                   miqSelectPickerEvent('#{item_per_page[1]}', '#{url}');
+      .col-md-12.col-lg-6
         %fieldset
           %h3
             = _('Topology Default Items in View')

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -445,8 +445,7 @@ describe EmsCloudController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryBot.create(:user, :features => "none")
-      session[:settings] = {:views     => {:vm_summary_cool => "summary"},
-                            :quadicons => {}}
+      session[:settings] = {:views => {:vm_summary_cool => "summary"}}
       @ems = FactoryBot.create(:ems_amazon)
     end
 

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -12,7 +12,7 @@ describe EmsContainerController do
 
   describe "#show" do
     before do
-      session[:settings] = {:views => {}, :quadicons => {}}
+      session[:settings] = {:views => {}}
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryBot.create(:user)
       @container = FactoryBot.create(:ems_kubernetes)

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -51,9 +51,8 @@ describe HostController do
 
     it 'edit renders GTL grid with selected Host records' do
       session[:host_items] = [h1.id, h2.id]
-      session[:settings] = {:views     => {:host => 'grid'},
-                            :display   => {:quad_truncate => 'f'},
-                            :quadicons => {:host => 'foo'}}
+      session[:settings] = {:views   => {:host => 'grid'},
+                            :display => {:quad_truncate => 'f'}}
 
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name       => 'Host',
@@ -298,7 +297,7 @@ describe HostController do
                                                                  :cpu_sockets          => 2,
                                                                  :cpu_cores_per_socket => 4,
                                                                  :cpu_total_cores      => 8))
-      session[:settings] = {:quadicons => {:host => 'foo'}}
+      session[:settings] = {}
     end
 
     subject { get :show, :params => {:id => @host.id} }


### PR DESCRIPTION
As discussed in https://github.com/ManageIQ/manageiq-ui-classic/issues/6069 and removed in https://github.com/ManageIQ/manageiq-decorators/pull/21, these settings now don't make sense, so they can be removed.

**Before:**
![Screenshot from 2019-10-01 17-49-46](https://user-images.githubusercontent.com/649130/65978451-06076d00-e474-11e9-8a5c-0aa018d8396b.png)

**After:**
![Screenshot from 2019-10-01 17-27-16](https://user-images.githubusercontent.com/649130/65978458-099af400-e474-11e9-817e-c85abbb6bcb6.png)

Depends on: https://github.com/ManageIQ/manageiq-decorators/pull/21
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/6252

@miq-bot add_label ivanchuk/no, cleanup, pending core
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 