### PR TITLE
[HAMMER] DialogUser - use DialogData.outputConversion before submit and refresh

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'openUrl', '$http', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, openUrl, $http) {
+ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'dialogId', 'apiSubmitEndpoint', 'apiAction', 'finishSubmitEndpoint', 'cancelEndpoint', 'resourceActionId', 'targetId', 'targetType', 'openUrl', '$http', 'DialogData', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, dialogId, apiSubmitEndpoint, apiAction, finishSubmitEndpoint, cancelEndpoint, resourceActionId, targetId, targetType, openUrl, $http, DialogData) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -63,14 +63,14 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
   function submitButtonClicked() {
     vm.dialogData.action = apiAction;
     miqService.sparkleOn();
-    var apiData;
+
+    var apiData = DialogData.outputConversion(vm.dialogData);
     if (apiSubmitEndpoint.match(/generic_objects/)) {
-      apiData = {action: apiAction, parameters: _.omit(vm.dialogData, 'action')};
+      apiData = {action: apiAction, parameters: _.omit(apiData, 'action')};
     } else if (apiAction === 'reconfigure') {
-      apiData = {action: apiAction, resource: _.omit(vm.dialogData, 'action')};
-    } else {
-      apiData = vm.dialogData;
+      apiData = {action: apiAction, resource: _.omit(apiData, 'action')};
     }
+
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]})
       .then(function(response) {
         if (vm.openUrl === "true") {

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'resourceActionId', 'targetId', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, resourceActionId, targetId) {
+ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dialogFieldRefreshService', 'miqService', 'dialogUserSubmitErrorHandlerService', 'resourceActionId', 'targetId', 'DialogData', function(API, dialogFieldRefreshService, miqService, dialogUserSubmitErrorHandlerService, resourceActionId, targetId, DialogData) {
   var vm = this;
 
   vm.$onInit = function() {
@@ -46,7 +46,10 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
   function submitButtonClicked() {
     miqService.sparkleOn();
 
-    var apiData = {action: 'reconfigure', resource: _.omit(vm.dialogData, 'action')};
+    var apiData = {
+      action: 'reconfigure',
+      resource: _.omit(DialogData.outputConversion(vm.dialogData), 'action'),
+    };
     var apiSubmitEndpoint = '/api/services/' + targetId;
 
     return API.post(apiSubmitEndpoint, apiData, {skipErrors: [400]}).then(function() {

--- a/app/assets/javascripts/services/dialog_field_refresh_service.js
+++ b/app/assets/javascripts/services/dialog_field_refresh_service.js
@@ -1,24 +1,28 @@
-ManageIQ.angular.app.service('dialogFieldRefreshService', ['API', function(API) {
-  this.refreshField = function(dialogData, dialogField, url, idList) {
-    this.areFieldsBeingRefreshed = true;
-    var data = angular.toJson({
+ManageIQ.angular.app.service('dialogFieldRefreshService', ['API', 'DialogData', function(API, DialogData) {
+  var self = this;
+
+  self.refreshField = function(dialogData, dialogField, url, idList) {
+    self.areFieldsBeingRefreshed = true;
+
+    var data = {
       action: 'refresh_dialog_fields',
       resource: {
-        dialog_fields: dialogData,
+        dialog_fields: DialogData.outputConversion(dialogData),
         fields: dialogField,
         resource_action_id: idList.resourceActionId,
         target_id: idList.targetId,
         target_type: idList.targetType,
       },
-    });
+    };
 
-    return new Promise(function(resolve) {
-      API.post(url + idList.dialogId, data).then(function(response) {
-        resolve(response.result[dialogField]);
+    return API.post(url + idList.dialogId, angular.toJson(data))
+      .then(function(response) {
+        // FIXME: API requests don't actually count towards $.active
         if ($.active < 1) {
-          this.areFieldsBeingRefreshed = false;
+          self.areFieldsBeingRefreshed = false;
         }
-      }.bind(this));
-    }.bind(this));
+
+        return response.result[dialogField];
+      });
   };
 }]);

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller.spec.js
@@ -7,7 +7,8 @@ describe('dialogUserController', function() {
                              _API_,
                              _dialogFieldRefreshService_,
                              _dialogUserSubmitErrorHandlerService_,
-                             _miqService_) {
+                             _miqService_,
+                             DialogData) {
     API = _API_;
     dialogFieldRefreshService = _dialogFieldRefreshService_;
     dialogUserSubmitErrorHandlerService = _dialogUserSubmitErrorHandlerService_;
@@ -42,6 +43,10 @@ describe('dialogUserController', function() {
       targetType: 'targettype',
       openUrl: false,
     });
+
+    DialogData.data = {
+      fields: {},
+    };
   }));
 
   describe('$onInit', function() {

--- a/spec/javascripts/helpers/object.values.js
+++ b/spec/javascripts/helpers/object.values.js
@@ -1,0 +1,7 @@
+if (! Object.values) {
+  Object.values = function(o) {
+    return Object.keys(o).map(function(k) {
+      return o[k];
+    });
+  }
+}

--- a/spec/javascripts/services/dialog_field_refresh_service_spec.js
+++ b/spec/javascripts/services/dialog_field_refresh_service_spec.js
@@ -14,7 +14,7 @@ describe('dialogFieldRefreshService', function() {
     };
 
     spyOn(API, 'post').and.callFake(function() {
-      return {then: function(response) { response(responseResult); }};
+      return Promise.resolve(responseResult);
     });
 
     DialogData.data = {
@@ -23,7 +23,7 @@ describe('dialogFieldRefreshService', function() {
   }));
 
   describe('#refreshField', function() {
-    var data = 'the data';
+    var data = { "the field": "data1" };
     var field = 'the field';
     var url = 'url';
     var idList = {
@@ -53,7 +53,7 @@ describe('dialogFieldRefreshService', function() {
       var requestData = {
         action: 'refresh_dialog_fields',
         resource: {
-          dialog_fields: 'the data',
+          dialog_fields: data,
           fields: 'the field',
           resource_action_id: '321',
           target_id: '456',

--- a/spec/javascripts/services/dialog_field_refresh_service_spec.js
+++ b/spec/javascripts/services/dialog_field_refresh_service_spec.js
@@ -3,7 +3,7 @@ describe('dialogFieldRefreshService', function() {
 
   beforeEach(module('ManageIQ'));
 
-  beforeEach(inject(function(dialogFieldRefreshService, _API_) {
+  beforeEach(inject(function(dialogFieldRefreshService, _API_, DialogData) {
     testDialogFieldRefreshService = dialogFieldRefreshService;
     API = _API_;
 
@@ -16,6 +16,10 @@ describe('dialogFieldRefreshService', function() {
     spyOn(API, 'post').and.callFake(function() {
       return {then: function(response) { response(responseResult); }};
     });
+
+    DialogData.data = {
+      fields: {},
+    };
   }));
 
   describe('#refreshField', function() {

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -12,6 +12,7 @@
 #
 src_files:
 - __spec__/helpers/i18n-test.js
+- __spec__/helpers/object.values.js
 - packs/runtime.js
 - packs/shims.js
 - packs/vendor.js


### PR DESCRIPTION
This is a hammer version of https://github.com/ManageIQ/manageiq-ui-classic/pull/6291
~~Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/6408 (merged and rebased)~~

(there was a conflict with dependency injection in dialog_user - there is no `dialogReplaceData` in hammer)

---

Depends on ManageIQ/ui-components#422

Right now, when submitting a service dialog,
we simply take the dialogData object, convert to JSON and send to the API.

To allow for output conversions, adding a DialogData.outputConversion method,
which should return the dialogData in a suitable format.

(Right now, all this really means is that it converts Dates to strings before JSON stringification.)

And the same needs to happen in refreshField for dynamic fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1744413

@miq-bot add_label bug