### PR TITLE
Fix saving of ems_refresh_worker and ems_metrics_collector_worker

### DIFF
--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -117,11 +117,15 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
           count: isDifferent('smart_proxy_worker.count'),
         },
         ems_metrics_collector_worker: {
-          memory_threshold: toRubyMethod(isDifferent('ems_metrics_collector_worker.defaults.memory_threshold')),
-          count: isDifferent('ems_metrics_collector_worker.defaults.count'),
+          defaults: {
+            memory_threshold: toRubyMethod(isDifferent('ems_metrics_collector_worker.defaults.memory_threshold')),
+            count: isDifferent('ems_metrics_collector_worker.defaults.count'),
+          },
         },
         ems_refresh_worker: {
-          memory_threshold: toRubyMethod(isDifferent('ems_refresh_worker.defaults.memory_threshold')),
+          defaults: {
+            memory_threshold: toRubyMethod(isDifferent('ems_refresh_worker.defaults.memory_threshold')),
+          },
         },
         reporting_worker: {
           memory_threshold: toRubyMethod(isDifferent('reporting_worker.memory_threshold')),


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1799443

Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/5528

Steps to reproduce:
1. Navigate to Configuration -> Settings -> (appliance) -> Workers
2. Change `Refresh worker` `Memory threshold` to something else
3. Change `C & U Data Collectors` `Memory threshold` and `Count` to something else
4. Save the changes
5. Refresh the page

Before:
Values stay same as original ones
After:
Values are changed to ones you selected

Just making loaded data same as sent one. See https://github.com/ManageIQ/manageiq-ui-classic/blob/6a179e6a9ec1ee5bc8964d3e4487adf328dc53fb/app/javascript/components/workers-form/workers-form.jsx#L39-L44 and https://github.com/ManageIQ/manageiq-ui-classic/blob/6a179e6a9ec1ee5bc8964d3e4487adf328dc53fb/app/javascript/components/workers-form/workers-form.jsx#L52-L55

@miq-bot add_label bug, ivanchuk/yes

