### PR TITLE
Remove useless toolbar button for Container Build scan (SSA)

### DIFF
--- a/app/helpers/application_helper/toolbar/container_build_center.rb
+++ b/app/helpers/application_helper/toolbar/container_build_center.rb
@@ -1,20 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerBuildCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_build_vmdb', [
-    select(
-      :container_build_vmdb_choice,
-      nil,
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_build_scan,
-          'fa fa-search fa-lg',
-          N_('Perform SmartState Analysis on this item'),
-          N_('Perform SmartState Analysis'),
-          :confirm => N_("Perform SmartState Analysis on this item?")),
-      ]
-    ),
-  ])
   button_group('container_build_policy', [
     select(
       :container_build_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_builds_center.rb
+++ b/app/helpers/application_helper/toolbar/container_builds_center.rb
@@ -1,24 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerBuildsCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_build_vmdb', [
-    select(
-      :container_build_vmdb_choice,
-      nil,
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_build_scan,
-          'fa fa-search fa-lg',
-          N_('Perform SmartState Analysis on the selected items'),
-          N_('Perform SmartState Analysis'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled      => false,
-          :onwhen       => "1+"),
-      ]
-    ),
-  ])
   button_group('container_build_policy', [
     select(
       :container_build_policy_choice,


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6300

In this PR, I am removing toolbar button for _SmartState Analysis_ of _Container Builds_ because it does not make sense, it never worked ("A successful build generates a new image, that could be scanned of course").

**Before:**
List view:
![cbuild_before1](https://user-images.githubusercontent.com/13417815/71190956-c9cef600-2285-11ea-84c9-f77ccafd4103.png)
Textual summary screen:
![cbuild_before2](https://user-images.githubusercontent.com/13417815/71190962-cc315000-2285-11ea-815d-36b67a8bdd10.png)

**After:**
![cbuild_after1](https://user-images.githubusercontent.com/13417815/71190971-ce93aa00-2285-11ea-8fd1-623822d7fed2.png)
![cbuild_after2](https://user-images.githubusercontent.com/13417815/71190975-d05d6d80-2285-11ea-880d-9b647106b58f.png)


