### PR TITLE
Refactor optimization_controller to use default breadcrumbs methods

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -34,7 +34,7 @@ module Mixins
 
       if !features? || options[:not_tree]
         # Append breadcrumb from @record item (eg "Openstack") when on some action page (not show, display)
-        breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title])) if not_show_page?
+        breadcrumbs.push(build_breadcrumbs_no_explorer(options[:record_info], options[:record_title])) if not_show_page? || options[:include_record]
 
         # Append tag and policy breadcrumb if they exist
         breadcrumbs.push(special_page_breadcrumb(@tagitems || @politems || @ownershipitems || @retireitems))

--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -22,32 +22,17 @@ class OptimizationController < ApplicationController
 
   def breadcrumbs_options
     {
-      :breadcrumbs => [
+      :breadcrumbs    => [
         {:title => _('Overview')},
-        bc_optimization,
-        bc_report,
-        {:title => @title},
+        {:title => _("Optimization"), :url => controller_url},
       ],
+      :record_info    => @report || @record,
+      :include_record => action_name == 'show'
     }
   end
 
-  def data_for_breadcrumbs(*)
-    breadcrumbs_options[:breadcrumbs].compact
-  end
-  helper_method :data_for_breadcrumbs
-
-  # show optimization when in saved reports or report results
-  def bc_optimization
-    return nil if params[:id].blank? && params[:action] == 'show_list'
-
-    {:title => _("Optimization"), :url => url_for_only_path(:action => 'show_list', :id => nil)}
-  end
-
-  # show report when in report results
-  def bc_report
-    return nil if @report.nil?
-
-    {:title => @report.name, :url => url_for_only_path(:action => 'show_list', :id => @report.id)}
+  def gtl_url
+    'show_list'
   end
 
   def index
@@ -84,7 +69,6 @@ class OptimizationController < ApplicationController
   def show_saved_reports
     @record = find_record_with_rbac(MiqReport, params[:id])
     @title = @record.name
-    @gtl_url = 'show_list' # breadcrumbs
     @center_toolbar = 'optimizations'
 
     @table = gtl_saved(@record)

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -255,6 +255,36 @@ describe Mixins::BreadcrumbsMixin do
             ]
           )
         end
+
+        context ":include_record set" do
+          let(:breadcrumbs_options) do
+            {
+              :breadcrumbs    => [
+                {:title => _("First Layer")},
+                {:title => _("Second Layer")},
+              ],
+              :record_info    => {
+                :id   => 1234,
+                :name => "record_info_title"
+              },
+              :include_record => true
+            }
+          end
+
+          it "creates breadcrumbs with :include_record set" do
+            allow(subject).to receive(:action_name).and_return("show")
+            allow(subject).to receive(:params).and_return({})
+
+            expect(subject.data_for_breadcrumbs).to eq(
+              [
+                {:title => "First Layer"},
+                {:title => "Second Layer"},
+                {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"},
+                {:title => "Title"}
+              ]
+            )
+          end
+        end
       end
 
       it "not contain header on show_list page" do

--- a/spec/controllers/optimization_controller_spec.rb
+++ b/spec/controllers/optimization_controller_spec.rb
@@ -135,7 +135,7 @@ describe OptimizationController do
 
         it "links to both parents" do
           expect(controller.data_for_breadcrumbs.pluck(:url)).to eq([nil,
-                                                                     '/optimization/show_list',
+                                                                     '/optimization',
                                                                      "/optimization/show_list/#{report.id}",
                                                                      nil])
         end


### PR DESCRIPTION
**Description**

Refactores `optimization_controller` to use default breadcrumbs methods

The optimization_controller overrides the whole breadcrumbs logic and uses its own. That creates inconsistency. 

However, there is no need to do it. The only difference within this controller is the structure:

**Standard**

`SHOW_LIST > SHOW > ACTION`

**Optimization**

`SHOW_LIST > SHOW_LIST > SHOW`

Breadcrumbs mixin do not show specific breadcrumbs when a user is on `SHOW` action, because all info it needs is in `@title`, so It doesn't use info provided in `:record_info` (= `@record` or whatever is set to be used.)

So, I provided an option to `breadcrumb_mixin` which can enforce to use `:record_info`, the option is already used in explorer controller to do the same things: `:include_record`

