### PR TITLE
[WIP] Rename towhat to target_class_name

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -578,11 +578,11 @@ class MiqPolicyController < ApplicationController
                         elsif @edit
                           _("Editing %{model} Condition \"%{name}\"") %
                             {:name  => @condition.description,
-                             :model => ui_lookup(:model => @edit[:new][:towhat])}
+                             :model => ui_lookup(:model => @edit[:new][:target_class_name])}
                         else
                           _("%{model} Condition \"%{name}\"") %
                             {:name  => @condition.description,
-                             :model => ui_lookup(:model => @condition.towhat)}
+                             :model => ui_lookup(:model => @condition.target_class_name)}
                         end
     when 'ev'
       presenter.update(:main_div, r[:partial => 'event_details', :locals => {:read_only => true}])
@@ -895,7 +895,7 @@ class MiqPolicyController < ApplicationController
         @right_cell_div = "policy_list"
       end
     elsif x_active_tree == :condition_tree
-      @conditions = Condition.where(:towhat => @sb[:folder].camelize).sort_by { |c| c.description.downcase }
+      @conditions = Condition.where(:target_class_name => @sb[:folder].camelize).sort_by { |c| c.description.downcase }
       set_search_text
       @conditions = apply_search_filter(@search_text, @conditions) if @search_text.present?
       @right_cell_text = _("All %{typ} Conditions") % {:typ => ui_lookup(:model => @sb[:folder].try(:camelize))}

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -9,9 +9,9 @@ module MiqPolicyController::Conditions
 
       @condition = @edit[:condition_id] ? Condition.find(@edit[:condition_id]) : Condition.new
       if @condition.try(:id)
-        add_flash(_("Edit of %{model} Condition \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => @edit[:new][:towhat]), :name => @condition.description})
+        add_flash(_("Edit of %{model} Condition \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => @edit[:new][:target_class_name]), :name => @condition.description})
       else
-        add_flash(_("Add of new %{model} Condition was cancelled by the user") % {:model => ui_lookup(:model => @edit[:new][:towhat])})
+        add_flash(_("Add of new %{model} Condition was cancelled by the user") % {:model => ui_lookup(:model => @edit[:new][:target_class_name])})
       end
       @sb[:action] = @edit = nil
       get_node_info(x_node)
@@ -42,7 +42,7 @@ module MiqPolicyController::Conditions
       condition = @condition # Get new or existing record
       condition.description = @edit[:new][:description]
       condition.notes = @edit[:new][:notes]
-      condition.towhat = @edit[:new][:towhat] if adding # Set the proper model if adding a record
+      condition.target_class_name = @edit[:new][:target_class_name] if adding # Set the proper model if adding a record
       exp_remove_tokens(@edit[:new][:expression])
       condition.expression = MiqExpression.new(@edit[:new][:expression])
       exp_remove_tokens(@edit[:new][:applies_to_exp])
@@ -68,11 +68,11 @@ module MiqPolicyController::Conditions
         if adding
           case x_active_tree
           when :condition_tree
-            @new_condition_node = "xx-#{condition.towhat.camelize(:lower)}_co-#{condition.id}"
+            @new_condition_node = "xx-#{condition.target_class_name.camelize(:lower)}_co-#{condition.id}"
             replace_right_cell(:nodetype => "co", :replace_trees => %i[condition], :remove_form_buttons => true)
           when :policy_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
-            @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{node_ids["p"]}_co-#{condition.id}"
+            @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.target_class_name.downcase}_p-#{node_ids["p"]}_co-#{condition.id}"
             replace_right_cell(:nodetype => "co", :replace_trees => %i[policy_profile policy condition], :remove_form_buttons => true)
           when :policy_profile_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
@@ -127,7 +127,7 @@ module MiqPolicyController::Conditions
       add_flash(_("Condition no longer exists"), :error)
     else
       conditions.push(params[:id])
-      @new_condition_node = "xx-#{con.towhat.camelize(:lower)}"
+      @new_condition_node = "xx-#{con.target_class_name.camelize(:lower)}"
     end
     process_conditions(conditions, "destroy") unless conditions.empty?
     get_node_info(@new_condition_node)
@@ -165,10 +165,10 @@ module MiqPolicyController::Conditions
     @edit[:key] = "condition_edit__#{@condition.id || "new"}"
     @edit[:rec_id] = @condition.id || nil
 
-    @edit[:new][:towhat] = if params[:id] && params[:typ] != "new" # If editing existing condition, grab model
-                             Condition.find(params[:id]).towhat
+    @edit[:new][:target_class_name] = if params[:id] && params[:typ] != "new" # If editing existing condition, grab model
+                             Condition.find(params[:id]).target_class_name
                            else
-                             x_active_tree == :condition_tree ? @sb[:folder].camelize : MiqPolicy.find(@sb[:node_ids][x_active_tree]["p"]).towhat
+                             x_active_tree == :condition_tree ? @sb[:folder].camelize : MiqPolicy.find(@sb[:node_ids][x_active_tree]["p"]).target_class_name
                            end
 
     @edit[:condition_id] = @condition.id
@@ -192,7 +192,7 @@ module MiqPolicyController::Conditions
     @expkey = :expression # Set expression key to expression
     @edit[@expkey].history.reset(@edit[:expression][:expression])
     @edit[:expression][:exp_table] = exp_build_table(@edit[:expression][:expression])
-    @edit[:expression][:exp_model] = @edit[:new][:towhat] # Set model for the exp editor
+    @edit[:expression][:exp_model] = @edit[:new][:target_class_name] # Set model for the exp editor
 
     # Populate exp editor fields for the applies_to_exp column
     @edit[:applies_to_exp] ||= ApplicationController::Filter::Expression.new
@@ -209,7 +209,7 @@ module MiqPolicyController::Conditions
     @edit[@expkey].history.reset(@edit[:applies_to_exp][:expression])
     @edit[:applies_to_exp][:exp_table] = exp_build_table(@edit[:applies_to_exp][:expression])
     @expkey = :expression                                                           # Reset to default to editing the expression column
-    @edit[:applies_to_exp][:exp_model] = @edit[:new][:towhat]                       # Set model for the exp editor
+    @edit[:applies_to_exp][:exp_model] = @edit[:new][:target_class_name]                       # Set model for the exp editor
 
     @edit[:current] = copy_hash(@edit[:new])
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -32,7 +32,7 @@ module MiqPolicyController::Policies
     policy.updated_by = session[:userid]
 
     if @policy.id.blank?
-      policy.towhat = @edit[:new][:towhat]
+      policy.target_class_name = @edit[:new][:target_class_name]
       policy.created_by = session[:userid]
     end
 
@@ -57,7 +57,7 @@ module MiqPolicyController::Policies
     end
 
     if @policy.id.blank? && policy.mode == "compliance" # New compliance policy
-      event = MiqEventDefinition.find_by(:name => "#{policy.towhat.downcase}_compliance_check") # Get the compliance event record
+      event = MiqEventDefinition.find_by(:name => "#{policy.target_class_name.downcase}_compliance_check") # Get the compliance event record
       policy.sync_events([event]) # Set the default compliance event in the policy
       action_list = [[MiqAction.find_by(:name => 'compliance_failed'), {:qualifier => :failure, :synchronous => true}]]
       policy.replace_actions_for_event(event, action_list) # Add in the default action for the compliance event
@@ -151,7 +151,7 @@ module MiqPolicyController::Policies
       else
         policies.push(params[:id])
       end
-      self.x_node = @new_policy_node = policies_node(pol.mode, pol.towhat)
+      self.x_node = @new_policy_node = policies_node(pol.mode, pol.target_class_name)
     end
     process_policies(policies, "destroy") unless policies.empty?
     add_flash(_("The selected Policies were deleted")) if @flash_array.nil?
@@ -191,13 +191,13 @@ module MiqPolicyController::Policies
     peca_get_all('policy', -> { get_view(MiqPolicy, :named_scope => [[:with_mode, @sb[:mode].downcase], [:with_towhat, @sb[:nodeid].camelize]]) })
   end
 
-  def policies_node(mode, towhat)
+  def policies_node(mode, target_class_name)
     ["xx-#{mode.downcase}",
-     "xx-#{mode.downcase}-#{towhat.camelize(:lower)}"].join("_")
+     "xx-#{mode.downcase}-#{target_class_name.camelize(:lower)}"].join("_")
   end
 
   def policy_node(policy)
-    [policies_node(policy.mode, policy.towhat), "p-#{policy.id}"].join("_")
+    [policies_node(policy.mode, policy.target_class_name), "p-#{policy.id}"].join("_")
   end
 
   private
@@ -222,7 +222,7 @@ module MiqPolicyController::Policies
     @edit[:new][:description] = @policy.description
     @edit[:new][:active] = @policy.active.nil? ? true : @policy.active                    # Set active, default to true
     @edit[:new][:notes] = @policy.notes
-    @edit[:new][:towhat] = @policy.id ? @policy.towhat : @sb[:folder].split('-').last.camelize # Set the towhat model
+    @edit[:new][:target_class_name] = @policy.id ? @policy.target_class_name : @sb[:folder].split('-').last.camelize # Set the target_class_name model
 
     case @edit[:typ]                  # Build fields based on what is being edited
     when "conditions"                 # Editing condition assignments
@@ -231,7 +231,7 @@ module MiqPolicyController::Policies
       conditions.each { |c| @edit[:new][:conditions][c.description] = c.id } # Build a hash for the members list box
 
       @edit[:choices] = {}
-      Condition.where(:towhat => @edit[:new][:towhat]).each { |c| @edit[:choices][c.description] = c.id } # Build a hash for the policies to choose from
+      Condition.where(:target_class_name => @edit[:new][:target_class_name]).each { |c| @edit[:choices][c.description] = c.id } # Build a hash for the policies to choose from
 
       @edit[:new][:conditions].each_key { |key| @edit[:choices].delete(key) } # Remove any choices that are in the members list box
     when "events" # Editing event assignments
@@ -245,7 +245,7 @@ module MiqPolicyController::Policies
         @edit[:allevents][e.etype.description].push([e.description, e.id.to_s])
       end
     else # Editing basic information and policy scope
-      build_expression(@policy, @edit[:new][:towhat])
+      build_expression(@policy, @edit[:new][:target_class_name])
     end
 
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -121,11 +121,11 @@ module MiqPolicyController::PolicyProfiles
 
     @edit[:new][:policies] = {}
     policies = @profile.members # Get the member sets
-    policies.each { |p| @edit[:new][:policies][ui_lookup(:model => p.towhat) + " #{p.mode.capitalize}: " + p.description] = p.id } # Build a hash for the members list box
+    policies.each { |p| @edit[:new][:policies][ui_lookup(:model => p.target_class_name) + " #{p.mode.capitalize}: " + p.description] = p.id } # Build a hash for the members list box
 
     @edit[:choices] = {}
     MiqPolicy.all.each do |p|
-      @edit[:choices][ui_lookup(:model => p.towhat) + " #{p.mode.capitalize}: " + p.description] = p.id # Build a hash for the policies to choose from
+      @edit[:choices][ui_lookup(:model => p.target_class_name) + " #{p.mode.capitalize}: " + p.description] = p.id # Build a hash for the policies to choose from
     end
 
     @edit[:new][:policies].each_key do |key|
@@ -151,7 +151,7 @@ module MiqPolicyController::PolicyProfiles
   # Get information for a profile
   def profile_get_info(profile)
     @record = @profile = profile
-    @profile_policies = @profile.miq_policies.sort_by { |p| [p.towhat, p.mode, p.description.downcase] }
+    @profile_policies = @profile.miq_policies.sort_by { |p| [p.target_class_name, p.mode, p.description.downcase] }
     @right_cell_text = _("Policy Profile \"%{name}\"") % {:name => @profile.description}
     @right_cell_div = "profile_details"
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -159,8 +159,6 @@ module OpsController::Settings::Schedules
     elsif schedule_automation_request?(schedule)
       action_type = schedule.sched_action[:method]
       automate_request = fetch_automate_request_vars(schedule)
-    elsif schedule.towhat.nil?
-      action_type = "vm"
     elsif schedule.resource_type.nil?
       action_type = "vm"
     else

--- a/app/helpers/application_helper/toolbar/condition_center.rb
+++ b/app/helpers/application_helper/toolbar/condition_center.rb
@@ -34,13 +34,13 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
           :condition_delete,
           'pficon pficon-delete fa-lg',
           t = proc do
-            _('Delete this %{condition_type} Condition') % {:condition_type => ui_lookup(:model => @condition.towhat)}
+            _('Delete this %{condition_type} Condition') % {:condition_type => ui_lookup(:model => @condition.target_class_name)}
           end,
           t,
           :url_parms    => "main_div",
           :send_checked => true,
           :klass        => ApplicationHelper::Button::Condition,
-          :confirm      => proc { _("Are you sure you want to delete this %{condition_type} Condition?") % {:condition_type => ui_lookup(:model => @condition.towhat)} }),
+          :confirm      => proc { _("Are you sure you want to delete this %{condition_type} Condition?") % {:condition_type => ui_lookup(:model => @condition.target_class_name)} }),
         button(
           :condition_remove,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
             }
           end,
           proc do
-            _('Copy this %{policy_type} Policy') % {:policy_type => ui_lookup(:model => @policy.towhat)}
+            _('Copy this %{policy_type} Policy') % {:policy_type => ui_lookup(:model => @policy.target_class_name)}
           end,
           :confirm   => proc do
                           _("Are you sure you want to create Policy [%{new_policy_description}] from this Policy?") % {
@@ -37,13 +37,13 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
           :policy_delete,
           'pficon pficon-delete fa-lg',
           t = proc do
-            _('Delete this %{policy_type} Policy') % {:policy_type => ui_lookup(:model => @policy.towhat)}
+            _('Delete this %{policy_type} Policy') % {:policy_type => ui_lookup(:model => @policy.target_class_name)}
           end,
           t,
           :url_parms    => "main_div",
           :send_checked => true,
           :klass        => ApplicationHelper::Button::PolicyDelete,
-          :confirm      => proc { _("Are you sure you want to delete this %{policy_type} Policy?") % {:policy_type => ui_lookup(:model => @policy.towhat)} },
+          :confirm      => proc { _("Are you sure you want to delete this %{policy_type} Policy?") % {:policy_type => ui_lookup(:model => @policy.target_class_name)} },
           :options      => {:feature => 'policy_delete'}),
         button(
           :condition_edit,

--- a/app/presenters/tree_builder_condition.rb
+++ b/app/presenters/tree_builder_condition.rb
@@ -46,10 +46,10 @@ class TreeBuilderCondition < TreeBuilder
 
   # level 2 - conditions
   def x_get_tree_custom_kids(parent, count_only)
-    towhat = parent[:id].camelize
-    return super unless MiqPolicyController::UI_FOLDERS.collect(&:name).include?(towhat)
+    target_class_name = parent[:id].camelize
+    return super unless MiqPolicyController::UI_FOLDERS.collect(&:name).include?(target_class_name)
 
-    objects = Condition.where(:towhat => towhat)
+    objects = Condition.where(:target_class_name => target_class_name)
     count_only_or_objects(count_only, objects, :description)
   end
 end

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -71,10 +71,10 @@ class TreeBuilderPolicy < TreeBuilder
     end
 
     # level 3 - actual policies
-    mode, towhat = parent[:id].split('-')
-    towhat = towhat.camelize
-    if MiqPolicyController::UI_FOLDERS.collect(&:name).include?(towhat)
-      objects = MiqPolicy.where(:mode => mode, :towhat => towhat)
+    mode, target_class_name = parent[:id].split('-')
+    target_class_name = target_class_name.camelize
+    if MiqPolicyController::UI_FOLDERS.collect(&:name).include?(target_class_name)
+      objects = MiqPolicy.where(:mode => mode, :target_class_name => target_class_name)
 
       return count_only_or_objects(count_only, objects, :description)
     end

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -26,7 +26,7 @@ class TreeBuilderPolicyProfile < TreeBuilder
   def x_get_tree_pp_kids(parent, count_only)
     count_only_or_objects(count_only,
                           parent.miq_policies,
-                          ->(a) { a.towhat + a.mode + a.description.downcase })
+                          ->(a) { a.target_class_name + a.mode + a.description.downcase })
   end
 
   # level 3 - conditions & events for policy

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -32,10 +32,10 @@ class TreeBuilderProtect < TreeBuilder
 
   def x_get_tree_hash_kids(parent, count_only)
     nodes = parent[:nodes].map do |policy|
-      icon = policy.towhat.safe_constantize.try(:decorate).try(:fonticon)
+      icon = policy.target_class_name.safe_constantize.try(:decorate).try(:fonticon)
       {
         :id           => "policy_#{policy.id}",
-        :text         => prefixed_title("#{ui_lookup(:model => policy.towhat)} #{policy.mode.capitalize}", policy.description),
+        :text         => prefixed_title("#{ui_lookup(:model => policy.target_class_name)} #{policy.mode.capitalize}", policy.description),
         :icon         => "#{icon}#{policy.active ? '' : ' fa-inactive'}",
         :tip          => policy.description,
         :hideCheckbox => true,

--- a/app/presenters/tree_node/miq_policy.rb
+++ b/app/presenters/tree_node/miq_policy.rb
@@ -3,7 +3,7 @@ module TreeNode
     set_attribute(:text) do
       if @tree.instance_of?(TreeBuilderPolicyProfile)
         ViewHelper.capture do
-          ViewHelper.concat(ViewHelper.content_tag(:strong, "#{ui_lookup(:model => @object.towhat)} #{@object.mode.titleize}: "))
+          ViewHelper.concat(ViewHelper.content_tag(:strong, "#{ui_lookup(:model => @object.target_class_name)} #{@object.mode.titleize}: "))
           ViewHelper.concat(ERB::Util.html_escape(@object.description))
         end
       else

--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -255,7 +255,7 @@
             %table.table.table-striped.table-bordered.table-hover
               %tbody
                 - @action_policies.each do |p|
-                  - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{p.id}"
+                  - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.target_class_name.camelize(:lower)}_p-#{p.id}"
                   %tr{:title => _("Click to view Policy"),
                     :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                     %td.table-view-pf-select

--- a/app/views/miq_policy/_condition_details.html.haml
+++ b/app/views/miq_policy/_condition_details.html.haml
@@ -103,7 +103,7 @@
               %table.table.table-striped.table-bordered.table-hover
                 %tbody
                   - @condition_policies.each do |p|
-                    - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{p.id}"
+                    - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.target_class_name.camelize(:lower)}_p-#{p.id}"
                     %tr{:title => _("Click to view Policy"),
                       :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                       %td.table-view-pf-select

--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -14,7 +14,7 @@
         %tbody
           - @conditions.each do |c|
             %tr{:title => _("View this Condition"),
-              :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.towhat.camelize(:lower)}_co-#{c.id}');"}
+              :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.target_class_name.camelize(:lower)}_co-#{c.id}');"}
               %td.table-view-pf-select
                 %i.fa.fa-diamond
               %td

--- a/app/views/miq_policy/_event_details.html.haml
+++ b/app/views/miq_policy/_event_details.html.haml
@@ -23,7 +23,7 @@
           %table.table.table-striped.table-bordered.table-hover
             %tbody
               - @event_policies.each do |p|
-                - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.towhat.camelize(:lower)}_p-#{p.id}"
+                - id = "xx-#{p.mode.downcase}_xx-#{p.mode.downcase}-#{p.target_class_name.camelize(:lower)}_p-#{p.id}"
                 %tr{:title => _("Click to view Policy"),
                   :onclick => remote_function(:url => "/miq_policy/x_show/#{id}?accord=policy")}
                   %td.table-view-pf-select

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -86,7 +86,7 @@
         - if @edit[:typ] == "conditions"
           %h3= _("Condition Selection")
           .col-md-5
-            = _("Available %{model} Conditions:") % {:model => ui_lookup(:model => @edit[:new][:towhat])}
+            = _("Available %{model} Conditions:") % {:model => ui_lookup(:model => @edit[:new][:target_class_name])}
             %span#choices_chosen_div
               = select_tag('choices_chosen[]',
                 options_for_select(@edit[:choices].sort),

--- a/app/views/miq_policy/_profile_details.html.haml
+++ b/app/views/miq_policy/_profile_details.html.haml
@@ -76,13 +76,13 @@
         %table.table.table-striped.table-bordered.table-hover
           %tbody
             - @profile_policies.each do |p|
-              %tr{:title => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.towhat)},
+              %tr{:title => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.target_class_name)},
                 :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_p-#{p.id}');"}
                 %td.table-view-pf-select
                   %i{:class => p.decorate.fonticon}
                 %td
                   %b
-                    #{ui_lookup(:model => p.towhat)} #{p.mode.capitalize}:
+                    #{ui_lookup(:model => p.target_class_name)} #{p.mode.capitalize}:
                   &nbsp;
                   = h(p.description)
       %hr

--- a/spec/controllers/miq_policy_controller/conditions_spec.rb
+++ b/spec/controllers/miq_policy_controller/conditions_spec.rb
@@ -19,11 +19,11 @@ describe MiqPolicyController::Conditions do
         allow(subject).to receive(:load_edit).and_return(true)
         allow(subject).to receive(:replace_right_cell)
         allow(subject).to receive(:x_active_tree).and_return(:condition_tree)
-        subject.instance_variable_set(:@edit, :new => {:towhat         => 'ContainerReplicator',
-                                                       :description    => 'New_condition',
-                                                       :notes          => nil,
-                                                       :expression     => {},
-                                                       :applies_to_exp => {"???"=>"???"}})
+        subject.instance_variable_set(:@edit, :new => {:target_class_name => 'ContainerReplicator',
+                                                       :description       => 'New_condition',
+                                                       :notes             => nil,
+                                                       :expression        => {},
+                                                       :applies_to_exp    => {"???"=>"???"}})
         subject.instance_variable_set(:@sb, {})
       end
 

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -16,7 +16,7 @@ describe MiqPolicyController do
       it "Correct active tree node is saved in @sb after Policy is added" do
         new = {}
         new[:mode] = "compliance"
-        new[:towhat] = "ContainerGroup"
+        new[:target_class_name] = "ContainerGroup"
         new[:description] = "Test_description"
         new[:expression] =  {">" => {"count" => "ContainerGroup.advanced_settings", "value" => "1"}}
         controller.instance_variable_set(:@edit, :new     => new,
@@ -41,7 +41,7 @@ describe MiqPolicyController do
                                                 :active_tree => :policy_tree,
                                                 :folder      => "compliance-containerGroup",
                                                 :nodeid      => "containerGroup"}}
-        session[:edit] = {:new => {:mode => "compliance", :towhat => "ContainerGroup"}}
+        session[:edit] = {:new => {:mode => "compliance", :target_class_name => "ContainerGroup"}}
         post :x_button, :params => { :pressed => "policy_new", :typ => "basic" }
         expect(response).to render_template("layouts/exp_atom/_editor")
         expect(response).to render_template("layouts/_exp_editor")

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -55,7 +55,7 @@ describe TreeBuilderProtect do
       roots = @protect_tree.send(:x_get_tree_roots)
       kids = @protect_tree.send(:x_get_tree_hash_kids, roots[0], false)
       expect(kids[0][:id]).to eq("policy_#{@kids[0].id}")
-      expect(kids[0][:text]).to eq("<strong>#{ui_lookup(:model => @kids[0].towhat)} #{@kids[0].mode.capitalize}:</strong> #{@kids[0].description}".html_safe)
+      expect(kids[0][:text]).to eq("<strong>#{ui_lookup(:model => @kids[0].target_class_name)} #{@kids[0].mode.capitalize}:</strong> #{@kids[0].description}".html_safe)
       expect(kids[0][:icon]).to eq("pficon pficon-virtual-machine fa-inactive")
       expect(kids[0][:tip]).to eq(@kids[0].description)
       expect(kids[0][:hideCheckbox]).to eq(true)

--- a/spec/presenters/tree_node/miq_policy_spec.rb
+++ b/spec/presenters/tree_node/miq_policy_spec.rb
@@ -1,6 +1,6 @@
 describe TreeNode::MiqPolicy do
   subject { described_class.new(object, nil, nil) }
-  let(:object) { FactoryBot.create(:miq_policy, :towhat => 'Vm', :active => true, :mode => 'control') }
+  let(:object) { FactoryBot.create(:miq_policy, :target_class_name => 'Vm', :active => true, :mode => 'control') }
 
   include_examples 'TreeNode::Node#key prefix', 'p-'
   include_examples 'TreeNode::Node#text description'


### PR DESCRIPTION
Fixes deprecation warnings of towhat.

Note, this PR replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/4890 (I didn't have permission to force push on Julian's fork of this repo)

- [x] [Cross-repo-tests](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/82)
- [ ] Depends on [core PR](https://github.com/ManageIQ/manageiq/pull/18165)
- [ ] Depends on [schema PR](https://github.com/ManageIQ/manageiq-schema/pull/314)
- [ ] To be merged with [api PR](https://github.com/ManageIQ/manageiq-api/pull/770)
