### PR TITLE
Reconfigure: use detailed RBAC features.

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -47,7 +47,7 @@ class MiqRequestController < ApplicationController
       if provision_request.kind_of?(VmCloudReconfigureRequest)
         resizevms
       else
-        reconfigurevms
+        vm_reconfigure
       end
     end
   end

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -77,15 +77,14 @@ module Mixins
             end
             reconfigure_ids = recs.collect(&:to_i)
           end
+
           if @explorer
             reconfigure(reconfigure_ids)
             session[:changed] = true # need to enable submit button when screen loads
             @refresh_partial = "vm_common/reconfigure"
-          elsif role_allows?(:feature => "vm_reconfigure")
+          elsif
             # redirect to build the ownership screen
             javascript_redirect(:controller => rec_cls.to_s, :action => 'reconfigure', :req_id => request_id, :rec_ids => reconfigure_ids, :escape => false)
-          else
-            head :ok
           end
         end
 

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -87,9 +87,7 @@ module Mixins
         end
 
         alias_method :image_reconfigure, :reconfigurevms
-        alias_method :instance_reconfigure, :reconfigurevms
         alias_method :vm_reconfigure, :reconfigurevms
-        alias_method :miq_template_reconfigure, :reconfigurevms
 
         def get_reconfig_limits(reconfigure_ids)
           @reconfig_limits = VmReconfigureRequest.request_limits(:src_ids => reconfigure_ids)

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -407,11 +407,11 @@ module Mixins
 
         def reconfigure_handle_submit_button
           options = {:src_ids => params[:objectIds]}
-          if params[:cb_memory] == 'true' && role_allows?(:feature => 'vm_reconfigure_cpu')
+          if params[:cb_memory] == 'true' && role_allows?(:feature => 'vm_reconfigure_memory')
             options[:vm_memory] = params[:memory_type] == "MB" ? params[:memory] : params[:memory].to_i * 1024
           end
 
-          if params[:cb_cpu] == 'true' && role_allows?(:feature => 'vm_reconfigure_memory')
+          if params[:cb_cpu] == 'true' && role_allows?(:feature => 'vm_reconfigure_cpu')
             options[:cores_per_socket]  = params[:cores_per_socket_count].nil? ? 1 : params[:cores_per_socket_count].to_i
             options[:number_of_sockets] = params[:socket_count].nil? ? 1 : params[:socket_count].to_i
             vccores = params[:cores_per_socket_count].to_i.zero? ? 1 : params[:cores_per_socket_count].to_i

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -80,7 +80,7 @@ module Mixins
             reconfigure(reconfigure_ids)
             session[:changed] = true # need to enable submit button when screen loads
             @refresh_partial = "vm_common/reconfigure"
-          elsif
+          else
             # redirect to build the ownership screen
             javascript_redirect(:controller => 'vm', :action => 'reconfigure', :req_id => request_id, :rec_ids => reconfigure_ids, :escape => false)
           end

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -43,9 +43,12 @@ module Mixins
           render :json => request_hash
         end
 
-        # Reconfigure selected VMs
         def reconfigurevms
-          assert_privileges(params[:pressed])
+          rbac_feature_base = params[:pressed] + '_all'
+          unless role_allows?(:feature => rbac_feature_base, :any => true)
+            raise MiqException::RbacPrivilegeException, _('The user is not authorized for this task or item.')
+          end
+
           # check to see if coming from show_list or drilled into vms from another CI
           rec_cls = "vm"
           # if coming in to edit from miq_request list view
@@ -378,13 +381,43 @@ module Mixins
           end
         end
 
+        # parameter to accept for vm reconfiguration based on role permissions
+        def reconfigure_param_list
+          list = []
+
+          if role_allows?(:feature => 'vm_reconfigure_disks')
+            list += [
+              %i[vmAddDisks disk_add],
+              %i[vmResizeDisks disk_resize],
+              %i[vmRemoveDisks disk_remove]
+            ]
+          end
+
+          if role_allows?(:feature => 'vm_reconfigure_networks')
+            list += [
+              %i[vmAddNetworkAdapters network_adapter_add],
+              %i[vmRemoveNetworkAdapters network_adapter_remove],
+              %i[vmEditNetworkAdapters network_adapter_edit],
+            ]
+          end
+
+          if role_allows?(:feature => 'vm_reconfigure_drives')
+            list += [
+              %i[vmConnectCDRoms cdrom_connect],
+              %i[vmDisconnectCDRoms cdrom_disconnect]
+            ]
+          end
+
+          list
+        end
+
         def reconfigure_handle_submit_button
           options = {:src_ids => params[:objectIds]}
-          if params[:cb_memory] == 'true'
+          if params[:cb_memory] == 'true' && role_allows?(:feature => 'vm_reconfigure_cpu')
             options[:vm_memory] = params[:memory_type] == "MB" ? params[:memory] : params[:memory].to_i * 1024
           end
 
-          if params[:cb_cpu] == 'true'
+          if params[:cb_cpu] == 'true' && role_allows?(:feature => 'vm_reconfigure_memory')
             options[:cores_per_socket]  = params[:cores_per_socket_count].nil? ? 1 : params[:cores_per_socket_count].to_i
             options[:number_of_sockets] = params[:socket_count].nil? ? 1 : params[:socket_count].to_i
             vccores = params[:cores_per_socket_count].to_i.zero? ? 1 : params[:cores_per_socket_count].to_i
@@ -392,15 +425,7 @@ module Mixins
             options[:number_of_cpus] = vccores * vsockets
           end
 
-          # set the disk_add and disk_remove options
-          [%i[vmAddDisks disk_add],
-           %i[vmResizeDisks disk_resize],
-           %i[vmRemoveDisks disk_remove],
-           %i[vmAddNetworkAdapters network_adapter_add],
-           %i[vmRemoveNetworkAdapters network_adapter_remove],
-           %i[vmEditNetworkAdapters network_adapter_edit],
-           %i[vmConnectCDRoms cdrom_connect],
-           %i[vmDisconnectCDRoms cdrom_disconnect]].each do |params_key, options_key|
+          reconfigure_param_list.each do |params_key, options_key|
              next if params[params_key].blank?
              params[params_key].each do |_key, p|
                p.transform_values! { |v| eval_if_bool_string(v) }

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -43,14 +43,12 @@ module Mixins
           render :json => request_hash
         end
 
-        def reconfigurevms
-          rbac_feature_base = params[:pressed] + '_all'
-          unless role_allows?(:feature => rbac_feature_base, :any => true)
+        # reconfiguration for VMs only
+        def vm_reconfigure
+          unless role_allows?(:feature => 'vm_reconfigure_all', :any => true)
             raise MiqException::RbacPrivilegeException, _('The user is not authorized for this task or item.')
           end
 
-          # check to see if coming from show_list or drilled into vms from another CI
-          rec_cls = "vm"
           # if coming in to edit from miq_request list view
           recs = checked_or_params
           if !session[:checked_items].nil? && (@lastaction == "set_checked_items" || params[:pressed] == "miq_request_edit")
@@ -84,12 +82,9 @@ module Mixins
             @refresh_partial = "vm_common/reconfigure"
           elsif
             # redirect to build the ownership screen
-            javascript_redirect(:controller => rec_cls.to_s, :action => 'reconfigure', :req_id => request_id, :rec_ids => reconfigure_ids, :escape => false)
+            javascript_redirect(:controller => 'vm', :action => 'reconfigure', :req_id => request_id, :rec_ids => reconfigure_ids, :escape => false)
           end
         end
-
-        alias_method :image_reconfigure, :reconfigurevms
-        alias_method :vm_reconfigure, :reconfigurevms
 
         def get_reconfig_limits(reconfigure_ids)
           @reconfig_limits = VmReconfigureRequest.request_limits(:src_ids => reconfigure_ids)

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basi
   needs :@record
 
   def visible?
-    role_allows?(:identifier => 'vm_reconfigure_all', :any => true) && @record.reconfigurable?
+    role_allows?(:feature => 'vm_reconfigure_all', :any => true) && @record.reconfigurable?
   end
 end

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basi
   needs :@record
 
   def visible?
-    @record.reconfigurable?
+    role_allows?(:identifier => 'vm_reconfigure_all', :any => true) && @record.reconfigurable?
   end
 end

--- a/app/helpers/application_helper/button/vm_reconfigure_multiple.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure_multiple.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::VmReconfigureMultiple < ApplicationHelper::Button::Basic
+  def visible?
+    role_allows?(:feature => 'vm_reconfigure_all', :any => true)
+  end
+end

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -76,15 +76,6 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1"),
-        button(
-          :image_reconfigure,
-          'pficon pficon-edit fa-lg',
-          N_('Reconfigure the Memory/CPUs of selected items'),
-          N_('Reconfigure Selected items'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -100,6 +100,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-edit fa-lg',
           N_('Reconfigure the Memory/CPUs of selected items'),
           N_('Reconfigure Selected items'),
+          :klass        => ApplicationHelper::Button::VmReconfigureMultiple,
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -45,11 +45,6 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
                        'ff ff-database-squeezed fa-lg',
                        N_('CPU/Memory Recommendations of this Image'),
                        N_('Right-Size Recommendations')),
-                     button(
-                       :image_reconfigure,
-                       'pficon pficon-edit fa-lg',
-                       N_('Reconfigure the Memory/CPU of this Image'),
-                       N_('Reconfigure this Image')),
                    ]
                  ),
                ])

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -7,109 +7,111 @@
                                "ng-show"       => "vm.afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3= _('Options')
-  .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
-    %label.col-md-2.control-label
-      = _('Memory')
-    .col-md-1
-      %input{"bs-switch"       => "",
-             "type"            => "checkbox",
-             "name"            => "cb_memory",
-             "ng-model"        => "vm.cb_memory",
-             "ng-change"       => "vm.cbChange()",
-             "switch-on-text"  => _("Yes"),
-             "switch-off-text" => _("No")}
-    #memory_div{"ng-if" => "vm.cb_memory"}
-      .col-md-4
-        %input.form-control{"type"              => "text",
-                            "id"                => "memory_value",
-                            "name"              => "memory",
-                            "ng-model"          => "vm.reconfigureModel.memory",
-                            "ng-change"         => "vm.cbChange()",
-                            "maxlength"         => "50",
-                            "ng-pattern"        => "/^[-+]?[0-9]+$/",
-                            "miqrequired"       => "",
-                            "checkchange"       => "",
-                            "auto-focus"        => "",
-                            "validate-multiple" => "4",
-                            :miqmin             => "#{@reconfig_limits[:min__vm_memory]}",
-                            :miqmax             => "#{@reconfig_limits[:max__vm_memory]}",
-                            :memtype            => "{{vm.reconfigureModel.memory_type}}"}
-        %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$invalid"}
-          = _(" Memory value not in range or not a multiple of 4")
-        %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$required"}
-          = _(" Valid memory value required")
-      .col-md-2
-        = select_tag('mem_type',
-                     options_for_select(%w(MB GB)),
-                     "ng-model"                    => "vm.reconfigureModel.memory_type",
-                     "ng-change"                   => "vm.memtypeChanged()",
-                     "maxlength"                   => "20",
-                     "required"                    => "",
-                     "selectpicker-for-select-tag" => "")
-        = (@reconfig_memory_note)
-  .form-group
-    %label.col-md-2.control-label
-      = _('Processors')
-    .col-md-1
-      %input{"bs-switch"       => "",
-         "type"            => "checkbox",
-         "name"            => "cb_cpu",
-         "ng-model"        => "vm.cb_cpu",
-         "ng-change"       => "vm.cbChange()",
-         "switch-on-text"  => _("Yes"),
-         "switch-off-text" => _("No")}
-    %br
-    #cpu_div{"ng-if" => "vm.cb_cpu", :style => "margin-left: 20px"}
-      %h3= _(' Processor Options')
-      - if @socket_options.length > 1
-        .form-group{"ng-class" => "{'has-error': angularForm.socket_count.$invalid}"}
-          %label.col-md-2.control-label
-            = _('Sockets')
-          .col-md-2
-            = select_tag('socket_count',
-                        options_for_select([["<#{_('Choose')}>", '']] + @socket_options, disabled: ["<#{_('Choose')}>", nil]),
-                        "ng-model"                    => "vm.reconfigureModel.socket_count",
-                        "ng-change"                   => "vm.processorValueChanged()",
-                        "miqrequired"                 => "",
-                        "maxlength"                   => "100",
-                        "checkchange"                 => "",
-                        "selectpicker-for-select-tag" => "")
-            - if @socket_options.length <= 1
-              @socket_options[0]
-      -  if @cores_options.length > 1
-        .form-group{"ng-class" => "{'has-error': angularForm.cores_per_socket_count.$invalid}"}
-          %label.col-md-2.control-label
-            = _('Cores Per Socket')
-          .col-md-2
-            = select_tag('cores_per_socket_count',
-                          options_for_select([["<#{_('Choose')}>", '']] + @cores_options, disabled: ["<#{_('Choose')}>", nil]),
-                          "ng-model"                    => "vm.reconfigureModel.cores_per_socket_count",
+  - if role_allows?(:feature => 'vm_reconfigure_memory')
+    .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
+      %label.col-md-2.control-label
+        = _('Memory')
+      .col-md-1
+        %input{"bs-switch"       => "",
+               "type"            => "checkbox",
+               "name"            => "cb_memory",
+               "ng-model"        => "vm.cb_memory",
+               "ng-change"       => "vm.cbChange()",
+               "switch-on-text"  => _("Yes"),
+               "switch-off-text" => _("No")}
+      #memory_div{"ng-if" => "vm.cb_memory"}
+        .col-md-4
+          %input.form-control{"type"              => "text",
+                              "id"                => "memory_value",
+                              "name"              => "memory",
+                              "ng-model"          => "vm.reconfigureModel.memory",
+                              "ng-change"         => "vm.cbChange()",
+                              "maxlength"         => "50",
+                              "ng-pattern"        => "/^[-+]?[0-9]+$/",
+                              "miqrequired"       => "",
+                              "checkchange"       => "",
+                              "auto-focus"        => "",
+                              "validate-multiple" => "4",
+                              :miqmin             => "#{@reconfig_limits[:min__vm_memory]}",
+                              :miqmax             => "#{@reconfig_limits[:max__vm_memory]}",
+                              :memtype            => "{{vm.reconfigureModel.memory_type}}"}
+          %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$invalid"}
+            = _(" Memory value not in range or not a multiple of 4")
+          %span{"style"=>"color:red", "ng-show" => "angularForm.memory.$required"}
+            = _(" Valid memory value required")
+        .col-md-2
+          = select_tag('mem_type',
+                       options_for_select(%w(MB GB)),
+                       "ng-model"                    => "vm.reconfigureModel.memory_type",
+                       "ng-change"                   => "vm.memtypeChanged()",
+                       "maxlength"                   => "20",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+          = (@reconfig_memory_note)
+  - if role_allows?(:feature => 'vm_reconfigure_cpu')
+    .form-group
+      %label.col-md-2.control-label
+        = _('Processors')
+      .col-md-1
+        %input{"bs-switch"       => "",
+           "type"            => "checkbox",
+           "name"            => "cb_cpu",
+           "ng-model"        => "vm.cb_cpu",
+           "ng-change"       => "vm.cbChange()",
+           "switch-on-text"  => _("Yes"),
+           "switch-off-text" => _("No")}
+      %br
+      #cpu_div{"ng-if" => "vm.cb_cpu", :style => "margin-left: 20px"}
+        %h3= _(' Processor Options')
+        - if @socket_options.length > 1
+          .form-group{"ng-class" => "{'has-error': angularForm.socket_count.$invalid}"}
+            %label.col-md-2.control-label
+              = _('Sockets')
+            .col-md-2
+              = select_tag('socket_count',
+                          options_for_select([["<#{_('Choose')}>", '']] + @socket_options, disabled: ["<#{_('Choose')}>", nil]),
+                          "ng-model"                    => "vm.reconfigureModel.socket_count",
                           "ng-change"                   => "vm.processorValueChanged()",
-                          "ng-pattern"                  => "/^[-+]?[0-9]+$/",
                           "miqrequired"                 => "",
                           "maxlength"                   => "100",
                           "checkchange"                 => "",
                           "selectpicker-for-select-tag" => "")
-            - if @cores_options.length <= 1
-              @cores_options[0]
-            %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
-              =_("Note: a restart of the virtual machine might be required for the changes to apply.")
-        .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
-          %label.col-sm-2.control-label
-            = _('Total Processors')
-          .col-md-2
-            %input.form-control{"type"           => "text",
-                                "id"             => "total_cpus",
-                                "name"           => "total_cpus",
-                                "ng-model"       => "vm.reconfigureModel.total_cpus",
-                                :readonly        => '',
-                                "maxlength"      => "50",
-                                "validate_total" => "",
-                                "miqmax"         => "#{@reconfig_limits[:max__total_vcpus]}",
-                                "auto-focus"     => ""}
-            %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
-              = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks?
+              - if @socket_options.length <= 1
+                @socket_options[0]
+        -  if @cores_options.length > 1
+          .form-group{"ng-class" => "{'has-error': angularForm.cores_per_socket_count.$invalid}"}
+            %label.col-md-2.control-label
+              = _('Cores Per Socket')
+            .col-md-2
+              = select_tag('cores_per_socket_count',
+                            options_for_select([["<#{_('Choose')}>", '']] + @cores_options, disabled: ["<#{_('Choose')}>", nil]),
+                            "ng-model"                    => "vm.reconfigureModel.cores_per_socket_count",
+                            "ng-change"                   => "vm.processorValueChanged()",
+                            "ng-pattern"                  => "/^[-+]?[0-9]+$/",
+                            "miqrequired"                 => "",
+                            "maxlength"                   => "100",
+                            "checkchange"                 => "",
+                            "selectpicker-for-select-tag" => "")
+              - if @cores_options.length <= 1
+                @cores_options[0]
+              %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
+                =_("Note: a restart of the virtual machine might be required for the changes to apply.")
+          .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
+            %label.col-sm-2.control-label
+              = _('Total Processors')
+            .col-md-2
+              %input.form-control{"type"           => "text",
+                                  "id"             => "total_cpus",
+                                  "name"           => "total_cpus",
+                                  "ng-model"       => "vm.reconfigureModel.total_cpus",
+                                  :readonly        => '',
+                                  "maxlength"      => "50",
+                                  "validate_total" => "",
+                                  "miqmax"         => "#{@reconfig_limits[:max__total_vcpus]}",
+                                  "auto-focus"     => ""}
+              %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
+                = _(" Total processors value larger than the maximum allowed")
+  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
     %hr
     %div
       %h3

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -299,7 +299,7 @@
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters?
+  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
     %hr
     %div
       %h3
@@ -402,7 +402,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms?
+  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
     %div
       %h3
         = _('CD/DVD Drives')

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -1,5 +1,11 @@
 - @angular_form = true
 
+-# Base for reconfigure RBAC features.
+-# Either:
+-#   * 'vm_reconfigure_'    for infra VMs or
+-#   * 'image_reconfigure_' for cloud images.
+- base = controller_name == 'vm_infra' ? 'vm_reconfigure_' : 'image_reconfigure_'
+
 %form#form_div.form-horizontal{"name"          => "angularForm",
                                "ng-controller" => "reconfigureFormController as vm",
                                "miq-form"      => 'true',
@@ -7,7 +13,7 @@
                                "ng-show"       => "vm.afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3= _('Options')
-  - if role_allows?(:feature => 'vm_reconfigure_memory')
+  - if role_allows?(:feature => "#{base}memory")
     .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
       %label.col-md-2.control-label
         = _('Memory')
@@ -48,7 +54,7 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
           = (@reconfig_memory_note)
-  - if role_allows?(:feature => 'vm_reconfigure_cpu')
+  - if role_allows?(:feature => "#{base}cpu")
     .form-group
       %label.col-md-2.control-label
         = _('Processors')
@@ -111,7 +117,7 @@
                                   "auto-focus"     => ""}
               %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
                 = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
+  - if supports_reconfigure_disks? && role_allows?(:feature => "#{base}disks")
     %hr
     %div
       %h3
@@ -301,7 +307,7 @@
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
+  - if supports_reconfigure_network_adapters? && role_allows?(:feature => "#{base}networks")
     %hr
     %div
       %h3
@@ -404,7 +410,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
+  - if supports_reconfigure_cdroms? && role_allows?(:feature => "#{base}drives")
     %div
       %h3
         = _('CD/DVD Drives')

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -95,7 +95,7 @@
               - if @cores_options.length <= 1
                 @cores_options[0]
               %span.help-block{"ng-if" => "angularForm.cores_per_socket_count.$dirty"}
-                =_("Note: a restart of the virtual machine might be required for the changes to apply.")
+                = _("Note: a restart of the virtual machine might be required for the changes to apply.")
           .form-group{"ng-class" => "{'has-error': angularForm.total_cpus.$invalid}"}
             %label.col-sm-2.control-label
               = _('Total Processors')

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -1,11 +1,5 @@
 - @angular_form = true
 
--# Base for reconfigure RBAC features.
--# Either:
--#   * 'vm_reconfigure_'    for infra VMs or
--#   * 'image_reconfigure_' for cloud images.
-- base = controller_name == 'vm_infra' ? 'vm_reconfigure_' : 'image_reconfigure_'
-
 %form#form_div.form-horizontal{"name"          => "angularForm",
                                "ng-controller" => "reconfigureFormController as vm",
                                "miq-form"      => 'true',
@@ -13,7 +7,7 @@
                                "ng-show"       => "vm.afterGet"}
   = render :partial => "layouts/flash_msg"
   %h3= _('Options')
-  - if role_allows?(:feature => "#{base}memory")
+  - if role_allows?(:feature => 'vm_reconfigure_memory')
     .form-group{"ng-class" => "{'has-error': angularForm.memory.$invalid}"}
       %label.col-md-2.control-label
         = _('Memory')
@@ -54,7 +48,7 @@
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
           = (@reconfig_memory_note)
-  - if role_allows?(:feature => "#{base}cpu")
+  - if role_allows?(:feature => 'vm_reconfigure_cpu')
     .form-group
       %label.col-md-2.control-label
         = _('Processors')
@@ -117,7 +111,7 @@
                                   "auto-focus"     => ""}
               %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
                 = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks? && role_allows?(:feature => "#{base}disks")
+  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
     %hr
     %div
       %h3
@@ -307,7 +301,7 @@
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters? && role_allows?(:feature => "#{base}networks")
+  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
     %hr
     %div
       %h3
@@ -410,7 +404,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms? && role_allows?(:feature => "#{base}drives")
+  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
     %div
       %h3
         = _('CD/DVD Drives')

--- a/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb
@@ -1,5 +1,10 @@
 describe ApplicationHelper::Button::VmReconfigure do
   describe '#visible?' do
+    before do
+      @view_context = setup_view_context_with_sandbox({})
+      allow(@view_context).to receive(:role_allows?).and_return(true)
+    end
+
     context "record is vmware vm" do
       before do
         @record = FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_infra))

--- a/spec/shared/helpers/application_helper_buttons.rb
+++ b/spec/shared/helpers/application_helper_buttons.rb
@@ -1,6 +1,6 @@
 shared_examples_for 'will be skipped for this record' do |message|
   it message.to_s do
-    view_context = setup_view_context_with_sandbox({})
+    view_context = @view_context || setup_view_context_with_sandbox({})
     button = described_class.new(view_context, {}, {'record' => @record}, {})
     expect(button.visible?).to be_falsey
   end
@@ -8,7 +8,7 @@ end
 
 shared_examples_for 'will not be skipped for this record' do |message|
   it message.to_s do
-    view_context = setup_view_context_with_sandbox({})
+    view_context = @view_context || setup_view_context_with_sandbox({})
     button = described_class.new(view_context, {}, {'record' => @record}, {})
     expect(button.visible?).to be_truthy
   end


### PR DESCRIPTION
### Add more detailed RBAC permissions to the VM reconfigure screen

Alternative to: https://github.com/ManageIQ/manageiq-ui-classic/pull/6409

Depends on: https://github.com/ManageIQ/manageiq/pull/19566 (see that one for a detailed description)

closes: https://bugzilla.redhat.com/show_bug.cgi?id=1770022
closes: https://github.com/ManageIQ/manageiq-ui-classic/issues/6422

### Description

1. A separate feature is added for each of memory cpu network disks cdroms 
 -- https://github.com/ManageIQ/manageiq/pull/19566
 1. a new `:hidden` feature is added to replace the current `vm_reconfigure` (more on that below)
 1. a new feature is added `vm_reconfigure_all` that is a parent feature of the features from 1

`vm_reconfigure` cannot be a direct parent of the new features because both
 * a) the logic for checking permissions when displaying a button and
 * b) (more importantly) the logic for checking permissions when a button is pressed are designed to deal with a single feature.

The case a) is dealt with in `app/helpers/application_helper/button/vm_reconfigure.rb`. This means that the `vm_reconfigure` feature is checked by the generic button code first (always enabled) and then the extra code in VmReconfigure button has a say.

b) is handled by making the `vm_reconfigure` always on (makes the generic button rbac test pass) and then checking the individual permissions in the code that handles creation of the reconfiguration request.

 * Next I am removing extra aliases that exist but do not have either buttons leading to them or rbac features.
 * Also removing an extra rbac check that would not work for the `image` case.

 * Finally based on discussion with Loic and Adam, I am removing the non-VM (image) code.
The case is not accessible due to a test for `VmTemplate` early in the processing code. Seems this never worked and according to discussions and testing it's really so.

### TODO
~~I was not able to test this changes for the `image` case because I was not able to find any cloud image that would be reconfigurable.~~ Removed that part.

