### PR TITLE
Add Refresh button to individual Dashboard Widget

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -147,8 +147,9 @@ class DashboardController < ApplicationController
 
   def widget_chart_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
-    blank = widget.contents_for_user(current_user).blank?
-    datum = blank ? nil : widget.contents_for_user(current_user).contents
+    widget_content = widget.contents_for_user(current_user)
+    blank = widget_content.blank?
+    datum = blank ? nil : widget_content.contents
     content = nil
     if datum.blank?
       state = 'no_data'
@@ -183,8 +184,9 @@ class DashboardController < ApplicationController
 
   def widget_report_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
-    blank = widget.contents_for_user(current_user).blank?
-    content = blank ? nil : widget.contents_for_user(current_user).contents
+    widget_content = widget.contents_for_user(current_user)
+    blank = widget_content.blank?
+    content = blank ? nil : widget_content.contents
     render :json => {
       :blank     => blank,
       :content   => content,

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -371,7 +371,7 @@ class DashboardController < ApplicationController
     w = MiqWidget.find(params[:widget])
     task_id = w.queue_generate_content
     if task_id
-      render :json => {:task => task_id}, :status => 200
+      render :json => {:task_id => task_id.to_s}, :status => 200
     else
       render :json => {:message => _("There was an error during refresh.")}, :status => 400
     end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -147,8 +147,9 @@ class DashboardController < ApplicationController
 
   def widget_chart_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
-    datum = widget.contents_for_user(current_user).contents
-    content = nil
+    blank = widget.contents_for_user(current_user).blank?
+    datum = blank ? nil : widget.contents_for_user(current_user).contents
+    content = ""
     if datum.blank?
       state = 'no_data'
     elsif Charting.data_ok?(datum)
@@ -157,8 +158,10 @@ class DashboardController < ApplicationController
     else
       state = 'invalid'
     end
+    binding.pry
     render :json => {:content   => content,
                      :minimized => widget_minimized?(params[:id]),
+                     :blank     => blank.to_s,
                      :state     => state}
   end
 
@@ -170,7 +173,8 @@ class DashboardController < ApplicationController
                   {:description => shortcut.description, :href => shortcut.miq_shortcut.url}
                 end
     render :json => {:shortcuts => shortcuts,
-                     :minimized => widget_minimized?(params[:id])}
+                     :minimized => widget_minimized?(params[:id]),
+                     :blank     => "false"}
   end
 
   def widget_minimized?(id)
@@ -180,8 +184,12 @@ class DashboardController < ApplicationController
 
   def widget_report_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
+    blank = widget.contents_for_user(current_user).blank?
+    content = blank ? '' : widget.contents_for_user(current_user).contents
+    binding.pry
     render :json => {
-      :content   => widget.contents_for_user(current_user).contents,
+      :blank     => blank.to_s,
+      :content   => content,
       :minimized => widget_minimized?(params[:id])
     }
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -149,7 +149,7 @@ class DashboardController < ApplicationController
     widget = find_record_with_rbac(MiqWidget, params[:id])
     blank = widget.contents_for_user(current_user).blank?
     datum = blank ? nil : widget.contents_for_user(current_user).contents
-    content = ""
+    content = nil
     if datum.blank?
       state = 'no_data'
     elsif Charting.data_ok?(datum)
@@ -184,7 +184,7 @@ class DashboardController < ApplicationController
   def widget_report_data
     widget = find_record_with_rbac(MiqWidget, params[:id])
     blank = widget.contents_for_user(current_user).blank?
-    content = blank ? '' : widget.contents_for_user(current_user).contents
+    content = blank ? nil : widget.contents_for_user(current_user).contents
     render :json => {
       :blank     => blank.to_s,
       :content   => content,

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -360,6 +360,13 @@ class DashboardController < ApplicationController
     end
   end
 
+  def widget_refresh
+    assert_privileges("widget_generate_content")
+    w = MiqWidget.find(params[:widget])
+    w.queue_generate_content
+    render :json => {:task => MiqTask.last.id.to_s}, :status => 200
+  end
+
   # A widget has been dropped
   def widget_dd_done
     if params[:col1] || params[:col2] || params[:col3]

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -375,7 +375,7 @@ class DashboardController < ApplicationController
     if task_id
       render :json => {:task_id => task_id.to_s}, :status => 200
     else
-      render :json => {:message => _("There was an error during refresh.")}, :status => 400
+      render :json => {:error => {:message => _("There was an error during refresh.")}}, :status => 400
     end
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -158,7 +158,6 @@ class DashboardController < ApplicationController
     else
       state = 'invalid'
     end
-    binding.pry
     render :json => {:content   => content,
                      :minimized => widget_minimized?(params[:id]),
                      :blank     => blank.to_s,
@@ -186,7 +185,6 @@ class DashboardController < ApplicationController
     widget = find_record_with_rbac(MiqWidget, params[:id])
     blank = widget.contents_for_user(current_user).blank?
     content = blank ? '' : widget.contents_for_user(current_user).contents
-    binding.pry
     render :json => {
       :blank     => blank.to_s,
       :content   => content,
@@ -371,8 +369,8 @@ class DashboardController < ApplicationController
   def widget_refresh
     assert_privileges("widget_generate_content")
     w = MiqWidget.find(params[:widget])
-    w.queue_generate_content
-    render :json => {:task => MiqTask.last.id.to_s}, :status => 200
+    task_id = w.queue_generate_content
+    render :json => {:task => task_id}, :status => 200
   end
 
   # A widget has been dropped

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -370,7 +370,11 @@ class DashboardController < ApplicationController
     assert_privileges("widget_generate_content")
     w = MiqWidget.find(params[:widget])
     task_id = w.queue_generate_content
-    render :json => {:task => task_id}, :status => 200
+    if task_id
+      render :json => {:task => task_id}, :status => 200
+    else
+      render :json => {:message => _("There was an error during refresh.")}, :status => 400
+    end
   end
 
   # A widget has been dropped

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -160,7 +160,7 @@ class DashboardController < ApplicationController
     end
     render :json => {:content   => content,
                      :minimized => widget_minimized?(params[:id]),
-                     :blank     => blank.to_s,
+                     :blank     => blank,
                      :state     => state}
   end
 
@@ -173,7 +173,7 @@ class DashboardController < ApplicationController
                 end
     render :json => {:shortcuts => shortcuts,
                      :minimized => widget_minimized?(params[:id]),
-                     :blank     => "false"}
+                     :blank     => false}
   end
 
   def widget_minimized?(id)
@@ -186,7 +186,7 @@ class DashboardController < ApplicationController
     blank = widget.contents_for_user(current_user).blank?
     content = blank ? nil : widget.contents_for_user(current_user).contents
     render :json => {
-      :blank     => blank.to_s,
+      :blank     => blank,
       :content   => content,
       :minimized => widget_minimized?(params[:id])
     }

--- a/app/javascript/angular/dashboard/dropdown-menu.js
+++ b/app/javascript/angular/dashboard/dropdown-menu.js
@@ -1,8 +1,7 @@
 ManageIQ.angular.app.component('dropdownMenu', {
   bindings: {
     widgetId: '@',
-    buttonsData: '@',
-    refreshFunction: '<',
+    buttonsData: '<',
   },
   controllerAs: 'vm',
   controller() {
@@ -10,16 +9,14 @@ ManageIQ.angular.app.component('dropdownMenu', {
 
     vm.$onInit = function() {
       vm.dropdown_id = `btn_${vm.widgetId}`;
-      vm.buttons = JSON.parse(vm.buttonsData);
+      vm.buttons = vm.buttonsData;
     };
 
     vm.click = function(button) {
-      if (button.refresh) {
-        vm.refreshFunction();
-        return false;
-      } else {
-        return true;
+      if (button.onclick) {
+        return button.onclick();
       }
+      return true;
     };
   },
   template: `

--- a/app/javascript/angular/dashboard/dropdown-menu.js
+++ b/app/javascript/angular/dashboard/dropdown-menu.js
@@ -2,6 +2,7 @@ ManageIQ.angular.app.component('dropdownMenu', {
   bindings: {
     widgetId: '@',
     buttonsData: '@',
+    refreshFunction: '<',
   },
   controllerAs: 'vm',
   controller() {
@@ -10,6 +11,15 @@ ManageIQ.angular.app.component('dropdownMenu', {
     vm.$onInit = function() {
       vm.dropdown_id = `btn_${vm.widgetId}`;
       vm.buttons = JSON.parse(vm.buttonsData);
+    };
+
+    vm.click = function(button) {
+      if (button.refresh) {
+        vm.refreshFunction();
+        return false;
+      } else {
+        return true;
+      }
     };
   },
   template: `
@@ -29,6 +39,7 @@ ManageIQ.angular.app.component('dropdownMenu', {
              data-method="{{button.dataMethod}}"
              data-miq_sparkle_on="{{button.sparkleOn ? 'true' : 'false'}}"
              href="{{button.href}}"
+             ng-click="vm.click(button)"
              id="{{button.id}}"
              ng-attr-data-remote="{{button.dataRemote}}"
              ng-attr-target="{{button.target}}"

--- a/app/javascript/angular/dashboard/dropdown-menu.js
+++ b/app/javascript/angular/dashboard/dropdown-menu.js
@@ -12,9 +12,9 @@ ManageIQ.angular.app.component('dropdownMenu', {
       vm.buttons = vm.buttonsData;
     };
 
-    vm.click = function(button) {
+    vm.click = function(button, event) {
       if (button.onclick) {
-        return button.onclick();
+        return button.onclick(event);
       }
       return true;
     };
@@ -36,7 +36,7 @@ ManageIQ.angular.app.component('dropdownMenu', {
              data-method="{{button.dataMethod}}"
              data-miq_sparkle_on="{{button.sparkleOn ? 'true' : 'false'}}"
              href="{{button.href}}"
-             ng-click="vm.click(button)"
+             ng-click="vm.click(button, $event)"
              id="{{button.id}}"
              ng-attr-data-remote="{{button.dataRemote}}"
              ng-attr-target="{{button.target}}"

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -56,7 +56,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
         });
     };
 
-    vm.refresh = function() {
+    vm.refresh = function(event) {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
           vm.widgetModel = null;
@@ -68,6 +68,8 @@ ManageIQ.angular.app.component('widgetWrapper', {
           miqService.handleFailure(e);
           deferred.reject();
         });
+      event.preventDefault();
+      return false;
     };
 
     vm.widgetUrl = function() {

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -53,8 +53,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
           miqSparkleOn();
-          API.wait_for_task(response.data.task)
-            .then(vm.refreshWidgetHTML(true));
+          return API.wait_for_task(response.data.task).then(vm.refreshWidgetHTML(true));
         })
         .catch((e) => {
           vm.error = true;

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -38,7 +38,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
           }
           if (refreshed) {
             miqSparkleOff();
-            add_flash(sprintf(__('Dashboard "%s" was refreshed', vm.widgetTitle)), 'success');
+            add_flash(sprintf(__('Dashboard "%s" was refreshed'), vm.widgetTitle), 'success');
           }
           deferred.resolve();
         })

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -60,7 +60,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
           vm.widgetModel = null;
-          return API.wait_for_task(response.data.task_id).then(vm.refreshWidgetHTML(true));
+          return API.wait_for_task(response.data.task_id).then(() => vm.refreshWidgetHTML(true));
         })
         .catch((e) => {
           vm.error = true;

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -27,7 +27,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
       vm.innerDivId = `dd_w${vm.widgetId}_box`;
       vm.refreshWidgetHTML(false);
       vm.parsedButtons = JSON.parse(vm.widgetButtons);
-      const refreshButton = vm.parsedButtons.find(ob => ob.id.includes("refresh"));
+      const refreshButton = vm.parsedButtons.find(ob => ob.refresh);
       if (refreshButton) {
         refreshButton.onclick = vm.refresh;
       };

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -85,12 +85,12 @@ ManageIQ.angular.app.component('widgetWrapper', {
           </div>
         </div>
         <widget-error ng-if="vm.error === true"></widget-error>
-        <widget-spinner ng-if="!vm.widgetModel && vm.widgetBlank == 'false' && !vm.error"></widget-spinner>
-        <div ng-if="vm.widgetModel.blank === 'true' || vm.widgetModel"
+        <widget-spinner ng-if="!vm.widgetModel && vm.widgetBlank == false && !vm.error"></widget-spinner>
+        <div ng-if="vm.widgetModel"
              ng-attr-id="{{vm.innerDivId}}"
              ng-class="{ hidden: vm.widgetModel.minimized, mc:true }">
-          <widget-empty ng-if="vm.widgetModel.blank === 'true'"></widget-empty>
-          <div ng-if="vm.widgetModel.blank === 'false'"
+          <widget-empty ng-if="vm.widgetModel.blank === true"></widget-empty>
+          <div ng-if="vm.widgetModel.blank === false"
                ng-switch on="vm.widgetType">
             <widget-menu ng-switch-when="menu"
                          widget-id="{{vm.widgetId}}"

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -45,10 +45,12 @@ ManageIQ.angular.app.component('widgetWrapper', {
             miqSparkleOff();
             add_flash(sprintf(__('Dashboard "%s" was refreshed'), vm.widgetTitle), 'success');
           }
+          vm.error = false;
           deferred.resolve();
         })
         .catch((e) => {
           vm.error = true;
+          vm.widgetModel = null;
           miqService.handleFailure(e);
           deferred.reject();
         });
@@ -57,11 +59,12 @@ ManageIQ.angular.app.component('widgetWrapper', {
     vm.refresh = function() {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
-          miqSparkleOn();
+          vm.widgetModel = null;
           return API.wait_for_task(response.data.task_id).then(vm.refreshWidgetHTML(true));
         })
         .catch((e) => {
           vm.error = true;
+          vm.widgetModel = null;
           miqService.handleFailure(e);
           deferred.reject();
         });
@@ -89,7 +92,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
           </div>
         </div>
         <widget-error ng-if="vm.error === true"></widget-error>
-        <widget-spinner ng-if="!vm.widgetModel && vm.widgetBlank == false && !vm.error"></widget-spinner>
+        <widget-spinner ng-if="!vm.widgetModel && !vm.error"></widget-spinner>
         <div ng-if="vm.widgetModel"
              ng-attr-id="{{vm.innerDivId}}"
              ng-class="{ hidden: vm.widgetModel.minimized, mc:true }">

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -53,7 +53,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
           miqSparkleOn();
-          return API.wait_for_task(response.data.task).then(vm.refreshWidgetHTML(true));
+          return API.wait_for_task(response.data.task_id).then(vm.refreshWidgetHTML(true));
         })
         .catch((e) => {
           vm.error = true;

--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -26,6 +26,11 @@ ManageIQ.angular.app.component('widgetWrapper', {
       vm.divId = `w_${vm.widgetId}`;
       vm.innerDivId = `dd_w${vm.widgetId}_box`;
       vm.refreshWidgetHTML(false);
+      vm.parsedButtons = JSON.parse(vm.widgetButtons);
+      const refreshButton = vm.parsedButtons.find(ob => ob.id.includes("refresh"));
+      if (refreshButton) {
+        refreshButton.onclick = vm.refresh;
+      };
     };
 
     vm.refreshWidgetHTML = function(refreshed) {
@@ -76,8 +81,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
         <div class="card-pf-body">
           <div class="card-pf-heading-kebab">
             <dropdown-menu widget-id="{{vm.widgetId}}"
-                           buttons-data="{{vm.widgetButtons}}"
-                           refresh-function="vm.refresh"></dropdown-menu>
+                           buttons-data="vm.parsedButtons"></dropdown-menu>
             <h2 class="card-pf-title sortable-handle ui-sortable-handle"
                 style="cursor:move">
               {{vm.widgetTitle}}

--- a/app/javascript/spec/dashboard/widget-empty.spec.js
+++ b/app/javascript/spec/dashboard/widget-empty.spec.js
@@ -20,9 +20,9 @@ describe('widget-empty', () => {
     $compile = _$compile_;
     const response = {
       data: {
-        content: '',
+        content: null,
         minimized: false,
-        blank: 'true',
+        blank: true,
       },
       status: 200,
       statusText: 'OK',
@@ -38,7 +38,7 @@ describe('widget-empty', () => {
   it('is rendered in widget-wrapper if blank is set to true', (done) => {
     element = angular.element(`
       <form name="angularForm">
-        <widget-wrapper widget-id="42" widget-buttons="null" widget-type="report"></widget-wrapper>
+        <widget-wrapper widget-id="42" widget-buttons="[]" widget-type="report"></widget-wrapper>
       </form>
     `);
     element = $compile(element)($scope);

--- a/app/javascript/spec/dashboard/widget-empty.spec.js
+++ b/app/javascript/spec/dashboard/widget-empty.spec.js
@@ -48,9 +48,9 @@ describe('widget-empty', () => {
     $ctrl.promise.catch(() => null).then(() => {
       $scope.$digest();
 
-        const widget = element.find('widget-empty');
-        expect(widget).toHaveLength(1);
-        done();
+      const widget = element.find('widget-empty');
+      expect(widget).toHaveLength(1);
+      done();
     });
   });
 });

--- a/app/javascript/spec/dashboard/widget-wrapper.spec.js
+++ b/app/javascript/spec/dashboard/widget-wrapper.spec.js
@@ -1,4 +1,5 @@
 import { module, inject } from './mocks';
+require('../helpers/API.js');
 
 require('../helpers/getJSONFixtures.js');
 
@@ -8,7 +9,10 @@ describe('widget-wrapper', () => {
   let $compile;
   const widgetTypes = ['chart', 'menu', 'report'];
 
-  beforeEach(module('ManageIQ'));
+  beforeEach(() => {
+    module('ManageIQ');
+    angular.mock.module('miq.api');
+  });
 
   beforeEach(inject((_$compile_, $rootScope, $http) => {
     $scope = $rootScope;
@@ -20,11 +24,17 @@ describe('widget-wrapper', () => {
         content: '<div></div>',
         minimized: false,
         shortcuts: [],
+        blank: "false",
       },
       status: 200,
       statusText: 'OK',
     };
     spyOn($http, 'get').and.callFake(() => Promise.resolve(response));
+    spyOn(window.vanillaJsAPI, 'post').and.returnValue(Promise.resolve({
+      results: [
+        { success: true, message: 'some' },
+      ],
+    }));
   }));
 
   widgetTypes.forEach((widget) => {

--- a/app/javascript/spec/dashboard/widget-wrapper.spec.js
+++ b/app/javascript/spec/dashboard/widget-wrapper.spec.js
@@ -24,7 +24,7 @@ describe('widget-wrapper', () => {
         content: '<div></div>',
         minimized: false,
         shortcuts: [],
-        blank: "false",
+        blank: false,
       },
       status: 200,
       statusText: 'OK',
@@ -41,7 +41,7 @@ describe('widget-wrapper', () => {
     it(`renders widget-${widget} when widget-type is ${widget}`, (done) => {
       element = angular.element(`
         <form name="angularForm">
-          <widget-wrapper widget-id="42" widget-blank="false" widget-buttons="null" widget-type="${widget}"></widget-wrapper>
+          <widget-wrapper widget-id="42" widget-blank="false" widget-buttons="[]" widget-type="${widget}"></widget-wrapper>
         </form>
       `);
       element = $compile(element)($scope);

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -84,13 +84,12 @@ class WidgetPresenter
                    :dataMethod => 'post')
     end
     if @widget.content_type != 'menu'
-      buttons.push(:id        => "w_#{@widget.id}_refresh",
-                   :title     => _("Refresh this Widget"),
-                   :name      => _("Refresh"),
-                   :fonticon  => 'fa fa-refresh fa-fw',
-                   :href      => 'javascript:;',
-                   :refresh   => true,
-                   :sparkleOn => true)
+      buttons.push(:id       => "w_#{@widget.id}_refresh",
+                   :title    => _("Refresh this Widget"),
+                   :name     => _("Refresh"),
+                   :fonticon => 'fa fa-refresh fa-fw',
+                   :href     => 'javascript:;',
+                   :refresh  => true)
     end
 
     buttons.to_json

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -88,7 +88,6 @@ class WidgetPresenter
                    :title    => _("Refresh this Widget"),
                    :name     => _("Refresh"),
                    :fonticon => 'fa fa-refresh fa-fw',
-                   :href     => 'javascript:;',
                    :refresh  => true)
     end
 

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -83,13 +83,16 @@ class WidgetPresenter
                    :sparkleOn  => true,
                    :dataMethod => 'post')
     end
-    buttons.push(:id        => "w_#{@widget.id}_refresh",
-                 :title     => _("Refresh this Widget"),
-                 :name      => _("Refresh"),
-                 :fonticon  => 'fa fa-refresh fa-fw',
-                 :href      => 'javascript:;',
-                 :refresh   => true,
-                 :sparkleOn => true)
+    if @widget.content_type != 'menu'
+      buttons.push(:id        => "w_#{@widget.id}_refresh",
+                   :title     => _("Refresh this Widget"),
+                   :name      => _("Refresh"),
+                   :fonticon  => 'fa fa-refresh fa-fw',
+                   :href      => 'javascript:;',
+                   :refresh   => true,
+                   :sparkleOn => true)
+    end
+
     buttons.to_json
   end
 

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -78,11 +78,18 @@ class WidgetPresenter
                    :title      => _("Zoom in on this chart"),
                    :name       => _("Zoom in"),
                    :href       => '/dashboard/widget_zoom?widget=' + @widget.id.to_s,
-                   :fonticon   => 'fa  fa-plus fa-fw',
+                   :fonticon   => 'fa fa-plus fa-fw',
                    :dataRemote => true,
                    :sparkleOn  => true,
                    :dataMethod => 'post')
     end
+    buttons.push(:id        => "w_#{@widget.id}_refresh",
+                 :title     => _("Refresh this Widget"),
+                 :name      => _("Refresh"),
+                 :fonticon  => 'fa fa-refresh fa-fw',
+                 :href      => 'javascript:;',
+                 :refresh   => true,
+                 :sparkleOn => true)
     buttons.to_json
   end
 

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,10 +1,8 @@
 %div{:id => "ww_#{presenter.widget.id}"}
   - last_run, next_run = last_next_run(presenter.widget)
-  - widget_blank = presenter.widget.content_type == 'menu' ? false : presenter.widget.contents_for_user(current_user).blank?
   %widget-wrapper{"widget-id"       => presenter.widget.id,
                   "widget-type"     => presenter.widget.content_type,
                   "widget-buttons"  => presenter.widget_buttons,
-                  "widget-blank"    => widget_blank,
                   "widget-last-run" => last_run,
                   "widget-next-run" => next_run,
                   "widget-title"    => presenter.widget.title}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1196,6 +1196,7 @@ Rails.application.routes.draw do
         widget_add
         widget_close
         widget_dd_done
+        widget_refresh
         widget_toggle_minmax
         widget_zoom
       )


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703068

This applies to all Dashboard Widgets except Menu ones.

Go to Overview -> Dashboard

Before:
![image](https://user-images.githubusercontent.com/9210860/67483627-80d43a00-f666-11e9-99e8-ae6482b975e1.png)

After:
![image](https://user-images.githubusercontent.com/9210860/67483417-17ecc200-f666-11e9-9814-d9545568681e.png)
![image](https://user-images.githubusercontent.com/9210860/67948096-4d088f80-fbe5-11e9-9bb3-f0ed4986467f.png)


@miq-bot add_label enhancement, ivanchuk/no, cloud intel/dashboard, wip, core pending

TODO:
- [x] get `MiqTask` id from `MiqWidget.queue_generate_content` https://github.com/ManageIQ/manageiq/pull/19445 merged
- [x] fix random errors after refreshing the page
- [x] find an easy way to test it - deleting `EmsCluster` in console
- [x] fix specs
- [x] should all MiqWidgets be refreshed? Yes