### PR TITLE
Enable reconfiguring VMs displayed in a nested list

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -933,7 +933,7 @@ module ApplicationController::CiProcessing
     when "#{pfx}_shelve_offload"            then shelveoffloadvms
     when "#{pfx}_reset"                     then resetvms
     when "#{pfx}_check_compliance"          then check_compliance_vms
-    when "#{pfx}_reconfigure"               then reconfigurevms
+    when "#{pfx}_reconfigure"               then vm_reconfigure
     when "#{pfx}_resize"                    then resizevms
     when "#{pfx}_evacuate"                  then evacuatevms
     when "#{pfx}_live_migrate"              then livemigratevms

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -7,6 +7,15 @@ describe ApplicationController do
     allow(controller).to receive(:role_allows?).and_return(true)
   end
 
+  describe '#process_vm_buttons' do
+    before { controller.params = {:pressed => 'vm_reconfigure'} }
+
+    it 'calls vm_reconfigure for reconfiguring VMs' do
+      expect(controller).to receive(:vm_reconfigure)
+      controller.send(:process_vm_buttons, 'vm')
+    end
+  end
+
   describe "#generic_button_operation" do
     let(:vm1) { FactoryBot.create(:vm_redhat) }
     let(:vm2) { FactoryBot.create(:vm_microsoft) }

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -99,6 +99,18 @@ describe ResourcePoolController do
         end
       end
     end
+
+    context 'reconfigure VMs' do
+      before do
+        controller.instance_variable_set(:@display, 'vms')
+        controller.params = {:pressed => 'vm_reconfigure'}
+      end
+
+      it 'calls vm_reconfigure' do
+        expect(controller).to receive(:vm_reconfigure)
+        controller.send(:button)
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6606

It was not possible to reconfigure VMs displayed in any nested list, error occurred. The core of the problem was calling `reconfigurevms` method which does not exist, instead of `vm_reconfigure` from the `Reconfigure` [module](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/mixins/actions/vm_actions/reconfigure.rb#L47).
Originally, I've found the issue while displaying VMs through Resource Pool's textual summary.

**Before:**
![reconfig_before](https://user-images.githubusercontent.com/13417815/72352976-8bd9bc00-36e3-11ea-8f82-8cd3551bcea2.png)

**After:**
![reconfig_after](https://user-images.githubusercontent.com/13417815/72352987-8ed4ac80-36e3-11ea-8b12-9bb9f9d56020.png)
