### PR TITLE
Add APP_PATH to allow using Rails directly

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -3,7 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/manageiq/ui/engine', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/manageiq/ui/classic/engine', __FILE__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)

--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,7 @@
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/manageiq/ui/classic/engine', __FILE__)
+APP_PATH    = File.expand_path("../../spec/manageiq/config/application", __FILE__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)


### PR DESCRIPTION
This PR enables running rails console and rails server directly from the manageiq-ui-classic using the spec/manageiq as the containing app.

@himdel Please review

