### PR TITLE
Use the backend logic for zone deletion

### DIFF
--- a/app/helpers/application_helper/button/zone_delete.rb
+++ b/app/helpers/application_helper/button/zone_delete.rb
@@ -2,19 +2,7 @@ class ApplicationHelper::Button::ZoneDelete < ApplicationHelper::Button::Basic
   needs :@selected_zone
 
   def disabled?
-    @error_message = if @selected_zone.name.downcase == 'default'
-                       _("'Default' zone cannot be deleted")
-                     elsif relationships?
-                       _('Cannot delete a Zone that has Relationships')
-                     end
+    @error_message = @selected_zone.message_for_invalid_delete
     @error_message.present?
-  end
-
-  private
-
-  def relationships?
-    @selected_zone.ext_management_systems.count > 0 ||
-      @selected_zone.miq_schedules.count > 0 ||
-      @selected_zone.miq_servers.count > 0
   end
 end

--- a/spec/helpers/application_helper/buttons/zone_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_delete_spec.rb
@@ -1,43 +1,25 @@
 describe ApplicationHelper::Button::ZoneDelete do
-  let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:zone_name) { 'NotDefault' }
-  let(:selected_zone) { FactoryBot.create(:zone, :name => zone_name) }
-  let(:button) { described_class.new(view_context, {}, {'selected_zone' => selected_zone}, {}) }
+  let(:view_context)  { setup_view_context_with_sandbox({}) }
+  let(:selected_zone) { FactoryBot.create(:zone) }
+  let(:button)        { described_class.new(view_context, {}, {'selected_zone' => selected_zone}, {}) }
 
   describe '#calculate_properties' do
-    let(:set_relationships) {}
-    before do
-      set_relationships
-      button.calculate_properties
+    context "when a message is returned" do
+      before do
+        expect(selected_zone).to receive(:message_for_invalid_delete).and_return("an error message")
+        button.calculate_properties
+      end
+
+      it_behaves_like 'a disabled button', "an error message"
     end
 
-    context 'when selected zone is the default one' do
-      let(:zone_name) { 'Default' }
-      it_behaves_like 'a disabled button', "'Default' zone cannot be deleted"
-    end
-
-    context 'when selected zone is not the default one' do
-      context 'and zone has ext_management_systems' do
-        let(:set_relationships) { selected_zone.ext_management_systems << FactoryBot.create(:ext_management_system) }
-        it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
+    context "when a message is not returned" do
+      before do
+        expect(selected_zone).to receive(:message_for_invalid_delete).and_return(nil)
+        button.calculate_properties
       end
 
-      context 'and zone has miq_schedules' do
-        let(:set_relationships) do
-          EvmSpecHelper.local_guid_miq_server_zone
-          selected_zone.miq_schedules << FactoryBot.create(:miq_schedule)
-        end
-        it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
-      end
-
-      context 'and zone has miq_servers' do
-        let(:set_relationships) { selected_zone.miq_servers << FactoryBot.create(:miq_server) }
-        it_behaves_like 'a disabled button', 'Cannot delete a Zone that has Relationships'
-      end
-
-      context 'and zone has no relationships' do
-        it_behaves_like 'an enabled button'
-      end
+      it_behaves_like 'an enabled button'
     end
   end
 end


### PR DESCRIPTION
This logic was duplicated, so we can use the version in core

I'm not sure why we were preventing deletion when a zone had schedules, but the zone model has a `dependent_destroy` so I figure we can ignore those.

~~Requires https://github.com/ManageIQ/manageiq/pull/19770~~ Merged