### PR TITLE
Allow performing SSA on Datastores in Datastore Clusters accordion

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -676,7 +676,7 @@ module ApplicationController::CiProcessing
                           :flash_msg  => @flash_array[0][:message])
       return
     end
-    if @lastaction == "show_list"
+    if %w[show_list storage_list storage_pod_list].include?(@lastaction)
       show_list unless @explorer
       @refresh_partial = "layouts/gtl"
       return


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6241

There was an issue with Datastores and SSA: The selected Datastore was not accessible while performing SSA from the list of Datastores of selected Datastore Cluster.

**Details:**
In `generic_button_operation` method, called by `scanstorage` after clicking on _Perform SmartState Analysis_ toolbar button, `screen_redirection` is called. However, in this method, logic for `@lastaction` different than `"show_list"` is missing ([see](https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L679)). The result is that it calls `show` instead of `show_list` [here](https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L685) (it does not 'go' into the proper condition and does not call `return` when it should so we fall into the next condition with `show` call). And this is simply wrong because we are in the list of Datastores, we want to call `show_list`.
I changed the condition and added some more possibilities for `@lastaction`, the same as it already is in a different place (for deleting Datastores, where it already fixes the same problem), see [this](https://github.com/hstastna/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L827). This all is just because `@lastaction` is very specific, it is set to `"storage_pod_list"`. Not sure how important is to set `@lastaction` to such value but I am not going to change it.
For other methods, it simply works just because `@lastaction` is set to `"show_list"` or there is `options[:redirect]` present (in `screen_redirection`). Or, simply `generic_button_operation` is not called at all.

---

**Before:**
![ssa_before](https://user-images.githubusercontent.com/13417815/66749238-9e94e880-ee89-11e9-98cd-8fe26618af58.png)

**After:**
![ssa_after](https://user-images.githubusercontent.com/13417815/66750700-668fa480-ee8d-11e9-9bf5-87039c0e26ea.png)
