### PR TITLE
Remove ems_ref_obj

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -311,7 +311,7 @@ class EmsInfraController < ApplicationController
       end
     end
 
-    host_physical_resource_ids = hosts.map(&:ems_ref_obj)
+    host_physical_resource_ids = hosts.map(&:ems_ref)
     parent_resource_names = []
     host_physical_resource_ids.each do |pr_id|
       host_resource = resources_by_physical_resource_id[pr_id]

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -206,7 +206,7 @@ describe EmsInfraController do
       p1 = FactoryBot.create(:orchestration_stack_parameter, :name => "compute-1::count", :value => 1)
       p2 = FactoryBot.create(:orchestration_stack_parameter, :name => "controller-1::count", :value => 1)
       stack_parameters = [p1, p2]
-      r1 = FactoryBot.create(:orchestration_stack_resource, :physical_resource => @host1.ems_ref_obj)
+      r1 = FactoryBot.create(:orchestration_stack_resource, :physical_resource => @host1.ems_ref)
       r2 = FactoryBot.create(:orchestration_stack_resource, :physical_resource => "1", :logical_resource => "1")
       stack_resources = [r1, r2]
       @orchestration_stack = FactoryBot.create(:orchestration_stack, :parameters => stack_parameters, :resources => stack_resources)


### PR DESCRIPTION
The ems_ref_obj attribute is (soon to be was) used by VMware to store the full VIM class.  Most providers just set this to be equal to the ems_ref.

We are deleting this ems_ref_obj attribute because it is a serialized yaml column and requires us to have the VimBroker required in core.

Core issue: https://github.com/ManageIQ/manageiq/pull/19430