### PR TITLE
Remove custom "static" class

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -663,20 +663,9 @@ table.table.table-selectable tbody tr.selected td {
   color: #fff;
 }
 
-/* static class form-horizontal for displaying static info with reduced row height */
-.form-horizontal.static .form-group {
-  margin-bottom: 5px;
-  min-height: 28px;
-}
+/* resize images displayed in form-group labels */
 
-/* resize png files displayed in form-groups */
-
-.form-horizontal.static .form-group img {
-  height: 20px;
-  width: 20px;
-}
-
-.form-horizontal.static .form-group .control-labelimage img {
+.control-labelimage img {
   height: 80px;
   width: 80px;
 }

--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -1,5 +1,5 @@
 = render :partial => "layouts/flash_msg"
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.col-md-2.control-label
       = _('Name')

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -17,7 +17,7 @@
     = miq_tab_content('basic') do
       %h3
         = _('Basic Information')
-      .form-horizontal.static
+      .form-horizontal
         .form-group
           %label.col-md-3.control-label
             = _('Name / Description')
@@ -170,7 +170,7 @@
       = miq_tab_content('details') do
         %h3
           = _('Basic Information')
-        .form-horizontal.static
+        .form-horizontal
           .form-group
             %label.col-md-3.control-label
               = _('Long Description')
@@ -245,7 +245,7 @@
         %h3
           = _('Provisioning Info')
         .col-md-12.col-lg-6
-          .form-horizontal.static
+          .form-horizontal
             .form-group
               %label.col-md-3.control-label
                 = _('Repository')
@@ -302,7 +302,7 @@
               .col-md-9
                 = _(ViewHelper::VERBOSITY_LEVELS[provisioning[:verbosity]])
         .col-md-12.col-lg-6
-          .form-horizontal.static
+          .form-horizontal
             .form-group
               %label.col-md-3.control-label
                 = _("Variables & Default Values")
@@ -339,7 +339,7 @@
           %h3
             = _('Retirement Info')
           .col-md-12.col-lg-6
-            .form-horizontal.static
+            .form-horizontal
               .form-group
                 %label.col-md-3.control-label
                   = _('Repository')
@@ -401,7 +401,7 @@
                 .col-md-9
                   = _(ViewHelper::VERBOSITY_LEVELS[retirement[:verbosity]])
           .col-md-12.col-lg-6
-            .form-horizontal.static
+            .form-horizontal
               .form-group
                 %label.col-md-3.control-label
                   = _("Variables & Default Values")

--- a/app/views/catalog/_stcat_tree_show.html.haml
+++ b/app/views/catalog/_stcat_tree_show.html.haml
@@ -1,6 +1,6 @@
 .maincontent
   = render :partial => "layouts/flash_msg"
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Name')

--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -1,6 +1,6 @@
 .maincontent
   = render :partial => "layouts/flash_msg"
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-1.control-labelimage{:rowspan => 9}
         - if @record.picture

--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -4,7 +4,7 @@
 #form_div
   %h3
     = _('Basic Info')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Description')
@@ -19,7 +19,7 @@
   /Add a new selector for the currencies
   %h3
     = _('Currencies')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Select currency: ')

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -1,7 +1,7 @@
 = render :partial => 'layouts/flash_msg'
 - breakdown_present = @record.chargeback_rate_details.any? { |d| d.sub_metric.present? }
 %h3= _('Basic Info')
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.col-md-2.control-label
       = _('Description')

--- a/app/views/generic_object_definition/_show_custom_button.html.haml
+++ b/app/views/generic_object_definition/_show_custom_button.html.haml
@@ -3,7 +3,7 @@
   -# don't need basic info box for Unassigned button group
   %h3
     = _('Basic Information')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.control-label.col-md-2
         = _('Text')

--- a/app/views/generic_object_definition/_show_custom_button_group.html.haml
+++ b/app/views/generic_object_definition/_show_custom_button_group.html.haml
@@ -2,7 +2,7 @@
 - if @record && @record.kind_of?(CustomButtonSet)
   %h3
     = _('Basic Information')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.control-label.col-md-2
         = _('Text')

--- a/app/views/host/_config.html.haml
+++ b/app/views/host/_config.html.haml
@@ -3,7 +3,7 @@
 - when "devices"
   - devices = devices_details
   - if devices.present?
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         - devices.each do |item|
           %label.col-md-2.control-label
@@ -15,7 +15,7 @@
 - when "os_info"
   - os_info = os_info_details
   - if os_info.present?
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         - os_info.each do |item|
           %label.col-md-2.control-label
@@ -39,7 +39,7 @@
 - when "hv_info"
   - vmminfo = vmm_info_details
   - if vmminfo
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         - vmminfo.each do |item|
           %label.col-md-2.control-label

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -54,7 +54,7 @@
     - elsif mode == "save"
       = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'exp_editor_flash'} if params[:button] != 'save'
       .modal-body
-        .form-horizontal.static
+        .form-horizontal
           .form-group
             %label.control-label.col-md-5
               = _("Search Expression")

--- a/app/views/layouts/_group_filter_expression.html.haml
+++ b/app/views/layouts/_group_filter_expression.html.haml
@@ -1,7 +1,7 @@
 - if @edit.nil?
   %h3
     = _('Filter Expression')
-  .form-horizontal.static
+  .form-horizontal
     - if @group && @group.entitlement && @group.entitlement.filter_expression && @group.entitlement.filter_expression.kind_of?(MiqExpression)
       = h(@group.entitlement.filter_expression.to_human)
     - else

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -9,7 +9,7 @@
   - else
     %h3
       = _('Main Info')
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         = format_form_group(_('Type'), location_fancy_name(@ae_method.location))
       .form-group
@@ -40,7 +40,7 @@
     - elsif @ae_method.location == 'expression'
       = @expression
     - elsif playbook_style_location?(@ae_method.location)
-      .form-horizontal.static
+      .form-horizontal
         - if @ae_method.location == 'playbook'
           .form-group
             = format_form_group(_('Repository'), @playbook_details[:repository])

--- a/app/views/miq_ae_customization/_dialog_info.html.haml
+++ b/app/views/miq_ae_customization/_dialog_info.html.haml
@@ -2,7 +2,7 @@
 #info_div{:style => display}
   %h3
     = _('Basic Information')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Label')

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -15,7 +15,7 @@
               - group = tg.resource
               %h3{:title => group.description}
                 = group.label
-              .form-horizontal.static
+              .form-horizontal
                 - group.ordered_dialog_resources.select(&:visible).each do |g|
                   - field = g.resource
                   .form-group

--- a/app/views/miq_ae_customization/_old_dialogs_details.html.haml
+++ b/app/views/miq_ae_customization/_old_dialogs_details.html.haml
@@ -6,7 +6,7 @@
     = render :partial => "layouts/flash_msg"
     %h3
       = _('Basic Information')
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.col-md-2.control-label
           = _('Name')

--- a/app/views/miq_ae_tools/_results_uri.html.haml
+++ b/app/views/miq_ae_tools/_results_uri.html.haml
@@ -3,7 +3,7 @@
     %br
     %h3
       = _('Object Info')
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.control-label.col-md-2
           = _('URI')

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -44,7 +44,7 @@
         - when "create_snapshot"
           %h3
             = _('Snapshot Settings')
-          .form-horizontal.static
+          .form-horizontal
             .form-group
               %label.control-label.col-md-2= _('Name')
               .col-md-8
@@ -53,7 +53,7 @@
           %hr
         - when "delete_snapshots_by_age"
           %h3= _('Snapshot Age Settings')
-          .form-horizontal.static
+          .form-horizontal
             .form-group
               %label.control-label.col-md-2= _('Delete if older than')
               .col-md-8

--- a/app/views/miq_policy/_alert_profile_details.html.haml
+++ b/app/views/miq_policy/_alert_profile_details.html.haml
@@ -10,7 +10,7 @@
       - if @edit
         -# Show basic info box with description only in edit mode
         %h3= _('Basic Information')
-        %div{:class => "form-horizontal#{@edit ? "" : ".static"} "}
+        .form-horizontal
           .form-group
             %label.control-label.col-md-2= _("Description")
             .col-md-8

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -3,7 +3,7 @@
     #event_info_div
       = render :partial => "layouts/flash_msg"
       %h3= _("Basic Information")
-      .form-horizontal.static
+      .form-horizontal
         .form-group
           %label.control-label.col-md-2= _("Event Group")
           .col-md-10

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -33,7 +33,7 @@
 
       - else
         %h3= _('Basic Information')
-        .form-horizontal.static
+        .form-horizontal
           .form-group
             %label.control-label.col-md-2= _('Active')
             .col-md-8
@@ -56,7 +56,7 @@
       - if @edit
         - if @edit[:typ] == "basic"
           %h3= _("Scope")
-          .form-horizontal.static
+          .form-horizontal
             .form-group
               %label.control-label.col-md-2
               .col-md-8
@@ -65,7 +65,7 @@
 
       - else
         %h3= _("Scope")
-        .form-horizontal.static
+        .form-horizontal
           .form-group
             %label.control-label.col-md-2
             .col-md-8

--- a/app/views/ops/_ap_show.html.haml
+++ b/app/views/ops/_ap_show.html.haml
@@ -2,7 +2,7 @@
 #ap_info
   %h3
     = _("Info")
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _("Name")
@@ -26,7 +26,7 @@
     - if @category
       %h3
         = _("Categories")
-      .form-horizontal.static
+      .form-horizontal
         - @category.sort.each do |c|
           .form-group
             .col-md-8
@@ -49,7 +49,7 @@
   - unless @selected_scan.mode == "Host"
     - if @registry
       %h3= _("Registry Items")
-      .form-horizontal.static
+      .form-horizontal
         - @registry.sort_by { |r| r["key"] }.each do |k|
           .form-group
             .col-md-8
@@ -58,7 +58,7 @@
   - if @nteventlog
     %h3
       = _("Event Log Items")
-    .form-horizontal.static
+    .form-horizontal
       - @nteventlog.sort_by { |l| l[:name] }.each do |k|
         .form-group
           .col-md-8

--- a/app/views/ops/_db_info.html.haml
+++ b/app/views/ops/_db_info.html.haml
@@ -2,7 +2,7 @@
 - if @vmdb_index
   %h3
     #{_("Index")}: #{h(@vmdb_index.name)}
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _("Name")
@@ -14,7 +14,7 @@
   - if metrics
     %h3
       = _("Metrics")
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.col-md-2.control-label
           = _("Rows")
@@ -43,7 +43,7 @@
 - elsif @table
   %h3
     #{_("Table")}: #{h(@table.name)}
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _("Name")

--- a/app/views/ops/_logs_selected.html.haml
+++ b/app/views/ops/_logs_selected.html.haml
@@ -5,7 +5,7 @@
 
 #selected_div
   %h3= _("Basic Info")
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label= _("Log Depot URI")
       .col-md-10

--- a/app/views/ops/_rbac_tag_box.html.haml
+++ b/app/views/ops/_rbac_tag_box.html.haml
@@ -1,5 +1,5 @@
 %h3= _("Smart Management")
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.col-md-2.control-label
       = current_tenant.name

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -1,6 +1,6 @@
 = render(:partial => "layouts/flash_msg")
 #schedule_info
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.control-label.col-md-2= _("Description")
       .col-md-10

--- a/app/views/ops/_selected_by_roles.html.haml
+++ b/app/views/ops/_selected_by_roles.html.haml
@@ -1,6 +1,6 @@
 -# tree type is servers by role
 - if rec.class == ServerRole
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label= _("Role")
       .col-md-10
@@ -16,7 +16,7 @@
         %p.form-control-static= h(max == 0 ? _("unlimited") : max)
 - else
   -# record class is AssignedServerRole
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label
         %i.pficon.pficon-server

--- a/app/views/ops/_selected_by_servers.html.haml
+++ b/app/views/ops/_selected_by_servers.html.haml
@@ -1,6 +1,6 @@
 -# tree type is roles by server
 - if rec.class == MiqServer
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-3.control-label= _('Server')
       .col-md-9
@@ -61,7 +61,7 @@
           = h(rec["version"])
 - else
   -# record class is AssignedServerRole
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-3.control-labelimage
         %i.ff.ff-user-role.fa-5x

--- a/app/views/ops/_server_desc.html.haml
+++ b/app/views/ops/_server_desc.html.haml
@@ -1,6 +1,6 @@
 #desc_content.desc_content
   %h3= h(@selected_server["name"])
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.col-md-2.control-label= _("Hostname")
       .col-md-9

--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -1,7 +1,7 @@
 - if @sb[:active_tab] == "settings_evm_servers"
   - if @servers
     %h3= _("Basic Information")
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.col-md-2.control-label
           = _("Name")
@@ -35,7 +35,7 @@
             = (@selected_zone.settings.key?(:concurrent_vm_scans) && @selected_zone.settings[:concurrent_vm_scans] > 0) ? @selected_zone.settings[:concurrent_vm_scans] : _("Unlimited")
 
     %h3= _("Relationships")
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.col-md-2.control-label
           = _("Servers")

--- a/app/views/ops/_settings_import_tags_tab.html.haml
+++ b/app/views/ops/_settings_import_tags_tab.html.haml
@@ -5,7 +5,7 @@
     %hr
     %h3
       = _("Upload %{customer_name} Tag Assignments for VMs") % {:customer_name => session[:customer_name]}
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         .col-md-8
           = form_tag({:action => "upload_csv",

--- a/app/views/ops/rhn/_info_subscribed.html.haml
+++ b/app/views/ops/rhn/_info_subscribed.html.haml
@@ -1,7 +1,7 @@
 %p
   = _("Appliances in this region can be registered with:")
 
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2
       = _("Service")

--- a/app/views/report/_db_show.html.haml
+++ b/app/views/report/_db_show.html.haml
@@ -1,6 +1,6 @@
 %h3
   = _('Basic Information')
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2
       = _('Name')

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -1,7 +1,7 @@
 = render :partial => "layouts/flash_msg"
 - if @sb[:active_tab] == "report_info"
   - if @sb[:miq_report_id] && @miq_report
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.control-label.col-md-2= _('ID')
         .col-md-10

--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -1,6 +1,6 @@
 = render :partial => "layouts/flash_msg"
 %h3= _("Schedule Info")
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2= _('Description')
     .col-md-10

--- a/app/views/report/_widget_show.html.haml
+++ b/app/views/report/_widget_show.html.haml
@@ -2,7 +2,7 @@
   - s = @widget.miq_schedule
   - tz = @timezone = s && s.run_at && s.run_at[:tz] ? s.run_at[:tz] : session[:user_tz]
   %h3= _('Basic Information')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.control-label.col-md-2
         - if @widget.read_only
@@ -29,7 +29,7 @@
   %hr
   - unless @sb[:wtype] == "m"
     %h3= _('Status')
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.control-label.col-md-2= _('Current Status')
         .col-md-10
@@ -54,7 +54,7 @@
   - when "m"
     - title = _("Menu Shortcuts")
   %h3= title
-  .form-horizontal.static
+  .form-horizontal
     - if @sb[:wtype] == "r"
       .form-group
         %label.control-label.col-md-2
@@ -121,7 +121,7 @@
   %hr
   - unless @sb[:wtype] == "m"
     %h3= _('Timer')
-    .form-horizontal.static
+    .form-horizontal
       - if s.kind_of?(MiqSchedule)
         .form-group
           %label.control-label.col-md-2= _('Run At')
@@ -142,7 +142,7 @@
               %br= _('Edit this Widget to configure a timer.')
     %hr
   %h3= _('Visibility')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       %label.control-label.col-md-2= _('Show')
       .col-md-10

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -64,7 +64,7 @@
     -# don't need basic info box for Unassigned button group
     %h3
       = _('Basic Information')
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.control-label.col-md-2
           = _('Text')

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -2,7 +2,7 @@
 
 %h3
   = _('Basic Information')
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2
       = _('Button Type')
@@ -67,7 +67,7 @@
 
 %h3
   = _('Object Details')
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2
       = _('System/Process/')
@@ -87,7 +87,7 @@
 
 %h3
   = _('Object Attribute')
-.form-horizontal.static
+.form-horizontal
   .form-group
     %label.control-label.col-md-2
       = _('Type')
@@ -118,7 +118,7 @@
 
 %h3
   = _('Visibility Expression')
-.form-horizontal.static
+.form-horizontal
   - if @custom_button && !@custom_button.visibility_expression.nil? && @custom_button.visibility_expression.kind_of?(MiqExpression)
     = h(@custom_button.visibility_expression.to_human)
   - else
@@ -130,7 +130,7 @@
 - if @resolve[:new][:attrs].empty?
   = render :partial => 'layouts/info_msg', :locals => {:message => _("No Attribute/Value Pairs found.")}
 - else
-  .form-horizontal.static
+  .form-horizontal
     - @resolve[:new][:attrs].each_with_index do |attr, i|
       .form-group
         %label.control-label.col-md-2
@@ -143,7 +143,7 @@
 
 %h3
   = _('Visibility')
-.form-horizontal.static
+.form-horizontal
   - show_to = @custom_button.visibility.nil? || (@custom_button.visibility && @custom_button.visibility[:roles] && @custom_button.visibility[:roles][0] == "_ALL_") ? _("To All") : _("By Role")
   .form-group
     %label.control-label.col-md-2

--- a/app/views/static/ansible-raw-stdout.html.haml
+++ b/app/views/static/ansible-raw-stdout.html.haml
@@ -14,7 +14,7 @@
 %div{'ng-if' => "$ctrl.data"}
   %h3
     = _('Standard Output')
-  .form-horizontal.static
+  .form-horizontal
     .form-group
       .col-md-9
         %div{'ng-bind-html' => "$ctrl.sanitized"}

--- a/app/views/vm_common/_snapshots_desc.html.haml
+++ b/app/views/vm_common/_snapshots_desc.html.haml
@@ -6,7 +6,7 @@
 
 #desc_content.desc_content
   - if session[:snap_selected].present? || @record.snapshots.count > 0
-    .form-horizontal.static
+    .form-horizontal
       .form-group
         %label.control-label.col-sm-2
           = _('Description')


### PR DESCRIPTION
This PR removes the custom "static" class that was used to adjust (tighten up) form-group styling when displaying text and images vs inputs. 

Follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/6395

