### PR TITLE
Cypress - toolbars (and accordion)

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -33,17 +33,18 @@ ManageIQ implements the following cypress extensions:
 ##### navigation
 
 * `cy.menu('Compute', 'Infrastructure', 'VMs')` - navigates the main menu
-* TODO `cy.accordion('Service Dialogs')` - switch accordions
+* `cy.accordion('Service Dialogs')` - expand accordion
 * TODO `cy.treeSelect('All VMs & Templates', 'HyperV', 'SCVMM')` - switch tree items
-* TODO `cy.toolbar('Configuration', 'Edit this VM')` - trigger toolbar buttons
+* `cy.toolbar('Configuration', 'Edit this VM')` - trigger toolbar buttons
 * TODO `cy.gtlClick('RHEL72_1')` - trigger gtl items
+* TODO `cy.tab('Report Info')` - switch miq tabs
 
 TODO allow using {id:...} instead of string label for menu items, gtl items, tree nodes, accordions, toolbar items
 
 ##### inspection
 
 * `cy.menuItems()` - parse the main menu and yield an object tree
-* TODO `cy.toolbarItem(...)` - yields an object describing a toolbar button state, or null
+* `cy.toolbarItem(...)` - yields an object describing a toolbar button state, or null
 
 #### assertions
 

--- a/cypress/integration/ui/toolbar.spec.js
+++ b/cypress/integration/ui/toolbar.spec.js
@@ -1,0 +1,51 @@
+describe('Toolbar', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("click toolbar buttons", () => {
+    // click a button group button
+    cy.menu('Compute', 'Infrastructure', 'Virtual Machines')
+      .accordion('VMs & Templates')
+      .toolbar('Lifecycle', 'Provision VMs');
+
+    // click a standalone button
+    cy.menu('Services', 'Requests')
+      .toolbar('Refresh');
+  });
+
+  it("inspect toolbar buttons", () => {
+    cy.menu('Services', 'Catalogs')
+      .accordion('Catalog Items')
+      // FIXME: tree helper
+      .get('.node-treeview-sandt_tree[data-nodeid="0.0"]').click(); // tree root
+
+    // enabled group
+    cy.toolbarItem('Configuration').then((item) => {
+      expect(item.id).to.equal('catalogitem_vmdb_choice');
+      expect(item.label).to.equal('Configuration');
+      expect(item.disabled).to.equal(false);
+    });
+
+    // disabled group
+    cy.toolbarItem('Policy').then((item) => {
+      expect(item.id).to.equal('catalogitem_policy_choice');
+      expect(item.label).to.equal('Policy');
+      expect(item.disabled).to.equal(true);
+    });
+
+    // enabled button
+    cy.toolbarItem('Configuration', 'Add a New Catalog Item').then((item) => {
+      expect(item.id).to.equal('catalogitem_vmdb_choice__atomic_catalogitem_new');
+      expect(item.label).to.equal('Add a New Catalog Item');
+      expect(item.disabled).to.equal(false);
+    });
+
+    // disabled button
+    cy.toolbarItem('Configuration', 'Edit Selected Item').then((item) => {
+      expect(item.id).to.equal('catalogitem_vmdb_choice__catalogitem_edit');
+      expect(item.label).to.equal('Edit Selected Item');
+      expect(item.disabled).to.equal(true);
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -89,6 +89,88 @@ Cypress.Commands.add("menuItems", () => {
     .then((maintab) => children(maintab[0], '#maintab', 0, '.nav-pf-secondary-nav', '.nav-pf-tertiary-nav'));
 });
 
+// cy.accordion('Catalog Items') - click accordion, unless already expanded
+Cypress.Commands.add('accordion', (text) => {
+  cy.get('#main-content');  // ensure screen loads first
+
+  let ret = cy.get('#accordion')
+    .find('.panel-title a')
+    .contains(new RegExp(`^${text}$`))
+
+  ret.then((el) => {
+    // do not collapse if expanded
+    if (el.is('.collapsed')) {
+      el.click();
+    }
+    return el;
+  });
+
+  return ret.parents('.panel');
+});
+
+// cy.toolbarItem('Configuration', 'Edit this VM') - return a toolbar button state
+Cypress.Commands.add('toolbarItem', (...items) => {
+  expect(items.length).to.be.within(1, 2);
+
+  let ret = cy.get('#toolbar')
+    .find(items[1] ? '.dropdown-toggle' : 'button')
+    .contains(items[0]);
+
+  if (items[1]) {
+    ret = ret.siblings('.dropdown-menu')
+      .find('a > span')
+      .contains(items[1])
+      .parents('a > span');
+  }
+
+  return ret.then((el) => {
+    return {
+      id: el[0].id,
+      label: el.text().trim(),
+      icon: el.find('i'),
+      disabled: !items[1] ? !!el.prop('disabled') : !!el.parents('li').hasClass('disabled'),
+    };
+  });
+});
+
+// cy.toolbar('Configuration', 'Edit this VM') - click a toolbar button
+// TODO {id: 'view_grid'|'view_tile'|'view_list'} for the view toolbar
+// TODO {id: 'download_choice'}, .. for the download dropdown
+// TODO: some alias for having %i.fa-download, .fa-refresh, .pficon-print, .fa-arrow-left
+// TODO custom buttons
+Cypress.Commands.add('toolbar', (...items) => {
+  expect(items.length).to.be.within(1, 2);
+
+  let ret = cy.get('#toolbar')
+    .contains(items[1] ? '.dropdown-toggle' : 'button', items[0]);
+    // by-id: #id on button instead of .contains
+
+  ret = ret.then((el) => {
+    // FIXME: better message
+    expect(!!el.prop('disabled')).to.be.false;
+    return el;
+  });
+
+  if (items[1]) {
+    ret.click();
+    // a doesn't react to click here, have to click the span
+    ret = ret.siblings('.dropdown-menu')
+      .find('a > span')
+      .contains(items[1])
+      .parents('a > span');
+      // by-id: #id on the same span
+
+    ret = ret.then((el) => {
+      // FIXME: better message
+      expect(el.parents('li').hasClass('disabled')).to.be.false;
+      return el;
+    });
+  }
+
+  return ret.click();
+  // TODO .dropdown-toggle#vm_lifecycle_choice
+});
+
 // assertions
 
 Cypress.Commands.add("expect_explorer_title", (text) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+// cy.login() - log in
 // FIXME: use cy.request and inject cookie and localStorage.miqToken
 Cypress.Commands.add("login", (user = 'admin', password = 'smartvm') => {
   cy.visit('/');
@@ -35,8 +36,7 @@ Cypress.Commands.add("login", (user = 'admin', password = 'smartvm') => {
 
 // cy.menu('Compute', 'Infrastructure', 'VMs') - navigate the main menu
 Cypress.Commands.add("menu", (...items) => {
-  expect(items.length > 0).to.equal(true);
-  expect(items.length < 4).to.equal(true);
+  expect(items.length).to.be.within(1, 3);
 
   const selectors = [
     '#main-menu',
@@ -44,23 +44,26 @@ Cypress.Commands.add("menu", (...items) => {
     '.nav-pf-tertiary-nav',
   ];
 
-  let ret = cy;
+  let ret = cy.get(`${selectors[0]} > ul > li`)
+    .contains('a', items[0])
+    .parent();
 
   items.forEach((item, index) => {
-    if (index > 0) {
-      ret = ret.trigger('mouseover');
+    if (index === 0) {
+      return;
     }
 
-    ret = ret
-      .get(`${selectors[index]} > ul > li`)
-      .contains('a', item);
+    ret = ret.trigger('mouseover')
+      .find(`${selectors[index]} > ul > li`)
+      .contains('a', item)
+      .parent();
   });
 
   return ret.click();
   // TODO support by id: cy.get('li[id=menu_item_provider_foreman]').click({ force: true });
 });
 
-// returns an array of top level menu items with {title, href, items (array of children), selector, click() method}
+// cy.menuItems() - returns an array of top level menu items with {title, href, items (array of children), selector, click() method}
 Cypress.Commands.add("menuItems", () => {
   const children = (parent, parentSelector, level, ...selectors) => {
     if (! parent)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -146,13 +146,13 @@ Cypress.Commands.add('toolbar', (...items) => {
     // by-id: #id on button instead of .contains
 
   ret = ret.then((el) => {
-    // FIXME: better message
-    expect(!!el.prop('disabled')).to.be.false;
+    assert.equal(!!el.prop('disabled'), false, "Parent toolbar button disabled");
     return el;
   });
 
   if (items[1]) {
     ret.click();
+
     // a doesn't react to click here, have to click the span
     ret = ret.siblings('.dropdown-menu')
       .find('a > span')
@@ -161,8 +161,7 @@ Cypress.Commands.add('toolbar', (...items) => {
       // by-id: #id on the same span
 
     ret = ret.then((el) => {
-      // FIXME: better message
-      expect(el.parents('li').hasClass('disabled')).to.be.false;
+      assert.equal(el.parents('li').hasClass('disabled'), false, "Child toolbar button disabled");
       return el;
     });
   }


### PR DESCRIPTION
Adds more cypress helpers:

* `cy.accordion('Service Templates')` - expands the accordion (if not already expanded) and returns it for subsequent find,
* `cy.toolbarItem('Configuration', 'Edit this VM')` - find a toolbar item and returns a promise with details `{id, label, icon, disabled}`
* `cy.toolbar('Configuration', 'Edit this VM')` - clicks a toolbar item

And a test testing a bunch of toolbar items,
and a fix to menu helper to respect the section when an item with same name exists in multiple sections.