### PR TITLE
Conteiner build TextualSummary fixes.

### DIFF
--- a/app/helpers/container_build_helper/textual_summary.rb
+++ b/app/helpers/container_build_helper/textual_summary.rb
@@ -19,6 +19,7 @@ module ContainerBuildHelper::TextualSummary
   def textual_group_build_instances
     TextualMultilabel.new(
       _("Build Instances"),
+      :wide                   => true,
       :additional_table_class => "table-fixed",
       :values                 => collect_build_pods,
       :labels                 => [

--- a/app/helpers/container_build_helper/textual_summary.rb
+++ b/app/helpers/container_build_helper/textual_summary.rb
@@ -34,7 +34,9 @@ module ContainerBuildHelper::TextualSummary
   end
 
   def collect_build_pods
-    builds = @record.container_build_pods.collect do |build_pod|
+    @record.container_build_pods
+           .order('completion_timestamp desc')
+           .collect do |build_pod|
       [
         build_pod.name,
         build_pod.phase,
@@ -47,7 +49,6 @@ module ContainerBuildHelper::TextualSummary
         parse_duration(build_pod.duration),
       ]
     end
-    builds.sort! { |a, b| Time.parse(b[7] || Time.current.to_s).to_i <=> Time.parse(a[7] || Time.current.to_s).to_i }
   end
 
   #

--- a/app/helpers/textual_multilabel.rb
+++ b/app/helpers/textual_multilabel.rb
@@ -1,5 +1,5 @@
 TextualMultilabel = Struct.new(:title, :options) do
   def locals
-    {:title => title, :rows => options[:values], :labels => options[:labels], :component => 'SimpleTable'}
+    {:title => title, :rows => options[:values], :labels => options[:labels], :component => 'SimpleTable', :wide => options[:wide]}
   end
 end


### PR DESCRIPTION
 * TextualSummary: make "Build Instances" wide.
 * Container build: sort instances in SQL.

After:
![wide-2020-01-06_10-41](https://user-images.githubusercontent.com/51095/71809794-1df11d00-3071-11ea-91fa-b408561c9058.png)
