### PR TITLE
Disable "Apply" button when all sections are deselected.

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -433,6 +433,7 @@ module ApplicationController::Compare
       set_checked_sections
       render :update do |page|
         page << javascript_prologue
+        page << javascript_for_miq_button_visibility(!session[:selected_sections].empty?)
         page << "miqSparkle(false);"
         # head :ok
       end
@@ -440,8 +441,8 @@ module ApplicationController::Compare
   end
 
   def set_checked_sections
+    session[:selected_sections] = []
     if params[:all_checked]
-      session[:selected_sections] = []
       params[:all_checked].each do |a|
         s = a.split(':')
         if s.length > 1
@@ -1194,12 +1195,14 @@ module ApplicationController::Compare
     @rows = []
     @cols = []
     @compressed = session[:miq_compressed]
+    session[:selected_sections] ||= []
 
     comp_add_header(view)
     comp_add_total(view)
 
     # Build the sections, records, and fields rows
     view.master_list.each_slice(3) do |section, records, fields| # section is a symbol, records and fields are arrays
+      session[:selected_sections].push(section[:name]) if view.include[section[:name]][:checked] && !session[:selected_sections].include?(section[:name])
       next unless view.include[section[:name]][:checked]
       comp_add_section(view, section, records, fields) # Go build the section row if it's checked
       if !records.nil? # If we have records, build record rows
@@ -1774,12 +1777,14 @@ module ApplicationController::Compare
     @layout = view.report.db == "VmOrTemplate" ? @sb[:compare_db].underscore : view.report.db.underscore
     @compressed = session[:miq_compressed]
     @exists_mode = session[:miq_exists_mode]
+    session[:selected_sections] ||= []
 
     drift_add_header(view)
     drift_add_total(view)
 
     # Build the sections, records, and fields rows
     view.master_list.each_slice(3) do |section, records, fields| # section is a symbol, records and fields are arrays
+      session[:selected_sections].push(section[:name]) if view.include[section[:name]][:checked] && !session[:selected_sections].include?(section[:name])
       if view.include[section[:name]][:checked]
         drift_add_section(view, section, records, fields) # Go build the section row if it's checked
         if !records.nil? # If we have records, build record rows

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -26,13 +26,19 @@
       miqTreeResetState('#{j_str @sections_tree.name}');
     = render(:partial => 'shared/tree', :locals => {:tree => @sections_tree, :name => @sections_tree.name})
   .spacer
-  = link_to(_('Apply'),
-    {:action => 'sections_field_changed', :check => @lastaction},
-    "data-miq_sparkle_on"  => true,
-    "data-miq_sparkle_off" => true,
-    :remote                => true,
-    "data-method"          => :post,
-    :title                 => _('Apply sections'),
-    :class                 => "btn btn-primary pull-right",
-    :alt                   => _('Apply sections'),
-    :id                    => "sections_commit")
+  %table{:width => "100%"}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on{:style => "display:#{session[:selected_sections].empty? ? "none" : "display"};"}
+          = link_to(_('Apply'),
+            {:action => 'sections_field_changed', :check => @lastaction},
+            "data-miq_sparkle_on"  => true,
+            "data-miq_sparkle_off" => true,
+            :remote                => true,
+            "data-method"          => :post,
+            :title                 => _('Apply sections'),
+            :class                 => "btn btn-primary pull-right",
+            :alt                   => _('Apply sections'),
+            :id                    => "sections_commit")
+        #buttons_off{:style => "display:#{session[:selected_sections].empty? ? "display" : "none"};"}
+          = button_tag(_("Apply"), :class => "btn btn-primary disabled", :title => _('At least one section must be selected'))

--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -150,6 +150,22 @@ describe EmsClusterController do
       row = controller.send(:comp_record_data_compressed, 1, nil, nil, true)
       expect(row).to eq(:col2=> '<div class=""><i class="compare-diff" title="Missing"></i></div>')
     end
+
+    it "sets session[:selected_sections] to empty array when last section on screen is unchecked" do
+      session[:selected_sections] = [:_model_]
+      controller.params = {:id => "xx-group_Properties_xx-group_Properties%253A_model_", :check => "false"}
+      allow(controller).to receive(:render)
+      controller.send(:sections_field_changed)
+      expect(session[:selected_sections]).to eq([])
+    end
+
+    it "sets selected sections in session[:selected_sections]" do
+      session[:selected_sections] = [:_model_]
+      controller.params = {:all_checked => ["xx-group_Properties_xx-group_Properties:_model_", "xx-group_Properties_xx-group_Properties:hardware"], :id => "xx-group_Properties_xx-group_Properties%253Ahardware", :check => "true"}
+      allow(controller).to receive(:render)
+      controller.send(:sections_field_changed)
+      expect(session[:selected_sections]).to eq(["_model_", "hardware"])
+    end
   end
 
   context 'drifts' do

--- a/spec/views/layouts/listnav/_compare_sections.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_compare_sections.html.haml_spec.rb
@@ -1,0 +1,48 @@
+describe 'layouts/_compare_sections.html.haml' do
+  before do
+    set_controller_for_view("host")
+    @sb = {
+      "compare_db"      => "Host",
+      "miq_temp_params" => "all",
+      "trees"           => {
+        "all_sections_tree" => {
+          "tree"         => :all_sections_tree,
+          "klass_name"   => "TreeBuilderSections",
+          "open_nodes"   => [],
+          "full_ids"     => true,
+          "checkboxes"   => true,
+          "three_checks" => true,
+          "oncheck"      => "miqOnCheckSections",
+          "check_url"    => "/host/sections_field_changed/",
+          "active_node"  => "xx-group_Properties"
+        }
+      }
+    }
+    MiqReport.seed
+    rpt = MiqReport.find_by(:filename => "hosts.yaml", :template_type => "compare")
+    @sections_tree = TreeBuilderSections.new(:all_sections_tree,
+                                             @sb,
+                                             true,
+                                             :data            => MiqCompare.new({:ids=>[1, 2]}, rpt),
+                                             :controller_name => "host",
+                                             :current_tenant  => "manageiq")
+  end
+
+  it 'Apply button is enabled' do
+    allow(view).to receive(:session).and_return(:selected_sections => [:_model_])
+    render :partial => 'layouts/listnav/compare_sections'
+    apply_buttons_on = "<div id='buttons_on' style='display:display;'>"
+    apply_button_off = "<div id='buttons_off' style='display:none;'>"
+    expect(response).to include(apply_buttons_on)
+    expect(response).to include(apply_button_off)
+  end
+
+  it 'Apply button is disabled' do
+    allow(view).to receive(:session).and_return(:selected_sections => [])
+    render :partial => 'layouts/listnav/compare_sections'
+    apply_buttons_on = "<div id='buttons_on' style='display:none;'>"
+    apply_button_off = "<div id='buttons_off' style='display:display;'>"
+    expect(response).to include(apply_buttons_on)
+    expect(response).to include(apply_button_off)
+  end
+end


### PR DESCRIPTION
Apply button should only be enabled when atleast one section is selected to compare/drift.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740406

before
![before](https://user-images.githubusercontent.com/3450808/66337635-89f6a480-e90d-11e9-870a-523314c2c7dd.png)

after
![after](https://user-images.githubusercontent.com/3450808/66337643-8ebb5880-e90d-11e9-8a3c-ed9c85fb5c16.png)

This PR disabled Apply button if user deselects the last checked item on the screen, forces user to select at least one section to compare.

@hstastna please review/test