### PR TITLE
Service Catalog styling fix

### DIFF
--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -2,14 +2,14 @@
   = render :partial => "layouts/flash_msg"
   .form-horizontal.static
     .form-group
-      %label.col-md-1.control-labelimage{:rowspan => 9}
+      %label.col-md-2.control-labelimage{:rowspan => 9}
         - if @record.picture
           %img{:src => "#{@record.picture.url_path}?#{rand(99_999_999)}"}/
         - else
           %i.fa.fa-cube.fa-4x
         %br
         %br
-      .col-md-9
+      .col-md-8
         .form-group
           %label.col-md-2.control-label
             = _('Name')


### PR DESCRIPTION
This PR adjusts the columns on the Service Catalog order screen to prevent the text and image from overlapping.

Old
<img width="915" alt="Screen Shot 2019-11-12 at 11 44 17 AM" src="https://user-images.githubusercontent.com/1287144/68691645-12d2b280-0542-11ea-93e9-54c7cdf68ff4.png">

New
<img width="917" alt="Screen Shot 2019-11-12 at 11 44 42 AM" src="https://user-images.githubusercontent.com/1287144/68691644-12d2b280-0542-11ea-84b5-db56db7f3dd6.png">


