### PR TITLE
Disable Save/Reset buttons after discarding changes for Subscription

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -179,8 +179,13 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       $scope.pglogicalReplicationModel.port       = '';
       $scope.pglogicalReplicationModel.addEnabled = false;
     } else {
-      var original_values = $scope.modelCopy.subscriptions[idx];
       var subscription    = $scope.pglogicalReplicationModel.subscriptions[idx];
+      var original_values = subscription;
+
+      if ($scope.modelCopy.subscriptions[idx]) {
+        original_values = $scope.modelCopy.subscriptions[idx];
+      }
+
       $scope.pglogicalReplicationModel.updateEnabled = false;
       subscription.dbname   = original_values.dbname;
       subscription.host     = original_values.host;

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -149,6 +149,11 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     }
     $scope.pglogicalReplicationModel.addEnabled = false;
     $scope.pglogicalReplicationModel.updateEnabled = false;
+
+    // check if subscriptions changed
+    if (angular.equals($scope.pglogicalReplicationModel.subscriptions, $scope.modelCopy.subscriptions)) {
+      $scope.angularForm.$setPristine();
+    }
   };
 
   // delete an existing subscription
@@ -183,6 +188,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       subscription.password = original_values.password;
       subscription.port     = original_values.port;
     }
+    $scope.angularForm.$setPristine();
   };
 
   // validate subscription, all required fields should have data


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1757800

Fix responding _Save/Reset_ buttons after discarding changes for Subscriptions if there is no change in Subscriptions. Fix also responding the buttons after clicking on _Accept_ button. Setting the form as pristine solves the problems.

The second commit fixes error about undefined variable:
![error](https://user-images.githubusercontent.com/13417815/66995481-60890600-f0cf-11e9-8900-e506c3e2dd40.png)
You can get this error if you create a new Subscription and before saving it, you decide to make changes so you click on _Update_ and make some change but then you click on _Discard_ because you've changed your mind.

---

**Before:**
![before](https://user-images.githubusercontent.com/13417815/66995458-57983480-f0cf-11e9-883d-59990b1e0e1f.png)

**After:**
![after](https://user-images.githubusercontent.com/13417815/66995462-59fa8e80-f0cf-11e9-89d0-25a022ebc9b2.png)
