### PR TITLE
Allow editing Groups from the list view

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_groups_center.rb
@@ -19,8 +19,8 @@ class ApplicationHelper::Toolbar::MiqGroupsCenter < ApplicationHelper::Toolbar::
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,
-          :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::RbacGroupEdit),
+          :onwhen       => "1"
+        ),
         button(
           :rbac_group_delete,
           'pficon pficon-delete fa-lg',


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1803952

Setting `ApplicationHelper::Button::RbacGroupEdit` for "Edit" button to be enabled/disabled in the toolbar in the list view of _Groups_ works only for toolbar in the details page of a Group. `@record` is required to be set. `disabled?` method checks if the `@record` is read only. However, there isn't any `@record` set while displaying list of Groups so it did not work at all in such a screen.

Fortunately, after clicking on _Edit the selected Group_ in the toolbar `rbac_edit_reset` is called, in `rbac_group_edit` in _OpSController_. This method 'finds' the appropriate record according to the id in `params[:miq_grid_checks]` together with checking if the record is read only, and also sets the appropriate flash message which is displayed later. If we can edit the Group, editing screen will be rendered as expected.

---

**Before:**
![no-edit](https://user-images.githubusercontent.com/13417815/75782153-c2849800-5d5e-11ea-9cb2-6c1cd9242839.png)

**After:**
![read_only](https://user-images.githubusercontent.com/13417815/75782128-b8fb3000-5d5e-11ea-8c6b-aea156badf42.png)

