### PR TITLE
Update session[:host_items] also if only one Host in a nested list was selected for editing

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -43,7 +43,7 @@ module ApplicationController::CiProcessing
       @redirect_controller = "vm"
     when "host_edit"
       @redirect_controller = "host"
-      session[:host_items] = obj if obj.length > 1
+      session[:host_items] = obj.length > 1 ? obj : nil
     end
     @redirect_id = obj[0] if obj.length == 1 # not redirecting to an id if multi host are selected for credential edit
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -814,6 +814,28 @@ describe ApplicationController do
       end
     end
   end
+
+  describe '#edit_record' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:session).and_return(:host_items => [1, 2])
+      controller.params = {:pressed => 'host_edit', :miq_grid_checks => '1'}
+    end
+
+    it 'sets session[:host_items] to nil' do
+      controller.send(:edit_record)
+      expect(controller.session[:host_items]).to be_nil
+    end
+
+    context 'multiple Hosts selected in a nested list for editing' do
+      before { controller.params = {:pressed => 'host_edit', :miq_grid_checks => '1, 2, 3'} }
+
+      it 'sets session[:host_items]' do
+        controller.send(:edit_record)
+        expect(controller.session[:host_items]).to eq([1, 2, 3])
+      end
+    end
+  end
 end
 
 describe HostController do


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1782568

There was an issue regarding editing one Host displayed in a nested list, after navigating away from the editing screen with more Hosts selected for editing: multi Host edit screen was displayed instead of the screen for editing one Host we selected.

The problem was caused by not setting `session[:host_items]` properly. The value for the variable was updated/set only if we selected more than one Host in the nested list (`if obj.length > 1`). Now with the simple change in the original condition, `session[:host_items]` is set back to `nil` if we chose only one Host so then the proper screen for editing one Host can be [displayed](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/host_controller.rb#L130).

**Before:**
![host_before](https://user-images.githubusercontent.com/13417815/73183708-8f296a80-411b-11ea-8b6e-e2216e72b9f3.png)

**After**:
![host_after](https://user-images.githubusercontent.com/13417815/73183715-92bcf180-411b-11ea-8d0a-bad4bf099e0f.png)
