### PR TITLE
Compare Treegrid fix

### DIFF
--- a/app/views/layouts/_compare.html.haml
+++ b/app/views/layouts/_compare.html.haml
@@ -18,15 +18,6 @@
             - (@cols.length - 1).times do |i|
               %td
                 = row["col#{i + 1}".to_sym].to_s.html_safe
-- unless @explorer
-  #buttons{:align => 'right'}
-    = link_to(_('Cancel'),
-              {:action => 'compare_cancel'},
-               :class  => 'btn btn-default',
-               :alt    => t = _('Cancel'),
-               :title  => t,
-               :method => :post)
-
     :javascript
       $('.table-treegrid').treegrid({
         callback: function (e) {
@@ -36,3 +27,12 @@
           miqJqueryRequest('/' + ManageIQ.controller + '/compare_set_state?rowId=' + exp_id + '&state=' + state);
         }
       });
+
+- unless @explorer
+  #buttons{:align => 'right'}
+    = link_to(_('Cancel'),
+              {:action => 'compare_cancel'},
+               :class  => 'btn btn-default',
+               :alt    => t = _('Cancel'),
+               :title  => t,
+               :method => :post)


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/6012, where an indent caused the treegrid not to be rendered for Explorer-based compare screens.

Old
<img width="1114" alt="Screen Shot 2019-11-14 at 3 02 26 PM" src="https://user-images.githubusercontent.com/1287144/68892046-15730a80-06f0-11ea-8b39-6bc65fa33789.png">

New
<img width="1128" alt="Screen Shot 2019-11-14 at 3 00 37 PM" src="https://user-images.githubusercontent.com/1287144/68892047-15730a80-06f0-11ea-8381-ba15ea29f7de.png">
