### PR TITLE
Display name instead of [object Object] for the Host in Network Port's Relationships table

### DIFF
--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -86,7 +86,7 @@ module NetworkPortHelper::TextualSummary
     return nil unless @record.device_type == "Host"
     {
       :icon  => "pficon pficon-container-node",
-      :value => @record.device,
+      :value => @record.device.name,
       :link  => url_for_only_path(
         :controller => "host",
         :action     => "show",

--- a/spec/helpers/network_port_helper/textual_summary_spec.rb
+++ b/spec/helpers/network_port_helper/textual_summary_spec.rb
@@ -11,4 +11,20 @@ describe NetworkPortHelper::TextualSummary do
     security_groups
     host
   )
+
+  describe '#textual_host' do
+    let(:host) { FactoryBot.create(:host) }
+    let(:port) { FactoryBot.create(:network_port, :device_type => 'Host', :device => host) }
+
+    before do
+      instance_variable_set(:@record, port)
+      allow(self).to receive(:url_for_only_path).and_return("/host/show/#{host.id}")
+    end
+
+    it 'returns Host of selected Network Port' do
+      expect(textual_host[:icon]).to eq('pficon pficon-container-node')
+      expect(textual_host[:value]).to eq(host.name)
+      expect(textual_host[:link]).to eq("/host/show/#{host.id}")
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6311

There was `[object Object]` displayed for the **Host in Network Port's Relationships table**, in textual summary. Adding `name` to `@record.device` for the _value_ parameter simply solves this issue.

**Before:**
![ntw_before](https://user-images.githubusercontent.com/13417815/68675712-b75fef00-0558-11ea-88cb-50412a941c38.png)

**After:**
![ntw_after](https://user-images.githubusercontent.com/13417815/68675713-b9c24900-0558-11ea-8272-e36ef841d1e7.png)
