### PR TITLE
Set grid type in GTLs on migrate, retire and evacuate screens

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -12,6 +12,7 @@ module Mixins
           @evacuate_items = find_records_with_rbac(VmOrTemplate, session[:evacuate_items]).sort_by(&:name)
           build_targets_hash(@evacuate_items)
           @view = get_db_view(VmOrTemplate)
+          @gtl_type = "grid"
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/live_migrate.rb
+++ b/app/controllers/mixins/actions/vm_actions/live_migrate.rb
@@ -25,6 +25,7 @@ module Mixins
           @live_migrate_items = find_records_with_rbac(VmOrTemplate.order(:name), session[:live_migrate_items])
           build_targets_hash(@live_migrate_items)
           @view = get_db_view(VmOrTemplate)
+          @gtl_type = "grid"
 
           render :action => "show" unless @explorer
         end

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -96,6 +96,7 @@ module Mixins
           session[:cat] = nil # Clear current category
           build_targets_hash(@retireitems)
           @view = get_db_view(kls) # Instantiate the MIQ Report view object
+          @gtl_type = "grid"
           if @retireitems.length == 1 && !@retireitems[0].retires_on.nil?
             t = @retireitems[0].retires_on                                         # Single VM, set to current time
             w = @retireitems[0].retirement_warn if @retireitems[0].retirement_warn # Single VM, get retirement warn


### PR DESCRIPTION
These 3 screens have list view unlike the other ones with grid view. We probably forgot about these when converting to `report_data`, so making them consistent now. You can access all three features (set retirement date, evacuate, migrate) on the `Cloud -> Instances` screen under `Lifecycle` when selecting at least two of them. 

Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/6269

## Before:
![Screenshot from 2019-10-03 15-20-02](https://user-images.githubusercontent.com/649130/66130016-4e986500-e5f1-11e9-98e4-b63a763c0a1e.png)
![Screenshot from 2019-10-03 15-19-05](https://user-images.githubusercontent.com/649130/66130017-4e986500-e5f1-11e9-889f-058ae6d18993.png)
![Screenshot from 2019-10-03 15-18-33](https://user-images.githubusercontent.com/649130/66130019-4e986500-e5f1-11e9-936e-d8b06630c509.png)

## After:
![Screenshot from 2019-10-03 15-16-27](https://user-images.githubusercontent.com/649130/66129848-f6f9f980-e5f0-11e9-911b-4272c87c3a0e.png)
![Screenshot from 2019-10-03 15-16-14](https://user-images.githubusercontent.com/649130/66129849-f6f9f980-e5f0-11e9-9aea-14c2178866ba.png)
![Screenshot from 2019-10-03 15-15-57](https://user-images.githubusercontent.com/649130/66129850-f7929000-e5f0-11e9-9d71-e6f608a2657a.png)

@terezanovotna please approve

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label technical debt, ivanchuk/no, ux/review
