### PR TITLE
webpack - merge sharedPackages and resolve.alias

### DIFF
--- a/config/webpack/RailsEnginesPlugin.js
+++ b/config/webpack/RailsEnginesPlugin.js
@@ -4,11 +4,11 @@ const getPaths = require("enhanced-resolve/lib/getPaths");
 const forEachBail = require("enhanced-resolve/lib/forEachBail");
 
 module.exports = class RailsEnginesPlugin {
-  constructor(source, target, engines, { packages, root }) {
+  constructor(source, target, engines, root) {
     this.source = source;
     this.target = target;
     this.engines = engines;
-    this.shared = { packages, root };
+    this.root = root;
   }
 
   // match path to engine, even if it's under another engine's vendor (longest match)
@@ -52,10 +52,7 @@ module.exports = class RailsEnginesPlugin {
 
       if (engine.fallback) {
         console.warn(`RailsEnginesPlugin: no engine found for ${request.path} asking for ${request.request} (only a problem if you're *not* using yarn link)`);
-      }
-
-      if (this.shared.packages.includes(packageName) || engine.fallback) {
-        targetEngineModules = this.shared.root;
+        targetEngineModules = this.root;
       }
 
       if (! inNodeModules) {

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -20,14 +20,18 @@ const entryPath = join(settings.source_path, settings.source_entry_path);
 const moduleDir = engines['manageiq-ui-classic'].node_modules;
 
 const sharedPackages = [
+  'angular',
+  'graphql', // TODO remove once this gets added in manageiq-graphql
   'jquery',
   'lodash',
+  'moment',
   'patternfly-react',
   'patternfly-sass',
+  'prop-types',
   'react',
   'react-dom',
-  'prop-types',
-  'graphql', // TODO remove once this gets added in manageiq-graphql
+  'react-redux',
+  'redux',
 ];
 
 let packPaths = {};
@@ -129,12 +133,8 @@ module.exports = {
 
   resolve: {
     alias: {
-      'react': resolveModule('react'), // only ever use one react version
-      'redux': resolveModule('redux'), // only ever use one redux version
-      'react-redux': resolveModule('react-redux'), // only ever use one react-redux version
+      ...sharedPackages.reduce((acc, pkg) => ({ ...acc, [pkg]: resolveModule(pkg) }), {}),
       'bootstrap-select': '@pf3/select', // never use vanilla bootstrap-select
-      'moment': resolveModule('moment'), // fix moment-strftime peerDependency issue
-      'angular': resolveModule('angular'), // fix for "Tried to load angular more than once"
       '@patternfly/patternfly': resolveModule('NONEXISTENT'),
       '@patternfly/patternfly-next': resolveModule('NONEXISTENT'),
     },

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -141,7 +141,7 @@ module.exports = {
     extensions: settings.extensions,
     modules: [],
     plugins: [
-      new RailsEnginesPlugin('module', 'resolve', engines, { packages: sharedPackages, root: moduleDir }),
+      new RailsEnginesPlugin('module', 'resolve', engines, moduleDir),
     ],
   },
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "manageiq",
+  "name": "manageiq-ui-classic",
   "version": "1.0.0",
   "description": "ManageIQ Cloud Management Platform",
   "main": "index.js",


### PR DESCRIPTION
Right now, we have 2 ways of saying "I only want 1 version of this package" in webpack config:

* `sharedPackages` - a list of packages, used by `RailsEnginesPlugin` to ensure any require(pkg) from a plugin goes to our version of the package, not the plugin's version
* `resolve.alias` - mapping from package name to an explicit root/node_modules/package location, to use the root version instead of another version coming as a dependency of a dependency

Both are similar concepts (identical if we start treating plugins as npm dependencies),
and there is no situation where we'd want 1 version for all the plugins but not other packages,
nor a situation where we'd want 1 version in ui-classic and another in plugins,
so we can merge the 2.

=> moving all those packages to `sharedPackages`, leaving only renames and wipeouts in `resolve.alias`, and generating the rest of `resolve.alias` from `sharedPackages`.

(This makes the `sharedPackages` logic in `RailsEnginesPlugin` superfluous actually, as the alias always wins, so removing.)

Also fixes the package name for ui-classic to manageiq-ui-classic.

