### PR TITLE
Optimization - consistent date formats

### DIFF
--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -81,6 +81,7 @@ if (!window.ManageIQ) {
       prefillCount: 0,
       valueStyles: null,
     },
+    timezone: null, // session[:user_tz]
     toolbars: null,
     tree: {
       checkUrl: null,

--- a/app/javascript/optimization/transform.js
+++ b/app/javascript/optimization/transform.js
@@ -24,7 +24,7 @@ function queue(url) {
 }
 
 function formatDate(date) {
-  return date ? moment(date).format('MM/DD/YYYY h:mm:ss a') : null;
+  return date ? moment(date).tz(ManageIQ.timezone || 'UTC').format('MM/DD/YYYY HH:mm:ss z') : null;
 }
 
 function transformSaved({id, report_id, name, last_run_on, userid, url}) {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,6 +23,7 @@
       ManageIQ.charts.provider = "#{Charting.backend}";
       ManageIQ.browser = "#{j browser_info(:name_ui)}";
       ManageIQ.controller = "#{j controller_name}";
+      ManageIQ.timezone = '#{j ::ActiveSupport::TimeZone::MAPPING[session[:user_tz]]}';
 
     - if ::Settings.server.asynchronous_notifications
       :javascript


### PR DESCRIPTION
Overview > Optimization,
in the show_list views (`/optimization/show_list` and `/optimization/show_list/123`), we convert iso dates to the user representation in JS. 

But, for saved report views (both in Optimization and in Reports), we use the formatted value provided by the API (`/api/results/20892?expand_value_format=true&hash_attribute=result_set`).

Before, the show_list value was formatted as "07/22/2019 9:44:50 am", in browser-local timezone.
Now, the show_list value is formatted as "07/22/2019 09:44:50 UTC", in the timezone set in user settings.

![after](https://user-images.githubusercontent.com/289743/68395041-e47e5d00-0166-11ea-98a7-3114e2ff79bb.png)

This also exposes the current user timezone (`session[:user_tz]`) to JS (`ManageIQ.timezone`), in the `Europe/London` / `Etc/UTC`... format.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1769333