### PR TITLE
[WIP] Make the dialogUserController a little bit more API driven

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -8,17 +8,20 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
       '&target_type=' + targetType;
 
     API.get(url, {expand: 'resources', attributes: 'content'})
-      .then(function (data) { vm.dialog = data.content[0] })
+      .then(function (data) { vm._dialog = data.content[0] })
       .then(loadServiceRequest)
       .then(postprocess)
-      .then(function () { vm.dialogLoaded = true })
-      .then(miqService.refreshSelectpicker);
+      .then(function () {
+        vm.dialog = vm._dialog;
+        delete vm._dialog;
+        vm.dialogLoaded = true;
+      });
   };
 
   function postprocess(replace) {
     var promises = [];
 
-    _.forEach(vm.dialog.dialog_tabs, function(tab) {
+    _.forEach(vm._dialog.dialog_tabs, function(tab) {
       _.forEach(tab.dialog_groups, function(group) {
         _.forEach(group.dialog_fields, function(field) {
           // If the service request has been copied, replace the fields' default values from the original service request

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -8,13 +8,13 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
         '&target_id=' + targetId +
         '&target_type=' + targetType;
 
-      resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(init));
+      resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(postprocess));
     });
 
     Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
   };
 
-  function init(dialog) {
+  function postprocess(dialog) {
     vm.dialog = dialog.content[0];
     vm.dialogLoaded = true;
 

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -2,22 +2,19 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   var vm = this;
 
   vm.$onInit = function() {
-    var apiCall = new Promise(function(resolve) {
-      var url = '/api/service_dialogs/' + dialogId +
-        '?resource_action_id=' + resourceActionId +
-        '&target_id=' + targetId +
-        '&target_type=' + targetType;
+    var url = '/api/service_dialogs/' + dialogId +
+      '?resource_action_id=' + resourceActionId +
+      '&target_id=' + targetId +
+      '&target_type=' + targetType;
 
-      resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(postprocess));
-    });
-
-    Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
+    API.get(url, {expand: 'resources', attributes: 'content'})
+      .then(function (data) { vm.dialog = data.content[0] })
+      .then(postprocess)
+      .then(function () { vm.dialogLoaded = true })
+      .then(miqService.refreshSelectpicker);
   };
 
   function postprocess(dialog) {
-    vm.dialog = dialog.content[0];
-    vm.dialogLoaded = true;
-
     _.forEach(vm.dialog.dialog_tabs, function(tab) {
       _.forEach(tab.dialog_groups, function(group) {
         _.forEach(group.dialog_fields, function(field) {

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -175,7 +175,7 @@ class MiqRequestController < ApplicationController
     )
 
     if req.kind_of?(ServiceTemplateProvisionRequest)
-      @dialog_replace_data = req.options[:dialog].map { |key, val| {:name => key.split('dialog_').last, :value => val } }.to_json
+      @dialog_replace_request_id = org_req.id
       @new_dialog = true
       template = find_record_with_rbac(ServiceTemplate, req.source_id)
       resource_action = template.resource_actions.find { |r| r.action.downcase == 'provision' && r.dialog_id }

--- a/app/views/shared/dialogs/_dialog_user.html.haml
+++ b/app/views/shared/dialogs/_dialog_user.html.haml
@@ -29,5 +29,5 @@
   ManageIQ.angular.app.value('apiAction', '#{j_str(api_action)}');
   ManageIQ.angular.app.value('cancelEndpoint', '#{cancel_endpoint}');
   ManageIQ.angular.app.value('openUrl', '#{open_url}');
-  ManageIQ.angular.app.value('dialogReplaceData', '#{@dialog_replace_data}');
+  ManageIQ.angular.app.value('dialogReplaceRequestId', '#{@dialog_replace_request_id}');
   miq_bootstrap('.wrapper');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
@@ -43,7 +43,7 @@ describe('dialogUserController', function() {
       targetType: 'targettype',
       realTargetType: 'targettype',
       openUrl: false,
-      dialogReplaceData: null,
+      dialogReplaceRequestId: null,
     });
 
     DialogData.data = {
@@ -129,7 +129,7 @@ describe('dialogUserController', function() {
           realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
-          dialogReplaceData: null,
+          dialogReplaceRequestId: null,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});
@@ -165,7 +165,7 @@ describe('dialogUserController', function() {
           realTargetType: 'targettype',
           saveable: true,
           openUrl: false,
-          dialogReplaceData: null,
+          dialogReplaceRequestId: null,
         });
 
         $controller.setDialogData({data: {field1: 'field1'}, validations: { isValid : true}});


### PR DESCRIPTION
I went through the initialization process of the `dialogUserController`, flattened the promise chain and started thinking about retrieving stuff from the API. So far I was successful with the replacing of default values when duplicating a service request. The tags are also loaded from the [API](https://github.com/ManageIQ/manageiq-api/issues/704), replacing the original values coming from the schema.

[Eventually](https://github.com/ManageIQ/manageiq/issues/19483), I don't want to have these values in the dialog schema, but that's something we need to change in the backend. Also we can exist without this change for a while :wink:

There are some issues with the `TagControl` right now, because it's not using the `miqSelect` that has been already utilized in the dropdowns, but a [fix](https://github.com/ManageIQ/ui-components/pull/427) is already on its way.

The backend also sends us in the schema the `<None>` and `<Choose>` elements in dropdowns, which is a bad practice. My plan is to move this logic into the frontend as it is a presentation layer matter and it has nothing to do with the backend, that should provide data only. This would affect the `DropdownList` as well, because it uses a similar logic, but as its values are static, it would need a backend change.

Related issue: https://github.com/ManageIQ/manageiq/issues/19483
@miq-bot add_label refactoring, ivanchuk/no, angular dialogs