### PR TITLE
Drop the obsolete `edit` from PasswordField.defaultProps

### DIFF
--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -71,7 +71,6 @@ const PasswordField = ({
 
 PasswordField.propTypes = {
   FieldProvider: PropTypes.func.isRequired,
-  edit: PropTypes.bool,
   formOptions: PropTypes.shape({
     renderForm: PropTypes.func.isRequired,
   }).isRequired,
@@ -86,7 +85,6 @@ PasswordField.defaultProps = {
   changeEditLabel: __('Change'),
   isDisabled: false,
   validate: undefined,
-  edit: false,
 };
 
 export default PasswordField;


### PR DESCRIPTION
Missed this from https://github.com/ManageIQ/manageiq-ui-classic/pull/6706

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @rvsia 
@miq-bot assign @mzazrivec 