### PR TITLE
Fix toolbar button with function

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -33,9 +33,6 @@ class NetworkRouterController < ApplicationController
       return tag("VmOrTemplate")
     when "network_router_add_interface"
       javascript_redirect(:action => "add_interface_select", :id => checked_item_id)
-    when "network_router_delete"
-      delete_network_routers
-      javascript_redirect(previous_breadcrumb_url)
     when "network_router_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id)
     when "network_router_new"
@@ -103,36 +100,6 @@ class NetworkRouterController < ApplicationController
     session[:edit] = nil
     flash_to_session
     javascript_redirect(:action => "show_list")
-  end
-
-  def delete_network_routers
-    assert_privileges("network_router_delete")
-
-    routers = find_records_with_rbac(NetworkRouter, checked_or_params)
-
-    routers_to_delete = []
-    routers.each do |router|
-      if router.supports?(:delete)
-        routers_to_delete.push(router)
-      else
-        add_flash(_(router.unsupported_reason(:delete)), :error)
-      end
-    end
-    process_network_routers(routers_to_delete, "destroy") unless routers_to_delete.empty?
-
-    # refresh the list if applicable
-    if @lastaction == "show_list" && @breadcrumbs.last[:url].include?(@lastaction)
-      show_list
-      @refresh_partial = "layouts/gtl"
-    elsif @lastaction == "show" && @layout == "network_router"
-      @single_delete = true unless flash_errors?
-      add_flash(_("The selected Router was deleted")) if @flash_array.nil?
-      flash_to_session
-    else
-      drop_breadcrumb(:name => 'dummy', :url => " ") # missing a bc to get correctly back so here's a dummy
-      flash_to_session
-      redirect_to(previous_breadcrumb_url)
-    end
   end
 
   def edit

--- a/app/helpers/application_helper/toolbar/base.rb
+++ b/app/helpers/application_helper/toolbar/base.rb
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::Base
           'entity' => keys[:api][:entity].pluralize,
           'action' => keys[:api][:action]
         }
-      }.to_json
+      }
     }
     generic_button(:button, id, icon, title, text, keys)
   end

--- a/app/helpers/application_helper/toolbar/firmware_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registries_center.rb
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistriesCenter < ApplicationHelper::
                 :controller     => 'provider_dialogs',
                 :modal_title    => N_('Add a new Firmware Registry'),
                 :component_name => 'FirmwareRegistryForm',
-              }.to_json,
+              },
             }
           ),
           api_button(

--- a/app/helpers/application_helper/toolbar/firmware_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registry_center.rb
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistryCenter < ApplicationHelper::To
                 :controller => 'toolbarActions',
                 :payload    => {:entity => 'firmware_registries'},
                 :type       => 'delete'
-              }.to_json
+              }
             },
             :confirm => N_('Remove this Firmware Registry from Inventory?')
           )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_center.rb
@@ -28,11 +28,12 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionCenter < ApplicationHel
           'pficon pficon-delete fa-lg',
           N_('Remove this Generic Object Classes from Inventory'),
           :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete", "controller": "genericObjectDefinitionToolbarController", "entity": "Generic Object Class"}'},
+                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Class"}},
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonDelete,
           :confirm => N_("Warning: This Generic Object Class will be permanently removed!"),
         ),
       ]
     )
+
   ])
 end

--- a/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definitions_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionsCenter < ApplicationHe
           t = N_('Remove selected Generic Object Classes from Inventory'),
           t,
           :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete", "controller": "genericObjectDefinitionToolbarController", "entity": "Generic Object Class"}'},
+                       'function-data' => {:type => "delete", :controller => "genericObjectDefinitionToolbarController", :entity => "Generic Object Class"}},
           :enabled                     => false,
           :onwhen                      => "1+",
           :confirm => N_("Warning: This Generic Object Class will be permanently removed!")

--- a/app/helpers/application_helper/toolbar/network_router_center.rb
+++ b/app/helpers/application_helper/toolbar/network_router_center.rb
@@ -60,7 +60,7 @@ class ApplicationHelper::Toolbar::NetworkRouterCenter < ApplicationHelper::Toolb
                     :multiple => _('Network Routers')
                   }
                 }
-              }.to_json
+              }
             },
           )
         ]

--- a/app/helpers/application_helper/toolbar/network_routers_center.rb
+++ b/app/helpers/application_helper/toolbar/network_routers_center.rb
@@ -37,7 +37,7 @@ class ApplicationHelper::Toolbar::NetworkRoutersCenter < ApplicationHelper::Tool
                     :multiple => _('Network Routers')
                   }
                 }
-              }.to_json
+              }
             }
           )
         ]

--- a/app/helpers/application_helper/toolbar/optimizations_center.rb
+++ b/app/helpers/application_helper/toolbar/optimizations_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::OptimizationsCenter < ApplicationHelper::Toolb
       nil,
       :data  => {'function'      => 'sendDataWithRx',
                  'function-data' => {'controller' => 'OptimizationController',
-                                     'action'     => 'refresh'}.to_json},
+                                     'action'     => 'refresh'}},
       :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
   ])
 end

--- a/app/helpers/application_helper/toolbar/physical_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storage_center.rb
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::PhysicalStorageCenter < ApplicationHelper::Too
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "refresh", "controller": "physicalStorageToolbarController"}'},
+                         'function-data' => {:type => "refresh", :controller => "physicalStorageToolbarController"}},
             :confirm => N_("Refresh relationships and power states for all items related to this Physical Storage?"),
             :options => {:feature => :refresh}
           ),

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => '{"type": "refresh", "controller": "physicalStorageToolbarController"}'},
+                         'function-data' => {:type => "refresh", :controller => "physicalStorageToolbarController"}},
             :confirm => N_("Refresh relationships and power states for all items related to these Physical Storages?"),
             :options => {:feature => :refresh}
           ),

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -49,7 +49,7 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
           :data => {'function'      => 'sendDataWithRx',
                     'function-data' => {:controller     => 'provider_dialogs',
                                         :modal_title    => N_('Delete Catalog Item'),
-                                        :component_name => 'RemoveCatalogItemModal'}.to_json}
+                                        :component_name => 'RemoveCatalogItemModal'}}
         ),
         separator,
         button(

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -46,7 +46,8 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           :data         => {'function'      => 'sendDataWithRx',
                             'function-data' => {:controller     => 'provider_dialogs',
                                                 :modal_title    => N_('Delete Catalog Items'),
-                                                :component_name => 'RemoveCatalogItemModal'}.to_json}),
+                                                :component_name => 'RemoveCatalogItemModal'}}
+        ),
         separator,
         button(
           :catalogitem_ownership,

--- a/app/javascript/components/miq-toolbar.jsx
+++ b/app/javascript/components/miq-toolbar.jsx
@@ -86,12 +86,12 @@ const onClick = (button) => {
         buttonUrl += `/${ManageIQ.record.recordId}`;
       }
     }
-  } else if (button.function) {
+  } else if (button.data.function) {
     // Client-side buttons use 'function' and 'function-data'.
     // eval - returns a function returning the right function.
     /* eslint no-new-func: "off" */
-    const fn = new Function(`return ${button.function}`);
-    fn().call(button, button['function-data']);
+    const fn = new Function(`return ${button.data.function}`);
+    fn().call(button, button.data['function-data']);
     return;
   } else { // Most of (classic) buttons.
     // If no url was specified, run standard button ajax transaction.

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -195,68 +195,6 @@ describe NetworkRouterController do
     end
   end
 
-  describe "#delete_network_routers" do
-    let(:ems) { FactoryBot.create(:ems_openstack).network_manager }
-    let(:router) { FactoryBot.create(:network_router_openstack, :name => "router-01", :ext_management_system => ems) }
-
-    before do
-      stub_user(:features => :all)
-      setup_zone
-      controller.params = {:id => router.id}
-      controller.instance_variable_set(:@lastaction, "show")
-      controller.instance_variable_set(:@layout, "network_router")
-    end
-
-    it "it calls process_network_routers function" do
-      expect(controller).to receive(:process_network_routers).with([NetworkRouter], "destroy")
-
-      controller.send(:delete_network_routers)
-    end
-  end
-
-  describe "#delete" do
-    before do
-      stub_user(:features => :all)
-      EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryBot.create(:ems_openstack).network_manager
-      @router = FactoryBot.create(:network_router_openstack,
-                                   :ext_management_system => @ems)
-      session[:network_router_lastaction] = 'show'
-    end
-
-    let(:task_options) do
-      {
-        :action => "deleting Network Router for user %{user}" % {:user => controller.current_user.userid},
-        :userid => controller.current_user.userid
-      }
-    end
-    let(:queue_options) do
-      {
-        :class_name  => @router.class.name,
-        :method_name => 'raw_delete_network_router',
-        :instance_id => @router.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => @ems.my_zone,
-        :args        => []
-      }
-    end
-
-    it "queues the delete action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
-      controller.params = {:pressed => "network_router_delete",
-                           :id      => @router.id}
-      controller.instance_variable_set(:@lastaction, "show")
-      controller.instance_variable_set(:@layout, "network_router")
-      controller.instance_variable_set(:@breadcrumbs, [{:name => "foo", :url => "network_router/show_list"}, {:name => "bar", :url => "network_router/show"}])
-      expect(controller).to receive(:render)
-      controller.send(:button)
-      flash_messages = assigns(:flash_array)
-      expect(flash_messages.first).to eq(:message => "Delete initiated for 1 Network Router.",
-                                         :level   => :success)
-    end
-  end
-
   describe "#add_interface" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
Buttons with `data` will either not work or run through old code that was left behind. Not calling API.

Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/5997

One example is Network -> Network Routers -> summary or GTL page -> Configuration -> Delete

Before:
It works with "wrong" request on Networks Routers summary page
<img width="1642" alt="Screenshot 2019-10-10 at 10 39 42" src="https://user-images.githubusercontent.com/9210860/66552828-5785bb00-eb4a-11e9-855a-6c59599aac93.png">
Or it doesn't work on Network Routers with GTL
<img width="1665" alt="Screenshot 2019-10-10 at 10 41 38" src="https://user-images.githubusercontent.com/9210860/66552962-9156c180-eb4a-11e9-9c73-9ef25170c641.png">

After:
API is called and button works as expected
<img width="1661" alt="Screenshot 2019-10-10 at 10 37 58" src="https://user-images.githubusercontent.com/9210860/66552717-1e4d4b00-eb4a-11e9-9a8c-6713c5b5d4b4.png">


TODO:

- [x] Remove all `to_json` and "String" json

- [x] Remove old code -> `button/pressed` logic so it doesn't kinda work by going through it...

- [x] `manageiq-providers-lenovo/app/helpers/manageiq/providers/lenovo/toolbar_overrides/ems_physical_infra_center.rb` https://github.com/ManageIQ/manageiq-providers-lenovo/pull/280 independent of each other
- [x] `manageiq-providers-nuage/app/helpers/manageiq/providers/nuage/toolbar_overrides/network_router_center.rb` https://github.com/ManageIQ/manageiq-providers-nuage/pull/188 independent of each other
- [x] `manageiq-providers-redfish/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb` https://github.com/ManageIQ/manageiq-providers-redfish/pull/94 independent of each other
- [x] `manageiq-providers-redfish/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_server_center.rb` https://github.com/ManageIQ/manageiq-providers-redfish/pull/94 independent of each other

@miq-bot add_label wip, ivanchuk/no, toolbars