### PR TITLE
Remove deprecated validate_creds_task

### DIFF
--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -84,7 +84,7 @@ module Mixins
         @in_a_form = true
         ems_type = model.model_from_emstype(params[:emstype])
         result, details = if %w[ems_cloud ems_infra].include?(params[:controller])
-                            ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
+                            ems_type.verify_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
                           else
                             realtime_authentication_check(ems_type.new)
                           end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -75,7 +75,7 @@ describe EmsCloudController do
     end
 
     it "validates credentials for a new record" do
-      expect(ManageIQ::Providers::Amazon::CloudManager).to receive(:validate_credentials_task).with(
+      expect(ManageIQ::Providers::Amazon::CloudManager).to receive(:verify_credentials_task).with(
         match_array([
           'foo',
           'v2:{SRpWIJC0Y1AOrUrKC0KDiw==}',
@@ -322,7 +322,7 @@ describe EmsCloudController do
       let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default", :default_url => ""} }
 
       it "queues the authentication type if it is a cloud provider" do
-        expect(mocked_class).to receive(:validate_credentials_task)
+        expect(mocked_class).to receive(:verify_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -330,7 +330,7 @@ describe EmsCloudController do
         session[:selected_roles] = ['user_interface']
 
         expect(mocked_class).not_to receive(:raw_connect)
-        expect(mocked_class).to receive(:validate_credentials_task)
+        expect(mocked_class).to receive(:verify_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -343,7 +343,7 @@ describe EmsCloudController do
 
         it "queues the correct number of arguments" do
           expected_validate_args = [project, ManageIQ::Password.encrypt(service_account), compute_service, nil, true]
-          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
+          expect(mocked_class).to receive(:verify_credentials_task).with(expected_validate_args, nil, nil)
           controller.send(:create_ems_button_validate)
         end
       end
@@ -354,7 +354,7 @@ describe EmsCloudController do
       let(:mocked_class_controller) { "ems_infra" }
 
       it "queues the authentication check" do
-        expect(mocked_class).to receive(:validate_credentials_task)
+        expect(mocked_class).to receive(:verify_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -364,7 +364,7 @@ describe EmsCloudController do
 
         it "disables the broker" do
           expected_validate_args = [{:pass => nil, :user => nil, :ip => nil, :use_broker => false}]
-          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
+          expect(mocked_class).to receive(:verify_credentials_task).with(expected_validate_args, nil, nil)
           controller.send(:create_ems_button_validate)
         end
       end

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -556,7 +556,7 @@ describe EmsInfraController do
 
     it "validates credentials for a new record" do
       expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:build_connect_params)
-      expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:validate_credentials_task)
+      expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:verify_credentials_task)
 
       post :create, :params => {
         "button"           => "validate",


### PR DESCRIPTION
Core removal PR: https://github.com/ManageIQ/manageiq/pull/19346

see https://github.com/ManageIQ/manageiq/pull/19512

``` ruby
DEPRECATION WARNING: validate_credentials_task is deprecated and
will be removed from ManageIQ K-release (use verify_credentials_task instead)
(called from block (4 levels) in <top (required)> at
spec/models/mixins/authentication_mixin_spec.rb:293)
```

"If you want it solved a different way, just give the word" which word might that be exactly anyway, one wonders