### PR TITLE
Add fallback for clicking on a section w/o permissions.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -125,7 +125,14 @@ class DashboardController < ApplicationController
     end
 
     return if redirect_to_remembered(section.id)
-    redirect_to(section.default_redirect_url)
+
+    target_url = section.default_redirect_url
+
+    if target_url
+      redirect_to(target_url)
+    else
+      redirect_to(start_url_for_user(nil))
+    end
   end
 
   # New tab was pressed


### PR DESCRIPTION
Clicking on a section when the user (his role) has that section allowed but does not have any items under it enabled:

![cannot-redirect-to-nil-2019-11-14_15-49](https://user-images.githubusercontent.com/51095/68869168-0a70a800-06f9-11ea-8f30-cb76a710a5b2.png)


Newly there's a fallback to redirect to users initial page, so no further crash.