### PR TITLE
Remove invalid partials from login specs that aren't used

### DIFF
--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -8,8 +8,6 @@ describe "dashboard/login.html.haml" do
     end
 
     it "when authentication is 'database'" do
-      allow(view).to receive(:current_tenant).and_return(Tenant.seed)
-      allow(User).to receive(:mode).and_return("database")
       render
       expect(response).to have_selector("div#login_div:has(input#browser_name)")
       expect(response).to have_selector("div#login_div:has(input#browser_version)")
@@ -18,8 +16,6 @@ describe "dashboard/login.html.haml" do
     end
 
     it "when authentication is not 'database'" do
-      allow(view).to receive(:current_tenant).and_return(Tenant.seed)
-      allow(User).to receive(:mode).and_return("ldap")
       render
       expect(response).to have_selector("div#login_div:has(input#browser_name)")
       expect(response).to have_selector("div#login_div:has(input#browser_version)")
@@ -36,7 +32,6 @@ describe "dashboard/login.html.haml" do
     end
 
     it "show" do
-      allow(view).to receive(:current_tenant).and_return(Tenant.seed)
       stub_settings(:server => {}, :session => {:show_login_info => true}, :authentication => {})
       render
       labels.each do |label|
@@ -45,7 +40,6 @@ describe "dashboard/login.html.haml" do
     end
 
     it "hide" do
-      allow(view).to receive(:current_tenant).and_return(Tenant.seed)
       stub_settings(:server => {}, :session => {:show_login_info => false}, :authentication => {})
       render
       labels.each do |label|


### PR DESCRIPTION
With strict partials enabled, we can see that the `view` doesn't implement a `current_tenant` method, nor does the `User` model implement a `mode` method.

Removing these had no effect. The specs still pass.

Part of the cleanup effort at https://github.com/ManageIQ/manageiq-ui-classic/issues/6734