### PR TITLE
Remove extraneous line from OpsController::Settings::Schedules

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -386,7 +386,6 @@ module OpsController::Settings::Schedules
 
   def determine_filter_type_and_value(schedule)
     if schedule.sched_action && schedule.sched_action[:method] && !schedule_db_backup_or_automate(schedule)
-      !%w[db_backup automation_request].include?(schedule.sched_action[:method])
       if schedule.miq_search # See if a search filter is attached
         filter_type = schedule.miq_search.search_type == "user" ? "my" : "global"
         filter_value = schedule.miq_search.id


### PR DESCRIPTION
The line became extraneous with commit https://github.com/ManageIQ/manageiq-ui-classic/commit/dad7b825281d37a844dfd40e8f552311bda7141a#diff-27e8e9795d5f4a9a5087545e103d4e51R378