### PR TITLE
Toolbar view separation

### DIFF
--- a/app/javascript/components/miq-toolbar.jsx
+++ b/app/javascript/components/miq-toolbar.jsx
@@ -180,6 +180,11 @@ const filterViews = toolbarItems => toolbarItems
   .flat()
   .filter(i => i && i.id && i.id.indexOf('view_') === 0);
 
+const filterNonViews = toolbars => toolbars
+  .map(toolbar =>
+    toolbar.filter(i => i && i.id && i.id.indexOf('view_') !== 0)
+  );
+
 const sanitizeToolbars = arr => arr ? arr.filter(Boolean) : [];
 
 const toolbarReducer = (state, action) => {
@@ -230,8 +235,9 @@ const MiqToolbar = ({ toolbars: initToolbars }) => {
   const {count, toolbars} = state;
 
   const renderGenericToolbar = () => {
-    const groups = separateItems(toolbars.filter(item => !!item));
-    const views = filterViews(groups);
+    const all = separateItems(toolbars.filter(item => !!item));
+    const views = filterViews(all);
+    const groups = filterNonViews(all);
 
     return (
       <Toolbar


### PR DESCRIPTION
### Toolbar: remove view buttons from the toolbar.
    
In the Angular implementation the 'views' part of the toolbar is sent in 2x. Once separately and once together with the rest.
    
That logic was kept in the React implementation but now I am separating the two to simplify the logic inside the Toolbar component.

This is part of the work that is needed to fix: https://github.com/ManageIQ/manageiq-ui-classic/issues/6312

The problem is that exceptional handling of the `view_*` buttons later leads to the empty group. So I will be removing the exception from the `Toolbar` component in react-ui-component and move the special handling of view buttons closer to the source of the data.

To go before https://github.com/ManageIQ/react-ui-components/pull/155 (This PR can be merged separately, not the one to the react-ui-components).

~~To be rebased after https://github.com/ManageIQ/manageiq-ui-classic/pull/6321 is merged.~~