### PR TITLE
[HAMMER] Dropbox removed, in exchange for using support tool

### DIFF
--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -37,7 +37,7 @@
                                     :ng_reqd_uri         => "vm.miqDBBackupService.dbRequired(vm.logCollectionModel, vm.logCollectionModel.uri)",
                                     :ng_model_uri        => "vm.logCollectionModel.uri",
                                     :ng_model_uri_prefix => "vm.logCollectionModel.uri_prefix",
-                                    :ng_readonly         => "vm.logCollectionModel.log_protocol == 'Red Hat Dropbox'",
+                                    :ng-readonly         => "vm.logCollectionModel.log_protocol == 'Red Hat Support' || vm.logCollectionModel.log_protocol == 'Red Hat Drobox'",
                                     :uri_prefix_display  =>  "{{vm.logCollectionModel.uri_prefix}}://"}
 
   %auth-credentials{'ng-if'               => 'vm.miqDBBackupService.credsProtocol(vm.logCollectionModel)',


### PR DESCRIPTION
Manual backport of #6330 and #6341

Make both red hat dropbox and support tool read-only

https://bugzilla.redhat.com/show_bug.cgi?id=1765635

Note, there's still test files referencing the changed dropbox strings but #6330 passed tests and didn't include them.  If needed, we can do another upstream PR for master/hammer to get them:

```
02:38:05 ~/Code/manageiq-ui-classic (hammer_backport_6330_dropbox_out_support_tool_in) (2.6.5) - git grep "Red Hat Dropbox"
spec/javascripts/controllers/ops/log_collection_form_controller_spec.js:        depot_name: 'Red Hat Dropbox',
spec/javascripts/controllers/ops/log_collection_form_controller_spec.js:        vm.logCollectionModel.log_protocol = 'Red Hat Dropbox';
spec/javascripts/controllers/ops/log_collection_form_controller_spec.js:        $httpBackend.whenGET('/ops/log_protocol_changed/123456?log_protocol=Red Hat Dropbox').respond(200, logProtocolChangedFormResponse);
0
```