### PR TITLE
Completely remove the records2table method as its obsolete

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -162,7 +162,6 @@ module ApplicationController::PolicySupport
     # session[:pol_db] = session[:pol_db] == Vm ? VmOrTemplate : session[:pol_db]
     @politems = session[:pol_db].find(session[:pol_items]).sort_by(&:name) # Get the db records
     @view = get_db_view(session[:pol_db], :clickable => false) # Instantiate the MIQ Report view object
-    @view.table = ReportFormatter::Converter.records2table(@politems, @view.cols + ['id'])
 
     @edit = {}
     @edit[:explorer] = true if @explorer
@@ -226,7 +225,6 @@ module ApplicationController::PolicySupport
     @catinfo = {}
     @lastaction = "policy_sim"
     @pol_view = get_db_view(session[:tag_db], :clickable => false) # Instantiate the MIQ Report view object
-    @pol_view.table = ReportFormatter::Converter.records2table(@tagitems, @pol_view.cols + ['id'])
 
     # Build the profiles selection list
     @all_profs = {}

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -164,7 +164,6 @@ module ApplicationController::Tags
     @tagitems = @tagging.constantize.where(:id => @object_ids).sort_by { |t| t.name.try(:downcase).to_s }
 
     @view = get_db_view(@tagging, :clickable => false) # Instantiate the MIQ Report view object
-    @view.table = ReportFormatter::Converter.records2table(@tagitems, @view.cols + ['id'])
 
     @edit[:new][:assignments] = assignments = @tagitems.map do |tagitem|
       Classification.find_assigned_entries(tagitem).reject { |e| e.parent.read_only? }

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -151,7 +151,6 @@ class HostController < ApplicationController
       end
       build_targets_hash(hostitems)
       @view = get_db_view(Host) # Instantiate the MIQ Report view object
-      @view.table = ReportFormatter::Converter.records2table(hostitems, @view.cols + ['id'])
     end
   end
 

--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -12,7 +12,6 @@ module Mixins
           @evacuate_items = find_records_with_rbac(VmOrTemplate, session[:evacuate_items]).sort_by(&:name)
           build_targets_hash(@evacuate_items)
           @view = get_db_view(VmOrTemplate)
-          @view.table = ReportFormatter::Converter.records2table(@evacuate_items, @view.cols + ['id'])
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/live_migrate.rb
+++ b/app/controllers/mixins/actions/vm_actions/live_migrate.rb
@@ -25,7 +25,6 @@ module Mixins
           @live_migrate_items = find_records_with_rbac(VmOrTemplate.order(:name), session[:live_migrate_items])
           build_targets_hash(@live_migrate_items)
           @view = get_db_view(VmOrTemplate)
-          @view.table = ReportFormatter::Converter.records2table(@live_migrate_items, @view.cols + ['id'])
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -103,7 +103,6 @@ module Mixins
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
           @edit[:object_ids] = @ownershipitems
           @view = get_db_view(klass == VmOrTemplate ? Vm : klass, :clickable => false) # Instantiate the MIQ Report view object
-          @view.table = ReportFormatter::Converter.records2table(@ownershipitems, @view.cols + ['id'])
           session[:edit] = @edit
         end
 

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -96,7 +96,6 @@ module Mixins
           session[:cat] = nil # Clear current category
           build_targets_hash(@retireitems)
           @view = get_db_view(kls) # Instantiate the MIQ Report view object
-          @view.table = ReportFormatter::Converter.records2table(@retireitems, @view.cols + ['id'])
           if @retireitems.length == 1 && !@retireitems[0].retires_on.nil?
             t = @retireitems[0].retires_on                                         # Single VM, set to current time
             w = @retireitems[0].retirement_warn if @retireitems[0].retirement_warn # Single VM, get retirement warn

--- a/lib/report_formatter/converter.rb
+++ b/lib/report_formatter/converter.rb
@@ -1,21 +1,5 @@
 module ReportFormatter
   class Converter
-    # generate a ruport table from an array of db objects
-    def self.records2table(records, only_columns)
-      return Ruport::Data::Table.new if records.blank?
-
-      data_records = records.map do |r|
-        only_columns.each_with_object({}) do |column, attrs|
-          attrs[column] = r.send(column) if r.respond_to?(column)
-        end
-      end
-
-      column_names = data_records.flat_map(&:keys).uniq
-
-      Ruport::Data::Table.new(:data         => data_records,
-                              :column_names => column_names)
-    end
-
     # generate a ruport table from an array of hashes where the keys are the column names
     def self.hashes2table(hashes, options)
       return Ruport::Data::Table.new if hashes.blank?


### PR DESCRIPTION
The result of the `records2table` is never used as we fetch the GTL contents in a separate `report_data` request. Therefore, this method generates data that's never used, throttling the performance of the rendered page. I found this while I was trying to smuggle in some extra information from the policy simulation results to the report data, but failed.

@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label cleanup, technical debt, ivanchuk/no, cloud intel/reporting