### PR TITLE
Renamed 'Generic Object Classes' to 'Generic Object Definitions'

### DIFF
--- a/app/assets/javascripts/components/generic_object/generic-object-definition.js
+++ b/app/assets/javascripts/components/generic_object/generic-object-definition.js
@@ -16,7 +16,7 @@ function genericObjectDefinitionFormController(API, miqService, $q, $scope) {
   vm.$onInit = function() {
     ManageIQ.angular.scope = $scope;
 
-    vm.entity = __('Generic Object Class');
+    vm.entity = __('Generic Object Definition');
     vm.saveable = miqService.saveable;
     vm.afterGet = false;
 

--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -188,14 +188,14 @@ class GenericObjectDefinitionController < ApplicationController
   def root_node_info
     @root_node = true
     @center_toolbar = 'generic_object_definitions'
-    @right_cell_text = _("All %{models}") % {:models => _("Generic Object Classes")}
+    @right_cell_text = _("All %{models}") % {:models => _("Generic Object Definitions")}
   end
 
   def god_node_info(node)
     @god_node = true
     @center_toolbar = 'generic_object_definition'
     @record = GenericObjectDefinition.find(node.split('-').last)
-    @right_cell_text = _("Generic Object Class %{record_name}") % {:record_name => @record.name}
+    @right_cell_text = _("Generic Object Definition %{record_name}") % {:record_name => @record.name}
     @gtl_type = nil
   end
 
@@ -306,7 +306,7 @@ class GenericObjectDefinitionController < ApplicationController
       {
         :role  => "god_accord",
         :name  => :god,
-        :title => _("Generic Object Classes"),
+        :title => _("Generic Object Definitions"),
       },
     ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
   end

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
         button(
           :generic_object_definition_edit,
           'pficon pficon-edit fa-lg',
-          t = N_('Edit this Generic Object Class'),
+          t = N_('Edit this Generic Object Definition'),
           t,
         ),
         button(
@@ -26,11 +26,11 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
         button(
           :generic_object_definition_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Generic Object Classes from Inventory'),
+          N_('Remove this Generic Object Definitions from Inventory'),
           :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Class"}},
+                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Definition"}},
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonDelete,
-          :confirm => N_("Warning: This Generic Object Class will be permanently removed!"),
+          :confirm => N_("Warning: This Generic Object Definition will be permanently removed!"),
         ),
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
           :data    => {'function'      => 'sendDataWithRx',
                        'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Definition"}},
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonDelete,
-          :confirm => N_("Warning: This Generic Object Definition will be permanently removed!"),
+          :confirm => N_("Warning: This Generic Object Definition will be permanently removed!")
         ),
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
@@ -8,13 +8,13 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionsCenter < ApplicationHe
         button(
           :generic_object_definition_new,
           'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a new Generic Object Class'),
+          t = N_('Add a new Generic Object Definition'),
           t,
         ),
         button(
           :generic_object_definition_edit,
           'pficon pficon-edit fa-lg',
-          N_('Edit selected Generic Object Class'),
+          N_('Edit selected Generic Object Definition'),
           :enabled      => false,
           :onwhen       => "1",
           :url_parms    => "edit_div",
@@ -23,13 +23,13 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionsCenter < ApplicationHe
         button(
           :generic_object_definition_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Generic Object Classes from Inventory'),
+          t = N_('Remove selected Generic Object Definitions from Inventory'),
           t,
           :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Class"}},
+                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Definitions"}},
           :enabled                     => false,
           :onwhen                      => "1+",
-          :confirm => N_("Warning: This Generic Object Class will be permanently removed!")
+          :confirm => N_("Warning: This Generic Object Definition will be permanently removed!")
         ),
       ]
     )

--- a/app/presenters/tree_builder_generic_object_definition.rb
+++ b/app/presenters/tree_builder_generic_object_definition.rb
@@ -7,7 +7,7 @@ class TreeBuilderGenericObjectDefinition < TreeBuilder
 
   def root_options
     {
-      :text    => t = _('All Generic Object Classes'),
+      :text    => t = _('All Generic Object Definitions'),
       :tooltip => t
     }
   end

--- a/app/views/generic_object_definition/_show_god.html.haml
+++ b/app/views/generic_object_definition/_show_god.html.haml
@@ -13,7 +13,7 @@
             %img{:src => "#{@record.picture.url_path}", :style => "width:100px; height:100px;"}
 
 %generic-object-definition-toolbar#generic_object_definition_show_form{'record-id'    => @record.id,
-                                                                       'entity'       => _('Generic Object Class'),
+                                                                       'entity'       => _('Generic Object Definition'),
                                                                        'entity-name'  => @record.name,
                                                                        'redirect-url' => "/generic_object_definition",}
 :javascript

--- a/app/views/generic_object_definition/_show_list.html.haml
+++ b/app/views/generic_object_definition/_show_list.html.haml
@@ -9,7 +9,7 @@
 - if @custom_button_node
   = render :partial => 'generic_object_definition/show_custom_button'
 
-%generic-object-definition-toolbar#generic_object_definition_show_list_form{'entity' => _('Generic Object Class'), 'redirect-url' => "/generic_object_definition"}
+%generic-object-definition-toolbar#generic_object_definition_show_list_form{'entity' => _('Generic Object Definition'), 'redirect-url' => "/generic_object_definition"}
 
 :javascript
   miq_bootstrap('#generic_object_definition_show_list_form');

--- a/app/views/generic_object_definition/_show_list.html.haml
+++ b/app/views/generic_object_definition/_show_list.html.haml
@@ -9,7 +9,8 @@
 - if @custom_button_node
   = render :partial => 'generic_object_definition/show_custom_button'
 
-%generic-object-definition-toolbar#generic_object_definition_show_list_form{'entity' => _('Generic Object Definition'), 'redirect-url' => "/generic_object_definition"}
+%generic-object-definition-toolbar#generic_object_definition_show_list_form{'entity' => _('Generic Object Definition'),
+                                                                            'redirect-url' => "/generic_object_definition"}
 
 :javascript
   miq_bootstrap('#generic_object_definition_show_list_form');

--- a/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
@@ -1,5 +1,5 @@
 - return if @display == 'generic_objects' || @display == 'main'
-= miq_accordion_panel(_("Generic Object Classes"), true, "god") do
+= miq_accordion_panel(_("Generic Object Definitions"), true, "god") do
   :javascript
     ManageIQ.tree.data['#{@tree.name}'] = #{@tree.locals_for_render[:bs_tree]};
   %tree_div{'ng-controller' => 'treeViewController as vm'}

--- a/product/views/GenericObjectDefinition.yaml
+++ b/product/views/GenericObjectDefinition.yaml
@@ -9,7 +9,7 @@
 #
 
 # Report title
-title: Generic Object Classes
+title: Generic Object Definitions
 
 # Menu name
 name: GenericObjectDefinition

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -529,7 +529,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :type  => :button,
           :icon  => "pficon pficon-edit fa-lg",
           :title => "Edit selected Generic Object Definition",
-          :text  => "Edit selected Generic Object Definition",
+          :text  => "Edit selected Generic Object Definition"
         )
         expect(items[2]).to include(
           :id      => "generic_object_definition_configuration__generic_object_definition_delete",

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -519,8 +519,8 @@ describe ApplicationHelper, "::ToolbarBuilder" do
         expect(items[0]).to include(
           :id      => "generic_object_definition_configuration__generic_object_definition_new",
           :type    => :button,
-          :title   => "Add a new Generic Object Class",
-          :text    => "Add a new Generic Object Class",
+          :title   => "Add a new Generic Object Definition",
+          :text    => "Add a new Generic Object Definition",
           :onwhen  => nil,
           :enabled => true,
         )
@@ -528,15 +528,15 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :id    => "generic_object_definition_configuration__generic_object_definition_edit",
           :type  => :button,
           :icon  => "pficon pficon-edit fa-lg",
-          :title => "Edit selected Generic Object Class",
-          :text  => "Edit selected Generic Object Class",
+          :title => "Edit selected Generic Object Definition",
+          :text  => "Edit selected Generic Object Definition",
         )
         expect(items[2]).to include(
           :id      => "generic_object_definition_configuration__generic_object_definition_delete",
           :type    => :button,
           :icon    => "pficon pficon-delete fa-lg",
-          :title   => "Remove selected Generic Object Classes from Inventory",
-          :text    => "Remove selected Generic Object Classes from Inventory",
+          :title   => "Remove selected Generic Object Definitions from Inventory",
+          :text    => "Remove selected Generic Object Definitions from Inventory",
           :onwhen  => "1+",
           :enabled => false,
         )


### PR DESCRIPTION
In UI, except of the name _'Generic Object Definitions'_ we are also often using _'Generic Object Classes'_ for the same entity.

In code the entity is usually referred as _'Generic Object Definitions'_.

I'd prefer to have them united, therefore suggesting the changes.

If _'Class'_ does make more sense from the users point of view, let's unite at least the UI labels.

Steps for Testing/QA
-------------------------------

![Screencast from 2019-10-09 12-25-35](https://user-images.githubusercontent.com/1187051/66481172-d669ed80-ea8f-11e9-879e-ef7ffdad8ce6.gif)
