### PR TITLE
Refactoring automate import error messages.

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -164,10 +164,8 @@ Classes updated/added: %{class_stats}
 Instances updated/added: %{instance_stats}
 Methods updated/added: %{method_stats}") % stat_options, :success)
           end
-        rescue MiqAeException::DomainNotAccessible
-          add_flash(_('Error: Selected domain is locked'), :error)
-        rescue MiqAeException::AttributeNotFound => e
-          add_flash(e.message, :error)
+        rescue MiqAeException::Error => bang
+          add_flash(_("Error: %{message}") % {:message => bang.message}, :error)
         end
       else
         add_flash(_("Error: Datastore import file upload expired"), :error)

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -98,15 +98,9 @@ class GitBasedDomainImportService
     task = MiqTask.wait_for_taskid(task_id)
 
     domain = task.task_results
-    error_message = if task.message == _('multiple domains')
-                      _('Selected branch or tag contains more than one domain')
-                    elsif task.message == _('locked domain')
-                      _('Selected domain is locked')
-                    else
-                      _('Selected branch or tag does not contain a valid domain')
-                    end
-    raise MiqException::Error, error_message unless domain.kind_of?(MiqAeDomain)
-    domain.update_attribute(:enabled, true)
+    raise MiqException::Error, task.message unless domain.kind_of?(MiqAeDomain)
+
+    domain.update(:enabled => true)
   end
 
   def refresh(git_repo_id)

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -181,7 +181,7 @@ describe MiqAeToolsController do
         end
 
         context 'when importing playbook method type' do
-          let(:error_msg) { "Error: Playbook method 'method_name' contains below listed error(s):" }
+          let(:error_msg) { "Playbook method 'method_name' contains below listed error(s):" }
 
           it 'returns the flash message' do
             allow(automate_import_service).to receive(:import_datastore).and_raise(
@@ -189,7 +189,7 @@ describe MiqAeToolsController do
             )
             post :import_automate_datastore, :params => params, :xhr => true
             expect(response.body).to eq(
-              [{:message => error_msg, :level => :error}].to_json
+              [{:message => "Error: #{error_msg}", :level => :error}].to_json
             )
           end
         end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -79,8 +79,8 @@ describe GitBasedDomainImportService do
 
       it "calls 'import' with the correct options" do
         allow(task).to receive(:task_results).and_return(domain)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
-        expect(domain).to receive(:update_attribute).with(:enabled, true)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update).with(:enabled => true)
 
         subject.import(git_repo.id, ref_name, 321)
       end
@@ -93,8 +93,8 @@ describe GitBasedDomainImportService do
 
       it "calls 'import' with the correct options" do
         allow(task).to receive(:task_results).and_return(domain)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
-        expect(domain).to receive(:update_attribute).with(:enabled, true)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update).with(:enabled => true)
         subject.import(git_repo.id, ref_name, 321)
       end
     end
@@ -107,7 +107,7 @@ describe GitBasedDomainImportService do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
-          MiqException::Error, "Selected branch or tag does not contain a valid domain"
+          MiqException::Error, "MiqException::Error"
         )
       end
 
@@ -117,7 +117,7 @@ describe GitBasedDomainImportService do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
-          MiqException::Error, 'Selected branch or tag contains more than one domain'
+          MiqException::Error, 'multiple domains'
         )
       end
     end


### PR DESCRIPTION
Description
---------------
Refactoring the automate import error messages logic to let the backend produce them. Since the error message creation has been split between UI and backend, we are now moving it into the backend where it belongs.

This PR is related to https://github.com/ManageIQ/manageiq-automation_engine/pull/395