### PR TITLE
Allow tagging or managing policies for Replicators, Pods, Nodes, Images

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -400,8 +400,8 @@ module Mixins
         custom_buttons if params[:pressed] == "custom_button"
 
         return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything
-        return if ["#{table_name}_tag", "#{table_name}_protect", "#{table_name}_timeline"].include?(params[:pressed]) &&
-                  @flash_array.nil? # Tag screen showing, so return
+        return if ["#{table_name}_tag", "#{display_s}_tag", "#{table_name}_protect", "#{display_s}_protect", "#{table_name}_timeline"].include?(params[:pressed]) &&
+                  @flash_array.nil? # Screen for Edit Tags or Manage Policies action showing, so return
 
         check_if_button_is_implemented
       end
@@ -487,7 +487,7 @@ module Mixins
       assert_privileges("#{model.name.underscore}_check_compliance")
       ids = find_records_with_rbac(model, checked_or_params).ids
       process_check_compliance(model, ids)
-      show_list
+      @lastaction == 'show_list' ? show_list : show
       ids.count
     end
 

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -305,6 +305,11 @@ describe EmsContainerController do
                 expect(controller).to receive(:tag).with(display_s.classify.safe_constantize)
                 controller.send(:button)
               end
+
+              it 'returns before calling check_if_button_is_implemented' do
+                expect(controller).not_to receive(:check_if_button_is_implemented)
+                controller.send(:button)
+              end
             end
 
             context "managing policies of selected #{items}" do
@@ -314,13 +319,28 @@ describe EmsContainerController do
                 expect(controller).to receive(:assign_policies).with(display_s.classify.safe_constantize)
                 controller.send(:button)
               end
+
+              it 'returns before calling check_if_button_is_implemented' do
+                expect(controller).not_to receive(:check_if_button_is_implemented)
+                controller.send(:button)
+              end
             end
 
             context "checking compliance of selected #{items}" do
               let(:press) { "#{display_s}_check_compliance" }
 
+              before do
+                allow(controller).to receive(:process_check_compliance)
+                controller.instance_variable_set(:@lastaction, 'show')
+              end
+
               it 'calls check_compliance_nested method with proper model class' do
                 expect(controller).to receive(:check_compliance_nested).with(display_s.classify.safe_constantize)
+                controller.send(:button)
+              end
+
+              it 'calls show method' do
+                expect(controller).to receive(:show)
                 controller.send(:button)
               end
             end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6303

There was an issue regarding Container Replicators, Pods, Nodes, Images displayed in a nested list: `Button not yet implemented` occurred after trying to tag or manage policies of selected items, **if _Check Compliance of Last Known Configuration_ was initiated before other policy actions**.

---

**Details:**
The issue is caused [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Button_not_implement_ContainerReplicators_Pods_Nodes_Imgs?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54L490). The problem was that `@lastaction` was set to `"show"` but this fact was not checked at all, in `check_compliance_nested`, and calling `show_list` method was the one and only option. You can compare this with the code in `check_compliance` [method](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Button_not_implement_ContainerReplicators_Pods_Nodes_Imgs?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R474) which is called if _Check Compliance of Last Known Configuration_ action is applied on items not displayed in a nested list: `show_list` or `show` is [called](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Button_not_implement_ContainerReplicators_Pods_Nodes_Imgs?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R480).

**Why not only `show_list`**?
If we call `show_list`, then `process_show_list` is called, where `@display` variable is set to `nil` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L191), instead of still being set to for example `"container_groups"` (if nested list of _Container Pods_ is displayed). And this leads to errors for the next actions. We cannot always call `show_list`. Checking `@lastaction` and deciding whether to call `show_list` or `show` is necessary for proper behavior, because calling for example `tag` [method](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common.rb#L364) depends on `@display`, see [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/ems_common.rb#L358).

**Another issue:**
`check_if_button_is_implemented` method is [called](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Button_not_implement_ContainerReplicators_Pods_Nodes_Imgs?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R406) for tagging and managing policies actions, and in this method `"Button not yet implemented"` error flash message is set even when the button IS implemented and when tagging works fine. However, this message is never rendered and tagging screen (or manage policies screen) is rendered instead. It does not matter now but it could matter in the future. To achieve consistency I've added `"#{display_s}_tag",` and `"#{display_s}_protect"` to the array [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6379/files#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R403), the same as it is there for tagging other items displayed in other controllers (see `"#{table_name}_tag"` [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Button_not_implement_ContainerReplicators_Pods_Nodes_Imgs?expand=1#diff-c32dcaa7dedd2b85b7ee0ce6036b3f54R403)).

---

**Before:**
![compliance_before](https://user-images.githubusercontent.com/13417815/68304789-ce10cc80-00a6-11ea-9e65-42cc518dae48.png)

**After:**
![compliance_after](https://user-images.githubusercontent.com/13417815/68304795-d10bbd00-00a6-11ea-967d-1af56340af32.png)
