### PR TITLE
Redirect to proper screen after editing selected Hosts in a nested list

### DIFF
--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -499,6 +499,66 @@ describe HostController do
     end
   end
 
+  describe '#edit' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:session).and_return(:host_items => [h1.id, h2.id])
+      controller.instance_variable_set(:@breadcrumbs, [])
+    end
+
+    it 'adds breadcrumb to the @breadcrumbs array while editing multiple Hosts' do
+      controller.send(:edit)
+      expect(controller.instance_variable_get(:@breadcrumbs)).to eq([{:name => 'Edit Hosts', :url => '/host/edit/'}])
+    end
+  end
+
+  describe '#update' do
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:session).and_return(:host_items => nil)
+    end
+
+    context 'canceling editing' do
+      before { controller.params = {:button => 'cancel', :id => h1.id} }
+
+      it 'calls flash_and_redirect' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Edit of Host \"%{name}\" was cancelled by the user") % {:name => h1.name})
+        controller.send(:update)
+      end
+
+      context 'selecting multiple Hosts' do
+        before { allow(controller).to receive(:session).and_return(:host_items => [h1.id, h2.id]) }
+
+        it 'calls flash_and_redirect' do
+          expect(controller).to receive(:flash_and_redirect).with(_('Edit of credentials for selected Hosts was cancelled by the user'))
+          controller.send(:update)
+        end
+      end
+    end
+
+    context 'saving changes' do
+      before do
+        allow(controller).to receive(:set_record_vars).and_return(true)
+        controller.instance_variable_set(:@breadcrumbs, [])
+        controller.params = {:button => 'save', :id => h1.id}
+      end
+
+      it 'calls flash_and_redirect' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Host \"%{name}\" was saved") % {:name => h1.name})
+        controller.send(:update)
+      end
+
+      context 'selecting multiple Hosts' do
+        before { allow(controller).to receive(:session).and_return(:host_items => [h1.id, h2.id]) }
+
+        it 'calls flash_and_redirect' do
+          expect(controller).to receive(:flash_and_redirect).with(_('Credentials/Settings saved successfully'))
+          controller.send(:update)
+        end
+      end
+    end
+  end
+
   describe '#report_data' do
     before do
       stub_user(:features => :all)


### PR DESCRIPTION
**Fixes issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6615
**DEPENDS ON:** https://github.com/ManageIQ/manageiq-ui-classic/pull/6687 (merged)

In this PR, I used new `flash_and_redirect` method (originally `cancel_action` + some little change there) to solve redirection to the proper screen after editing selected Host(s) displayed in a nested list. Originally, I found the issue when displaying Hosts through Cluster's textual summary. Note that `flash_and_redirect` could be used in many more controllers => less code in controllers + proper redirecting in any case. But also note that it relies on what's in `@breadcrumbs`.

Due to using `flash_and_redirect` I could delete some unnecessary lines of the code in _HostController_ and achieved proper redirecting after succcessful saving the changes or also after canceling editing (not only from a nested list of Hosts). And this is true for both - selecting an individual Host in the list (`session[:host_items]` is `nil`) or also multiple Hosts.

One extra [change](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Redirect_after_Host_edit_through_Cluster?expand=1#diff-9cb6a33e58e751fbe3fffc18deeda0a1R138) I made in _HostController_ regarding editing multiple Hosts is there because of missing info in `@breadcrumbs` later. Note that for editing only one selected Host, this is [already there](https://github.com/ManageIQ/manageiq-ui-classic/compare/master...hstastna:Redirect_after_Host_edit_through_Cluster?expand=1#diff-9cb6a33e58e751fbe3fffc18deeda0a1R135).

---

Before editing selected Host(s) displayed in a nested list:
![before_edit](https://user-images.githubusercontent.com/13417815/75914441-0f4a9a80-5e55-11ea-9142-7b8835e7fab7.png)

**Before:**
![host_before](https://user-images.githubusercontent.com/13417815/75914414-ff32bb00-5e54-11ea-9647-968fa602b356.png)

**After:**
![host_after](https://user-images.githubusercontent.com/13417815/75914418-01951500-5e55-11ea-8dc5-fc5c328c1d17.png)
