### PR TITLE
Fix cancel buttons and some history cleanup

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -425,6 +425,7 @@ module ApplicationController::Compare
   # AJAX driven routine to check for changes in ANY field on the form
   def sections_field_changed
     @keep_compare = true
+    @explorer = %w[VMs Templates].include?(session[:db_title])
     if params[:check] == "drift"
       drift_checked
     elsif params[:check] == "compare_miq"

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -26,7 +26,7 @@ module ApplicationController::Explorer
   end
 
   def x_history
-    self.x_node = data_for_breadcrumbs[data_for_breadcrumbs.length - 2][:key]
+    self.x_node = x_tree[:active_node]
     params[:id] = parse_nodetype_and_id(x_node).last
     params[:id].nil? && 'root'.eql?(params[:id]) ? show : tree_select
   end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -25,34 +25,10 @@ module ApplicationController::Explorer
     end
   end
 
-  # Historical tree item selected
   def x_history
-    @hist = x_tree_history[params[:item].to_i] # Set instance var so we know hist button was pressed
-    # remove id that is used in replace_right_cell method in vm_common
-    @sb[@sb[:active_accord]] = nil if @sb.fetch_path(@sb[:active_accord]) && @sb[@sb[:active_accord]] != @hist[:id]
-    if @hist[:button] # Button press from show screen
-      self.x_node = @hist[:id]
-      params[:id] = parse_nodetype_and_id(x_node).last
-      params[:x_show] = @hist[:item]
-      params[:pressed] = @hist[:button] # Look like we came in with this action
-      params[:display] = @hist[:display]
-      x_button
-    elsif @hist[:display] # Display link from show screen
-      self.x_node = @hist[:id]
-      params[:id] = parse_nodetype_and_id(x_node).last
-      params[:display] = @hist[:display]
-      show
-    elsif @hist[:action] # Action link from show screen
-      self.x_node = @hist[:id]
-      params[:id] = parse_nodetype_and_id(x_node).last
-      params[:x_show] = @hist[:item]
-      params[:action] = @hist[:action] # Look like we came in with this action
-      session[:view] = @hist[:view] if @hist[:view]
-      send(@hist[:action])
-    else # Normal explorer tree/link click
-      params[:id] = @hist[:id]
-      tree_select
-    end
+    self.x_node = data_for_breadcrumbs[data_for_breadcrumbs.length - 2][:key]
+    params[:id] = parse_nodetype_and_id(x_node).last
+    params[:id].nil? && 'root'.eql?(params[:id]) ? show : tree_select
   end
 
   # FIXME: the code below has to be converted into proper actions called though

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1821,10 +1821,7 @@ class CatalogController < ApplicationController
         build_toolbar("x_gtl_view_tb") unless record_showing || @in_a_form
       end
 
-    unless @in_a_form
-      c_tb = build_toolbar(center_toolbar_filename) unless x_active_tree == :svccat_tree
-      h_tb = build_toolbar("x_history_tb")
-    end
+    c_tb = build_toolbar(center_toolbar_filename) unless x_active_tree == :svccat_tree && @in_a_form
 
     presenter ||= ExplorerPresenter.right_cell(
       :active_tree => x_active_tree,
@@ -1929,9 +1926,9 @@ class CatalogController < ApplicationController
     if %w[ot_add ot_edit ot_copy service_dialog_from_ot].include?(action)
       presenter.hide(:toolbar, :paging_div, :form_buttons_div)
     else
-      presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
+      presenter.set_visibility(c_tb.present? || v_tb.present?, :toolbar)
     end
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb)
 
     presenter[:record_id] = determine_record_id_for_presenter
     presenter[:lock_sidebar] = @edit && @edit[:current] || action == 'copy_catalog'

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -271,9 +271,7 @@ class GenericObjectDefinitionController < ApplicationController
                  when :button       then process_custom_button_node(presenter, node)
                  end
 
-    h_tb = build_toolbar("x_history_tb")
-
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb)
     presenter.set_visibility(true, :toolbar)
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
 

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -497,13 +497,11 @@ class InfraNetworkingController < ApplicationController
              end
     end
 
-    h_tb = build_toolbar("x_history_tb") unless @in_a_form
-
     cb_tb = build_toolbar(Mixins::CustomButtons::Result.new(@nodetype == 'sw' ? :single : :list))
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb, :custom => cb_tb)
 
-    presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
+    presenter.set_visibility(c_tb.present? || v_tb.present?, :toolbar)
 
     presenter[:record_id] = @record.try(:id)
 

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -273,7 +273,6 @@ class MiqAeClassController < ApplicationController
     get_node_info(x_node) if !@in_a_form && !@angular_form && @button != "reset"
 
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
-    h_tb = build_toolbar("x_history_tb")
 
     presenter = ExplorerPresenter.new(
       :active_tree     => x_active_tree,
@@ -333,7 +332,6 @@ class MiqAeClassController < ApplicationController
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
 
     # Rebuild the toolbars
-    presenter.reload_toolbars(:history => h_tb)
     if c_tb.present?
       presenter.show(:toolbar)
       presenter.reload_toolbars(:center => c_tb)
@@ -2630,8 +2628,6 @@ class MiqAeClassController < ApplicationController
     @git_repo_id = git_repo.id
     @right_cell_text = _("Refreshing branch/tag for Git-based Domain")
 
-    h_tb = build_toolbar("x_history_tb")
-
     presenter = ExplorerPresenter.new(
       :active_tree     => x_active_tree,
       :right_cell_text => @right_cell_text,
@@ -2656,7 +2652,6 @@ class MiqAeClassController < ApplicationController
       }
     ])
 
-    presenter.reload_toolbars(:history => h_tb)
     presenter.show(:toolbar)
 
     render :json => presenter.for_render

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -310,11 +310,10 @@ class MiqAeCustomizationController < ApplicationController
   def rebuild_toolbars(presenter)
     unless @in_a_form
       c_tb = build_toolbar(center_toolbar_filename) if center_toolbar_filename
-      h_tb = build_toolbar("x_history_tb") if x_active_tree != :dialogs_tree
     end
 
-    presenter.set_visibility(h_tb.present? || c_tb.present?, :toolbar)
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb)
+    presenter.set_visibility(c_tb.present?, :toolbar)
+    presenter.reload_toolbars(:center => c_tb)
   end
 
   def render_proc

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -457,7 +457,6 @@ class MiqPolicyController < ApplicationController
     end
 
     c_tb = build_toolbar(center_toolbar_filename)
-    h_tb = build_toolbar('x_history_tb')
 
     # Build a presenter to render the JS
     presenter ||= ExplorerPresenter.new(
@@ -633,7 +632,7 @@ class MiqPolicyController < ApplicationController
     end
     presenter[:right_cell_text] = @right_cell_text = right_cell_text
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb)
+    presenter.reload_toolbars(:center => c_tb)
 
     if ((@edit && @edit[:new]) || @assign) && params[:action] != "x_search_by_name"
       locals = {

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -468,11 +468,9 @@ module Mixins
         v_tb = build_toolbar(record_showing ? "x_summary_view_tb" : "x_gtl_view_tb")
       end
 
-      h_tb = build_toolbar("x_history_tb") unless @in_a_form
+      presenter.reload_toolbars(:center => c_tb, :view => v_tb)
 
-      presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
-
-      presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
+      presenter.set_visibility(c_tb.present? || v_tb.present?, :toolbar)
 
       presenter[:record_id] = @record.try(:id)
 

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -121,12 +121,10 @@ class PxeController < ApplicationController
     presenter = ExplorerPresenter.new(:active_tree => x_active_tree)
 
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
-    h_tb = build_toolbar('x_history_tb')
 
     reload_trees_by_presenter(presenter, trees)
 
     # Rebuild the toolbars
-    presenter.reload_toolbars(:history => h_tb)
     case x_active_tree
     when :pxe_servers_tree
       presenter.update(:main_div, r[:partial => "pxe_server_list"])

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -665,7 +665,6 @@ class ReportController < ApplicationController
     partial = options[:partial] ? options[:partial] : set_partial_name
     unless @in_a_form
       c_tb = build_toolbar(center_toolbar_filename)
-      h_tb = build_toolbar("x_history_tb") unless x_active_tree == :export_tree
       v_tb = build_toolbar("report_view_tb") if @report && %i[reports_tree savedreports_tree].include?(x_active_tree)
     end
 
@@ -862,7 +861,7 @@ class ReportController < ApplicationController
     end
     presenter.set_visibility(!@in_a_form, :toolbar)
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb)
 
     presenter[:record_id] = (locals && locals[:record_id]) || determine_record_id_for_presenter
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -416,7 +416,6 @@ class ServiceController < ApplicationController
       end
       c_tb = build_toolbar(center_toolbar_filename)
     end
-    h_tb = build_toolbar("x_history_tb") unless @in_a_form
 
     presenter = ExplorerPresenter.new(
       :active_tree     => x_active_tree,
@@ -465,9 +464,9 @@ class ServiceController < ApplicationController
     # Clear the JS gtl_list_grid var if changing to a type other than list
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb, :custom => cb_tb)
 
-    presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.blank?, :toolbar)
+    presenter.set_visibility(c_tb.present? || v_tb.blank?, :toolbar)
 
     presenter[:record_id] = determine_record_id_for_presenter
 

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -429,12 +429,11 @@ class StorageController < ApplicationController
 
   def rebuild_toolbars(record_showing, presenter)
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
-    h_tb = build_toolbar('x_history_tb')
     v_tb = build_toolbar('x_gtl_view_tb') unless record_showing || (x_active_tree == :storage_pod_tree && x_node == 'root') || @in_a_form
     cb_tb = build_toolbar(custom_toolbar_explorer)
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :view => v_tb, :custom => cb_tb)
-    presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
+    presenter.reload_toolbars(:center => c_tb, :view => v_tb, :custom => cb_tb)
+    presenter.set_visibility(c_tb.present? || v_tb.present?, :toolbar)
     presenter[:record_id] = @record.try(:id)
 
     # Hide/show searchbox depending on if a list is showing

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1103,7 +1103,6 @@ module VmCommon
     elsif @sb[:action] == 'vmtree_info'
       c_tb = build_toolbar("x_vm_vmtree_center_tb")
     end
-    h_tb = build_toolbar("x_history_tb") unless @in_a_form
 
     # Build presenter to render the JS command for the tree update
     presenter ||= ExplorerPresenter.new(
@@ -1233,9 +1232,9 @@ module VmCommon
 
     presenter[:right_cell_text] = @right_cell_text
 
-    presenter.reload_toolbars(:history => h_tb, :center => c_tb, :custom => cb_tb, :view => v_tb)
+    presenter.reload_toolbars(:center => c_tb, :custom => cb_tb, :view => v_tb)
 
-    presenter.set_visibility(h_tb.present? || c_tb.present? || v_tb.present?, :toolbar)
+    presenter.set_visibility(c_tb.present? || v_tb.present?, :toolbar)
 
     presenter[:record_id] = @record.try(:id)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -661,8 +661,6 @@ module ApplicationHelper
   # Return a blank tb if a placeholder is needed for AJAX explorer screens, return nil if no center toolbar to be shown
   delegate :center_toolbar_filename, :to => :_toolbar_chooser
 
-  delegate :history_toolbar_filename, :to => :_toolbar_chooser
-
   delegate :x_view_toolbar_filename, :to => :_toolbar_chooser
 
   delegate :view_toolbar_filename, :to => :_toolbar_chooser
@@ -697,9 +695,7 @@ module ApplicationHelper
   #
   def calculate_toolbars
     toolbars = {}
-    if inner_layout_present? # x_taskbar branch
-      toolbars['history_tb'] = history_toolbar_filename
-    elsif display_back_button? # taskbar branch
+    if display_back_button? # taskbar branch
       toolbars['summary_center_tb'] = controller.restful? ? "summary_center_restful_tb" : "summary_center_tb"
     end
 

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -8,14 +8,6 @@ class ApplicationHelper::ToolbarChooser
     @explorer ? center_toolbar_filename_explorer : center_toolbar_filename_classic
   end
 
-  def history_toolbar_filename
-    if x_active_tree == :dialogs_tree || %w[chargeback miq_ae_tools miq_capacity_utilization miq_policy_rsop ops].include?(@layout)
-      nil
-    else
-      'x_history_tb'
-    end
-  end
-
   def x_view_toolbar_filename
     if x_gtl_view_tb_render?
       'x_gtl_view_tb'


### PR DESCRIPTION
Cleaning up some missed history toolbar remnants and fixing the broken cancel buttons (Compare, Policy Simulation) caused by #6050.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6222