### PR TITLE
Revert #6664 to fix credential validation

### DIFF
--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -84,7 +84,7 @@ module Mixins
         @in_a_form = true
         ems_type = model.model_from_emstype(params[:emstype])
         result, details = if %w[ems_cloud ems_infra].include?(params[:controller])
-                            ems_type.verify_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
+                            ems_type.validate_credentials_task(get_task_args(ems_type), session[:userid], params[:zone])
                           else
                             realtime_authentication_check(ems_type.new)
                           end

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -76,7 +76,7 @@ describe EmsCloudController do
     end
 
     it "validates credentials for a new record" do
-      expect(ManageIQ::Providers::Amazon::CloudManager).to receive(:verify_credentials_task).with(
+      expect(ManageIQ::Providers::Amazon::CloudManager).to receive(:validate_credentials_task).with(
         match_array([
           'foo',
           'v2:{SRpWIJC0Y1AOrUrKC0KDiw==}',
@@ -324,7 +324,7 @@ describe EmsCloudController do
       let(:mocked_params) { {:controller => mocked_class_controller, :cred_type => "default", :default_url => ""} }
 
       it "queues the authentication type if it is a cloud provider" do
-        expect(mocked_class).to receive(:verify_credentials_task)
+        expect(mocked_class).to receive(:validate_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -332,7 +332,7 @@ describe EmsCloudController do
         session[:selected_roles] = ['user_interface']
 
         expect(mocked_class).not_to receive(:raw_connect)
-        expect(mocked_class).to receive(:verify_credentials_task)
+        expect(mocked_class).to receive(:validate_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -345,7 +345,7 @@ describe EmsCloudController do
 
         it "queues the correct number of arguments" do
           expected_validate_args = [project, ManageIQ::Password.encrypt(service_account), compute_service, nil, true]
-          expect(mocked_class).to receive(:verify_credentials_task).with(expected_validate_args, nil, nil)
+          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
           controller.send(:create_ems_button_validate)
         end
       end
@@ -356,7 +356,7 @@ describe EmsCloudController do
       let(:mocked_class_controller) { "ems_infra" }
 
       it "queues the authentication check" do
-        expect(mocked_class).to receive(:verify_credentials_task)
+        expect(mocked_class).to receive(:validate_credentials_task)
         controller.send(:create_ems_button_validate)
       end
 
@@ -366,7 +366,7 @@ describe EmsCloudController do
 
         it "disables the broker" do
           expected_validate_args = [{:pass => nil, :user => nil, :ip => nil, :use_broker => false}]
-          expect(mocked_class).to receive(:verify_credentials_task).with(expected_validate_args, nil, nil)
+          expect(mocked_class).to receive(:validate_credentials_task).with(expected_validate_args, nil, nil)
           controller.send(:create_ems_button_validate)
         end
       end

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -591,7 +591,7 @@ describe EmsInfraController do
 
     it "validates credentials for a new record" do
       expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:build_connect_params)
-      expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:verify_credentials_task)
+      expect(ManageIQ::Providers::Microsoft::InfraManager).to receive(:validate_credentials_task)
 
       post :create, :params => {
         "button"           => "validate",


### PR DESCRIPTION
This reverts commit 2f00acf9fb8eb900b25a3e78a5091960e51c3f46, reversing changes made to 60a70b2d5ef61711e0fe58c432ee61bce60d88fd.

https://github.com/ManageIQ/manageiq-ui-classic/pull/6664 was merged before the backend was ready, credential validation is broken right now