### PR TITLE
Fix VmInfra Reconfigure specs

### DIFF
--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -612,7 +612,7 @@ describe ApplicationController do
   it "Certain actions should be allowed only for a VM record" do
     feature = MiqProductFeature.find_all_by_identifier(["everything"])
     login_as FactoryBot.create(:user, :features => feature)
-    vm = FactoryBot.create(:vm_vmware)
+    vm = FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_infra))
     controller.params = {:id => vm.id}
     actions = %i(vm_right_size vm_reconfigure)
     actions.each do |action|

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -517,8 +517,9 @@ describe VmInfraController do
 
   it 'the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown' do
     vm = FactoryBot.create(:vm_vmware,
-                            :host     => host_2x2,
-                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                           :ext_management_system => FactoryBot.create(:ems_infra),
+                           :host     => host_2x2,
+                           :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -534,8 +535,9 @@ describe VmInfraController do
 
   it 'the reconfigure tab for a single vmware vm should display the list of disks' do
     vm = FactoryBot.create(:vm_vmware,
-                            :host     => host_2x2,
-                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                           :ext_management_system => FactoryBot.create(:ems_infra),
+                           :host     => host_2x2,
+                           :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}
@@ -551,8 +553,9 @@ describe VmInfraController do
 
   it 'the reconfigure tab displays the submit and cancel buttons' do
     vm = FactoryBot.create(:vm_vmware,
-                            :host     => host_2x2,
-                            :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
+                           :ext_management_system => FactoryBot.create(:ems_infra),
+                           :host     => host_2x2,
+                           :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB, :virtual_hw_version => "07"))
     allow(controller).to receive(:x_node).and_return("v-#{vm.id}")
 
     get :show, :params => {:id => vm.id}

--- a/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::VmReconfigure do
   describe '#visible?' do
     context "record is vmware vm" do
       before do
-        @record = FactoryBot.create(:vm_vmware)
+        @record = FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_infra))
       end
 
       it_behaves_like "will not be skipped for this record"


### PR DESCRIPTION
Without an EMS a VM doesn't support reconfigure.

Broken by:
https://github.com/ManageIQ/manageiq-providers-vmware/pull/467
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/421