### PR TITLE
Allow performing operations on Instances of a chosen Cloud Network

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -23,8 +23,6 @@ class CloudNetworkController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
-    when "cloud_network_tag"
-      return tag("CloudNetwork")
     when 'cloud_network_delete'
       delete_networks
       javascript_redirect(previous_breadcrumb_url)
@@ -32,19 +30,8 @@ class CloudNetworkController < ApplicationController
       javascript_redirect(:action => "edit", :id => checked_item_id)
     when "cloud_network_new"
       javascript_redirect(:action => "new")
-    when "cloud_subnet_tag"
-      return tag("CloudSubnet")
-    when "custom_button"
-      custom_buttons
-      return
-    when 'instance_compare'
-      return comparemiq
-    when "instance_tag"
-      return tag("VmOrTemplate")
-    when "network_router_tag"
-      return tag("NetworkRouter")
-    when "floating_ip_tag"
-      return tag("FloatingIp")
+    else
+      super
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1727,6 +1727,7 @@ Rails.application.routes.draw do
         edit
         index
         new
+        protect
         show
         show_list
         tagging_edit
@@ -1737,8 +1738,9 @@ Rails.application.routes.draw do
         create
         dynamic_checkbox_refresh
         form_field_changed
-        quick_search
         listnav_search_selected
+        protect
+        quick_search
         sections_field_changed
         show
         show_list


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6309

This PR fixes the issue regarding _Instances_ displayed through a _Cloud Network's_ _Relationships_: **nothing happened in the UI for almost all of the operations in the toolbar**, for some operations error `No template found for CloudNetworkController#button` occurred.

The logic for operations on nested list of Instances was missing, in `cloud_network` controller. I'm adding appropriate logic by using `button` method from _GenericButtonMixin_.

In this PR, I'm also adding missing routes for managing policies of selected Instances.

Also **_Check Compliance of Last Known Configuration_** action will be fixed after merging this PR together with https://github.com/ManageIQ/manageiq-ui-classic/pull/6426 (MERGED).

---

**This PR does not fix:**
- missing _Submit_ and _Cancel_ buttons for _Evacuate selected Instances_ operation. But at least, the operation now finally works with this PR, regarding Instances and `cloud_network`. The issue regarding buttons will be fixed in a follow up PR. More about this issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6480
- **_Resume_** Power operation on Instances displayed in a list (no matter if nested list or not, no matter which screen or controller). Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6487
- **_Shelve Offload_** Power operation on Instances displayed in a nested list (no matter which screen or controller). Nothing happens in the UI. Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6489

---

**Before:** (nothing happens in the UI, after clicking on _Manage Policies_ in the toolbar)
![manage-before](https://user-images.githubusercontent.com/13417815/69746291-3867da80-1144-11ea-925b-c94bc7a445d2.png)

**After:** (Managing Policies for selected Instance works well)
![manage-after](https://user-images.githubusercontent.com/13417815/69746295-3aca3480-1144-11ea-92a7-3ef8c96948c9.png)