### PR TITLE
Enable Check Compliance toolbar button for nested list of VMs and make it work

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -616,15 +616,21 @@ module ApplicationController::CiProcessing
   def testable_action(action)
     controller = params[:controller]
     vm_infra_untestable_actions = %w[check_compliance_queue destroy refresh_ems vm_miq_request_new]
-    ems_cluster_untestable_actions = %w[scan]
-    if controller == "vm_infra"
-      return vm_infra_untestable_actions.exclude?(action)
-    end
-    if controller == "ems_cluster" || @display == 'ems_clusters'
-      return ems_cluster_untestable_actions.exclude?(action)
-    end
+    ems_cluster_untestable_actions = %w[check_compliance_queue scan]
+    other_untestable_actions = %w[check_compliance_queue]
 
-    true
+    return false if @display == 'ems_clusters' && action == 'scan'
+
+    case controller
+    when 'ems_cluster'
+      ems_cluster_untestable_actions.exclude?(action)
+    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'resource_pool', 'storage', 'vm_cloud'
+      other_untestable_actions.exclude?(action)
+    when 'vm_infra'
+      vm_infra_untestable_actions.exclude?(action)
+    else
+      true
+    end
   end
 
   # Maps UI actions to queryable feature in case it is not possible

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -388,6 +388,18 @@ module ApplicationController::CiProcessing
 
   def check_compliance_vms
     assert_privileges(params[:pressed])
+
+    records = find_records_with_rbac(record_class, checked_or_params)
+    # Check each record if there is any compliance policy assigned to it
+    if records.any? { |record| !record.has_compliance_policies? }
+      javascript_flash(
+        :text       => _('No Compliance Policies assigned to one or more of the selected items'),
+        :severity   => :error,
+        :scroll_top => true
+      )
+      return
+    end
+
     generic_button_operation('check_compliance_queue', _('Check Compliance'), vm_button_action)
   end
   alias image_check_compliance check_compliance_vms

--- a/app/controllers/ems_cluster_controller.rb
+++ b/app/controllers/ems_cluster_controller.rb
@@ -89,7 +89,7 @@ class EmsClusterController < ApplicationController
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else
-      render_flash
+      render_flash unless performed?
     end
   end
 

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -349,7 +349,7 @@ class HostController < ApplicationController
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else
-      render_flash
+      render_flash unless performed?
     end
   end
 

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -58,7 +58,7 @@ class ResourcePoolController < ApplicationController
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else
-      render_flash
+      render_flash unless performed?
     end
   end
 

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -122,7 +122,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :url_parms    => "main_div",
           :send_checked => true,
           :confirm      => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled      => false,
+          :enabled      => true,
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::InstanceCheckCompare),
       ]

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -151,7 +151,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :url_parms    => "main_div",
           :send_checked => true,
           :confirm      => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled      => false,
+          :enabled      => true,
           :onwhen       => "1+",
           :klass        => ApplicationHelper::Button::VmCheckCompliance),
       ]

--- a/spec/controllers/availability_zone_controller_spec.rb
+++ b/spec/controllers/availability_zone_controller_spec.rb
@@ -1,42 +1,64 @@
 describe AvailabilityZoneController do
   describe "#show" do
+    let(:params) { {:id => zone.id} }
+    let(:zone) { FactoryBot.create(:availability_zone) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      @zone = FactoryBot.create(:availability_zone)
       login_as FactoryBot.create(:user_admin)
     end
 
-    subject do
-      get :show, :params => {:id => @zone.id}
+    subject { get :show, :params => params }
+
+    render_views
+
+    it 'renders listnav partial' do
+      is_expected.to have_http_status 200
+      is_expected.to render_template(:partial => "layouts/listnav/_availability_zone")
     end
 
-    context "render listnav partial" do
-      render_views
+    context 'display timeline' do
+      let(:params) { {:id => zone.id, :display => 'timeline'} }
 
-      it do
+      it 'renders listnav partial' do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_availability_zone")
       end
     end
   end
 
-  describe "#show display=timeline" do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      @zone = FactoryBot.create(:availability_zone)
-      login_as FactoryBot.create(:user_admin)
-    end
+  describe '#button' do
+    context 'Check Compliance of Last Known Configuration on Instances' do
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+      let(:av_zone) { FactoryBot.create(:availability_zone) }
 
-    subject do
-      get :show, :params => {:id => @zone.id, :display => 'timeline'}
-    end
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => av_zone.id.to_s, :controller => 'availability_zone'}
+      end
 
-    context "render listnav partial" do
-      render_views
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
 
-      it do
-        is_expected.to have_http_status 200
-        is_expected.to render_template(:partial => "layouts/listnav/_availability_zone")
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          vm_instance.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
       end
     end
   end

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -40,6 +40,38 @@ describe CloudTenantController do
         controller.send(:button)
       end
     end
+
+    context 'Check Compliance of Last Known Configuration on Instances' do
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => tenant.id.to_s, :controller => 'cloud_tenant'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm_instance.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   describe "#tags_edit" do

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -1,6 +1,7 @@
 describe EmsCloudController do
   let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
   let(:zone) { FactoryBot.build(:zone) }
+
   describe "#create" do
     before do
       allow(controller).to receive(:check_privileges).and_return(true)
@@ -264,7 +265,7 @@ describe EmsCloudController do
     end
   end
 
-  context "#build_credentials only contains credentials that it supports and has a username for in params" do
+  describe "#build_credentials only contains credentials that it supports and has a username for in params" do
     let(:mocked_ems)    { double(ManageIQ::Providers::Openstack::CloudManager) }
     let(:default_creds) { {:userid => "default_userid", :password => "default_password"} }
     let(:amqp_creds)    { {:userid => "amqp_userid",    :password => "amqp_password"} }
@@ -294,7 +295,7 @@ describe EmsCloudController do
     end
   end
 
-  context "#update_ems_button_validate" do
+  describe "#update_ems_button_validate" do
     let(:mocked_ems) { FactoryBot.create(:ems_openstack) }
 
     it "calls authentication_check with save = false" do
@@ -308,8 +309,9 @@ describe EmsCloudController do
     end
   end
 
-  context "#create_ems_button_validate" do
+  describe "#create_ems_button_validate" do
     let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default"} }
+
     before do
       allow(controller).to receive(:render)
       controller.params = mocked_params
@@ -668,9 +670,8 @@ describe EmsCloudController do
 
   describe "#sync_users" do
     let(:ems) { FactoryBot.create(:ems_openstack_with_authentication) }
-    before do
-      stub_user(:features => :all)
-    end
+
+    before { stub_user(:features => :all) }
 
     it "redirects when request is successful" do
       expect(controller).to receive(:find_record_with_rbac).and_return(ems)
@@ -717,6 +718,7 @@ describe EmsCloudController do
 
   context "'Set Default' button rendering in listnav" do
     render_views
+
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
@@ -782,5 +784,39 @@ describe EmsCloudController do
     end
 
     include_examples 'hiding tenant column for non admin user', :name => "Name", :emstype_description => "Type"
+  end
+
+  describe '#button' do
+    context 'Check Compliance of Last Known Configuration on Instances' do
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+      let(:ems) { FactoryBot.create(:ems_openstack) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => ems.id.to_s, :controller => 'ems_cloud'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm_instance.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/ems_cluster_controller_spec.rb
+++ b/spec/controllers/ems_cluster_controller_spec.rb
@@ -1,5 +1,7 @@
 describe EmsClusterController do
   describe "#button" do
+    before { allow(controller).to receive(:performed?) }
+
     it "when VM Right Size Recommendations is pressed" do
       controller.params = {:pressed => "vm_right_size"}
       expect(controller).to receive(:vm_right_size)
@@ -58,6 +60,39 @@ describe EmsClusterController do
       expect(controller).to receive(:render)
       controller.button
       expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+
+    context 'Check Compliance action on VMs of a Cluster' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+      let(:cluster) { FactoryBot.create(:ems_cluster) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:render)
+        allow(controller).to receive(:show)
+        controller.instance_variable_set(:@display, 'vms')
+        controller.params = {:miq_grid_checks => vm.id.to_s, :pressed => 'vm_check_compliance', :id => cluster.id.to_s, :controller => 'ems_cluster'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          vm.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
     end
 
     context 'Smart State Analysis' do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -125,6 +125,38 @@ describe EmsInfraController do
         end
       end
     end
+
+    context 'Check Compliance of Last Known Configuration on VMs' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+      let(:ems_infra) { FactoryBot.create(:ems_vmware) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'vms')
+        controller.params = {:miq_grid_checks => vm.id.to_s, :pressed => 'vm_check_compliance', :id => ems_infra.id.to_s, :controller => 'ems_infra'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   describe "#create" do
@@ -307,6 +339,7 @@ describe EmsInfraController do
 
   describe "#show" do
     render_views
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryBot.create(:user, :features => "none")
@@ -351,6 +384,7 @@ describe EmsInfraController do
 
     context "display=timeline" do
       let(:url_params) { {:display => 'timeline'} }
+
       it do
         bypass_rescue
         is_expected.to have_http_status 200
@@ -436,6 +470,7 @@ describe EmsInfraController do
       FactoryBot.create(:ems_vmware)
       get :show_list
     end
+
     it { expect(response.status).to eq(200) }
   end
 

--- a/spec/controllers/flavor_controller_spec.rb
+++ b/spec/controllers/flavor_controller_spec.rb
@@ -1,15 +1,17 @@
 describe FlavorController do
+  let(:flavor) { FactoryBot.create(:flavor) }
+
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     stub_user(:features => :all)
-    @flavor = FactoryBot.create(:flavor)
   end
 
   describe "#show" do
-    subject { get :show, :params => {:id => @flavor.id} }
+    subject { get :show, :params => {:id => flavor.id} }
 
     context "render listnav partial" do
       render_views
+
       it do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_flavor")
@@ -18,16 +20,18 @@ describe FlavorController do
 
     context "with @search_text set" do
       render_views
+
+      before { controller.instance_variable_set(:@search_text, 'search text') }
+
       it "doesn't render @search_text in summary screen" do
-        controller.instance_variable_set(:@search_text, 'search text')
-        get :show, :params => {:id => @flavor.id}
+        get :show, :params => {:id => flavor.id}
         expect(response.body).not_to include('search text')
         expect(controller.instance_variable_get(:@title)).not_to include('search text')
       end
     end
   end
 
-  describe 'button' do
+  describe '#button' do
     context 'when "flavor_create" is pressed' do
       it 'redirects to "#new"' do
         expect(controller).to receive(:javascript_redirect).with(:action => 'new')
@@ -39,7 +43,7 @@ describe FlavorController do
       it 'queues deletion of selected flavors' do
         expect(controller).to receive(:delete_flavors).and_call_original
         expect_any_instance_of(Flavor).to receive(:delete_flavor_queue)
-        post :button, :params => {:pressed => 'flavor_delete', :miq_grid_checks => @flavor.id}
+        post :button, :params => {:pressed => 'flavor_delete', :miq_grid_checks => flavor.id}
       end
     end
 
@@ -47,6 +51,38 @@ describe FlavorController do
       it 'calls "tag" for "Flavor"' do
         expect(controller).to receive(:tag).with(Flavor)
         post :button, :params => {:pressed => 'flavor_tag'}
+      end
+    end
+
+    context 'Check Compliance of Last Known Configuration on Instances' do
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => flavor.id.to_s, :controller => 'flavor'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm_instance.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
       end
     end
   end

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -176,4 +176,38 @@ describe HostAggregateController do
       }
     end
   end
+
+  describe '#button' do
+    context 'Check Compliance of Last Known Configuration on Instances' do
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => aggregate.id.to_s, :controller => 'host_aggregate'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm_instance.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -172,6 +172,38 @@ describe HostController do
         expect(controller.send(:record_class)).to eq(Storage)
       end
     end
+
+    context 'Check Compliance of Last Known Configuration on VMs' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'vms')
+        controller.params = {:miq_grid_checks => vm.id.to_s, :pressed => 'vm_check_compliance', :id => h1.id.to_s, :controller => 'host'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          vm.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   describe "#set_record_vars" do
@@ -334,6 +366,7 @@ describe HostController do
 
     context "render" do
       render_views
+
       it "show and listnav correctly for summary page" do
         is_expected.to have_http_status 200
         is_expected.to render_template('host/show')
@@ -352,6 +385,7 @@ describe HostController do
 
   describe "#set_credentials" do
     let(:mocked_host) { double(Host) }
+
     it "uses params[:default_password] for validation if one exists" do
       controller.params = {:default_userid   => "default_userid",
                            :default_password => "default_password2"}

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -66,6 +66,39 @@ describe ResourcePoolController do
         end
       end
     end
+
+    context 'Check Compliance action on VMs of a Resource Pool' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+      let(:resource_pool) { FactoryBot.create(:resource_pool) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:drop_breadcrumb)
+        allow(controller).to receive(:performed?)
+        allow(controller).to receive(:render)
+        controller.params = {:miq_grid_checks => vm.id.to_s, :pressed => 'vm_check_compliance', :id => resource_pool.id.to_s, :controller => 'resource_pool'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          vm.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -116,6 +116,37 @@ describe StorageController do
         end
       end
     end
+
+    context 'Check Compliance action on VMs of a Datastore' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@display, 'vms')
+        controller.params = {:miq_grid_checks => vm.id.to_s, :pressed => 'vm_check_compliance', :id => storage.id.to_s, :controller => 'storage'}
+      end
+
+      it 'does not initiate Check Compliance because of missing Compliance policies' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+      end
+
+      context 'VM Compliance policy set' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          vm.add_policy(policy)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   context 'render_views' do
@@ -366,6 +397,7 @@ describe StorageController do
 
   describe "#tags_edit" do
     let!(:user) { stub_user(:features => :all) }
+
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       @ds = FactoryBot.create(:storage, :name => "Datastore-01")
@@ -443,14 +475,10 @@ describe StorageController do
     end
 
     context 'setting right cell text' do
-      before do
-        controller.instance_variable_set(:@right_cell_text, 'All Datastores')
-      end
+      before { controller.instance_variable_set(:@right_cell_text, 'All Datastores') }
 
       context 'searching text' do
-        before do
-          controller.instance_variable_set(:@search_text, 'Datastore')
-        end
+        before { controller.instance_variable_set(:@search_text, 'Datastore') }
 
         it 'updates right cell text according to search text' do
           controller.send(:get_node_info, 'root')

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -413,6 +413,34 @@ describe VmInfraController do
     expect(response.status).to eq(200)
   end
 
+  context 'Check Compliance action on VMs' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:performed?)
+      allow(controller).to receive(:render)
+      controller.params = {:miq_grid_checks => vm_vmware.id.to_s, :pressed => 'vm_check_compliance', :controller => 'vm_infra'}
+    end
+
+    it 'does not initiate Check Compliance because of missing Compliance policies' do
+      controller.send(:x_button)
+      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'No Compliance Policies assigned to one or more of the selected items', :level => :error}])
+    end
+
+    context 'VM Compliance policy set' do
+      let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+      before do
+        vm_vmware.add_policy(policy)
+        allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+      end
+
+      it 'initiates Check Compliance action' do
+        controller.send(:x_button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+      end
+    end
+  end
+
   context 'Mixins::Actions::VmActions::Ownership' do
     let(:vm) { FactoryBot.create(:vm_vmware) }
   end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6378
Related PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/3810

**This PR:**
- enables _Check Compliance..._ toolbar button also for nested list of VMs/Instances, to achieve more consistent behavior in MIQ, only for items in _Compute > Infra > VMs_ and in _Compute > Clouds > Instances_)
- makes the action work for the items displayed through _Relationships_ of Infra provider, Cluster, Host, Resource Pool, Datastore, Cloud provider, Availability Zone, Host Aggregate, Cloud Tenant, Flavor, Key Pair (nothing was needed to do for Orchestration Stack's Instances because the button is not present in the list view, only in summary screen)
  - _Note_: `check_compliance_queue` is not testable by SupportsFeatureMixin nor AvailabilityMixin, so changes in `testable_action` are necessary.
- helps to make the action work also for Instances displayed through Cloud Network's _Relationships_, see also https://github.com/ManageIQ/manageiq-ui-classic/pull/6458
- adds missing check if all of the selected VMs have appropriate necessary policies assigned (VM Compliance Policy); with this check it does not allow user to perform the action on VMs without such policies; the method [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6426/files#diff-f1f6a3f494376ee01e37a02d4ffa4ae9R6) is not the check we need, or at least, this is not in a right place. This method only sets if the button will be enabled or disabled it does not care about the selected items, and I think that it also does not work well: `@error_message` is set even when `@record` is `nil` - and this is confusing, it does not make sense to me: How can I say if the record has some policy or not if the record is unknown to me? (And if we are in a nested list of VMs, `@record` is the provider and not any VM => such `disabled?` method is totally useless - and this is one of the reasons why Zitas PR makes sense and it is not a source of the issues I am fixing in this PR)

Also the change [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6426/files#diff-44003ee313a78ab3e3b556618f7085ffR637) is just the same fix as [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6349/files#diff-44003ee313a78ab3e3b556618f7085ffR623). I'm not sure how to avoid using `return` and to keep the behavior the same.

---

**Before:**
Checking compliance initiated even when selected item hasn't any compliance policies assigned!
![check_before](https://user-images.githubusercontent.com/13417815/69256690-291fe480-0bba-11ea-94c2-616541c8f0c3.png)
Not possible to check compliance for nested list of VMs:
![check_before2](https://user-images.githubusercontent.com/13417815/69256698-2c1ad500-0bba-11ea-8eed-4bbe954f1e2b.png)

**After:**
![check_after](https://user-images.githubusercontent.com/13417815/69256717-32a94c80-0bba-11ea-9818-26d89129e7a4.png)
![check_after2](https://user-images.githubusercontent.com/13417815/69256725-34731000-0bba-11ea-986f-ebbbd21fdf14.png)
