### PR TITLE
Change disk options in oVirts provisioning dialog

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -428,7 +428,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:addr_mode, :disk_format, :sysprep_identification, :schedule_type, :cloud_network_selection_method].include?(field)
+      - elsif [:addr_mode, :disk_format, :sysprep_identification, :schedule_type, :cloud_network_selection_method, :disk_sparsity].include?(field)
         -# Radio Button fields
         .col-md-8
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -143,7 +143,7 @@
             :keys                       => keys})
   - when :hardware
     - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
-              :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
+              :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
     = render(:partial => "/miq_request/prov_dialog_fieldset",


### PR DESCRIPTION
The user will now be able to select a specific disk format and sparsity
for the disks with validation.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1726590
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/459
Depends on: https://github.com/ManageIQ/manageiq/pull/19849
Related to: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/453

![Screenshot from 2020-02-19 15-24-57](https://user-images.githubusercontent.com/3274731/74838357-26a16800-532c-11ea-80c1-e905886a1ad5.png)

![Screenshot from 2020-02-19 15-27-44](https://user-images.githubusercontent.com/3274731/74838538-6cf6c700-532c-11ea-9ac1-c2d2dfaca916.png)
