### PR TITLE
Do not display disabled domains in automate entrypoint selections

### DIFF
--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -6,7 +6,7 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
   end
 
   def x_get_tree_roots
-    count_only_or_objects(false, filter_ae_objects(User.current_tenant.visible_domains))
+    count_only_or_objects(false, filter_ae_objects(User.current_tenant.enabled_domains))
   end
 
   def override(node, object)


### PR DESCRIPTION
The disabled domains should not be displayed in automate entrypoint trees. 

@miq-bot add_label bug
@miq-bot assign @h-kataria 
cc @tinaafitz 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740915