### PR TITLE
Fixed right cell title to show missing info for Policy record.

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -276,6 +276,9 @@ module MiqPolicyController::Policies
 
     if x_active_tree == :policy_tree
       @policy_profiles = @policy.memberof.sort_by { |pp| pp.description.downcase }
+    elsif x_active_tree == :policy_profile_tree
+      @sb[:mode] = @policy.mode
+      @sb[:nodeid] = @policy.towhat
     end
   end
 end


### PR DESCRIPTION
When clicking on a Policy node in Policy Profiles accordion, right cell title was not displaying the model and mode of Policy in the title similar to how it is displayed in the tree node on the left.

Fixes #3114

before
![before](https://user-images.githubusercontent.com/3450808/70731380-995ee900-1cd4-11ea-976a-085c6af5c797.png)

after
![after1](https://user-images.githubusercontent.com/3450808/70731167-408f5080-1cd4-11ea-8efd-be85521d795f.png)
