### PR TITLE
Display child services on bundled service summary screens if available

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -18,7 +18,7 @@
     .tab-content
       = miq_tab_content("details", 'default', :class => 'cm-tab') do
         = render :partial => "layouts/textual_groups_generic"
-        - child_services = @record.direct_service_children.select(&:display)
+        - child_services = @record.direct_service_children
         - unless child_services.blank?
           .row
             .col-md-12.col-lg-6


### PR DESCRIPTION
When having a catalog bundle that has at least one catalog item, the provisioning creates multiple services in a hierarchy. However, these services are not accessible through the UI as their `display` attribute is set to `false`. Hiding them in the GTL and trees makes sense, but we would like to see those child services at least from the summary screens.

Steps to reproduce: https://github.com/ManageIQ/manageiq-ui-classic/issues/4391#issuecomment-563260453

**Before:**
![Screenshot from 2019-12-09 10-23-47](https://user-images.githubusercontent.com/649130/70448185-002e9900-1a6e-11ea-8410-634b039f80d2.png)

**After:**
![Screenshot from 2019-12-09 10-23-10](https://user-images.githubusercontent.com/649130/70448168-f9078b00-1a6d-11ea-8783-523c33a5f2fe.png)

Fixes #4391 
cc @d-m-u 