### PR TITLE
Delete Resume button for VMs and Instances

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -61,15 +61,6 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :confirm => N_("Shelve Offload this Instance?"),
             :klass   => ApplicationHelper::Button::GenericFeatureButton,
             :options => {:feature => :shelve_offload}),
-          included_class.button(
-            :instance_resume,
-            nil,
-            N_('Resume this Instance'),
-            N_('Resume'),
-            :icon    => "fa fa-play fa-lg",
-            :confirm => N_("Resume this Instance?"),
-            :klass   => ApplicationHelper::Button::GenericFeatureButton,
-            :options => {:feature => :start}),
           included_class.separator,
           included_class.button(
             :instance_guest_restart,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -256,17 +256,6 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :confirm      => N_("Shelve Offload the selected items?"),
           :enabled      => false,
           :onwhen       => "1+"),
-        button(
-          :instance_resume,
-          nil,
-          N_('Resume the selected items'),
-          N_('Resume'),
-          :icon         => 'fa fa-play fa-lg',
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Resume the selected items?"),
-          :enabled      => false,
-          :onwhen       => "1+"),
         separator,
         button(
           :instance_guest_restart,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1738584

Go to:
Compute -> Clouds -> Instances -> check one or more -> toolbar Power -> click Resume

Before:
<img width="1445" alt="Screenshot 2020-01-07 at 16 09 13" src="https://user-images.githubusercontent.com/9210860/71905277-1fe9d780-3168-11ea-9d21-792bd5f7bcd6.png">

Nothing happens in UI but there's an error in log
```ruby
 FATAL -- : Error caught: [ActionController::RoutingError] invalid button action
/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:81:in `x_button'
```
After: **no Resume button**
<img width="1444" alt="Screenshot 2020-01-07 at 15 46 49" src="https://user-images.githubusercontent.com/9210860/71905077-b23dab80-3167-11ea-933a-ed9a34dac79e.png">

Removing because:

- I didn't find any mention of `resume` with 
` VmOrTemplate.descendants.select{ |x| x.instance_methods.include?(:resume)}.count`, `VmOrTemplate.descendants.select{ |x| x.instance_methods.include?(:raw_resume)}.count`, ` VmOrTemplate.descendants.select{ |x| x.methods.include?(:resume)}.count` and ` VmOrTemplate.descendants.select{ |x| x.methods.include?(:raw_resume)}.count`

- The Resume button checks that a VM has start feature but never calls a method. Generic code that handles all Power buttons tries to call a method `instance_resume` that never existed in UI.

- It seems that it never worked since `Anand`. There's no method for Resume button.

- No VM has some kind of resume method(I would expect `raw_resume` or `resume` based on other Power action methods naming)

Leaving Provider Resume related code as is.

@miq-bot add_label bug, ivanchuk/yes, hammer/yes, wip