### PR TITLE
Allow performing operations on Instances of a chosen Cloud Subnet

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -636,7 +636,7 @@ module ApplicationController::CiProcessing
     case controller
     when 'ems_cluster'
       ems_cluster_untestable_actions.exclude?(action)
-    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'security_group', 'storage', 'vm_cloud'
+    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_subnet', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'security_group', 'storage', 'vm_cloud'
       other_untestable_actions.exclude?(action)
     when 'vm_infra'
       vm_infra_untestable_actions.exclude?(action)

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -23,24 +23,14 @@ class CloudSubnetController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
-    when "cloud_subnet_tag"
-      return tag("CloudSubnet")
     when 'cloud_subnet_delete'
       delete_subnets
     when "cloud_subnet_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id)
     when "cloud_subnet_new"
       javascript_redirect(:action => "new")
-    when "custom_button"
-      custom_buttons
-    when 'instance_compare'
-      comparemiq
     else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      super
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1694,6 +1694,7 @@ Rails.application.routes.draw do
         edit
         index
         new
+        protect
         show
         show_list
         tagging_edit
@@ -1705,6 +1706,7 @@ Rails.application.routes.draw do
         dynamic_checkbox_refresh
         form_field_changed
         listnav_search_selected
+        protect
         quick_search
         sections_field_changed
         show

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -127,7 +127,7 @@ describe CloudSubnetController do
     before { stub_user(:features => :all) }
 
     it "builds create screen" do
-      post :button, :params => { :pressed => "cloud_subnetnew", :format => :js }
+      post :button, :params => { :pressed => "cloud_subnet_new", :format => :js }
 
       expect(assigns(:flash_array)).to be_nil
     end
@@ -243,6 +243,144 @@ describe CloudSubnetController do
 
       it 'redirects to action new' do
         expect(controller).to receive(:javascript_redirect).with(:action => 'new')
+        controller.send(:button)
+      end
+    end
+
+    context 'editing Cloud Subnet' do
+      let(:params) { {:pressed => 'cloud_subnet_edit', :id => cloud_subnet.id.to_s} }
+
+      it 'redirects to action edit' do
+        expect(controller).to receive(:javascript_redirect).with(:action => 'edit', :id => cloud_subnet.id.to_s)
+        controller.send(:button)
+      end
+    end
+
+    context 'deleting Cloud Subnet' do
+      let(:params) { {:pressed => 'cloud_subnet_delete'} }
+
+      it 'calls delete_subnets' do
+        expect(controller).to receive(:delete_subnets)
+        controller.send(:button)
+      end
+    end
+
+    context 'custom buttons' do
+      let(:params) { {:pressed => 'custom_button'} }
+
+      it 'calls custom_buttons method' do
+        expect(controller).to receive(:custom_buttons)
+        controller.send(:button)
+      end
+    end
+
+    %w[cloud_subnet network_port security_group].each do |item|
+      context "tagging #{item.camelize}" do
+        let(:params) { {:pressed => "#{item}_tag"} }
+
+        it 'calls tag method' do
+          expect(controller).to receive(:tag).with(item.camelize.safe_constantize)
+          controller.send(:button)
+        end
+      end
+    end
+
+    context 'tagging Instances in a nested list' do
+      let(:params) { {:pressed => 'instance_tag'} }
+
+      it 'calls tag method' do
+        expect(controller).to receive(:tag).with(VmOrTemplate)
+        controller.send(:button)
+      end
+    end
+
+    %w[delete evacuate pause refresh reset resize retire scan shelve start stop suspend terminate].each do |action|
+      context "#{action} for selected Instances displayed in a nested list" do
+        let(:params) { {:pressed => "instance_#{action}"} }
+
+        it "calls #{action + 'vms'} method" do
+          allow(controller).to receive(:show)
+          allow(controller).to receive(:performed?).and_return(true)
+          expect(controller).to receive((action + 'vms').to_sym)
+          controller.send(:button)
+        end
+      end
+    end
+
+    context 'editing Instance displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_edit'} }
+
+      it 'calls edit_record method' do
+        allow(controller).to receive(:render_or_redirect_partial)
+        expect(controller).to receive(:edit_record)
+        controller.send(:button)
+      end
+    end
+
+    context 'setting Ownership for Instances in a nested list' do
+      let(:params) { {:pressed => 'instance_ownership'} }
+
+      it 'calls set_ownership' do
+        expect(controller).to receive(:set_ownership)
+        controller.send(:button)
+      end
+    end
+
+    context 'managing policies for Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_protect'} }
+
+      it 'calls assign_policies method' do
+        expect(controller).to receive(:assign_policies).with(VmOrTemplate)
+        controller.send(:button)
+      end
+    end
+
+    context 'policy simulation for Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_policy_sim'} }
+
+      it 'calls polsimvms method' do
+        expect(controller).to receive(:polsimvms)
+        controller.send(:button)
+      end
+    end
+
+    context 'provisioning Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_miq_request_new'} }
+
+      it 'calls prov_redirect' do
+        allow(controller).to receive(:render_or_redirect_partial)
+        expect(controller).to receive(:prov_redirect)
+        controller.send(:button)
+      end
+    end
+
+    context 'retirement for Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_retire_now'} }
+
+      it 'calls retirevms_now' do
+        allow(controller).to receive(:show)
+        allow(controller).to receive(:performed?).and_return(true)
+        expect(controller).to receive(:retirevms_now)
+        controller.send(:button)
+      end
+    end
+
+    context 'Live Migrate of Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_live_migrate'} }
+
+      it 'calls livemigratevms' do
+        expect(controller).to receive(:livemigratevms)
+        controller.send(:button)
+      end
+    end
+
+    context 'Soft Reboot of Instances displayed in a nested list' do
+      let(:params) { {:pressed => 'instance_guest_restart'} }
+
+      it 'calls guestreboot' do
+        allow(controller).to receive(:show)
+        allow(controller).to receive(:performed?).and_return(true)
+        expect(controller).to receive(:guestreboot)
         controller.send(:button)
       end
     end

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -384,6 +384,36 @@ describe CloudSubnetController do
         controller.send(:button)
       end
     end
+
+    context 'Check Compliance of Instances displayed in a nested list' do
+      let(:params) { {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => cloud_subnet.id.to_s, :controller => 'cloud_subnet'} }
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+
+      before { allow(controller).to receive(:performed?).and_return(true) }
+
+      it 'calls check_compliance_vms' do
+        allow(controller).to receive(:show)
+        expect(controller).to receive(:check_compliance_vms)
+        controller.send(:button)
+      end
+
+      context 'Instance with VM Compliance policy assigned' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          allow(controller).to receive(:assert_privileges)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+          allow(controller).to receive(:drop_breadcrumb)
+          vm_instance.add_policy(policy)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 
   include_examples '#download_summary_pdf', :cloud_subnet_openstack


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6309

This PR fixes the issue regarding _Instances_ displayed through a _Cloud Subnet's_ _Relationships_: **nothing happened in the UI for almost all of the operations in the toolbar**, for some operations error `No template found for CloudSubnetController#button` occurred.

The logic for operations on nested list of Instances was missing, in `cloud_subnet` controller. I'm adding appropriate logic by using `button` method from _GenericButtonMixin_.

In this PR, I'm also adding missing routes for managing policies of selected Instances.

Also **_Check Compliance of Last Known Configuration_** action will be working after merging this PR together with https://github.com/ManageIQ/manageiq-ui-classic/pull/6426 (MERGED).

In this PR, also a small bug in one spec for `cloud_subnet` controller is [fixed](https://github.com/ManageIQ/manageiq-ui-classic/pull/6488/files#diff-1b7110bb8d5431d3346d0d3516a00646R130). This spec was passing accidentally, due to the (not very good) implementation in `button` method in the controller.

---

**This PR does not fix:**
- missing _Submit_ and _Cancel_ buttons for _Evacuate selected Instances_ operation. But at least, the operation now finally works with this PR, regarding Instances and `cloud_subnet`. The issue regarding buttons will be fixed in a follow up PR. More: https://github.com/ManageIQ/manageiq-ui-classic/issues/6480
- **_Resume_** Power operation on Instances displayed in a list (no matter if nested list or not, no matter which screen or controller). Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6487
- **_Shelve Offload_** Power operation on Instances displayed in a nested list (no matter which screen or controller). Nothing happens in the UI. Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6489

---

**Before:** (for _Refresh Relationships and Power States_ nothing happens in the UI)
![refresh-before](https://user-images.githubusercontent.com/13417815/70158841-36f46000-16b8-11ea-95d1-507c8b1a3468.png)

**After:**
![refresh-after](https://user-images.githubusercontent.com/13417815/70158850-3b207d80-16b8-11ea-8125-a07ab44f0915.png)
