### PR TITLE
Update toolbar snapshots

### DIFF
--- a/app/javascript/spec/toolbar/__snapshots__/miq-toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/miq-toolbar.spec.jsx.snap
@@ -53,7 +53,7 @@ exports[`<MiqToolbar /> renders ok for generic case 1`] = `
         key="0"
         onClick={[Function]}
       >
-        <span
+        <div
           className="miq-toolbar-group form-group"
         >
           <ToolbarButton
@@ -84,7 +84,7 @@ exports[`<MiqToolbar /> renders ok for generic case 1`] = `
               />
             </button>
           </ToolbarButton>
-        </span>
+        </div>
       </ToolbarGroup>
       <ToolbarView
         onClick={[Function]}


### PR DESCRIPTION
Fixes travis failure

~~Probably just cached `yarn.lock` file, or~~ some dependency's update -> It comes from ManageIQ/react-ui-components#157

In UI toolbars seems OK.

@martinpovolny 