### PR TITLE
Use new last_screen_url for redirecting and update cancel_action in GenericFormMixin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1971,6 +1971,11 @@ class ApplicationController < ActionController::Base
     raise _("Unauthorized object or action") unless ids.length == filtered.length
   end
 
+  def last_screen_url
+    @breadcrumbs.last[:url]
+  end
+  helper_method(:last_screen_url)
+
   def previous_breadcrumb_url
     @breadcrumbs[-2][:url]
   end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -604,10 +604,10 @@ module ApplicationController::MiqRequestMethods
     if @explorer
       @sb[:action] = nil
       replace_right_cell
-    elsif @breadcrumbs && (@breadcrumbs.empty? || @breadcrumbs.last[:url] == "/vm/show_list")
+    elsif @breadcrumbs && (@breadcrumbs.empty? || last_screen_url == "/vm/show_list")
       javascript_redirect(:action => "show_list", :controller => "vm")
     else
-      javascript_redirect(@breadcrumbs.last[:url])
+      javascript_redirect(last_screen_url)
     end
   end
 

--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -141,7 +141,7 @@ class CloudNetworkController < ApplicationController
     options = edit_form_params
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Cloud Network \"%{name}\" was cancelled by the user") % {:name => @network.name})
+      flash_and_redirect(_("Edit of Cloud Network \"%{name}\" was cancelled by the user") % {:name => @network.name})
 
     when "save"
       if @network.supports_update?

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -152,7 +152,7 @@ class CloudSubnetController < ApplicationController
     @subnet = find_record_with_rbac(CloudSubnet, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Subnet \"%{name}\" was cancelled by the user") % {:name => @subnet.name})
+      flash_and_redirect(_("Edit of Subnet \"%{name}\" was cancelled by the user") % {:name => @subnet.name})
 
     when "save"
       if @subnet.supports_create?

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -134,7 +134,7 @@ class CloudTenantController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Cloud Tenant \"%{name}\" was cancelled by the user") % {:name => @tenant.name})
+      flash_and_redirect(_("Edit of Cloud Tenant \"%{name}\" was cancelled by the user") % {:name => @tenant.name})
 
     when "save"
       options = form_params

--- a/app/controllers/cloud_volume_backup_controller.rb
+++ b/app/controllers/cloud_volume_backup_controller.rb
@@ -36,7 +36,7 @@ class CloudVolumeBackupController < ApplicationController
     @backup = find_record_with_rbac(CloudVolumeBackup, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Restore to Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @backup.name})
+      flash_and_redirect(_("Restore to Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @backup.name})
 
     when "restore"
       # volume_id to restore to is optional

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -84,7 +84,7 @@ class CloudVolumeController < ApplicationController
     @volume = find_record_with_rbac(CloudVolume, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Attaching Cloud Volume \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Attaching Cloud Volume \"%{name}\" was cancelled by the user") % {
         :name => @volume.name
       })
     when "attach"
@@ -138,7 +138,7 @@ class CloudVolumeController < ApplicationController
     @volume = find_record_with_rbac(CloudVolume, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Detaching Cloud Volume \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Detaching Cloud Volume \"%{name}\" was cancelled by the user") % {
         :name => @volume.name
       })
 
@@ -205,7 +205,7 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_new")
     case params[:button]
     when "cancel"
-      cancel_action(_("Add of new Cloud Volume was cancelled by the user"))
+      flash_and_redirect(_("Add of new Cloud Volume was cancelled by the user"))
 
     when "add"
       @volume = CloudVolume.new
@@ -282,7 +282,7 @@ class CloudVolumeController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
+      flash_and_redirect(_("Edit of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
 
     when "save"
       options = form_params
@@ -388,7 +388,7 @@ class CloudVolumeController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Backup of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
+      flash_and_redirect(_("Backup of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
 
     when "create"
       options = {}
@@ -451,7 +451,7 @@ class CloudVolumeController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Restore of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
+      flash_and_redirect(_("Restore of Cloud Volume \"%{name}\" was cancelled by the user") % {:name => @volume.name})
 
     when "restore"
       @backup = find_record_with_rbac(CloudVolumeBackup, params[:backup_id])
@@ -507,7 +507,7 @@ class CloudVolumeController < ApplicationController
     @volume = find_record_with_rbac(CloudVolume, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Snapshot of Cloud Volume \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Snapshot of Cloud Volume \"%{name}\" was cancelled by the user") % {
         :name => @volume.name
       })
     when "create"

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -360,7 +360,7 @@ class CloudVolumeController < ApplicationController
     delete_cloud_volumes(volumes_to_delete) unless volumes_to_delete.empty?
 
     # refresh the list if applicable
-    if @lastaction == "show_list" && @breadcrumbs.last[:url].include?(@lastaction)
+    if @lastaction == "show_list" && last_screen_url.include?(@lastaction)
       show_list
       @refresh_partial = "layouts/gtl"
     elsif @lastaction == "show" && @layout == "cloud_volume"

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -125,7 +125,7 @@ class FloatingIpController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Floating IP \"%{address}\" was cancelled by the user") % { :address => @floating_ip.address })
+      flash_and_redirect(_("Edit of Floating IP \"%{address}\" was cancelled by the user") % {:address => @floating_ip.address})
 
     when "save"
       if @floating_ip.supports_update?

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -4,6 +4,7 @@ class HostAggregateController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  include Mixins::GenericFormMixin
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
@@ -348,14 +349,6 @@ class HostAggregateController < ApplicationController
         :details => task.message
       }, :error)
     end
-  end
-
-  # Set flash message, add it to session, redirect to proper screen and render the flash message
-  def flash_and_redirect(message, level = :success)
-    session[:edit] = nil
-    add_flash(message, level)
-    flash_to_session
-    javascript_redirect(previous_breadcrumb_url)
   end
 
   private

--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -173,7 +173,7 @@ class HostAggregateController < ApplicationController
       redirect_to(previous_breadcrumb_url)
     else # list of Host Aggregates
       @refresh_partial = "layouts/gtl" if @lastaction == "show_list"
-      redirect_to(@breadcrumbs[-1][:url])
+      redirect_to(last_screen_url)
     end
   end
 
@@ -197,7 +197,7 @@ class HostAggregateController < ApplicationController
       }, :error)
       session[:flash_msgs] = @flash_array
       @in_a_form = false
-      redirect_to(@breadcrumbs[-1][:url])
+      redirect_to(last_screen_url)
     else
       drop_breadcrumb(
         :name => _("Add Host to Host Aggregate \"%{name}\"") % {:name => @host_aggregate.name},
@@ -281,7 +281,7 @@ class HostAggregateController < ApplicationController
       }, :error)
       session[:flash_msgs] = @flash_array
       @in_a_form = false
-      redirect_to(@breadcrumbs[-1][:url])
+      redirect_to(last_screen_url)
     else
       drop_breadcrumb(
         :name => _("Remove Host from Host Aggregate \"%{name}\"") % {:name => @host_aggregate.name},

--- a/app/controllers/mixins/generic_form_mixin.rb
+++ b/app/controllers/mixins/generic_form_mixin.rb
@@ -1,8 +1,9 @@
 module Mixins
   module GenericFormMixin
-    def cancel_action(message)
+    # Set flash message, add it to session, redirect to proper screen and render the flash message
+    def flash_and_redirect(*args)
       session[:edit] = nil
-      flash_to_session(message, :warning)
+      flash_to_session(*args)
       javascript_redirect(previous_breadcrumb_url)
     end
 

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -108,7 +108,7 @@ class NetworkRouterController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Edit of Router \"%{name}\" was cancelled by the user") % {:name => @router.name})
+      flash_and_redirect(_("Edit of Router \"%{name}\" was cancelled by the user") % {:name => @router.name})
 
     when "save"
       options = form_params(params)
@@ -179,7 +179,7 @@ class NetworkRouterController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Add Interface on Subnet to Router \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Add Interface on Subnet to Router \"%{name}\" was cancelled by the user") % {
         :name => @router.name
       })
 
@@ -272,7 +272,7 @@ class NetworkRouterController < ApplicationController
 
     case params[:button]
     when "cancel"
-      cancel_action(_("Remove Interface on Subnet from Router \"%{name}\" was cancelled by the user") % {
+      flash_and_redirect(_("Remove Interface on Subnet from Router \"%{name}\" was cancelled by the user") % {
         :name => @router.name
       })
 

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -56,7 +56,7 @@ class VmCloudController < ApplicationController
     @vm = find_record_with_rbac(VmCloud, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Attaching Cloud Volume to Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => @vm.name})
+      flash_and_redirect(_("Attaching Cloud Volume to Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => @vm.name})
     when "attach"
       volume = find_record_with_rbac(CloudVolume, params[:volume_id])
       if volume.is_available?(:attach_volume)
@@ -108,7 +108,7 @@ class VmCloudController < ApplicationController
     @vm = find_record_with_rbac(VmCloud, params[:id])
     case params[:button]
     when "cancel"
-      cancel_action(_("Detaching a Cloud Volume from Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => @vm.name})
+      flash_and_redirect(_("Detaching a Cloud Volume from Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => @vm.name})
 
     when "detach"
       volume = find_record_with_rbac(CloudVolume, params[:volume_id])
@@ -155,9 +155,9 @@ class VmCloudController < ApplicationController
     replace_right_cell
   end
 
-  def cancel_action(message)
+  def flash_and_redirect(message)
     session[:edit] = nil
-    add_flash(message)
+    flash_to_session(message)
     @record = @sb[:action] = nil
     replace_right_cell
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -104,6 +104,18 @@ describe ApplicationController do
     end
   end
 
+  describe '#last_screen_url' do
+    it 'returns the last url' do
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'previous_url'}, {:url => 'last_url'}])
+      expect(controller.send(:last_screen_url)).to eq('last_url')
+    end
+
+    it 'raises error' do
+      controller.instance_variable_set(:@breadcrumbs, [])
+      expect { controller.send(:previous_breadcrumb_url) }.to raise_error(NoMethodError)
+    end
+  end
+
   describe "#find_checked_items" do
     it "returns empty array when button is pressed from summary screen with params as symbol" do
       controller.params = {:id => "1"}

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -182,6 +182,18 @@ describe CloudNetworkController do
     end
   end
 
+  describe '#update' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => network.id}
+    end
+
+    it 'calls flash_and_redirect for canceling editing Cloud Network' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Edit of Cloud Network \"%{name}\" was cancelled by the user") % {:name => network.name})
+      controller.send(:update)
+    end
+  end
+
   describe "#delete" do
     let(:network) { FactoryBot.create(:cloud_network_openstack, :ext_management_system => ems) }
     let(:task_options) do

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -207,6 +207,18 @@ describe CloudSubnetController do
     end
   end
 
+  describe '#update' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => cloud_subnet.id}
+    end
+
+    it 'calls flash_and_redirect for canceling editing Cloud Subnet' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Edit of Subnet \"%{name}\" was cancelled by the user") % {:name => cloud_subnet.name})
+      controller.send(:update)
+    end
+  end
+
   describe "#delete" do
     let(:task_options) do
       {

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -198,6 +198,18 @@ describe CloudTenantController do
     end
   end
 
+  describe '#update' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => tenant.id}
+    end
+
+    it 'calls flash_and_redirect for canceling editing Cloud Tenant' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Edit of Cloud Tenant \"%{name}\" was cancelled by the user") % {:name => tenant.name})
+      controller.send(:update)
+    end
+  end
+
   describe "#delete" do
     let(:task_options) do
       {

--- a/spec/controllers/cloud_volume_backup_controller_spec.rb
+++ b/spec/controllers/cloud_volume_backup_controller_spec.rb
@@ -1,9 +1,10 @@
 describe CloudVolumeBackupController do
+  let(:backup) { FactoryBot.create(:cloud_volume_backup) }
+
   describe "#tags_edit" do
     let(:classification) { FactoryBot.create(:classification) }
     let(:tag1) { FactoryBot.create(:classification_tag, :parent => classification) }
     let(:tag2) { FactoryBot.create(:classification_tag, :parent => classification) }
-    let(:backup) { FactoryBot.create(:cloud_volume_backup) }
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -41,6 +42,18 @@ describe CloudVolumeBackupController do
       expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
       expect(assigns(:edit)).to be_nil
       expect(response.status).to eq(200)
+    end
+  end
+
+  describe '#backup_restore' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => backup.id}
+    end
+
+    it 'calls flash_and_redirect for canceling restoring Cloud Volume Backup' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Restore to Cloud Volume \"%{name}\" was cancelled by the user") % {:name => backup.name})
+      controller.send(:backup_restore)
     end
   end
 end

--- a/spec/controllers/mixins/generic_form_mixin_spec.rb
+++ b/spec/controllers/mixins/generic_form_mixin_spec.rb
@@ -1,0 +1,17 @@
+describe Mixins::GenericFormMixin do
+  describe '#flash_and_redirect' do
+    let(:controller) { HostAggregateController.new }
+
+    before do
+      allow(controller).to receive(:session).and_return(:edit => {:expression => {}})
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'previous_url'}, {:url => 'last_url'}])
+    end
+
+    it 'calls flash_to_session, javascript_redirect and sets session[:edit] to nil' do
+      expect(controller).to receive(:flash_to_session).with('Message', :error)
+      expect(controller).to receive(:javascript_redirect).with('previous_url')
+      controller.send(:flash_and_redirect, 'Message', :error)
+      expect(controller.session[:edit]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,7 +1,7 @@
 describe NetworkRouterController do
   include_examples :shared_examples_for_network_router_controller, %w(openstack azure google amazon)
 
-  describe "#tags_edit" do
+  describe "#tagging_edit" do
     let!(:user) { stub_user(:features => :all) }
 
     before do
@@ -513,6 +513,30 @@ describe NetworkRouterController do
           expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => 'Check Compliance initiated for 1 VM and Instance from the ManageIQ Database', :level => :success}])
         end
       end
+    end
+  end
+
+  context 'canceling provided actions on Network Router' do
+    let(:router) { FactoryBot.create(:network_router) }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => router.id}
+    end
+
+    it 'calls flash_and_redirect for canceling editing Network Router' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Edit of Router \"%{name}\" was cancelled by the user") % {:name => router.name})
+      controller.send(:update)
+    end
+
+    it 'calls flash_and_redirect for canceling adding Interface on Subnet to Router' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Add Interface on Subnet to Router \"%{name}\" was cancelled by the user") % {:name => router.name})
+      controller.send(:add_interface)
+    end
+
+    it 'calls flash_and_redirect for canceling removing Interface on Subnet from Router' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Remove Interface on Subnet from Router \"%{name}\" was cancelled by the user") % {:name => router.name})
+      controller.send(:remove_interface)
     end
   end
 end

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -248,6 +248,42 @@ describe VmCloudController do
     end
   end
 
+  context 'canceling actions on Instances' do
+    let(:instance) { FactoryBot.create(:vm_cloud) }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      controller.params = {:button => 'cancel', :id => instance.id}
+    end
+
+    it 'calls flash_and_redirect for canceling attaching Cloud Volume to Instance' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Attaching Cloud Volume to Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => instance.name})
+      controller.send(:attach_volume)
+    end
+
+    it 'calls flash_and_redirect for canceling detaching Cloud Volume from Instance' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Detaching a Cloud Volume from Instance \"%{instance_name}\" was cancelled by the user") % {:instance_name => instance.name})
+      controller.send(:detach_volume)
+    end
+  end
+
+  describe '#flash_and_redirect' do
+    before do
+      allow(controller).to receive(:session).and_return(:edit => {:expression => {}})
+      controller.instance_variable_set(:@record, FactoryBot.create(:vm_cloud))
+      controller.instance_variable_set(:@sb, :action => 'some_action')
+    end
+
+    it 'calls flash_to_session, replace_right_cell and sets session[:edit], @record and @sb[:action] to nil' do
+      expect(controller).to receive(:flash_to_session).with('Message')
+      expect(controller).to receive(:replace_right_cell)
+      controller.send(:flash_and_redirect, 'Message')
+      expect(controller.session[:edit]).to be_nil
+      expect(controller.instance_variable_get(:@record)).to be_nil
+      expect(controller.instance_variable_get(:@sb)[:action]).to be_nil
+    end
+  end
+
   include_examples '#download_summary_pdf', :vm_cloud
   include_examples '#download_summary_pdf', :template_azure
 


### PR DESCRIPTION
**Related PR and comment:** https://github.com/ManageIQ/manageiq-ui-classic/pull/6649#issuecomment-587464646

**This PR:**
- adds new `last_screen_url` and uses it instead of `@breacrumbs[-1][:url]` or `@breadcrumbs.last[:url]`
   - I used the name `last_screen_url` and not `last_breadcrumbs_url` because of the plans to get rid of usages of `@breadcrumbs`
- updates `cancel_action` and renames it to `flash_and_redirect` (which is more accurate and it is not used only while canceling some actions) in _GenericFormMixin_ module - this fixes the issue in some controllers with displaying (orange) warning flash message instead of successful one after user cancels some action
   - I left _VmCloud_ controller as it is with the original `cancel_action` because it differs from what it is in _GenericFormMixin_ (there is `@record` and calling `replace_right_cell` instead of `redirect_to`, in _VmCloud_ controller)
- removes `flash_and_redirect` from _HostAggregate_ controller as the same method can be used now from _GenericFormMixin_
- renames `cancel_action` and overrides it in _VmCloud_ controller to make it consistent with other controllers
- updates _SecurityGroupController_, use `flash_and_redirect` from _GenericFormMixin_, simplify the code little bit (also removes unnecessary code [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6687/commits/ede01212361026d0cd84b2f3efae125cda66abed#diff-fb5d22d19133a44dd2514b60ccf6a16cL194)), fixes 'wrong' redirect after deleting Security Group displayed through provider's summary screen, see the steps:

**Steps to reproduce redirecting issue after deleting Security Group:**
1. Go to _Networks > Providers_, click on some provider
2. Click on _Security Groups_ in _Relationships_ in textual summary of the provider (or in the Dashboard view, you need at least 1 Security Group to be there)
3. Click on some Security Group in the list
4. _Configuration > Delete this Security Group_
=> you will end up in the list of all Security Groups, not only all the Security Groups related to the selected provider! You can try the same through _Compute > Clouds > Security Groups_ (step 1). You should end up in the same list as in step 2.

**Before:**
![delete_before](https://user-images.githubusercontent.com/13417815/74859007-87d63500-5346-11ea-9c18-f4ebe6bb02f1.png)

**After:**
![delete_after](https://user-images.githubusercontent.com/13417815/74859014-899ff880-5346-11ea-83a8-e6d753175287.png)

**Note:**
We could use `flash_and_redirect` in many more places. This would lead to simplyfying the code and probably also to fixing other possible issues with redirecting to appropriate screens after some actions. But this PR is mainly about using it instead of `cancel_action`.