### PR TITLE
Remove deprecated factory_by_name

### DIFF
--- a/spec/presenters/tree_node/availability_zone_spec.rb
+++ b/spec/presenters/tree_node/availability_zone_spec.rb
@@ -9,8 +9,7 @@ describe TreeNode::AvailabilityZone do
     availability_zone_openstack_null
     availability_zone_vmware
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'az-'

--- a/spec/presenters/tree_node/configured_system_spec.rb
+++ b/spec/presenters/tree_node/configured_system_spec.rb
@@ -6,8 +6,7 @@ describe TreeNode::ConfiguredSystem do
     configured_system_foreman
     configured_system_ansible_tower
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'cs-'

--- a/spec/presenters/tree_node/container_spec.rb
+++ b/spec/presenters/tree_node/container_spec.rb
@@ -2,8 +2,7 @@ describe TreeNode::Container do
   subject { described_class.new(object, nil, nil) }
 
   %i(container kubernetes_container).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'cnt-'

--- a/spec/presenters/tree_node/customization_template_spec.rb
+++ b/spec/presenters/tree_node/customization_template_spec.rb
@@ -7,8 +7,7 @@ describe TreeNode::CustomizationTemplate do
     customization_template_sysprep
     customization_template_cloud_init
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'ct-'

--- a/spec/presenters/tree_node/ems_cluster_spec.rb
+++ b/spec/presenters/tree_node/ems_cluster_spec.rb
@@ -2,8 +2,7 @@ describe TreeNode::EmsCluster do
   subject { described_class.new(object, nil, nil) }
 
   %i(ems_cluster ems_cluster_openstack).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'c-'

--- a/spec/presenters/tree_node/ems_folder_spec.rb
+++ b/spec/presenters/tree_node/ems_folder_spec.rb
@@ -8,8 +8,7 @@ describe TreeNode::EmsFolder do
     inventory_group
     inventory_root_group
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'f-'

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -49,11 +49,10 @@ describe TreeNode::ExtManagementSystem do
     # :ems_network                       => {},
     # :ems_storage                       => {}
   }.each do |factory, spec|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
-      before(:all) { klass.constantize.skip_callback(:save, :after, :stop_event_monitor_queue_on_change) if spec[:suppress_callback] }
-
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
+
+      before(:each) { object.class.skip_callback(:save, :after, :stop_event_monitor_queue_on_change) if spec[:suppress_callback] }
 
       include_examples 'TreeNode::Node#key prefix', spec.fetch(:key_prefix, 'e-')
       include_examples 'TreeNode::Node#tooltip prefix', spec.fetch(:tip_prefix, 'Provider')

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -36,7 +36,7 @@ describe TreeNode::ExtManagementSystem do
     :ems_amazon_network               => {},
     :ems_google_network               => {},
     :ems_nuage_network                => {},
-    :ems_openstack_network            => { :suppress_callback => true },
+    :ems_openstack_network            => { :suppress_callback => ManageIQ::Providers::Openstack::NetworkManager },
     :ems_vmware_cloud_network         => {},
     :ems_cinder                       => {},
     :ems_swift                        => {},
@@ -50,9 +50,9 @@ describe TreeNode::ExtManagementSystem do
     # :ems_storage                       => {}
   }.each do |factory, spec|
     context(factory.to_s) do
-      let(:object) { FactoryBot.create(factory) }
+      before(:all) { spec[:suppress_callback].skip_callback(:save, :after, :stop_event_monitor_queue_on_change) if spec[:suppress_callback] }
 
-      before(:each) { object.class.skip_callback(:save, :after, :stop_event_monitor_queue_on_change) if spec[:suppress_callback] }
+      let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', spec.fetch(:key_prefix, 'e-')
       include_examples 'TreeNode::Node#tooltip prefix', spec.fetch(:tip_prefix, 'Provider')

--- a/spec/presenters/tree_node/host_spec.rb
+++ b/spec/presenters/tree_node/host_spec.rb
@@ -9,8 +9,7 @@ describe TreeNode::Host do
     host_vmware
     host_vmware_esx
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'h-'

--- a/spec/presenters/tree_node/pxe_image_spec.rb
+++ b/spec/presenters/tree_node/pxe_image_spec.rb
@@ -6,8 +6,7 @@ describe TreeNode::PxeImage do
     pxe_image_ipxe
     pxe_image_pxelinux
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'pi-'

--- a/spec/presenters/tree_node/vm_or_template_spec.rb
+++ b/spec/presenters/tree_node/vm_or_template_spec.rb
@@ -17,8 +17,7 @@ describe TreeNode::VmOrTemplate do
     template_vmware
     template_xen
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory, :name => "template", :template => true) }
 
       include_examples 'TreeNode::Node#key prefix', 't-'
@@ -48,8 +47,7 @@ describe TreeNode::VmOrTemplate do
     vm_vmware
     vm_xen
   ).each do |factory|
-    klass = FactoryBot.factory_by_name(factory).instance_variable_get(:@class_name)
-    context(klass) do
+    context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }
 
       include_examples 'TreeNode::Node#key prefix', 'v-'


### PR DESCRIPTION
I'm getting a bunch of

    DEPRECATION WARNING: factory_by_name is deprecated and will be removed from factory_bot 6.0 (called from block (2 levels) in <top (required)> at /home/travis/build/ManageIQ/manageiq-ui-classic/spec/presenters/tree_node/availability_zone_spec.rb:12)

during travis, it seems like all of those come from the tree node specs (from https://github.com/ManageIQ/manageiq/pull/12458),
and with one exception, only serve to set the context name

that one exception later creates an actual object from the factory, so we can get the klass that way

Cc @skateman , WDYT?