### PR TITLE
Use YAML.load to load classes beyond the basic types

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -168,7 +168,7 @@ module ApplicationController::MiqRequestMethods
 
     unless %w[image_miq_request_new miq_template_miq_request_new].include?(params[:pressed])
       path_to_report = ManageIQ::UI::Classic::Engine.root.join("product", "views", provisioning_report).to_s
-      @view = MiqReport.new(YAML.safe_load(File.open(path_to_report), [Symbol]))
+      @view = MiqReport.new(YAML.load(File.open(path_to_report)))
       @view.db = get_template_kls.to_s
       report_scopes = %i[eligible_for_provisioning non_deprecated]
       options = options_for_provisioning(@view.db, report_scopes)

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -51,7 +51,7 @@ describe ApplicationController do
     it "use report_name when is passed" do
       report_name = "ProvisionCloudTemplates.yaml"
       path_to_report = ManageIQ::UI::Classic::Engine.root.join("product", "views", report_name).to_s
-      view = MiqReport.new(YAML.safe_load(File.open(path_to_report), [Symbol]))
+      view = MiqReport.new(YAML.load(File.open(path_to_report)))
       expect(controller).to_not receive(:get_db_view)
       controller.params = {:active_tree => "instances_tree"}
       controller.params = {:model_name => "ManageIQ::Providers::CloudManager::Template"}

--- a/spec/support/report_helper.rb
+++ b/spec/support/report_helper.rb
@@ -72,7 +72,7 @@ module Spec
       end
 
       def null_data_chart_with_basic_condition
-        exp = YAML.safe_load('--- !ruby/object:MiqExpression
+        exp = YAML.load('--- !ruby/object:MiqExpression
         exp:
           INCLUDES:
             field: Name
@@ -82,7 +82,7 @@ module Spec
       end
 
       def null_data_chart_with_complex_condition
-        exp = YAML.safe_load('--- !ruby/object:MiqExpression
+        exp = YAML.load('--- !ruby/object:MiqExpression
         exp:
           and:
           - IS:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1789153

Followup to https://github.com/ManageIQ/manageiq/pull/19701

At the very least, we know MiqExpression objects are in the YAML but other
custom classes could be in the YAML so we need to use YAML.load to return to the
prior behavior.