### PR TITLE
Allow editing and other actions on selected Host Aggregate

### DIFF
--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -158,11 +158,7 @@ class HostAggregateController < ApplicationController
   def delete_host_aggregates
     assert_privileges("host_aggregate_delete")
 
-    host_aggregates = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "host_aggregate")
-                        find_checked_items
-                      else
-                        [params[:id]]
-                      end
+    host_aggregates = checked_or_params
 
     if host_aggregates.empty?
       add_flash(_("No Host Aggregates were selected for deletion."), :error)
@@ -183,14 +179,12 @@ class HostAggregateController < ApplicationController
 
     # refresh the list if applicable
     if @lastaction == "show_list"
-      show_list
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "host_aggregate"
       @single_delete = true unless flash_errors?
-      if @flash_array.nil?
-        add_flash(_("The selected Host Aggregate was deleted"))
-      end
     end
+    flash_to_session
+    redirect_to(:action => 'show_list')
   end
 
   def add_host_select

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -255,7 +255,7 @@ module Mixins
         when 'host_aggregate_new'               then javascript_redirect(:action => 'new')
         when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_delete'            then delete_host_aggregates
-        when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_item_id)
+        when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_item_id)
         when 'host_aggregate_tag'               then tag(HostAggregate)
         # Storages
@@ -302,7 +302,7 @@ module Mixins
                      "#{pfx}_evacuate"].include?(params[:pressed]) &&
                     @flash_array.nil?
 
-          unless ["host_edit", 'host_aggregate_edit', "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
+          unless ["host_edit", 'host_aggregate_edit', 'host_aggregate_add_host', "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
                   "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
             @refresh_div = "main_div"
             @refresh_partial = "layouts/gtl"

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -256,7 +256,7 @@ module Mixins
         when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_delete'            then delete_host_aggregates
         when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_or_params, :controller => 'host_aggregate')
-        when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_item_id)
+        when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_tag'               then tag(HostAggregate)
         # Storages
         when "storage_delete"                   then deletestorages
@@ -302,8 +302,8 @@ module Mixins
                      "#{pfx}_evacuate"].include?(params[:pressed]) &&
                     @flash_array.nil?
 
-          unless ["host_edit", 'host_aggregate_edit', 'host_aggregate_add_host', "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                  "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
+          unless ["host_edit", 'host_aggregate_edit', 'host_aggregate_add_host', 'host_aggregate_remove_host', "#{pfx}_edit", "#{pfx}_miq_request_new",
+                  "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
             @refresh_div = "main_div"
             @refresh_partial = "layouts/gtl"
             show                                                        # Handle EMS buttons

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -253,7 +253,7 @@ module Mixins
         when "host_provide"                     then providehosts
         # Host Aggregates
         when 'host_aggregate_new'               then javascript_redirect(:action => 'new')
-        when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_item_id)
+        when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_delete'            then delete_host_aggregates
         when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_item_id)
         when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_item_id)
@@ -302,7 +302,7 @@ module Mixins
                      "#{pfx}_evacuate"].include?(params[:pressed]) &&
                     @flash_array.nil?
 
-          unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
+          unless ["host_edit", 'host_aggregate_edit', "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
                   "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
             @refresh_div = "main_div"
             @refresh_partial = "layouts/gtl"
@@ -408,10 +408,6 @@ module Mixins
 
       if single_delete_test
         single_delete_redirect
-      elsif params[:pressed] == "host_aggregate_edit"
-        javascript_redirect :controller => "host_aggregate",
-                            :action     => "edit",
-                            :id         => find_record_with_rbac(HostAggregate, checked_or_params)
       elsif params[:pressed] == "cloud_tenant_edit"
         javascript_redirect :controller => "cloud_tenant",
                             :action     => "edit",
@@ -460,7 +456,7 @@ module Mixins
       elsif params[:pressed].ends_with?("_edit") ||
             ["#{pfx}_miq_request_new", "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed]) ||
             params[:pressed] == 'vm_rename' && @flash_array.nil?
-        render_or_redirect_partial(pfx)
+        render_or_redirect_partial(pfx) unless performed?
       else
         if @refresh_div == "main_div" && @lastaction == "show_list"
           replace_gtl_main_div

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -254,7 +254,7 @@ module Mixins
         # Host Aggregates
         when 'host_aggregate_new'               then javascript_redirect(:action => 'new')
         when 'host_aggregate_edit'              then javascript_redirect(:action => 'edit', :id => checked_or_params, :controller => 'host_aggregate')
-        when 'host_aggregate_delete'            then delete_host_aggregates
+        when 'host_aggregate_delete'            then javascript_redirect(:action => 'delete_host_aggregates', :id => params[:id], :miq_grid_checks => params[:miq_grid_checks], :controller => 'host_aggregate')
         when 'host_aggregate_add_host'          then javascript_redirect(:action => 'add_host_select', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_remove_host'       then javascript_redirect(:action => 'remove_host_select', :id => checked_or_params, :controller => 'host_aggregate')
         when 'host_aggregate_tag'               then tag(HostAggregate)
@@ -302,7 +302,7 @@ module Mixins
                      "#{pfx}_evacuate"].include?(params[:pressed]) &&
                     @flash_array.nil?
 
-          unless ["host_edit", 'host_aggregate_edit', 'host_aggregate_add_host', 'host_aggregate_remove_host', "#{pfx}_edit", "#{pfx}_miq_request_new",
+          unless ["host_edit", 'host_aggregate_edit', 'host_aggregate_add_host', 'host_aggregate_remove_host', 'host_aggregate_delete', "#{pfx}_edit", "#{pfx}_miq_request_new",
                   "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename', 'flavor_create', 'flavor_delete'].include?(params[:pressed])
             @refresh_div = "main_div"
             @refresh_partial = "layouts/gtl"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,7 @@ Rails.application.routes.draw do
     :host_aggregate           => {
       :get  => %w(
         add_host_select
+        delete_host_aggregates
         download_data
         download_summary_pdf
         edit
@@ -261,6 +262,7 @@ Rails.application.routes.draw do
         add_host
         add_host_select
         button
+        delete_host_aggregates
         listnav_search_selected
         create
         protect

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -1,14 +1,15 @@
 describe HostAggregateController do
-  describe "#show" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @aggregate = FactoryBot.create(:host_aggregate)
-      login_as FactoryBot.create(:user_admin)
-    end
+  let(:ems) { FactoryBot.create(:ems_openstack) }
+  let(:aggregate) { FactoryBot.create(:host_aggregate_openstack, :ext_management_system => ems) }
+  let(:host) { FactoryBot.create(:host_openstack_infra, :ext_management_system => ems) }
 
-    subject do
-      get :show, :params => {:id => @aggregate.id}
-    end
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+    login_as FactoryBot.create(:user_admin)
+  end
+
+  describe "#show" do
+    subject { get :show, :params => {:id => aggregate.id} }
 
     context "render listnav partial" do
       render_views
@@ -23,13 +24,6 @@ describe HostAggregateController do
   include_examples '#download_summary_pdf', :host_aggregate_openstack
 
   describe "#create" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack)
-      @aggregate = FactoryBot.create(:host_aggregate_openstack)
-    end
-
     let(:task_options) do
       {
         :action => "creating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
@@ -38,35 +32,27 @@ describe HostAggregateController do
     end
     let(:queue_options) do
       {
-        :class_name  => @aggregate.class.name,
+        :class_name  => aggregate.class.name,
         :method_name => "create_aggregate",
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => "ems_operations",
-        :zone        => @ems.my_zone,
-        :args        => [@ems.id, {:name => "foo", :ems_id => @ems.id.to_s }]
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {:name => "foo", :ems_id => ems.id.to_s }]
       }
     end
 
     it "builds create screen" do
-      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => ems.id }
       expect(assigns(:flash_array)).to be_nil
     end
 
     it "queues the create action" do
       expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => @ems.id }
+      post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => ems.id }
     end
   end
 
   describe "#update" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack)
-      @aggregate = FactoryBot.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
-    end
-
     let(:task_options) do
       {
         :action => "updating Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
@@ -75,146 +61,131 @@ describe HostAggregateController do
     end
     let(:queue_options) do
       {
-        :class_name  => @aggregate.class.name,
+        :class_name  => aggregate.class.name,
         :method_name => "update_aggregate",
-        :instance_id => @aggregate.id,
+        :instance_id => aggregate.id,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => "ems_operations",
-        :zone        => @ems.my_zone,
+        :zone        => ems.my_zone,
         :args        => [{:name => "foo"}]
       }
     end
 
     it "builds edit screen" do
-      post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
+      post :update, :params => { :button => "save", :format => :js, :id => aggregate.id, :name => "foo" }
       expect(assigns(:flash_array)).to be_nil
     end
 
     it "queues the update action" do
       expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-      post :update, :params => { :button => "save", :format => :js, :id => @aggregate.id, :name => "foo" }
+      post :update, :params => { :button => "save", :format => :js, :id => aggregate.id, :name => "foo" }
     end
   end
 
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack)
-      @aggregate = FactoryBot.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
+  describe "#delete_host_aggregates" do
+    let(:params) { {:id => aggregate.id.to_s} }
+
+    before { controller.params = params }
+
+    context 'deleting Host Aggregate' do
+      before { allow(controller).to receive(:redirect_to) }
+
+      it 'calls process_host_aggregates with selected Host Aggregates' do
+        expect(controller).to receive(:process_host_aggregates).with([aggregate], 'destroy')
+        controller.send(:delete_host_aggregates)
+      end
     end
 
-    context "#edit" do
-      let(:task_options) do
-        {
-          :action => "deleting Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "delete_aggregate",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => []
-        }
+    it 'sets flash message and redirects to show_list' do
+      expect(controller).to receive(:flash_to_session)
+      expect(controller).to receive(:redirect_to).with(:action => 'show_list')
+      controller.send(:delete_host_aggregates)
+      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Delete initiated for 1 Host Aggregate.", :level => :success}])
+    end
+
+    context 'Host Aggregates displayed in a nested list' do
+      let(:params) { {:miq_grid_checks => aggregate.id.to_s} }
+
+      context 'deleting selected Host Aggregates' do
+        before { allow(controller).to receive(:redirect_to) }
+
+        it 'calls process_host_aggregates with selected Host Aggregates' do
+          expect(controller).to receive(:process_host_aggregates).with([aggregate], 'destroy')
+          controller.send(:delete_host_aggregates)
+        end
       end
 
-      it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :button, :params => { :id => @aggregate.id, :pressed => "host_aggregate_delete", :format => :js }
+      it 'sets flash message and redirects to show_list' do
+        expect(controller).to receive(:flash_to_session)
+        expect(controller).to receive(:redirect_to).with(:action => 'show_list')
+        controller.send(:delete_host_aggregates)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Delete initiated for 1 Host Aggregate.", :level => :success}])
       end
     end
   end
 
   describe "#add_host" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack)
-      @aggregate = FactoryBot.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
-      @host = FactoryBot.create(:host_openstack_infra, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "Adding Host to Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "add_host",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [host.id]
+      }
     end
 
-    context "#add_host" do
-      let(:task_options) do
-        {
-          :action => "Adding Host to Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "add_host",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@host.id]
-        }
-      end
+    it "builds add host screen" do
+      post :button, :params => { :pressed => "host_aggregate_add_host", :format => :js, :id => aggregate.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "builds add host screen" do
-        post :button, :params => { :pressed => "host_aggregate_add_host", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the add host action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :add_host, :params => { :button => "addHost", :format => :js, :id => @aggregate.id, :host_id => @host.id }
-      end
+    it "queues the add host action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :add_host, :params => { :button => "addHost", :format => :js, :id => aggregate.id, :host_id => host.id }
     end
   end
 
   describe "#remove_host" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack)
-      @aggregate = FactoryBot.create(:host_aggregate_openstack,
-                                      :ext_management_system => @ems)
-      @host = FactoryBot.create(:host_openstack_infra, :ext_management_system => @ems)
+    let(:task_options) do
+      {
+        :action => "Removing Host from Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
+        :userid => controller.current_user.userid
+      }
+    end
+    let(:queue_options) do
+      {
+        :class_name  => aggregate.class.name,
+        :method_name => "remove_host",
+        :instance_id => aggregate.id,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => ems.my_zone,
+        :args        => [host.id]
+      }
     end
 
-    context "#remove_host" do
-      let(:task_options) do
-        {
-          :action => "Removing Host from Host Aggregate for user %{user}" % {:user => controller.current_user.userid},
-          :userid => controller.current_user.userid
-        }
-      end
-      let(:queue_options) do
-        {
-          :class_name  => @aggregate.class.name,
-          :method_name => "remove_host",
-          :instance_id => @aggregate.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
-          :args        => [@host.id]
-        }
-      end
+    it "builds remove host screen" do
+      post :button, :params => { :pressed => "host_aggregate_remove_host", :format => :js, :id => aggregate.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
 
-      it "builds remove host screen" do
-        post :button, :params => { :pressed => "host_aggregate_remove_host", :format => :js, :id => @aggregate.id }
-        expect(assigns(:flash_array)).to be_nil
-      end
-
-      it "queues the remove host action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-        post :remove_host, :params => {
-          :button  => "removeHost",
-          :format  => :js,
-          :id      => @aggregate.id,
-          :host_id => @host.id
-        }
-      end
+    it "queues the remove host action" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      post :remove_host, :params => {
+        :button  => "removeHost",
+        :format  => :js,
+        :id      => aggregate.id,
+        :host_id => host.id
+      }
     end
   end
 end

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -96,6 +96,15 @@ describe EmsCloudController do
             controller.send(:button)
           end
         end
+
+        context 'removing Host from Host Aggregate' do
+          let(:pressed) { 'host_aggregate_remove_host' }
+
+          it 'calls javascript_redirect to redirect to host_aggregate controller' do
+            expect(controller).to receive(:javascript_redirect).with(:action => 'remove_host_select', :id => [aggregate.id], :controller => 'host_aggregate')
+            controller.send(:button)
+          end
+        end
       end
     end
   end

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -105,6 +105,15 @@ describe EmsCloudController do
             controller.send(:button)
           end
         end
+
+        context 'deleting Host Aggregate' do
+          let(:pressed) { 'host_aggregate_delete' }
+
+          it 'calls javascript_redirect to redirect to host_aggregate controller' do
+            expect(controller).to receive(:javascript_redirect).with(:action => 'delete_host_aggregates', :id => nil, :miq_grid_checks => aggregate.id.to_s, :controller => 'host_aggregate')
+            controller.send(:button)
+          end
+        end
       end
     end
   end

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -1,6 +1,6 @@
 describe EmsCloudController do
   context "::EmsCommon" do
-    context "#new" do
+    describe "#new" do
       before do
         stub_user(:features => :all)
         allow(controller).to receive(:drop_breadcrumb)
@@ -19,7 +19,7 @@ describe EmsCloudController do
       end
     end
 
-    context "#button" do
+    describe "#button" do
       before do
         stub_user(:features => :all)
         EvmSpecHelper.create_guid_miq_server_zone
@@ -29,8 +29,8 @@ describe EmsCloudController do
         allow(controller).to receive(:role_allows?).and_return(true)
         ems = FactoryBot.create(:ems_vmware)
         vm = FactoryBot.create(:vm_vmware,
-                                :ext_management_system => ems,
-                                :storage               => FactoryBot.create(:storage))
+                               :ext_management_system => ems,
+                               :storage               => FactoryBot.create(:storage))
         post :button, :params => { :pressed => "instance_retire", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
         expect(response.status).to eq 200
         expect(response.body).to include('vm/retire')
@@ -49,8 +49,8 @@ describe EmsCloudController do
         allow(controller).to receive(:role_allows?).and_return(true)
         ems = FactoryBot.create(:ems_vmware)
         vm = FactoryBot.create(:vm_vmware,
-                                :ext_management_system => ems,
-                                :storage               => FactoryBot.create(:storage))
+                               :ext_management_system => ems,
+                               :storage               => FactoryBot.create(:storage))
         post :button, :params => { :pressed => "instance_tag", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'instances' }
         expect(response.status).to eq 200
         expect(response.body).to include('ems_cloud/tagging_edit')
@@ -60,7 +60,7 @@ describe EmsCloudController do
         allow(controller).to receive(:role_allows?).and_return(true)
         ems = FactoryBot.create(:ems_amazon)
         vm = FactoryBot.create(:vm_amazon,
-                                :ext_management_system => ems)
+                               :ext_management_system => ems)
         post :button, :params => { :pressed => "image_tag", "check_#{vm.id}" => "1", :format => :js, :id => ems.id, :display => 'images' }
         expect(response.status).to eq 200
         expect(response.body).to include('ems_cloud/tagging_edit')
@@ -69,6 +69,24 @@ describe EmsCloudController do
       it "when Delete Button is pressed for CloudObjectStoreContainer" do
         expect(controller).to receive(:process_cloud_object_storage_buttons)
         post :button, :params => { :pressed => "cloud_object_store_container_delete" }
+      end
+
+      context 'actions on Host Aggregates displayed through Cloud Provider' do
+        let(:aggregate) { FactoryBot.create(:host_aggregate) }
+
+        before do
+          allow(controller).to receive(:performed?).and_return(true)
+          controller.params = {:pressed => pressed, :miq_grid_checks => aggregate.id.to_s}
+        end
+
+        context 'editing Host Aggregate' do
+          let(:pressed) { 'host_aggregate_edit' }
+
+          it 'calls javascript_redirect to redirect to host_aggregate controller' do
+            expect(controller).to receive(:javascript_redirect).with(:action => 'edit', :id => [aggregate.id], :controller => 'host_aggregate')
+            controller.send(:button)
+          end
+        end
       end
     end
   end
@@ -102,7 +120,8 @@ describe EmsContainerController do
   context "::EmsCommon" do
     context "adding new provider without hawkular endpoint" do
       def test_creating(emstype)
-        raise ArgumentError, "Unsupported type [#{emstype}]" unless %w(kubernetes openshift).include?(emstype)
+        raise ArgumentError, "Unsupported type [#{emstype}]" unless %w[kubernetes openshift].include?(emstype)
+
         @ems = ExtManagementSystem.model_from_emstype(emstype).new
         controller.params = {:name             => 'NimiCule',
                              :default_userid   => '_',
@@ -307,7 +326,7 @@ describe EmsContainerController do
 end
 
 describe EmsInfraController do
-  context "#show_link" do
+  describe "#show_link" do
     let(:ems) { FactoryBot.create(:ems_infra) }
     it "sets relative url" do
       controller.instance_variable_set(:@table_name, "ems_infra")
@@ -320,7 +339,7 @@ end
 
 describe EmsNetworkController do
   context "::EmsCommon" do
-    context "#button" do
+    describe "#button" do
       before do
         stub_user(:features => :all)
         EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -87,6 +87,15 @@ describe EmsCloudController do
             controller.send(:button)
           end
         end
+
+        context 'adding Host to Host Aggregate' do
+          let(:pressed) { 'host_aggregate_add_host' }
+
+          it 'calls javascript_redirect to redirect to host_aggregate controller' do
+            expect(controller).to receive(:javascript_redirect).with(:action => 'add_host_select', :id => [aggregate.id], :controller => 'host_aggregate')
+            controller.send(:button)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6227

---

Various errors occurred after displaying Host Aggregates from Relationships table of a Cloud Provider and providing selected **actions on a selected Host Aggregate**. Only tagging and Download worked for selected Host Aggregates. The same problems occurred for actions of Host Aggregates displayed in a list directly thru _Compute > Clouds > Host Aggregates_ and also actions provided from details page of a Host Aggregate. This PR fixes errors and allows us to provide selected actions.

**Editing Host Aggregate:**
The DoubleRenderError regarding editing a Host Aggregate was fixed by removing an extra unnecessary code [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Actions_Cloud_Providers_Host_Aggregate?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54L411) (because we already call `javascript_redirect` with same parameters [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Actions_Cloud_Providers_Host_Aggregate?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R256)) and adding `unless performed?` [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Actions_Cloud_Providers_Host_Aggregate?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R459). But that was not enough, we also had to [prevent calling](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Actions_Cloud_Providers_Host_Aggregate?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R305) unnecessary `show` [method](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Actions_Cloud_Providers_Host_Aggregate?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R309).

**Adding Host to Host Aggregate**:
This action did not work because of calling `javascript_redirect` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common.rb#L258) and `show` method [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common.rb#L309). After solving this problem, I also had to specify the name of the controller for redirecting and setting `id` properly, too, to [make it work](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/0f920e8041caf63c8f02151077d218c0c7b6adac#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R258).

**Removing Host from Host Aggregate:**
Similarly as for adding Host to Host Aggregate.

**Deleting Host Aggregate:**
I've refactored `delete_host_aggregates` little bit, in host_aggregate controller. I've used `checked_or_params` [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c545b44e548fd14385a7d607aeabc8d8R161) which works well, no matter if `params[:pressed]` or `params[:miq_grid_checks]` is set.
I've also had to solve calling `show_list` and displaying the list of Host Aggregates after deleting the selected ones. This is solved [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c545b44e548fd14385a7d607aeabc8d8R187).
For displaying flash message about deleting Host Aggregates, I had to call `flash_to_session` [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c545b44e548fd14385a7d607aeabc8d8R186). These changes work well for Host Aggregates displayed also in a nested list or also for individual Host Aggregates (while displaying details page of a Host Aggregate). I've also removed some [unnecessary code](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c545b44e548fd14385a7d607aeabc8d8L190-L192) as `add_flash` was already called [earlier](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c545b44e548fd14385a7d607aeabc8d8R178). 
But how do we call `delete_host_aggregates` properly? I had to make [another change](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R257) to solve this (also with solving calling unnecessary `show` method [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6267/commits/3aef3f2d29c8f15caa06ff88d8dc75d0f8cdd768#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R305)). And finally, I've added `delete_host_aggregates` to routes. The reasons for this change, are, hopefully, obvious.
Also note that, originally, `delete_host_aggregates` method was in the same file as the `button` method, which is now in _ems_common.rb_ (see https://github.com/ManageIQ/manageiq/pull/11980).
I've also refactored the specs little bit.

---

**After:**
![edit_host_agg](https://user-images.githubusercontent.com/13417815/66115893-0c136000-e5d2-11e9-888e-6f3a1503d5b1.png)
![add_host](https://user-images.githubusercontent.com/13417815/66132767-df713f80-e5f5-11e9-8f13-c4a61d71a619.png)
![remove_host](https://user-images.githubusercontent.com/13417815/66144777-c3779900-e609-11e9-9214-ac9abe6551c5.png)
![delete_agg](https://user-images.githubusercontent.com/13417815/66327082-81609700-e92a-11e9-9442-6c861713c6d0.png)
