### PR TITLE
eslint: disable camelcase rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,9 +105,6 @@
     "brace-style": [2, "1tbs", {
       "allowSingleLine": false
     }],
-    "camelcase": [2, {
-      "properties": "never"
-    }],
     "comma-spacing": [2, {
       "before": false,
       "after": true
@@ -186,9 +183,7 @@
     }],
     "func-names": 0,
     "no-mixed-spaces-and-tabs": 2,
-    "camelcase": [ "warn", {
-      "properties": "never"
-    }],
+    "camelcase": 0,
 
     "curly": [ "warn", "all" ],
     "no-eq-null": 0,

--- a/app/assets/javascripts/.eslintrc.json
+++ b/app/assets/javascripts/.eslintrc.json
@@ -4,7 +4,6 @@
     "miqHideSearchClearButton": true // local miq_application.js
   },
   "rules": {
-    "camelcase": "off",
     "key-spacing": ["error", {
       "mode": "minimum"
     }],

--- a/app/javascript/components/async-credentials/async-provider-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-provider-credentials.jsx
@@ -6,7 +6,7 @@ const AsyncProviderCredentials = ({ ...props }) => {
   const asyncValidate = (fields, fieldNames) => new Promise((resolve, reject) => {
     const resource = pick(fields, fieldNames);
     API.post('/api/providers', { action: 'verify_credentials', resource }).then(({ results: [result] }) => {
-      const { task_id, success } = result; // eslint-disable-line camelcase
+      const { task_id, success } = result;
       // The request here can either create a background task or fail
       return success ? API.wait_for_task(task_id) : Promise.reject(result);
       // The wait_for_task request can succeed with valid or invalid credentials

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.jsx
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.jsx
@@ -30,12 +30,12 @@ const PxeServersForm = ({ id }) => {
         .then(({
           id: _id,
           href: _h,
-          pxe_menus, // eslint-disable-line camelcase
+          pxe_menus,
           authentications,
           ...data
         }) => setInitialValues({
           ...data,
-          pxe_menus: pxe_menus.map(({ file_name }) => ({ file_name })), // eslint-disable-line camelcase
+          pxe_menus: pxe_menus.map(({ file_name }) => ({ file_name })),
           authentication: authentications[0] ? ({
             userid: authentications[0].userid,
           }) : ({}),

--- a/app/javascript/components/tree-view/hierarchical-tree-view.jsx
+++ b/app/javascript/components/tree-view/hierarchical-tree-view.jsx
@@ -1,4 +1,3 @@
-/* eslint camelcase: ["warn", {allow: ["bs_tree", "tree_name", "click_url", "check_url", "allow_reselect"]}] */
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/app/javascript/spec/toolbar-actions/toolbar-actions-generic.spec.js
+++ b/app/javascript/spec/toolbar-actions/toolbar-actions-generic.spec.js
@@ -30,7 +30,7 @@ describe('Toolbar actions', () => {
   });
 
   describe('Generic action', () => {
-    let add_flash; // eslint-disable-line camelcase
+    let add_flash;
 
     beforeEach(() => {
       spyOn(window.vanillaJsAPI, 'post').and.returnValue(Promise.resolve({
@@ -38,8 +38,8 @@ describe('Toolbar actions', () => {
           { success: true, message: 'some' },
         ],
       }));
-      add_flash = jasmine.createSpy('add_flash'); // eslint-disable-line camelcase
-      window.add_flash = add_flash; // eslint-disable-line camelcase
+      add_flash = jasmine.createSpy('add_flash');
+      window.add_flash = add_flash;
     });
 
     test('should send correct data', () => {


### PR DESCRIPTION
No point in enforcing camelCase when all API properties are underscore_cased.

Disables the [camelcase rule](https://eslint.org/docs/rules/camelcase).