### PR TITLE
Update the page after clearing Search text, for non-explorer screens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -552,9 +552,11 @@ class ApplicationController < ActionController::Base
   end
 
   def adv_search_text_clear
+    @search_text = @sb[:search_text] = nil
     if params[:in_explorer] == "true"
-      @search_text = @sb[:search_text] = nil
       reload
+    else
+      javascript_redirect(last_screen_url)
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -473,6 +473,34 @@ describe ApplicationController do
     end
   end
 
+  describe '#adv_search_text_clear' do
+    before do
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'last url'}])
+      controller.instance_variable_set(:@sb, :search_text => 'Search text')
+    end
+
+    it 'sets @search_text and @sb[:search_text] to nil' do
+      allow(controller).to receive(:javascript_redirect)
+      controller.send(:adv_search_text_clear)
+      expect(controller.instance_variable_get(:@search_text)).to be_nil
+      expect(controller.instance_variable_get(:@sb)[:search_text]).to be_nil
+    end
+
+    it 'calls javascript_redirect for non-explorer' do
+      expect(controller).to receive(:javascript_redirect).with('last url')
+      controller.send(:adv_search_text_clear)
+    end
+
+    context 'explorer screen' do
+      before { controller.params = {:in_explorer => 'true'} }
+
+      it 'calls reload' do
+        expect(controller).to receive(:reload)
+        controller.send(:adv_search_text_clear)
+      end
+    end
+  end
+
   context "private methods" do
     describe "#process_params_model_view" do
       it "with options[:model_name]" do


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6613

There was an issue in non-explorer based screens: after search for some name and then clicking on "**X**" in the _Search_ field, nothing happened in the UI together with:
```
No template found for CloudTenantController#adv_search_text_clear, rendering head :no_content.
```
This was due to the missing case for non-explorer screen in `adv_search_text_clear` method. We have to call `javascript_redirect` to update both main div and the title of the page.

Also `@search_text` and `@sb[:search_text]` was not cleared properly. We have to clear it, no matter if we are in explorer or non-explorer screen.

---

**Before:**
![search_before](https://user-images.githubusercontent.com/13417815/76544850-08410f00-6489-11ea-8205-cdf9d157dac0.png)

**After:**
![search_after](https://user-images.githubusercontent.com/13417815/76545032-52c28b80-6489-11ea-8378-339b6aa086a8.png)

