### PR TITLE
Cypress: menu helper

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -2,6 +2,11 @@
 
 #### Run
 
+Please note that the rails server has to be running first:
+
+    bin/rails s
+
+
 Run without interaction:
 
     yarn cypress:run
@@ -10,7 +15,7 @@ Will run the tests in console, and output a screengrab and screenshot in `cypres
 
 Run interactively:
 
-    yarn cupress:open
+    yarn cypress:open
 
 Opens a chrome instance for debugging.
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,0 +1,47 @@
+### cypress in manageiq-ui-classic
+
+#### Run
+
+Run without interaction:
+
+    yarn cypress:run
+
+Will run the tests in console, and output a screengrab and screenshot in `cypress/screenshots` and `cypress/videos`.
+
+Run interactively:
+
+    yarn cupress:open
+
+Opens a chrome instance for debugging.
+
+
+#### Write
+
+Actual tests can be found in `cypress/integration/ui/`.
+
+ManageIQ implements the following cypress extensions:
+
+##### login
+
+`cy.login()` - logs in as admin
+
+##### navigation
+
+* `cy.menu('Compute', 'Infrastructure', 'VMs')` - navigates the main menu
+* TODO `cy.accordion('Service Dialogs')` - switch accordions
+* TODO `cy.treeSelect('All VMs & Templates', 'HyperV', 'SCVMM')` - switch tree items
+* TODO `cy.toolbar('Configuration', 'Edit this VM')` - trigger toolbar buttons
+* TODO `cy.gtlClick('RHEL72_1')` - trigger gtl items
+
+TODO allow using {id:...} instead of string label for menu items, gtl items, tree nodes, accordions, toolbar items
+
+##### inspection
+
+* `cy.menuItems()` - parse the main menu and yield an object tree
+* TODO `cy.toolbarItem(...)` - yields an object describing a toolbar button state, or null
+
+#### assertions
+
+* `cy.expect_explorer_title('Active Services')` - check the title on an explorer screen
+* `cy.expect_show_list_title('Cloud Providers')` - check the title on a show\_list screen
+* TODO `cy.expect_layout('miq-layout-center_div_with_listnav')` - check current layout

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/ui/menu.spec.js
+++ b/cypress/integration/ui/menu.spec.js
@@ -33,4 +33,33 @@ describe('Menu', () => {
     cy.menu('Overview')
       .expect_explorer_title('All Saved Reports');
   });
+
+  it.skip("all menu items lead to non-error screens", () => {
+    //FIXME: remove .skip once graphql_explorer stops erroring
+    //FIXME: ignore custom items
+
+    const check = (item) => {
+      //if (Math.random() > 0.2)
+      //  return;
+
+      cy.log('check', item);
+
+      cy.visit(item.href)
+        .get('[class*=miq-layout]');
+    };
+
+    const recurse = (items) => {
+      items.forEach((item) => {
+        recurse(item.items);
+
+        if (! item.items.length) {
+          // leaf node
+          check(item);
+        }
+      });
+    };
+
+    cy.menuItems()
+      .then((menu) => recurse(menu));
+  });
 });

--- a/cypress/integration/ui/menu.spec.js
+++ b/cypress/integration/ui/menu.spec.js
@@ -1,0 +1,32 @@
+describe('Menu', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("menu items", () => {
+    cy.menuItems()
+      .then((menu) => {
+        cy.log(menu);
+
+        expect(menu.length > 9).to.equal(true);
+        expect(menu[0].title).to.equal('Overview');
+        expect(menu[0].items[1].title).to.equal('Reports');
+        expect(menu[2].items[1].items[3].title).to.equal('Virtual Machines');
+      });
+
+    cy.menu('Overview')
+      .get('widget-wrapper');
+
+    cy.menu('Services')
+      .expect_explorer_title('Active Services');
+
+    cy.menu('Compute')
+      .expect_show_list_title('Cloud Providers');
+
+    cy.menu('Overview', 'Reports')
+      .expect_explorer_title('All Saved Reports');
+
+    cy.menu('Compute', 'Infrastructure', 'Virtual Machines')
+      .expect_explorer_title('All VMs & Templates');
+  });
+});

--- a/cypress/integration/ui/menu.spec.js
+++ b/cypress/integration/ui/menu.spec.js
@@ -28,5 +28,9 @@ describe('Menu', () => {
 
     cy.menu('Compute', 'Infrastructure', 'Virtual Machines')
       .expect_explorer_title('All VMs & Templates');
+
+    // test it remembers the last Overview > * screen used
+    cy.menu('Overview')
+      .expect_explorer_title('All Saved Reports');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -71,7 +71,7 @@ Cypress.Commands.add("menuItems", () => {
     parent.querySelectorAll(':scope > li > a').forEach((el, i) => {
       const itemSelector = `${parentSelector} > li:nth-child(${i + 1}) > a`;
       items.push({
-        title: el.innerText.trim(),
+        title: el.text.trim(),
         href: el.href,
         items: children(el.parentElement.querySelector(`${selector} > ul`), `${itemSelector.replace(/ > a$/, '')} > div > ul`, level + 1, ...rest),
         selector: itemSelector,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -85,3 +85,17 @@ Cypress.Commands.add("menuItems", () => {
   return cy.get('#maintab')
     .then((maintab) => children(maintab[0], '#maintab', 0, '.nav-pf-secondary-nav', '.nav-pf-tertiary-nav'));
 });
+
+// assertions
+
+Cypress.Commands.add("expect_explorer_title", (text) => {
+  return cy.get('#explorer_title_text').should((elem) => {
+    expect(elem.text().trim()).to.equal(text);
+  });
+});
+
+Cypress.Commands.add("expect_show_list_title", (text) => {
+  return cy.get('#main-content h1').should((elem) => {
+    expect(elem.text().trim()).to.equal(text);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,12 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+// FIXME: use cy.request and inject cookie and localStorage.miqToken
+Cypress.Commands.add("login", (user = 'admin', password = 'smartvm') => {
+  cy.visit('/');
+
+  cy.get('#user_name').type(user);
+  cy.get('#user_password').type(password);
+  return cy.get('#login').click();
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,3 +32,30 @@ Cypress.Commands.add("login", (user = 'admin', password = 'smartvm') => {
   cy.get('#user_password').type(password);
   return cy.get('#login').click();
 });
+
+// cy.menu('Compute', 'Infrastructure', 'VMs') - navigate the main menu
+Cypress.Commands.add("menu", (...items) => {
+  expect(items.length > 0).to.equal(true);
+  expect(items.length < 4).to.equal(true);
+
+  const selectors = [
+    '#main-menu',
+    '.nav-pf-secondary-nav',
+    '.nav-pf-tertiary-nav',
+  ];
+
+  let ret = cy;
+
+  items.forEach((item, index) => {
+    if (index > 0) {
+      ret = ret.trigger('mouseover');
+    }
+
+    ret = ret
+      .get(`${selectors[index]} > ul > li`)
+      .contains('a', item);
+  });
+
+  return ret.click();
+  // TODO support by id: cy.get('li[id=menu_item_provider_foreman]').click({ force: true });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -89,13 +89,9 @@ Cypress.Commands.add("menuItems", () => {
 // assertions
 
 Cypress.Commands.add("expect_explorer_title", (text) => {
-  return cy.get('#explorer_title_text').should((elem) => {
-    expect(elem.text().trim()).to.equal(text);
-  });
+  return cy.get('#explorer_title_text').contains(text);
 });
 
 Cypress.Commands.add("expect_show_list_title", (text) => {
-  return cy.get('#main-content h1').should((elem) => {
-    expect(elem.text().trim()).to.equal(text);
-  });
+  return cy.get('#main-content h1').contains(text);
 });

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "compression-webpack-plugin": "~1.1.11",
     "core-js-compat": "~3.2.1",
     "css-loader": "~0.28.11",
-    "cypress": "^3.8.3",
+    "cypress": "~4.0.1",
     "duplicate-package-checker-webpack-plugin": "~3.0.0",
     "enhanced-resolve": "~4.0.0",
     "enzyme": "^3.9.0",


### PR DESCRIPTION
Cypress was added in #6646,
this updates it to 4.0,
adds a couple of helpers for navigating around the menus,
and adds a menu spec.

Helpers added here:

* `cy.login()` - logs in, the current implementation is wrong, but works, will replace with cookie & token injection in a separate PR
* `cy.menu('Automation', 'Automate', 'Customization')` - navigate in the menu
* `cy.menuItems()` - returns an object tree parsed from the actual menu items
* `cy.expect_explorer_title(text)` - assertion that we're on an explorer screen with a specific title
* `cy.expect_show_list_title(text)` - assertion that we're on an show_list screen with a specific title

Tests added:

* ensure menu structure is sane, click through a few menu items and validate screen titles, ensure last section url works
* (SKIPped for now) go through every menu item and check that it uses a layout (ie. not empty, or an error screen) - skipped because graphql_explorer currently does error out (https://github.com/ManageIQ/manageiq-ui-classic/pull/6675)

And a README with docs and plans for future helpers.