### PR TITLE
Report results: fix export to PDF.

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -230,8 +230,7 @@ module ApplicationController::Compare
   # Send the current compare data in PDF format
   def compare_to_pdf
     @compare = Marshal.load(session[:miq_compare])
-    rpt = create_compare_report
-    render_pdf(rpt)
+    render_pdf_internal(create_compare_report)
   end
 
   # Cancel Compare and return to the previous screen; for non-explorer screens
@@ -516,8 +515,7 @@ module ApplicationController::Compare
   # Send the current drift data in PDF format
   def drift_to_pdf
     @compare = Marshal.load(session[:miq_compare])
-    rpt = create_drift_report
-    render_pdf(rpt)
+    render_pdf_internal(create_drift_report)
   end
 
   def drift_history

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -34,10 +34,10 @@ module ApplicationController::ReportDownloads
     result ||= MiqReportResult.for_user(current_user).find(session[:report_result_id]) if session[:report_result_id]
 
     # This branch is used when called from e.g. compare_to_pdf
-    result ||= (
-      userid = "#{session[:userid]}|#{request.session_options[:id]}|adhoc"
-      report.build_create_results(:userid => userid)
-    )
+    result ||= begin
+                 userid = "#{session[:userid]}|#{request.session_options[:id]}|adhoc"
+                 report.build_create_results(:userid => userid)
+               end
 
     render_pdf_internal_rr(report, result)
   end
@@ -185,8 +185,7 @@ module ApplicationController::ReportDownloads
 
   def rrr_from_report_results(report_result_id)
     rr = MiqReportResult.for_user(current_user).find(report_result_id)
-    report = rr.report_results # TODO: this is strange
-    report.report_run_time = rr.last_run_on # TODO: is this line needed?
+    report = rr.report_results
     [report, rr]
   end
 

--- a/app/helpers/optimize_helper.rb
+++ b/app/helpers/optimize_helper.rb
@@ -27,14 +27,9 @@ module OptimizeHelper
 
   def download_file(typ, report, filename)
     case typ
-    when "txt"
-      send_data(report.to_text,
-                :filename => "#{filename}.txt")
-    when "csv"
-      send_data(report.to_csv,
-                :filename => "#{filename}.csv")
-    when "pdf"
-      render_pdf(report)
+    when 'txt' then send_data(report.to_text, :filename => "#{filename}.txt")
+    when 'csv' then send_data(report.to_csv, :filename => "#{filename}.csv")
+    when 'pdf' then render_pdf_internal(report)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2748,6 +2748,7 @@ Rails.application.routes.draw do
         report_only
         sample_chart
         sample_timeline
+        print_report
         send_report_data
         tree_autoload
         tree_select

--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -47,11 +47,11 @@ describe ApplicationController do
           :include => {
             :hardware            => {:fetch => false, :fetched => false, :checked => false, :group => "Properties"},
             :_model_             => {:fetch => true,  :fetched => false, :checked => true,  :group => "Properties"},
-            :"hardware.disks"    => {:fetch => false, :fetched => false, :checked => false, :key   => "", :group   => "Properties"},
-            :"hardware.cdroms"   => {:fetch => false, :fetched => false, :checked => false, :key   => "", :group   => "Properties"},
-            :"hardware.floppies" => {:fetch => false, :fetched => false, :checked => false, :key   => "", :group   => "Properties"},
-            :"hardware.nics"     => {:fetch => false, :fetched => false, :checked => false, :key   => "", :group   => "Properties"},
-            :"hardware.volumes"  => {:fetch => false, :fetched => false, :checked => false, :key   => :name, :group   => "Properties"}
+            :"hardware.disks"    => {:fetch => false, :fetched => false, :checked => false, :key => "", :group => "Properties"},
+            :"hardware.cdroms"   => {:fetch => false, :fetched => false, :checked => false, :key => "", :group => "Properties"},
+            :"hardware.floppies" => {:fetch => false, :fetched => false, :checked => false, :key => "", :group => "Properties"},
+            :"hardware.nics"     => {:fetch => false, :fetched => false, :checked => false, :key => "", :group => "Properties"},
+            :"hardware.volumes"  => {:fetch => false, :fetched => false, :checked => false, :key => :name, :group => "Properties"}
           }
         }
       )
@@ -59,7 +59,7 @@ describe ApplicationController do
 
     it 'builds the compare report and renders it' do
       session[:miq_compare] = Marshal.dump(compare)
-      controller.instance_variable_set(:@sb, {:compare_db => 'Vm'})
+      controller.instance_variable_set(:@sb, :compare_db => 'Vm')
 
       expect(controller).to receive(:create_compare_report).and_call_original
       expect(controller).to receive(:render_pdf_internal).and_call_original
@@ -81,7 +81,7 @@ describe ApplicationController do
       user = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
       report = create_and_generate_report_for_user("Vendor and Guest OS", user)
 
-      session[:view] = report #FactoryBot.create(:miq_report, :col_order => [])
+      session[:view] = report
       session[:paged_view_search_options] = {}
       controller.params = {:download_type => 'pdf'}
 
@@ -91,7 +91,7 @@ describe ApplicationController do
           :layout   => '/layouts/print',
           :locals   => hash_including(
             :report # the report does not match due to a ".dup" call in the controller.
-          ),
+          )
         )
       )
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -529,7 +529,6 @@ describe DashboardController do
     end
   end
 
-
   describe "widget_to_pdf" do
     before do
       EvmSpecHelper.local_miq_server
@@ -545,12 +544,11 @@ describe DashboardController do
         .with(report, report.miq_report_results.first)
         .and_call_original
 
-      get :widget_to_pdf, :params => { :rr_id => report_result_id }
+      get :widget_to_pdf, :params => {:rr_id => report_result_id}
 
       expect(response).to render_template('layouts/print/report')
     end
   end
-
 
   def skip_data_checks(url = '/')
     allow_any_instance_of(UserValidationService).to receive(:server_ready?).and_return(true)

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'helpers/report_helper_spec'
+
 describe DashboardController do
   context "POST authenticate" do
     before { EvmSpecHelper.create_guid_miq_server_zone }
@@ -526,6 +528,29 @@ describe DashboardController do
       end
     end
   end
+
+
+  describe "widget_to_pdf" do
+    before do
+      EvmSpecHelper.local_miq_server
+      stub_user(:features => :all)
+    end
+
+    it "renders the print layout" do
+      user = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      report = create_and_generate_report_for_user("Vendor and Guest OS", user)
+      report_result_id = report.miq_report_results.first.id
+
+      expect(controller).to receive(:report_print_options)
+        .with(report, report.miq_report_results.first)
+        .and_call_original
+
+      get :widget_to_pdf, :params => { :rr_id => report_result_id }
+
+      expect(response).to render_template('layouts/print/report')
+    end
+  end
+
 
   def skip_data_checks(url = '/')
     allow_any_instance_of(UserValidationService).to receive(:server_ready?).and_return(true)

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1180,7 +1180,8 @@ describe ReportController do
       allow(User).to receive(:server_timezone).and_return("UTC")
       sb[:rep_tree_build_time] = Time.now.utc
       MiqWidgetSet.seed
-      @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
+      user2 = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      @rpt = create_and_generate_report_for_user("Vendor and Guest OS", user2)
 
       expect(controller).to receive(:reload_trees_by_presenter).with(
         instance_of(ExplorerPresenter),
@@ -1261,7 +1262,7 @@ describe ReportController do
         role = MiqUserRole.find_by(:name => "EvmRole-operator")
 
         # User1 with 2 groups(Group1,Group2), current group for User2 is Group2
-        create_user_with_group('User2', "Group1", role)
+        @user2 = create_user_with_group('User2', "Group1", role)
 
         @user1 = create_user_with_group('User1', "Group2", role)
         @user1.miq_groups << MiqGroup.where(:description => "Group1")
@@ -1272,7 +1273,7 @@ describe ReportController do
         before do
           os = OperatingSystem.create(:name => "RHEL 7", :product_name => "RHEL7")
           FactoryBot.create(:vm_vmware, :operating_system => os)
-          @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User2")
+          @rpt = create_and_generate_report_for_user("Vendor and Guest OS", @user2)
         end
 
         pending "is allowed to see report created under Group1 for User 1(with current group Group2)" do
@@ -1508,6 +1509,44 @@ describe ReportController do
       context 'a number' do
         let(:param) { "1234" }
         it { is_expected.to be_falsey }
+      end
+    end
+  end
+
+  context 'displaying reports' do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      allow(controller).to receive(:server_timezone).and_return('UTC')
+      @user2 = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+    end
+
+    describe "#print_report" do
+      render_views
+
+      let(:report_result_id) do
+        report = create_and_generate_report_for_user("Vendor and Guest OS", @user2)
+        report.miq_report_results.first.id
+      end
+
+      it 'renders the print layout' do
+        get :print_report, params: { :id => report_result_id }
+        expect(response).to render_template('layouts/print/report')
+      end
+    end
+
+    describe "report_print_options" do
+
+      it 'returns the print options' do
+        report = create_and_generate_report_for_user("Vendor and Guest OS", @user2)
+        result = report.miq_report_results.first
+
+        expect(controller.send(:report_print_options, report, result)).to match(
+          :page_layout => 'landscape',
+          :page_size   => report.page_size || 'a4',
+          :run_date    => format_timezone(result.last_run_on, result.user_timezone, "gtl"),
+          :title       => result.name
+        )
       end
     end
   end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1530,13 +1530,12 @@ describe ReportController do
       end
 
       it 'renders the print layout' do
-        get :print_report, params: { :id => report_result_id }
+        get :print_report, :params => {:id => report_result_id}
         expect(response).to render_template('layouts/print/report')
       end
     end
 
     describe "report_print_options" do
-
       it 'returns the print options' do
         report = create_and_generate_report_for_user("Vendor and Guest OS", @user2)
         result = report.miq_report_results.first

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -42,4 +42,24 @@ describe UtilizationController do
       expect(controller.data_for_breadcrumbs).to eq([{:title=>"Overview"}, {:title=>"Utilization"}])
     end
   end
+
+  describe "report_download" do
+    before do
+      stub_user(:features => :all)
+      setup_zone
+    end
+
+    it "generates the HTML report for PDF export" do
+      session[:sandboxes] = { controller.controller_name => { :title => 'test report' } }
+      expect(controller).to receive(:summ_hashes).and_return([
+        { "section" => _("Basic Info"), "item" => "neco",   "value" => "1" },
+        { "section" => _("CPU"),        "item" => "jinyho", "value" => "1" },
+        { "section" => _("Memory"),     "item" => "tady",   "value" => "2" },
+        { "section" => _("Disk"),       "item" => "bude",   "value" => "3" },
+      ])
+
+      get :report_download, :params => { :typ => 'pdf' }
+      expect(response.status).to eq(200)
+    end
+  end
 end

--- a/spec/controllers/utilization_controller_spec.rb
+++ b/spec/controllers/utilization_controller_spec.rb
@@ -50,15 +50,17 @@ describe UtilizationController do
     end
 
     it "generates the HTML report for PDF export" do
-      session[:sandboxes] = { controller.controller_name => { :title => 'test report' } }
-      expect(controller).to receive(:summ_hashes).and_return([
-        { "section" => _("Basic Info"), "item" => "neco",   "value" => "1" },
-        { "section" => _("CPU"),        "item" => "jinyho", "value" => "1" },
-        { "section" => _("Memory"),     "item" => "tady",   "value" => "2" },
-        { "section" => _("Disk"),       "item" => "bude",   "value" => "3" },
-      ])
+      session[:sandboxes] = {controller.controller_name => {:title => 'test report'}}
+      expect(controller).to receive(:summ_hashes).and_return(
+        [
+          {"section" => _("Basic Info"), "item" => "neco",   "value" => "1"},
+          {"section" => _("CPU"),        "item" => "jinyho", "value" => "1"},
+          {"section" => _("Memory"),     "item" => "tady",   "value" => "2"},
+          {"section" => _("Disk"),       "item" => "bude",   "value" => "3"},
+        ]
+      )
 
-      get :report_download, :params => { :typ => 'pdf' }
+      get :report_download, :params => {:typ => 'pdf'}
       expect(response.status).to eq(200)
     end
   end

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -3,11 +3,11 @@ def create_user_with_group(user_id, group_name, role)
   FactoryBot.create(:user, :userid => user_id, :miq_groups => [group])
 end
 
-def create_and_generate_report_for_user(report_name, user_id)
+def create_and_generate_report_for_user(report_name, user)
   MiqReport.seed_report(report_name)
   @rpt = MiqReport.where(:name => report_name).last
-  @rpt.generate_table(:userid => user_id)
-  report_result = @rpt.build_create_results(:userid => user_id)
+  @rpt.generate_table(:userid => user.userid)
+  report_result = @rpt.build_create_results(:userid => user.userid, :miq_group_id => user.current_group.id)
   report_result.reload
   @rpt
 end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -17,7 +17,7 @@ describe TreeBuilderReportSavedReports do
         @user2.miq_groups << MiqGroup.where(:description => "Group1")
 
         login_as @user2
-        @rpt = create_and_generate_report_for_user("Vendor and Guest OS", "User1")
+        @rpt = create_and_generate_report_for_user("Vendor and Guest OS", @user1)
       end
 
       describe "#x_get_tree_roots" do


### PR DESCRIPTION
* when generating the PDF, use existing report resuts

that means separating the TXT/CSV branches from the PDF one

* extract method `report_print_options`

Fixes problem introduced (or surfaced) in:
https://github.com/ManageIQ/manageiq-ui-classic/pull/6367 reported here: https://github.com/ManageIQ/manageiq-ui-classic/issues/6493

When PDF was requested a task was fired to generate a new report result of type 'pdf'. However then the PDF generation is done via browser from HTML markup. For that the newly generated report results where useless so the previous ones where used prior to my change. So the new report result generation was unnecessary and the results where thrown away.

Important change:
 * Newly the existing HTML is used, 
 * no task is executed, no waiting.
 * trying to separate paths where ReportResult is present vs where one needs to be calculated.
 * adding test coverage

### Covered areas
 * export/print widged
 * export/print compare report
 * export/print from GTL
 * export from Utilization report

### TODO:

  * ~~Utilization Trend Summary PDF report (test & write a spec)~~
  * TODOs
  * other call paths?
  * rbac feature?
