### PR TITLE
Mixin the TextualSummaryHelper to fix invalid partials, part 2

### DIFF
--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -1,4 +1,6 @@
 describe VmHelper::TextualSummary do
+  include TextualSummaryHelper
+
   it "#textual_server" do
     server  = FactoryBot.build(:miq_server)
     @record = FactoryBot.build(:vm_vmware, :miq_server => server)


### PR DESCRIPTION
At the moment with strict partials enabled you will see several errors like this:
```
1) VmHelper::TextualSummary #textual_server
     Failure/Error: allow(self).to receive(:textual_key_value_group).and_return([])
       #<RSpec::ExampleGroups::VmHelperTextualSummary "#textual_server" (./spec/helpers/vm_helper/textual_summary_spec.rb:2)> does not implement: textual_key_value_group
     # ./spec/helpers/vm_helper/textual_summary_spec.rb:10:in `block (2 levels) in <top (required)>'
```
This is testing module methods, so my solution was to simply include the module into the test itself, since the before block is applying partials to self.

Followup to https://github.com/ManageIQ/manageiq-ui-classic/pull/6750, but this one applies to the vm_helper instead of the host_helper.