### PR TITLE
Force user group reload after changing permissions so tree is correct

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1386,6 +1386,7 @@ module OpsController::OpsRbac
   def populate_role_features(role)
     role.miq_product_features =
       MiqProductFeature.find_all_by_identifier(rbac_compact_features(@edit[:new][:features]))
+    User.current_user.reload
   end
 
   # Validate some of the role fields


### PR DESCRIPTION
We have an issue where a custom role has "Access Restriction for Services, VM and Templates" set to something, the user can still see the full list of users, and when set to none, you only see the previous user logged in the tree from when there was a restriction set.

User.current_user is still using the incorrect group setting because we never reload it. 

Forcing a reload makes us load the right group with the right permissions here and the accordion changes when the users and group visibility changes as it should.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1766756

@miq-bot add_label bug