### PR TITLE
POC Add debride

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     env: TEST_SUITE=spec:compile
   - rvm: 2.5.7
     env: TEST_SUITE=spec:jest
+  - rvm: 2.5.7
+    env: TEST_SUITE=spec:debride
 bundler_args: "--no-deployment"
 before_install: source tools/ci/before_install.sh
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - TEST_SUITE=spec:javascript
   - TEST_SUITE=spec:compile
   - TEST_SUITE=spec:jest
+  - TEST_SUITE=spec:debride
 matrix:
   exclude:
   - rvm: 2.5.7

--- a/Rakefile
+++ b/Rakefile
@@ -56,6 +56,12 @@ namespace :spec do
     exit $CHILD_STATUS.exitstatus
   end
 
+  desc "Run Debride"
+  task :debride do
+    system('bash tools/ci/dead_method_check.sh')
+    exit 0
+  end
+
   namespace :jest do
     desc 'Run Jest tests with node debugger'
     task :debug do

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", ">= 5.0.0.1", "< 5.3"
+  s.add_dependency "debride"
+
 
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.5"

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", ">= 5.0.0.1", "< 5.3"
-  s.add_dependency "debride"
-
 
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.5"
@@ -36,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
   s.add_development_dependency "rails-controller-testing", '~> 1.0.2'
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "debride"
 
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
   s.add_development_dependency "jasmine", "~> 3.4.0"

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -12,20 +12,3 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   yarn list
   echo "travis_fold:end:YARN_LOCK"
 fi
-
-# Run only against PR that is based on master
-if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" != "false" -a "$TRAVIS_BRANCH" = "master" ]; then
-  OLD=`mktemp`
-  NEW=`mktemp`
-
-  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
-
-  git checkout  master -- app/
-
-  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
-
-  echo "New possibly dead methods"
-
-  diff -Naur "$OLD" "$NEW" | grep '^+ '
-fi
-

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -13,7 +13,7 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   echo "travis_fold:end:YARN_LOCK"
 fi
 
-if [ "$TEST_SUITE" = "spec"  && "$TRAVIS_PULL_REQUEST"]; then
+if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" ]; then
   OLD=`mktemp`
   NEW=`mktemp`
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -13,24 +13,21 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   echo "travis_fold:end:YARN_LOCK"
 fi
 
-OLD=`mktemp`
-NEW=`mktemp`
+if [ "$TEST_SUITE" = "spec" ]; then
+  OLD=`mktemp`
+  NEW=`mktemp`
 
-echo "Debride run"
-bundle exec debride --version
-bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
-echo "Debride done new"
+  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
 
-git checkout  master
+  git checkout  master
 
-# remove once it's merged
-gem install debride
+  # remove once it's merged
+  gem install debride
 
-debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
-echo "Debride done old"
+  debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
 
+  echo "New possibly dead methods"
 
-echo "New possibly dead methods"
-
-diff -Naur "$OLD" "$NEW"
+  diff -Naur "$OLD" "$NEW"
+fi
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -26,6 +26,6 @@ if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" != "false" -a "$TRAVIS_BRA
 
   echo "New possibly dead methods"
 
-  diff -Naur "$OLD" "$NEW" | grep '^+'
+  diff -Naur "$OLD" "$NEW" | grep '^+ '
 fi
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -13,7 +13,8 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   echo "travis_fold:end:YARN_LOCK"
 fi
 
-if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" ]; then
+# Run only against PR that is based on master
+if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" != "false" -a "$TRAVIS_BRANCH" = "master" ]; then
   OLD=`mktemp`
   NEW=`mktemp`
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -12,3 +12,25 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   yarn list
   echo "travis_fold:end:YARN_LOCK"
 fi
+
+OLD=`mktemp`
+NEW=`mktemp`
+
+echo "Debride run"
+bundle exec debride --version
+bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
+echo "Debride done new"
+
+git checkout  master
+
+# remove once it's merged
+gem install debride
+
+debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
+echo "Debride done old"
+
+
+echo "New possibly dead methods"
+
+diff -Naur "$OLD" "$NEW"
+

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -25,6 +25,6 @@ if [ "$TEST_SUITE" = "spec" -a "$TRAVIS_PULL_REQUEST" ]; then
 
   echo "New possibly dead methods"
 
-  diff -Naur "$OLD" "$NEW"
+  diff -Naur "$OLD" "$NEW" | grep '^+'
 fi
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -19,12 +19,9 @@ if [ "$TEST_SUITE" = "spec" ]; then
 
   bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
 
-  git checkout  master
+  git checkout  master -- app/
 
-  # remove once it's merged
-  gem install debride
-
-  debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
+  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
 
   echo "New possibly dead methods"
 

--- a/tools/ci/after_install.sh
+++ b/tools/ci/after_install.sh
@@ -13,7 +13,7 @@ if [ "$TEST_SUITE" = "spec:javascript" ]; then
   echo "travis_fold:end:YARN_LOCK"
 fi
 
-if [ "$TEST_SUITE" = "spec" ]; then
+if [ "$TEST_SUITE" = "spec"  && "$TRAVIS_PULL_REQUEST"]; then
   OLD=`mktemp`
   NEW=`mktemp`
 

--- a/tools/ci/dead_method_check.sh
+++ b/tools/ci/dead_method_check.sh
@@ -1,0 +1,17 @@
+# Run only against PR that is based on master
+if [ "$TRAVIS_PULL_REQUEST" != "false" -a "$TRAVIS_BRANCH" = "master" ]; then
+  OLD=`mktemp`
+  NEW=`mktemp`
+
+  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$NEW"
+
+  git checkout  master -- app/
+
+  bundle exec debride --rails app/controllers/ | cut -d ":" -f1 > "$OLD"
+
+  echo -e "\n"
+  echo "New possibly dead methods:"
+  echo -e "\n"
+  diff -Naur "$OLD" "$NEW" | grep '^+ '
+  echo -e "\n"
+fi


### PR DESCRIPTION
Add `debride` to look for dead method. It uses results from `master` as a whitelist so it only points out possibly dead methods that are introduced by a PR. 

Test will always pass as it's up to author/reviewer to decide if it's really a dead method.

It will only run on PRs based on master.
 
Tested with something like this
```diff
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -172,6 +172,10 @@ class CloudTenantController < ApplicationController
     javascript_redirect(:action => "show", :id => tenant_id)
   end
 
+  def dead_method
+    cloud_tenant_form_fields
+  end
+
   def cloud_tenant_form_fields
     assert_privileges("cloud_tenant_edit")
     tenant = find_record_with_rbac(CloudTenant, params[:id])
```
Dead method found:
![image](https://user-images.githubusercontent.com/9210860/73760058-20788c80-476d-11ea-8a87-575e09f15d71.png)


No dead method:
![image](https://user-images.githubusercontent.com/9210860/73853034-7f530a00-4830-11ea-907f-e1ccd87f4b8e.png)



TODO:
- [x] add new test case
- [x] return from other specs instead of running them

Next step: use a bot to comment on PRs with dead methods.