### PR TITLE
Native viewer

### DIFF
--- a/app/helpers/application_helper/button/vm_native_console.rb
+++ b/app/helpers/application_helper/button/vm_native_console.rb
@@ -1,0 +1,16 @@
+class ApplicationHelper::Button::VmNativeConsole < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.vendor == 'redhat'
+  end
+
+  def disabled?
+    begin
+      @record.validate_native_console_support
+    rescue MiqException::RemoteConsoleNotSupportedError => err
+      @error_message = _('VM Native Console error: %{error}') % {:error => err}
+    end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -269,7 +269,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('VM Console'),
           :keepSpinner => true,
           :url         => "html5_console",
-          :klass       => ApplicationHelper::Button::VmHtml5Console),
+          :klass       => ApplicationHelper::Button::VmHtml5Console
+        ),
         button(
           :vm_vmrc_console,
           'pficon pficon-screen fa-lg',
@@ -278,7 +279,17 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :keepSpinner => true,
           :url         => "vmrc_console",
           :confirm     => N_("Opening a VMRC console requires that VMRC is installed and pre-configured to work in your browser. Are you sure?"),
-          :klass   => ApplicationHelper::Button::VmVmrcConsole),
+          :klass       => ApplicationHelper::Button::VmVmrcConsole
+        ),
+        button(
+          :vm_native_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a native console for this VM'),
+          N_('Native Console'),
+          :keepSpinner => true,
+          :url         => "native_console",
+          :klass       => ApplicationHelper::Button::VmNativeConsole
+        ),
         button(
           :cockpit_console,
           'pficon pficon-screen fa-lg',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3127,6 +3127,7 @@ Rails.application.routes.draw do
         right_size_print
         launch_html5_console
         launch_vmrc_console
+        launch_native_console
         perf_chart_chooser
         policies
         protect
@@ -3188,6 +3189,7 @@ Rails.application.routes.draw do
         vm_pre_prov
         vm_vdi
         html5_console
+        native_console
         wait_for_task
         win32_services
         ownership_update
@@ -3215,6 +3217,7 @@ Rails.application.routes.draw do
         explorer
         launch_html5_console
         launch_vmrc_console
+        launch_native_console
         retirement_info
         reconfigure_form_fields
         policies
@@ -3286,6 +3289,7 @@ Rails.application.routes.draw do
         vm_pre_prov
         vmrc_console
         html5_console
+        native_console
         wait_for_task
         win32_services
         x_button

--- a/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
@@ -1,0 +1,34 @@
+describe ApplicationHelper::Button::VmNativeConsole do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:record) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#calculate_properties' do
+    before(:each) do
+      remote_console_validation
+      button.calculate_properties
+    end
+
+    context 'and remote control is supported' do
+      let(:remote_console_validation) do
+        allow(record).to receive(:validate_native_console_support).and_return(true)
+      end
+      it_behaves_like 'an enabled button'
+    end
+    context 'and remote control is not supported' do
+      let(:err_msg) { 'Remote console is not supported' }
+      let(:remote_console_validation) do
+        allow(record).to receive(:validate_native_console_support)
+          .and_raise(MiqException::RemoteConsoleNotSupportedError, err_msg)
+      end
+      it_behaves_like 'a disabled button', "VM Native Console error: Remote console is not supported"
+    end
+  end
+end


### PR DESCRIPTION
Show native viewer button for redhat providers and allow
connection file to be downloaded after requiring it via task

related to BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1451594

Depends on:
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/452
* https://github.com/ManageIQ/manageiq/pull/19675 