### PR TITLE
[WIP] test coveralls 0.8 instead of 0.7 on travis

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails-controller-testing", '~> 1.0.2'
   s.add_development_dependency "simplecov"
   s.add_development_dependency "coveralls", '~> 0.8.23'
+  s.add_dependency "coveralls", '~> 0.8.23'
 
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
   s.add_development_dependency "jasmine", "~> 3.4.0"

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-rspec", '~> 4.7.3'
   s.add_development_dependency "rails-controller-testing", '~> 1.0.2'
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "coveralls", '~> 0.8.23'
 
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
   s.add_development_dependency "jasmine", "~> 3.4.0"


### PR DESCRIPTION
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/645991960#L2415

```
    Coveralls encountered an exception:
    NoMethodError
    undefined method `coverage' for #<SimpleCov::SourceFile:0x000000004bd2fb40>
    manageiq-ui-classic/vendor/bundle/gems/coveralls-0.7.1/lib/coveralls/simplecov.rb:50:in `block in format'
    ruby-2.5.7/lib/ruby/2.5.0/forwardable.rb:229:in `each'
    ruby-2.5.7/lib/ruby/2.5.0/forwardable.rb:229:in `each'
    coveralls-0.7.1/lib/coveralls/simplecov.rb:40:in `format'
    simplecov-0.18.1/lib/simplecov/result.rb:49:in `format!'
    simplecov-0.18.1/lib/simplecov/configuration.rb:196:in `block in at_exit'
    simplecov-0.18.1/lib/simplecov.rb:201:in `run_exit_tasks!'
    simplecov-0.18.1/lib/simplecov/defaults.rb:31:in `block in <top (required)>'
```

the core is using coveralls 0.8.23 and not failing, testing if it fixes it