### PR TITLE
Add missing ui-lookup to make Object Attribute consistent

### DIFF
--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -92,7 +92,7 @@
     %label.control-label.col-md-2
       = _('Type')
     .col-md-8
-      = @resolve[:new][:target_class]
+      = ui_lookup(:model =>@resolve[:new][:target_class])
   - if @resolve[:new][:target_class] && !@resolve[:new][:target_class].blank?
     .form-group
       %label.control-label.col-md-2


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740119

Go to Services -> Catalogs -> Catalog Items -> click on a Button

Object Attribute - Type is different for Show(first pic) and Edit(second pic). 

Before:
<img width="807" alt="Screenshot 2019-10-14 at 16 18 38" src="https://user-images.githubusercontent.com/9210860/66758609-e40fe080-ee9e-11e9-94bc-5fc77f466675.png">
<img width="684" alt="Screenshot 2019-10-14 at 16 13 44" src="https://user-images.githubusercontent.com/9210860/66758602-dfe3c300-ee9e-11e9-8041-cbc1028fe240.png">
After:
<img width="727" alt="Screenshot 2019-10-14 at 16 13 25" src="https://user-images.githubusercontent.com/9210860/66758601-dfe3c300-ee9e-11e9-9cc5-215a6e61e4cd.png">
<img width="684" alt="Screenshot 2019-10-14 at 16 13 44" src="https://user-images.githubusercontent.com/9210860/66758602-dfe3c300-ee9e-11e9-8041-cbc1028fe240.png">

@miq-bot add_label ivanchuk/yes, bug