### PR TITLE
Check button.data isn't null

### DIFF
--- a/app/javascript/components/miq-toolbar.jsx
+++ b/app/javascript/components/miq-toolbar.jsx
@@ -86,7 +86,7 @@ const onClick = (button) => {
         buttonUrl += `/${ManageIQ.record.recordId}`;
       }
     }
-  } else if (button.data.function) {
+  } else if (button.data && button.data.function) {
     // Client-side buttons use 'function' and 'function-data'.
     // eval - returns a function returning the right function.
     /* eslint no-new-func: "off" */


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/6289

When clicking a button without `button.data.function` which is majority of buttons it explodes... 

Before:
<img width="1671" alt="Screenshot 2019-10-14 at 13 22 08" src="https://user-images.githubusercontent.com/9210860/66747781-a5b9f780-ee85-11e9-8bfe-6cac919e11f1.png">

After:
It works

@himdel please have a look. Thanks

@miq-bot add_label toolbars, 