### PR TITLE
Don't test exact queue_options when testing operations

### DIFF
--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -112,9 +112,6 @@ describe CloudNetworkController do
         :class_name  => ems.class.name,
         :method_name => 'create_cloud_network',
         :instance_id => ems.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{
           :admin_state_up        => true,
           :external_facing       => false,
@@ -135,7 +132,7 @@ describe CloudNetworkController do
     end
 
     it "queues the create action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
 
       post :create, :params => {
         :button                => 'add',
@@ -166,9 +163,6 @@ describe CloudNetworkController do
         :class_name  => network.class.name,
         :method_name => 'raw_update_cloud_network',
         :instance_id => network.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{:name => "test2", :admin_state_up => false, :shared => false, :external_facing => false}]
       }
     end
@@ -182,7 +176,7 @@ describe CloudNetworkController do
     end
 
     it "queues the update action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
 
       post :update, :params => { :button => "save", :format => :js, :id => network.id, :name => "test2" }
     end
@@ -201,9 +195,6 @@ describe CloudNetworkController do
         :class_name  => network.class.name,
         :method_name => 'raw_delete_cloud_network',
         :instance_id => network.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => []
       }
     end
@@ -217,7 +208,7 @@ describe CloudNetworkController do
     end
 
     it "queues the delete action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       expect(controller).to receive(:render)
 
       controller.send(:button)

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -111,9 +111,6 @@ describe CloudSubnetController do
         :class_name  => ems.class.name,
         :method_name => 'create_cloud_subnet',
         :instance_id => ems.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{
           :name             => 'test',
           :ip_version       => 4,
@@ -136,7 +133,7 @@ describe CloudSubnetController do
     end
 
     it "queues the create action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
 
       post :create, :params => {
         :button           => 'add',
@@ -168,9 +165,6 @@ describe CloudSubnetController do
         :class_name  => cloud_subnet.class.name,
         :method_name => 'raw_update_cloud_subnet',
         :instance_id => cloud_subnet.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{
           :name             => 'test2',
           :enable_dhcp      => false,
@@ -190,7 +184,7 @@ describe CloudSubnetController do
     end
 
     it "queues the update action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
 
       post :update, :params => {
         :button           => 'save',
@@ -216,9 +210,6 @@ describe CloudSubnetController do
         :class_name  => cloud_subnet.class.name,
         :method_name => 'raw_delete_cloud_subnet',
         :instance_id => cloud_subnet.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => []
       }
     end
@@ -229,7 +220,7 @@ describe CloudSubnetController do
     end
 
     it "queues the delete action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
 
       post :button, :params => { :id => cloud_subnet.id, :pressed => "cloud_subnet_delete", :format => :js }
     end

--- a/spec/controllers/cloud_volume_controller_spec.rb
+++ b/spec/controllers/cloud_volume_controller_spec.rb
@@ -65,8 +65,6 @@ describe CloudVolumeController do
           :class_name  => @volume.class.name,
           :method_name => "backup_create",
           :instance_id => @volume.id,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
           :args        => [{:name => "backup_name"}]
         }
       end
@@ -149,8 +147,6 @@ describe CloudVolumeController do
           :class_name  => @volume.class.name,
           :method_name => "backup_restore",
           :instance_id => @volume.id,
-          :role        => "ems_operations",
-          :zone        => @ems.my_zone,
           :args        => [@backup.ems_ref]
         }
       end
@@ -161,7 +157,7 @@ describe CloudVolumeController do
       end
 
       it "queues restore from a cloud backup action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :backup_restore, :params => { :button => "restore",
           :format => :js, :id => @volume.id, :backup_id => @backup.id }
       end
@@ -189,9 +185,6 @@ describe CloudVolumeController do
           :class_name  => @volume.class.name,
           :instance_id => @volume.id,
           :method_name => 'create_volume_snapshot',
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => [{:name => "snapshot_name"}]
         }
       end
@@ -202,7 +195,7 @@ describe CloudVolumeController do
       end
 
       it "queues the create cloud snapshot action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :snapshot_create, :params => { :button => "create",
           :format => :js, :id => @volume.id, :snapshot_name => 'snapshot_name' }
       end
@@ -226,8 +219,6 @@ describe CloudVolumeController do
         {
           :class_name  => "CloudVolume",
           :method_name => 'create_volume',
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => @task_options
         }
       end

--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -69,15 +69,12 @@ describe CloudVolumeSnapshotController do
           :class_name  => @snapshot.class.name,
           :instance_id => @snapshot.id,
           :method_name => 'delete_snapshot',
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => []
         }
       end
 
       it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :button, :params => { :id => @snapshot.id, :pressed => "cloud_volume_snapshot_delete", :format => :js }
       end
     end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -108,9 +108,6 @@ describe FloatingIpController do
           :class_name  => @ems.class.name,
           :method_name => 'create_floating_ip',
           :instance_id => @ems.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => [{}]
         }
       end
@@ -121,7 +118,7 @@ describe FloatingIpController do
       end
 
       it "queues the create action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :create, :params => { :button => "add", :format => :js, :name => 'test',
                                    :tenant_id => 'id', :ems_id => @ems.id }
       end
@@ -148,9 +145,6 @@ describe FloatingIpController do
           :class_name  => @floating_ip.class.name,
           :method_name => 'raw_update_floating_ip',
           :instance_id => @floating_ip.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => [{:network_port_ems_ref => ""}]
         }
       end
@@ -161,7 +155,7 @@ describe FloatingIpController do
       end
 
       it "queues the update action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :update, :params => { :button => "save", :format => :js, :id => @floating_ip.id,
                                    :network_port => {:ems_ref => ""}}
       end
@@ -188,15 +182,12 @@ describe FloatingIpController do
           :class_name  => @floating_ip.class.name,
           :method_name => 'raw_delete_floating_ip',
           :instance_id => @floating_ip.id,
-          :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => 'ems_operations',
-          :zone        => @ems.my_zone,
           :args        => []
         }
       end
 
       it "queues the delete action" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
         post :button, :params => { :id => @floating_ip.id, :pressed => "floating_ip_delete", :format => :js }
       end
     end

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -34,9 +34,6 @@ describe HostAggregateController do
       {
         :class_name  => aggregate.class.name,
         :method_name => "create_aggregate",
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => ems.my_zone,
         :args        => [ems.id, {:name => "foo", :ems_id => ems.id.to_s }]
       }
     end
@@ -47,7 +44,7 @@ describe HostAggregateController do
     end
 
     it "queues the create action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :create, :params => { :button => "add", :format => :js, :name => 'foo', :ems_id => ems.id }
     end
   end
@@ -64,9 +61,6 @@ describe HostAggregateController do
         :class_name  => aggregate.class.name,
         :method_name => "update_aggregate",
         :instance_id => aggregate.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => ems.my_zone,
         :args        => [{:name => "foo"}]
       }
     end
@@ -77,7 +71,7 @@ describe HostAggregateController do
     end
 
     it "queues the update action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :update, :params => { :button => "save", :format => :js, :id => aggregate.id, :name => "foo" }
     end
   end
@@ -136,9 +130,6 @@ describe HostAggregateController do
         :class_name  => aggregate.class.name,
         :method_name => "add_host",
         :instance_id => aggregate.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => ems.my_zone,
         :args        => [host.id]
       }
     end
@@ -149,7 +140,7 @@ describe HostAggregateController do
     end
 
     it "queues the add host action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :add_host, :params => { :button => "addHost", :format => :js, :id => aggregate.id, :host_id => host.id }
     end
   end
@@ -166,9 +157,6 @@ describe HostAggregateController do
         :class_name  => aggregate.class.name,
         :method_name => "remove_host",
         :instance_id => aggregate.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => ems.my_zone,
         :args        => [host.id]
       }
     end
@@ -179,7 +167,7 @@ describe HostAggregateController do
     end
 
     it "queues the remove host action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :remove_host, :params => {
         :button  => "removeHost",
         :format  => :js,

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -116,9 +116,6 @@ describe NetworkRouterController do
         :class_name  => @ems.class.name,
         :method_name => 'create_network_router',
         :instance_id => @ems.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => @ems.my_zone,
         :args        => [{
           :name            => 'test',
           :admin_state_up  => 'true',
@@ -135,7 +132,7 @@ describe NetworkRouterController do
     end
 
     it "queues the create action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :create, :params => {
         :button           => 'add',
         :controller       => 'network_router',
@@ -172,9 +169,6 @@ describe NetworkRouterController do
         :class_name  => @router.class.name,
         :method_name => 'raw_update_network_router',
         :instance_id => @router.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => @ems.my_zone,
         :args        => [{:name => "foo2", :external_gateway_info => {}}]
       }
     end
@@ -185,7 +179,7 @@ describe NetworkRouterController do
     end
 
     it "queues the update action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :update, :params => {
         :button => "save",
         :format => :js,
@@ -215,9 +209,6 @@ describe NetworkRouterController do
         :class_name  => @router.class.name,
         :method_name => "raw_add_interface",
         :instance_id => @router.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => @ems.my_zone,
         :args        => [@subnet.id]
       }
     end
@@ -274,7 +265,7 @@ describe NetworkRouterController do
 
     it "queues the add interface action" do
       stub_user(:features => :all)
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :add_interface, :params => {
         :button          => "add",
         :format          => :js,
@@ -305,9 +296,6 @@ describe NetworkRouterController do
         :class_name  => @router.class.name,
         :method_name => "raw_remove_interface",
         :instance_id => @router.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => @ems.my_zone,
         :args        => [@subnet.id]
       }
     end
@@ -318,7 +306,7 @@ describe NetworkRouterController do
     end
 
     it "queues the remove interface action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :remove_interface, :params => {
         :button          => "remove",
         :format          => :js,

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -97,9 +97,6 @@ describe SecurityGroupController do
         :class_name  => ems.class.name,
         :method_name => 'create_security_group',
         :instance_id => ems.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{:name => "test"}]
       }
     end
@@ -111,7 +108,7 @@ describe SecurityGroupController do
     end
 
     it "queues the create action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :create, :params => { :button => "add", :format => :js, :name => 'test',
                                  :tenant_id => 'id', :ems_id => ems.id }
     end
@@ -130,9 +127,6 @@ describe SecurityGroupController do
         :class_name  => security_group.class.name,
         :method_name => 'raw_update_security_group',
         :instance_id => security_group.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [{:name => "foo2", :description => "New desc"}]
       }
     end
@@ -147,9 +141,6 @@ describe SecurityGroupController do
         :class_name  => security_group.class.name,
         :method_name => 'raw_create_security_group_rule',
         :instance_id => security_group.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => [security_group.ems_ref, "outbound", { :ethertype => "", :port_range_min => nil,
            :port_range_max => nil, :protocol => "tcp", :remote_group_id => nil, :remote_ip_prefix => nil }]
       }
@@ -162,8 +153,10 @@ describe SecurityGroupController do
     end
 
     it "queues the update action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(security_group_task_options, security_group_queue_options)
-      expect(MiqTask).to receive(:generic_action_with_callback).with(firewall_rule_task_options, firewall_rule_queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback)
+        .with(security_group_task_options, hash_including(security_group_queue_options))
+      expect(MiqTask).to receive(:generic_action_with_callback)
+        .with(firewall_rule_task_options, hash_including(firewall_rule_queue_options))
       post :update, :params => { :button          => "save",
                                  :format          => :js,
                                  :id              => security_group.id,
@@ -186,15 +179,12 @@ describe SecurityGroupController do
         :class_name  => security_group.class.name,
         :method_name => 'raw_delete_security_group',
         :instance_id => security_group.id,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => 'ems_operations',
-        :zone        => ems.my_zone,
         :args        => []
       }
     end
 
     it "queues the delete action" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options))
       post :button, :params => { :id => security_group.id, :pressed => "security_group_delete", :format => :js }
     end
   end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -79,7 +79,7 @@ describe GitBasedDomainImportService do
 
       it "calls 'import' with the correct options" do
         allow(task).to receive(:task_results).and_return(domain)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
         expect(domain).to receive(:update_attribute).with(:enabled, true)
 
         subject.import(git_repo.id, ref_name, 321)
@@ -93,7 +93,7 @@ describe GitBasedDomainImportService do
 
       it "calls 'import' with the correct options" do
         allow(task).to receive(:task_results).and_return(domain)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
         expect(domain).to receive(:update_attribute).with(:enabled, true)
         subject.import(git_repo.id, ref_name, 321)
       end
@@ -104,7 +104,7 @@ describe GitBasedDomainImportService do
 
       it "raises an exception with a message about invalid domain" do
         allow(task).to receive(:task_results).and_return(nil)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
           MiqException::Error, "Selected branch or tag does not contain a valid domain"
@@ -114,7 +114,7 @@ describe GitBasedDomainImportService do
       it "raises an exception with a message about multiple domains" do
         allow(task).to receive(:task_results).and_return(nil)
         allow(task).to receive(:message).and_return('multiple domains')
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
           MiqException::Error, 'Selected branch or tag contains more than one domain'
@@ -135,7 +135,7 @@ describe GitBasedDomainImportService do
       let(:git_branches) { [double("GitBranch", :name => ref_name)] }
 
       it "calls 'queue_import' with the correct options" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
       end
@@ -147,7 +147,7 @@ describe GitBasedDomainImportService do
       let(:ref_type) { "tag" }
 
       it "calls 'queue_import' with the correct options" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
       end
@@ -179,7 +179,7 @@ describe GitBasedDomainImportService do
       end
 
       it "calls 'queue_import' with the correct options" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321)).to eq(task.id)
       end
@@ -199,7 +199,7 @@ describe GitBasedDomainImportService do
       end
 
       it "calls 'queue_import' with additional auth args using stringified keys" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321, "userid" => "bob", :verify_ssl => false)).to eq(task.id)
       end
@@ -219,7 +219,7 @@ describe GitBasedDomainImportService do
       end
 
       it "calls 'queue_import' with an encrypted password" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321, "userid" => "bob", :password => "secret")).to eq(task.id)
       end
@@ -236,7 +236,7 @@ describe GitBasedDomainImportService do
     end
 
     it "calls 'queue_refresh' with the correct options" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
       expect(subject.queue_refresh(git_repo.id)).to eq(task.id)
     end
@@ -258,7 +258,7 @@ describe GitBasedDomainImportService do
     context "success" do
       it "calls 'refresh' with the correct options and succeeds" do
         allow(task).to receive(:task_results).and_return(true)
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect(subject.refresh(git_repo.id)).to be_truthy
       end
@@ -268,7 +268,7 @@ describe GitBasedDomainImportService do
       let(:status) { "Failed" }
       let(:message) { "My Error Message" }
       it "calls 'refresh' with the correct options and fails" do
-        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
         expect { subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
       end
@@ -289,13 +289,13 @@ describe GitBasedDomainImportService do
     end
 
     it "#destroy_domain" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
       expect(subject.destroy_domain(domain.id)).to be_truthy
     end
 
     it "#queue_destroy_domain" do
-      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
 
       expect(subject.queue_destroy_domain(domain.id)).to eq(task.id)
     end


### PR DESCRIPTION
Only need to test for the values that are relevent to the tests (e.g.
instance_id, method_name, args).

Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/6504