### PR TITLE
Fix double ng-if

### DIFF
--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -130,9 +130,8 @@
                 %option{"value" => ""}
                   = "<#{_('Choose')}>"
 
-    .form-group{"ng-if" =>"#{ng_model}.#{prefix}_inventory!==undefined",
-                "ng-class" => "{'has-error': angularForm.#{prefix}_inventory.$invalid}",
-                "ng-if" => "#{ng_model}.location==='playbook'"}
+    .form-group{"ng-if" =>"#{ng_model}.location==='playbook'",
+                "ng-class" => "{'has-error': angularForm.#{prefix}_inventory.$invalid}"}
       %label.col-md-3.control-label
         = _("Hosts")
       .col-md-9


### PR DESCRIPTION
@miq-bot add_label wip, cleanup, ivanchuk/no

Fix following error in spec log:
```
app/views/layouts/angular/_ansible_form_options_angular.html.haml:133:
warning: key "ng-if" is duplicated and overwritten on line 135
```

Places to check it works:
Services -> Catalogs -> Catalog Items -> create/edit -> Hosts show only for Ansible Playbook
Automation -> Automate -> Explorer -> create/edit a method -> Hosts show only for Ansible Playbook

Hosts pic:
![image](https://user-images.githubusercontent.com/9210860/68468094-a2612400-0217-11ea-90ef-b7723b54a24e.png)


Remove check `"#{ng_model}.#{prefix}_inventory!==undefined"` as it's always set for Ansible Playbook and `"#{ng_model}.location==='playbook'"` makes sure it's not shown for other methods/catalog items.