### PR TITLE
Entry Point modal styling fix

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -642,7 +642,7 @@ td.action > .btn.btn-default {
 
 /// custom modal class for Entry Point (creates scrollable area)
 
-#automate_treebox {
+#automate_treebox, #automate_catalog_treebox {
   height: 350px !important;
   overflow-y: auto !important;
 }


### PR DESCRIPTION
The PR restores the styling required for the entry point modal to be properly formatted.

Issue: #6494

Old
<img width="1347" alt="Screen Shot 2019-12-09 at 2 46 27 PM" src="https://user-images.githubusercontent.com/1287144/70467515-5e21a780-1a93-11ea-9d2f-48cff83f2e65.png">

New
<img width="1347" alt="Screen Shot 2019-12-09 at 2 29 18 PM" src="https://user-images.githubusercontent.com/1287144/70467514-5e21a780-1a93-11ea-90bb-bd08ffe7e78c.png">


