### PR TITLE
Toolbars: use kebabLimit to set number of visible custom buttons.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1340,4 +1340,9 @@ module ApplicationHelper
   def camelize_quadicon(quad)
     quad.keys.each_with_object({}) { |k, h| h[k.to_s.camelcase(:lower)] = quad[k] }
   end
+
+  def miq_toolbar(toolbars)
+    limit = ::Settings.ui.custom_button_count || 3
+    react('MiqToolbar', :kebabLimit => limit, :toolbars => toolbars)
+  end
 end

--- a/app/javascript/components/miq-toolbar.jsx
+++ b/app/javascript/components/miq-toolbar.jsx
@@ -220,7 +220,7 @@ const initState = {
 };
 
 /* Wrapper class for generic toolbars and special toolbars. */
-const MiqToolbar = ({ toolbars: initToolbars }) => {
+const MiqToolbar = ({ kebabLimit, toolbars: initToolbars }) => {
   const [state, dispatch] = useReducer(toolbarReducer, {...initState, toolbars: sanitizeToolbars(initToolbars)});
 
   useEffect(() => {
@@ -241,6 +241,7 @@ const MiqToolbar = ({ toolbars: initToolbars }) => {
 
     return (
       <Toolbar
+	kebabLimit={kebabLimit}
         count={count}
         groups={groups}
         views={views}
@@ -271,6 +272,7 @@ const MiqToolbar = ({ toolbars: initToolbars }) => {
 
 MiqToolbar.propTypes = {
   toolbars: PropTypes.arrayOf(PropTypes.any).isRequired,
+  kebabLimit: PropTypes.number.isRequired,
 };
 
 export default MiqToolbar;

--- a/app/javascript/spec/toolbar/miq-toolbar.spec.jsx
+++ b/app/javascript/spec/toolbar/miq-toolbar.spec.jsx
@@ -46,17 +46,17 @@ describe('<MiqToolbar />', () => {
   });
 
   it('renders DashboardToolbar', () => {
-    const t = shallow(<MiqToolbar toolbars={dashboardData} />);
+    const t = shallow(<MiqToolbar kebabLimit={3} toolbars={dashboardData} />);
     expect(t.find(DashboardToolbar)).toHaveLength(1);
   });
 
   it('renders TopologyToolbar', () => {
-    const t = shallow(<MiqToolbar toolbars={topologyData} />);
+    const t = shallow(<MiqToolbar kebabLimit={3} toolbars={topologyData} />);
     expect(t.find(TopologyToolbar)).toHaveLength(1);
   });
 
   it('renders Toolbar', () => {
-    const t = shallow(<MiqToolbar toolbars={genericData} />);
+    const t = shallow(<MiqToolbar kebabLimit={3} toolbars={genericData} />);
     expect(t.find(Toolbar)).toHaveLength(1);
   });
 });

--- a/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
@@ -5,7 +5,7 @@
   .row.toolbar-pf#toolbar
     .col-sm-12
       - if @widgets_menu
-        = react 'MiqToolbar', :toolbars => toolbar_from_hash
+        = miq_toolbar toolbar_from_hash
   .row#main-content.miq-body.miq-layout-center_div_dashboard_no_listnav
     .col-md-12
       .spacer

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -7,7 +7,7 @@
       - if !@in_a_form && taskbar_in_header?
         .row.toolbar-pf#toolbar
           .col-sm-12
-            = react 'MiqToolbar', :toolbars => toolbar_from_hash
+            = miq_toolbar toolbar_from_hash
       .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
         .col-md-12
         - if layout_uses_tabs?

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -7,7 +7,7 @@
       .col-sm-12
         - if @layout == "dashboard"
           = render :partial => "/layouts/tabs"
-        = react 'MiqToolbar', :toolbars => toolbar_from_hash
+        = miq_toolbar toolbar_from_hash
   .row.max-height
     .col-sm-8.col-md-9.col-sm-push-4.col-md-push-3.max-height
       #main-content.row.miq-layout-center_div_with_listnav

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -10,7 +10,7 @@
       = render :partial => "layouts/breadcrumbs"
     .row.toolbar-pf#toolbar.miq-toolbar-menu
       .col-sm-12
-        = react 'MiqToolbar', :toolbars => toolbar_from_hash
+        = miq_toolbar toolbar_from_hash
     .row.max-height
       .max-height{:class => simulate? ? 'col-sm-7 col-md-8 col-sm-push-5 col-md-push-4' : 'col-sm-8 col-md-9 col-sm-push-4 col-md-push-3'}
         #main-content.row.miq-layout-center_div_with_listnav

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 :ui:
   :custom_menu:
+  :custom_button_count: 3
 docs:
   :ansible_provider: http://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#adding-an-ansible-tower-provider
   :cloud_provider: http://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#cloud_providers

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@data-driven-forms/pf3-component-mapper": "~1.18.0",
     "@data-driven-forms/react-form-renderer": "~1.18.0",
-    "@manageiq/react-ui-components": "~0.11.56",
+    "@manageiq/react-ui-components": "~0.11.57",
     "@manageiq/ui-components": "~1.3.3",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",


### PR DESCRIPTION
To be used with 
https://github.com/ManageIQ/react-ui-components/pull/162

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1683703

depends on: https://github.com/ManageIQ/react-ui-components/pull/162

![kebabLimit1-2019-12-11_10-31](https://user-images.githubusercontent.com/51095/70609107-8af3cd00-1c01-11ea-80ea-4cf8a5e8c107.png)
![kebabLimit2-2019-12-11_10-32](https://user-images.githubusercontent.com/51095/70609119-8fb88100-1c01-11ea-89b5-a88c77c4fdf0.png)
