### PR TITLE
Rename usage ChargebackRateDetailCurrency to Currency

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -922,7 +922,7 @@ class CatalogController < ApplicationController
         st.add_resource(request) if need_prov_dialogs?(@edit[:new][:st_prov_type])
       end
     end
-    st.currency = @edit[:new][:currency] ? ChargebackRateDetailCurrency.find_by(:id => @edit[:new][:currency].to_i) : nil
+    st.currency = @edit[:new][:currency] ? Currency.find_by(:id => @edit[:new][:currency].to_i) : nil
     st.price    = st.currency ? @edit[:new][:price] : nil if @edit[:new][:price]
 
     if st.save
@@ -1061,7 +1061,7 @@ class CatalogController < ApplicationController
     st.generic_subtype = @edit[:new][:generic_subtype] if @edit[:new][:st_prov_type] == 'generic'
     st.zone_id = @edit[:new][:zone_id]
     st.additional_tenants = Tenant.where(:id => @edit[:new][:tenant_ids]) # Selected Additional Tenants in the tree
-    st.currency = @edit[:new][:currency] ? ChargebackRateDetailCurrency.find_by(:id => @edit[:new][:currency].to_i) : nil
+    st.currency = @edit[:new][:currency] ? Currency.find_by(:id => @edit[:new][:currency].to_i) : nil
     st.price    = st.currency ? @edit[:new][:price] : nil if @edit[:new][:price]
   end
 
@@ -1276,7 +1276,7 @@ class CatalogController < ApplicationController
   end
 
   def code_currency_label(currency)
-    _('Price / Month (in %{currency})') % {:currency => ChargebackRateDetailCurrency.find(currency).code}
+    _('Price / Month (in %{currency})') % {:currency => Currency.find(currency).code}
   end
 
   def checked_tenants

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -258,7 +258,7 @@ class ChargebackController < ApplicationController
     tier[:fixed_rate]    = 0.0
     tier[:variable_rate] = 0.0
 
-    code_currency = ChargebackRateDetailCurrency.find_by(:id => detail[:currency]).code
+    code_currency = Currency.find_by(:id => detail[:currency]).code
     add_row(detail_index, tier_index - 1, code_currency)
   end
 
@@ -560,7 +560,7 @@ class ChargebackController < ApplicationController
     @edit[:new][:description] = params[:description] if params[:description]
     if params[:currency]
       @edit[:new][:currency] = params[:currency].to_i
-      rate_detail_currency = ChargebackRateDetailCurrency.find(params[:currency])
+      rate_detail_currency = Currency.find(params[:currency])
       @edit[:new][:code_currency] = "#{rate_detail_currency.symbol} [#{rate_detail_currency.full_name}]"
     end
     @edit[:new][:details].each_with_index do |detail, detail_index|

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -275,7 +275,7 @@ describe CatalogController do
       end
       let(:st) { FactoryBot.create(:service_template) }
       let(:symbol) { '฿' }
-      let(:currency) { FactoryBot.create(:chargeback_rate_detail_currency, :symbol => symbol) }
+      let(:currency) { FactoryBot.create(:currency, :symbol => symbol) }
 
       before do
         allow(controller).to receive(:replace_right_cell)
@@ -1185,10 +1185,10 @@ describe CatalogController do
         {:display            => '1',
          :reconfigure_fqname => ''}
       end
-      let(:some_currency) { ChargebackRateDetailCurrency.first }
+      let(:some_currency) { Currency.first }
 
       before do
-        ChargebackRateDetailCurrency.seed
+        Currency.seed
         controller.params = params.merge(other_params)
       end
 

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -400,7 +400,7 @@ describe ChargebackController do
       end
 
       before do
-        [ChargebackRateDetailCurrency, ChargebackRate].each(&:seed)
+        [Currency, ChargebackRate].each(&:seed)
       end
 
       it "adds new chargeback rate using default values" do


### PR DESCRIPTION
we renamed model(and related tables, ...) ChargebackRateDetailCurrency to Currency

~~at this moment: backend is pending: https://github.com/ManageIQ/manageiq/pull/19538~~

at this moment: backend is merged:https://github.com/ManageIQ/manageiq/pull/19350


@miq-bot add_label backend pending, technical debt


@miq-bot assign @mzazrivec 

