### PR TITLE
Mixin the TextualSummaryHelper to fix invalid partials

### DIFF
--- a/spec/helpers/host_helper/textual_summary_spec.rb
+++ b/spec/helpers/host_helper/textual_summary_spec.rb
@@ -1,4 +1,6 @@
 describe HostHelper::TextualSummary do
+  include TextualSummaryHelper
+
   before do
     instance_variable_set(:@record, FactoryBot.create(:host_openstack_infra,
                                                        :type => ManageIQ::Providers::Openstack::InfraManager::Host))


### PR DESCRIPTION
At the moment with strict partials enabled you will see several errors like this:

```
1) HostHelper::TextualSummary#textual_group Authentication Status
     Failure/Error: allow(self).to receive(:textual_authentications).and_return([])
       #<RSpec::ExampleGroups::HostHelperTextualSummary::TextualGroup_8 "Authentication Status" (./spec/shared/helpers/textual_summary_helper_methods.rb:24)> does not implement: textual_authentications
     Shared Example Group: "textual_group" called from ./spec/helpers/host_helper/textual_summary_spec.rb:66
     # ./spec/helpers/host_helper/textual_summary_spec.rb:7:in `block (2 levels) in <top (required)>'
```
This is testing module methods, so my solution was to simply include the module into the test itself, since the `before` block is applying partials to `self`.

Normally I would create a dummy class and extend the module on it, but with all these shared examples I couldn't get it to work.