### PR TITLE
Allow performing Shelve Offload operation for Instances in a nested list

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -912,7 +912,7 @@ module ApplicationController::CiProcessing
     when "#{pfx}_suspend"                   then suspendvms
     when "#{pfx}_pause"                     then pausevms
     when "#{pfx}_shelve"                    then shelvevms
-    when "#{pfx}_shelveoffloadvms"          then shelveoffloadvms
+    when "#{pfx}_shelve_offload"            then shelveoffloadvms
     when "#{pfx}_reset"                     then resetvms
     when "#{pfx}_check_compliance"          then check_compliance_vms
     when "#{pfx}_reconfigure"               then reconfigurevms

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -120,7 +120,7 @@ class OrchestrationStackController < ApplicationController
     elsif @refresh_div == "main_div" && @lastaction == "show_list"
       replace_gtl_main_div
     else
-      render_flash
+      render_flash unless performed?
     end
   end
 

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -27,6 +27,19 @@ describe CloudTenantController do
 
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
+
+    context 'Shelve offload applied on Instances displayed in a nested list' do
+      before do
+        controller.params = {:pressed => 'instance_shelve_offload'}
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:show)
+      end
+
+      it 'calls shelveoffloadvms' do
+        expect(controller).to receive(:shelveoffloadvms)
+        controller.send(:button)
+      end
+    end
   end
 
   describe "#tags_edit" do

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -71,6 +71,19 @@ describe EmsCloudController do
         post :button, :params => { :pressed => "cloud_object_store_container_delete" }
       end
 
+      context 'Shelve offload applied on Instances displayed in a nested list' do
+        before do
+          controller.params = {:pressed => 'instance_shelve_offload'}
+          allow(controller).to receive(:performed?).and_return(true)
+          allow(controller).to receive(:show)
+        end
+
+        it 'calls shelveoffloadvms' do
+          expect(controller).to receive(:shelveoffloadvms)
+          controller.send(:button)
+        end
+      end
+
       context 'actions on Host Aggregates displayed through Cloud Provider' do
         let(:aggregate) { FactoryBot.create(:host_aggregate) }
 

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -238,6 +238,19 @@ describe OrchestrationStackController do
       it 'returns proper record class' do
         expect(controller.send(:record_class)).to eq(VmOrTemplate)
       end
+
+      context 'Shelve offload action' do
+        before do
+          controller.params = {:pressed => 'instance_shelve_offload'}
+          allow(controller).to receive(:performed?).and_return(true)
+          allow(controller).to receive(:show)
+        end
+
+        it 'calls shelveoffloadvms' do
+          expect(controller).to receive(:shelveoffloadvms)
+          controller.send(:button)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6489

_Shelve Offload_ power operation on Instances displayed in a **nested list** did not work: nothing happened in the UI. The issue was present in `process_vm_buttons` method where `shelveoffloadvms` should have been called, and it didn't. The method simply didn't correspond to what's in `params[:pressed]`, after clicking on `Shelve Offload` in the toolbar.

In this PR, I am also adding specs for `button` method for controllers 'under' _Compute > Clouds_. For `orchestration_stack` controller, I am also fixing _DoubleRender_ error by adding `unless performed?` [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Shelve_Offload_Instances_nested_list?expand=1#diff-c825546e2b4be699311249312a23bd63R123).

---

**Before:** (nothing happened in the UI)
![shelve_before](https://user-images.githubusercontent.com/13417815/70166367-e5060700-16c4-11ea-8173-88615ac20d09.png)

**After:** (appropriate flash message being rendered)
![shelve_after](https://user-images.githubusercontent.com/13417815/70166372-e6cfca80-16c4-11ea-97d2-c85f2ef557e7.png)
