### PR TITLE
Machine Credential: don't access options hash when null

### DIFF
--- a/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
+++ b/app/assets/javascripts/controllers/ansible_credentials/ansible_credentials_form_controller.js
@@ -118,7 +118,7 @@ ManageIQ.angular.app.controller('ansibleCredentialsFormController', ['$window', 
         } else {
           vm.credentialModel[key] = '';
 
-          if (response.options[key]) {
+          if (response.options && response.options[key]) {
             vm.credentialModel[key] = response.options[key];
           } else if (response[key]) {
             vm.credentialModel[key] = response[key];


### PR DESCRIPTION
We need to be able correctly handle ansible credential resources, which have options hash set to `nil` / `null`.

1. Create a machine credential, set username & password, nothing else!
2. Try to edit the credential
3. Observe the following javascript error:
```
angular.js:14961 TypeError: Cannot read property 'userid' of null
    at ansible_credentials_form_controller.self-d9df03bc8f1484db2a02d83c534e63b7e78fa04f4ba970174ce3945bb8a3fda3.js?body=1:122
    at Array.forEach (<anonymous>)
    at ansible_credentials_form_controller.self-d9df03bc8f1484db2a02d83c534e63b7e78fa04f4ba970174ce3945bb8a3fda3.js?body=1:114
    at processQueue (angular.js:17330)
    at angular.js:17378
    at Scope.$digest (angular.js:18515)
    at angular.js:18835
    at completeOutstandingRequest (angular.js:6439)
    at angular.js:6718 "Possibly unhandled rejection: {}"
```

Alternatively, you can create the problematic resource in rails console with:
```
machine01 = Authentication.select{|auth| auth.type == "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"}.first.dup
machine01.name = 'machine01'
machine01.options = nil
machine01.save
```

https://bugzilla.redhat.com/show_bug.cgi?id=1775093