### PR TITLE
Fix node ID generation for MiqAeClassController#open_parent_nodes

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -229,7 +229,7 @@ class MiqAeClassController < ApplicationController
       if i == nodes.length - 1
         selected_node = x_node.split("-")
         parents.push(record.ae_class) if %w[aei aem].include?(selected_node[0])
-        self.x_node = "#{selected_node[0]}-#{record.id}"
+        self.x_node = TreeBuilder.build_node_id(record)
         parents.push(record)
       else
         ns = MiqAeNamespace.lookup_by_fqname(nodes[0..i].join("/"))


### PR DESCRIPTION
So this is crazy, the node ID generation was wrongly implemented and it was ont possible that it ever worked. Of course there's no way that we could see this visually as the `open_parent_nodes` usually gets triggered by a node activation on the last level. However, the tests were failing just sometimes if the record identifiers for the `MiqAeMethod` and `MiqAeClass` were the same, which in testing on a clear database is in most of the cases true.

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @hstastna 
@miq-bot add_label bug

Closes https://github.com/ManageIQ/manageiq-ui-classic/pull/6370