### PR TITLE
Pretty print the webpack list

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -171,7 +171,7 @@ namespace :webpacker do
 
     if $?.success?
       $stdout.puts "[Webpacker] Compiled digests for all packs in #{Webpacker::Configuration.entry_path}:"
-      $stdout.puts JSON.parse(File.read(Webpacker::Configuration.manifest_path))
+      $stdout.puts JSON.parse(File.read(Webpacker::Configuration.manifest_path)).pretty_inspect
     else
       $stderr.puts "[Webpacker] Compilation Failed"
       exit!


### PR DESCRIPTION
A handful of times I've had to look at this list and it's hard to read as a single line.  This PR changes it to pretty print for better readability.

Now:

```text
[Webpacker] Compiled digests for all packs in /Users/jfrey/dev/manageiq-ui-classic/app/javascript/packs:
{"manageiq-providers-lenovo/component-definitions-common.js"=>
  "/packs/manageiq-providers-lenovo/component-definitions-common-834f716388d45ec8b228.js",
 "manageiq-providers-nuage/component-definitions-common.js"=>
  "/packs/manageiq-providers-nuage/component-definitions-common-ab780fac00d877a46d0a.js",
 "manageiq-providers-redfish/component-definition-common.js"=>
  "/packs/manageiq-providers-redfish/component-definition-common-688b7778ac4f1ba2afea.js",
 "manageiq-ui-classic/angular-common.js"=>
  "/packs/manageiq-ui-classic/angular-common-58c160ff4ca035d8a5cb.js",
 "manageiq-ui-classic/application-common.js"=>
  "/packs/manageiq-ui-classic/application-common-e3750e7f319ea8af5aa3.js",
 "manageiq-ui-classic/component-definitions-common.js"=>
  "/packs/manageiq-ui-classic/component-definitions-common-8f8686e27d0a47d06377.js",
 "manageiq-ui-classic/globals.js"=>
  "/packs/manageiq-ui-classic/globals-3005b7712f21a3fccf3f.js",
 "manageiq-ui-classic/print.js"=>
  "/packs/manageiq-ui-classic/print-7371d12f1eef4bf5364c.js",
 "manageiq-ui-classic/provider-dialogs-common.js"=>
  "/packs/manageiq-ui-classic/provider-dialogs-common-891cdc0be75a49118ae0.js",
 "manageiq-ui-classic/provisioning-actions-common.js"=>
  "/packs/manageiq-ui-classic/provisioning-actions-common-c8f5a557fac88de807b8.js",
 "manageiq-ui-classic/toolbar-actions-common.js"=>
  "/packs/manageiq-ui-classic/toolbar-actions-common-1041dc0ad01f8a6a6963.js",
 "manageiq-v2v/migration.js"=>
  "/packs/manageiq-v2v/migration-47fc84600f1b5c379889.js",
 "manageiq-v2v/polyfills.js"=>
  "/packs/manageiq-v2v/polyfills-0c2fbe35ce2af18a2d8d.js",
 "runtime.js"=>"/packs/runtime-21acf8de622f56dba48a.js",
 "shims.js"=>"/packs/shims-a3ac7c8fbf9b56ad78a3.js",
 "vendor.js"=>"/packs/vendor-4a704a974017204b1f21.js"}
```