### PR TITLE
remote_consoles - use jquery from npm, not jquery-rails

### DIFF
--- a/app/assets/javascripts/remote_consoles/spice.js
+++ b/app/assets/javascripts/remote_consoles/spice.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require jquery/dist/jquery.js
 //= require spice-html5-bower/spice-html5-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/assets/javascripts/remote_consoles/vnc.js
+++ b/app/assets/javascripts/remote_consoles/vnc.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require jquery/dist/jquery.js
 //= require novnc-rails
 //= require_tree ../locale
 //= require gettext/all

--- a/app/assets/javascripts/remote_consoles/webmks.js
+++ b/app/assets/javascripts/remote_consoles/webmks.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require jquery/dist/jquery.js
 //= require jquery-ui/ui/unique-id.js
 //= require jquery-ui/ui/widget.js
 //= require jquery-ui/ui/widgets/dialog.js


### PR DESCRIPTION
The remote console code is still using the asset pipeline and `// require jquery` won't find the npm package, and loads the `jquery-rails` gem. Switching to the node_modules version.

cc @skateman, @Fryguy 