### PR TITLE
ReportDataTable - fix error when data.report is null

### DIFF
--- a/app/javascript/components/report-data-table.jsx
+++ b/app/javascript/components/report-data-table.jsx
@@ -83,7 +83,7 @@ const parseReportRows = reportData => reportData
   }));
 
 const reduceLoadedData = (state, action) => {
-  const columns = parseReportColumns(action.data);
+  const columns = action.data && action.data.report ? parseReportColumns(action.data) : [];
 
   // Setting the initial filter field to the first one, if not yet set.
   const filter = { ...state.filter };


### PR DESCRIPTION
when you try to load a saved report that's still being generated,
`GET /api/results/20893`, the response will contain

```
result_set: []
report: null
last_run_on: null
```

because all those fields are only set when the report is done generating.

That leads to infinispinner and

```
report-data-table.jsx:74 Uncaught TypeError: Cannot read property 'col_order' of null
    at parseReportColumns (report-data-table.jsx:74)
    at reduceLoadedData (report-data-table.jsx:86)
    at reducer (report-data-table.jsx:112)
    at updateReducer (react-dom.development.js:15444)
    at Object.useReducer (react-dom.development.js:16060)
    at useReducer (react.development.js:1567)
    at ReportDataTable (report-data-table.jsx:188)
    at renderWithHooks (react-dom.development.js:15108)
    at updateFunctionComponent (react-dom.development.js:16925)
    at beginWork$1 (react-dom.development.js:18498)
```
(accessing `data.report.col_order`)

This change enables the component to load, and show No Records Found.

![no_report](https://user-images.githubusercontent.com/289743/68397201-b00ca000-016a-11ea-973f-06feccc4d524.png)
