### PR TITLE
Fix CloudVolume constantization issues by using try/safe_constantize

### DIFF
--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -13,8 +13,7 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::But
   # disable button if no active providers support create action
   def disabled?
     ExtManagementSystem.none? do |ems|
-      Module.const_defined?("#{ems.class}::CloudVolume") &&
-        ems.class::CloudVolume.supports_create?
+      "#{ems.class}::CloudVolume".safe_constantize.try(:supports_create?)
     end
   end
 end


### PR DESCRIPTION
Somehow Travis started to fail on `Module.const_defined?` for the openstack providers `CloudVolume` with Ruby 2.6. First I thought it's the new top-level constant lookup change, but I was not able to reproduce it locally. So I am changing the code to a little safer approach by using `safe_constantize` and `try`.

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label bug, ivanchuk/no