### PR TITLE
Make Save button disabled after canceling User's password changes

### DIFF
--- a/app/assets/javascripts/miq_change_stored_password.js
+++ b/app/assets/javascripts/miq_change_stored_password.js
@@ -12,6 +12,8 @@ function changeStoredPassword(pfx, url) {
   $('#' + prefix + 'verify').removeAttr('disabled');
   $('#' + prefix + 'password').val('');
   $('#' + prefix + 'verify').val('');
+  $('#' + prefix + 'password').attr('placeholder', '');
+  $('#' + prefix + 'verify').attr('placeholder', '');
   miqJqueryRequest(url + '?' + prefix + 'password' + '=' + '&' + prefix + 'verify' + '=');
   $('#' + prefix + 'password').focus();
 }
@@ -27,7 +29,9 @@ function cancelPasswordChange(pfx, url) {
   $('#' + prefix + 'verify_group').css('display', 'none');
   $('#' + prefix + 'password').attr('disabled', 'disabled');
   $('#' + prefix + 'verify').attr('disabled', 'disabled');
-  $('#' + prefix + 'password').val(storedPasswordPlaceholder);
-  $('#' + prefix + 'verify').val(storedPasswordPlaceholder);
+  $('#' + prefix + 'password').attr('placeholder', storedPasswordPlaceholder);
+  $('#' + prefix + 'verify').attr('placeholder', storedPasswordPlaceholder);
+  $('#' + prefix + 'password').val('');
+  $('#' + prefix + 'verify').val('');
   miqJqueryRequest(url + '?' + prefix + 'password' + '=' + '&' + prefix + 'verify' + '=' + '&restore_password=true');
 }

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -61,9 +61,10 @@
           .col-md-8
             %span.input-group{:style => "width: 100%"}
               = password_field_tag("password",
-                                   @edit[:new][:userid].blank? ? "" : stored_password_placeholder,
+                                   "",
                                    :maxlength         => 50,
                                    :disabled          => @edit[:new][:userid].blank? ? false : true,
+                                   :placeholder       => @edit[:new][:userid].blank? ? "" : stored_password_placeholder,
                                    :class             => "form-control",
                                    "data-miq_observe" => observe_url_json)
               - if @edit[:new][:userid] == "admin"


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1762791

There was a bug regarding responding of _Save_ button (_Save_ and _Reset_ buttons are together enabled or disabled like one) on changes of User's password: after clicking on _Cancel_ button for canceling editing the password (not canceling editing User's info!), _Save_ button was still enabled even when there wasn't any change in the User's info, and after clicking on _Save_ error occurred.

The core of the problem is `value` vs. `placeholder` attribute of `password_field_tag`. Because of that, string with dots _'●●●●●●●●'_ appeared in `params[:password]` after clicking on _Cancel_ button, so then this value was copied to `@edit[:new][:password]` (which was `nil` originally, at the beginning of editing User's info) and [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L760) `changed` variable was set to `true`, so then _Save, Reset_ buttons remained enabled.

[Here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/miq_change_stored_password.js#L30) is the place where we've set dots as a value, after canceling editing password. I don't see any reason for it. Also, the name of the variable `storedPasswordPlaceholder` used there also suggests that it's about setting the placeholder, not value.

---

Editing User's password - _Save, Reset_ buttons enabled as expected:
![cancel_passwd](https://user-images.githubusercontent.com/13417815/67967717-653cd680-fc06-11e9-9f24-8cffd580b85c.png)

**Before:** (after canceling User's password change _Save, Reset_ buttons still enabled!)
![before-after_cancel_passwd](https://user-images.githubusercontent.com/13417815/67967703-5ce49b80-fc06-11e9-8ed1-e658da0536da.png)

**After:** (after canceling User's password change _Save, Reset_ buttons disabled as expected)
![after_cancel_passwd](https://user-images.githubusercontent.com/13417815/67967712-5f46f580-fc06-11e9-9d0a-4b86ca755bdd.png)
