### PR TITLE
Display only one Back button for Policy simulation

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -460,6 +460,7 @@ module VmCommon
                                                               :options   => @policy_options)
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
+      @sb[:explorer] = true
       if session[:policies].empty?
         render_flash(_("No policies were selected for Policy Simulation."), :error)
         return
@@ -467,11 +468,13 @@ module VmCommon
       @in_a_form = true
       replace_right_cell(:action => 'policy_sim', :refresh_breadcrumbs => false)
     else
+      @sb[:explorer] = nil
       render :template => 'vm/show'
     end
   end
 
   def policy_show_options
+    @explorer = @sb[:explorer]
     if params[:passed] == "null" || params[:passed] == ""
       @policy_options[:passed] = false
       @policy_options[:failed] = true
@@ -495,6 +498,7 @@ module VmCommon
 
   # Show/Unshow out of scope items
   def policy_options
+    @explorer = @sb[:explorer]
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     @policy_options ||= {}
     @policy_options[:out_of_scope] = (params[:out_of_scope] == "1")

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -46,7 +46,7 @@ describe VmOrTemplateController do
     end
   end
 
-  describe '#reload ' do
+  describe '#reload' do
     before do
       login_as FactoryBot.create(:user_with_group, :role => "operator")
       allow(controller).to receive(:tree_select).and_return(nil)
@@ -332,6 +332,79 @@ describe VmOrTemplateController do
       controller.params = {:server_id => '42'}
       controller.send(:evm_relationship_get_form_vars)
       expect(assigns(:edit)[:new][:server]).to eq(controller.params[:server_id])
+    end
+  end
+
+  describe '#policy_show_options' do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    before do
+      allow(controller).to receive(:render)
+      controller.instance_variable_set(:@sb, {})
+      controller.params = {:id => vm.id}
+    end
+
+    it 'sets @explorer to nil' do
+      controller.send(:policy_show_options)
+      expect(controller.instance_variable_get(:@explorer)).to be_nil
+    end
+
+    context 'explorer screen' do
+      before { controller.instance_variable_set(:@sb, :explorer => true) }
+
+      it 'sets @explorer to true' do
+        controller.send(:policy_show_options)
+        expect(controller.instance_variable_get(:@explorer)).to be(true)
+      end
+    end
+  end
+
+  describe '#policies' do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    before do
+      allow(controller).to receive(:render)
+      allow(controller).to receive(:session).and_return(:policies => {})
+      controller.instance_variable_set(:@sb, {})
+      controller.params = {:id => vm.id}
+    end
+
+    it 'sets @sb[:explorer] to false' do
+      controller.send(:policies)
+      expect(controller.instance_variable_get(:@sb)[:explorer]).to be_nil
+    end
+
+    context 'explorer screen' do
+      before { allow(controller).to receive(:session).and_return(:policies => {}, :edit => {:explorer => true}) }
+
+      it 'sets @sb[:explorer] to true' do
+        controller.send(:policies)
+        expect(controller.instance_variable_get(:@sb)[:explorer]).to be(true)
+      end
+    end
+  end
+
+  describe '#policy_options' do
+    let(:vm) { FactoryBot.create(:vm_vmware) }
+
+    before do
+      allow(controller).to receive(:render)
+      controller.instance_variable_set(:@sb, {})
+      controller.params = {:id => vm.id}
+    end
+
+    it 'sets @explorer to false' do
+      controller.send(:policy_options)
+      expect(controller.instance_variable_get(:@explorer)).to be_nil
+    end
+
+    context 'explorer screen' do
+      before { controller.instance_variable_set(:@sb, :explorer => true) }
+
+      it 'sets @explorer to false' do
+        controller.send(:policy_options)
+        expect(controller.instance_variable_get(:@explorer)).to be(true)
+      end
     end
   end
 


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6263#issuecomment-543140001

This PR fixes issue with displaying two _Back_ buttons after making changes during Policy simulation. The core of the problem was that `@explorer` variable was not set and it should be set (to `true`) because we were in explorer screen. But still, why is knowing that we are in explorer screen so important? For our case mainly because we don't want to display 'other' _Back_ button which is usually displayed for non-explorer screens during Policy simulation. There's a check for this [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_policies.html.haml#L15). So if `@explorer` is not properly set, another _Back_ button is displayed.

I am fixing the issue by adding appropriate conditions and setting `@explorer` variable again, in `policy_show_options`, because this method is called if any change was made during Policy simulation. With this we can make sure that `@explorer` will be properly set all the time, not just in the beginning of Policy simulation. We need to use `@sb[:explorer]` not to lose the info about being in explorer screen, while making more changes during Policy simulation.

No, it was not possible to fix this simply by displaying/hiding the footer with _Back_ button, as this button is in __x_edit_html.haml_ (originally, before I implemented _Back_ button for non explorer screens) which is rendered by calling `replace_right_cell`  - and this is good only for explorer screens, does not work for non-explorer ones, in our case.

**Steps:** (in case that the video in the issue was not clear; same for Instances)
1. _Compute > Infra > VMs_
2. Choose some VM(s), check the checkboxes
3. _Policy > Policy Simulation_
4. Select a Policy Profile to add
5. Click on some VM below (quadicon)
6. Make changes in _Options_ section

TODO:
- ~~fix disappearing _Back_ button after making changes in Policy simulation's _Options_ section, for VMs displayed in a nested list (for example through Provider's dashboard)~~
- ~~what about 'Show out of scope items' option?~~ solution [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6316/files#diff-5910cce3bec4cd624ba288de86215b4cR501)
- ~~spec for `policies` method in vm_common.rb~~

---

**Before:**
![polsim_before](https://user-images.githubusercontent.com/13417815/67095859-37dc3b80-f1b7-11e9-9f90-b0581f3b17eb.png)

**After:**
![polsim_after](https://user-images.githubusercontent.com/13417815/67095412-23e40a00-f1b6-11e9-87c6-ef756934856f.png)

