### PR TITLE
Update toolbar snapshots for react-ui-components 0.11.56, fix jest on travis

### DIFF
--- a/app/javascript/spec/toolbar/__snapshots__/miq-toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/miq-toolbar.spec.jsx.snap
@@ -91,8 +91,12 @@ exports[`<MiqToolbar /> renders ok for generic case 1`] = `
         views={Array []}
       >
         <div
-          className="toolbar-pf-view-selector pull-right form-group"
-        />
+          className="toolbar-pf-action-right"
+        >
+          <div
+            className="form-group toolbar-pf-view-selector"
+          />
+        </div>
       </ToolbarView>
     </div>
   </Toolbar>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "~1.18.0",
     "@data-driven-forms/react-form-renderer": "~1.18.0",
-    "@manageiq/react-ui-components": "~0.11.53",
+    "@manageiq/react-ui-components": "~0.11.56",
     "@manageiq/ui-components": "~1.3.3",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",


### PR DESCRIPTION
and update to that version specifically

the change in https://github.com/ManageIQ/react-ui-components/pull/158

was picked up by travis and started breaking ui jest tests, fixing.

(Failure: https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/612037181#L2994)
