### PR TITLE
Remove pending specs

### DIFF
--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -310,59 +310,6 @@ describe AutomationManagerController do
       controller.send(:build_accordions_and_trees)
     end
 
-    # FIXME: This needs to be splin into separate tests.
-    # Also: we cannot directly test data rendered in the grid as this goes
-    # throught the GTL component and the /report_data JSON endpoint.
-    pending "renders the list view based on the nodetype(root,provider) and the search associated with it" do
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.params = {:id => "root"}
-      controller.instance_variable_set(:@search_text, "manager")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data.size).to eq(3)
-
-      ems_id = ems_key_for_provider(automation_provider1)
-      controller.params = {:id => ems_id}
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].name).to eq("testinvgroup")
-
-      controller.params = {:id => "at"}
-      controller.instance_variable_set(:@search_text, "2")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].name).to eq("ansibletest2 Automation Manager")
-
-      invgroup_id2 = inventory_group_key(@inventory_group2)
-      controller.params = {:id => invgroup_id2}
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].hostname).to eq("test2b_ans_configured_system")
-
-      controller.instance_variable_set(:@search_text, "2b")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].hostname).to eq("test2b_ans_configured_system")
-
-      allow(controller).to receive(:x_node).and_return("root")
-      allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.params = {:id => "automation_manager_cs_filter"}
-      controller.send(:accordion_select)
-      controller.instance_variable_set(:@search_text, "brew")
-      allow(controller).to receive(:x_tree).and_return(:type => :providers)
-      controller.params = {:id => "automation_manager_providers"}
-      controller.send(:accordion_select)
-
-      controller.params = {:id => "root"}
-      controller.send(:tree_select)
-      search_text = controller.instance_variable_get(:@search_text)
-      expect(search_text).to eq("manager")
-      view = controller.instance_variable_get(:@view)
-      show_adv_search = controller.instance_variable_get(:@show_adv_search)
-      expect(view.table.data.size).to eq(3)
-      expect(show_adv_search).to eq(true)
-    end
-
     it "renders tree_select for ansible tower job templates tree node" do
       allow(controller).to receive(:x_active_tree).and_return(:configuration_scripts_tree)
       controller.instance_variable_set(:@in_report_data, true)

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -313,110 +313,6 @@ describe ProviderForemanController do
       controller.send(:build_accordions_and_trees)
     end
 
-    pending "renders the list view based on the nodetype(root,provider,config_profile) and the search associated with it" do
-      controller.params = {:id => "root"}
-      controller.instance_variable_set(:@search_text, "manager")
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data.size).to eq(2)
-
-      controller.params = {:id => "xx-fr"}
-      controller.instance_variable_set(:@search_text, "manager")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data.size).to eq(2)
-
-      ems_id = ems_key_for_provider(@provider)
-      controller.params = {:id => ems_id}
-      controller.send(:tree_select)
-      gtl_init_data = controller.init_report_data('reportDataController')
-      expect(gtl_init_data[:data][:model_name]).to eq("manageiq/providers/configuration_managers")
-      expect(gtl_init_data[:data][:activeTree]).to eq("configuration_manager_providers_tree")
-      expect(gtl_init_data[:data][:parentId]).to eq(ems_id)
-      expect(gtl_init_data[:data][:isExplorer]).to eq(true)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].description).to eq("testprofile")
-
-      controller.instance_variable_set(:@search_text, "2")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].description).to eq("testprofile2")
-      config_profile_id2 = config_profile_key(@config_profile2)
-      controller.params = {:id => config_profile_id2}
-      controller.send(:tree_select)
-      gtl_init_data = controller.init_report_data('reportDataController')
-      expect(gtl_init_data[:data][:model_name]).to eq("manageiq/providers/configuration_managers")
-      expect(gtl_init_data[:data][:activeTree]).to eq("configuration_manager_providers_tree")
-      expect(gtl_init_data[:data][:parentId]).to eq(config_profile_id2)
-      expect(gtl_init_data[:data][:isExplorer]).to eq(true)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].hostname).to eq("test2a_configured_system")
-
-      controller.instance_variable_set(:@search_text, "2b")
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].hostname).to eq("test2b_configured_system")
-
-      allow(controller).to receive(:x_node).and_return("root")
-      allow(controller).to receive(:x_tree).and_return(:type => :filter)
-      controller.params = {:id => "configuration_manager_cs_filter"}
-      controller.send(:accordion_select)
-      controller.instance_variable_set(:@search_text, "brew")
-      allow(controller).to receive(:x_tree).and_return(:type => :providers)
-      controller.params = {:id => "configuration_manager_providers"}
-      controller.send(:accordion_select)
-
-      controller.params = {:id => "root"}
-      controller.send(:tree_select)
-      search_text = controller.instance_variable_get(:@search_text)
-      expect(search_text).to eq("manager")
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data.size).to eq(2)
-    end
-
-    pending "renders tree_select for a ConfigurationManagerForeman node that contains an unassigned profile" do
-      ems_id = ems_key_for_provider(@provider)
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.params = {:id => ems_id}
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      gtl_init_data = controller.init_report_data('reportDataController')
-      expect(gtl_init_data[:data][:model_name]).to eq("manageiq/providers/configuration_managers")
-      expect(gtl_init_data[:data][:activeTree]).to eq("configuration_manager_providers_tree")
-      expect(gtl_init_data[:data][:parentId]).to eq(ems_id)
-      expect(gtl_init_data[:data][:isExplorer]).to eq(true)
-      expect(view.table.data[0].data).to include('description' => "testprofile")
-      expect(view.table.data[2]).to include('description' => "Unassigned Profiles Group",
-                                            'name'        => "Unassigned Profiles Group")
-    end
-
-    pending "renders tree_select for a ConfigurationManagerForeman node that contains only an unassigned profile" do
-      ems_id = ems_key_for_provider(@provider2)
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.params = {:id => ems_id}
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0]).to include('description' => "Unassigned Profiles Group",
-                                            'name'        => "Unassigned Profiles Group")
-    end
-
-    pending "renders tree_select for an 'Unassigned Profiles Group' node for the first provider" do
-      controller.params = {:id => "-#{ems_id_for_provider(@provider)}-unassigned"}
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].data).to include('hostname' => "configured_system_unprovisioned")
-    end
-
-    pending "renders tree_select for an 'Unassigned Profiles Group' node for the second provider" do
-      controller.instance_variable_set(:@in_report_data, true)
-      controller.params = {:id => "-#{ems_id_for_provider(@provider2)}-unassigned"}
-      controller.send(:tree_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data[0].data).to include('hostname' => "configured_system_unprovisioned2")
-    end
-
     it "calls get_view with the associated dbname for the Configuration Management Providers accordion" do
       stub_user(:features => :all)
       allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_providers_tree)
@@ -454,19 +350,6 @@ describe ProviderForemanController do
                                                     :gtl_dbname => :cm_configured_systems, :dbname => :cm_configured_systems).and_call_original
       allow(controller).to receive(:build_listnav_search_list)
       controller.send(:accordion_select)
-    end
-
-    pending "does not display an automation manger configured system in the Configured Systems accordion" do
-      controller.instance_variable_set(:@in_report_data, true)
-      stub_user(:features => :all)
-      FactoryBot.create(:configured_system_ansible_tower)
-      allow(controller).to receive(:x_active_tree).and_return(:configuration_manager_cs_filter_tree)
-      allow(controller).to receive(:x_active_accord).and_return(:configuration_manager_cs_filter)
-      allow(controller).to receive(:build_listnav_search_list)
-      controller.params = {:id => "configuration_manager_cs_filter_accord"}
-      controller.send(:accordion_select)
-      view = controller.instance_variable_get(:@view)
-      expect(view.table.data.size).to eq(5)
     end
   end
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1276,22 +1276,6 @@ describe ReportController do
           @rpt = create_and_generate_report_for_user("Vendor and Guest OS", @user2)
         end
 
-        pending "is allowed to see report created under Group1 for User 1(with current group Group2)" do
-          controller.instance_variable_set(:@in_report_data, true)
-          controller.params = {:controller => "report", :action => "explorer"}
-          seed_session_trees('report', :saved_reports)
-          allow(controller).to receive(:get_view_calculate_gtl_type).and_return("list")
-          allow(controller).to receive(:get_view_pages_perpage).and_return(20)
-
-          controller.send(:get_all_saved_reports)
-
-          displayed_items = controller.instance_variable_get(:@pages)[:items]
-          expect(displayed_items).to eq(1)
-
-          expected_report_id = controller.instance_variable_get(:@view).table.data.last.miq_report_id
-          expect(expected_report_id).to eq(@rpt.id)
-        end
-
         it "is allowed to see miq report result for User1(with current group Group2)" do
           report_result_id = @rpt.miq_report_results.first.id
           controller.params = {:id => report_result_id,


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/2383 . 

Tests will be replaced by https://github.com/ManageIQ/manageiq-ui-classic/pull/6672 with `cypress` ones.

Before:
<img width="1262" alt="Screenshot 2020-02-11 at 15 35 14" src="https://user-images.githubusercontent.com/9210860/74246065-3abde780-4ce4-11ea-9c3d-24b3eeff5710.png">
<img width="1169" alt="Screenshot 2020-02-11 at 15 35 33" src="https://user-images.githubusercontent.com/9210860/74246073-3d204180-4ce4-11ea-8681-b29b45188bac.png">
After:
<img width="1266" alt="Screenshot 2020-02-11 at 15 34 41" src="https://user-images.githubusercontent.com/9210860/74246081-401b3200-4ce4-11ea-9898-673b833d05f7.png">
