### PR TITLE
EMS validation: send only the listed fields to the API

### DIFF
--- a/app/javascript/components/async-credentials/async-provider-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-provider-credentials.jsx
@@ -1,12 +1,11 @@
+import { pick } from 'lodash';
 import React from 'react';
 import AsyncCredentials from './async-credentials';
 
 const AsyncProviderCredentials = ({ ...props }) => {
-  const asyncValidate = fields => new Promise((resolve, reject) => {
-    API.post('/api/providers', {
-      action: 'verify_credentials',
-      resource: fields,
-    }).then(({ results: [result] }) => {
+  const asyncValidate = (fields, fieldNames) => new Promise((resolve, reject) => {
+    const resource = pick(fields, fieldNames);
+    API.post('/api/providers', { action: 'verify_credentials', resource }).then(({ results: [result] }) => {
       const { task_id, success } = result; // eslint-disable-line camelcase
       // The request here can either create a background task or fail
       return success ? API.wait_for_task(task_id) : Promise.reject(result);


### PR DESCRIPTION
The provider validation component doesn't need to send all the data to the API. Especially if there are more than one validation components in a single form, because there's no way to distinguish between which one is being validated. My solution is to just send the fields under the component itself + the explicitly specified dependencies.