### PR TITLE
Refactor FloatingIpController and its specs

### DIFF
--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -25,8 +25,6 @@ class FloatingIpController < ApplicationController
     @refresh_div = "main_div"
 
     case params[:pressed]
-    when "floating_ip_tag"
-      tag("FloatingIp")
     when 'floating_ip_delete'
       delete_floating_ips
     when "floating_ip_edit"
@@ -34,11 +32,7 @@ class FloatingIpController < ApplicationController
     when "floating_ip_new"
       javascript_redirect(:action => "new")
     else
-      if !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      super
     end
   end
 


### PR DESCRIPTION
Regarding my recent changes in [_CloudSubnetController_](https://github.com/ManageIQ/manageiq-ui-classic/pull/6488) and some more controllers, I've decided to make small changes also in _FloatingIpController_ and its specs.

In this PR, I'm also adding new tests regarding `button` method, for example for proper calling `tag` method while tagging selected Floating IP or for redirecting to `new` or `edit` methods while adding/editing a Floating IP.

And with `super` we end up in the `button` method in [_GenericButtonMixin_](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/generic_button_mixin.rb#L43).

**How to test:**
Go to _Networks > Floating IPs_ and check if all the actions from the toolbar work.