### PR TITLE
Dialog Editor, ExplorerPresenter - make sure all ids are strings in javascript

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -323,7 +323,7 @@ class InfraNetworkingController < ApplicationController
       partial_locals = {:controller =>'infra_networking'}
       if partial == 'layouts/x_gtl'
         partial_locals[:action_url] = @lastaction
-        presenter[:parent_id] = @record.id.to_s # Set parent rec id for JS function miqGridSort to build URL
+        presenter[:parent_id] = @record.id # Set parent rec id for JS function miqGridSort to build URL
         presenter[:parent_class] = params[:controller] # Set parent class for URL also
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1183,7 +1183,7 @@ module VmCommon
         partial_locals[:action_url] = @lastaction
 
         # Set parent record id & class for JS function miqGridSort to build URL
-        presenter[:parent_id]    = @record.id.to_s
+        presenter[:parent_id]    = @record.id
         presenter[:parent_class] = params[:controller]
       end
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])

--- a/app/helpers/miq_ae_customization_helper.rb
+++ b/app/helpers/miq_ae_customization_helper.rb
@@ -2,7 +2,7 @@ module MiqAeCustomizationHelper
   def dialog_id_action
     url = request.parameters
     if url[:id].present?
-      {:id => @record.id, :action => 'edit'}
+      {:id => @record.id.to_s, :action => 'edit'}
     elsif url[:copy].present?
       {:id => url[:copy], :action => 'copy'}
     else

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -288,10 +288,11 @@ class ExplorerPresenter
       toolbar
     end
 
+    # ids are nil or string
     data[:record] = {
-      :parentId    => @options[:parent_id],
+      :parentId    => @options[:parent_id]&.to_s,
       :parentClass => @options[:parent_class],
-      :recordId    => @options[:record_id],
+      :recordId    => @options[:record_id]&.to_s,
     }
 
     if @options[:osf_node].present?

--- a/spec/presenters/explorer_presenter_spec.rb
+++ b/spec/presenters/explorer_presenter_spec.rb
@@ -25,9 +25,9 @@ describe ExplorerPresenter do
     end
 
     context "#[:record_id]" do
-      it 'sets :record object' do
+      it 'sets :record object, ensuring string id' do
         @presenter[:record_id] = 666
-        expect(subject[:record][:recordId]).to eq(666)
+        expect(subject[:record][:recordId]).to eq("666")
       end
     end
 


### PR DESCRIPTION
for regions > 9006, our bigint ids become floats in javascript, and can be off-by-one. (Original issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/1405)

This makes sure the dialog editor works in those regions:

* the `dialog_id_action` change fixes the result of the `requestDialogId` dialog editor controller method, controlling where to load the dialog data from
* the `ExplorerPresenter` change fixes the toolbar (Edit) button failing (becuase it uses `ManageIQ.record.recordId`, which was set to a number otherwise)
  * (the infra_networking & vm_common change only remove the now extra `to_s` because it's handled in ExplorerPresenter now)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1769968