### PR TITLE
Allow performing operations on Instances of a chosen Security Group

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -636,7 +636,7 @@ module ApplicationController::CiProcessing
     case controller
     when 'ems_cluster'
       ems_cluster_untestable_actions.exclude?(action)
-    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'storage', 'vm_cloud'
+    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'security_group', 'storage', 'vm_cloud'
       other_untestable_actions.exclude?(action)
     when 'vm_infra'
       vm_infra_untestable_actions.exclude?(action)

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -24,28 +24,14 @@ class SecurityGroupController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
-    when "instance_tag"
-      return tag("VmOrTemplate")
-    when 'instance_compare'
-      comparemiq
-    when "network_port_tag"
-      return tag("NetworkPort")
-    when "security_group_tag"
-      return tag("SecurityGroup")
     when "security_group_delete"
       delete_security_groups
     when "security_group_edit"
       javascript_redirect(:action => "edit", :id => checked_item_id(params))
     when 'security_group_new'
       javascript_redirect(:action => "new")
-    when "custom_button"
-      custom_buttons
     else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      super
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1624,6 +1624,7 @@ Rails.application.routes.draw do
         download_summary_pdf
         index
         new
+        protect
         show
         show_list
         tagging_edit
@@ -1633,8 +1634,9 @@ Rails.application.routes.draw do
         button
         create
         form_field_changed
-        quick_search
         listnav_search_selected
+        protect
+        quick_search
         sections_field_changed
         show
         show_list


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6309

This PR fixes the issue regarding _Instances_ displayed through a _Security Group's_ _Relationships_: **nothing happened in the UI for almost all of the operations in the toolbar** (tagging and comparing Instances worked).

The logic for operations on nested list of Instances was missing, in `security_group` controller. I'm adding appropriate logic by using `button` method from _GenericButtonMixin_.

In this PR, I'm also adding missing routes for managing policies of selected Instances.

Also **_Check Compliance of Last Known Configuration_** on Instances of a Security Group will be working after merging this PR together with https://github.com/ManageIQ/manageiq-ui-classic/pull/6426 (MERGED).

---

**What else needs to be fixed:**
- missing _Submit_ and _Cancel_ buttons for _Evacuate selected Instances_ operation. But at least, the operation now finally works with this PR, regarding Instances and `security_group` controller. The issue regarding buttons will be fixed in another PR. More: https://github.com/ManageIQ/manageiq-ui-classic/issues/6480
- **_Resume_** Power operation on Instances displayed in a list (no matter if nested list or not, no matter which screen or controller). Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6487
- **_Shelve Offload_** Power operation on Instances displayed in a nested list (no matter which screen or controller). Nothing happens in the UI. Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6489

---

**Before:** (_Manage Policies_ action, nothing happens in the UI)
![manage_policies_before](https://user-images.githubusercontent.com/13417815/70539705-5e3da800-1b64-11ea-8601-4c4f5fdea1b8.png)

**After:**
![manage_policies_after](https://user-images.githubusercontent.com/13417815/70539723-6269c580-1b64-11ea-946d-ecd5f3fd5bcf.png)
