### PR TITLE
Inherit `edit` under the AsyncCredentials using the existing context

### DIFF
--- a/app/javascript/components/async-credentials/async-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-credentials.jsx
@@ -70,7 +70,7 @@ const AsyncCredentials = ({
   };
 
   return (
-    <PasswordContext.Provider value={name}>
+    <PasswordContext.Provider value={{ name, edit }}>
       {formOptions.renderForm(fields.map(field => ({
         ...field,
         isDisabled: field.isDisabled || validating,

--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState, useContext, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -13,7 +13,6 @@ import { checkValidState } from './helper';
 import RequiredLabel from '../../forms/required-label';
 
 const PasswordField = ({
-  edit,
   formOptions,
   isDisabled,
   FieldProvider, // eslint-disable-line no-unused-vars
@@ -22,6 +21,7 @@ const PasswordField = ({
   changeEditLabel,
   ...rest
 }) => {
+  const { name: secretKey, edit } = useContext(PasswordContext);
   const [editMode, setEditMode] = useState(!edit);
   const secretField = {
     component: edit ? 'credentials-password-edit' : componentTypes.TEXT_FIELD,
@@ -32,44 +32,40 @@ const PasswordField = ({
     ...rest,
   };
   return (
-    <PasswordContext.Consumer>
-      {secretKey => (
-        <Fragment>
-          {edit && editMode && formOptions.renderForm([{
-            ...secretField,
-            editMode: !editMode,
-            buttonLabel: cancelEditLabel,
-            setEditMode: () => {
-              formOptions.change(rest.name, undefined);
-              if (checkValidState(formOptions, secretKey)) {
-                formOptions.change(secretKey, formOptions.getFieldState(secretKey).initial);
-              }
-              setEditMode(editMode => !editMode); // reset edit mode
-            },
-          }], formOptions) }
-          {edit && !editMode && (
-            <FormGroup>
-              <ControlLabel>
-                {rest.isRequired ? <RequiredLabel label={rest.label} /> : rest.label }
-              </ControlLabel>
-              <InputGroup>
-                <FormControl
-                  id={`${rest.name}-password-placeholder`}
-                  autoFocus
-                  placeholder="●●●●●●●●"
-                  disabled
-                  type="password"
-                />
-                <InputGroup.Button>
-                  <Button type="button" onClick={() => setEditMode(editMode => !editMode)}>{changeEditLabel}</Button>
-                </InputGroup.Button>
-              </InputGroup>
-            </FormGroup>
-          )}
-          {!edit && formOptions.renderForm([secretField], formOptions)}
-        </Fragment>
+    <Fragment>
+      {edit && editMode && formOptions.renderForm([{
+        ...secretField,
+        editMode: !editMode,
+        buttonLabel: cancelEditLabel,
+        setEditMode: () => {
+          formOptions.change(rest.name, undefined);
+          if (checkValidState(formOptions, secretKey)) {
+            formOptions.change(secretKey, formOptions.getFieldState(secretKey).initial);
+          }
+          setEditMode(editMode => !editMode); // reset edit mode
+        },
+      }], formOptions) }
+      {edit && !editMode && (
+        <FormGroup>
+          <ControlLabel>
+            {rest.isRequired ? <RequiredLabel label={rest.label} /> : rest.label }
+          </ControlLabel>
+          <InputGroup>
+            <FormControl
+              id={`${rest.name}-password-placeholder`}
+              autoFocus
+              placeholder="●●●●●●●●"
+              disabled
+              type="password"
+            />
+            <InputGroup.Button>
+              <Button type="button" onClick={() => setEditMode(editMode => !editMode)}>{changeEditLabel}</Button>
+            </InputGroup.Button>
+          </InputGroup>
+        </FormGroup>
       )}
-    </PasswordContext.Consumer>
+      {!edit && formOptions.renderForm([secretField], formOptions)}
+    </Fragment>
   );
 };
 

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
@@ -101,7 +101,6 @@ const createSchema = isEditing => ({
             component: 'password-field',
             name: 'authentication.password',
             label: __('Password'),
-            edit: isEditing,
             isRequired: true,
             validate: [{ type: validatorTypes.REQUIRED }],
           }],

--- a/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
@@ -2,7 +2,12 @@
 
 exports[`Async credentials component should render correctly 1`] = `
 <ContextProvider
-  value="async-wrapper"
+  value={
+    Object {
+      "edit": false,
+      "name": "async-wrapper",
+    }
+  }
 >
   <DummyComponent
     isDisabled={false}

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
   FieldProvider={[Function]}
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  edit={true}
+  edit={false}
   formOptions={
     Object {
       "change": [MockFunction],
@@ -105,6 +105,7 @@ exports[`Secret switch field component should render correctly in non edit mode 
 >
   <DummyComponent
     component="text-field"
+    edit={false}
     isDisabled={false}
     name="foo"
     type="password"
@@ -117,6 +118,7 @@ exports[`Secret switch field component should render correctly in non edit mode 
     <button
       component="text-field"
       disabled={false}
+      edit={false}
       name="foo"
       type="button"
     >

--- a/app/javascript/spec/async-credentials/password-field.spec.js
+++ b/app/javascript/spec/async-credentials/password-field.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import PasswordField from '../../components/async-credentials/password-field';
+import { PasswordContext } from '../../components/async-credentials/async-credentials';
 import { FieldProviderComponent as FieldProvider } from '../helpers/fieldProvider';
 
 const DummyComponent = ({
@@ -13,6 +14,7 @@ const DummyComponent = ({
   setEditMode,
   ...props
 }) => <button {...props} onClick={setEditMode} disabled={isDisabled} type="button">{buttonLabel || 'Dummy'}</button>;
+
 
 describe('Secret switch field component', () => {
   let initialProps;
@@ -41,12 +43,12 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly in non edit mode', () => {
-    const wrapper = mount(<PasswordField {...initialProps} />);
+    const wrapper = mount(<PasswordContext.Provider value={{}}><PasswordField {...initialProps} /></PasswordContext.Provider>);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render correctly in edit mode', () => {
-    const wrapper = mount(<PasswordField {...initialProps} edit />);
+    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
@@ -57,7 +59,7 @@ describe('Secret switch field component', () => {
    * https://github.com/airbnb/enzyme/issues/2011
    */
   it('should render correctly switch to editing', () => {
-    const wrapper = mount(<PasswordField {...initialProps} edit />);
+    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
     expect(wrapper.find(DummyComponent)).toHaveLength(0);
     wrapper.find('button').simulate('click');
     wrapper.update();
@@ -65,7 +67,7 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly reset sercret field', () => {
-    const wrapper = mount(<PasswordField {...initialProps} edit />);
+    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
     wrapper.find('button').simulate('click');
     expect(wrapper.find(DummyComponent)).toHaveLength(1);
     wrapper.find('button').simulate('click');

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -80,7 +80,6 @@ exports[`PxeServersForm should render correctly 1`] = `
                       },
                       Object {
                         "component": "password-field",
-                        "edit": false,
                         "isRequired": true,
                         "label": "Password",
                         "name": "authentication.password",


### PR DESCRIPTION
When working with the `AsyncCredentials` component in editing mode, it is not enough to set the `edit` prop on the parent component, this value needs to be passed down to the child password component(s). This is very impractical as the schema has to contain a redundant value in a nested structure and it causes trouble with the provider forms.

One solution would be to have parametrized provider forms, which so far I was able to avoid successfully. In order to keep the provider forms as simple as possible, I am proposing to reuse the existing `PasswordContext` to inherit the `edit` prop further to the password component. To make the code a little cleaner, I also rewrote the `Context.Consumer` into a hook.

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @rvsia 
@miq-bot add_label react, enhancement