### PR TITLE
Display name of Container Pod instead of HTML in Container Build's Textual summary

### DIFF
--- a/app/helpers/container_build_helper/textual_summary.rb
+++ b/app/helpers/container_build_helper/textual_summary.rb
@@ -83,10 +83,10 @@ module ContainerBuildHelper::TextualSummary
 
   def link_to_pod(container_group)
     if container_group
-      link_to(container_group.name,
-              :action     => 'show',
-              :controller => 'container_group',
-              :id         => container_group.id)
+      {:value => container_group.name,
+       :link  => url_for_only_path(:action     => 'show',
+                                   :controller => 'container_group',
+                                   :id         => container_group.id)}
     else
       _("No Pod")
     end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6572

There was HTML code in the _Build Instances_ table in textual summary of selected _Container Build_. I've replaced `link_to` by `value.link` + `value.value` in this PR. Making the link look like a link wil be done in a follow up PR (in react-ui-components repo).

---

**Before:**
![pod_before](https://user-images.githubusercontent.com/13417815/71674404-5f38b280-2d7b-11ea-9e22-d68a92faca3c.png)

**After:**
![container](https://user-images.githubusercontent.com/13417815/71818912-9d3f1a80-308a-11ea-9f22-22c491396aee.png)

