### PR TITLE
Locked data driven forms version to ~1.18.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@data-driven-forms/pf3-component-mapper": "^1.15.6",
-    "@data-driven-forms/react-form-renderer": "^1.15.6",
+    "@data-driven-forms/pf3-component-mapper": "~1.18.0",
+    "@data-driven-forms/react-form-renderer": "~1.18.0",
     "@manageiq/react-ui-components": "~0.11.48",
     "@manageiq/ui-components": "~1.3.1",
     "@pf3/select": "~1.12.6",


### PR DESCRIPTION
Version `1.19.x` of data driven forms causes jest to fail. Until we find solution there we should lock it to version 1.18