### PR TITLE
[WIP] Support detail features for VM reconfigure.

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -77,15 +77,14 @@ module Mixins
             end
             reconfigure_ids = recs.collect(&:to_i)
           end
+
           if @explorer
             reconfigure(reconfigure_ids)
             session[:changed] = true # need to enable submit button when screen loads
             @refresh_partial = "vm_common/reconfigure"
-          elsif role_allows?(:feature => "vm_reconfigure")
+          elsif
             # redirect to build the ownership screen
             javascript_redirect(:controller => rec_cls.to_s, :action => 'reconfigure', :req_id => request_id, :rec_ids => reconfigure_ids, :escape => false)
-          else
-            head :ok
           end
         end
 

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -87,9 +87,7 @@ module Mixins
         end
 
         alias_method :image_reconfigure, :reconfigurevms
-        alias_method :instance_reconfigure, :reconfigurevms
         alias_method :vm_reconfigure, :reconfigurevms
-        alias_method :miq_template_reconfigure, :reconfigurevms
 
         def get_reconfig_limits(reconfigure_ids)
           @reconfig_limits = VmReconfigureRequest.request_limits(:src_ids => reconfigure_ids)

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -2,6 +2,7 @@ class ApplicationHelper::Button::Basic < Hash
   include ActionView::Helpers::TextHelper
 
   delegate :role_allows?, :parse_nodetype_and_id, :to => :@view_context
+  delegate :role_allows_any?, :to => '@view_context.current_user'
 
   def initialize(view_context, view_binding, instance_data, props)
     @view_context  = view_context

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basi
   needs :@record
 
   def visible?
-    @record.reconfigurable?
+    role_allows_any?(:identifiers => %w(vm_reconfigure_cpu vm_reconfigure_memory vm_reconfigure_networks vm_reconfigure_disks)) && @record.reconfigurable?
   end
 end

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -7,109 +7,111 @@
                                "ng-show"       => "vm.afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3= _('Options')
-  .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
-    %label.col-md-2.control-label
-      = _('Memory')
-    .col-md-1
-      %input{"bs-switch"       => "",
-             "type"            => "checkbox",
-             "name"            => "cb_memory",
-             "ng-model"        => "vm.cb_memory",
-             "ng-change"       => "vm.cbChange()",
-             "switch-on-text"  => _("Yes"),
-             "switch-off-text" => _("No")}
-    #memory_div{"ng-if" => "vm.cb_memory"}
-      .col-md-4
-        %input.form-control{"type"              => "text",
-                            "id"                => "memory_value",
-                            "name"              => "memory",
-                            "ng-model"          => "vm.reconfigureModel.memory",
-                            "ng-change"         => "vm.cbChange()",
-                            "maxlength"         => "50",
-                            "ng-pattern"        => "/^[-+]?[0-9]+$/",
-                            "miqrequired"       => "",
-                            "checkchange"       => "",
-                            "auto-focus"        => "",
-                            "validate-multiple" => "4",
-                            :miqmin             => "#{@reconfig_limits[:min__vm_memory]}",
-                            :miqmax             => "#{@reconfig_limits[:max__vm_memory]}",
-                            :memtype            => "{{vm.reconfigureModel.memory_type}}"}
-        %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$invalid"}
-          = _(" Memory value not in range or not a multiple of 4")
-        %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$required"}
-          = _(" Valid memory value required")
-      .col-md-2
-        = select_tag('mem_type',
-                     options_for_select(%w(MB GB)),
-                     "ng-model"                    => "vm.reconfigureModel.memory_type",
-                     "ng-change"                   => "vm.memtypeChanged()",
-                     "maxlength"                   => "20",
-                     "required"                    => "",
-                     "selectpicker-for-select-tag" => "")
-        = (@reconfig_memory_note)
-  .form-group
-    %label.col-md-2.control-label
-      = _('Processors')
-    .col-md-1
-      %input{"bs-switch"       => "",
-         "type"            => "checkbox",
-         "name"            => "cb_cpu",
-         "ng-model"        => "vm.cb_cpu",
-         "ng-change"       => "vm.cbChange()",
-         "switch-on-text"  => _("Yes"),
-         "switch-off-text" => _("No")}
-    %br
-    #cpu_div{"ng-if" => "vm.cb_cpu", :style => "margin-left: 20px"}
-      %h3= _(' Processor Options')
-      - if @socket_options.length > 1
-        .form-group{"ng-class" => "{'has-error': angularForm.socket_count.$invalid}"}
-          %label.col-md-2.control-label
-            = _('Sockets')
-          .col-md-2
-            = select_tag('socket_count',
-                        options_for_select([["<#{_('Choose')}>", '']] + @socket_options, disabled: ["<#{_('Choose')}>", nil]),
-                        "ng-model"                    => "vm.reconfigureModel.socket_count",
-                        "ng-change"                   => "vm.processorValueChanged()",
-                        "miqrequired"                 => "",
-                        "maxlength"                   => "100",
-                        "checkchange"                 => "",
-                        "selectpicker-for-select-tag" => "")
-            - if @socket_options.length <= 1
-              @socket_options[0]
-      -  if @cores_options.length > 1
-        .form-group{"ng-class" => "{'has-error': angularForm.cores_per_socket_count.$invalid}"}
-          %label.col-md-2.control-label
-            = _('Cores Per Socket')
-          .col-md-2
-            = select_tag('cores_per_socket_count',
-                          options_for_select([["<#{_('Choose')}>", '']] + @cores_options, disabled: ["<#{_('Choose')}>", nil]),
-                          "ng-model"                    => "vm.reconfigureModel.cores_per_socket_count",
+  - if role_allows?(:feature => 'vm_reconfigure_memory')
+    .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Memory')
+      .col-md-1
+        %input{"bs-switch"       => "",
+               "type"            => "checkbox",
+               "name"            => "cb_memory",
+               "ng-model"        => "vm.cb_memory",
+               "ng-change"       => "vm.cbChange()",
+               "switch-on-text"  => _("Yes"),
+               "switch-off-text" => _("No")}
+      #memory_div{"ng-if" => "vm.cb_memory"}
+        .col-md-4
+          %input.form-control{"type"              => "text",
+                              "id"                => "memory_value",
+                              "name"              => "memory",
+                              "ng-model"          => "vm.reconfigureModel.memory",
+                              "ng-change"         => "vm.cbChange()",
+                              "maxlength"         => "50",
+                              "ng-pattern"        => "/^[-+]?[0-9]+$/",
+                              "miqrequired"       => "",
+                              "checkchange"       => "",
+                              "auto-focus"        => "",
+                              "validate-multiple" => "4",
+                              :miqmin             => "#{@reconfig_limits[:min__vm_memory]}",
+                              :miqmax             => "#{@reconfig_limits[:max__vm_memory]}",
+                              :memtype            => "{{vm.reconfigureModel.memory_type}}"}
+          %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$invalid"}
+            = _(" Memory value not in range or not a multiple of 4")
+          %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$required"}
+            = _(" Valid memory value required")
+        .col-md-2
+          = select_tag('mem_type',
+                       options_for_select(%w(MB GB)),
+                       "ng-model"                    => "vm.reconfigureModel.memory_type",
+                       "ng-change"                   => "vm.memtypeChanged()",
+                       "maxlength"                   => "20",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+          = (@reconfig_memory_note)
+  - if role_allows?(:feature => 'vm_reconfigure_cpu')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Processors')
+      .col-md-1
+        %input{"bs-switch"       => "",
+           "type"            => "checkbox",
+           "name"            => "cb_cpu",
+           "ng-model"        => "vm.cb_cpu",
+           "ng-change"       => "vm.cbChange()",
+           "switch-on-text"  => _("Yes"),
+           "switch-off-text" => _("No")}
+      %br
+      #cpu_div{"ng-if" => "vm.cb_cpu", :style => "margin-left: 20px"}
+        %h3= _(' Processor Options')
+        - if @socket_options.length > 1
+          .form-group{"ng-class" => "{'has-error': angularForm.socket_count.$invalid}"}
+            %label.col-md-2.control-label
+              = _('Sockets')
+            .col-md-2
+              = select_tag('socket_count',
+                          options_for_select([["<#{_('Choose')}>", '']] + @socket_options, disabled: ["<#{_('Choose')}>", nil]),
+                          "ng-model"                    => "vm.reconfigureModel.socket_count",
                           "ng-change"                   => "vm.processorValueChanged()",
-                          "ng-pattern"                  => "/^[-+]?[0-9]+$/",
                           "miqrequired"                 => "",
                           "maxlength"                   => "100",
                           "checkchange"                 => "",
                           "selectpicker-for-select-tag" => "")
-            - if @cores_options.length <= 1
-              @cores_options[0]
-            %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
-              =_("Note: a restart of the virtual machine might be required for the changes to apply.")
-        .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
-          %label.col-sm-2.control-label
-            = _('Total Processors')
-          .col-md-2
-            %input.form-control{"type"           => "text",
-                                "id"             => "total_cpus",
-                                "name"           => "total_cpus",
-                                "ng-model"       => "vm.reconfigureModel.total_cpus",
-                                :readonly        => '',
-                                "maxlength"      => "50",
-                                "validate_total" => "",
-                                "miqmax"         => "#{@reconfig_limits[:max__total_vcpus]}",
-                                "auto-focus"     => ""}
-            %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
-              = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks?
+              - if @socket_options.length <= 1
+                @socket_options[0]
+        -  if @cores_options.length > 1
+          .form-group{"ng-class" => "{'has-error': angularForm.cores_per_socket_count.$invalid}"}
+            %label.col-md-2.control-label
+              = _('Cores Per Socket')
+            .col-md-2
+              = select_tag('cores_per_socket_count',
+                            options_for_select([["<#{_('Choose')}>", '']] + @cores_options, disabled: ["<#{_('Choose')}>", nil]),
+                            "ng-model"                    => "vm.reconfigureModel.cores_per_socket_count",
+                            "ng-change"                   => "vm.processorValueChanged()",
+                            "ng-pattern"                  => "/^[-+]?[0-9]+$/",
+                            "miqrequired"                 => "",
+                            "maxlength"                   => "100",
+                            "checkchange"                 => "",
+                            "selectpicker-for-select-tag" => "")
+              - if @cores_options.length <= 1
+                @cores_options[0]
+              %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
+                =_("Note: a restart of the virtual machine might be required for the changes to apply.")
+          .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
+            %label.col-sm-2.control-label
+              = _('Total Processors')
+            .col-md-2
+              %input.form-control{"type"           => "text",
+                                  "id"             => "total_cpus",
+                                  "name"           => "total_cpus",
+                                  "ng-model"       => "vm.reconfigureModel.total_cpus",
+                                  :readonly        => '',
+                                  "maxlength"      => "50",
+                                  "validate_total" => "",
+                                  "miqmax"         => "#{@reconfig_limits[:max__total_vcpus]}",
+                                  "auto-focus"     => ""}
+              %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
+                = _(" Total processors value larger than the maximum allowed")
+  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
     %hr
     %div
       %h3

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -299,7 +299,7 @@
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters?
+  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
     %hr
     %div
       %h3
@@ -402,7 +402,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms?
+  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
     %div
       %h3
         = _('CD/DVD Drives')

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -1,5 +1,11 @@
 - @angular_form = true
 
+-# Base for reconfigure RBAC features.
+-# Either:
+-#   * 'vm_reconfigure_'    for infra VMs or
+-#   * 'image_reconfigure_' for cloud images.
+- base = controller_name == 'vm_infra' ? 'vm_reconfigure_' : 'image_reconfigure_'
+
 %form#form_div.form-horizontal{"name"          => "angularForm",
                                "ng-controller" => "reconfigureFormController as vm",
                                "miq-form"      => 'true',
@@ -7,7 +13,7 @@
                                "ng-show"       => "vm.afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3= _('Options')
-  - if role_allows?(:feature => 'vm_reconfigure_memory')
+  - if role_allows?(:feature => "#{base}memory")
     .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
       %label.col-md-2.control-label
         = _('Memory')
@@ -48,7 +54,7 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
           = (@reconfig_memory_note)
-  - if role_allows?(:feature => 'vm_reconfigure_cpu')
+  - if role_allows?(:feature => "#{base}cpu")
     .form-group
       %label.col-md-2.control-label
         = _('Processors')
@@ -111,7 +117,7 @@
                                   "auto-focus"     => ""}
               %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
                 = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
+  - if supports_reconfigure_disks? && role_allows?(:feature => "#{base}disks")
     %hr
     %div
       %h3
@@ -301,7 +307,7 @@
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
+  - if supports_reconfigure_network_adapters? && role_allows?(:feature => "#{base}networks")
     %hr
     %div
       %h3
@@ -404,7 +410,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
+  - if supports_reconfigure_cdroms? && role_allows?(:feature => "#{base}drives")
     %div
       %h3
         = _('CD/DVD Drives')


### PR DESCRIPTION
 1. A separate feature is added for each of memory cpu network disks cdroms 
 -- https://github.com/ManageIQ/manageiq/pull/19503
 1. a new `:hidden` feature is added to replace the current `vm_reconfigure` (more on that below)
 1. a new feature is added `vm_reconfigure_all` that is a parent feature of the features from 1

`vm_reconfigure` cannot be a direct parent of the new features because both
 * a) the logic for checking permissings when displaying a button and
 * b) (more importantly) the logic for checking permissinos when a button is pressed are designed to deal with a single feature.

The case a) is dealt with in `app/helpers/application_helper/button/vm_reconfigure.rb`. This means that the `vm_reconfigure` feature is checked by the generic button code first (always enabled) and then the extra code in VmReconfigure button has a say.

b) is handled by making the `vm_reconfigure` always on (makes the generic button rbac test pass) and then checking the individual permissions in the code that handles creation of the reconfiguration request.

 * Next I am removing extra aliases that exist but do not have either buttons leading to them or rbac features.
 * Also removing an extra rbac check that would not work for the `image` case.

I was not able to test this changes for the `image` case because I was not able to find any cloud image that would be reconfigurable. Help is welcome.

### TODO:

 * app/helpers/application_helper/button/vm_reconfigure.rb is now VM only, generalize or fix the other buttons too.

depends on : https://github.com/ManageIQ/manageiq/pull/19503


ping @h-kataria, @mzazrivec, @himdel detailed review a help with testing is hightly needed. Thx!