### PR TITLE
Allow non-JSON responses in miqFetch (add `options.skipJsonParsing`)

### DIFF
--- a/app/javascript/http_api/fetch.js
+++ b/app/javascript/http_api/fetch.js
@@ -22,6 +22,7 @@ function processOptions(options) {
   delete o.type;
   delete o.url;
   delete o.transformResponse;
+  delete o.skipJsonParsing;
 
   o.headers = o.headers || {};
 
@@ -62,7 +63,7 @@ function processData(o) {
   return null;
 }
 
-function processResponse(response) {
+function processResponse(response, options = {}) {
   if (response.status === 204) {
     // No content
     return Promise.resolve(null);
@@ -76,12 +77,17 @@ function processResponse(response) {
       .then(rejectWithData(response));
   }
 
+  if (options.skipJsonParsing) {
+    // For reading headers and parsing non-JSON responses
+    return Promise.resolve(response);
+  }
+
   return response.json();
 }
 
 function responseAndError(options = {}) {
   return (response) => {
-    let ret = processResponse(response);
+    let ret = processResponse(response, options);
 
     if ((response.status === 401) && !options.skipLoginRedirect) {
       // Unauthorized - always redirect to dashboard#login


### PR DESCRIPTION
In https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/37, we are adding a new API endpoint which delivers a binary response (`content-disposition: attachment`) intended for the UI to make available as a file download. Rationale for the decision to handle the file download via the API instead of a UI worker can be found in the relevant discussions at https://github.com/RedHatCloudForms/cfme-migration_analytics/issues/19 and https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/33.

Currently, [the `API` methods provided here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/http_api/api.js) (which we must use to handle authentication) assume API responses will always be JSON, and [call `response.json()` as part of processing the `fetch()` response](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/http_api/fetch.js#L79). This causes an error when trying to make a call to the new endpoint, since it is returning binary gzip data.

This PR adds a new option to `miqFetch` called `skipJsonParsing` which simply skips that `.json()` call, instead resolving the promise with the raw `response` object directly. This gives the calling function in the UI access to `response.blob()` and `response.headers()`, which are necessary for reading the binary data and attachment filename.

To test these changes, you can run the following code in a browser's JavaScript console:
```js
API.get('/api', { skipJsonParsing: true }).then(response => console.log({ response }));
```

Links
----------------
BZ for backport to ivanchuk: https://bugzilla.redhat.com/show_bug.cgi?id=1788730
JIRA task for feature: https://issues.redhat.com/browse/MIGENG-241
Issue for feature: https://github.com/RedHatCloudForms/cfme-migration_analytics/issues/19
Dependent PR: https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/37
Initial closed PR with implementation context: https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/33