### PR TITLE
Show also external vlans in nic reconf

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -19,7 +19,8 @@ module Mixins
 
           if @reconfigitems.size == 1
             vm = @reconfigitems.first
-            @vlan_options = get_vlan_options(vm.host_id)
+            @vlan_options = vm.try(:available_vlans) || get_vlan_options(vm.host_id)
+
             @avail_adapter_names = vm.try(:available_adapter_names) || []
             @iso_options = get_iso_options(vm)
           end


### PR DESCRIPTION
This is a proposal to allow the ovirt provider to define available vlans
for the NICs reconfiguration view.

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/478
Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1751151
