### PR TITLE
Deal with zones when running in pods

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -355,6 +355,14 @@ module OpsController::Settings::Common
     javascript_flash
   end
 
+  def update_server_zone(server)
+    zone = Zone.find_by(:name => @edit[:new][:server][:zone])
+    return true if zone.nil? || server.zone == zone
+
+    server.zone = zone
+    server.save
+  end
+
   def settings_update_save
     settings_get_form_vars
     return unless @edit
@@ -378,10 +386,10 @@ module OpsController::Settings::Common
       @edit[:new][:authentication][:ldaphost].reject!(&:blank?) if @edit[:new][:authentication][:ldaphost]
       @changed = (@edit[:new] != @edit[:current])
       server = MiqServer.find(@sb[:selected_server_id])
-      zone = Zone.find_by(:name => @edit[:new][:server][:zone])
-      unless zone.nil? || server.zone == zone
-        server.zone = zone
-        server.save
+      if !update_server_zone(server)
+        server.errors.full_messages.each { |message| add_flash(message, :error) }
+        render_flash
+        return
       end
       @update = server.settings
     when "settings_custom_logos" # Custom Logo tab

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -74,4 +74,8 @@ module OpsHelper
   def server_zones
     @server_zones ||= Zone.visible.in_my_region.pluck(:name)
   end
+
+  def server_zone_title_text
+    _("The server zone cannot be changed when running in containers") if server_zones.length > 1 && !MiqServer.zone_is_modifiable?
+  end
 end

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -49,12 +49,13 @@
       %label.col-md-2.control-label
         = _("Zone*")
       .col-md-8
-        - if server_zones.length == 1
+        - if !MiqServer.zone_is_modifiable?
           = text_field_tag("server_zone",
                             @edit[:new][:server][:zone],
                             :maxlength => 15,
                             :disabled => true,
                             :class => "form-control",
+                            :title => server_zone_title_text,
                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         - else
           = select_tag('server_zone',

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -359,6 +359,46 @@ describe OpsController do
       end
     end
 
+    describe "#update_server_zone" do
+      let(:server) { FactoryBot.create(:miq_server) }
+
+      it "returns true when no zone is set" do
+        original_zone = server.zone
+        new_data = {:server => {:zone => nil}}
+        controller.instance_variable_set(:@edit, :new => new_data)
+
+        expect(controller.send(:update_server_zone, server)).to be_truthy
+        expect(server.reload.zone).to eq(original_zone)
+      end
+
+      it "returns true when the zone is unchanged" do
+        original_zone = server.zone
+        new_data = {:server => {:zone => original_zone.name}}
+        controller.instance_variable_set(:@edit, :new => new_data)
+
+        expect(controller.send(:update_server_zone, server)).to be_truthy
+        expect(server.reload.zone).to eq(original_zone)
+      end
+
+      it "returns true when the zone is updated successfully" do
+        new_zone = FactoryBot.create(:zone)
+        new_data = {:server => {:zone => new_zone.name}}
+        controller.instance_variable_set(:@edit, :new => new_data)
+
+        expect(controller.send(:update_server_zone, server)).to be_truthy
+        expect(server.reload.zone).to eq(new_zone)
+      end
+
+      it "returns false when the zone update fails" do
+        original_zone = server.zone
+        new_data = {:server => {:zone => Zone.maintenance_zone.name}}
+        controller.instance_variable_set(:@edit, :new => new_data)
+
+        expect(controller.send(:update_server_zone, server)).to be_falsey
+        expect(server.reload.zone).to eq(original_zone)
+      end
+    end
+
     describe '#settings_update_save' do
       context "save config settings" do
         it 'for selected server' do


### PR DESCRIPTION
This PR changes the update logic for a server's zone to handle and display any validation errors one of which was added in https://github.com/ManageIQ/manageiq/pull/19789/commits/7174cc8643f096899c83e2ce3e74d19349c89de4

Additionally, after testing this out, it seemed like not such a great UX so I also disabled the drop-down when we find that it's not possible to change zones and added a title text to inform the user why the box was disabled.

Depends on https://github.com/ManageIQ/manageiq/pull/19789

@miq-bot assign @himdel 