### PR TITLE
Allow add/delete of global filters based upon user's allowed features

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -48,7 +48,7 @@ module ApplicationController::AdvancedSearch
       add_flash(_("Search Name is required"), :error) if params[:button] == 'saveit'
       false
     else
-      s = @edit[@expkey].build_search(@edit[:new_search_name], @edit[:search_type], session[:userid])
+      s = @edit[@expkey].build_search(@edit[:new_search_name], role_allows?(:feature => 'add_global_filter') ? @edit[:search_type] : nil, session[:userid])
       s.filter = MiqExpression.new(@edit[:new][@expkey]) # Set the new expression
       if s.save
         add_flash(_("%{model} search \"%{name}\" was saved") %

--- a/app/presenters/tree_builder_ops_rbac_features.rb
+++ b/app/presenters/tree_builder_ops_rbac_features.rb
@@ -23,7 +23,7 @@ class TreeBuilderOpsRbacFeatures < TreeBuilder
       Vmdb::PermissionStores.instance.can?(section.id) && !section.kind_of?(Menu::Item)
     end
 
-    top_nodes += %w[all_vm_rules api_exclusive sui ops_explorer].collect do |additional_feature|
+    top_nodes += %w[all_vm_rules api_exclusive sui ops_explorer common_features].collect do |additional_feature|
       MiqProductFeature.obj_features[additional_feature] &&
         MiqProductFeature.obj_features[additional_feature][:feature]
     end

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -77,7 +77,7 @@
                                  :class             => "form-control",
                                  "data-miq_focus"   => true,
                                  "data-miq_observe" => {:interval => ".5", :url => url2}.to_json)
-          - if report_admin_user?
+          - if role_allows?(:feature => 'add_global_filter')
             .form-group
               %label.control-label.col-md-5
                 = _("Global search:")

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -29,7 +29,7 @@
                      :title   => t,
                      :onclick => "miqAjaxButton('#{url_for_only_path(:action => 'adv_search_button', :button => "apply")}');$('#advsearchModal').modal('hide');")
       - if @edit[@expkey][:selected] && @edit[@expkey][:selected][:typ] != "default" && @edit[@expkey][:selected][:id] != 0
-        - if report_admin_user? || @edit[@expkey][:selected][:typ] == "user"
+        - if role_allows?(:feature => 'add_global_filter') || @edit[@expkey][:selected][:typ] == "user"
           - actual_filter = @edit[@expkey][:selected][:description]
           - confirm_msg = _("Delete the %{model} filter named %{filter}?") % {:model  => ui_lookup(:model => @edit[@expkey][:exp_model]),
                                                                               :filter => actual_filter}

--- a/spec/presenters/tree_builder_ops_rbac_features_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_features_spec.rb
@@ -3,6 +3,7 @@ describe TreeBuilderOpsRbacFeatures do
     %w(
       all_vm_rules
       api_exclusive
+      common_features
       instance
       instance_view
       instance_show_list


### PR DESCRIPTION
This PR addresses issues mention in https://github.com/ManageIQ/manageiq-ui-classic/pull/6253

Core PR https://github.com/ManageIQ/manageiq/pull/19916

before any user could add/delete global filters 
![before1](https://user-images.githubusercontent.com/3450808/75588907-9360e480-5a47-11ea-8c04-bfd5242ddaf2.png)

![before2](https://user-images.githubusercontent.com/3450808/75588916-965bd500-5a47-11ea-8172-e350b8edf9d3.png)

after only user can add/delete global filter if they have access to the new feature

user without access to "Add Global Filter"

![after1](https://user-images.githubusercontent.com/3450808/75791089-103ad980-5d3a-11ea-932f-261d0391a1bf.png)
![after2](https://user-images.githubusercontent.com/3450808/75791096-129d3380-5d3a-11ea-892d-f97f6ce336ca.png)
![after3](https://user-images.githubusercontent.com/3450808/75791102-14ff8d80-5d3a-11ea-9bfd-71144f6d2896.png)

user with access to "Add Global Filter", have access to "Delete" button and "Global Search" checkbox
![after4](https://user-images.githubusercontent.com/3450808/75791146-247ed680-5d3a-11ea-9b38-f6e67ac3ba20.png)

![after5](https://user-images.githubusercontent.com/3450808/75791158-2779c700-5d3a-11ea-9686-4687ce04f00c.png)

![after6](https://user-images.githubusercontent.com/3450808/75791179-2d6fa800-5d3a-11ea-9886-36efafce1fa8.png)

