### PR TITLE
Redirect to proper controller for Edit and other actions on selected Host Aggregate

### DIFF
--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -202,11 +202,7 @@ class HostAggregateController < ApplicationController
       }, :error)
       session[:flash_msgs] = @flash_array
       @in_a_form = false
-      if @lastaction == "show_list"
-        redirect_to(:action => "show_list")
-      else
-        redirect_to(:action => "show", :id => params[:id])
-      end
+      redirect_to(@breadcrumbs[-1][:url])
     else
       drop_breadcrumb(
         :name => _("Add Host to Host Aggregate \"%{name}\"") % {:name => @host_aggregate.name},
@@ -263,21 +259,16 @@ class HostAggregateController < ApplicationController
     task = MiqTask.find(task_id)
     host = Host.find(host_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Host \"%{hostname}\" added to Host Aggregate \"%{name}\"") % {
+      flash_and_redirect(_("Host \"%{hostname}\" added to Host Aggregate \"%{name}\"") % {
         :hostname => host.name,
         :name     => host_aggregate_name
       })
     else
-      add_flash(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
+      flash_and_redirect(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
         :name    => host_aggregate_name,
         :details => task.message
       }, :error)
     end
-
-    @breadcrumbs&.pop
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(:action => "show", :id => host_aggregate_id)
   end
 
   def remove_host_select

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -102,7 +102,7 @@ class HostAggregateController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Host Aggregate \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Edit of Host Aggregate \"%{name}\" was cancelled by the user") % {
         :name => @host_aggregate.name
       })
 
@@ -140,17 +140,13 @@ class HostAggregateController < ApplicationController
     host_aggregate_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Host Aggregate \"%{name}\" updated") % {:name => host_aggregate_name})
+      flash_and_redirect(_("Host Aggregate \"%{name}\" updated") % {:name => host_aggregate_name})
     else
-      add_flash(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
+      flash_and_redirect(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
         :name    => host_aggregate_name,
         :details => task.message
       }, :error)
     end
-
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(previous_breadcrumb_url)
   end
 
   def delete_host_aggregates
@@ -225,7 +221,7 @@ class HostAggregateController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Add Host to Host Aggregate \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Add Host to Host Aggregate \"%{name}\" was cancelled by the user") % {
         :name => @host_aggregate.name
       })
 
@@ -318,7 +314,7 @@ class HostAggregateController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Remove Host from Host Aggregate \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Remove Host from Host Aggregate \"%{name}\" was cancelled by the user") % {
         :name => @host_aggregate.name
       })
 
@@ -377,9 +373,10 @@ class HostAggregateController < ApplicationController
     javascript_redirect(:action => "show", :id => host_aggregate_id)
   end
 
-  def cancel_action(message)
+  # Set flash message, add it to session, redirect to proper screen and render the flash message
+  def flash_and_redirect(message, level = :success)
     session[:edit] = nil
-    add_flash(message)
+    add_flash(message, level)
     flash_to_session
     javascript_redirect(previous_breadcrumb_url)
   end

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -175,14 +175,15 @@ class HostAggregateController < ApplicationController
     end
     process_host_aggregates(host_aggregates_to_delete, "destroy") unless host_aggregates_to_delete.empty?
 
-    # refresh the list if applicable
-    if @lastaction == "show_list"
-      @refresh_partial = "layouts/gtl"
-    elsif @lastaction == "show" && @layout == "host_aggregate"
-      @single_delete = true unless flash_errors?
-    end
     flash_to_session
-    redirect_to(:action => 'show_list')
+    # refresh the list
+    if @lastaction == "show" && @layout == "host_aggregate" # Textual Summary of Host Aggregate
+      @single_delete = true unless flash_errors?
+      redirect_to(previous_breadcrumb_url)
+    else # list of Host Aggregates
+      @refresh_partial = "layouts/gtl" if @lastaction == "show_list"
+      redirect_to(@breadcrumbs[-1][:url])
+    end
   end
 
   def add_host_select

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -72,18 +72,13 @@ class HostAggregateController < ApplicationController
     host_aggregate_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Host Aggregate \"%{name}\" created") % {:name => host_aggregate_name})
+      flash_and_redirect(_("Host Aggregate \"%{name}\" created") % {:name => host_aggregate_name})
     else
-      add_flash(_("Unable to create Host Aggregate \"%{name}\": %{details}") % {
+      flash_and_redirect(_("Unable to create Host Aggregate \"%{name}\": %{details}") % {
         :name    => host_aggregate_name,
         :details => task.message
       }, :error)
     end
-
-    @breadcrumbs&.pop
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(:action => "show_list")
   end
 
   def edit

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -380,11 +380,9 @@ class HostAggregateController < ApplicationController
 
   def cancel_action(message)
     session[:edit] = nil
-    @breadcrumbs&.pop
-    javascript_redirect(:action    => @lastaction,
-                        :id        => @host_aggregate.id,
-                        :display   => session[:host_aggregate_display],
-                        :flash_msg => message)
+    add_flash(message)
+    flash_to_session
+    javascript_redirect(previous_breadcrumb_url)
   end
 
   private

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -148,11 +148,9 @@ class HostAggregateController < ApplicationController
       }, :error)
     end
 
-    @breadcrumbs&.pop
     session[:edit] = nil
-    session[:flash_msgs] = @flash_array.dup if @flash_array
-
-    javascript_redirect(:action => "show", :id => host_aggregate_id)
+    flash_to_session
+    javascript_redirect(previous_breadcrumb_url)
   end
 
   def delete_host_aggregates

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -286,11 +286,7 @@ class HostAggregateController < ApplicationController
       }, :error)
       session[:flash_msgs] = @flash_array
       @in_a_form = false
-      if @lastaction == "show_list"
-        redirect_to(:action => "show_list")
-      else
-        redirect_to(:action => "show", :id => params[:id])
-      end
+      redirect_to(@breadcrumbs[-1][:url])
     else
       drop_breadcrumb(
         :name => _("Remove Host from Host Aggregate \"%{name}\"") % {:name => @host_aggregate.name},
@@ -347,21 +343,16 @@ class HostAggregateController < ApplicationController
     task = MiqTask.find(task_id)
     host = Host.find(host_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Host \"%{hostname}\" removed from Host Aggregate \"%{name}\"") % {
+      flash_and_redirect(_("Host \"%{hostname}\" removed from Host Aggregate \"%{name}\"") % {
         :hostname => host.name,
         :name     => host_aggregate_name
       })
     else
-      add_flash(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
+      flash_and_redirect(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
         :name    => host_aggregate_name,
         :details => task.message
       }, :error)
     end
-
-    @breadcrumbs&.pop
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(:action => "show", :id => host_aggregate_id)
   end
 
   # Set flash message, add it to session, redirect to proper screen and render the flash message

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -202,7 +202,7 @@ module Mixins
     def button
       @edit = session[:edit] # Restore @edit for adv search box
 
-      params[:display] = @display if ["vms", "hosts", "storages", "instances", "images", "orchestration_stacks"].include?(@display) # Were we displaying vms/hosts/storages
+      params[:display] = @display if ["vms", "hosts", 'host_aggregates', "storages", "instances", "images", "orchestration_stacks"].include?(@display) # Were we displaying vms/hosts/storages
       params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
       # Handle buttons from sub-items screen

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -79,20 +79,21 @@ describe HostAggregateController do
   describe "#delete_host_aggregates" do
     let(:params) { {:id => aggregate.id.to_s} }
 
-    before { controller.params = params }
-
-    context 'deleting Host Aggregate' do
-      before { allow(controller).to receive(:redirect_to) }
-
-      it 'calls process_host_aggregates with selected Host Aggregates' do
-        expect(controller).to receive(:process_host_aggregates).with([aggregate], 'destroy')
-        controller.send(:delete_host_aggregates)
-      end
+    before do
+      allow(controller).to receive(:redirect_to)
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'some_url'}])
+      controller.instance_variable_set(:@lastaction, 'show_list')
+      controller.params = params
     end
 
-    it 'sets flash message and redirects to show_list' do
+    it 'calls process_host_aggregates with selected Host Aggregates' do
+      expect(controller).to receive(:process_host_aggregates).with([aggregate], 'destroy')
+      controller.send(:delete_host_aggregates)
+    end
+
+    it 'sets flash message and redirects properly' do
       expect(controller).to receive(:flash_to_session)
-      expect(controller).to receive(:redirect_to).with(:action => 'show_list')
+      expect(controller).to receive(:redirect_to).with('some_url')
       controller.send(:delete_host_aggregates)
       expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Delete initiated for 1 Host Aggregate.", :level => :success}])
     end
@@ -100,18 +101,25 @@ describe HostAggregateController do
     context 'Host Aggregates displayed in a nested list' do
       let(:params) { {:miq_grid_checks => aggregate.id.to_s} }
 
-      context 'deleting selected Host Aggregates' do
-        before { allow(controller).to receive(:redirect_to) }
+      before { controller.instance_variable_set(:@lastaction, nil) }
 
-        it 'calls process_host_aggregates with selected Host Aggregates' do
-          expect(controller).to receive(:process_host_aggregates).with([aggregate], 'destroy')
-          controller.send(:delete_host_aggregates)
-        end
+      it 'sets flash message and redirects to last url' do
+        expect(controller).to receive(:flash_to_session)
+        expect(controller).to receive(:redirect_to).with('some_url')
+        controller.send(:delete_host_aggregates)
+        expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Delete initiated for 1 Host Aggregate.", :level => :success}])
+      end
+    end
+
+    context 'textual summary of Host Aggregate' do
+      before do
+        controller.instance_variable_set(:@breadcrumbs, [{:url => 'some_previous_url'}, {:url => 'some_url'}])
+        controller.instance_variable_set(:@lastaction, 'show')
+        controller.instance_variable_set(:@layout, 'host_aggregate')
       end
 
-      it 'sets flash message and redirects to show_list' do
-        expect(controller).to receive(:flash_to_session)
-        expect(controller).to receive(:redirect_to).with(:action => 'show_list')
+      it 'sets flash message and redirects to previous url' do
+        expect(controller).to receive(:redirect_to).with('some_previous_url')
         controller.send(:delete_host_aggregates)
         expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Delete initiated for 1 Host Aggregate.", :level => :success}])
       end

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -49,6 +49,33 @@ describe HostAggregateController do
     end
   end
 
+  describe '#create_finished' do
+    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:status) { 'Error' }
+
+    before do
+      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
+      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => aggregate.name}})
+    end
+
+    it 'calls flash_and_redirect with appropriate arguments' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Unable to create Host Aggregate \"%{name}\": %{details}") % {
+        :name    => aggregate.name,
+        :details => miq_task.message
+      }, :error)
+      controller.send(:create_finished)
+    end
+
+    context 'succesful creating of new Host Aggregate' do
+      let(:status) { 'ok' }
+
+      it 'calls flash_and_redirect with appropriate arguments' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Host Aggregate \"%{name}\" created") % {:name => aggregate.name})
+        controller.send(:create_finished)
+      end
+    end
+  end
+
   describe "#update" do
     let(:task_options) do
       {

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -198,6 +198,48 @@ describe HostAggregateController do
     end
   end
 
+  describe '#add_host_select' do
+    before do
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'previous_url'}, {:url => 'last_url'}])
+      controller.params = {:id => aggregate.id}
+    end
+
+    it 'calls redirect_to with last url' do
+      expect(controller).to receive(:redirect_to).with('last_url')
+      controller.send(:add_host_select)
+    end
+  end
+
+  describe '#add_host_finished' do
+    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => status, :message => 'some message') }
+    let(:status) { 'Error' }
+
+    before do
+      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
+      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :id => aggregate.id, :name => aggregate.name, :host_id => host.id}})
+    end
+
+    it 'calls flash_and_redirect with appropriate arguments' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Unable to update Host Aggregate \"%{name}\": %{details}") % {
+        :name    => aggregate.name,
+        :details => miq_task.message
+      }, :error)
+      controller.send(:add_host_finished)
+    end
+
+    context 'succesful adding Host to Host Aggregate' do
+      let(:status) { 'ok' }
+
+      it 'calls flash_and_redirect with appropriate arguments' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Host \"%{hostname}\" added to Host Aggregate \"%{name}\"") % {
+          :hostname => host.name,
+          :name     => aggregate.name
+        })
+        controller.send(:add_host_finished)
+      end
+    end
+  end
+
   describe "#remove_host" do
     let(:task_options) do
       {

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -90,6 +90,18 @@ describe EmsCloudController do
         before do
           allow(controller).to receive(:performed?).and_return(true)
           controller.params = {:pressed => pressed, :miq_grid_checks => aggregate.id.to_s}
+          controller.instance_variable_set(:@display, 'host_aggregates')
+        end
+
+        context 'setting params[:display] because of a nested list' do
+          let(:pressed) { 'host_aggregate_edit' }
+
+          before { allow(controller).to receive(:render) }
+
+          it 'sets params[:display]' do
+            controller.send(:button)
+            expect(controller.params[:display]).to eq('host_aggregates')
+          end
         end
 
         context 'editing Host Aggregate' do


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6323

**This PR:**
- sets `params[:display]` from `@display` also for Host Aggregates, in the `button` method in _EmsCommon_ mixin
- fixes "wrong" redirect after **editing Host Aggregate** displayed through provider's summary page, we end up in a same page as before the action, when
  - clicking on _Cancel_ button in Edit page
  - clicking on _Save_ button
      - succesful saving of the change
      - unable to save changes because of missing credentials 
- fixes "wrong" redirect after **deleting Host Aggregate**
  - selected from the list/nested list of Host Aggregates (through provider)
  - from textual summary of Host Aggregate
- fixes "wrong" redirect after **adding Host to selected Host Aggregate** displayed through provider's summary when
  - clicking on _Cancel_ button
  - clicking on _Add_ button
  - no Hosts are available to add to selected Host Aggregate
- fixes "wrong" redirect after **removing Host from selected Host Aggregate** displayed through provider's summary when
  - clicking on _Cancel_ button
  - clicking on _Remove_ button
  - no Hosts are available to remove from selected Host Aggregate
- changes `cancel_action` little bit, to be able to add also error messages to `@flash_array`, renames the method to `flash_and_redirect` according to what it really does
- simplifies `create_finished` method (for **adding new Host Aggregate**) and some others in HostAggregate controller, to use `flash_and_redirect` method (nothing was needed to fix regarding adding new Host Aggregates but I think this is mainly because this action is used only in one place so there aren't any possibilities to redirect to any "wrong" screen after this action)

**Note:**
Everything works also for items displayed through _Compute > Clouds > Host Aggregates_, with the changes in this PR.

---

**Before:**
After canceling editing selected Host Aggregate:
![edit-before](https://user-images.githubusercontent.com/13417815/73772434-6a1ea280-4780-11ea-875f-0968826e6c12.png)
After saving changes if Edit was not applicable on selected Host Aggregate:
![no_edit_before](https://user-images.githubusercontent.com/13417815/73782089-b9b99a00-4791-11ea-9273-fdff0af25cec.png)

**After:**
![edit-after](https://user-images.githubusercontent.com/13417815/73772443-6ee35680-4780-11ea-8f7e-e4d42a52ae39.png)
![no_edit_after](https://user-images.githubusercontent.com/13417815/73782130-d0f88780-4791-11ea-9102-5ec05a87761c.png)

---

**Next ideas/steps (for follow up PRs):**
- create new method in app controller which would return `@breadcrumbs[-1][:url]`, maybe `last_beadcrumb_url` as this could be used in more places
- check `GenericFormMixin` and think about an existing `cancel_action` method, maybe edit it, maybe rename and then maybe better use this method in _HostAggregateController_
- check _SecurityGroupController_ and think about better using the method from  `GenericFormMixin`
