### PR TITLE
Refactor ResourcePool controller, make Edit VM through Resource Pool work

### DIFF
--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -12,7 +12,7 @@ module Mixins
       return [:finished, pfx] if vm_button_redirected?(pfx, pressed)
 
       unless ["#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-              "#{pfx}_migrate", "#{pfx}_publish"].include?(pressed)
+              "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename'].include?(pressed)
         @refresh_div = "main_div"
         @refresh_partial = "layouts/gtl"
         show # Handle VMs buttons
@@ -79,8 +79,9 @@ module Mixins
         return
       end
 
-      if params[:pressed].ends_with?("_edit") || ["#{pfx}_miq_request_new", "#{pfx}_clone",
-                                                  "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])
+      if params[:pressed].ends_with?("_edit") ||
+         ["#{pfx}_miq_request_new", "#{pfx}_clone", "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed]) ||
+         params[:pressed] == 'vm_rename' && @flash_array.nil?
         render_or_redirect_partial(pfx)
       elsif @refresh_div == "main_div" && @lastaction == "show_list"
         replace_gtl_main_div

--- a/app/controllers/resource_pool_controller.rb
+++ b/app/controllers/resource_pool_controller.rb
@@ -4,6 +4,7 @@ class ResourcePoolController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::GenericButtonMixin
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
@@ -17,48 +18,20 @@ class ResourcePoolController < ApplicationController
   def button
     @edit = session[:edit] # Restore @edit for adv search box
     params[:display] = @display if %w[all_vms vms resource_pools].include?(@display) # Were we displaying sub-items
-    if %w[all_vms vms resource_pools].include?(@display) # Need to check, since RPs contain RPs
 
-      if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
-                                       "miq_template_",
-                                       "guest_")
-
-        pfx = pfx_for_vm_button_pressed(params[:pressed])
-        process_vm_buttons(pfx)
-
-        return if ["#{pfx}_policy_sim", "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_protect",
-                   "#{pfx}_retire", "#{pfx}_right_size", "#{pfx}_ownership",
-                   "#{pfx}_reconfigure"].include?(params[:pressed]) &&
-                  @flash_array.nil? # Some other screen is showing, so return
-
-        unless ["#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
-                "#{pfx}_migrate", "#{pfx}_publish", 'vm_rename'].include?(params[:pressed])
-          @refresh_div = "main_div"
-          @refresh_partial = "layouts/gtl"
-          show
-        end
+    @refresh_div = 'main_div' unless @display # Default div for button.rjs to refresh
+    case params[:pressed]
+    when 'resource_pool_delete'
+      deleteresourcepools
+      if @refresh_div == 'main_div' && @lastaction == 'show_list'
+        replace_gtl_main_div
+      else
+        render_flash unless performed?
       end
+    when 'resource_pool_protect'
+      assign_policies(ResourcePool)
     else
-      @refresh_div = "main_div" # Default div for button.rjs to refresh
-      tag(ResourcePool) if params[:pressed] == "resource_pool_tag"
-      deleteresourcepools if params[:pressed] == "resource_pool_delete"
-      assign_policies(ResourcePool) if params[:pressed] == "resource_pool_protect"
-    end
-
-    return if %w[resource_pool_tag resource_pool_protect].include?(params[:pressed]) && @flash_array.nil? # Tag screen showing, so return
-
-    check_if_button_is_implemented
-
-    if single_delete_test
-      single_delete_redirect
-    elsif ["#{pfx}_miq_request_new", "#{pfx}_migrate", "#{pfx}_clone",
-           "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed]) ||
-          params[:pressed] == 'vm_rename' && @flash_array.nil?
-      render_or_redirect_partial(pfx)
-    elsif @refresh_div == "main_div" && @lastaction == "show_list"
-      replace_gtl_main_div
-    else
-      render_flash unless performed?
+      super
     end
   end
 

--- a/spec/controllers/resource_pool_controller_spec.rb
+++ b/spec/controllers/resource_pool_controller_spec.rb
@@ -18,13 +18,6 @@ describe ResourcePoolController do
       expect(controller.send(:flash_errors?)).not_to be_truthy
     end
 
-    it "when VM Retire is pressed" do
-      controller.params = {:pressed => "vm_retire"}
-      expect(controller).to receive(:retirevms).once
-      controller.button
-      expect(controller.send(:flash_errors?)).not_to be_truthy
-    end
-
     it "when VM Manage Policies is pressed" do
       controller.params = {:pressed => "vm_protect"}
       expect(controller).to receive(:assign_policies).with(VmOrTemplate)
@@ -98,16 +91,253 @@ describe ResourcePoolController do
           expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
         end
       end
+
+      it 'calls check_compliance_vms' do
+        expect(controller).to receive(:check_compliance_vms)
+        controller.send(:button)
+      end
     end
 
     context 'reconfigure VMs' do
-      before do
-        controller.instance_variable_set(:@display, 'vms')
-        controller.params = {:pressed => 'vm_reconfigure'}
-      end
+      before { controller.params = {:pressed => 'vm_reconfigure'} }
 
       it 'calls vm_reconfigure' do
         expect(controller).to receive(:vm_reconfigure)
+        controller.send(:button)
+      end
+    end
+
+    context 'Extract Running Processes for selected VMs' do
+      let(:vm) { FactoryBot.create(:vm_vmware) }
+
+      before do
+        allow(controller).to receive(:assert_privileges)
+        allow(controller).to receive(:show)
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:render)
+        controller.params = {:pressed => 'vm_collect_running_processes', :miq_grid_checks => vm.id.to_s}
+      end
+
+      it 'calls getprocessesvms' do
+        expect(controller).to receive(:getprocessesvms)
+        controller.send(:button)
+      end
+
+      it 'sets error flash message' do
+        controller.send(:button)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Collect Running Processes action does not apply to selected items', :level => :error}])
+      end
+    end
+
+    context 'Compare selected VMs' do
+      before { controller.params = {:pressed => 'vm_compare'} }
+
+      it 'calls comparemiq' do
+        expect(controller).to receive(:comparemiq)
+        controller.send(:button)
+      end
+    end
+
+    context 'Edit selected VM' do
+      before do
+        allow(controller).to receive(:render_or_redirect_partial)
+        controller.params = {:pressed => 'vm_edit'}
+      end
+
+      it 'calls edit_record' do
+        expect(controller).to receive(:edit_record)
+        controller.send(:button)
+      end
+    end
+
+    context 'Rename selected VM' do
+      before do
+        allow(controller).to receive(:performed?).and_return(true)
+        controller.params = {:pressed => 'vm_rename'}
+      end
+
+      it 'calls vm_rename' do
+        expect(controller).to receive(:vm_rename)
+        controller.send(:button)
+      end
+    end
+
+    context 'Set ownership for selected VMs' do
+      before { controller.params = {:pressed => 'vm_ownership'} }
+
+      it 'calls set_ownership' do
+        expect(controller).to receive(:set_ownership)
+        controller.send(:button)
+      end
+    end
+
+    context 'Policy Simulation for selected VMs' do
+      before { controller.params = {:pressed => 'vm_policy_sim'} }
+
+      it 'calls polsimvms' do
+        expect(controller).to receive(:polsimvms)
+        controller.send(:button)
+      end
+    end
+
+    context 'Provision VMs' do
+      before do
+        allow(controller).to receive(:render_or_redirect_partial)
+        controller.params = {:pressed => 'vm_miq_request_new'}
+      end
+
+      it 'calls prov_redirect' do
+        expect(controller).to receive(:prov_redirect).with(no_args)
+        controller.send(:button)
+      end
+    end
+
+    context 'Clone VMs' do
+      before do
+        allow(controller).to receive(:render_or_redirect_partial)
+        controller.params = {:pressed => 'vm_clone'}
+      end
+
+      it 'calls prov_redirect with appropriate argument' do
+        expect(controller).to receive(:prov_redirect).with('clone')
+        controller.send(:button)
+      end
+    end
+
+    context 'Publish VM to a Template' do
+      before do
+        allow(controller).to receive(:render_or_redirect_partial)
+        controller.params = {:pressed => 'vm_publish'}
+      end
+
+      it 'calls prov_redirect with appropriate argument' do
+        expect(controller).to receive(:prov_redirect).with('publish')
+        controller.send(:button)
+      end
+    end
+
+    context 'Retire VMs' do
+      before do
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:show)
+        controller.params = {:pressed => 'vm_retire_now'}
+      end
+
+      it 'calls retirevms_now' do
+        expect(controller).to receive(:retirevms_now)
+        controller.send(:button)
+      end
+    end
+
+    context 'Shutdown Guest of a VM' do
+      before do
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:show)
+        controller.params = {:pressed => 'vm_guest_shutdown'}
+      end
+
+      it 'calls guestshutdown' do
+        expect(controller).to receive(:guestshutdown)
+        controller.send(:button)
+      end
+    end
+
+    context 'Restart Guest of a VM' do
+      before do
+        allow(controller).to receive(:performed?).and_return(true)
+        allow(controller).to receive(:show)
+        controller.params = {:pressed => 'vm_guest_restart'}
+      end
+
+      it 'calls guestshutdown' do
+        expect(controller).to receive(:guestreboot)
+        controller.send(:button)
+      end
+    end
+
+    %w[delete refresh reset retire scan start stop suspend].each do |action|
+      context "#{action} for selected VMs displayed in a nested list" do
+        before { controller.params = {:pressed => "vm_#{action}"} }
+
+        it "calls #{action + 'vms'} method" do
+          allow(controller).to receive(:show)
+          allow(controller).to receive(:performed?).and_return(true)
+          expect(controller).to receive((action + 'vms').to_sym)
+          controller.send(:button)
+          expect(controller.send(:flash_errors?)).not_to be_truthy
+        end
+      end
+    end
+
+    context 'deleting Resource Pool' do
+      before do
+        allow(controller).to receive(:performed?).and_return(true)
+        controller.instance_variable_set(:@lastaction, 'show_list')
+        controller.instance_variable_set(:@display, nil)
+        controller.params = {:pressed => 'resource_pool_delete'}
+      end
+
+      it 'calls deleteresourcepools and replace_gtl_main_div' do
+        expect(controller).to receive(:deleteresourcepools)
+        expect(controller).to receive(:replace_gtl_main_div)
+        controller.send(:button)
+      end
+
+      context 'default div to refresh' do
+        before do
+          allow(controller).to receive(:deleteresourcepools)
+          allow(controller).to receive(:replace_gtl_main_div)
+        end
+
+        it 'sets @refresh_div to main div' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@refresh_div)).to eq('main_div')
+        end
+      end
+
+      context 'nested list of Resource Pools' do
+        before do
+          allow(controller).to receive(:performed?).and_return(false)
+          controller.instance_variable_set(:@display, 'resource_pools')
+        end
+
+        it 'calls deleteresourcepools and render_flash' do
+          expect(controller).to receive(:deleteresourcepools)
+          expect(controller).to receive(:render_flash)
+          controller.send(:button)
+        end
+      end
+    end
+
+    context 'managing policies of Resource Pools' do
+      before do
+        controller.instance_variable_set(:@display, nil)
+        controller.params = {:pressed => 'resource_pool_protect'}
+      end
+
+      it 'calls assign_policies' do
+        expect(controller).to receive(:assign_policies).with(ResourcePool)
+        controller.send(:button)
+      end
+
+      context 'default div to refresh' do
+        before { allow(controller).to receive(:assign_policies) }
+
+        it 'sets @refresh_div to main div' do
+          controller.send(:button)
+          expect(controller.instance_variable_get(:@refresh_div)).to eq('main_div')
+        end
+      end
+    end
+
+    context 'tagging Resource Pool' do
+      before do
+        controller.instance_variable_set(:@display, nil)
+        controller.params = {:pressed => 'resource_pool_tag'}
+      end
+
+      it 'calls tag method' do
+        expect(controller).to receive(:tag).with(ResourcePool)
         controller.send(:button)
       end
     end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6617

In this PR, I've simplified `button` method in `resource_pool` controller to use `button` method in `GenericButtonMixin`. With this refactoring, I've achieved to make editing selected VM displayed in a nested list (through Resource Pool's _Relationships_ table) work.

I've added also little changes to `GenericButtonMixin` to keep the original logic regarding renaming VM. This will help also other controllers to use `button` method in the mixin without adding extra conditions in those controllers, regarding renaming VM.

**Before:** (nothing happens)
![edit_before](https://user-images.githubusercontent.com/13417815/72626451-06584500-394b-11ea-9639-36cab59fcdd5.png)

**After:** (editing form being rendered successfully)
![edit_after](https://user-images.githubusercontent.com/13417815/72626442-03f5eb00-394b-11ea-8646-453899aacf91.png)
