### PR TITLE
Allow performing SSA on Clusters of Infra provider

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -620,7 +620,7 @@ module ApplicationController::CiProcessing
     if controller == "vm_infra"
       return vm_infra_untestable_actions.exclude?(action)
     end
-    if controller == "ems_cluster"
+    if controller == "ems_cluster" || @display == 'ems_clusters'
       return ems_cluster_untestable_actions.exclude?(action)
     end
     true

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -784,6 +784,27 @@ describe ApplicationController do
       expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
     end
   end
+
+  describe '#testable_action' do
+    before { controller.params = {:controller => 'vm_infra'} }
+
+    %w[reboot_guest reset shutdown_guest start stop suspend].each do |op|
+      it "returns true for #{op} operation on a VM" do
+        expect(controller.send(:testable_action, op)).to be(true)
+      end
+    end
+
+    context 'Clusters displayed from dashboard of a Provider' do
+      before do
+        controller.params = {:controller => 'ems_infra'}
+        controller.instance_variable_set(:@display, 'ems_clusters')
+      end
+
+      it 'returns false for SmartState Analysis and Clusters' do
+        expect(controller.send(:testable_action, 'scan')).to be(false)
+      end
+    end
+  end
 end
 
 describe HostController do
@@ -830,7 +851,7 @@ describe HostController do
                                             :url  => "/host/guest_applications/#{@host.id}"}])
     end
 
-    it "plularizes breadcrumb name" do
+    it "pluralizes breadcrumb name" do
       expect(controller.send(:breadcrumb_name, nil)).to eq("Hosts")
     end
   end
@@ -1068,20 +1089,6 @@ describe EmsCloudController do
         expect(controller).to receive(:delete_flavors).and_call_original
         expect_any_instance_of(Flavor).to receive(:delete_flavor_queue)
         post :button, :params => {:pressed => 'flavor_delete', :miq_grid_checks => flavor.id}
-      end
-    end
-  end
-end
-
-describe VmInfraController do
-  describe '#testable_action' do
-    before { controller.params = {:controller => 'vm_infra'} }
-
-    context 'power operations and vm infra controller' do
-      %w(reboot_guest reset shutdown_guest start stop suspend).each do |op|
-        it "returns true for #{op} operation on a VM" do
-          expect(controller.send(:testable_action, op)).to be(true)
-        end
       end
     end
   end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6338

There is an issue with Clusters and SSA: The selected Cluster is not accessible while performing SSA from the list of Clusters of selected Infrastructure Provider (It works well from textual summary of a Cluster). This PR together with already merged https://github.com/ManageIQ/manageiq-ui-classic/pull/6224 fixes the issue.

**Details:**
There are two problems which cause the issue:
1. wrong record is being set in `generic_button_operation` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L611), we get the actual provider instead of the selected Cluster
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/6224 fixes it [MERGED]
2. `testable_action` returns `true` instead of `false` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L612)
  - THIS PR fixes it

If you look into the code of `testable_action` method, it definitely says that SSA is [not testable](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L644) action for Clusters. It usually returns `false` for performing SSA while being in `ems_cluster` controller (_Compute > Infra > Clusters_ or textual summary of a Cluster). This should be consistent for Clusters and SSA action, no matter navigation steps.
The logic for SSA  and nested list of Clusters is missing in `testable_action` method. But how to achieve what we need just with the name of the actual controller and name of the action? How to recognize that we are about to perform SSA on Clusters while being in a different controller (`ems_infra` in our case)? There are also other types of items available for SSA. So we need to check something else, we need to get more information. I've decided to check `@display` as it contains the information we need. If `@display` will not be set, everything will be ok, too. Yes, it is an extra check but I think this is the best solution, at least for now.
Another solution would be completely avoiding going through `generic_button_operation` method, as it is for some other actions, but I don't consider this as a better solution.

---

**Before:**
![ssa_before](https://user-images.githubusercontent.com/13417815/67793070-82449e80-fa7a-11e9-954b-d84719116759.png)

**After:**
![ssa_after](https://user-images.githubusercontent.com/13417815/67793084-85d82580-fa7a-11e9-8f43-3d2b8efdd4c2.png)
