### PR TITLE
Fix SVG upload, render

### DIFF
--- a/app/assets/javascripts/components/generic_object/custom-image.js
+++ b/app/assets/javascripts/components/generic_object/custom-image.js
@@ -50,7 +50,7 @@ function customImageController($timeout) {
       vm.picture.extension = 'png';
     } else if (imageFile.type === 'image/jpg' || imageFile.type === 'image/jpeg') {
       vm.picture.extension = 'jpg';
-    } else if (imageFile.type === 'image/svg') {
+    } else if (imageFile.type === 'image/svg' || imageFile.type === 'image/svg+xml') {
       vm.picture.extension = 'svg';
     } else {
       vm.angularForm.generic_object_definition_image_file_status.$setValidity('incompatibleFileType', false);

--- a/app/controllers/picture_controller.rb
+++ b/app/controllers/picture_controller.rb
@@ -10,6 +10,7 @@ class PictureController < ApplicationController
 
     fresh_when(:etag => picture.md5, :public => true)
 
+    extension = 'svg+xml' if extension == 'svg'
     send_data(picture.content, :type => "image/#{extension}", :disposition => 'inline') if stale?
   end
 end


### PR DESCRIPTION
In generic object, we allow upload of custom svg images, but the code only matches the old image/svg,
but can't handle image/svg+xml which is what chrome now uses.

Similarly, PicturesController sets the type to image/svg on download, which causes the browser to render a placeholder instead.
Fixing to use svg+xml for mime type, but keep svg as extension.

Cc @Fryguy (assuming that's the way we go with the svg issue)
(This does not deal with the other places which currently don't allow svgs.)