### PR TITLE
Remove old  class

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -687,11 +687,6 @@ table.table.table-selectable tbody tr.selected td {
   margin-top: 2px;
 }
 
-/* Ensure .form-control-static doesn't change height when it's empty - Bootstrap fix #15699 */
-.form-control-static {
-  min-height: ($line-height-computed + $font-size-small - 20);
-}
-
 /* prevents empty dd from collapsing */
 
 .dl-horizontal > dd::after {


### PR DESCRIPTION
This PR removes the custom "form-control-static" class. The class in now part of Bootstrap: https://github.com/twbs/bootstrap/pull/15699

<img width="1181" alt="Screen Shot 2019-11-11 at 11 22 37 AM" src="https://user-images.githubusercontent.com/1287144/68603069-98d4f780-0475-11ea-88ca-a54b23f0b815.png">
