### PR TITLE
[WIP] Remove reference to removed method #generate_ui_api_token

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -67,7 +67,6 @@ class DashboardController < ApplicationController
       return head(:forbidden) unless known_redirect_host?(url.hostname)
     end
 
-    url.fragment = "access_token=#{generate_ui_api_token(current_user[:userid])}"
     redirect_to(url.to_s)
   end
 


### PR DESCRIPTION
This was removed in f161abde29c273761a77113ef14652a9935f0d10, but
this reference was missed and is breaking cockpit webconsoles

https://bugzilla.redhat.com/show_bug.cgi?id=1779988

@miq-bot add_label bug, blocker, ivanchuk/yes
@miq-bot assign @skateman 