### PR TITLE
Display Search box in Infra Networking page

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -265,7 +265,11 @@ class InfraNetworkingController < ApplicationController
 
     options = {:model => "Switch", :named_scope => :shareable}
     process_show_list(options) if @show_list
-    @right_cell_text = _("All Switches")
+    @right_cell_text = if @search_text
+                         _("All Switches (Names with \"%{search_text}\")") % {:search_text => @search_text}
+                       else
+                         _("All Switches")
+                       end
     options
   end
 

--- a/app/views/infra_networking/explorer.html.haml
+++ b/app/views/infra_networking/explorer.html.haml
@@ -11,3 +11,6 @@
   -# Showing a list of switches
   #main_div
     = render(:partial => 'layouts/x_gtl')
+  -# Show Search box
+  :javascript
+    #{javascript_show_if_exists("adv_searchbox_div")}

--- a/spec/controllers/infra_networking_controller_spec.rb
+++ b/spec/controllers/infra_networking_controller_spec.rb
@@ -68,6 +68,23 @@ describe InfraNetworkingController do
         expect(ApplicationHelper::Toolbar::InfraNetworkingCenter).to receive(:definition).and_call_original.at_least(:once)
         post :tree_select, :params => { :id => nodeid }
       end
+
+      context 'right cell text' do
+        let(:text) { 'switch' }
+
+        before do
+          allow(controller).to receive(:load_or_clear_adv_search)
+          allow(controller).to receive(:render)
+          controller.instance_variable_set(:@r, {})
+          controller.instance_variable_set(:@sb, :active_tree => :infra_networking_tree)
+          controller.params = {:search_text => text, :id => 'root'}
+        end
+
+        it 'updates title of the page according to the search text' do
+          controller.send(:tree_select)
+          expect(controller.instance_variable_get(:@right_cell_text)).to eq("All Switches (Names with \"#{text}\")")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6519

This PR fixes two issues in Infra Networking page regarding Search box:
- **displaying the Search box** when accessing the page for the first time:
div with id `adv_searchbox_div`, containing _Search_ box and button for _Advanced Search_, is [ usually not displayed](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_x_adv_searchbox.html.haml#L4) (see its style in the haml). I made the element displayed by [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/js_helper.rb#L37) method, through `javascript_show_if_exists` in the haml for [infra networking explorer](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:No_Searchbox_Infra_Networking?expand=1#diff-e80bb90efca3c5ad3b2e8a62562ba4bdR16).
- **displaying "(Names with ...)" in the title** of the page while searching for some Switch:
this is simply fixed by updating the `@right_cell_text` if `@search_text` is present 

**Note:**
In other pages where we want Search box to be displayed (and where it works, of course), the Search is displayed because visibility of [the div](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_x_adv_searchbox.html.haml#L4) is usually set by calling `rebuild_toolbars` method through `replace_right_cell`, see [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/infra_networking_controller.rb#L512).
Also in many pages, Adv Search is displayed together with the Search, so there is [the code](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_content.html.haml#L67) which checks if Advanced Search should be displayed and then makes the whole div to be displayed. I consider this logic not ideal because, however Advanced Search is never displayed without the Search, it is not true for the opposite claim, we have some pages where we want to display only Search. And both Search and Advanced search are, unfortunately, placed in the same div. So if `show_advanced_search?` returns `false`, there is no chance to display Search box only, without any extra code (for example calling `javascript_show_if_exists` in appropriate hamls or calling `rebuild_toolbars` or [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/storage/_storage_list.html.haml#L5)).

---

**Before:**
No Search box when first time in:
![switch_before1](https://user-images.githubusercontent.com/13417815/70716436-aab3ef80-1cec-11ea-8213-e60a8f5e9ba1.png)
Title not updated while using Search box:
![switch_before2](https://user-images.githubusercontent.com/13417815/70716440-adaee000-1cec-11ea-8c4c-f9bb548dff51.png)

**After:**
![switch_after1](https://user-images.githubusercontent.com/13417815/70716452-b1426700-1cec-11ea-84d8-5ee8c3adcf9e.png)
![switch_after2](https://user-images.githubusercontent.com/13417815/70716459-b4d5ee00-1cec-11ea-9db3-ae64578b74b0.png)


