### PR TITLE
Make Advanced Search in Services screen reactive also in other tabs

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -317,8 +317,9 @@ class ServiceController < ApplicationController
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
 
-    # Reset session to same values as first time in
-    session[:adv_search]["Service"] = session[:edit] = nil if session[:adv_search] && params[:action] != 'x_search_by_name'
+    # Set session properly - the same as when the filter is cleared
+    # No need to edit session here again if adv_search_clear was called
+    listnav_search_selected(0) if session[:adv_search] && %w[adv_search_button adv_search_clear x_search_by_name].exclude?(params[:action])
 
     case TreeBuilder.get_model_for_prefix(@nodetype)
     when "Service"

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -321,6 +321,8 @@ class ServiceController < ApplicationController
     # No need to edit session here again if adv_search_clear was called
     listnav_search_selected(0) if session[:adv_search] && %w[adv_search_button adv_search_clear x_search_by_name].exclude?(params[:action])
 
+    @edit = session[:edit]
+
     case TreeBuilder.get_model_for_prefix(@nodetype)
     when "Service"
       show_record(id)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -371,7 +371,7 @@ describe ServiceController do
         let(:edit) { {:new => {}, :adv_search_applied => {:text => " - Filtered by Filter1"}} }
 
         before do
-          controller.instance_variable_set(:@edit, edit)
+          allow(controller).to receive(:session).and_return(:edit => edit)
           controller.instance_variable_set(:@right_cell_text, nil)
           controller.instance_variable_set(:@sb, {})
         end
@@ -461,6 +461,20 @@ describe ServiceController do
         expect(controller).to receive(:listnav_search_selected).with(0)
         controller.send(:get_node_info, 'xx-rsrv')
       end
+    end
+  end
+
+  describe '#get_node_info' do
+    let(:edit) { {:new => {}, :adv_search_applied => {:text => " - Filtered by Filter1"}} }
+
+    before do
+      allow(controller).to receive(:session).and_return(:edit => edit)
+      controller.instance_variable_set(:@sb, {})
+    end
+
+    it 'sets @edit according to the session[:edit]' do
+      controller.send(:get_node_info, 'xx-rsrv')
+      expect(controller.instance_variable_get(:@edit)).to eq(controller.session[:edit])
     end
   end
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -408,24 +408,58 @@ describe ServiceController do
 
   context 'clicking on Active/Retired Services node in the tree, after applying a filter' do
     describe '#get_node_info' do
-      let(:s) { {:adv_search => {"Service" => {:expression => {}}}, :edit => {:expression => {}}} }
+      let(:edit) do
+        {
+          :expression         => expression,
+          :new                => {:expression => {'CONTAINS' => {'tag' => 'Some tag', 'value' => 'test'}}},
+          :adv_search_name    => 'Some filter',
+          :new_search_name    => 'Some filter',
+          :adv_search_applied => {:text => " - Filtered by \"Some filter\"",
+                                  :exp  => {'CONTAINS' => {'tag' => 'Some tag', 'value' => 'test'}}}
+        }
+      end
+
+      let(:expression) do
+        ApplicationController::Filter::Expression.new.tap do |e|
+          e.expression = {'CONTAINS' => {'tag' => 'Some tag', 'value' => 'test'}, :token => 2}
+          e.exp_table = [["Service.My Company Tags : Some tag CONTAINS 'Test'", 2]]
+          e.exp_token = nil
+          e.history = ApplicationController::Filter::ExpressionEditHistory.new([{'CONTAINS' => {'tag' => 'Some tag', 'value' => 'test'}, :token => 2}])
+          e.selected = {:id => 123, :name => 'Some filter', :description => 'Some filter', :typ => 'default'}
+        end
+      end
+
+      let(:new_expression) do
+        ApplicationController::Filter::Expression.new.tap do |e|
+          e.expression = {'???' => '???', :token => 3}
+          e.exp_key = '???'
+          e.exp_orig_key = '???'
+          e.exp_table = [['???', 3]]
+          e.exp_token = 3
+          e.history = ApplicationController::Filter::ExpressionEditHistory.new([{'???' => '???'}])
+          e.selected = {:id => 0, :description => 'All'}
+          e.val1 = e.val2 = {:type => nil}
+        end
+      end
 
       before do
-        allow(controller).to receive(:session).and_return(s)
+        allow(controller).to receive(:session).and_return(:adv_search => {"Service" => edit}, :edit => edit)
         controller.params = {:action => 'tree_select'}
+        controller.instance_variable_set(:@edit, edit)
+        controller.instance_variable_set(:@expkey, :expression)
+        controller.instance_variable_set(:@explorer, true)
         controller.instance_variable_set(:@sb, {})
       end
 
-      it 'resets session to same values as first time in, for Active Services' do
+      it 'sets session to default values, for Active Services' do
         controller.send(:get_node_info, 'xx-asrv')
-        expect(controller.session[:edit]).to be_nil
-        expect(controller.session[:adv_search]["Service"]).to be_nil
+        expect(controller.session[:edit][:expression]).to eq(new_expression)
+        expect(controller.session[:edit]).to eq(controller.session[:adv_search]["Service"])
       end
 
-      it 'resets session to same values as first time in, for Retired Services' do
+      it 'calls listnav_search_selected' do
+        expect(controller).to receive(:listnav_search_selected).with(0)
         controller.send(:get_node_info, 'xx-rsrv')
-        expect(controller.session[:edit]).to be_nil
-        expect(controller.session[:adv_search]["Service"]).to be_nil
       end
     end
   end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1803947

The first commit in this PR fixes the error occurred after opening _Advanced Search_ in _My Services_ screen again (see the first steps to reproduce in the BZ) and also makes Adv Search/expression editor work properly. The second commit fixes another scenario I've found in Advanced Search:

1. Go to _Services > My Services_
2. Click on some Service **in accordion**
3. Click on _Active/Retired Services_ node in accordion
4. Open _Advanced Search_

---

When accessing the page for the very first time, `explorer` method is called in _ServiceController_, and with this method `@edit` is properly set. Then in `get_node_info` (called by `replace_right_cell` in `explorer`), `session[:edit]` is [here](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Services_Adv_search_not_reactive?expand=1#diff-e4046e1d448a629c478f2a2d28286089L321) already set to `nil` (not being reset there in this situation) but this does not matter because next in application controller, `session[:edit]` is set according to the `@edit` variable [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1856).

Different situation is when we are already in _My Services_ screen and when we click, for example, on _Active Services_ node in accordion. The same stuff should be displayed as when first time in, but `tree_select` is called (not `explorer`) which does not care about setting `@edit` again. Next in application controller, when `session[:edit]` is set according to `@edit` variable, we end up with both variables set to `nil`, so we loose the information. But we do need it for any further actions with _Advanced Search_: for example when opening Advanced Search later, `adv_search_toggle` is called, and if `@edit` is set to `nil`, error occurs when checking `@edit[:adv_search_open]` [here](https://github.com/ManageIQ/manageiq-ui-classic/blame/master/app/controllers/application_controller/filter.rb#L178), obviously.

In other screens this works well (check for example `tree_select` in _VmCommon_ module), because in `tree_select`, `adv_search_build` is called, together with something like `session[:edit] = @edit` so the problematic situation [is covered](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/vm_common.rb#L879-L881), `@edit` or the session are set properly. However, this is missing in `ServiceController`'s `tree_select` method.

---

**Before:**
_Advanced Search_ not working, after choosing _Field_ no other options appeared (+ error in log):
![session_before](https://user-images.githubusercontent.com/13417815/75180325-407fe800-573c-11ea-95b5-8e1e1a97dc16.png)

**After:**
_Advanced Search_ working as expected (and no error):
![session_after](https://user-images.githubusercontent.com/13417815/75179410-4bd21400-573a-11ea-9c0a-8904fe0b3224.png)

---

**Note:**
There is another bug related to Adv Search in _My Services_ screen, but NOT related to the BZ I am fixing in this PR or to the changes in this PR: https://github.com/ManageIQ/manageiq-ui-classic/issues/6708