### PR TITLE
Allow performing operations on Instances of a chosen Network Router

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -636,7 +636,7 @@ module ApplicationController::CiProcessing
     case controller
     when 'ems_cluster'
       ems_cluster_untestable_actions.exclude?(action)
-    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'resource_pool', 'storage', 'vm_cloud'
+    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'storage', 'vm_cloud'
       other_untestable_actions.exclude?(action)
     when 'vm_infra'
       vm_infra_untestable_actions.exclude?(action)

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -23,14 +23,6 @@ class NetworkRouterController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
-    when "cloud_subnet_tag"
-      return tag("CloudSubnet")
-    when "custom_button"
-      custom_buttons
-    when 'instance_compare'
-      comparemiq
-    when "instance_tag"
-      return tag("VmOrTemplate")
     when "network_router_add_interface"
       javascript_redirect(:action => "add_interface_select", :id => checked_item_id)
     when "network_router_edit"
@@ -39,12 +31,8 @@ class NetworkRouterController < ApplicationController
       javascript_redirect(:action => "new")
     when "network_router_remove_interface"
       javascript_redirect(:action => "remove_interface_select", :id => checked_item_id)
-    when "network_router_tag"
-      return tag("NetworkRouter")
-    when "floating_ip_tag"
-      return tag("FloatingIp")
     else
-      render_flash
+      super
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1791,6 +1791,7 @@ Rails.application.routes.draw do
         edit
         index
         new
+        protect
         remove_interface_select
         show
         show_list
@@ -1804,6 +1805,7 @@ Rails.application.routes.draw do
         create
         form_field_changed
         listnav_search_selected
+        protect
         quick_search
         remove_interface
         remove_interface_select

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -484,5 +484,35 @@ describe NetworkRouterController do
         controller.send(:button)
       end
     end
+
+    context 'Check Compliance of Instances displayed in a nested list' do
+      let(:params) { {:miq_grid_checks => vm_instance.id.to_s, :pressed => 'instance_check_compliance', :id => router.id.to_s, :controller => 'network_router'} }
+      let(:vm_instance) { FactoryBot.create(:vm_or_template) }
+
+      before { allow(controller).to receive(:performed?).and_return(true) }
+
+      it 'calls check_compliance_vms' do
+        allow(controller).to receive(:show)
+        expect(controller).to receive(:check_compliance_vms)
+        controller.send(:button)
+      end
+
+      context 'Instance with VM Compliance policy assigned' do
+        let(:policy) { FactoryBot.create(:miq_policy, :mode => 'compliance', :towhat => 'Vm', :active => true) }
+
+        before do
+          EvmSpecHelper.create_guid_miq_server_zone
+          allow(controller).to receive(:assert_privileges)
+          allow(MiqPolicy).to receive(:policy_for_event?).and_return(true)
+          allow(controller).to receive(:drop_breadcrumb)
+          vm_instance.add_policy(policy)
+        end
+
+        it 'initiates Check Compliance action' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6309

This PR fixes the issue regarding _Instances_ displayed through a _Network Router's_ _Relationships_: **nothing happened in the UI for almost all of the operations in the toolbar** (tagging and comparing Instances worked).

The logic for operations on nested list of Instances was missing, in `network_router` controller. I'm adding appropriate logic by using `button` method from _GenericButtonMixin_.

In this PR, I'm also adding missing routes for managing policies of selected Instances.

Also **_Check Compliance of Last Known Configuration_** on Instances of a chosen Network Router will be working after merging this PR together with https://github.com/ManageIQ/manageiq-ui-classic/pull/6426 (MERGED).

---

**What else needs to be fixed:**
- missing _Submit_ and _Cancel_ buttons for _Evacuate selected Instances_ operation. But at least, the operation now finally works with this PR, regarding Instances and `network_router` controller. The issue regarding buttons will be fixed in another PR. More: https://github.com/ManageIQ/manageiq-ui-classic/issues/6480
- **_Resume_** Power operation on Instances displayed in a list (no matter if nested list or not, no matter which screen or controller). Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6487
- **_Shelve Offload_** Power operation on Instances displayed in a nested list (no matter which screen or controller). Nothing happens in the UI. Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6489

---

**Before:** (_SmartState Analysis_, nothing happens in the UI)
![router_before](https://user-images.githubusercontent.com/13417815/70233813-99546b80-175f-11ea-8867-2a9dc07a1595.png)

**After:** (SSA successfully initiated for selected Instance)
![router_after](https://user-images.githubusercontent.com/13417815/70233823-9ce7f280-175f-11ea-8499-40fd16a0746a.png)
