### PR TITLE
Remove custom "no-border" class

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -894,10 +894,6 @@ fieldset {
   opacity: 0.4;
 }
 
-.no-border {
-  border: none !important;
-}
-
 .sortable-placeholder {
   background-color: rgba(255, 255, 255, 0.8);
   border: 2px dashed #ddd;

--- a/app/views/ops/_settings_help_menu_tab.html.haml
+++ b/app/views/ops/_settings_help_menu_tab.html.haml
@@ -7,31 +7,31 @@
     %strong
       = _("Any change to the help menu will take effect upon a full page reload.")
   = form_tag({:action => "settings_update_help_menu"}, :class => "form-horizontal", :method => :post) do
-    %table.table
+    %table.table.table-borderless
       %tr
-        %th.no-border
+        %th
           = _('Menu item label')
-        %th.no-border
+        %th
           = _('URL')
-        %th.no-border
+        %th
           = _('Open in')
 
       - Menu::Manager.menu(:help) do |menu|
         - menu.items.each do |item|
           %tr
             - val = @edit[:new][item.id.to_sym].try(:[], :type) || item.defaults[:type]
-            %td.no-border
+            %td
               = text_field_tag("#{item.id}_title", @edit[:new][item.id.to_sym].try(:[], :title),
                                :placeholder       => item.defaults[:title],
                                :class             => 'form-control',
                                'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
-            %td.no-border
+            %td
               = text_field_tag("#{item.id}_href", @edit[:new][item.id.to_sym].try(:[], :href),
                                :placeholder => item.defaults[:href],
                                :class => 'form-control',
                                'data-miq_observe' => {:interval => '.5', :url => url}.to_json,
                                :disabled => val.to_s == 'modal')
-            %td.no-border
+            %td
               = select_tag("#{item.id}_type", options_for_select([[_("Current Window"), 'default'],
                                                                  [_("New Window"), "new_window"],
                                                                  [_("About Modal"),  "modal"]], val.to_s),


### PR DESCRIPTION
This PR replaces the custom "no-border" class with the standard Bootstrap "table-borderless" class.

<img width="1177" alt="Screen Shot 2019-11-21 at 10 44 24 AM" src="https://user-images.githubusercontent.com/1287144/69353123-063e1080-0c4c-11ea-9d16-83bfc2f8b696.png">
