### PR TITLE
Allow importing Tags for VM using a CSV file

### DIFF
--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -73,7 +73,7 @@ module OpsController::Settings::Upload
       rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
       else
-        imp.errors.each_value { |msg| add_flash(msg, :error) }
+        imp.errors.each { |_field, msg| add_flash(msg, :error) }
         add_flash(_("Import validation complete: %{good_record}, %{bad_record}") % {
           :good_record => n_("%{num} good record", "%{num} good records", imp.stats[:good]) % {:num => imp.stats[:good]},
           :bad_record  => n_("%{num} bad record", "%{num} bad records", imp.stats[:bad]) % {:num => imp.stats[:bad]}

--- a/spec/controllers/ops_controller/settings/upload_spec.rb
+++ b/spec/controllers/ops_controller/settings/upload_spec.rb
@@ -1,0 +1,17 @@
+describe OpsController do
+  describe '#upload_csv' do
+    let(:file) { StringIO.new("name,category,entry\nevm1,Environment,Test") }
+
+    before do
+      allow(controller).to receive(:load_edit).and_return(true)
+      allow(controller).to receive(:redirect_to)
+      controller.instance_variable_set(:@sb, :active_tab => 'settings_tags', :selected_server_id => 123)
+      controller.params = {:typ => 'tag', :upload => {:file => ActionDispatch::Http::UploadedFile.new(:tempfile => file)}}
+    end
+
+    it 'adds error flash message to @flash_array regarding importing tags for VM using a CSV file' do
+      controller.send(:upload_csv)
+      expect(controller.instance_variable_get(:@flash_array)).to include(:message => 'Name: evm1: Unable to find VM', :level => :error)
+    end
+  end
+end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1792185

This PR simply fixes the bug regarding importing Tags for VMs using a CSV file, introduced [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/3643/files#diff-8d3cbf9c4fd28532293661e4b69b1abdL80-L83).

**Before:**
![import_before](https://user-images.githubusercontent.com/13417815/72918768-882ee080-3d46-11ea-9fc5-106356d4f6a5.png)

**After:**
![import_after](https://user-images.githubusercontent.com/13417815/72918774-89f8a400-3d46-11ea-989f-8c3f7ce87b31.png)

---

**Exact steps to reproduce:**
1. Create a CSV file with tags for a VM, in an appropriate format, see [documentation](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/5.0/html/general_configuration/configuration) and "4.1.1.4.6. Importing Tags for Virtual Machines"
2. Go to _Configuration > Settings_ accordion
3. Click on the region name in accordion
4. Click on _Tags_ tab
5. Go to _Import Tags_ tab, upload the CSV file
=> error:
```
[----] I, [2020-01-22T17:00:33.703791 #14555:5e6567c]  INFO -- : Processing by OpsController#upload_csv as HTML
[----] I, [2020-01-22T17:00:33.703921 #14555:5e6567c]  INFO -- :   Parameters: {"utf8"=>"✓", "authenticity_token"=>"F+r6XckBb4BFzxBPX0UgRJxpBUSbIKKz8g/NvA+eVFs7W+rH7ub1pBUPvHL6+OEgEcgSB64nZN/R+ZxAIRmTSQ==", "upload"=>{"file"=>#<ActionDispatch::Http::UploadedFile:0x00007f4e0630a858 @tempfile=#<Tempfile:/tmp/RackMultipart20200122-14555-o64xg6.csv>, @original_filename="import_tags1.csv", @content_type="text/csv", @headers="Content-Disposition: form-data; name=\"upload[file]\"; filename=\"import_tags1.csv\"\r\nContent-Type: text/csv\r\n">}, "commit"=>"Upload", "typ"=>"tag"}
[----] F, [2020-01-22T17:00:33.733957 #14555:5e6567c] FATAL -- : Error caught: [NoMethodError] undefined method `each_value' for #<ActiveModel::Errors:0x00007f4e06241570>
Did you mean?  each_slice
/home/hstastna/manageiq/manageiq-ui-classic/app/controllers/ops_controller/settings/upload.rb:76:in `upload_csv'
```