### PR TITLE
Do not include switches into VMs and Templates tree

### DIFF
--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -34,7 +34,7 @@ class TreeBuilderVandt < TreeBuilder
     #   so taking them from the relationship records can cut down on the huge
     #   VM query.
 
-    tree = ems.subtree_arranged(:except_type => "VmOrTemplate")
+    tree = ems.subtree_arranged(:except_type => ["VmOrTemplate", "Switch"])
 
     prune_rbac(ems, tree)
     prune_non_vandt_folders(tree)


### PR DESCRIPTION
The `ovirt` provider includes `ExternalDistributedVirtualSwitch` objects in the provider folder hierarchy which causes a crash on the `Providers -> Infrastructure -> VMs and Templates` screen. We don't really want to display these switches in that tree, so by skipping them from the ancestry hiearachy the problem is solved.

@miq-bot add_label bug, jansa/yes?
@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @mzazrivec 
cc @gekorob please review it