### PR TITLE
Remove invalid tagdata stub

### DIFF
--- a/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
+++ b/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
@@ -6,7 +6,6 @@ shared_examples '#download_summary_pdf' do |object|
     before do
       allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
       allow(controller).to receive(:server_timezone).and_return('UTC')
-      allow(controller).to receive(:get_tagdata).and_return(nil)
       login_as FactoryBot.create(:user_admin)
       stub_user(:features => :all)
       get :download_summary_pdf, :params => {:id => record.id}

--- a/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
+++ b/spec/shared/controllers/shared_example_for_download_summary_pdf.rb
@@ -6,7 +6,7 @@ shared_examples '#download_summary_pdf' do |object|
     before do
       allow(PdfGenerator).to receive(:pdf_from_string).and_return("")
       allow(controller).to receive(:server_timezone).and_return('UTC')
-      allow(controller).to receive(:tagdata).and_return(nil)
+      allow(controller).to receive(:get_tagdata).and_return(nil)
       login_as FactoryBot.create(:user_admin)
       stub_user(:features => :all)
       get :download_summary_pdf, :params => {:id => record.id}


### PR DESCRIPTION
Within `spec/shared/controllers/shared_example_for_download_summary_pdf.rb` there is this partial defined:

`allow(controller).to receive(:tagdata).and_return(nil)`

However, there's no `tagdata` method defined on any controllers, so if strict partial validation is enabled, the result is an error like this:

```
6) VmCloudController download pdf file request returns 200
     Failure/Error: allow(controller).to receive(:tagdata).and_return(nil)
       #<VmCloudController:0x00005642f3a63650 @_action_has_layout=true, @_routes=nil ...snip...> does not implement: tagdata

```

There is, however, a method called `get_tagdata`, so I'm assuming that's what was meant here. Perhaps it was changed at some point and this simply wasn't updated. In any case, updating it eliminates about 80 errors overall.

Part of the effort to address https://github.com/ManageIQ/manageiq-ui-classic/issues/6734

Edit: we can just remove it.