### PR TITLE
Fix logout on group change

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -696,16 +696,6 @@ function miqEnterPressed(e) {
   return (keycode === 13);
 }
 
-function storeUserFeatures() {
-  delete window.localStorage.userFeatures;
-  return window.http.get('/api?attributes=identity')
-    .then(function(data) {
-      window.localStorage.userFeatures = JSON.stringify(data.identity.miq_groups.find(function(group) {
-        return data.identity.group === group.description;
-      }).product_features);
-    });
-}
-
 // Send login authentication via ajax
 function miqAjaxAuth(url) {
   miqEnableLoginFields(false);
@@ -979,7 +969,7 @@ function miqShowAE_Tree(typ) {
 
 // Toggle the user options div in the page header
 function miqToggleUserOptions(id) {
-  miqJqueryRequest(miqPassFields('/dashboard/change_group', {to_group: id}), { done: storeUserFeatures });
+  miqJqueryRequest(miqPassFields('/dashboard/change_group', {to_group: id}));
 }
 
 // Check for enter/escape on quick search box

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -970,6 +970,10 @@ function miqShowAE_Tree(typ) {
 // Toggle the user options div in the page header (:onclick from layouts/user_options)
 function miqChangeGroup(id) {
   miqSparkleOn();
+
+  // prevent login redirect once current requests fail after the group gets changed
+  ManageIQ.logoutInProgress = true;
+
   miqJqueryRequest(miqPassFields('/dashboard/change_group', {to_group: id}));
 }
 
@@ -1543,7 +1547,7 @@ var fontIconChar = _.memoize(function(klass) {
 
 function redirectLogin(msg) {
   if (ManageIQ.logoutInProgress) {
-    return; // prevent double redirect after pressing the Logout button
+    return; // prevent double redirect after pressing the Logout button or when changing group
   }
 
   add_flash(msg, 'warning');

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -967,8 +967,9 @@ function miqShowAE_Tree(typ) {
   return true;
 }
 
-// Toggle the user options div in the page header
-function miqToggleUserOptions(id) {
+// Toggle the user options div in the page header (:onclick from layouts/user_options)
+function miqChangeGroup(id) {
+  miqSparkleOn();
   miqJqueryRequest(miqPassFields('/dashboard/change_group', {to_group: id}));
 }
 

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -48,7 +48,7 @@ if (!window.ManageIQ) {
     i18n: {
       mark_translated_strings: false,
     },
-    logoutInProgress: false,  // prevent redirectLogin *during* logout
+    logoutInProgress: false,  // prevent redirectLogin *during* logout and group change
     mouse: {
       x: null, // mouse X coordinate for popup menu
       y: null, // mouse Y coordinate for popup menu

--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -30,7 +30,7 @@
                   %li
                     %a{:title   => _("Change to this Group"),
                       :href     => "#",
-                      :onclick  => "miqSparkle(true); miqToggleUserOptions(#{group.id})"}
+                      :onclick  => "miqChangeGroup('#{j_str group.id}')"}
                       = group.description
       - else
         %li.disabled


### PR DESCRIPTION
Similar to #6065 (that one is during logout),
when changing group, ongoing requests can fail because their credentials are no longer valid.

Using the `logoutInProgress` mechanism introduced in #6065 to prevent redirects to the login screen during group change as well.

* also renamed the "Change to this Group" onclick handler from `miqToggleUserOptions` to `miqChangeGroup`, changed the group id from number to string, and enabled sparkle
* also removing `storeUserFeatures` (`localStorage.userFeatures`) - comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/4756 - was postponed, no longer happening on login since https://github.com/ManageIQ/manageiq-ui-classic/pull/5164, and I'm changing the last caller now, so removing.

https://bugzilla.redhat.com/show_bug.cgi?id=1759291