### PR TITLE
Use uri_attributes in CustomButton instead of ae_attributes 

### DIFF
--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -189,10 +189,9 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       display_for: vm.customButtonModel.display_for,
       submit_how: vm.customButtonModel.submit_how,
     };
-
-    Object.assign(vm.customButtonModel.uri_attributes, _.zipObject(
+    vm.customButtonModel.uri_attributes = _.zipObject(
       vm.customButtonModel.attribute_names,
-      vm.customButtonModel.attribute_values));
+      vm.customButtonModel.attribute_values);
     vm.customButtonModel.uri_attributes.request = vm.customButtonModel.request;
 
     vm.customButtonModel.resource_action = {

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -186,11 +186,10 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       submit_how: vm.customButtonModel.submit_how,
     };
 
-    vm.customButtonModel.uri_attributes = _.zipObject(
+    Object.assign(vm.customButtonModel.uri_attributes, _.zipObject(
       vm.customButtonModel.attribute_names,
-      vm.customButtonModel.attribute_values);
+      vm.customButtonModel.attribute_values));
     vm.customButtonModel.uri_attributes.request = vm.customButtonModel.request;
-    vm.customButtonModel.uri_attributes.service_template = vm.customButtonModel.uri_attributes.service_template;
 
     vm.customButtonModel.resource_action = {
       id : vm.customButtonModel.resource_id,

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -186,11 +186,11 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       submit_how: vm.customButtonModel.submit_how,
     };
 
-    vm.customButtonModel.resource_action.ae_attributes = _.zipObject(
+    vm.customButtonModel.uri_attributes = _.zipObject(
       vm.customButtonModel.attribute_names,
       vm.customButtonModel.attribute_values);
-    vm.customButtonModel.resource_action.ae_attributes.request = vm.customButtonModel.request;
-    vm.customButtonModel.resource_action.ae_attributes.service_template = vm.customButtonModel.uri_attributes.service_template;
+    vm.customButtonModel.uri_attributes.request = vm.customButtonModel.request;
+    vm.customButtonModel.uri_attributes.service_template = vm.customButtonModel.uri_attributes.service_template;
 
     vm.customButtonModel.resource_action = {
       id : vm.customButtonModel.resource_id,
@@ -199,7 +199,6 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       ae_class: 'PROCESS',
       ae_instance: vm.customButtonModel.ae_instance,
       ae_message: vm.customButtonModel.ae_message,
-      ae_attributes: vm.customButtonModel.resource_action.ae_attributes,
     };
 
     if (vm.customButtonModel.current_visibility === 'role') {
@@ -209,7 +208,7 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     }
     // set uri_attributes to default for non-Ansible button
     if (vm.customButtonModel.button_type === "default") {
-      vm.customButtonModel.uri_attributes = {"request": vm.customButtonModel.request, service_template: null, hosts: null};
+      Object.assign(vm.customButtonModel.uri_attributes, {"request": vm.customButtonModel.request, service_template: null, hosts: null});
     };
 
     vm.customButtonModel.visibility = {
@@ -303,8 +302,8 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
       vm.customButtonModel.attribute_values = [];
     }
 
-    vm.customButtonModel.attribute_values = Object.values(vm.customButtonModel.resource_action.ae_attributes);
-    vm.customButtonModel.attribute_names = Object.keys(vm.customButtonModel.resource_action.ae_attributes);
+    vm.customButtonModel.attribute_values = Object.values(vm.customButtonModel.uri_attributes);
+    vm.customButtonModel.attribute_names = Object.keys(vm.customButtonModel.uri_attributes);
     vm.customButtonModel.noOfAttributeValueRows = vm.customButtonModel.attribute_names.length;
 
     vm.modelCopy = angular.element.extend(true, {}, vm.customButtonModel);

--- a/app/assets/javascripts/components/generic_object/main-custom-button-form.js
+++ b/app/assets/javascripts/components/generic_object/main-custom-button-form.js
@@ -131,9 +131,13 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
   };
 
   vm.resetClicked = function(angularForm) {
-    vm.customButtonModel = angular.element.extend(true, {}, vm.modelCopy);
+    vm.customButtonModel = angular.extend({}, vm.modelCopy);
 
-    assignAllObjectsToKeyValueArrays(true);
+    vm.customButtonModel.attribute_values = Object.values(vm.customButtonModel.resource_action.ae_attributes);
+    vm.customButtonModel.attribute_names = Object.keys(vm.customButtonModel.resource_action.ae_attributes);
+    vm.customButtonModel.noOfAttributeValueRows = vm.customButtonModel.attribute_names.length;
+
+    vm.modelCopy = angular.extend({}, vm.customButtonModel);
 
     angularForm.$setUntouched(true);
     angularForm.$setPristine(true);
@@ -292,19 +296,6 @@ function mainCustomButtonFormController(API, miqService, $q, $http) {
     } else {
       vm.inventory = "manual";
     }
-    vm.modelCopy = angular.element.extend(true, {}, vm.customButtonModel);
-  }
-
-  function assignAllObjectsToKeyValueArrays(purge) {
-    if (purge) {
-      vm.customButtonModel.attribute_names = [];
-      vm.customButtonModel.attribute_values = [];
-    }
-
-    vm.customButtonModel.attribute_values = Object.values(vm.customButtonModel.uri_attributes);
-    vm.customButtonModel.attribute_names = Object.keys(vm.customButtonModel.uri_attributes);
-    vm.customButtonModel.noOfAttributeValueRows = vm.customButtonModel.attribute_names.length;
-
     vm.modelCopy = angular.element.extend(true, {}, vm.customButtonModel);
   }
 }

--- a/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
+++ b/spec/javascripts/components/generic_object_definition/main-custom-button-form_spec.js
@@ -64,7 +64,7 @@ describe('main-custom-button-form', function() {
         .then( function() {
           expect(add_flash).toHaveBeenCalledWith("Name has already been taken", "error");
           expect(add_flash).toHaveBeenCalledWith("Description has already been taken", "error");
-          expect(vm.customButtonModel.resource_action.ae_attributes).toHaveAttr('service_template');
+          expect(vm.customButtonModel.uri_attributes).toHaveAttr('service_template');
           done();
       })
         .catch(function () {


### PR DESCRIPTION
`custom_button.uri_attributes=` saves to `custom_button.resource_action_ae_attributes` with some checks so UI should send the data only via `uri_attributes` otherwise it gets rewritten by API.

Related to https://github.com/ManageIQ/manageiq-api/pull/728 .

@miq-bot add_label bug