### PR TITLE
Update Access Restriction to current state in role detail

### DIFF
--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -30,7 +30,7 @@
               = javascript_tag(javascript_focus('name'))
         .form-group
           %label.col-md-4.control-label
-            = _('Access Restriction for Services, VMs, and Templates')
+            = _('Access Restriction for Catalog Items, Orchestration Stacks, Key Pairs, Services, VMs, and Templates')
           .col-md-8
             - if !@edit
               - if @role.settings.kind_of?(Hash) && @role.settings.fetch_path(:restrictions, :vms)


### PR DESCRIPTION
this option `Access Restriction` works with model which have `OwnershipMixin` included so I am updating the label according to current state.

@miq-bot assign @mzazrivec 
@miq-bot add_label technical debt

before

![Screenshot 2019-10-02 at 16 55 27](https://user-images.githubusercontent.com/14937244/66055216-804bf600-e535-11e9-814a-0546203ac4a8.png)


after
![Screenshot 2019-10-02 at 16 55 06](https://user-images.githubusercontent.com/14937244/66055270-922d9900-e535-11e9-8da4-957ea2c8eef8.png)
