### PR TITLE
Add required interface methods for BreadcrumbsMixin specs

### DIFF
--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -1,6 +1,12 @@
 describe Mixins::BreadcrumbsMixin do
   class BreadcrumbsTestController < ActionController::Base
     include Mixins::BreadcrumbsMixin
+
+    def gtl_url; end
+    def features; end
+    def x_active_tree; end
+    def x_active_accord; end
+    def x_node; end
   end
 
   subject { BreadcrumbsTestController.new }

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -1,9 +1,5 @@
 describe Mixins::BreadcrumbsMixin do
-  class BreadcrumbsTestController < ActionController::Base
-    include Mixins::BreadcrumbsMixin
-  end
-
-  subject { BreadcrumbsTestController.new }
+  subject { CatalogController.new }
 
   let(:tree) { TreeBuilderUtilization.new(:utilization_tree, {}, false) }
   let(:breadcrumbs_options) do
@@ -20,8 +16,6 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   context 'mixin loaded into an explorer controller' do
-    subject { CatalogController.new }
-
     before do
       subject.instance_variable_set(:@sb, :explorer => true)
 
@@ -443,7 +437,10 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   describe "#x_node_text" do
+    subject { ReportController.new }
+
     before { allow(subject).to receive(:x_active_tree).and_return(:utilization_tree) }
+
     it "sets text to @x_node_text" do
       subject.send(:x_node_text=, "VM UTIL 1")
 

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -1,12 +1,6 @@
 describe Mixins::BreadcrumbsMixin do
   class BreadcrumbsTestController < ActionController::Base
     include Mixins::BreadcrumbsMixin
-
-    def gtl_url; end
-    def features; end
-    def x_active_tree; end
-    def x_active_accord; end
-    def x_node; end
   end
 
   subject { BreadcrumbsTestController.new }
@@ -240,6 +234,7 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   context 'mixin loaded into a non-explorer controller' do
+    subject { MiqRequestController.new }
     describe '#data_for_breadcrumbs' do
       it "creates breadcrumbs" do
         expect(subject.data_for_breadcrumbs).to eq(
@@ -275,7 +270,7 @@ describe Mixins::BreadcrumbsMixin do
             [
               {:title => "First Layer"},
               {:title => "Second Layer"},
-              {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"},
+              {:title => "record_info_title", :url => "/#{subject.controller_name}/show/1234"},
               {:title => "Title"}
             ]
           )
@@ -288,7 +283,7 @@ describe Mixins::BreadcrumbsMixin do
             [
               {:title => "First Layer"},
               {:title => "Second Layer"},
-              {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"}
+              {:title => "record_info_title", :url => "/#{subject.controller_name}/show/1234"}
             ]
           )
         end
@@ -316,7 +311,7 @@ describe Mixins::BreadcrumbsMixin do
               [
                 {:title => "First Layer"},
                 {:title => "Second Layer"},
-                {:title => "record_info_title", :url => "/breadcrumbs_test/show/1234"},
+                {:title => "record_info_title", :url => "/#{subject.controller_name}/show/1234"},
                 {:title => "Title"}
               ]
             )

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -20,6 +20,8 @@ describe Mixins::BreadcrumbsMixin do
   end
 
   context 'mixin loaded into an explorer controller' do
+    subject { CatalogController.new }
+
     before do
       subject.instance_variable_set(:@sb, :explorer => true)
 
@@ -235,6 +237,7 @@ describe Mixins::BreadcrumbsMixin do
 
   context 'mixin loaded into a non-explorer controller' do
     subject { MiqRequestController.new }
+
     describe '#data_for_breadcrumbs' do
       it "creates breadcrumbs" do
         expect(subject.data_for_breadcrumbs).to eq(


### PR DESCRIPTION
With strict partials enabled some of the breadcrumb mixin specs fail because they're stubbing methods that haven't been defined. ~~Since the mixin appears to require the implementation of these methods anyway, I simply added some empty definitions in the test class. With these in place, the specs then pass.~~

Edit: original plan scrapped, just use real controllers that mixin the BreadcrumbsMixin.

Part of the cleanup effort created at https://github.com/ManageIQ/manageiq-ui-classic/issues/6734