### PR TITLE
Fixed error when saving replication subscription with params[:subscriptions]been nil

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -231,7 +231,7 @@ module OpsController::Settings::Common
   def prepare_subscriptions_for_saving
     to_save = []
     to_remove = []
-    params[:subscriptions].each do |_k, subscription_params|
+    params[:subscriptions]&.each do |_k, subscription_params|
       subscription = find_or_new_subscription(subscription_params['id'])
       if subscription.id && subscription_params['remove'] == "true"
         to_remove << subscription


### PR DESCRIPTION
it is possible situation when saving subscription invoked but there is no any subscription to save and  params[:subscriptions] is nil, this lead to 
```FATAL -- : Error caught: [NoMethodError] undefined method prepare_subscriptions_for_saving'```
as described in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1759511#c7

@miq-bot add-label bug