### PR TITLE
Hide Advanced Search in Config Mgmt Providers screen

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -12,7 +12,7 @@ module ApplicationController::Explorer
 
   def replace_search_box(presenter, locals = {})
     presenter.replace(:adv_searchbox_div, r[:partial => 'layouts/x_adv_searchbox', :locals => locals])
-    presenter.replace(:advsearchModal, r[:partial => 'layouts/adv_search'])
+    presenter.replace(:advsearchModal, r[:partial => 'layouts/adv_search']) unless locals[:nameonly]
   end
 
   def try_build_tree(tree_symbol)

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -411,6 +411,7 @@ class InfraNetworkingController < ApplicationController
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end
+    replace_search_box(presenter)
   end
 
   def action_type(type, amount)

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -305,8 +305,7 @@ module Mixins
       record_showing = leaf_record
       presenter = rendering_objects
       get_tagdata(@record) if @record.try(:taggings)
-      update_partials(record_showing, presenter)
-      replace_search_box(presenter)
+      update_partials(record_showing, presenter) # replace_search_box is called whithin update_partials
       handle_bottom_cell(presenter)
       reload_trees_by_presenter(presenter, trees)
       rebuild_toolbars(record_showing, presenter)

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -96,7 +96,7 @@ class ProviderForemanController < ApplicationController
         self.x_node = params[:id]
         quick_search_show # User will input the value
       end
-    elsif x_active_tree == :configuration_manager_providers_tree && x_node != 'root' # Providers accordion, without Advanced Search
+    elsif provider_active_tree? && x_node != 'root' # Providers accordion, without Advanced Search
       listnav_search_selected(0)
     end
   end
@@ -326,7 +326,7 @@ class ProviderForemanController < ApplicationController
 
   def default_node
     return unless x_node == "root"
-    if x_active_tree == :configuration_manager_providers_tree
+    if provider_active_tree?
       options = {:model => "ManageIQ::Providers::ConfigurationManager"}
       @show_list ? process_show_list(options) : options.merge!(update_options)
       @right_cell_text = _("All Configuration Management Providers")

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -1,6 +1,6 @@
 describe VmInfraController do
   describe "ApplicationController::Explorer concern" do
-    context "#valid_active_node" do
+    describe "#valid_active_node" do
       let(:active_tree) { :stcat_tree }
 
       it "root node" do
@@ -33,7 +33,7 @@ describe VmInfraController do
       end
     end
 
-    context "#rbac_filtered_objects" do
+    describe "#rbac_filtered_objects" do
       let(:ems_folder) { FactoryBot.create(:ems_folder) }
       let!(:ems) { FactoryBot.create(:ems_vmware, :ems_folders => [ems_folder]) }
       let(:user)       { FactoryBot.create(:user_admin) }
@@ -59,7 +59,7 @@ describe VmInfraController do
 end
 
 describe ReportController do
-  context '#tree_add_child_nodes' do
+  describe '#tree_add_child_nodes' do
     it 'calls tree_add_child_nodes TreeBuilder method' do
       widget = FactoryBot.create(:miq_widget)
       controller.instance_variable_set(:@sb,
@@ -76,6 +76,24 @@ describe ReportController do
                    :state      => {:expanded => false},
                    :selectable => true}]
       expect(nodes).to eq(expected)
+    end
+  end
+end
+
+describe ProviderForemanController do
+  describe '#replace_search_box' do
+    let(:presenter) { ExplorerPresenter.new(:active_tree => :configuration_manager_providers_tree) }
+
+    it 'replaces advsearchModal' do
+      expect(presenter).to receive(:replace).with(:adv_searchbox_div, '')
+      expect(presenter).not_to receive(:replace).with(:advsearchModal, '')
+      controller.send(:replace_search_box, presenter, :nameonly => true)
+    end
+
+    it 'does not replace advsearchModal' do
+      expect(presenter).to receive(:replace).with(:adv_searchbox_div, '')
+      expect(presenter).to receive(:replace).with(:advsearchModal, '')
+      controller.send(:replace_search_box, presenter)
     end
   end
 end

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -141,4 +141,15 @@ describe InfraNetworkingController do
       controller.send(:rebuild_toolbars, true, presenter)
     end
   end
+
+  describe '#update_partials' do
+    let(:presenter) { ExplorerPresenter.new(:active_tree => :infra_networking_tree) }
+
+    before { controller.instance_variable_set(:@sb, :active_tree => :infra_networking_tree) }
+
+    it 'calls replace_search_box' do
+      expect(controller).to receive(:replace_search_box).with(presenter)
+      controller.send(:update_partials, false, presenter)
+    end
+  end
 end

--- a/spec/controllers/mixins/manager_controller_mixin_spec.rb
+++ b/spec/controllers/mixins/manager_controller_mixin_spec.rb
@@ -1,0 +1,18 @@
+describe Mixins::ManagerControllerMixin do
+  describe '#replace_right_cell' do
+    let(:controller) { ProviderForemanController.new }
+
+    before do
+      allow(controller).to receive(:leaf_record)
+      allow(controller).to receive(:rebuild_toolbars)
+      allow(controller).to receive(:render)
+      allow(controller).to receive(:tag_action).and_return(false)
+      controller.instance_variable_set(:@sb, {})
+    end
+
+    it 'calls replace_search_box only once' do
+      expect(controller).to receive(:replace_search_box).once
+      controller.send(:replace_right_cell)
+    end
+  end
+end

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -2,6 +2,7 @@ describe ProviderForemanController do
   render_views
 
   let(:tags) { ["/managed/quota_max_memory/2048"] }
+
   before do
     allow(controller).to receive(:data_for_breadcrumbs).and_return({})
     @zone = EvmSpecHelper.local_miq_server.zone
@@ -735,6 +736,30 @@ describe ProviderForemanController do
       controller.send(:show)
       expect(controller.instance_variable_get(:@explorer)).to be(true)
       expect(controller.params[:action]).to eq('tree-select')
+    end
+  end
+
+  describe '#load_or_clear_adv_search' do
+    before do
+      allow(controller).to receive(:model_from_active_tree)
+      controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_providers_tree)
+    end
+
+    it 'checks if being in a Configuration Manager Providers tree' do
+      expect(controller).to receive(:provider_active_tree?).and_return(true)
+      controller.send(:load_or_clear_adv_search)
+    end
+  end
+
+  describe '#default_node' do
+    before do
+      allow(controller).to receive(:x_node).and_return('root')
+      controller.instance_variable_set(:@sb, :active_tree => :configuration_manager_providers_tree)
+    end
+
+    it 'checks if being in a Configuration Manager Providers tree' do
+      expect(controller).to receive(:provider_active_tree?).and_return(true)
+      controller.send(:default_node)
     end
   end
 

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -193,7 +193,7 @@ describe VmOrTemplateController do
                                                             :locals  => {:controller => "vm"}).exactly(1).times
       expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_adv_searchbox",
                                                             :locals  => {:nameonly => true}).exactly(1).times
-      expect(controller).to receive(:render_to_string).with(:partial => "layouts/adv_search").exactly(1).times
+      expect(controller).not_to receive(:render_to_string).with(:partial => "layouts/adv_search")
       expect(controller).to receive(:render_to_string).with(:partial => "layouts/x_edit_buttons",
                                                             :locals  => {:action_url      => "prov_edit",
                                                                          :record_id       => vm.id,


### PR DESCRIPTION
**Fixes BZ:** https://bugzilla.redhat.com/show_bug.cgi?id=1777493

**This PR:**
- prevents one extra calling of `replace_search_box` method in ManagerControllerMixin in `replace_right_cell` method, especially for `provider_foreman` and `automation_manager` controllers - this change fixes appearing Adv Search in _Config > Mgmt > Providers_ accordion which is not supported there, so it does not appear there anymore, and it works for any item in the tree in _Providers_ accordion in the appropriate screen
- adds `replace_search_box` method to `infra_networking` controllers to `update_partials` method where it is missing - according to the removing the method from ManagerControllerMixin => with such changes we avoid adding extra conditions in `replace_right_cell` in ManagerControllerMixin :) (in `storage` controller, no need to add `replace_search_box`, see the code)
- fixes error (see the BZ) after clicking on another item in the tree, in _Config > Mgmt > Providers_ accordion, by adding a condition to `replace_search_box` method (because doing anything with `layouts/adv_search` does not make sense if we don't want to render _Adv Search_ at all, and `locals[:nameonly]` "decides" if _Adv Search_ will or will not be [displayed](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_x_adv_searchbox.html.haml#L1)), also makes _Search_ field to appear and work there
- replaces a condition with `provider_active_tree?` where it is possible, in `provider_foreman` controller, to simplify the code little bit

---

**Before:**
_Adv Search_ appears, after step 3 (see the BZ):
![foreman-before1](https://user-images.githubusercontent.com/13417815/69870580-9e717080-12b0-11ea-9ed2-2307dcec7e37.png)
After clicking on another item in accordion:
![foreman-before2](https://user-images.githubusercontent.com/13417815/69870583-a0d3ca80-12b0-11ea-9795-894af81b0270.png)

**After:**
![foreman-after1](https://user-images.githubusercontent.com/13417815/69870590-a5987e80-12b0-11ea-9dd8-2a53eceb4386.png)
![foreman-after2](https://user-images.githubusercontent.com/13417815/69870593-a7fad880-12b0-11ea-907e-5dddd8fd400d.png)
