### PR TITLE
Call `miqCheckForChanges` before changing tabs.

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -902,12 +902,16 @@ function miq_tabs_init(id, url, parms) {
         return sum + '&' + key + '=' + value;
       }, '?tab_id=' + currTabTarget);
 
-      miqObserveRequest(url + urlParams, {beforeSend: true})
-        .catch(function(err) {
-          add_flash(__('Error requesting data from server'), 'error');
-          console.log(err);
-          return Promise.reject(err);
-        });
+      if (miqCheckForChanges()) {
+        miqObserveRequest(url + urlParams, {beforeSend: true})
+          .catch(function (err) {
+            add_flash(__('Error requesting data from server'), 'error');
+            console.log(err);
+            return Promise.reject(err);
+          });
+      } else {
+        return false;
+      }
     }
   });
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -902,7 +902,8 @@ function miq_tabs_init(id, url, parms) {
         return sum + '&' + key + '=' + value;
       }, '?tab_id=' + currTabTarget);
 
-      if (miqCheckForChanges()) {
+      var editMode = typeof parms !== 'undefined' && parms['edit_mode'] !== 'undefined' && parms['edit_mode'] === 'true';
+      if (editMode || miqCheckForChanges()) {
         miqObserveRequest(url + urlParams, {beforeSend: true})
           .catch(function (err) {
             add_flash(__('Error requesting data from server'), 'error');

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -907,7 +907,7 @@ function miq_tabs_init(id, url, parms) {
         miqObserveRequest(url + urlParams, {beforeSend: true})
           .catch(function (err) {
             add_flash(__('Error requesting data from server'), 'error');
-            console.log(err);
+            console.error(err);
             return Promise.reject(err);
           });
       } else {

--- a/app/views/miq_request/_prov_wf.html.haml
+++ b/app/views/miq_request/_prov_wf.html.haml
@@ -28,5 +28,5 @@
                   = render :partial => "/miq_request/prov_host_dialog", :locals => partial_locals
 
 :javascript
-  miq_tabs_init('#prov_tabs', '/miq_request/prov_field_changed');
+  miq_tabs_init('#prov_tabs', '/miq_request/prov_field_changed', {edit_mode: 'true'});
 

--- a/app/views/ops/_ap_form.html.haml
+++ b/app/views/ops/_ap_form.html.haml
@@ -61,4 +61,4 @@
           = miq_tab_content('event_log', @sb[:ap_active_tab]) do
             = render :partial => "ap_form_nteventlog", :locals => {:entry => entry, :edit => edit}
 :javascript
-  miq_tabs_init('#ap_tabs', '/ops/ap_set_active_tab');
+  miq_tabs_init('#ap_tabs', '/ops/ap_set_active_tab', {edit_mode: 'true'});


### PR DESCRIPTION
This will force user to save any unsaved changes in the form before changing the tab.

Issue #6213

Prompts user if they want to abandon changes after they have made changes to the form and trying to change the tabs in Configuration explorer. Tested this on several screens in OPS explorer, tried several other screens with tabs, seems to be working fine now. @hstastna please test