### PR TITLE
Fix loading of Network Port details screen

### DIFF
--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -59,6 +59,8 @@ module NetworkPortHelper::TextualSummary
         h[:title] = _("Show Instance")
       end
       h
+    elsif device.kind_of?(LoadBalancer)
+      device.name
     else
       device
     end

--- a/spec/shared/controllers/shared_network_manager_context.rb
+++ b/spec/shared/controllers/shared_network_manager_context.rb
@@ -47,6 +47,16 @@ shared_context :shared_network_manager_context do |t|
                                                             :security_groups       => [@security_group],
                                                             :floating_ip           => @floating_ip,
                                                             :ext_management_system => @ems)
+
+    @load_balancer = FactoryBot.create(:load_balancer)
+    @load_balancer.network_ports << @network_port = FactoryBot.create("network_port_#{t}".to_sym,
+                                                                      :name                  => "eth0",
+                                                                      :mac_address           => "06:04:25:40:8e:79",
+                                                                      :device                => @load_balancer,
+                                                                      :security_groups       => [@security_group],
+                                                                      :floating_ip           => @floating_ip,
+                                                                      :ext_management_system => @ems)
+
     FactoryBot.create(:cloud_subnet_network_port,
                        :cloud_subnet => @cloud_subnet,
                        :network_port => @network_port,


### PR DESCRIPTION
When Network Port has a device of type LoadBalancer, loading of details screen throws a missing route error because LoadBalancer views no longer exist in UI. This change shows LoadBalancer information as a static name instead of a link.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1758593

before
![before](https://user-images.githubusercontent.com/3450808/66326005-40e72600-e8f6-11e9-8aea-34fb755c7e9c.png)

after
![after](https://user-images.githubusercontent.com/3450808/66326032-4cd2e800-e8f6-11e9-938b-f33bc1b1f2cf.png)
