### PR TITLE
Add Refresh button to Ansible Tower Jobs page

### DIFF
--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -34,6 +34,9 @@ class ConfigurationJobController < ApplicationController
       configuration_job_delete
     when "configuration_job_tag"
       tag(ManageIQ::Providers::AnsibleTower::AutomationManager::Job)
+    when "configuration_job_reload"
+      replace_gtl_main_div
+      return
     end
     return if %w[configuration_job_tag].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing, so return
 

--- a/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
@@ -1,4 +1,15 @@
 class ApplicationHelper::Toolbar::ConfigurationJobsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configuration_job_reloading', [
+    button(
+      :configuration_job_reload,
+      'fa fa-refresh fa-lg',
+      N_('Refresh this page'),
+      N_('Refresh'),
+      :url_parms    => "main_div",
+      :send_checked => true,
+      :klass        => ApplicationHelper::Button::ButtonWithoutRbacCheck
+    ),
+  ])
   button_group('configuration_job_vmdb', [
     select(
       :configuration_job_vmdb_choice,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749098

Go to Automation -> Ansible Tower -> Jobs

Before:
<img width="1663" alt="Screenshot 2019-10-11 at 13 13 28" src="https://user-images.githubusercontent.com/9210860/66647342-eff26d00-ec28-11e9-82ea-5fde78b1bd28.png">

After:
<img width="1672" alt="Screenshot 2019-10-11 at 13 08 20" src="https://user-images.githubusercontent.com/9210860/66647168-78244280-ec28-11e9-81ab-ba1434248cbb.png">

How to reproduce:
- go to Automation -> Ansible Tower -> Jobs
- add some Jobs via console `ManageIQ::Providers::AnsibleTower::AutomationManager::Job.create!(:name => "name")`
- click Refresh

@miq-bot add_label ivanchuk/no, enhancement, changelog/no, toolbars