### PR TITLE
Refactor _show_list template and fix error regarding cloning VMs from a nested list

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -322,8 +322,8 @@ class HostController < ApplicationController
     if single_delete_test
       single_delete_redirect
     elsif params[:pressed].ends_with?("_edit") ||
-          ["#{pfx}_miq_request_new", "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed]) ||
-          params[:pressed] == 'vm_rename' && @flash_array.nil?
+          ["#{pfx}_miq_request_new", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed]) ||
+          ["#{pfx}_clone", 'vm_rename'].include?(params[:pressed]) && @flash_array.nil?
       if @flash_array
         show_list
         replace_gtl_main_div

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -810,6 +810,14 @@ module ApplicationHelper
     @default_search.blank? && search_id.to_i.zero?
   end
 
+  def expression_selected_id_or_name(id_or_name, search)
+    @edit[:expression][:selected] && @edit[:expression][:selected][id_or_name] == search && !@edit[:custom_search]
+  end
+
+  def expression_selected_nil_or_id(search_id)
+    @edit[:expression][:selected].nil? && @edit[:selected].nil? || expression_selected_id_or_name(:id, search_id.to_i)
+  end
+
   # Returns description of a filter, for default filter also with "(Default)"
   def search_description(search)
     if default_search?(search.name) ||
@@ -818,6 +826,30 @@ module ApplicationHelper
       _("%{description} (Default)") % {:description => search.description}
     else
       _("%{description}") % {:description => search.description}
+    end
+  end
+
+  # Returns class for a filter from Global filters to highlight it
+  def def_searches_active_filter?(search)
+    if @edit && @edit[:expression] &&
+       ((default_search?(search.name) || no_default_search?(search.id)) && expression_selected_nil_or_id(search.id) ||
+        (@edit[:expression][:selected] && @edit[:expression][:selected][:id].zero? && search.id.to_i.zero? ||
+         expression_selected_id_or_name(:name, search.name)))
+      'active'
+    else
+      ''
+    end
+  end
+
+  # Returns class for a filter from My filters to highlight it
+  def my_searches_active_filter?(search)
+    if @edit && @edit[:expression] &&
+       (default_search?(search.name) && expression_selected_nil_or_id(search.id) ||
+        (@edit[:expression][:selected].nil? && search.id.to_i.zero? ||
+         expression_selected_id_or_name(:name, search.name)))
+      'active'
+    else
+      ''
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -802,6 +802,25 @@ module ApplicationHelper
        vm].include?(@layout)
   end
 
+  def default_search?(search_name)
+    @default_search.present? && @default_search.name == search_name
+  end
+
+  def no_default_search?(search_id)
+    @default_search.blank? && search_id.to_i.zero?
+  end
+
+  # Returns description of a filter, for default filter also with "(Default)"
+  def search_description(search)
+    if default_search?(search.name) ||
+       no_default_search?(search.id) &&
+       settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0'
+      _("%{description} (Default)") % {:description => search.description}
+    else
+      _("%{description}") % {:description => search.description}
+    end
+  end
+
   # Do we show or hide the clear_search link in the list view title
   def clear_search_status
     !!(@edit&.fetch_path(:adv_search_applied, :text))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -813,8 +813,8 @@ module ApplicationHelper
   # Returns description of a filter, for default filter also with "(Default)"
   def search_description(search)
     if default_search?(search.name) ||
-       no_default_search?(search.id) &&
-       settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0'
+       @edit && no_default_search?(search.id) &&
+       settings_default('0', :default_search, @edit&.dig(@expkey, :exp_model).to_s.to_sym).to_s == '0'
       _("%{description} (Default)") % {:description => search.description}
     else
       _("%{description}") % {:description => search.description}

--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -9,14 +9,7 @@
       = miq_accordion_panel(_("Global Filters"), true, "#{@view.db}_def_searches") do
         %ul.nav.nav-pills.nav-stacked
           - @def_searches.each do |search|
-            - li_class = ""
-            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.zero?)
-              -# highlight if default is selected, or first time in
-              - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
-                - li_class = "active"
-            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected] && @edit[:expression][:selected][:id].zero? && search.id.to_i.zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
-              - li_class = "active"
-            %li{:class => li_class}
+            %li{:class => def_searches_active_filter?(search)}
               = link_to(search_description(search).html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},
                 :remote       => true,
@@ -30,13 +23,7 @@
       = miq_accordion_panel(_("My Filters"), false, "#{@view.db}_my_searches") do
         %ul.nav.nav-pills.nav-stacked
           - @my_searches.each do |search|
-            - li_class = ""
-            - if !@default_search.blank? && @default_search.name == search.name
-              - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
-                - li_class = "active"
-            - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && search.id.to_i.zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
-              - li_class = "active"
-            %li{:class => "#{li_class}"}
+            %li{:class => my_searches_active_filter?(search)}
               = link_to(search_description(search).html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},
                 :remote       => true,

--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -10,17 +10,14 @@
         %ul.nav.nav-pills.nav-stacked
           - @def_searches.each do |search|
             - li_class = ""
-            - search_name = search.description
             - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.zero?)
               -# highlight if default is selected, or first time in
               - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
                 - li_class = "active"
             - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected] && @edit[:expression][:selected][:id].zero? && search.id.to_i.zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
-            - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.zero? && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
-              - search_name << " (#{_('Default')})"
             %li{:class => li_class}
-              = link_to(search_name.html_safe,
+              = link_to(search_description(search).html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},
                 :remote       => true,
                 "data-method" => :post,
@@ -34,16 +31,13 @@
         %ul.nav.nav-pills.nav-stacked
           - @my_searches.each do |search|
             - li_class = ""
-            - search_name = search.description
             - if !@default_search.blank? && @default_search.name == search.name
               - if @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && @edit[:selected].nil?) || (!@edit[:expression][:selected].nil? && @edit[:expression][:selected][:id] == search.id.to_i && !@edit[:custom_search]))
                 - li_class = "active"
             - elsif @edit && @edit[:expression] && ((@edit[:expression][:selected].nil? && search.id.to_i.zero?) || (@edit[:expression][:selected] && @edit[:expression][:selected][:name] == search.name && !@edit[:custom_search]))
               - li_class = "active"
             %li{:class => "#{li_class}"}
-              - if (!@default_search.blank? && @default_search.name == search.name) || (@default_search.blank? && search.id.to_i.zero? && settings_default('0', :default_search, @edit[@expkey][:exp_model].to_s.to_sym).to_s == '0')
-                - search_name << " (#{_('Default')})"
-              = link_to(search.description.html_safe,
+              = link_to(search_description(search).html_safe,
                 {:action => 'listnav_search_selected', :id => search.id, :button => "apply"},
                 :remote       => true,
                 "data-method" => :post,

--- a/spec/views/layouts/listnav/_show_list.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_show_list.html.haml_spec.rb
@@ -13,6 +13,11 @@ describe "layouts/listnav/_show_list.html.haml" do
     expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description}</a>")
   end
 
+  it 'sets filter as inactive in accordion' do
+    render :partial => 'layouts/listnav/show_list'
+    expect(response).to include("<li class=''>")
+  end
+
   context 'default filter' do
     before do
       assign(:edit, :expression => {:exp_model => 'Host'})
@@ -26,12 +31,35 @@ describe "layouts/listnav/_show_list.html.haml" do
       expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description} (Default)</a>")
     end
 
+    it 'sets filter as active in accordion' do
+      render :partial => 'layouts/listnav/show_list'
+      expect(response).to include("<li class='active'>")
+    end
+
     context 'default filter already set' do
       before { assign(:default_search, search) }
 
       it 'updates name of a default filter and creates a link for it' do
         render :partial => 'layouts/listnav/show_list'
         expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description} (Default)</a>")
+      end
+    end
+
+    context '@edit[:expression][:selected] set' do
+      before { assign(:edit, :expression => {:exp_model => 'Host', :selected => {:id => 0}}) }
+
+      it 'sets filter as active in accordion' do
+        render :partial => 'layouts/listnav/show_list'
+        expect(response).to include("<li class='active'>")
+      end
+
+      context '@edit[:expression][:selected][:name] set' do
+        before { assign(:edit, :expression => {:exp_model => 'Host', :selected => {:id => 123, :name => search.name}}) }
+
+        it 'sets filter as active in accordion' do
+          render :partial => 'layouts/listnav/show_list'
+          expect(response).to include("<li class='active'>")
+        end
       end
     end
   end
@@ -51,14 +79,43 @@ describe "layouts/listnav/_show_list.html.haml" do
   context 'My Filters' do
     before do
       set_controller_for_view('host')
+      assign(:def_searches, nil)
+      assign(:expkey, :expression)
       assign(:my_searches, [search])
       assign(:panels, {})
+      assign(:settings, {})
       assign(:view, FactoryBot.create(:miq_report_filesystem, :db => 'Host'))
     end
 
     it 'creates a link for a regular filter in accordion' do
       render :partial => 'layouts/listnav/show_list'
       expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description}</a>")
+    end
+
+    it 'sets filter as inactive in accordion' do
+      render :partial => 'layouts/listnav/show_list'
+      expect(response).to include("<li class=''>")
+    end
+
+    context '@edit[:expression][:selected][:name] set' do
+      before { assign(:edit, :expression => {:exp_model => 'Host', :selected => {:id => 123, :name => search.name}}) }
+
+      it 'sets filter as active in accordion' do
+        render :partial => 'layouts/listnav/show_list'
+        expect(response).to include("<li class='active'>")
+      end
+    end
+
+    context 'default filter set' do
+      before do
+        assign(:default_search, search)
+        assign(:edit, :expression => {:exp_model => 'Host', :selected => {:id => search.id}})
+      end
+
+      it 'sets filter as active in accordion' do
+        render :partial => 'layouts/listnav/show_list'
+        expect(response).to include("<li class='active'>")
+      end
     end
   end
 end

--- a/spec/views/layouts/listnav/_show_list.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_show_list.html.haml_spec.rb
@@ -1,0 +1,64 @@
+describe "layouts/listnav/_show_list.html.haml" do
+  let(:search) { FactoryBot.create(:miq_search) }
+
+  before do
+    set_controller_for_view('host')
+    assign(:def_searches, [search])
+    assign(:panels, {})
+    assign(:view, FactoryBot.create(:miq_report_filesystem, :db => 'Host'))
+  end
+
+  it 'creates a link for a regular filter in accordion' do
+    render :partial => 'layouts/listnav/show_list'
+    expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description}</a>")
+  end
+
+  context 'default filter' do
+    before do
+      assign(:edit, :expression => {:exp_model => 'Host'})
+      assign(:expkey, :expression)
+      assign(:settings, :default_search => {:AvailabilityZone => 123})
+      search.id = 0
+    end
+
+    it 'updates name of a default filter and creates a link for it' do
+      render :partial => 'layouts/listnav/show_list'
+      expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description} (Default)</a>")
+    end
+
+    context 'default filter already set' do
+      before { assign(:default_search, search) }
+
+      it 'updates name of a default filter and creates a link for it' do
+        render :partial => 'layouts/listnav/show_list'
+        expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description} (Default)</a>")
+      end
+    end
+  end
+
+  context 'displaying nested list of VMs and not setting @edit' do
+    before do
+      assign(:settings, :default_search => {:AvailabilityZone => 123})
+      search.id = 0
+    end
+
+    it 'does not set filter as default' do
+      render :partial => 'layouts/listnav/show_list'
+      expect(response).not_to include("(Default)")
+    end
+  end
+
+  context 'My Filters' do
+    before do
+      set_controller_for_view('host')
+      assign(:my_searches, [search])
+      assign(:panels, {})
+      assign(:view, FactoryBot.create(:miq_report_filesystem, :db => 'Host'))
+    end
+
+    it 'creates a link for a regular filter in accordion' do
+      render :partial => 'layouts/listnav/show_list'
+      expect(response).to include("<a data-method=\"post\" title=\"Apply this filter\" onclick=\"return miqCheckForChanges()\" data-remote=\"true\" href=\"/host/listnav_search_selected/#{search.id}?button=apply\">#{search.description}</a>")
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/4615

This PR is supposed to take care about `_show_list` template, to make it readable, and also it fixes the error regarding cloning VMs from a nested list and also one another bug in the template.

**How to reproduce the error:**
1. Go to _Compute → Infrastructure → Hosts / Nodes_
2. Click on some Host to display its summary
3. Click on VMs in _Relationships_ table
4. Select such VMs in the list (checkboxes), that _Clone_ action is not applicable on them
5. Choose _Lifecycle → Clone selected item_
=> error:
```
[----] I, [2020-01-08T16:28:25.647485 #21081:5f6d7e0]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/listnav/_show_list.html.haml (1582.2ms)
[----] I, [2020-01-08T16:28:25.647765 #21081:5f6d7e0]  INFO -- :   Rendered /home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/_listnav.html.haml (1588.5ms)
[----] F, [2020-01-08T16:28:25.648246 #21081:5f6d7e0] FATAL -- : Error caught: [ActionView::Template::Error] undefined method `[]' for nil:NilClass
/home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/listnav/_show_list.html.haml:21:in `block (2 levels) in __home_hstastna_manageiq_manageiq_ui_classic_app_views_layouts_listnav__show_list_html_haml__4390895541003510046_70121927935680'
/home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/listnav/_show_list.html.haml:11:in `each'
/home/hstastna/manageiq/manageiq-ui-classic/app/views/layouts/listnav/_show_list.html.haml:11:in `block in __home_hstastna_manageiq_manageiq_ui_classic_app_views_layouts_listnav__show_list_html_haml__4390895541003510046_70121927935680'
```
Note that if _Clone_ action applies to selected VMs, error does not occur.

The error was caused by checking `@edit[@expkey][:exp_model]` in the template without `@edit` being set. This is due to the missing logic in `host` controller (in `button` method) for the cases when we are not supposed to clone selected VM. For the VMs which can be cloned, there was no problem regarding cloning them.

We could add an extra condition to already not very readable `host` controller (probably in follow up PR; and we wouldn't end up in the template at all). But we still should care about all of the variables used in the `_show_list` template, and not to rely just on the logic anywhere else. So In this PR, I'm adding missing check for `@edit` to the template and also providing some refactoring. Also I am fixing another [small bug](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Show_list_err_default_search?expand=1#diff-b42a85be8d855fbf457334c1557a50feL46) where `search.description` was used instead of `search_name` which was set [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Show_list_err_default_search?expand=1#diff-b42a85be8d855fbf457334c1557a50feL37) - and then never used in the template.

**Before:**
![clone_before](https://user-images.githubusercontent.com/13417815/71998764-817d7500-3240-11ea-83bc-f757bc9a3039.png)

**After:**
![clone_after2](https://user-images.githubusercontent.com/13417815/71998773-84786580-3240-11ea-9284-fdbab90de3eb.png)




