### PR TITLE
Fix cancel/reset buttons' reaction to C&U collection checkboxes

### DIFF
--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -155,7 +155,7 @@ module OpsController::Settings::CapAndU
   def cu_collection_get_form_vars
     if params[:id]
       nodetype = params[:id].split('_')
-      node_type = if params[:tree_name] == 'cluster'
+      node_type = if params[:tree_name] == 'cluster_tree'
                     if nodetype[0] == 'xx-NonCluster'
                       nodetype.size == 2 ? ['NonCluster', nodetype[1]] : ['NonCluster']
                     else
@@ -165,9 +165,9 @@ module OpsController::Settings::CapAndU
     end
     @edit[:new][:all_clusters] = params[:all_clusters] == 'true' if params[:all_clusters]
     @edit[:new][:all_storages] = params[:all_storages] == 'true' if params[:all_storages]
-    if params[:tree_name] == 'datastore'
+    if params[:tree_name] == 'datastore_tree'
       datastore_tree_settings
-    elsif params[:tree_name] == 'cluster'
+    elsif params[:tree_name] == 'cluster_tree'
       cluster_tree_settings(node_type)
     end
   end


### PR DESCRIPTION
Saving the changes under `C&U Collection` under `Settings -> Region` was not possible as the tree names were not adjusted with the `_tree` suffix. It has been probably caused by the tree name/id unification and it might affect the ivanchuk release.

![Screenshot from 2019-11-20 11-11-21](https://user-images.githubusercontent.com/649130/69229852-87cb6b00-0b86-11ea-83b9-2258937d68b0.png)

@miq-bot add_label bug, trees

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6430