### PR TITLE
Set patternfly-react to 2.39.14 exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "numeral": "~2.0.6",
     "patternfly": "~3.59.1",
     "patternfly-bootstrap-treeview": "~2.1.7",
-    "patternfly-react": "~2.39.10",
+    "patternfly-react": "2.39.14",
     "prop-types": "^15.6.0",
     "proxy-polyfill": "^0.1.7",
     "react": "~16.9.0",


### PR DESCRIPTION
patternfly-react [2.39.15](https://github.com/patternfly/patternfly-react/compare/patternfly-react@2.39.14...patternfly-react@2.39.15) is the newest release and causes a production only bug...

    VM1387 vendor-b2ef7d1….js:25 Uncaught ReferenceError: Cannot access 'Lc' before initialization
    at Module.<anonymous> (VM1387 vendor-b2ef7d1….js:25)
    at f (VM1390 runtime-06564b9….js:1)
    at VM1387 vendor-b2ef7d…4efb994af989.js:111
    at Object.<anonymous> (VM1387 vendor-b2ef7d…4efb994af989.js:111)
    at f (VM1390 runtime-06564b9….js:1)
    at Module.1145 (VM1389 component-def…a27d403918d91a.js:1)
    at f (VM1390 runtime-06564b9….js:1)
    at t (VM1390 runtime-06564b9….js:1)
    at Array.r [as push] (VM1390 runtime-06564b9….js:1)
    at VM1389 component-def…a27d403918d91a.js:1

the file being `VerticalNavItemHelper.js:360`.

This could be a bug in patternfly-react, or it could be that the dependencies difference is causing react-ui-components to pull in a separate older version and failing on that somehow.

Either way, the quick fix is to force the exact version that works.