### PR TITLE
Reimplement token generation for cockpit webconsole proxy

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -67,7 +67,10 @@ class DashboardController < ApplicationController
       return head(:forbidden) unless known_redirect_host?(url.hostname)
     end
 
-    url.fragment = "access_token=#{generate_ui_api_token(current_user[:userid])}"
+    @api_user_token_service ||= Api::UserTokenService.new
+    token = @api_user_token_service.generate_token(current_user[:userid], "ui")
+
+    url.fragment = "access_token=#{token}"
     redirect_to(url.to_s)
   end
 


### PR DESCRIPTION
generate_ui_api_token was removed in f161abde29c273761a77113ef14652a9935f0d10
but this reference was left.

This behavior is still required for cockpit so the contents of the
removed method are now baked into #cockpit_redirect

https://bugzilla.redhat.com/show_bug.cgi?id=1779988

@miq-bot add_label bug, blocker, ivanchuk/yes
@miq-bot assign @skateman