### PR TITLE
Fix eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,7 @@
     "valid-typeof": 2,
     "dot-notation": [2, {
       "allowKeywords": true
-      }],
+    }],
     "guard-for-in": 2,
     "no-caller": 2,
     "no-div-regex": 2,
@@ -102,32 +102,31 @@
     "radix": 2,
     "wrap-iife": [2, "any"],
     "yoda": 2,
-    "brace-style": [2,
-    "1tbs", {
+    "brace-style": [2, "1tbs", {
       "allowSingleLine": false
-      }],
+    }],
     "camelcase": [2, {
       "properties": "never"
-      }],
+    }],
     "comma-spacing": [2, {
       "before": false,
       "after": true
-      }],
+    }],
     "comma-style": [2, "last"],
     "eol-last": 2,
     "key-spacing": [2, {
-        "beforeColon": false,
-        "afterColon": true
-        }],
+      "beforeColon": false,
+      "afterColon": true
+    }],
     "new-cap": [2, {
       "newIsCap": true
-      }],
+    }],
     "new-parens": 2,
     "no-array-constructor": 2,
     "no-lonely-if": 1,
     "no-multiple-empty-lines": [2, {
       "max": 2
-      }],
+    }],
     "no-nested-ternary": 2,
     "no-new-object": 2,
     "no-spaced-func": 2,
@@ -139,7 +138,7 @@
     "semi-spacing": [2, {
       "before": false,
       "after": true
-      }],
+    }],
     "keyword-spacing": 2,
     "space-before-blocks": 2,
     "space-before-function-paren": [2, "never"],
@@ -147,7 +146,7 @@
     "spaced-comment": [2, "always",  {
       "exceptions": ["-", "+"],
       "markers": ["=", "!"]          // space here to support sprockets directives
-      }],
+    }],
     // }}} (except for removing the JSX rules, and anything we override)
 
     "indent": [ "error", 2, {

--- a/app/javascript/.eslintrc.json
+++ b/app/javascript/.eslintrc.json
@@ -20,10 +20,20 @@
     "func-names": 0,
     "implicit-arrow-linebreak": "off",
     "import/prefer-default-export": "off",
+    "indent": [ "error", 2, {
+      "SwitchCase": 1,
+      "VariableDeclarator": 1
+    }],
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true
+    }],
     "max-len": ["error", {
       "code": 150,
       "ignoreComments": true
     }],
+    "no-extra-boolean-cast": "off",
+    "no-shadow": "off",
     "no-underscore-dangle": "off",
     "no-unused-vars": ["error", {
       "args": "after-used",
@@ -32,11 +42,17 @@
       "caughtErrors": "all",
       "caughtErrorsIgnorePattern": "^_"
     }],
-    "no-use-before-define": ["error", { "functions": false, "classes": false }],
+    "no-use-before-define": ["error", {
+      "functions": false,
+      "classes": false
+    }],
+    "quotes": [ "warn", "single", {
+      "avoidEscape": true,
+      "allowTemplateLiterals": true
+    }],
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": [1, "always"],
-    "space-before-function-paren": [2, "never"],
-    "no-extra-boolean-cast": "off",
-    "no-shadow": "off"
+    "semi": [2, "always"],
+    "space-before-function-paren": [2, "never"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@babel/register": "~7.6.0",
     "angular-mocks": "~1.6.9",
     "autoprefixer": "~6.7.7",
+    "babel-eslint": "~8.1.0",
     "babel-jest": "~24.9.0",
     "babel-loader": "~8.0.6",
     "compression-webpack-plugin": "~1.1.11",


### PR DESCRIPTION
I eagerly removed babel-eslint as unused in https://github.com/ManageIQ/manageiq-ui-classic/pull/6211,

but turns out that running `yarn run lint` (or any other `eslint` invocation) fails on missing `babel-eslint`.
Adding back :)

Turns out we can't use babel-eslint newer than 8.1*, 9.0 and newer fail with ` TypeError: Cannot read property 'range' of null`  (probably related to our version of eslint itself), so using 8.1 for now.


Also fixed some indentation issues in `.eslintrc.json` and a added back a few missing rules in the es6 eslintrc.json.