### PR TITLE
Remove Tags from Network Topology View and others

### DIFF
--- a/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/cloud_topology_controller.js
@@ -123,7 +123,6 @@ angular.module('ManageIQ').controller('cloudTopologyController', ['$scope', 'top
       case 'CloudManager':
         return { x: -20, y: -20, r: 28 };
       case 'AvailabilityZone':
-      case 'Tag':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
       case 'CloudTenant':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 19 };

--- a/app/assets/javascripts/controllers/topology/infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/infra_topology_controller.js
@@ -125,8 +125,6 @@ angular.module('ManageIQ').controller('infraTopologyController', ['$scope', 'top
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };
       case 'Host':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };
-      case 'Tag':
-        return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
       default:
         return defaultDimensions;
     }

--- a/app/assets/javascripts/controllers/topology/network_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/network_topology_controller.js
@@ -122,7 +122,6 @@ angular.module('ManageIQ').controller('networkTopologyController', ['$scope', 't
       case 'NetworkManager':
         return { x: -20, y: -20, r: 28 };
       case 'FloatingIp':
-      case 'Tag':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
       case 'NetworkRouter':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };

--- a/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
+++ b/app/assets/javascripts/controllers/topology/physical_infra_topology_controller.js
@@ -125,8 +125,6 @@ angular.module('ManageIQ').controller('physicalInfraTopologyController', ['$scop
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };
       case 'Host':
         return { x: defaultDimensions.x, y: defaultDimensions.y, r: defaultDimensions.r };
-      case 'Tag':
-        return { x: defaultDimensions.x, y: defaultDimensions.y, r: 13 };
       default:
         return defaultDimensions;
     }

--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -6,13 +6,6 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
       __('Status: ') + d.item.status,
     ];
 
-    if (d.item.kind === 'Tag') {
-      status = [
-        d.item.name,
-        __('Type: ') + d.item.display_kind,
-      ];
-    }
-
     if (d.item.kind === 'Host' || d.item.kind === 'Vm') {
       status.push(__('Provider: ') + d.item.provider);
     }
@@ -60,11 +53,9 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
           .style('top', mousePosition[1] + 'px');
         popup.append('h5').text('Actions on ' + data.item.display_kind);
 
-        if (data.item.kind !== 'Tag') {
-          popup.append('p').text(__('Go to summary page')).on('click', function() {
-            vm.dblclick(data);
-          });
-        }
+        popup.append('p').text(__('Go to summary page')).on('click', function() {
+          vm.dblclick(data);
+        });
 
         var canvasSize = [
           canvas.node().offsetWidth,
@@ -90,9 +81,6 @@ ManageIQ.angular.app.service('topologyService', ['$location', '$http', 'miqServi
     };
 
     vm.dblclick = function dblclick(d) {
-      if (d.item.kind === 'Tag') {
-        return false;
-      }
       $window.location.assign(topologyService.geturl(d));
     };
 

--- a/app/services/cloud_topology_service.rb
+++ b/app/services/cloud_topology_service.rb
@@ -2,12 +2,11 @@ class CloudTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::CloudManager
 
   @included_relations = [
-    :writable_classification_tags,
-    :availability_zones => [:writable_classification_tags, :vms => :writable_classification_tags],
-    :cloud_tenants      => [:writable_classification_tags, :vms => :writable_classification_tags],
+    :availability_zones => [:vms => nil],
+    :cloud_tenants      => [:vms => nil],
   ]
 
-  @kinds = %i[CloudManager AvailabilityZone CloudTenant Vm Tag]
+  @kinds = %i[CloudManager AvailabilityZone CloudTenant Vm]
 
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::CloudManager)

--- a/app/services/infra_topology_service.rb
+++ b/app/services/infra_topology_service.rb
@@ -2,21 +2,17 @@ class InfraTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::InfraManager
 
   @included_relations = [
-    :writable_classification_tags,
     :ems_clusters      => [
-      :writable_classification_tags,
       :hosts => [
-        :writable_classification_tags,
-        :vms => :writable_classification_tags
+        :vms => nil
       ]
     ],
     :clusterless_hosts => [
-      :writable_classification_tags,
-      :vms => :writable_classification_tags
+      :vms => nil
     ],
   ]
 
-  @kinds = %i[InfraManager EmsCluster Host Vm Tag]
+  @kinds = %i[InfraManager EmsCluster Host Vm]
 
   def entity_type(entity)
     if entity.kind_of?(Host)

--- a/app/services/network_topology_service.rb
+++ b/app/services/network_topology_service.rb
@@ -2,24 +2,20 @@ class NetworkTopologyService < TopologyService
   @provider_class = ManageIQ::Providers::NetworkManager
 
   @included_relations = [
-    :writable_classification_tags,
     :availability_zones => [
       :vms => [
-        :writable_classification_tags,
-        :floating_ips    => :writable_classification_tags,
-        :cloud_tenant    => :writable_classification_tags,
-        :security_groups => :writable_classification_tags,
+        :floating_ips    => nil,
+        :cloud_tenant    => nil,
+        :security_groups => nil,
       ]
     ],
     :cloud_subnets      => [
       :parent_cloud_subnet,
-      :writable_classification_tags,
       :vms,
-      :cloud_network  => :writable_classification_tags,
+      :cloud_network  => nil,
       :network_router => [
-        :writable_classification_tags,
         :cloud_network => [
-          :floating_ips => :writable_classification_tags
+          :floating_ips => nil
         ]
       ]
     ],
@@ -35,7 +31,7 @@ class NetworkTopologyService < TopologyService
     ]
   ]
 
-  @kinds = %i[NetworkRouter CloudSubnet Vm NetworkManager FloatingIp CloudNetwork NetworkPort CloudTenant SecurityGroup LoadBalancer Tag AvailabilityZone]
+  @kinds = %i[NetworkRouter CloudSubnet Vm NetworkManager FloatingIp CloudNetwork NetworkPort CloudTenant SecurityGroup LoadBalancer AvailabilityZone]
 
   def entity_type(entity)
     if entity.kind_of?(CloudNetwork) || entity.kind_of?(CloudSubnet)

--- a/app/services/physical_infra_topology_service.rb
+++ b/app/services/physical_infra_topology_service.rb
@@ -3,31 +3,25 @@ class PhysicalInfraTopologyService < TopologyService
 
   # Keep it in a 'topological order' e.g: racks, chassis, servers
   @included_relations = [
-    :writable_classification_tags,
     :physical_racks    => %i[
-      writable_classification_tags
       physical_chassis
       physical_servers
     ],
     :physical_chassis  => %i[
-      writable_classification_tags
       child_physical_chassis
       physical_servers
     ],
     :physical_servers  => [
-      :writable_classification_tags,
       :physical_switches,
       :host => [
-        :writable_classification_tags,
-        :vms => :writable_classification_tags
+        :vms => nil
       ]
     ],
     :physical_switches => [
-      :writable_classification_tags
     ],
   ]
 
-  @kinds = %i[PhysicalInfraManager PhysicalRack PhysicalChassis PhysicalServer Host Vm Tag PhysicalSwitch]
+  @kinds = %i[PhysicalInfraManager PhysicalRack PhysicalChassis PhysicalServer Host Vm PhysicalSwitch]
   @filter_properties = %i[kind status]
 
   # This priority mapping controls what connections will be present in the

--- a/app/services/topology_service.rb
+++ b/app/services/topology_service.rb
@@ -42,12 +42,7 @@ class TopologyService
   end
 
   def entity_name(entity)
-    if entity.kind_of?(Tag)
-      cls = entity.classification
-      [cls.parent, cls].map(&:description).join(': ')
-    else
-      entity.name
-    end
+    entity.name
   end
 
   # If needed, implemented this on its subclasses

--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -15,10 +15,6 @@
         %label
           %i.pficon.pficon-cloud-tenant
           = _("Cloud Tenants")
-      %kubernetes-topology-icon{tooltip_options, :kind => "Tag"}
-        %label
-          %i.fa.fa-tag
-          = _("Tags")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}

--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -15,10 +15,6 @@
         %label
           %i.pficon.pficon-cluster
           = _("Clusters")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
-        %label
-          %i.fa.fa-tag
-          = _("Tags")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -35,10 +35,6 @@
         %label
           %i.pficon.pficon-cloud-tenant
           = _("Cloud Tenants")
-      %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
-        %label
-          %i.fa.fa-tag
-          = _("Tags")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}

--- a/app/views/physical_infra_topology/show.html.haml
+++ b/app/views/physical_infra_topology/show.html.haml
@@ -28,10 +28,6 @@
           %label
             %i.pficon.pficon-virtual-machine
             = _("VMs")
-        %kubernetes-topology-filter{tooltipOptions, "filter-property" => "kind", "filter-value" => "Tag"}
-          %label
-            %i.fa.fa-tag
-            = _("Tags")
       .topology-filter-group
         %label#health_state
           = _("Health State: ")


### PR DESCRIPTION
**RFE:** https://bugzilla.redhat.com/show_bug.cgi?id=1529718

This PR completely removes _Tags_ from all of the Topology Views.

Related PRs:
https://github.com/ManageIQ/manageiq/pull/7931

---

**Before:** (_Networks > Topology_)
![network-before](https://user-images.githubusercontent.com/13417815/67860893-5d563700-fb1f-11e9-9c14-4d71aaa9c0a2.png)

**After:**
![network-after](https://user-images.githubusercontent.com/13417815/67860672-c0939980-fb1e-11e9-9a17-15559d94fea4.png)
