### PR TITLE
Fixed jest tests after React update

### DIFF
--- a/app/javascript/spec/automate-import-export-form/__snapshots__/import-datastore-via-git.spec.js.snap
+++ b/app/javascript/spec/automate-import-export-form/__snapshots__/import-datastore-via-git.spec.js.snap
@@ -1,8 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Import datastore via git component should render correctly 1`] = `
-<div>
-  <MiqFormRenderer
+<div
+  style={
+    Object {
+      "paddingBottom": 16,
+    }
+  }
+>
+  <Connect(MiqFormRenderer)
     disableSubmit={
       Array [
         "pristine",

--- a/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
+++ b/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
+
 import ImportDatastoreViaGit from '../../components/automate-import-export-form/import-datastore-via-git';
 import '../helpers/addFlash';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
 
 describe('Import datastore via git component', () => {
-  /**
-   * Shallow rendering is broken for some reason on newer version of jest
-   * mount snapshoting works but has thousands of lines
-   */
-  it.skip('should render correctly', () => {
+  it('should render correctly', () => {
     const wrapper = shallow(<ImportDatastoreViaGit />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/app/javascript/spec/catalog-form/catalog-form.spec.js
+++ b/app/javascript/spec/catalog-form/catalog-form.spec.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
+
 import CatalogForm from '../../components/catalog-form/catalog-form';
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import '../helpers/addFlash';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
 
 describe('Catalog form component', () => {
   let submitSpyMiqSparkleOn;
@@ -58,7 +60,7 @@ describe('Catalog form component', () => {
 
   it('should render add variant form', (done) => {
     fetchMock.getOnce(urlFreeTemplates, { resources });
-    const wrapper = shallow(<CatalogForm />).dive();
+    const wrapper = shallow(<CatalogForm />);
 
     setImmediate(() => {
       wrapper.update();
@@ -70,7 +72,7 @@ describe('Catalog form component', () => {
   it('should render edit variant form', (done) => {
     fetchMock.getOnce(urlFreeTemplates, { resources })
       .getOnce(urlTemplates, assignedResources);
-    const wrapper = shallow(<CatalogForm catalogId="1001" />).dive();
+    const wrapper = shallow(<CatalogForm catalogId="1001" />);
 
     setImmediate(() => {
       wrapper.update();

--- a/app/javascript/spec/cloud-network-form/cloud-network-form.spec.js
+++ b/app/javascript/spec/cloud-network-form/cloud-network-form.spec.js
@@ -5,7 +5,8 @@ import CloudNetworkForm from '../../components/cloud-network-form/cloud-network-
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import * as networkModule from '../../helpers/network-providers';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
+import {shallow } from 'enzyme';
 
 jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
 
@@ -67,7 +68,7 @@ describe('Cloud Network form component', () => {
   });
 
   it('should render form', (done) => {
-    const wrapper = shallow(<CloudNetworkForm />).dive();
+    const wrapper = shallow(<CloudNetworkForm />);
 
     setImmediate(() => {
       wrapper.update();
@@ -79,7 +80,7 @@ describe('Cloud Network form component', () => {
 
   it('should render edit variant', (done) => {
     fetchMock.getOnce('/api/cloud_networks/1?attributes=cloud_tenant.id,cloud_tenant.name,ext_management_system.name', networkMock);
-    const wrapper = shallow(<CloudNetworkForm cloudNetworkId="1" />).dive();
+    const wrapper = shallow(<CloudNetworkForm cloudNetworkId="1" />);
 
     setImmediate(() => {
       wrapper.update();

--- a/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
+++ b/app/javascript/spec/cloud-tenant-form/cloud-tenant-form.spec.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
 import CloudTenantForm from '../../components/cloud-tenant-form/cloud-tenant-form';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
 
 require('../helpers/miqSparkle.js');
 require('../helpers/miqAjaxButton.js');
@@ -27,14 +28,14 @@ describe('Cloud tenant form component', () => {
   });
 
   it('should render adding form variant', () => {
-    const wrapper = shallow(<CloudTenantForm emsChoices={emsChoices} />).dive();
+    const wrapper = shallow(<CloudTenantForm emsChoices={emsChoices} />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render editing form variant', () => {
     fetchMock
       .getOnce('/cloud_tenant/cloud_tenant_form_fields/1', { name: 'foo' });
-    const wrapper = shallow(<CloudTenantForm cloudTenantFormId={1} />).dive();
+    const wrapper = shallow(<CloudTenantForm cloudTenantFormId={1} />);
     expect(fetchMock._calls[0]).toHaveLength(2);
     expect(fetchMock._calls[0][0]).toEqual('/cloud_tenant/cloud_tenant_form_fields/1');
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/flavor-form/flavor-form.spec.js
+++ b/app/javascript/spec/flavor-form/flavor-form.spec.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
 import FlavorForm from '../../components/flavor-form/flavor-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import '../helpers/mockAsyncRequest';
 import '../helpers/miqSparkle';
 import '../helpers/miqAjaxButton';
 import '../helpers/miqFlashLater';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
 
 jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
 
@@ -43,7 +44,7 @@ describe('Flavor form component', () => {
     fetchMock
       .mock('/flavor/ems_list', emsList)
       .mock('/flavor/cloud_tenants', cloudTenants);
-    const wrapper = shallow(<FlavorForm />).dive();
+    const wrapper = shallow(<FlavorForm />);
     setImmediate(() => {
       wrapper.update();
       expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
+++ b/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { shallowToJson } from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
 
-import '../helpers/miqSparkle';
 import '../helpers/miqFlashLater';
 import '../helpers/sprintf';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import PxeServersForm from '../../components/pxe-servers-form/pxe-server-form';
-import { mount, shallow } from '../helpers/mountForm';
+import { mount } from '../helpers/mountForm';
+import '../helpers/miqSparkle';
 
 describe('PxeServersForm', () => {
   let initialProps;
@@ -21,7 +22,7 @@ describe('PxeServersForm', () => {
   });
 
   it('should render correctly', () => {
-    const wrapper = shallow(<PxeServersForm {...initialProps} />).dive();
+    const wrapper = shallow(<PxeServersForm {...initialProps} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
@@ -53,7 +54,8 @@ describe('PxeServersForm', () => {
       .postOnce('/api/pxe_servers', {});
 
     const wrapper = mount(<PxeServersForm {...initialProps} />);
-    const { form } = wrapper.find(MiqFormRenderer).children().children().children().instance();
+    const { form } = wrapper.find(MiqFormRenderer).children().children().children()
+.instance();
     /**
      * pause validation so we dont need async mocks
      */


### PR DESCRIPTION
Thanks to changes in react-redux shallow renders do not need redux-store. Component also no longer triggers render inside redux store Provider.

After https://github.com/ManageIQ/manageiq-ui-classic/pull/6176 snapshots wrapped in redux provider did break.

Using normal shallow render from enzyme does fix the issue.