### PR TITLE
[WIP] Replace pending GTL rspecs with cypress ones

### DIFF
--- a/cypress/integration/ui/gtl.spec.js
+++ b/cypress/integration/ui/gtl.spec.js
@@ -1,0 +1,16 @@
+describe('GTL', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("with data", () => {
+    cy.menu("Configuration");
+    cy.get('tr').last().click();
+    cy.gtl();
+  });
+
+  it("without data", () => {
+    cy.menu("Compute", "Physical Infrastructure", "Chassis");
+    cy.gtl_no_record();
+  });
+});

--- a/cypress/integration/ui/searchbox.spec.js
+++ b/cypress/integration/ui/searchbox.spec.js
@@ -1,0 +1,15 @@
+describe('Search box', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("is present", () => {
+    cy.menu("Configuration");
+    cy.get('div[class=panel-heading]').first().click();
+    cy.search_box();
+  });
+
+  it("is not present", () => {
+    cy.no_search_box();
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -95,3 +95,24 @@ Cypress.Commands.add("expect_explorer_title", (text) => {
 Cypress.Commands.add("expect_show_list_title", (text) => {
   return cy.get('#main-content h1').contains(text);
 });
+
+// GTL related helpers
+Cypress.Commands.add("gtl_error", () => {
+  return cy.get('#miq-gtl-view > #flash_msg_div').should('be.visible');
+});
+
+Cypress.Commands.add("gtl_no_record", () => {
+  return cy.get('#miq-gtl-view > div.no-record').should('be.visible');
+});
+
+Cypress.Commands.add("gtl", () => {
+  return cy.get('[ng-controller="reportDataController as dataCtrl"]').find('div.no-record').should('not.exist');
+});
+
+Cypress.Commands.add("search_box", () => {
+  return cy.get('#search_text').should('be.visible');
+});
+
+Cypress.Commands.add("no_search_box", () => {
+  return cy.get('#search_text').should('not.be.visible');
+});


### PR DESCRIPTION
Replaces rspecs deleted in https://github.com/ManageIQ/manageiq-ui-classic/pull/6629

@miq-bot add_label wip, test, gtls, configuration management

TODO:
Automation manager
- [ ] renders the list view based on the nodetype(root,provider) and the search associated with it

Foreman 
- [ ] renders the list view based on the nodetype(root,provider) and the search associated with it
- [ ] renders tree_select for a ConfigurationManagerForeman node that contains an unassigned profile
- [ ] renders tree_select for a ConfigurationManagerForeman node that contains only an unassigned profile *(note: subset of the test above 👆)*
- [ ] renders tree_select for an 'Unassigned Profiles Group' node for the first provider
- [ ] renders tree_select for an 'Unassigned Profiles Group' node for the second provider *(note: subset of the test above 👆)*
- [ ] does not display an automation manger configured system in the Configured Systems accordion

Reports
- [ ] is allowed to see report created under Group1 for User 1(with current group Group2) *(note: needs `Factory Girl`)*