### PR TITLE
[IVANCHUK] Toolbar delete button for Button/Button Group goes via generic API de…

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -14,6 +14,10 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
+  def data(input)
+    input
+  end
+
   def role_allows_feature?
     # for select buttons RBAC is checked only for nested buttons
     return true if self[:type] == :buttonSelect

--- a/app/helpers/application_helper/button/generic_object_definition_button_button_delete.rb
+++ b/app/helpers/application_helper/button/generic_object_definition_button_button_delete.rb
@@ -1,9 +1,5 @@
-class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::GenericObjectDefinitionButtonButtonDelete < ApplicationHelper::Button::Basic
   needs :@record
-
-  def disabled?
-    !@record.custom_buttons.count.zero?
-  end
 
   def data(_data)
     {'function'      => 'sendDataWithRx',

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
@@ -12,12 +12,11 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonCenter < Applicat
           :url => 'custom_button_edit',
         ),
         button(
-          :ab_button_delete,
+          :custom_button_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Button from Inventory'),
-          :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete_custom_button", "controller": "genericObjectDefinitionToolbarController", "entity": "Button"}'},
+          N_('Remove this Custom Button from Inventory'),
           :confirm => N_("Warning: This Button will be permanently removed!"),
+          :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonDelete
         )
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
@@ -18,13 +18,11 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonGroupCenter < App
           :url => 'custom_button_new',
         ),
         button(
-          :ab_button_delete,
+          :custom_button_set_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Button Group from Inventory'),
-          :data    => {'function'      => 'sendDataWithRx',
-                       'function-data' => '{"type": "delete_custom_button_set", "controller": "genericObjectDefinitionToolbarController", "entity": "Button Group"}'},
+          N_('Remove this Custom Button Group from Inventory'),
+          :confirm => N_("Warning: This Custom Button Group will be permanently removed!"),
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete,
-          :confirm => N_("Warning: This Button Group will be permanently removed!"),
         ),
       ]
     )

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -116,7 +116,7 @@ class ApplicationHelper::ToolbarBuilder
   def apply_common_props(button, input)
     button.update(
       :color        => input[:color],
-      :data         => input[:data],
+      :data         => button.data(input[:data]),
       :hidden       => button[:hidden] || !!input[:hidden],
       :icon         => input[:icon],
       :name         => button[:id],

--- a/app/javascript/toolbar-actions/delete.js
+++ b/app/javascript/toolbar-actions/delete.js
@@ -23,12 +23,17 @@ export function generateMessages(results) {
   }, { false: 0, true: 0 });
 }
 
-export function APIDelete(entity, resources, labels) {
+export function APIDelete(entity, resources, labels = { single: '', multiple: '' }, redirectUrl, name) {
   API.post(`/api/${entity}`, {
     action: 'delete',
     resources,
   }).then((data) => {
-    showMessage(generateMessages(data.results), labels);
+    if (redirectUrl) {
+      miqFlashLater({ message: sprintf(__('%s: "%s" was successfully deleted'), labels.single, name) });
+      window.location.href = redirectUrl;
+    } else {
+      showMessage(generateMessages(data.results), labels);
+    };
     return data;
   });
 }
@@ -41,6 +46,6 @@ export function onDelete(data, resources) {
   if (data.customAction) {
     customActionDelete(data, resources);
   } else {
-    APIDelete(data.entity, resources, data.labels);
+    APIDelete(data.entity, resources, data.labels, data.redirect_url, data.name);
   }
 }


### PR DESCRIPTION
Ivanchuk version of https://github.com/ManageIQ/manageiq-ui-classic/pull/6230 and https://github.com/ManageIQ/manageiq-ui-classic/pull/6214 (that got reverted by #6230)

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1744478
https://bugzilla.redhat.com/show_bug.cgi?id=1753289

Go to Automation -> Automate -> Generic Objects -> delete a custom button (delete a custom button group to make sure it works as well)

Before:
![image](https://user-images.githubusercontent.com/9210860/65244013-e83c1e80-dae9-11e9-8c4d-e83d22c04477.png)
or
<img width="1090" alt="Screenshot 2019-09-23 at 15 45 02" src="https://user-images.githubusercontent.com/9210860/65431048-2488bb00-de19-11e9-870a-476972671e55.png">


After:
<img width="1070" alt="Screenshot 2019-09-19 at 14 26 16" src="https://user-images.githubusercontent.com/9210860/65243823-76fc6b80-dae9-11e9-88c4-08dd7f1db936.png">

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=1753388

Go to Automation -> Automate -> Generic Objects - > delete a custom button(with or without Custom Button Group it shouldn't matter)

Actual result:
There's an error popup and message for a sec.  See Before pic.

Expected result:
No error message/popup. See After pic.

According to the BZ it happens in 70%. 

This fix should work for all possible delete actions on Generic Object Definition page. 

Before:
<img width="1442" alt="Screenshot 2019-09-24 at 14 58 14" src="https://user-images.githubusercontent.com/9210860/65513594-cbce2680-dedb-11e9-85bd-32306e8c586e.png">
After:
![image](https://user-images.githubusercontent.com/9210860/65513630-e0122380-dedb-11e9-99f9-705fa3338a98.png)

@miq-bot add_label wip
