### PR TITLE
Display only one Cancel button for Compare action

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1213,6 +1213,7 @@ module ApplicationController::Compare
     @grid_cols_json = @cols.to_json.to_s.html_safe
 
     @lastaction = "compare_miq"
+    @explorer = true if request.xml_http_request? && explorer_controller?
   end
 
   def compare_build_record_rows(view, section, records, fields)


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6263

This PR fixes issue with displaying two _Cancel_ buttons after making changes in _Comparison Sections_ for Compare action. The core of the problem was that `@explorer` variable, which is needed [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_compare.html.haml#L21), was not always properly set . The place where I put the condition was chosen the way that no matter which changes we make while comparing items, `@explorer` is properly set.

Note:
I've tested also other screens (explorer and non-explorer ones) under _Compute > Infra_ and also _Compte > Clouds_ and the changes work for them well.

---

**Before:**
![compare_before](https://user-images.githubusercontent.com/13417815/66468003-b7665e00-ea85-11e9-9640-30655386b78f.png)

**After:**
![compare_after](https://user-images.githubusercontent.com/13417815/66468008-b9302180-ea85-11e9-871b-f6ce57e35929.png)
