### PR TITLE
Fix TreeNode selectability and checkboxes for alert profile assign

### DIFF
--- a/app/presenters/tree_builder_alert_profile_obj.rb
+++ b/app/presenters/tree_builder_alert_profile_obj.rb
@@ -9,6 +9,8 @@ class TreeBuilderAlertProfileObj < TreeBuilder
 
   def override(node, object)
     node.checked = @selected.try(:include?, object.id)
+    node.hide_checkbox = false if object.kind_of?(Classification)
+    node.selectable = false
   end
 
   def tree_init_options


### PR DESCRIPTION
When assigning an alert profile to a tag category, it wasn't showing checkboxes due some previous refactoring. Also some nodes were unnecessarily selectable in the assignments tree, when there are checkboxes only.

**Before:**
![Screenshot from 2019-11-07 11-13-23](https://user-images.githubusercontent.com/649130/68380191-a1fd5600-014f-11ea-9fcc-ad3629cbcd6d.png)

**After:**
![Screenshot from 2019-11-07 11-12-19](https://user-images.githubusercontent.com/649130/68380108-7e3a1000-014f-11ea-8d56-d64f6f1cf880.png)


@miq-bot add_reviewer @brumik 
@miq-bot add_label bug, trees, ivanchuk/no
@miq-bot assign @mzazrivec 