### PR TITLE
Customized fonticon cleanup

### DIFF
--- a/app/assets/stylesheets/icon_customizations.scss
+++ b/app/assets/stylesheets/icon_customizations.scss
@@ -4,70 +4,67 @@
   padding-right: 3px;
 }
 
-/* begin icon class customizations */
-
-.fa-1xplus {
-  font-size: 1.18em; //custom resize for fa-tachometer on dashboard summary toggle
-}
-
-.pficon-folder-close-blue {
-  @extend .pficon-folder-close;
-  color: #3188c5;
-}
-
-.pficon-registry-unknown {
-  @extend .pficon-registry;
-  color: $color-warning;
-}
-
-.ff-condition::before {
-  color: #39a5dc; //pf-blue-300
-}
-
 .fa-inactive,
 .ff-inactive,
 .pficon-inactive {
   opacity: 0.6; // add styling to show inactive icon (policies, etc)
 }
 
-.pf-blue-info {
-    color: #0088ce; //pf-blue-400
+.fa-1xplus {
+  font-size: 1.18em; //custom resize for fa-tachometer on dashboard summary toggle
 }
 
 .popover {
   max-width: none;
 }
 
+.blue {color: #39a5dc;}   //pf-blue-300
+.blue-quad {color: #0099cc;}
+.green {color: #2d7623;}  //pf-green-500
+.orange {color: #ec7a08;} //pf-orange-400
+.purple {color: #40199a;} //pf-purple-600
+.red {color: #cc0000;}    //pf-red-100
+
 .compare-same {
-  @extend .fa, .fa-lg, .fa-check;
-  color: #403990;
+  @extend .fa, .fa-lg, .fa-check, .purple;
 }
 
 .compare-diff {
-  @extend .fa, .fa-lg, .fa-times;
-  color: #21a0ec;
+  @extend .fa, .fa-lg, .fa-times, .blue;
+}
+
+.import-add {
+  @extend .fa, .fa-lg, .fa-plus, .green;
+}
+
+.import-conflict {
+  @extend .fa, .fa-lg, .fa-times, .red;
+}
+
+.import-update {
+  @extend .fa, .fa-lg, .fa-check, .green;
 }
 
 .drift-delta {
-  @extend .fa, .fa-play, .fa-rotate-270;
-  color: #21a0ec;
-}
-
-.green > i {
-  color: #2d7623; //pf-green-500
-}
-
-.red > i {
-  color: #cc0000; //pf-red-100
-}
-
-.orange > i {
-  color: #ec7a08; //pf-orange-400
+  @extend .fa, .fa-play, .fa-rotate-270, .blue;
 }
 
 .fa-ruby {
-  @extend .fa, .fa-lg, .fa-diamond;
-  color: red;
+  @extend .fa, .fa-lg, .fa-diamond, .red;
 }
 
-/* end icon class customizations */
+.pf-blue-info {
+  @extend .blue;
+}
+
+.pficon-folder-close-blue {
+  @extend .pficon-folder-close, .blue;
+}
+
+.pficon-registry-unknown {
+  @extend .pficon-registry, .orange;
+}
+
+.single-wrapper .fonticon {
+  @extend .blue-quad;
+}

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -320,24 +320,8 @@ table.table.table-summary-screen tbody td img {
 /// ===================================================================
 
 /// ===================================================================
-/// begin quadicon styling
-/// ===================================================================
-
-miq-quadicon > .single-wrapper {
-  .fonticon > i {
-    color: #0099cc;
-  }
-}
-
-/// ===================================================================
-/// end quadicon styling
-/// ===================================================================
-
-/// ===================================================================
 /// begin report styling
 /// ===================================================================
-
-/// report column styling
 
 .miq_rpt_red_bg {
   background: #fbdbdb !important;
@@ -614,14 +598,6 @@ table.table.table-selectable tbody tr.selected td {
 #tab_div ul.list-inline li.active {
   color: $link-color !important;
   font-size: 16px;
-}
-
-.icon-green {
-  color: green;
-}
-
-.icon-red {
-  color: red;
 }
 
 /* Action cell */

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -334,9 +334,9 @@ class MiqPolicyController < ApplicationController
 
   def get_status_icon(status)
     case status
-    when :update then "fa-check icon-green"
-    when :add then "fa-plus icon-green"
-    when :conflict then "fa-times icon-red"
+    when :update then "import-update"
+    when :add then "import-add"
+    when :conflict then "import-conflict"
     end
   end
 

--- a/app/views/miq_policy/import.html.haml
+++ b/app/views/miq_policy/import.html.haml
@@ -13,7 +13,7 @@
           - @import.each do |item|
             %tr{'data-parent' => item[:parent]}
               %td{:class => 'treegrid-node'}
-                %span{:class => "icon node-icon fa fa-fw #{item[:icon]}"}
+                %span{:class => "icon node-icon #{item[:icon]}"}
                 %strong
                   = "#{item[:type]}: "
                 = item[:title]


### PR DESCRIPTION
This PR moves the color settings for Policy import icons and the quads  into the icon customizations file. It also cleans up the icons customizations.
