### PR TITLE
Async jest tests

### DIFF
--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -186,7 +186,9 @@ const ReportDataTable = (props) => {
 
   const [state, dispatch] = useReducer(reducer, initState);
 
-  useEffect(() => fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, state.pagination), []);
+  useEffect(() => {
+    fetchReportPage(dispatch, props.reportResultId, state.sortingColumns, state.pagination);
+  }, []);
 
   const columns = state.columns.map((item, index) => makeColumn(item.name, item.title, index));
   const filterColumns = state.columns.map((item, index) => makeFilterColumn(item.name, item.title, index));

--- a/app/javascript/spec/async-credentials/async-credentials.spec.js
+++ b/app/javascript/spec/async-credentials/async-credentials.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { FieldProviderComponent as FieldProvider } from '../helpers/fieldProvider';
@@ -36,36 +37,38 @@ describe('Async credentials component', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('should call async validation function on button click and set valid state to true', (done) => {
+  it('should call async validation function on button click and set valid state to true', async(done) => {
     const asyncValidate = jest.fn().mockReturnValue(new Promise(resolve => resolve('Ok')));
     const change = jest.fn();
     const wrapper = mount(<AsyncCredentials {...initialProps} formOptions={{ ...initialProps.formOptions, change }} asyncValidate={asyncValidate} />);
-    wrapper.find('button').simulate('click');
-    setImmediate(() => {
-      expect(asyncValidate).toHaveBeenCalledWith({
-        foo: 'value-foo',
-        bar: 'value-bar',
-        nonAsync: 'non-async',
-      }, ['foo', 'bar']);
-      expect(change).toHaveBeenCalledWith('async-wrapper', true);
-      done();
+
+    await act(async() => {
+      wrapper.find('button').simulate('click');
     });
+    expect(asyncValidate).toHaveBeenCalledWith({
+      foo: 'value-foo',
+      bar: 'value-bar',
+      nonAsync: 'non-async',
+    }, ['foo', 'bar']);
+    expect(change).toHaveBeenCalledWith('async-wrapper', true);
+    done();
   });
 
-  it('should call async validation function on button click and set valid state to false', (done) => {
+  it('should call async validation function on button click and set valid state to false', async(done) => {
     const asyncValidate = jest.fn().mockReturnValue(new Promise((_resolve, reject) => reject('Validation failed'))); // eslint-disable-line prefer-promise-reject-errors
     const change = jest.fn();
     const wrapper = mount(<AsyncCredentials {...initialProps} formOptions={{ ...initialProps.formOptions, change }} asyncValidate={asyncValidate} />);
-    wrapper.find('button').simulate('click');
-    setImmediate(() => {
-      expect(asyncValidate).toHaveBeenCalledWith({
-        foo: 'value-foo',
-        bar: 'value-bar',
-        nonAsync: 'non-async',
-      }, ['foo', 'bar']);
-      expect(change).toHaveBeenCalledWith('async-wrapper', false);
-      done();
+
+    await act(async() => {
+      wrapper.find('button').simulate('click');
     });
+    expect(asyncValidate).toHaveBeenCalledWith({
+      foo: 'value-foo',
+      bar: 'value-bar',
+      nonAsync: 'non-async',
+    }, ['foo', 'bar']);
+    expect(change).toHaveBeenCalledWith('async-wrapper', false);
+    done();
   });
 
   it('should correctly set invalid state after input change', () => {

--- a/app/javascript/spec/flavor-form/flavor-form.spec.js
+++ b/app/javascript/spec/flavor-form/flavor-form.spec.js
@@ -10,8 +10,6 @@ import '../helpers/miqAjaxButton';
 import '../helpers/miqFlashLater';
 import { mount } from '../helpers/mountForm';
 
-jest.mock('../../helpers/miq-redirect-back', () => jest.fn());
-
 describe('Flavor form component', () => {
   let submitSpyMiqSparkleOn;
   let submitSpyMiqSparkleOff;

--- a/app/javascript/spec/forms/input-with-dynamic-prefix.spec.js
+++ b/app/javascript/spec/forms/input-with-dynamic-prefix.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount, shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import { HelpBlock, InputGroup } from 'patternfly-react';
@@ -107,11 +108,13 @@ describe('DataDrivenInputWithPrefix', () => {
     const onChange = jest.fn();
     const wrapper = mount(<DataDrivenInputWithPrefix {...initialProps} input={{ onChange, value: '' }} />);
     /**
-     * select corret option from list
+     * select correct option from list
      */
-    wrapper.find(rawComponents.Select).children().instance().onChange({
-      label: 'Quxx',
-      value: 'https://',
+    act(() => {
+      wrapper.find(rawComponents.Select).children().instance().onChange({
+        label: 'Quxx',
+        value: 'https://',
+      });
     });
     expect(onChange).toHaveBeenCalledWith('https://');
     wrapper.update();

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -4,6 +4,7 @@ import fetchMock from 'fetch-mock';
 import { mount } from '../helpers/mountForm';
 import OpsTenantForm from '../../components/ops-tenant-form/ops-tenant-form';
 import MiqFormRenderer from '../../forms/data-driven-form';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 import '../helpers/miqSparkle';
 import '../helpers/addFlash';
@@ -166,7 +167,7 @@ describe('OpstTenantForm', () => {
     });
 
     wrapper.find('button').last().simulate('click');
-    expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'warning', message: 'Creation of new Project was canceled by the user.' });
+    expect(miqRedirectBack).toHaveBeenCalledWith('Creation of new Project was canceled by the user.', 'warning', '/foo/bar');
     done();
   });
 
@@ -192,7 +193,7 @@ describe('OpstTenantForm', () => {
         divisible: false,
         parent: { id: null },
       });
-      expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully added.' });
+      expect(miqRedirectBack).toHaveBeenCalledWith('Project "foo" has been successfully added.', 'success', '/foo/bar');
       done();
     }, 500);
   });
@@ -231,7 +232,7 @@ describe('OpstTenantForm', () => {
         divisible: false,
         use_config_for_attributes: true,
       });
-      expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully saved.' });
+      expect(miqRedirectBack).toHaveBeenCalledWith('Project "foo" has been successfully saved.', 'success', '/foo/bar');
       done();
     }, 500);
   });

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import fetchMock from 'fetch-mock';
 import { mount } from '../helpers/mountForm';
 import OpsTenantForm from '../../components/ops-tenant-form/ops-tenant-form';
@@ -32,39 +33,43 @@ describe('OpstTenantForm', () => {
     flashLaterSpy.mockReset();
   });
 
-  it('should mount form without initialValues', (done) => {
+  it('should mount form without initialValues', async(done) => {
     fetchMock.getOnce(`/api/tenants/${initialProps.recordId}?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible`, {
       name: 'foo',
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} />);
-    setImmediate(() => {
-      wrapper.update();
-      expect(wrapper.find(MiqFormRenderer).props().initialValues).toEqual({});
-      expect(fetchMock.calls().length).toEqual(0);
-      expect(sparkleOnSpy).not.toHaveBeenCalled();
-      expect(sparkleOffSpy).not.toHaveBeenCalled();
-      done();
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} />);
     });
+
+    wrapper.update();
+    expect(wrapper.find(MiqFormRenderer).props().initialValues).toEqual({});
+    expect(fetchMock.calls().length).toEqual(0);
+    expect(sparkleOnSpy).not.toHaveBeenCalled();
+    expect(sparkleOffSpy).not.toHaveBeenCalled();
+    done();
   });
 
-  it('should mount and set initialValues', (done) => {
+  it('should mount and set initialValues', async(done) => {
     fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
       name: 'foo',
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
-    setImmediate(() => {
-      wrapper.update();
-      expect(wrapper.find(MiqFormRenderer).props().initialValues).toEqual({
-        name: 'foo',
-      });
-      expect(fetchMock.calls()).toHaveLength(1);
-      expect(sparkleOnSpy).toHaveBeenCalled();
-      expect(sparkleOffSpy).toHaveBeenCalled();
-      done();
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
     });
+
+    wrapper.update();
+    expect(wrapper.find(MiqFormRenderer).props().initialValues).toEqual({
+      name: 'foo',
+    });
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(sparkleOnSpy).toHaveBeenCalled();
+    expect(sparkleOffSpy).toHaveBeenCalled();
+    done();
   });
 
-  it('should correctly check unique name', (done) => {
+  it('should correctly check unique name', async(done) => {
     fetchMock.getOnce('/api/tenants?filter[]=name=&expand=resources', {
       resources: [],
     });
@@ -80,32 +85,30 @@ describe('OpstTenantForm', () => {
         name: 'foo',
       }],
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} ancestry={1} />);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} ancestry={1} />);
+    });
     /**
      * first empty validation
      */
-    setTimeout(() => {
-      wrapper.update();
+    setTimeout(async() => {
       wrapper.find('input').first().simulate('change', { target: { value: 'foo' } });
       wrapper.update();
       /**
        * second validation with taken value
        */
       setTimeout(() => {
-        wrapper.update();
-        wrapper.update();
         expect(wrapper.find('.form-group').first().instance().className).toEqual('form-group has-error');
         wrapper.find('input').first().simulate('change', { target: { value: 'unique' } });
         wrapper.update();
-        setTimeout(() => {
-          expect(wrapper.find('.form-group').first().instance().className).toEqual('form-group');
-          done();
-        }, 500);
+        expect(wrapper.find('.form-group').first().instance().className).toEqual('form-group');
+        done();
       }, 500);
     }, 500);
   });
 
-  it('should render configuration which and change name isDisabled property', (done) => {
+  it('should render configuration which and change name isDisabled property', async(done) => {
     fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
       name: 'foo',
       description: 'bar',
@@ -115,23 +118,22 @@ describe('OpstTenantForm', () => {
     fetchMock.getOnce('/api/tenants?filter[]=name=foo&expand=resources', {
       resources: [],
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
-    /**
-     * mount
-     */
-    setTimeout(() => {
-      wrapper.update();
-      const pfSwitch = wrapper.find('.pf3-switch');
-      expect(wrapper.find('input').first().props().disabled).toEqual(true);
-      expect(pfSwitch).toHaveLength(1);
-      pfSwitch.find('input').simulate('change', { target: { checked: false } });
-      wrapper.update();
-      expect(wrapper.find('input').first().props().disabled).toEqual(false);
-      done();
-    }, 500);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
+    });
+
+    wrapper.update();
+    const pfSwitch = wrapper.find('.pf3-switch');
+    expect(wrapper.find('input').first().props().disabled).toEqual(true);
+    expect(pfSwitch).toHaveLength(1);
+    pfSwitch.find('input').simulate('change', { target: { checked: false } });
+    wrapper.update();
+    expect(wrapper.find('input').first().props().disabled).toEqual(false);
+    done();
   });
 
-  it('should call addFlash when reseting edit form', (done) => {
+  it('should call addFlash when reseting edit form', async(done) => {
     fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
       name: 'foo',
       description: 'bar',
@@ -141,31 +143,34 @@ describe('OpstTenantForm', () => {
     fetchMock.getOnce('/api/tenants?filter[]=name=foo&expand=resources', {
       resources: [],
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
-    /**
-     * mount
-     */
-    setTimeout(() => {
-      wrapper.update();
-      wrapper.find('input').first().simulate('change', { target: { value: 'bar' } });
-      wrapper.update();
-      wrapper.find('button').at(1).simulate('click');
-      expect(flashSpy).toHaveBeenCalledWith('All changes have been reset', 'warning');
-      done();
-    }, 500);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
+    });
+
+    wrapper.update();
+    wrapper.find('input').first().simulate('change', { target: { value: 'bar' } });
+    wrapper.update();
+    wrapper.find('button').at(1).simulate('click');
+    expect(flashSpy).toHaveBeenCalledWith('All changes have been reset', 'warning');
+    done();
   });
 
-  it('should call miqRedirectBack when canceling form', (done) => {
+  it('should call miqRedirectBack when canceling form', async(done) => {
     fetchMock.getOnce('/api/tenants?filter[]=name=&expand=resources', {
       resources: [],
     });
-    const wrapper = mount(<OpsTenantForm {...initialProps} />);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} />);
+    });
+
     wrapper.find('button').last().simulate('click');
     expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'warning', message: 'Creation of new Project was canceled by the user.' });
     done();
   });
 
-  it('should correctly add new entity.', (done) => {
+  it('should correctly add new entity.', async(done) => {
     fetchMock.getOnce('/api/tenants?filter[]=name=foo&expand=resources', {
       resources: [],
     });
@@ -174,23 +179,25 @@ describe('OpstTenantForm', () => {
     const wrapper = mount(<OpsTenantForm {...initialProps} />);
     wrapper.find('input').at(0).simulate('change', { target: { value: 'foo' } });
     wrapper.find('input').at(1).simulate('change', { target: { value: 'bar' } });
+
     wrapper.update();
-    setTimeout(() => {
-      wrapper.find('button').first().simulate('click');
-      setTimeout(() => {
-        expect(JSON.parse(fetchMock.calls()[1][1].body)).toEqual({
-          name: 'foo',
-          description: 'bar',
-          divisible: false,
-          parent: { id: null },
-        });
-        expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully added.' });
-        done();
-      }, 500);
+
+    setTimeout(async() => {
+      await act(async() => {
+        wrapper.find('button').first().simulate('click');
+      });
+      expect(JSON.parse(fetchMock.calls()[1][1].body)).toEqual({
+        name: 'foo',
+        description: 'bar',
+        divisible: false,
+        parent: { id: null },
+      });
+      expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully added.' });
+      done();
     }, 500);
   });
 
-  it('should correctly edit existing entity.', (done) => {
+  it('should correctly edit existing entity.', async(done) => {
     fetchMock.getOnce('/api/tenants/123?expand=resources&attributes=name,description,use_config_for_attributes,ancestry,divisible', {
       name: 'foo',
       description: 'bar',
@@ -203,25 +210,29 @@ describe('OpstTenantForm', () => {
     });
     fetchMock.putOnce('/api/tenants/123', {});
     fetchMock.postOnce('/ops/invalidate_miq_product_feature_caches', {});
-    const wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);
+    });
+
     wrapper.update();
-    setTimeout(() => {
-      wrapper.update();
+
+    await act(async() => {
       wrapper.find('input').at(1).simulate('change', { target: { value: 'desc' } });
-      wrapper.update();
-      setTimeout(() => {
+    });
+    wrapper.update();
+    setTimeout(async() => {
+      await act(async() => {
         wrapper.find('button').first().simulate('click');
-        setTimeout(() => {
-          expect(JSON.parse(fetchMock.calls()[2][1].body)).toEqual({
-            name: 'foo',
-            description: 'desc',
-            divisible: false,
-            use_config_for_attributes: true,
-          });
-          expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully saved.' });
-          done();
-        }, 500);
-      }, 500);
+      });
+      expect(JSON.parse(fetchMock.calls()[2][1].body)).toEqual({
+        name: 'foo',
+        description: 'desc',
+        divisible: false,
+        use_config_for_attributes: true,
+      });
+      expect(flashLaterSpy).toHaveBeenCalledWith({ level: 'success', message: 'Project "foo" has been successfully saved.' });
+      done();
     }, 500);
   });
 });

--- a/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
+++ b/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import fetchMock from 'fetch-mock';
 
 import '../helpers/addFlash';
@@ -30,118 +31,99 @@ describe('OrcherstrationTemplate form', () => {
     addFlashSpy.mockRestore();
   });
 
-  it('should call submit function', (done) => {
-    const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
+  it('should call submit function', async(done) => {
     fetchMock.postOnce('/api/orchestration_templates', {});
-    setTimeout(() => {
-      wrapper.update();
-      wrapper.find('input#name').simulate('change', { target: { value: 'foo' } });
-      /**
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
+    });
+    wrapper.update();
+    wrapper.find('input#name').simulate('change', { target: { value: 'foo' } });
+    /**
        * manually change content value
        * Code component is not standard input element
        * Two first parameters are codemirror element and data
        */
-      wrapper.find(CodeEditor).props().onChange(null, null, 'Some random content');
-      wrapper.update();
-      wrapper.find('button.btn.btn-primary').simulate('click');
-      expect(fetchMock.lastCall()).toBeTruthy();
-      expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
-        name: 'foo',
-        content: 'Some random content',
-      }));
-      expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
-      done();
-    });
+    wrapper.find(CodeEditor).props().onChange(null, null, 'Some random content');
+    wrapper.update();
+    wrapper.find('button.btn.btn-primary').simulate('click');
+    expect(fetchMock.lastCall()).toBeTruthy();
+    expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
+      name: 'foo',
+      content: 'Some random content',
+    }));
+    expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
+    done();
   });
 
   it('should call miqFlashLater on cancel action', () => {
     const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
-    setTimeout(() => {
-      wrapper.update();
-      wrapper.find('button').last().simulate('click');
-      expect(flashLaterSpy).toHaveBeenCalledWith({
-        level: 'success',
-        message: 'Creation of a new Orchestration Template was cancelled by the user',
-      });
+    wrapper.update();
+    wrapper.find('button').last().simulate('click');
+    expect(flashLaterSpy).toHaveBeenCalledWith({
+      level: 'success',
+      message: 'Creation of a new Orchestration Template was cancelled by the user',
     });
   });
 
-  it('should render edit variant', (done) => {
+  it('should render edit variant', async(done) => {
     fetchMock.patchOnce('/api/orchestration_templates/123', {});
     fetchMock.getOnce('/api/orchestration_templates/123?attributes=name,description,type,ems_id,draft,content', {
       name: 'foo',
       content: 'content',
     });
-    const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} otId={123} />);
-    /**
-     * async load
-     */
-    setImmediate(() => {
-      /**
-       * state update
-       */
-      setImmediate(() => {
-        wrapper.update();
-        wrapper.find('input#name').simulate('change', { target: { value: 'bar' } });
-        wrapper.update();
-        wrapper.find('button.btn.btn-primary').simulate('click');
-        /**
-         * after patch request
-         */
-        setImmediate(() => {
-          expect(fetchMock.lastCall()).toBeTruthy();
-          expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
-            name: 'bar',
-            content: 'content',
-          }));
-          expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
-          done();
-        });
-      });
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OrcherstrationTemplateForm {...initialProps} otId={123} />);
     });
+    wrapper.update();
+    wrapper.find('input#name').simulate('change', { target: { value: 'bar' } });
+    wrapper.update();
+    await act(async() => {
+      wrapper.find('button.btn.btn-primary').simulate('click');
+    });
+
+    expect(fetchMock.lastCall()).toBeTruthy();
+    expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
+      name: 'bar',
+      content: 'content',
+    }));
+    expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
+    done();
   });
 
-  it('should render copy variant', (done) => {
+  it('should render copy variant', async(done) => {
     fetchMock.postOnce('/api/orchestration_templates/123', {});
     fetchMock.getOnce('/api/orchestration_templates/123?attributes=name,description,type,ems_id,draft,content', {
       name: 'foo',
       content: 'content',
     });
-    const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} otId={123} copy />);
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OrcherstrationTemplateForm {...initialProps} otId={123} copy />);
+    });
+    wrapper.update();
+    wrapper.find('input#name').simulate('change', { target: { value: 'bar' } });
     /**
-     * async load
-     */
-    setImmediate(() => {
-      /**
-       * state update
-       */
-      setImmediate(() => {
-        wrapper.update();
-        wrapper.find('input#name').simulate('change', { target: { value: 'bar' } });
-        /**
          * manually change content value
          * Code component is not standard input element
          * Two first parameters are codemirror element and data
          */
-        wrapper.find(CodeEditor).props().onChange(null, null, 'updated content');
-        wrapper.update();
-        wrapper.find('button.btn.btn-primary').simulate('click');
-        /**
-         * after copy request
-         */
-        setImmediate(() => {
-          expect(fetchMock.lastCall()).toBeTruthy();
-          expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
-            action: 'copy',
-            resource: {
-              name: 'bar',
-              content: 'updated content',
-            },
-          }));
-          expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
-          done();
-        });
-      });
+    wrapper.find(CodeEditor).props().onChange(null, null, 'updated content');
+    wrapper.update();
+    await act(async() => {
+      wrapper.find('button.btn.btn-primary').simulate('click');
     });
+
+    expect(fetchMock.lastCall()).toBeTruthy();
+    expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
+      action: 'copy',
+      resource: {
+        name: 'bar',
+        content: 'updated content',
+      },
+    }));
+    expect(sparkleOnSpy).toHaveBeenCalledTimes(1);
+    done();
   });
 });

--- a/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
+++ b/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
@@ -10,13 +10,13 @@ import { mount } from '../helpers/mountForm';
 
 import CodeEditor from '../../components/code-editor';
 import OrcherstrationTemplateForm from '../../components/orchestration-template/orcherstration-template-form';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 describe('OrcherstrationTemplate form', () => {
   let initialProps;
   const sparkleOnSpy = jest.spyOn(window, 'miqSparkleOn');
   const sparkleOffSpy = jest.spyOn(window, 'miqSparkleOff');
   const addFlashSpy = jest.spyOn(window, 'add_flash');
-  const flashLaterSpy = jest.spyOn(window, 'miqFlashLater');
 
   beforeEach(() => {
     initialProps = {
@@ -60,10 +60,11 @@ describe('OrcherstrationTemplate form', () => {
     const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
     wrapper.update();
     wrapper.find('button').last().simulate('click');
-    expect(flashLaterSpy).toHaveBeenCalledWith({
-      level: 'success',
-      message: 'Creation of a new Orchestration Template was cancelled by the user',
-    });
+    expect(miqRedirectBack).toHaveBeenCalledWith(
+      'Creation of a new Orchestration Template was cancelled by the user',
+      'success',
+      '/catalog/explorer',
+    );
   });
 
   it('should render edit variant', async(done) => {

--- a/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
+++ b/app/javascript/spec/pxe-servers-form/pxe-server-form.spec.js
@@ -10,6 +10,7 @@ import MiqFormRenderer from '../../forms/data-driven-form';
 import PxeServersForm from '../../components/pxe-servers-form/pxe-server-form';
 import { mount } from '../helpers/mountForm';
 import '../helpers/miqSparkle';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 describe('PxeServersForm', () => {
   let initialProps;
@@ -95,7 +96,6 @@ describe('PxeServersForm', () => {
   });
 
   it('should sucesfully call cancel add server action', async(done) => {
-    const flashSpy = jest.spyOn(window, 'miqFlashLater');
     fetchMock
       .getOnce('/api/pxe_servers?expand=resources&filter[]=name=%27%27', { resources: [] });
 
@@ -105,12 +105,11 @@ describe('PxeServersForm', () => {
     });
 
     wrapper.find('button').last().simulate('click');
-    expect(flashSpy).toHaveBeenCalledWith({ level: 'success', message: 'Add of new PXE Server was cancelled by the user' });
+    expect(miqRedirectBack).toHaveBeenCalledWith('Add of new PXE Server was cancelled by the user', 'success', '/pxe/explorer');
     done();
   });
 
   it('should sucesfully call cancel edit server action', async(done) => {
-    const flashSpy = jest.spyOn(window, 'miqFlashLater');
     fetchMock.getOnce('/api/pxe_servers/123?attributes=access_url,authentications,customization_directory,name,pxe_directory,pxe_menus,uri,windows_images_directory', { // eslint-disable-line max-len
       pxe_menus: [{ file_name: 'bar' }],
       authentications: [],
@@ -125,7 +124,7 @@ describe('PxeServersForm', () => {
 
     wrapper.update();
     wrapper.find('button').last().simulate('click');
-    expect(flashSpy).toHaveBeenCalledWith({ level: 'success', message: 'Edit of PXE Server foo was cancelled by the user' });
+    expect(miqRedirectBack).toHaveBeenCalledWith('Edit of PXE Server foo was cancelled by the user', 'success', '/pxe/explorer');
     done();
   });
 });

--- a/app/javascript/spec/report-data-table.spec.js
+++ b/app/javascript/spec/report-data-table.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
-import { act } from 'react-test-renderer';
+import { act } from 'react-dom/test-utils';
 import { EmptyState, Paginator, Table } from 'patternfly-react';
 
 import './helpers/mockAsyncRequest';
@@ -11,6 +11,7 @@ import ReportDataTable from '../components/report-data-table';
 
 describe('<ReportDataTable />', () => {
   let initialProps;
+  jest.setTimeout(30000);
 
   beforeEach(() => {
     initialProps = {
@@ -36,42 +37,35 @@ sort_by=${sortBy}&sort_order=${sortDirection}&\
 limit=${limit}&offset=${offset}`;
   };
 
-  it('should fetch and display report data when instantiated', (done) => {
+  it('should fetch and display report data when instantiated', async(done) => {
     fetchMock.getOnce(requestUrl(), { report: { col_order: [] }, count: 1, result_set: [{ foo: 'bar' }] });
-
     let wrapper;
-    act(() => {
+    await act(async() => {
       wrapper = mount(<ReportDataTable {...initialProps} />);
     });
-
-    setTimeout(() => {
-      wrapper.update();
-
-      expect(fetchMock.calls()).toHaveLength(1);
-      expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
-      expect(wrapper.find(Table.PfProvider)).toHaveLength(1);
-      expect(wrapper.find(Paginator)).toHaveLength(1);
-      done();
-    });
+    wrapper.update();
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
+    expect(wrapper.find(Table.PfProvider)).toHaveLength(1);
+    expect(wrapper.find(Paginator)).toHaveLength(1);
+    done();
   });
 
-  it('should display empty state when there is no data', (done) => {
+  it('should display empty state when there is no data', async(done) => {
     fetchMock.getOnce(requestUrl(), { report: { col_order: [] }, count: 0, result_set: [] });
 
     let wrapper;
-    act(() => {
+    await act(async() => {
       wrapper = mount(<ReportDataTable {...initialProps} />);
     });
 
-    setTimeout(() => {
-      wrapper.update();
+    wrapper.update();
 
-      expect(fetchMock.calls()).toHaveLength(1);
-      expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
-      expect(wrapper.find(Table.PfProvider)).toHaveLength(0);
-      expect(wrapper.find(Paginator)).toHaveLength(0);
-      expect(wrapper.find(EmptyState)).toHaveLength(1);
-      done();
-    });
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(wrapper.find('div.table-view-pf-toolbar')).toHaveLength(1);
+    expect(wrapper.find(Table.PfProvider)).toHaveLength(0);
+    expect(wrapper.find(Paginator)).toHaveLength(0);
+    expect(wrapper.find(EmptyState)).toHaveLength(1);
+    done();
   });
 });

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -17,6 +17,7 @@ import Enzyme from 'enzyme';
 import EnzymeAdapter from 'enzyme-adapter-react-16';
 Enzyme.configure({ adapter: new EnzymeAdapter() });
 
+
 // mock document.body.createTextRange for code mirror
 document.body.createTextRange = () => ({
   setEnd: () => {},
@@ -46,3 +47,9 @@ Object.defineProperty(Array.prototype, 'flat', {
       }, []);
     }
 });
+
+/**
+ * mock redirect-back to avoid console errors about: error: not implemented: navigation (except hash changes)
+ * unfortunately this cannot be mocked in some helper file it will only work in global setup
+ */
+jest.mock('../app/javascript/helpers/miq-redirect-back', () => jest.fn());


### PR DESCRIPTION
closes #6271 

depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/6274

Uses async act wrapper around functional components state updates to remove this error from console:
```
Warning: An update to WorkersForm inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act

```