### PR TITLE
Make the filter not highlighted in accordion after it was created and not applied

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -54,7 +54,7 @@ module ApplicationController::AdvancedSearch
         add_flash(_("%{model} search \"%{name}\" was saved") %
           {:model => ui_lookup(:model => @edit[@expkey][:exp_model]),
            :name  => @edit[:new_search_name]})
-        @edit[@expkey].select_filter(s)
+        @edit[@expkey].last_loaded_filter(s) # Save the last search loaded
         @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description] unless @edit[@expkey][:exp_last_loaded].nil?
         @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
         # Build the expression table

--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -331,7 +331,7 @@ module ApplicationController::AdvancedSearch
         @edit = session[:edit]
         @view = session[:view]
         @edit[:adv_search_applied] = nil
-        @edit[:expression][:exp_last_loaded] = nil
+        @edit[:expression][:exp_last_loaded] = @edit[:expression][:selected] = nil
         session[:adv_search] ||= {}                                         # Create/reuse the adv search hash
         session[:adv_search][@edit[@expkey][:exp_model]] = copy_hash(@edit) # Save by model name in settings
         default_search = settings(:default_search, @view.db.to_s.to_sym)

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -148,11 +148,23 @@ module ApplicationController::Filter
       s
     end
 
-    # save the last search loaded
+    # Set the selected and last loaded filter
     def select_filter(miq_search, last_loaded = false)
-      self.selected = {:id => miq_search.id, :name => miq_search.name, :description => miq_search.description,
-                       :typ => miq_search.search_type}
+      self.selected = filter_info(miq_search)
       self.exp_last_loaded = selected if last_loaded
+    end
+
+    # Get the id, name, description and typ of a filter
+    def filter_info(miq_search)
+      {:id          => miq_search.id,
+       :name        => miq_search.name,
+       :description => miq_search.description,
+       :typ         => miq_search.search_type}
+    end
+
+    # Set the last loaded filter
+    def last_loaded_filter(miq_search)
+      self.exp_last_loaded = filter_info(miq_search)
     end
 
     def update_from_expression_editor(params)

--- a/spec/controllers/application_controller/advanced_search_spec.rb
+++ b/spec/controllers/application_controller/advanced_search_spec.rb
@@ -84,3 +84,24 @@ describe VmOrTemplateController, "::AdvancedSearch" do
     end
   end
 end
+
+describe AvailabilityZoneController, "::AdvancedSearch" do
+  let(:expr) { ApplicationController::Filter::Expression.new("=" => exp, :token => 1) }
+  let(:exp) { {:field => "Some_field", :value => "123"} }
+
+  describe '#adv_search_button_saveid' do
+    before do
+      stub_user(:features => :all)
+      controller.instance_variable_set(:@edit, :new => {:expression => {"=" => exp}}, :new_search_name => 'filter', :expression => expr)
+      controller.instance_variable_set(:@expkey, :expression)
+    end
+
+    subject { controller.instance_variable_get(:@edit)[:expression] }
+
+    it 'sets only @edit[@expkey][:exp_last_loaded]' do
+      controller.send(:adv_search_button_saveid)
+      expect(subject[:selected]).to be_nil
+      expect(subject[:exp_last_loaded]).to include(:name => "user_#{session[:userid]}_filter", :description => 'filter', :typ => 'user')
+    end
+  end
+end

--- a/spec/controllers/application_controller/filter/expression_spec.rb
+++ b/spec/controllers/application_controller/filter/expression_spec.rb
@@ -40,6 +40,38 @@ describe ApplicationController::Filter do
     end
   end
 
+  context 'selected and last loaded filter' do
+    let(:expression) { ApplicationController::Filter::Expression.new }
+    let(:search) { FactoryBot.create(:miq_search) }
+
+    describe '#filter_info' do
+      it 'returns id, name, description and type of the search' do
+        expect(expression.filter_info(search)).to eq(:id => search.id, :name => search.name, :description => search.description, :typ => search.search_type)
+      end
+    end
+
+    describe '#last_loaded_filter' do
+      it 'sets expression.exp_last_loaded' do
+        expression.last_loaded_filter(search)
+        expect(expression.exp_last_loaded).to eq(:id => search.id, :name => search.name, :description => search.description, :typ => search.search_type)
+      end
+    end
+
+    describe '#select_filter' do
+      it 'sets expression.selected and expression.exp_last_loaded' do
+        expression.select_filter(search, true)
+        expect(expression.selected).to eq(:id => search.id, :name => search.name, :description => search.description, :typ => search.search_type)
+        expect(expression.exp_last_loaded).to eq(expression.selected)
+      end
+
+      it 'sets only expression.selected' do
+        expression.select_filter(search)
+        expect(expression.selected).to eq(:id => search.id, :name => search.name, :description => search.description, :typ => search.search_type)
+        expect(expression.exp_last_loaded).to be_nil
+      end
+    end
+  end
+
   describe ReportController do
     let(:expression) do
       ApplicationController::Filter::Expression.new.tap do |e|
@@ -50,7 +82,7 @@ describe ApplicationController::Filter do
       end
     end
 
-    context '#update_from_expression_editor' do
+    describe '#update_from_expression_editor' do
       it "resets value of exp_key based upon type of field selected" do
         edit = {:record_filter => expression}
         edit[:new] = {:record_filter => {:test => "foo", :token => 1}}


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq-ui-classic/issues/6594

This PR fixes the bug in non-explorer screens regarding newly created filters. Such a filter was highlighted in accordion even when it was not applied. This was fixed by not setting `@edit[:expression][:selected]` right after saving the filter, only the `@edit[:expression][:exp_last_loaded]` which can be important for later actions.

Another bug was remaining the filter highlighed in accordion when the filter was cleared (by clicking on the blue "clear" in the title in the page). Again, this was caused by wrong value of `@edit[:expression][:selected]`, setting the value to nil was missing in `adv_search_clear` method.

**Before:**
After saving the new filter but not applying it, the filter is already highlighted in accordion,
the same happens after clearing the filter:
![save_before](https://user-images.githubusercontent.com/13417815/72261625-77c78900-3615-11ea-84e4-284ed5dd32ec.png)

**After:**
![save_after](https://user-images.githubusercontent.com/13417815/72261633-7b5b1000-3615-11ea-80c9-0489016b1ae8.png)
