### PR TITLE
Fixed code to pass in `service_template` in ae_attributes hash

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -190,6 +190,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       vm.customButtonModel.attribute_names,
       vm.customButtonModel.attribute_values);
     vm.customButtonModel.resource_action.ae_attributes.request = vm.customButtonModel.request;
+    vm.customButtonModel.resource_action.ae_attributes.service_template = vm.customButtonModel.uri_attributes.service_template;
 
     vm.customButtonModel.resource_action = {
       dialog_id: vm.customButtonModel.dialog_id,

--- a/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
+++ b/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
@@ -64,6 +64,7 @@ describe('main-custom-button-form', function() {
         .then( function() {
           expect(add_flash).toHaveBeenCalledWith("Name has already been taken", "error");
           expect(add_flash).toHaveBeenCalledWith("Description has already been taken", "error");
+          expect(vm.customButtonModel.resource_action.ae_attributes).toHaveAttr('service_template');
           done();
       })
         .catch(function () {


### PR DESCRIPTION
When creating a new GO Playbook custom button, code expects service_template to be included in the ae_attributes hash in order to save the value correctly inside uri_attributes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753338

@d-m-u cc

@ZitaNemeckova i am not sure if the spec test changes in this PR are correct, can you please review/help