### PR TITLE
Make the password-field component context-free and usable without validation

### DIFF
--- a/app/javascript/components/async-credentials/async-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-credentials.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, createContext } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, get, set } from 'lodash';
 import {
@@ -9,8 +9,6 @@ import {
 import ButtonSpinner from '../../forms/button-spinner';
 import CheckErrors from './check-errors';
 import { checkValidState } from './helper';
-
-export const PasswordContext = createContext();
 
 const AsyncCredentials = ({
   FieldProvider,
@@ -70,9 +68,10 @@ const AsyncCredentials = ({
   };
 
   return (
-    <PasswordContext.Provider value={{ name, edit }}>
+    <Fragment>
       {formOptions.renderForm(fields.map(field => ({
         ...field,
+        ...(field.component === 'password-field' ? { parent: name, edit } : undefined),
         isDisabled: field.isDisabled || validating,
         onChange: value => enhancedChange(value, field.name, name, formOptions.change),
       })), formOptions)}
@@ -103,7 +102,7 @@ const AsyncCredentials = ({
           </FormGroup>
         )}
       </FieldProvider>
-    </PasswordContext.Provider>
+    </Fragment>
   );
 };
 

--- a/app/javascript/components/async-credentials/async-provider-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-provider-credentials.jsx
@@ -1,8 +1,18 @@
-import { pick } from 'lodash';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { pick } from 'lodash';
+
 import AsyncCredentials from './async-credentials';
 
-const AsyncProviderCredentials = ({ ...props }) => {
+const AsyncProviderCredentials = ({ validate, ...props }) => {
+  if (!validate) {
+    // Pass down the required `edit` to the password component (if it exists)
+    return props.formOptions.renderForm(props.fields.map(field => ({
+      ...field,
+      ...(field.component === 'password-field' ? { edit: props.edit } : undefined),
+    })), props.formOptions);
+  }
+
   const asyncValidate = (fields, fieldNames) => new Promise((resolve, reject) => {
     const resource = pick(fields, fieldNames);
     API.post('/api/providers', { action: 'verify_credentials', resource }).then(({ results: [result] }) => {
@@ -21,7 +31,13 @@ const AsyncProviderCredentials = ({ ...props }) => {
   return <AsyncCredentials asyncValidate={asyncValidate} {...props} />;
 };
 
-AsyncProviderCredentials.propTypes = AsyncCredentials.propTypes;
-AsyncProviderCredentials.defaultProps = AsyncCredentials.defaultProps;
+AsyncProviderCredentials.propTypes = {
+  validate: PropTypes.bool,
+  ...AsyncCredentials.propTypes,
+};
+AsyncProviderCredentials.defaultProps = {
+  validate: true,
+  ...AsyncCredentials.defaultProps,
+};
 
 export default AsyncProviderCredentials;

--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -9,7 +9,6 @@ import {
   HelpBlock,
 } from 'patternfly-react';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
-import { PasswordContext } from './async-credentials';
 import { checkValidState } from './helper';
 import RequiredLabel from '../../forms/required-label';
 
@@ -21,9 +20,10 @@ const PasswordField = ({
   cancelEditLabel,
   changeEditLabel,
   helperText,
+  edit,
+  parent,
   ...rest
 }) => {
-  const { name: secretKey, edit } = useContext(PasswordContext);
   const [editMode, setEditMode] = useState(!edit);
   const secretField = {
     component: edit ? 'edit-password-field' : componentTypes.TEXT_FIELD,
@@ -42,8 +42,8 @@ const PasswordField = ({
         buttonLabel: cancelEditLabel,
         setEditMode: () => {
           formOptions.change(rest.name, undefined);
-          if (checkValidState(formOptions, secretKey)) {
-            formOptions.change(secretKey, formOptions.getFieldState(secretKey).initial);
+          if (parent && checkValidState(formOptions, parent)) {
+            formOptions.change(parent, formOptions.getFieldState(parent).initial);
           }
           setEditMode(editMode => !editMode); // reset edit mode
         },
@@ -83,6 +83,8 @@ PasswordField.propTypes = {
   isDisabled: PropTypes.bool,
   validate: PropTypes.func,
   helperText: PropTypes.string,
+  edit: PropTypes.bool,
+  parent: PropTypes.string,
 };
 
 PasswordField.defaultProps = {
@@ -91,6 +93,8 @@ PasswordField.defaultProps = {
   isDisabled: false,
   validate: undefined,
   helperText: undefined,
+  edit: false,
+  parent: undefined,
 };
 
 export default PasswordField;

--- a/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Async credentials component should render correctly 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "edit": false,
-      "name": "async-wrapper",
-    }
-  }
->
+<Fragment>
   <DummyComponent
     isDisabled={false}
     key="foo"
@@ -28,5 +21,5 @@ exports[`Async credentials component should render correctly 1`] = `
   >
     <Component />
   </FieldProviderComponent>
-</ContextProvider>
+</Fragment>
 `;

--- a/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Async credentials component should not render validation if validate=false 1`] = `
+<Fragment>
+  <DummyComponent
+    isDisabled={false}
+    key="foo"
+    name="foo"
+    onChange={[Function]}
+  />
+  <DummyComponent
+    isDisabled={false}
+    key="bar"
+    name="bar"
+    onChange={[Function]}
+  />
+  <FieldProviderComponent
+    initialValue={false}
+    name="async-wrapper"
+    validate={[Function]}
+  >
+    <Component />
+  </FieldProviderComponent>
+</Fragment>
+`;
+
 exports[`Async credentials component should render correctly 1`] = `
 <Fragment>
   <DummyComponent

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
   FieldProvider={[Function]}
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  edit={false}
+  edit={true}
   formOptions={
     Object {
       "change": [MockFunction],
@@ -105,7 +105,6 @@ exports[`Secret switch field component should render correctly in non edit mode 
 >
   <DummyComponent
     component="text-field"
-    edit={false}
     isDisabled={false}
     name="foo"
     type="password"
@@ -118,7 +117,6 @@ exports[`Secret switch field component should render correctly in non edit mode 
     <button
       component="text-field"
       disabled={false}
-      edit={false}
       name="foo"
       type="button"
     >

--- a/app/javascript/spec/async-credentials/async-credentials.spec.js
+++ b/app/javascript/spec/async-credentials/async-credentials.spec.js
@@ -37,6 +37,11 @@ describe('Async credentials component', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
+  it('should not render validation if validate=false', () => {
+    const wrapper = shallow(<AsyncCredentials {...initialProps} validate={false} />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
   it('should call async validation function on button click and set valid state to true', async(done) => {
     const asyncValidate = jest.fn().mockReturnValue(new Promise(resolve => resolve('Ok')));
     const change = jest.fn();

--- a/app/javascript/spec/async-credentials/password-field.spec.js
+++ b/app/javascript/spec/async-credentials/password-field.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import PasswordField from '../../components/async-credentials/password-field';
-import { PasswordContext } from '../../components/async-credentials/async-credentials';
 import { FieldProviderComponent as FieldProvider } from '../helpers/fieldProvider';
 
 const DummyComponent = ({
@@ -43,12 +42,12 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly in non edit mode', () => {
-    const wrapper = mount(<PasswordContext.Provider value={{}}><PasswordField {...initialProps} /></PasswordContext.Provider>);
+    const wrapper = mount(<PasswordField {...initialProps} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render correctly in edit mode', () => {
-    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
@@ -59,7 +58,7 @@ describe('Secret switch field component', () => {
    * https://github.com/airbnb/enzyme/issues/2011
    */
   it('should render correctly switch to editing', () => {
-    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     expect(wrapper.find(DummyComponent)).toHaveLength(0);
     wrapper.find('button').simulate('click');
     wrapper.update();
@@ -67,7 +66,7 @@ describe('Secret switch field component', () => {
   });
 
   it('should render correctly reset sercret field', () => {
-    const wrapper = mount(<PasswordContext.Provider value={{ edit: true }}><PasswordField {...initialProps} /></PasswordContext.Provider>);
+    const wrapper = mount(<PasswordField {...initialProps} edit />);
     wrapper.find('button').simulate('click');
     expect(wrapper.find(DummyComponent)).toHaveLength(1);
     wrapper.find('button').simulate('click');


### PR DESCRIPTION
The `password-field` component depends on the `async-credentials` as a parent component, which means that it can't be used without a validation. However, some providers (openstack) don't implement credential validation for certain endpoints (ssh key).

The binding between the two components is the `PasswordContext`, which be eliminated by *conditionally passing* the `edit` boolean and the `parent` component's name as a prop. I also had to add a test on the existence of the `parent`. By introducing the `validate` prop on the `async-credentials` the component can be extended to be able to render the underlying fields without validation and with the *conditional passing* of the `edit` boolean. 

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @himdel 
@miq-bot add_label react