### PR TITLE
Toolbar: pass keepSpinner to the toolbar.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -127,6 +127,7 @@ class ApplicationHelper::ToolbarBuilder
       end
     end
     button[:url_parms] = update_url_parms(safer_eval(input[:url_parms])) if input[:url_parms].present?
+    button[:keepSpinner] = input[:keepSpinner] if input.key?(:keepSpinner)
 
     if input[:popup] # special behavior: button opens window_url in a new window
       button[:popup] = true


### PR DESCRIPTION
The hard-coded exceptions for keeping the spinner up when buttons are
pressed where removed in the React rewrite. The behavior is now driven
by the keepSpinner option on a button. However this option was not
passed from the toolbar definition to the component. Fixing that now.

Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/6295
