### PR TITLE
Unify the service catalog order button handling on list/single views

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -48,9 +48,7 @@
                        :class   => "btn btn-primary",
                        :alt     => t = _("Order this Service"),
                        :title   => t,
-                       :onclick => "miqAjaxButton('#{url_for_only_path(:action => "svc_catalog_provision",
-                                                             :id     => @record.id,
-                                                           :button => "order")}');")
+                       :onclick => "miqOrderService(#{@record.id})")
 
 :javascript
   miq_bootstrap('#long_description');


### PR DESCRIPTION
When opening a service catalog's detail page, there's a missing route error in the order button's URL generation. However, the order button from the list view of all catalogs works as it should without any error. So I decided that instead of further debugging, I will just unify the two approaches and start using the `miqOrderService` in the single view the same way as it is being used in the list view.

![Screenshot from 2019-11-08 13-06-21](https://user-images.githubusercontent.com/649130/68475533-a21d5480-0228-11ea-840e-2468c0ff643f.png)

```
Error caught: [ActionView::Template::Error] No route matches {:action=>"svc_catalog_provision", :button=>"order", :controller=>"catalog", :id=>54}
```

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6350

@miq-bot add_label bug, ivanchuk/no, services