### PR TITLE
compare cleanup follow-up

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -843,14 +843,6 @@ fieldset {
   margin-left: 0
 }
 
-table.table-expanded tr td .piechart {
-  margin-left: 67px;
-}
-
-table.table-compressed tr td .piechart {
-  margin-left: 5px;
-}
-
 .treeview .icon.node-icon-background {
   color: #fff;
 }


### PR DESCRIPTION
This PR removes a couple of old compare/drift related selectors missed in the previous PRs.

This is a follow-up to:   https://github.com/ManageIQ/manageiq-ui-classic/pull/6424 and  https://github.com/ManageIQ/manageiq-ui-classic/pull/6436