### PR TITLE
 Limit metric rollups to just default time profile

### DIFF
--- a/app/services/ems_infra_dashboard_service.rb
+++ b/app/services/ems_infra_dashboard_service.rb
@@ -129,7 +129,7 @@ class EmsInfraDashboardService < EmsDashboardService
     tp = TimeProfile.profile_for_user_tz(current_user.id, current_user.get_timezone) || TimeProfile.default_time_profile
 
     @daily_metrics ||= begin
-      metric_rollup_scope = Metric::Helper.find_for_interval_name('daily', tp)
+      metric_rollup_scope = MetricRollup.where(:capture_interval_name => 'daily', :time_profile => tp)
       metric_rollup_scope = metric_rollup_scope.where(:resource => (@ems || ManageIQ::Providers::InfraManager.all))
       metric_rollup_scope.where('timestamp > ?', 30.days.ago.utc).order('timestamp')
     end

--- a/app/services/ems_infra_dashboard_service.rb
+++ b/app/services/ems_infra_dashboard_service.rb
@@ -128,9 +128,11 @@ class EmsInfraDashboardService < EmsDashboardService
     current_user = @controller.current_user
     tp = TimeProfile.profile_for_user_tz(current_user.id, current_user.get_timezone) || TimeProfile.default_time_profile
 
-    @daily_metrics ||= Metric::Helper.find_for_interval_name('daily', tp)
-                                     .where(:resource => (@ems || ManageIQ::Providers::InfraManager.all))
-                                     .where('timestamp > ?', 30.days.ago.utc).order('timestamp')
+    @daily_metrics ||= begin
+      metric_rollup_scope = Metric::Helper.find_for_interval_name('daily', tp)
+      metric_rollup_scope = metric_rollup_scope.where(:resource => (@ems || ManageIQ::Providers::InfraManager.all))
+      metric_rollup_scope.where('timestamp > ?', 30.days.ago.utc).order('timestamp')
+    end
   end
 
   def openstack?

--- a/app/services/ems_infra_dashboard_service.rb
+++ b/app/services/ems_infra_dashboard_service.rb
@@ -130,7 +130,7 @@ class EmsInfraDashboardService < EmsDashboardService
 
     @daily_metrics ||= begin
       metric_rollup_scope = MetricRollup.where(:capture_interval_name => 'daily', :time_profile => tp)
-      metric_rollup_scope = metric_rollup_scope.where(:resource => (@ems || ManageIQ::Providers::InfraManager.all))
+      metric_rollup_scope = metric_rollup_scope.where(:resource => @ems)
       metric_rollup_scope.where('timestamp > ?', 30.days.ago.utc).order('timestamp')
     end
   end

--- a/spec/services/ems_infra_dashboard_service_spec.rb
+++ b/spec/services/ems_infra_dashboard_service_spec.rb
@@ -25,5 +25,33 @@ describe EmsInfraDashboardService do
       expect(subject.recent_hosts_data[:recentResources][:xData].count).to eq(2)
       expect(subject.recent_hosts_data[:recentResources][:yData].count).to eq(2)
     end
+
+    describe "#ems_utilization" do
+      let(:user_admin)         { FactoryBot.create(:user_admin) }
+      let(:rollup_timestamp)   { Time.zone.parse("2016-01-12T00:00:00.00000000") }
+      let(:time_profile)       { FactoryBot.create(:time_profile_utc) }
+      let(:other_region)       { FactoryBot.create(:miq_region) }
+      let(:other_time_profile) { FactoryBot.create(:time_profile_utc, :in_other_region, :other_region => other_region) }
+
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        User.current_user = user_admin
+        Timecop.travel(rollup_timestamp)
+        MiqRegion.seed
+        FactoryGirl.create(:metric_rollup, :resource => @ems1, :capture_interval_name => 'daily', :derived_memory_used => 2.kilobytes, :timestamp => rollup_timestamp, :time_profile => time_profile)
+        FactoryGirl.create(:metric_rollup, :resource => @ems1, :capture_interval_name => 'daily', :derived_memory_used => 2.kilobytes, :timestamp => rollup_timestamp, :time_profile => other_time_profile)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      subject { EmsInfraDashboardService.new(@ems1.id, User, EmsInfra) }
+
+      it "skips duplicate metric rollups for calculation" do
+        utilization_data = subject.ems_utilization
+        expect(utilization_data[:memory][:used]).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Affected values are in circle.

before
<img width="977" alt="Screenshot 2019-12-13 at 11 24 27" src="https://user-images.githubusercontent.com/14937244/70793442-9975ec00-1d9b-11ea-8ac2-9c31f44e98b4.png">

after
<img width="996" alt="Screenshot 2019-12-13 at 11 22 41" src="https://user-images.githubusercontent.com/14937244/70793444-9bd84600-1d9b-11ea-9752-ccfba5c55256.png">


@miq-bot add_label ui

@miq-bot assign @mzazrivec 


# Link
https://bugzilla.redhat.com/show_bug.cgi?id=1776684

