### PR TITLE
Remove custom "table-borderless" class

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -518,14 +518,6 @@ table.table tbody td img {
   margin-top: 1px;
 }
 
-// Table View override for policy action options
-
-.table-borderless tbody tr td,
-.table-borderless tbody tr th,
-.table-borderless thead tr th {
-  border: none;
-}
-
 // override font-weight for dropdowns within table headers
 
 .table thead th select {


### PR DESCRIPTION
The PR removes the old custom "table-borderless" class in favor of the standard BS "table-borderless" class.

Follow-up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/6437
