### PR TITLE
Enable babel-loader caching

### DIFF
--- a/config/webpack/loaders.js
+++ b/config/webpack/loaders.js
@@ -6,6 +6,7 @@ const babelrc = require('../../.babelrc.js');
 let babelOptions = merge(babelrc, {
   babelrc: false,
   compact: false,
+  cacheDirectory: env.BABEL_CACHE_DIR || true, // defaults to node_modules/.cache/babel-loader
 });
 
 // set WEBPACK_VERBOSE=1 to get more warnings


### PR DESCRIPTION
By default, babel loader doesn't do any caching,
but we can enable it, and `bin/webpack` goes from 25 seconds to 17 on my machine, the second time (once cached).

So, enabling the cache,
and adding a way to override the location from the default `node_modules/.cache/babel-loader` by providing a different location via BABEL_CACHE_DIR env.
