### PR TITLE
[WIP] Don't let angular-patternfly rewrite ui-components lodash

### DIFF
--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_controller.js
@@ -10,8 +10,6 @@ ManageIQ.angular.app.controller('dialogUserController', ['API', 'dialogFieldRefr
 
       resolve(API.get(url, {expand: 'resources', attributes: 'content'}).then(init));
     });
-
-    Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
   };
 
   function init(dialog) {

--- a/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/assets/javascripts/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -8,8 +8,6 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
 
       resolve(API.get(url).then(init));
     });
-
-    Promise.resolve(apiCall).then(miqService.refreshSelectpicker);
   };
 
   function init(data) {

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -18,8 +18,6 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miqStaticAssets.treeView',
   'ngSanitize', // FIXME: require('angular-sanitize'),
   'patternfly',
-  'patternfly.charts',
-  'patternfly.views',
   'ui.bootstrap',
   'ui.codemirror',
 ]);

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -35,10 +35,6 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
     return miqJqueryRequest(url, options);
   };
 
-  this.refreshSelectpicker = function() {
-    $('select').selectpicker('refresh');
-  };
-
   this.sparkleOn = function() {
     miqSparkleOn();
   };

--- a/app/javascript/packs/globals.js
+++ b/app/javascript/packs/globals.js
@@ -35,20 +35,23 @@ require('patternfly/dist/js/patternfly-functions-charts.js');
 require('patternfly/dist/js/patternfly-functions-fixed-heights.js');
 require('patternfly/dist/js/patternfly-functions-tree-grid.js');
 
+window._ = require('lodash');
+
 window.angular = require('angular');
+require('angular-animate'); // angular-patternfly dependency
 require('angular-ui-bootstrap');
+require('angular-drag-and-drop-lists'); // angular-patternfly dependency
 require('angular-gettext');
 require('angular-sanitize');
 require('angular.validators');
 require('ng-annotate-loader!angular-ui-codemirror');
 require('angular-dragdrop'); // ngDragDrop, used by ui-components
 require('angular-ui-sortable'); // ui.sortable, used by ui-components
-require('angular-patternfly');
+require('angular-patternfly/dist/angular-patternfly'); // index overwrites lodash (with 3.10), don't use
 require('angular-bootstrap-switch');
 require('kubernetes-topology-graph');
-require('@manageiq/ui-components');
+require('@manageiq/ui-components'); // needs lodash on load
 
-window._ = require('lodash');
 window.numeral = require('numeral');
 window.sprintf = require('sprintf-js').sprintf;
 window.c3 = require('c3');

--- a/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
+++ b/spec/javascripts/controllers/dialog_user/dialog_user_controller_spec.js
@@ -26,7 +26,6 @@ describe('dialogUserController', function() {
     spyOn(miqService, 'redirectBack');
     spyOn(miqService, 'sparkleOn');
     spyOn(miqService, 'sparkleOff');
-    spyOn(miqService, 'refreshSelectpicker');
 
     $controller = _$controller_('dialogUserController', {
       API: API,
@@ -73,13 +72,6 @@ describe('dialogUserController', function() {
 
     it('sets dialogLoaded to true', function() {
       expect($controller.dialogLoaded).toEqual(true);
-    });
-
-    it('refreshes the selectpickers after resolving the api call', function(done) {
-      setTimeout(function() {
-        expect(miqService.refreshSelectpicker).toHaveBeenCalled();
-        done();
-      });
     });
   });
 

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -50,18 +50,6 @@ describe('miqService', function() {
     });
   });
 
-  describe('#refreshSelectpicker', function() {
-    beforeEach(function() {
-      spyOn($.fn, 'selectpicker');
-    });
-
-    it('refreshes all selects', function() {
-      testService.refreshSelectpicker();
-      expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('select');
-      expect($.fn.selectpicker.calls.mostRecent().args[0]).toEqual('refresh');
-    });
-  });
-
   describe('#sparkleOn', function() {
     it('calls the global miq sparkle on', function() {
       testService.sparkleOn();


### PR DESCRIPTION
`require('angular-patternfly')` loads a bunch of dependencies, including an ancient version of lodash (3.10.1).
ui-components gets loaded before the global gets rewritten with the right version, and keeps the old reference.

Leading to `_.toNumber is not a function` when dealing with numeric dropdowns in dialog editor.

This also changes the version of angular-ui-bootstrap used by ui-components from 0.14 to 2.x, once again because we're already specifying ~2.5 in package.json - needs https://github.com/ManageIQ/ui-components/pull/429