### PR TITLE
StorageScan button spec - fix spec after .ext_management_systems removal

### DIFF
--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -4,12 +4,9 @@ describe ApplicationHelper::Button::StorageScan do
   let(:feature) { :smartstate_analysis }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
-  let(:ems)                  { FactoryBot.create(:ems_vmware) }
-  let(:emss)                 { [ems] }
-  let(:emss_with_valid_auth) { [ems] }
+  let(:ems) { nil }
 
-  before { allow(record).to receive(:ext_management_systems).and_return(emss) }
-  before { allow(record).to receive(:ext_management_systems_with_authentication_status_ok).and_return(emss_with_valid_auth) }
+  before { allow(record).to receive(:ext_management_system).and_return(ems) }
 
   it_behaves_like 'a generic feature button after initialization'
 
@@ -24,14 +21,14 @@ describe ApplicationHelper::Button::StorageScan do
       end
 
       context 'but no EMSs are present' do
-        let(:emss) { [] }
         it_behaves_like 'a disabled button', 'Smartstate Analysis cannot be performed on selected Datastore'
       end
       context 'but no EMS has valid credentials for the Datastore' do
-        let(:emss_with_valid_auth) { [] }
+        let(:ems) { FactoryBot.create(:ems_vmware) }
         it_behaves_like 'a disabled button', 'There are no EMSs with valid credentials for this Datastore'
       end
       context 'with valid credentials for this Datastore' do
+        let(:ems) { FactoryBot.create(:ems_vmware_with_authentication) }
         it_behaves_like 'an enabled button'
       end
     end

--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -1,12 +1,10 @@
 describe ApplicationHelper::Button::StorageScan do
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryBot.create(:storage) }
+  let(:record) { FactoryBot.create(:storage, :ext_management_system => ems) }
   let(:feature) { :smartstate_analysis }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
   let(:ems) { nil }
-
-  before { allow(record).to receive(:ext_management_system).and_return(ems) }
 
   it_behaves_like 'a generic feature button after initialization'
 


### PR DESCRIPTION
`.ext_management_systems` was removed from Storage in https://github.com/ManageIQ/manageiq/pull/19754
fixing the specs to use `.ext_management_system` (singular).

Cc @kbrock 

Fixes red travis:

```
  1) ApplicationHelper::Button::StorageScan when feature is supported #calculate_properties with valid credentials for this Datastore behaves like an enabled button is expected to be truthy
     Failure/Error: expect(subject[:enabled]).to be_truthy

       expected: truthy value
            got: false
     Shared Example Group: "an enabled button" called from ./spec/helpers/application_helper/buttons/storage_scan_spec.rb:35
     # ./spec/support/examples_group/shared_examples_for_enabled_buttons.rb:4:in `block (2 levels) in <top (required)>'
  2) ApplicationHelper::Button::StorageScan when feature is supported #calculate_properties but no EMS has valid credentials for the Datastore behaves like a disabled button is expected to eq "There are no EMSs with valid credentials for this Datastore"
     Failure/Error: expect(subject[:title]).to eq(err_msg)

       expected: "There are no EMSs with valid credentials for this Datastore"
            got: "Smartstate Analysis cannot be performed on selected Datastore"

       (compared using ==)
     Shared Example Group: "a disabled button" called from ./spec/helpers/application_helper/buttons/storage_scan_spec.rb:32
     # ./spec/support/examples_group/shared_examples_for_disabled_buttons.rb:5:in `block (2 levels) in <top (required)>'

rspec ./spec/helpers/application_helper/buttons/storage_scan_spec.rb:35 # ApplicationHelper::Button::StorageScan when feature is supported #calculate_properties with valid credentials for this Datastore behaves like an enabled button is expected to be truthy
rspec ./spec/helpers/application_helper/buttons/storage_scan_spec.rb:32 # ApplicationHelper::Button::StorageScan when feature is supported #calculate_properties but no EMS has valid credentials for the Datastore behaves like a disabled button is expected to eq "There are no EMSs with valid credentials for this Datastore"
```