### PR TITLE
Remove invalid partials from catalog controller specs

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -16,7 +16,6 @@ describe CatalogController do
     before do
       stub_user(:features => :all)
       controller.instance_variable_set(:@settings, {})
-      allow_any_instance_of(ApplicationController).to receive(:fetch_path)
     end
 
     it "checks method x_edit_tags_reset when multiple records selected from list view" do
@@ -26,7 +25,6 @@ describe CatalogController do
       controller.instance_variable_set(:@sb, :action => nil)
       allow(controller).to receive(:checked_or_params).and_return(ServiceTemplate.all.ids)
       allow(controller).to receive(:find_checked_items).and_return(ServiceTemplate.all.ids)
-      allow(controller).to receive(:tag_edit_build_entries_pulldown).and_return(nil)
       allow(controller).to receive(:replace_right_cell).with(:action => nil)
       expect(controller).to receive(:x_tags_set_form_vars)
       controller.send(:x_edit_tags_reset, "ServiceTemplate")
@@ -39,7 +37,6 @@ describe CatalogController do
       controller.instance_variable_set(:@sb, :action => nil)
       allow(controller).to receive(:checked_or_params).and_return([])
       allow(controller).to receive(:find_checked_items).and_return([])
-      allow(controller).to receive(:tag_edit_build_entries_pulldown).and_return(nil)
       allow(controller).to receive(:replace_right_cell).with(:action => nil)
       expect(controller).to receive(:x_tags_set_form_vars)
       controller.send(:x_edit_tags_reset, "ServiceTemplate")


### PR DESCRIPTION
This PR removes invalid partials that cause errors if strict partial validation is enabled. Specifically, there is no `ApplicationController.fetch_path` method, nor is there a `tag_edit_build_entries_pulldown` method for the controller.

Removing these had no effect, i.e. the specs still pass.

Part of the cleanup effort at https://github.com/ManageIQ/manageiq-ui-classic/issues/6734