### PR TITLE
Rename SecretSwitchField to PasswordField in component mappings

### DIFF
--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -12,7 +12,7 @@ import { PasswordContext } from './async-credentials';
 import { checkValidState } from './helper';
 import RequiredLabel from '../../forms/required-label';
 
-const SecretSwitchField = ({
+const PasswordField = ({
   edit,
   formOptions,
   isDisabled,
@@ -73,7 +73,7 @@ const SecretSwitchField = ({
   );
 };
 
-SecretSwitchField.propTypes = {
+PasswordField.propTypes = {
   FieldProvider: PropTypes.func.isRequired,
   edit: PropTypes.bool,
   formOptions: PropTypes.shape({
@@ -85,7 +85,7 @@ SecretSwitchField.propTypes = {
   validate: PropTypes.func,
 };
 
-SecretSwitchField.defaultProps = {
+PasswordField.defaultProps = {
   cancelEditLabel: __('Cancel'),
   changeEditLabel: __('Change'),
   isDisabled: false,
@@ -93,4 +93,4 @@ SecretSwitchField.defaultProps = {
   edit: false,
 };
 
-export default SecretSwitchField;
+export default PasswordField;

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
@@ -98,7 +98,7 @@ const createSchema = isEditing => ({
             isRequired: true,
             validate: [{ type: validatorTypes.REQUIRED }],
           }, {
-            component: 'secret-switch-field',
+            component: 'password-field',
             name: 'authentication.password',
             label: __('Password'),
             edit: isEditing,

--- a/app/javascript/forms/mappers/formsFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formsFieldsMapper.jsx
@@ -8,7 +8,7 @@ import DualGroup from '../../components/dual-group';
 import DualListSelect from '../../components/dual-list-select';
 import EditSecretField from '../../components/async-credentials/edit-secret-field';
 import InputWithDynamicPrefix from '../input-with-dynamic-prefix';
-import SecretSwitchField from '../../components/async-credentials/secret-switch-field';
+import PasswordField from '../../components/async-credentials/password-field';
 import { DataDrivenFormCodeEditor } from '../../components/code-editor';
 
 const fieldsMapper = {
@@ -19,7 +19,7 @@ const fieldsMapper = {
   'dual-list-select': DualListSelect,
   'input-with-dynamic-prefix': InputWithDynamicPrefix,
   hr: () => <hr />,
-  'secret-switch-field': SecretSwitchField,
+  'password-field': PasswordField,
   'validate-credentials': AsyncCredentials,
   'validate-provider-credentials': AsyncProviderCredentials,
   [componentTypes.SELECT]: props => <components.SelectField classNamePrefix="miq-ddf-select" {...props} />,

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Secret switch field component should render correctly in edit mode 1`] = `
-<SecretSwitchField
+<PasswordField
   FieldProvider={[Function]}
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
@@ -84,11 +84,11 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
       </InputGroup>
     </div>
   </FormGroup>
-</SecretSwitchField>
+</PasswordField>
 `;
 
 exports[`Secret switch field component should render correctly in non edit mode 1`] = `
-<SecretSwitchField
+<PasswordField
   FieldProvider={[Function]}
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
@@ -123,5 +123,5 @@ exports[`Secret switch field component should render correctly in non edit mode 
       Dummy
     </button>
   </DummyComponent>
-</SecretSwitchField>
+</PasswordField>
 `;

--- a/app/javascript/spec/async-credentials/password-field.spec.js
+++ b/app/javascript/spec/async-credentials/password-field.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
-import SecretSwitchField from '../../components/async-credentials/secret-switch-field';
+import PasswordField from '../../components/async-credentials/password-field';
 import { FieldProviderComponent as FieldProvider } from '../helpers/fieldProvider';
 
 const DummyComponent = ({
@@ -41,12 +41,12 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly in non edit mode', () => {
-    const wrapper = mount(<SecretSwitchField {...initialProps} />);
+    const wrapper = mount(<PasswordField {...initialProps} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render correctly in edit mode', () => {
-    const wrapper = mount(<SecretSwitchField {...initialProps} edit />);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
@@ -57,7 +57,7 @@ describe('Secret switch field component', () => {
    * https://github.com/airbnb/enzyme/issues/2011
    */
   it('should render correctly switch to editing', () => {
-    const wrapper = mount(<SecretSwitchField {...initialProps} edit />);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     expect(wrapper.find(DummyComponent)).toHaveLength(0);
     wrapper.find('button').simulate('click');
     wrapper.update();
@@ -65,7 +65,7 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly reset sercret field', () => {
-    const wrapper = mount(<SecretSwitchField {...initialProps} edit />);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     wrapper.find('button').simulate('click');
     expect(wrapper.find(DummyComponent)).toHaveLength(1);
     wrapper.find('button').simulate('click');

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -79,7 +79,7 @@ exports[`PxeServersForm should render correctly 1`] = `
                         ],
                       },
                       Object {
-                        "component": "secret-switch-field",
+                        "component": "password-field",
                         "edit": false,
                         "isRequired": true,
                         "label": "Password",


### PR DESCRIPTION
This field is responsible for the passwords in credential validation forms, however, its naming was a little confusing. I needed a couple of days to actually hunt this component down and understand how this whole password hiding thing in the context of validation works.

I don't want others to get into this trap and also I would like to use this component in provider schemas, so I'd like to rename it to something more meaninfgul.

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @rvsia 
@miq-bot add_label react, enhancement