### PR TITLE
Render 'layouts/empty' partial correctly.

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -202,6 +202,7 @@ class ProviderForemanController < ApplicationController
   def provider_active_tree?
     x_active_tree == :configuration_manager_providers_tree
   end
+  helper_method(:provider_active_tree?)
 
   private
 
@@ -389,6 +390,10 @@ class ProviderForemanController < ApplicationController
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "configuration_profile",
                                     :locals  => {:controller => controller_name}])
+    elsif ManageIQ::Providers::ConfigurationManager.none? && provider_active_tree?
+      presenter.update(:main_div, r[:partial => "layouts/empty",
+                                    :locals  => {:add_message   => _("Add a new Configuration Management Provider"),
+                                                 :documentation => ::Settings.docs.configuration_provider}])
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end

--- a/app/views/provider_foreman/explorer.html.haml
+++ b/app/views/provider_foreman/explorer.html.haml
@@ -22,10 +22,11 @@
     = render(:partial => 'provider_foreman/configuration_script', :locals => {:controller => "provider_foreman"})
 - else
   #main_div
-    - if ManageIQ::Providers::ConfigurationManager.any?
-      = render(:partial => 'layouts/x_gtl')
-    - else
+    - if ManageIQ::Providers::ConfigurationManager.none? && provider_active_tree?
       = render :partial => 'layouts/empty',
                :locals => {:add_message => _("Add a new Configuration Management Provider"),
                            :documentation => ::Settings.docs.configuration_provider}
+    - else
+      = render(:partial => 'layouts/x_gtl')
+
 


### PR DESCRIPTION
- Render 'layouts/empty' partial when replacing right cell after accordion is switched from "Configured Systems" to "Providers" when there are no Foreman Providers in the database.
- Also render "layouts/empty" partial from explorer view only when active tree is Providers tree, existing code was rendering empty partial when returning back to explorer if "Configured Systems" was the last active accordion.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741310

before
![before](https://user-images.githubusercontent.com/3450808/75288554-957a3780-57ea-11ea-8447-cabadad49216.png)

after
![after](https://user-images.githubusercontent.com/3450808/75288537-8e532980-57ea-11ea-9304-0afdd35b4529.png)
