### PR TITLE
Do not store Performance::Options instances in the session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1735,7 +1735,7 @@ class ApplicationController < ActionController::Base
     @detail_sortdir = @sb[:detail_sortdir].nil? ? "ASC" : @sb[:detail_sortdir]    # sort column for detail lists
 
     # Get performance hash, if it is in the sandbox for the running controller
-    @perf_options = @sb[:perf_options] || Performance::Options.new
+    @perf_options = Performance::Options.load_from_hash(@sb[:perf_options])
 
     # Set @edit key default for the expression editor to use
     @expkey = session[:expkey] || :expression
@@ -1866,7 +1866,7 @@ class ApplicationController < ActionController::Base
     end
 
     # Put performance hash, if it exists, into the sandbox for the running controller
-    @sb[:perf_options] = @perf_options
+    @sb[:perf_options] = @perf_options.to_h
 
     # Save @assign hash in sandbox
     @sb[:assign] = @assign ? copy_hash(@assign) : nil

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -480,7 +480,7 @@ module ApplicationController::Performance
     # Set the perf options in the selected controller's sandbox
     cont = data_row["resource_type"].underscore.downcase.to_sym
     session[:sandboxes][cont] ||= {}
-    session[:sandboxes][cont][:perf_options] ||= Options.new
+    session[:sandboxes][cont][:perf_options] ||= {}
 
     # Copy general items from the current perf_options
     session[:sandboxes][cont][:perf_options][:index] = @perf_options[:index]

--- a/app/controllers/application_controller/performance/options.rb
+++ b/app/controllers/application_controller/performance/options.rb
@@ -32,6 +32,10 @@ module ApplicationController::Performance
     :tz,
     :tz_daily
   ) do
+    def self.load_from_hash(hash)
+      new(*(hash || {}).values)
+    end
+
     def update_from_params(params)
       self.typ         = params[:perf_typ]          if params[:perf_typ]
       self.days        = params[:perf_days]         if params[:perf_days]


### PR DESCRIPTION
Object defined in the ui-classic codebase can cause loading errors if serialized in the session. The session is being accessed from the API as well and if there's an instance of MiQ running without the ui-classic codebase, the serialized object cannot be deserialized. 

As a solution I'm converting the object's data into a hash and whenever it is loaded, I create a new instance manually. However, I'm not familiar with the area and I have no idea how to test this.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @PanSpagetka 
@miq-bot add_label bug, ivanchuk/no

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6534