### PR TITLE
Show name in success catalog form messages

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -631,7 +631,7 @@ class CatalogController < ApplicationController
       @in_a_form = false
       replace_right_cell
     when "save", "add"
-      add_flash(_("Catalog was saved"))
+      add_flash(_("Catalog \"%{name}\" was saved") % {:name => params[:name]})
       @changed = session[:changed] = false
       @in_a_form = false
       @edit = session[:edit] = nil

--- a/app/javascript/components/catalog-form/catalog-form.jsx
+++ b/app/javascript/components/catalog-form/catalog-form.jsx
@@ -68,7 +68,7 @@ class CatalogForm extends Component {
       }, {
         skipErrors: [400],
       })
-        .then(() => miqAjaxButton('/catalog/st_catalog_edit?button=add'))
+        .then(() => miqAjaxButton('/catalog/st_catalog_edit?button=add', { name: values.name }))
         .catch(error => add_flash(this.handleError(error), 'error'));
     }
 
@@ -104,7 +104,7 @@ class CatalogForm extends Component {
     }
 
     return Promise.all(promises)
-      .then(([{ id }]) => miqAjaxButton(`/catalog/st_catalog_edit/${id}?button=save`))
+      .then(([{ id }]) => miqAjaxButton(`/catalog/st_catalog_edit/${id}?button=save`, { name: values.name }))
       .catch(error => add_flash(this.handleError(error), 'error'));
   };
 

--- a/app/javascript/spec/catalog-form/catalog-form.spec.js
+++ b/app/javascript/spec/catalog-form/catalog-form.spec.js
@@ -163,7 +163,7 @@ describe('Catalog form component', () => {
     };
     wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(urlCreate)).toBe(true);
-      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit?button=add');
+      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit?button=add', { name: 'Some name' });
       done();
     });
   });
@@ -252,7 +252,7 @@ describe('Catalog form component', () => {
     wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(apiBase)).toBe(true);
       expect(fetchMock.called(`${apiBase}/service_templates`)).toBe(true);
-      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save');
+      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save', { name: 'Some name' });
       done();
     });
   });
@@ -277,7 +277,7 @@ describe('Catalog form component', () => {
     wrapper.children().instance().submitValues(values).then(() => {
       expect(fetchMock.called(apiBase)).toBe(true);
       expect(fetchMock.called(`${apiBase}/service_templates`)).toBe(false);
-      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save');
+      expect(spyMiqAjaxButton).toHaveBeenCalledWith('/catalog/st_catalog_edit/1001?button=save', { name: 'Some name' });
       done();
     });
   });


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1766276

**Steps to Reproduce:**
1.Go to Services -> Catalogs -> Catalogs accordion
2.Add or Update a catalog 
3.View the success message

**Actual results:**
Catalog was saved

**Expected results:**
Catalog "{catalog_name}" was saved

**Before**

![image](https://user-images.githubusercontent.com/32869456/67867746-2ab23b80-fb2b-11e9-811b-19f756f689f4.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/67867769-330a7680-fb2b-11e9-921f-47c381ce9c94.png)

@miq-bot add_label bug, ivanchuk/yes, changelog/yes

@h-kataria 