### PR TITLE
Display icons in GTLs on PXE screens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -865,8 +865,6 @@ class ApplicationController < ActionController::Base
       # Generate html for the list icon
       item = listicon_item(view, row['id'])
       icon, icon2, image = fonticon_or_fileicon(item)
-      # FIXME: adding exceptions here is a wrong approach
-      icon = nil if params[:controller] == 'pxe'
 
       # Clickable should be false only when it's explicitly set to false
       not_clickable = if params


### PR DESCRIPTION
I don't really know what was the idea behind this one line, but as we discussed in https://github.com/ManageIQ/manageiq-ui-classic/issues/6313, we want to minimize the exceptions in our codebase.

**Before:**
![Screenshot from 2019-11-15 19-32-39](https://user-images.githubusercontent.com/649130/68966575-c0fa8880-07de-11ea-9aa9-be9920b70ee6.png)

**After:**
![Screenshot from 2019-11-15 19-29-09](https://user-images.githubusercontent.com/649130/68967026-9eb53a80-07df-11ea-868f-a416120480af.png)

@miq-bot add_label bug, GTLs
@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @martinpovolny 

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6313