### PR TITLE
Display Cancel after applying changes in non-explorer Compare screen

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -420,7 +420,7 @@ module ApplicationController::Compare
   # AJAX driven routine to check for changes in ANY field on the form
   def sections_field_changed
     @keep_compare = true
-    @explorer = %w[VMs Templates].include?(session[:db_title])
+    @explorer = %w[VMs Templates].include?(session[:db_title]) && @display.nil?
     if params[:check] == "drift"
       section_checked(:drift)
     elsif params[:check] == "compare_miq"

--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -166,6 +166,34 @@ describe EmsClusterController do
       controller.send(:sections_field_changed)
       expect(session[:selected_sections]).to eq(["_model_", "hardware"])
     end
+
+    context 'changes in Comparison Sections' do
+      before do
+        allow(controller).to receive(:render)
+        allow(controller).to receive(:session).and_return(:db_title => 'VMs')
+        controller.instance_variable_set(:@display, 'instances')
+        controller.params = {:check => 'true'}
+      end
+
+      it 'sets @explorer to false' do
+        controller.send(:sections_field_changed)
+        expect(controller.instance_variable_get(:@explorer)).to be(false)
+      end
+
+      it 'calls set_checked_sections according to the params' do
+        expect(controller).to receive(:set_checked_sections)
+        controller.send(:sections_field_changed)
+      end
+
+      context 'explorer screen' do
+        before { controller.instance_variable_set(:@display, nil) }
+
+        it 'sets @explorer to true' do
+          controller.send(:sections_field_changed)
+          expect(controller.instance_variable_get(:@explorer)).to be(true)
+        end
+      end
+    end
   end
 
   context 'drifts' do


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6481

_Cancel_ button "disappeared" after applying changes in _Comparison Sections_ while comparing selected items displayed in a non-explorer screen. This happened because `@explorer` was accidentaly set to `true`.

The problem was that `%w[VMs Templates].include?(session[:db_title])` condition in `sections_field_changed` was simply not enough to set `@explorer` variable properly. The condition did not care about if we are in a nested list of VMs/Templates. And if we are, usually `@display` is set to `'vms'` or `'instances'`, so I used this variable for setting `@explorer` properly while making/applying changes in  in _Comparison Sections_. And we need `@explorer` to be set properly because of [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/layouts/_compare.html.haml#L31).

---

**Before:**
![sections_before](https://user-images.githubusercontent.com/13417815/70733147-0640a600-1d0a-11ea-98b4-d2f78d575af1.png)

**After:**
![sections_after](https://user-images.githubusercontent.com/13417815/70733153-09d42d00-1d0a-11ea-8c0d-ec6ad3476296.png)

