### PR TITLE
Replace "action" class in Chargeback with "action-cell"

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -582,14 +582,14 @@ table.table.table-selectable tbody tr.selected td {
 
 /* Sets font icon styling for view buttons on Default Views screen */
 
-#tab_div ul.list-inline a {
-  color: #222222 !important;
+#tab_div ul.list-inline {
   font-size: 16px;
-}
-
-#tab_div ul.list-inline li.active {
-  color: $link-color !important;
-  font-size: 16px;
+  a {
+    color: #222222 !important;
+  }
+  li.active {
+    color: $link-color !important;
+  }
 }
 
 /* Action cell */
@@ -597,25 +597,20 @@ table.table.table-selectable tbody tr.selected td {
 .action-cell {
   position: relative;
   width: 100px;
-}
-
-.action-cell .btn {
-  border: none;
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+  .btn {
+    border: none;
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 }
 
 /// chargeback edit view
 
 tr.rdetail > td {
   white-space: nowrap;
-}
-
-td.action > .btn.btn-default {
-  width: 50px;
 }
 
 .cards-pf .nav-tabs > li.active > a,

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -57,7 +57,7 @@
           %td{:rowspan => num_tiers}
             = select_tag("per_unit_#{detail_index}", options_for_select(measure[:measures], detail[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
         = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => 0}
-        %td.action
+        %td.action-cell
           = button_tag(_("Add"), :class => "btn btn-default", :alt => t = _("Add a new tier"), :title => t,
                                  :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_add",
                                                                        :detail_index => detail_index,
@@ -66,7 +66,7 @@
         - tier = @edit[:new][:tiers][detail_index][tier_index]
         %tr.rdetail{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}
           = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => detail_index, :url => url, :row_within_rate => tier_index}
-          %td.action
+          %td.action-cell
             = button_tag(_("Delete"), :class => "btn btn-default", :alt => t = _("Remove the tier"), :title => t,
                                       :onclick => "miqAjaxButton('#{url_for_only_path(:action => "cb_tier_remove",
                                                                             :index => "#{detail_index}-#{tier_index}",

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -28,7 +28,7 @@
     %td{:rowspan => n.to_s}
       = select_tag("per_unit_#{i}", options_for_select(measure[:measures], r[:per_unit]), "data-miq_observe" => {:url => url}.to_json)
   = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => i.to_i, :url => url, :row_within_rate => 0}
-  %td.action
+  %td.action-cell
     = button_tag(_("Add"),
                  :class   => "btn btn-default",
                  :alt     => t = _("Add a new tier"),

--- a/app/views/chargeback/_tier_row.haml
+++ b/app/views/chargeback/_tier_row.haml
@@ -5,7 +5,7 @@
 
 %tr.rdetail.new_tier{:id => "rate_detail_row_#{i}_#{n - 1}"}
   = render :partial => 'cb_tier_edit_values', :locals => {:detail_index => i.to_i, :url => url, :row_within_rate => n - 1}
-  %td.action
+  %td.action-cell
     = button_tag(_("Delete"),
                  :class   => "btn btn-default",
                  :alt     => t = _("Remove the tier"),


### PR DESCRIPTION
This PR replaces the custom "action" class used for styling buttons inside table cells in Chargeback with the "action-cell" class used elsewhere in the UI. There's also some reorg of "action cell" and "list-inline" selectors.

Old
<img width="1381" alt="Screen Shot 2019-12-11 at 10 08 59 AM" src="https://user-images.githubusercontent.com/1287144/70633578-c6d96300-1bfe-11ea-8431-f0a0e8e02d26.png">

New
<img width="1381" alt="Screen Shot 2019-12-11 at 10 02 33 AM" src="https://user-images.githubusercontent.com/1287144/70633623-d658ac00-1bfe-11ea-8fff-9fb8f96579fd.png">

