### PR TITLE
Remove unnecessary one-liner from cloudVolumeBackupForm

### DIFF
--- a/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
+++ b/app/assets/javascripts/components/cloud_volume_backup/cloud-volume-backup-form.js
@@ -57,7 +57,7 @@ function cloudVolumeBackupFormController(miqService, $http, $scope) {
 
   function getVolumeFormDataComplete(response) {
     vm.volume_choices = response.data.volume_choices;
-    if (foundVolumes()) {
+    if (vm.volume_choices.length > 0) {
       vm.cloudVolumeBackupModel.volume = vm.volume_choices[0];
     }
     vm.modelCopy = angular.copy(vm.cloudVolumeBackupModel);
@@ -66,10 +66,6 @@ function cloudVolumeBackupFormController(miqService, $http, $scope) {
 
   function resetModel() {
     vm.cloudVolumeBackupModel = angular.copy(vm.modelCopy);
-  }
-
-  function foundVolumes() {
-    return vm.volume_choices.length > 0;
   }
 
   vm.$onInit = init;


### PR DESCRIPTION
`foundVolumes()` is a one-liner and is being used in one place only.