### PR TITLE
Fix vm factory in prov_vm_grid haml spec

### DIFF
--- a/spec/views/miq_request/_prov_vm_grid.html.haml_spec.rb
+++ b/spec/views/miq_request/_prov_vm_grid.html.haml_spec.rb
@@ -26,7 +26,7 @@ describe 'miq_request/_prov_vm_grid.html.haml' do
     let(:admin_user) { FactoryBot.create(:user_with_group, :role => 'super_administrator') }
 
     before do
-      @vm = [FactoryBot.create(:template_openstack, :tenant => Tenant.root_tenant)]
+      @vm = FactoryBot.create(:template_openstack, :tenant => Tenant.root_tenant)
       allow(@vm).to receive(:name).and_return('name')
       allow(@vm).to receive(:operating_system).and_return('linux')
       allow(@vm).to receive(:platform).and_return('platform')


### PR DESCRIPTION
At the moment within `spec/views/miq_request/_prov_vm_grid.html.haml_spec.rb ` there are several stubbed methods that were inadvertently applied to `Array` instead of to the actual vm they were meant to apply to. With strict partials enabled this will cause failures.

Since an array doesn't appear to be necessary here, I removed it. The specs still pass.