### PR TITLE
Make Save button respond properly on changes in User's Available Groups

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -755,7 +755,7 @@ module OpsController::OpsRbac
     when "role"  then rbac_role_get_form_vars
     end
 
-    @edit[:new][:group] = rbac_user_get_group_ids.map(&:to_i) if rec_type == "user"
+    @edit[:new][:group] = rbac_user_get_group_ids if rec_type == "user"
 
     session[:changed] = changed = @edit[:new] != @edit[:current]
 
@@ -965,7 +965,7 @@ module OpsController::OpsRbac
     TreeBuilderOpsRbacFeatures.new("features_tree", @sb, true, :role => @role, :editable => @edit.present?)
   end
 
-  # Set form variables for role edit
+  # Set form variables for user edit
   def rbac_user_set_form_vars
     copy = @sb[:typ] == "copy"
     # save a shadow copy of the record if record is being copied
@@ -977,7 +977,7 @@ module OpsController::OpsRbac
     # prefill form fields for edit and copy action
     @edit[:new].merge!(:name  => @user.name,
                        :email => @user.email,
-                       :group => @user.miq_groups ? @user.miq_groups.map(&:id) : nil)
+                       :group => @user.miq_groups ? @user.miq_groups.map(&:id).sort : nil)
     unless copy
       @edit[:new].merge!(:userid   => @user.userid,
                          :password => @user.password,
@@ -1017,9 +1017,9 @@ module OpsController::OpsRbac
     when 'null', nil
       []
     when String
-      @edit[:new][:group].split(',').delete_if(&:blank?).sort
+      @edit[:new][:group].split(',').delete_if(&:blank?).map(&:to_i).sort
     when Array
-      @edit[:new][:group].sort
+      @edit[:new][:group].map(&:to_i).sort
     end
   end
 
@@ -1119,7 +1119,7 @@ module OpsController::OpsRbac
     params[:tree_typ] ? params[:tree_typ] + "_tree" : nil
   end
 
-  # Set form variables for user add/edit
+  # Set form variables for group add/edit
   def rbac_group_set_form_vars
     @assigned_filters = []
     @group = @record

--- a/app/views/ops/_rbac_group_selected.html.haml
+++ b/app/views/ops/_rbac_group_selected.html.haml
@@ -1,7 +1,6 @@
 #group_selected
-  - if @edit[:new][:group].present? && @edit[:new][:group] != 'null'
-    - selected_group_ids = @edit[:new][:group].split(',').delete_if(&:blank?)
-    - selected_groups = Rbac.filtered(MiqGroup.find(selected_group_ids)).map(&:description)
+  - if @edit[:new][:group].present?
+    - selected_groups = Rbac.filtered(MiqGroup.find(@edit[:new][:group])).map(&:description).sort
     - selected_groups.each do |g|
       %i.ff.ff-group
       = g

--- a/spec/views/ops/_rbac_group_selected.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_selected.html.haml_spec.rb
@@ -1,0 +1,14 @@
+describe 'ops/_rbac_group_selected.html.haml' do
+  let!(:group1) { FactoryBot.create(:miq_group) }
+  let!(:group2) { FactoryBot.create(:miq_group) }
+
+  before do
+    assign(:edit, :new => {:group => [group2.id, group1.id]})
+    allow(Rbac).to receive(:filtered).and_return([group2, group1])
+  end
+
+  it 'renders sorted selected groups' do
+    render :partial => 'ops/rbac_group_selected'
+    expect(rendered).to eq("<div id=\'group_selected\'>\n<i class=\'ff ff-group\'></i>\n#{group1.description}\n<br>\n<i class=\'ff ff-group\'></i>\n#{group2.description}\n<br>\n</div>\n")
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6364

In User's editing screen, _Save_ button wasn't responding properly on changes in _Available Groups_ section, especially if there were more groups selected in the drop down.

Another issue was improper order of groups in _Selected Groups_ section while adding/editing User. It was inconsistent with the User's details screen where the _Groups_ are properly ordered (by description).

This PR fixes both issues, together with fixing two improper comments in the code.

**Details:**
The improper response of _Save_ butto on changes in User's _Available Groups_ was caused by sorting the Groups' ids represented by [array of strings](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L1020). We need to put the ids from strings to integers AND THEN to sort the array of ids. We need to have ids in both `@edit[:new][:group]` and `@edit[:current][:group]` sorted to be able to compare them and then to set `changed` variable properly, for proper response of _Save_ button.

The second issue is fixed simply by adding `.sort` to the array of descriptions of selected groups. I've also removed unnecessary code in the same haml, as `@edit[:new][:group]` is already edited [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/ops_controller/ops_rbac.rb#L1015) before it is used in the haml, so no need to do the same stuff again in the haml, I mean splitting the string (`@edit[:new][:group]` is already an array of integers in the haml, not string!), and checking for `'null'`.

---

User's details screen, check the _Groups_ and their order - groups are alphabetically orderd:
![users_detail](https://user-images.githubusercontent.com/13417815/68034232-9b8b5c00-fcc1-11e9-8973-eed007962d55.png)

**Before:** bad response of _Save_ button and bad order of _Selected Groups_
![user_before](https://user-images.githubusercontent.com/13417815/68034215-96c6a800-fcc1-11e9-990c-88d33510515e.png)

**After:**
![user_after](https://user-images.githubusercontent.com/13417815/68031578-413bcc80-fcbc-11e9-8c9b-4e8454a60e59.png)
