### PR TITLE
Allow create Service Dialog from Template on Ansible/Templates screen, depending on navigation steps

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -444,7 +444,7 @@ class AutomationManagerController < ApplicationController
 
   def configscript_service_dialog
     assert_privileges("automation_manager_configuration_script_service_dialog")
-    cs = ConfigurationScript.find_by(:id => params[:id] || params[:miq_grid_checks])
+    cs = ConfigurationScript.find_by(:id => params[:miq_grid_checks] || params[:id])
     @edit = {:rec_id => cs.id}
     @in_a_form = true
     @right_cell_text = _("Adding a new Service Dialog from \"%{name}\"") % {:name => cs.name}


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6375

Relatively recently the _Configuration_ toolbar button was added to Ansible Tower Templates screen, with possibility to create Service Dialog from a selected Template in the list. However, this button appeared also on the screen with the list of Templates related to selected node in accordion, for example related to _Ansible Tower Automation Manager_. While being in such a screen, creating Service Dialog did not work, nothing happened in the UI, and error occurred.

The problem is exactly [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/automation_manager_controller.rb#L447). It's easy to achieve the situation when both `params[:id]` and `params[:miq_grid_checks]` are set, so we are trying to find the selected item using the id which is in `params[:id]` because `params[:id]` is present, but we are not successful, obviously. We don't have proper id in this situation. The proper id we want to find the selected item is always in `params[:miq_grid_checks]` if `params[:miq_grid_checks]` is present. If this was not true, then the fix wouldn't work.

I've made change the way that it checks `params[:miq_grid_checks]` first. And if it is not present, we can find the selected item as originally - by id set in `params[:id]`. This works well in all the kinds of lists or in details pages of Templates under `Automation > Ansible Tower > Explorer`. Looks like `params[:miq_grid_checks]` is never present if we are in a details page or in a list view with the _All Ansible Tower Templates_ node selected in accordion.

Related PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5968

---

**Before:** (nothing happens in the UI)
![template_before](https://user-images.githubusercontent.com/13417815/68787347-a048fc00-0641-11ea-89de-78b2f627fe8d.png)

**After:**
![template_after](https://user-images.githubusercontent.com/13417815/68787212-64159b80-0641-11ea-9865-dd15956cf2ae.png)
