### PR TITLE
Fix edit of GOD custom button

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -207,7 +207,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     }
     // set uri_attributes to default for non-Ansible button
     if (vm.customButtonModel.button_type == "default") {
-      vm.customButtonModel.uri_attributes = {"request": "", service_template: null, hosts: null};
+      vm.customButtonModel.uri_attributes = {"request": vm.customButtonModel.request, service_template: null, hosts: null};
     };
 
     vm.customButtonModel.visibility = {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753237

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5166

Steps to Reproduce:
1. Go to Automation -> Automate -> Generic Objects 
2. Create a custom button that has the "Request" as "ca", leave the "Message" as "create", the other fields are not as important
3. Edit the custom button request to "call_instance" 
4. Click to edit the custom button again

Before:
![image](https://user-images.githubusercontent.com/9210860/67283111-59009d00-f4d3-11e9-85cf-d6db7b37dd59.png)

After:
![image](https://user-images.githubusercontent.com/9210860/67282962-176ff200-f4d3-11e9-9f51-d51c2e49cde9.png)

@miq-bot add_label bug, generic objects, ivanchuk/yes