### PR TITLE
Dialog sample - fix render dropdowns

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -64,7 +64,9 @@
                             %label{:for => "dialog_field_radio_sample_2"} Option 2
 
                           - if field.type == "DialogFieldDropDownList"
-                            = select_tag("#{field.id}", options_for_select([_("Option 1"), _("Option 2")]), :class => 'selectpicker')
+                            - select_attrs = {:class => 'selectpicker'}
+                            - select_attrs[:multiple] = '' if field.multiselect?
+                            = select_tag("#{field.id}", options_for_select([_("Option 1"), _("Option 2")]), select_attrs)
 
                           - if field.show_refresh_button?
                             = button_tag(_('Refresh'), :disabled => true)
@@ -74,17 +76,9 @@
                             - val = copy_array(field.values.map {|x, y| x.nil? ? [x,_(y)] : [x, y]})
 
                             - if field.type == "DialogFieldDropDownList"
-                              - if field.required
-                                = select_tag(field_id, options_for_select(val.collect(&:reverse), field.default_value), :class => 'selectpicker')
-
-                              - else
-                                -# NOT REQUIRED
-                                = select_tag(field.id.to_s,
-                                             options_for_select(val.collect(&:reverse), field.default_value),
-                                             drop_down_options(field, "someURL"))
-                                :javascript
-                                  miqInitSelectPicker();
-
+                              - select_attrs = {:class => 'selectpicker'}
+                              - select_attrs[:multiple] = '' if field.multiselect?
+                              = select_tag(field.id, options_for_select(val.collect(&:reverse), field.default_value), select_attrs)
                             - else
                               - val.each_with_index do |rb, i|
                                 %input{:type     => "radio",
@@ -100,8 +94,10 @@
                       - when "DialogFieldButton"
                         = button_tag(_('Save'), :disabled => true)
                       - when "DialogFieldTagControl"
-                        - multiple = field.single_value? ? {} : {:multiple => true}
-                        = select_tag(field_id, options_for_select(dialog_dropdown_select_values(field)), multiple)
+                        - select_attrs = {:class => 'selectpicker'}
+                        - select_attrs[:multiple] = '' if field.multiselect?
+                        = select_tag(field_id, options_for_select(dialog_dropdown_select_values(field)), select_attrs)
 
 :javascript
   miq_tabs_init("#dialog_tabs");
+  miqInitSelectPicker();


### PR DESCRIPTION
Automation > Automate > Customization > Service Dialogs,
click a dialog, see right-side detail

before, if the dialog only has dynamic dropdowns, or only required non-dynamic dropdowns, no dropdown would get shown.

That's because they already have the .selectpicker class which hides the %select element, but the call to miqInitSelectPicker never happened outside the non-dynamic non-required branch, never rendering the selectpicker component.

now, all selects (including tags) should render in each case, with :multiple correctly set.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/5279
Cc @d-m-u 