### PR TITLE
Toolbars: remove unused variable.

### DIFF
--- a/app/helpers/application_helper/toolbar/compare_center.rb
+++ b/app/helpers/application_helper/toolbar/compare_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_all",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=all"),
+      :url_parms => "?compare_task=all"),
     twostate(
       :compare_diff,
       'ff ff-compare-different fa-lg',
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_differences",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=different"),
+      :url_parms => "?compare_task=different"),
     twostate(
       :compare_same,
       'ff ff-compare-same fa-lg',
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_same",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=same"),
+      :url_parms => "?compare_task=same"),
   ])
   button_group('compare_mode', [
     twostate(

--- a/app/helpers/application_helper/toolbar/drift_center.rb
+++ b/app/helpers/application_helper/toolbar/drift_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_all",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=all&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => "?compare_task=all&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
     twostate(
       :drift_diff,
       'ff ff-compare-different fa-lg',
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_differences",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=different&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => "?compare_task=different&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
     twostate(
       :drift_same,
       'ff ff-compare-same fa-lg',
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_same",
-      :url_parms => "?id=\#{$vms_comp}&compare_task=same&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => "?compare_task=same&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
   ])
   button_group('compare_mode', [
     twostate(


### PR DESCRIPTION
The variable is being `eval`ed and it does not exist.

 * Get rid of the unnecessary variable
 * Limit the need for `eval` as required in https://github.com/ManageIQ/manageiq-ui-classic/issues/2049