### PR TITLE
Display newly saved expression in Advanced Search in My Services

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -342,7 +342,7 @@ class ServiceController < ApplicationController
         @right_cell_text = _("Retired Services")
       end
     when "MiqSearch", nil # nil if applying a filter from Advanced search - and @nodetype is root
-      load_adv_search unless @nodetype == "root" # Select/load filter from Global/My Filters
+      load_adv_search unless @nodetype == "root" || %w[saveit].include?(params[:button]) # Select/load filter from Global/My Filters
       process_show_list
       @right_cell_text = _("All Services")
     end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6708

Calling `listnav_search_selected` in `load_adv_search` in _ServiceController_ caused that `@edit[@expkey][:exp_table]` was changed to the expression which was loaded **before** the new filter was saved. So this is why after saving the new filter, the 'previous' expression was suddenly displayed in _Advanced Search_, not the last created one. Usually in other controllers, `listnav_search_selected` is called in a different situation - when we want to apply some existing filter (or to clear it) and not when we save/create a new filter.

Moreover it is absolutely unnecessary to call the whole `load_adv_search` in _ServiceController_ regarding this situation. But we need the method for applying filters in accordion from from _Global/My Filters_ in _My Services_ screen. So I've added an extra condition to prevent calling it when unnecessary. Feel free to suggest any better fix for this situation.

---

**Before:**
![expr_before](https://user-images.githubusercontent.com/13417815/75702674-2d2dc900-5cb6-11ea-8422-99fdb99a3f6e.png)

**After:**
![expr-after](https://user-images.githubusercontent.com/13417815/75702683-30c15000-5cb6-11ea-8f04-61ab92e5ffd0.png)
