### PR TITLE
Fix toolbar on Reports tab on Overview -> Utilization screen

### DIFF
--- a/app/controllers/utilization_controller.rb
+++ b/app/controllers/utilization_controller.rb
@@ -213,7 +213,6 @@ class UtilizationController < ApplicationController
     presenter[:clear_selection] = x_node == ''
 
     presenter.reload_toolbars(:view => v_tb)
-    presenter.set_visibility(@sb[:active_tab] == 'report', :toolbar)
 
     presenter.update(:main_div, r[:partial => 'utilization_tabs'])
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])

--- a/app/helpers/application_helper/button/miq_capacity.rb
+++ b/app/helpers/application_helper/button/miq_capacity.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqCapacity < ApplicationHelper::Button::Basic
   def visible?
-    @view_context.sandbox[:active_tab] == 'report'
+    @view_context.sandbox[:active_tab] == 'report' && @sb[:summary].present?
   end
 end

--- a/app/helpers/application_helper/button/utilization_download.rb
+++ b/app/helpers/application_helper/button/utilization_download.rb
@@ -5,7 +5,7 @@ class ApplicationHelper::Button::UtilizationDownload < ApplicationHelper::Button
 
   def disabled?
     # to enable the button we are in the "Utilization" and have trend report
-    return false if @layout == 'miq_capacity_utilization' && @sb[:active_tab] == 'report' && @sb.fetch_path(:trend_rpt, :table, :data).present?
+    return false if @layout == 'miq_capacity_utilization' && @sb[:active_tab] == 'report' && @sb.fetch_path(:trend_rpt).present? && @sb[:summary].present?
 
     # otherwise the button is off
     @error_message = _('No records found for this report')

--- a/app/helpers/application_helper/button/utilization_download.rb
+++ b/app/helpers/application_helper/button/utilization_download.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::UtilizationDownload < ApplicationHelper::Button::Basic
   def disabled?
     # to enable the button we are in the "Utilization" and have trend report
-    return false if @layout == 'miq_capacity_utilization' && @sb[:active_tab] == 'report' && !@sb.fetch_path(:trend_rpt).table.data.empty?
+    return false if @layout == 'miq_capacity_utilization' && @sb[:active_tab] == 'report' && @sb.fetch_path(:trend_rpt, :table, :data).present?
 
     # otherwise the button is off
     @error_message = _('No records found for this report')

--- a/app/helpers/application_helper/button/utilization_download.rb
+++ b/app/helpers/application_helper/button/utilization_download.rb
@@ -1,4 +1,8 @@
 class ApplicationHelper::Button::UtilizationDownload < ApplicationHelper::Button::Basic
+  def visible?
+    @sb[:active_tab] == 'report'
+  end
+
   def disabled?
     # to enable the button we are in the "Utilization" and have trend report
     return false if @layout == 'miq_capacity_utilization' && @sb[:active_tab] == 'report' && @sb.fetch_path(:trend_rpt, :table, :data).present?

--- a/app/helpers/application_helper/toolbar/miq_capacity_view.rb
+++ b/app/helpers/application_helper/toolbar/miq_capacity_view.rb
@@ -28,7 +28,7 @@ class ApplicationHelper::Toolbar::MiqCapacityView < ApplicationHelper::Toolbar::
           'pficon pficon-print fa-lg',
           N_('Print or export this report in PDF format'),
           N_('Print or export as PDF'),
-          :klass     => ApplicationHelper::Button::Basic,
+          :klass     => ApplicationHelper::Button::MiqCapacity,
           :popup     => true,
           :url       => "/report_download",
           :url_parms => "?typ=pdf"),

--- a/spec/helpers/application_helper/buttons/miq_capacity_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_capacity_spec.rb
@@ -4,13 +4,23 @@ describe ApplicationHelper::Button::MiqCapacity do
 
   describe '#visible?' do
     subject { button.visible? }
-    context 'when active_tab == report' do
+    context 'when active_tab == report and @sb[:summary] is present' do
       let(:tab) { 'report' }
-      it { is_expected.to be_truthy }
+      it do
+        button.instance_variable_set(:@sb, :active_tab => "report", :summary => "data")
+        is_expected.to be(true)
+      end
+    end
+    context 'when active_tab == report and @sb[:summary] is empty' do
+      let(:tab) { 'report' }
+      it do
+        button.instance_variable_set(:@sb, :active_tab => "report", :summary => nil)
+        is_expected.to be(false)
+      end
     end
     context 'when active_tab != report' do
       let(:tab) { 'not_report' }
-      it { is_expected.to be_falsey }
+      it { is_expected.to be(false) }
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/utilization_download_spec.rb
+++ b/spec/helpers/application_helper/buttons/utilization_download_spec.rb
@@ -13,18 +13,24 @@ describe ApplicationHelper::Button::UtilizationDownload do
     context '#disabled?' do
       it 'when report tab has no data available' do
         report.table = OpenStruct.new(:data => [])
-        expect(button.disabled?).to be_truthy
+        expect(button.disabled?).to be(true)
       end
 
-      it 'when report tab has data' do
+      it 'when report tab has data and @sb[:summary] is not set' do
         report.table = OpenStruct.new(:data => [:foo => 'bar'])
-        expect(button.disabled?).to be_falsey
+        expect(button.disabled?).to be(true)
+      end
+
+      it 'when report tab has data and @sb[:summary] is set' do
+        button.instance_variable_set(:@sb, :active_tab => "report", :trend_rpt => report, :summary => "is set")
+        report.table = OpenStruct.new(:data => [:foo => 'bar'])
+        expect(button.disabled?).to be(false)
       end
 
       it 'when on summary tab' do
         button.instance_variable_set(:@sb, :active_tab => "summary", :trend_rpt => report)
         report.table = OpenStruct.new(:data => [:foo => 'bar'])
-        expect(button.disabled?).to be_truthy
+        expect(button.disabled?).to be(true)
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/6608

**Show toolbar when Report tab selected**
Go to Overview -> Utilization -> select a Provider -> click Report Tab -> No Download button

Before:
![image](https://user-images.githubusercontent.com/9210860/72740376-d5c01780-3ba5-11ea-99d0-dd274dc322a7.png)

After:
![image](https://user-images.githubusercontent.com/9210860/72738567-23d31c00-3ba2-11ea-999f-a81e8030b4e2.png)

**Do Not show toolbar when no data in Report**
Go to Overview -> Utilization -> select a Provider -> click Report Tab -> click another Provider -> click Download button and get an error
Before:
![image](https://user-images.githubusercontent.com/9210860/72790941-c6d57580-3c36-11ea-911c-bb87cc84aedc.png)

`[----] F, [2020-01-20T16:02:10.608136 #4597:3fe027b4a4b4] FATAL -- : Error caught: [NoMethodError] undefined method '[]' for nil:NilClass
/ManageIQ/manageiq-ui-classic/app/controllers/utilization_controller.rb:232:in 'summ_hashes'
/ManageIQ/manageiq-ui-classic/app/controllers/utilization_controller.rb:74:in 'report_download'`
After:
![image](https://user-images.githubusercontent.com/9210860/72738494-fbe3b880-3ba1-11ea-8862-5b0083cdce45.png)

@miq-bot add_label wip, bug, toolbars, ivanchuk/no