### PR TITLE
Identify invalid Catalog Items/Bundles in the UI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -883,14 +883,9 @@ class ApplicationController < ActionController::Base
                           :icon2 => icon2}.compact
       new_row[:cells].concat(::GtlFormatter.format_cols(view, row, self))
 
-      next unless @row_button # Show a button in the last col
-
-      new_row[:cells] << {
-        :is_button => true,
-        :text      => @row_button[:label],
-        :title     => @row_button[:title],
-        :onclick   => "#{@row_button[:function]}(\"#{row['id']}\");"
-      }
+      # Append a button if @row_button is set and the button is defined in the related decorator
+      button = item.decorate.try(:gtl_button_cell) if @row_button
+      new_row[:cells] << button if button
     end
 
     root

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -320,6 +320,7 @@ class CatalogController < ApplicationController
     kls = TreeBuilder.get_model_for_prefix(@nodetype) == "MiqTemplate" ? VmOrTemplate : ServiceTemplate
     @record = identify_record(id || params[:id], kls)
     @tenants_tree = build_tenants_tree if kls == ServiceTemplate # Build the tree with available tenants for the Catalog Item/Bundle
+    add_flash(_("This item is invalid"), :warning) unless @flash_array || @record.try(:template_valid?)
   end
 
   # ST clicked on in the explorer right cell

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -954,11 +954,7 @@ class CatalogController < ApplicationController
     if x_active_tree == :svccat_tree
       @gtl_buttons = %w[view_list view_tile]
       @gtl_small_tiles = true
-      if role_allows?(:feature => 'svc_catalog_provision')
-        @row_button = {:label    => _("Order"),
-                       :function => "miqOrderService",
-                       :title    => _("Order this Service")} # Show a button instead of the checkbox
-      end
+      @row_button = true if role_allows?(:feature => 'svc_catalog_provision') # Show a button instead of the checkbox
       options[:gtl_dbname] = :catalog
     end
     options[:named_scope] = scope

--- a/app/views/catalog/_svccat_tree_show.html.haml
+++ b/app/views/catalog/_svccat_tree_show.html.haml
@@ -44,11 +44,7 @@
     .form-group
       .col-md-1{:align => "center"}
         #buttons
-          = button_tag(_("Order"),
-                       :class   => "btn btn-primary",
-                       :alt     => t = _("Order this Service"),
-                       :title   => t,
-                       :onclick => "miqOrderService(#{@record.id})")
+          = button_tag(_("Order"), @record.decorate.gtl_button_cell.merge(:class => "btn btn-primary"))
 
 :javascript
   miq_bootstrap('#long_description');

--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -26,6 +26,7 @@ cols:
 - display
 #- provision_cost
 - created_at
+- template_valid?
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -50,6 +51,7 @@ col_order:
 - service_template_catalog.name
 #- provision_cost
 - created_at
+- template_valid?
 
 # Column titles, in order
 headers:
@@ -61,6 +63,7 @@ headers:
 - Catalog
 #- Cost
 - Created On
+- Valid
 
 col_formats:
 -

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -67,9 +67,7 @@ describe CatalogController do
     end
 
     describe '#x_button' do
-      before do
-        ApplicationController.handle_exceptions = true
-      end
+      before { ApplicationController.handle_exceptions = true }
 
       context 'corresponding methods are called for allowed actions' do
         CatalogController::CATALOG_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, actual_method|
@@ -476,6 +474,7 @@ describe CatalogController do
 
     describe "#ot_rendering" do
       render_views
+
       before do
         EvmSpecHelper.create_guid_miq_server_zone
         session[:settings] = {
@@ -964,6 +963,7 @@ describe CatalogController do
 
       describe '#replace_right_cell' do
         let(:dialog) { FactoryBot.create(:dialog) }
+
         before do
           allow(controller).to receive(:params).and_return(:action => 'dialog_provision')
           controller.instance_variable_set(:@in_a_form, true)
@@ -984,14 +984,8 @@ describe CatalogController do
     end
 
     describe '#service_template_list' do
-      let(:sandbox) { {:active_tree => tree} }
-
-      before do
-        controller.instance_variable_set(:@sb, sandbox)
-      end
-
       context 'Service Catalogs accordion' do
-        let(:tree) { :svccat_tree }
+        before { controller.instance_variable_set(:@sb, :active_tree => :svccat_tree) }
 
         it 'sets options for rendering proper type of view' do
           expect(controller).to receive(:process_show_list).with(:gtl_dbname => :catalog, :named_scope => {})
@@ -1001,7 +995,7 @@ describe CatalogController do
     end
 
     describe '#available_job_templates' do
-      it "" do
+      it "sets new available templates" do
         ems = FactoryBot.create(:automation_manager_ansible_tower)
         cs = FactoryBot.create(:configuration_script,
                                :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript')
@@ -1259,6 +1253,20 @@ describe CatalogController do
     it 'sets @tenants_tree' do
       controller.send(:identify_catalog, record.id)
       expect(controller.instance_variable_get(:@tenants_tree).name).to eq(:tenants_tree)
+    end
+
+    it 'does not add warning flash message for valid Catalog Item or Bundle' do
+      controller.send(:identify_catalog, record.id)
+      expect(controller.instance_variable_get(:@flash_array)).to be_nil
+    end
+
+    context 'invalid Catalog Item or Bundle' do
+      let(:record) { FactoryBot.create(:service_template, :service_resources => [FactoryBot.create(:service_resource)]) }
+
+      it 'adds warning flash message' do
+        controller.send(:identify_catalog, record.id)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'This item is invalid', :level => :warning}])
+      end
     end
   end
 

--- a/spec/views/catalog/_svccat_tree_show.html.haml_spec.rb
+++ b/spec/views/catalog/_svccat_tree_show.html.haml_spec.rb
@@ -1,0 +1,22 @@
+describe "catalog/_svccat_tree_show.html.haml" do
+  let(:service) { FactoryBot.create(:service_template) }
+
+  before do
+    assign(:record, service)
+    assign(:sb, {})
+  end
+
+  it 'enables Order button' do
+    render :partial => 'catalog/svccat_tree_show'
+    expect(response).to include("<button name=\"button\" type=\"submit\" is_button=\"true\" text=\"Order\" title=\"Order this Service\" alt=\"Order this Service\" onclick=\"miqOrderService(&quot;#{service.id}&quot;);\" class=\"btn btn-primary\">Order</button>")
+  end
+
+  context 'invalid Catalog items or Bundles' do
+    before { allow(service).to receive(:template_valid?).and_return(false) }
+
+    it 'disables Order button' do
+      render :partial => 'catalog/svccat_tree_show'
+      expect(response).to include("<button name=\"button\" type=\"submit\" is_button=\"true\" text=\"Order\" title=\"This Service cannot be ordered\" alt=\"This Service cannot be ordered\" disabled=\"disabled\" onclick=\"miqOrderService(&quot;#{service.id}&quot;);\" class=\"btn btn-primary\">Order</button>")
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6320
**DEPENDS ON:** https://github.com/ManageIQ/manageiq-decorators/pull/26 (merged)

This PR:
- adds a new column _Valid_ in the list view to display whether the Catalog Item/Bundle is valid or not
- displays warning as a flash message in the Catalog Item/Bundle details screen, if the item is invalid
- makes _Order_ button disabled for any invalid items

---

**After:**
_Services > Catalogs > Catalog Items_:
![valid](https://user-images.githubusercontent.com/13417815/73288789-eb63bb80-41fb-11ea-946a-00e6ea95bcfb.png)
_Services > Catalogs > Service Catalogs_:
![valid_2](https://user-images.githubusercontent.com/13417815/73288827-fc143180-41fb-11ea-9887-2540556967d1.png)
_Services > Catalogs > Service Catalogs_, details' screen of a selected Service:
![invalid](https://user-images.githubusercontent.com/13417815/73357172-1e5d8c00-429c-11ea-8cb3-c507ee10830d.png)
_Services > Catalogs > Catalog Items_,  details' screen of a selected Service:
![invalid2](https://user-images.githubusercontent.com/13417815/73357176-20bfe600-429c-11ea-8d5f-e1e661034c53.png)

