### PR TITLE
Set empty report submenus to empty arrays instead of empty strings

### DIFF
--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -86,7 +86,7 @@ module ReportController::Menus
       @edit[:temp_new] = []
       if @edit[:tree_arr].blank?
         # if all subfolders were deleted
-        @edit[:temp_new].push(@edit[:temp_arr][0], "")
+        @edit[:temp_new].push(@edit[:temp_arr][0], [])
       else
         @edit[:tree_arr].each do |el|
           old_folder = @edit[:tree_hash].key(el)


### PR DESCRIPTION
To be honest, I have no idea about how this piece of code works and looking at it I have a feeling that it needs some :fire: before touching it in the future. Anyway, it seems to fix the problem, but I need some clickety-testing.

@miq-bot assign @h-kataria 
@miq-bot add_label ivanchuk/yes, hammer/yes, bug

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1762363