### PR TITLE
Don't query for an exact type

### DIFF
--- a/app/controllers/storage_controller/storage_pod.rb
+++ b/app/controllers/storage_controller/storage_pod.rb
@@ -27,7 +27,7 @@ module StorageController::StoragePod
 
   def storage_pod_get_node_info(treenodeid)
     if treenodeid == "root"
-      @folders = EmsFolder.where(:type => "StorageCluster").sort
+      @folders = StorageCluster.all.sort
       # to check if Add customization template button should be enabled
       @right_cell_text = _("All Datastore Clusters")
       @right_cell_div  = "storage_pod_list"

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -12,7 +12,7 @@ class TreeBuilderStoragePod < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots
-    count_only_or_objects(false, EmsFolder.where(:type => 'StorageCluster'))
+    count_only_or_objects(false, StorageCluster.all)
   end
 
   def x_get_ems_folder_kids(object, count_only)


### PR DESCRIPTION
This will break as we subclass models per-provider e.g.
ManageIQ::Providers::Vmware::InfraManager::StorageCluster

Related: https://github.com/ManageIQ/manageiq/pull/19534