### PR TITLE
Disable clicking on Edit Tags without selecting Configured Systems

### DIFF
--- a/app/helpers/application_helper/toolbar/configured_system/automation/policy_mixin.rb
+++ b/app/helpers/application_helper/toolbar/configured_system/automation/policy_mixin.rb
@@ -15,7 +15,8 @@ module ApplicationHelper::Toolbar::ConfiguredSystem::Automation::PolicyMixin
             :url          => "tagging",
             :url_parms    => "main_div",
             :send_checked => true,
-            :enabled      => true
+            :enabled      => true,
+            :onwhen       => "1+"
           ),
         ]
       ),


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6361

There was an issue with Configured Systems' list and the toolbar button: it was possible to click on _Edit Tags_ without selecting any Configured System in the list. This led to an error, and nothing happened in the UI.

This PR fixes the issue by setting `:onwhen` attribute for the appropriate toolbar button which makes the button enabled if at least one item is selected in the list.

This PR fixes the issue for Configured Systems in _Automation > Ansible Tower > Explorer > Configured Systems_ accordion and also for Configured Systems displayed through selected Ansible Tower Provider's Inventory Group (_Configured Systems_ tab).

---

**Before:**
![config_before](https://user-images.githubusercontent.com/13417815/68139688-e065fb80-ff2a-11e9-8fdc-071cbd5a0b3a.png)

**After:**
![config_after1](https://user-images.githubusercontent.com/13417815/68139626-b9a7c500-ff2a-11e9-9f95-8c0ebe382fdb.png)
![config_after2](https://user-images.githubusercontent.com/13417815/68139630-bb718880-ff2a-11e9-8ed7-0a51a98e4d74.png)
