### PR TITLE
Prevent rendering User to Look Up form field twice and with same id

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -131,66 +131,44 @@
               = text_field_tag("user",
                                @edit[:new][:user],
                                :maxlength         => 255,
-                               :class => "form-control",
-                               "data-miq_observe" => {:interval => '.5',
-                                                      :url      => url}.to_json)
-            .col-md-12{:align => "right", :valign => "bottom"}
-              = link_to("Retrieve",
-                        {:action => "rbac_group_user_lookup",
-                         :button => "submit",
-                         :id     => @edit[:group_id] || "new"},
-                        :class                 => "btn btn-primary",
-                        :alt                   => t = _("LDAP Group Lookup"),
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :remote                => true,
-                        "data-method"          => :post,
-                        :title                 => t)
-
-          .form-group#user_id_form_group
-            %label.col-md-2.control-label
-              = _("User to Look Up")
-            .col-md-8
-              = text_field_tag("user",
-                               @edit[:new][:user],
-                               :maxlength         => 255,
                                :class             => "form-control",
                                "data-miq_observe" => {:interval => '.5',
                                                       :url      => url}.to_json)
 
-          .form-group#user_name_form_group
-            %label.col-md-2.control-label
-              = _("Username")
-            .col-md-8
-              = text_field_tag("user_id",
-                               @edit[:new][:user_id],
-                               :maxlength         => 255,
-                               :class             => "form-control",
-                               "data-miq_observe" => {:interval => '.5',
-                                                      :url      => url}.to_json)
+          - unless mode == "httpd"
+            .form-group#user_name_form_group
+              %label.col-md-2.control-label
+                = _("Username")
+              .col-md-8
+                = text_field_tag("user_id",
+                                 @edit[:new][:user_id],
+                                 :maxlength         => 255,
+                                 :class             => "form-control",
+                                 "data-miq_observe" => {:interval => '.5',
+                                                        :url      => url}.to_json)
 
-          .form-group#user_password_form_group
-            %label.col-md-2.control-label
-              = _("Password")
-            .col-md-8
-              = password_field_tag("password",
-                                   @edit[:new][:password],
-                                   :maxlength         => 50,
-                                   :class => "form-control",
-                                   "data-miq_observe" => {:interval => '.5',
-                                                          :url      => url}.to_json)
-            .col-md-12{:align => "right", :valign => "bottom"}
-              = link_to("Retrieve",
-                        {:action => "rbac_group_user_lookup",
-                         :button => "submit",
-                         :id     => @edit[:group_id] || "new"},
-                        :class                 => "btn btn-primary",
-                        :alt                   => t = _("LDAP Group Lookup"),
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        :remote                => true,
-                        "data-method"          => :post,
-                        :title                 => t)
+            .form-group#user_password_form_group
+              %label.col-md-2.control-label
+                = _("Password")
+              .col-md-8
+                = password_field_tag("password",
+                                     @edit[:new][:password],
+                                     :maxlength         => 50,
+                                     :class => "form-control",
+                                     "data-miq_observe" => {:interval => '.5',
+                                                            :url      => url}.to_json)
+          .col-md-12{:align => "right", :valign => "bottom"}
+            = link_to("Retrieve",
+                      {:action => "rbac_group_user_lookup",
+                       :button => "submit",
+                       :id     => @edit[:group_id] || "new"},
+                      :class                 => "btn btn-primary",
+                      :alt                   => t = _("LDAP Group Lookup"),
+                      "data-miq_sparkle_on"  => true,
+                      "data-miq_sparkle_off" => true,
+                      :remote                => true,
+                      "data-method"          => :post,
+                      :title                 => t)
 
   %hr
   %h3
@@ -219,16 +197,3 @@
 
 :javascript
   miq_tabs_init('#rbac_group_tabs');
-
-- if @edit
-  %script{:type => "text/javascript"}
-    - if ::Settings.authentication.mode == "httpd"
-      $('#user_id_ext_auth_form_group').show();
-      $('#user_id_form_group').hide();
-      $('#user_name_form_group').hide();
-      $('#user_password_form_group').hide();
-    - else
-      $('#user_id_ext_auth_form_group').hide();
-      $('#user_id_form_group').show();
-      $('#user_name_form_group').show();
-      $('#user_password_form_group').show();


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/2316

This PR solves the specific situation in LDAP user lookup form: **DOM ID** `"user"` was there **twice**. This was caused by https://github.com/ManageIQ/manageiq/pull/4042. The exactly [same field with the same id](https://github.com/ManageIQ/manageiq/pull/4042/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR116), that was [already there](https://github.com/ManageIQ/manageiq/pull/4042/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR138), was added in the haml, together with the [javascript for showing/hiding](https://github.com/ManageIQ/manageiq/pull/4042/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR241) the divs with the appropriate fields. This (not the best) solution was implemented for displaying/hiding [_Retrieve_](https://github.com/ManageIQ/manageiq/pull/4042/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR123) button next to the field.

Later, thanks to some cleanup in that area, this issue became obvious: the same field was rendered twice in the screen, all the divs were shown because the javascript was not executed - and this because `@edit` was `nil` - this all thanks to [this](https://github.com/ManageIQ/manageiq-ui-classic/pull/68/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR189) change.

**This PR cares about:**
- removing unnecessary extra field from the appropriate haml
- adding a simple condition for displaying _Retrieve_ button `if mode == "httpd"`
Note that `mode` is already set [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Broken_LDAP_user_lookup_form_ID_user_twice?expand=1#diff-dbe0fddf5aa74616c8f3f2f52c376abaL4), no need to use the whole condition as [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Broken_LDAP_user_lookup_form_ID_user_twice?expand=1#diff-dbe0fddf5aa74616c8f3f2f52c376abaL225).
- adding another similar condition for displaying Username and Password fields: `unless mode == "httpd"` because of [this](https://github.com/ManageIQ/manageiq/pull/4042/files#diff-dbe0fddf5aa74616c8f3f2f52c376abaR245-R246)
- removing the unnecessary javascript from the haml
- removing extra _Retrieve_ button as, according to the existing logic in the haml, _Retrieve_ button will always be there

Note:
Adding `- if @edit` to the haml (added in the haml during the later cleanup) is not necessary because it's already there [in the right place](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/ops/_rbac_group_details.html.haml#L121).
 