### PR TITLE
Move node expandedness evaluation into TreeNode::Node

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -215,8 +215,6 @@ class TreeBuilder
     node = TreeNode.new(object, pid, self)
     override(node, object) if self.class.method_defined?(:override) || self.class.private_method_defined?(:override)
 
-    node.expanded ||= expand_node?(node.key)
-
     if ancestry_kids || node.expanded || !@options[:lazy]
       (ancestry_kids || x_get_tree_objects(object, false, parents)).each do |o|
         node.nodes.push(x_build_node(o, node.key))

--- a/app/presenters/tree_node/hash.rb
+++ b/app/presenters/tree_node/hash.rb
@@ -20,7 +20,7 @@ module TreeNode
 
     set_attribute(:tooltip) { @object[:tip] }
 
-    set_attribute(:expanded) { @object[:expanded] }
+    set_attribute(:expanded) { @tree.try(:expand_node?, key) || @object[:expanded] || false }
 
     set_attribute(:key) do
       if @object[:id] == "-Unassigned"

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -111,6 +111,6 @@ module TreeNode
 
     set_attribute(:selectable, true)
     set_attribute(:checkable, true)
-    set_attribute(:expanded, false)
+    set_attribute(:expanded) { @tree.try(:expand_node?, key) || false }
   end
 end


### PR DESCRIPTION
Right now, the `TreeBuilder#x_build_node` is responsible for evaluating the expandedness of a given node. There's a way to predefine this in the `TreeNode::Node` using `set_attribute`, but it's not used to its full potential.

Here I'm extracting the expandedness evaluation based on the tree options/state into `TreeBuilder#expand_node?`. As this method is public, it's possible to call it from the `TreeNode::Node` in the `set_attribute(:expanded)`.

@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label refactoring, trees, ivanchuk/no