### PR TITLE
Display flash message after managing policies in non explorer screen

### DIFF
--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -63,6 +63,7 @@ module ApplicationController::PolicySupport
         replace_right_cell
       else
         @edit = nil                                       # Clear out the session :edit hash
+        session[:flash_msgs] = @flash_array
         redirect_to(previous_breadcrumb_url)
       end
     else                                                  # First time in,

--- a/spec/controllers/application_controller/policy_support_spec.rb
+++ b/spec/controllers/application_controller/policy_support_spec.rb
@@ -82,4 +82,19 @@ describe ApplicationController do
       expect(controller.session).to include(:edit => {:pol_items => [vm]})
     end
   end
+
+  describe '#protect' do
+    before do
+      allow(controller).to receive(:previous_breadcrumb_url)
+      allow(controller).to receive(:redirect_to)
+      allow(controller).to receive(:session).and_return(:edit => {})
+      controller.instance_variable_set(:@sb, {})
+      controller.params = {:button => 'cancel'}
+    end
+
+    it 'sets session[:flash_msgs] after canceling managing policies in non explorer screen' do
+      controller.send(:protect)
+      expect(controller.session[:flash_msgs]).to eq([{:message => 'Edit policy assignments was cancelled by the user', :level => :success}])
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6610

There was an issue in non explorer screens, after finishing managing policies of selected items (Resource Pools, Hosts, nested lists of VMs, Instances etc): flash message was not displayed. To display it, we need to put it into `session[:flash_msgs]`, the same as it is in some other places before redirecting.

**Before:**
![manage_before](https://user-images.githubusercontent.com/13417815/72624564-7c5aad00-3947-11ea-9ac0-16933cedd9f6.png)

**After:**
![manage_after](https://user-images.githubusercontent.com/13417815/72624572-7f559d80-3947-11ea-8792-ccc05151aba7.png)
