### PR TITLE
Generalize queue matching.

### DIFF
--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -77,7 +77,7 @@ describe CloudVolumeController do
       end
 
       it "queues the create cloud backup action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :backup_create, :params => { :button => "create",
           :format => :js, :id => @volume.id, :backup_name => 'backup_name' }
       end
@@ -238,7 +238,7 @@ describe CloudVolumeController do
       end
 
       it "queues the create cloud volume action form OpenStack" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :create, :params => @form_params.merge(:button => "add", :format => :js)
       end
     end


### PR DESCRIPTION
Generalize the matching to ignore extra keys.

Fix failing specs (probably broken from core):
```
...
       Diff:
       @@ -8,6 +8,7 @@
             :size=>1}],
          :class_name=>"CloudVolume",
          :method_name=>"create_volume",
       +  :queue_name=>nil,
          :role=>"ems_operations",
          :zone=>"Zone 40"}]
...
```

```
Failed examples:
2269 rspec ./spec/controllers/cloud_volume_controller_spec.rb[1:7:2:1:1:2] # CloudVolumeController#create_volume in Amazon EBS for volume type 'gp2' behaves like queue create volume task queues the create cloud volume action form OpenStack
2270 rspec ./spec/controllers/cloud_volume_controller_spec.rb[1:7:2:2:1:2] # CloudVolumeController#create_volume in Amazon EBS for volume type 'io1' behaves like queue create volume task queues the create cloud volume action form OpenStack
2271 rspec ./spec/controllers/cloud_volume_controller_spec.rb[1:7:2:3:1:2] # CloudVolumeController#create_volume in Amazon EBS for encrypted volume behaves like queue create volume task queues the create cloud volume action form OpenStack
2272 rspec ./spec/controllers/cloud_volume_controller_spec.rb[1:7:1:1:2] # CloudVolumeController#create_volume in OpenStack cloud behaves like queue create volume task queues the create cloud volume action form OpenStack
```


