### PR TITLE
Remove invalid partials, refactor unused factories in CheckedIdMixin

### DIFF
--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -1,15 +1,17 @@
 describe Mixins::CheckedIdMixin do
   describe '#find_records_with_rbac' do
-    # include tested mixin
-    let(:mixin) { Object.new.tap { |s| s.singleton_class.send(:include, described_class) } }
-    # create user, user role and group
+    # create user role and group
     let(:user_role) { FactoryBot.create(:miq_user_role) }
-    let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
-    let(:current_user) { FactoryBot.create(:user, :miq_groups => [group]) }
-    before do
-      allow(mixin).to receive(:current_user).and_return(current_user)
-      allow(current_user).to receive(:get_timezone).and_return("Prague")
+    let(:groups) { FactoryBot.create_list(:miq_group, 2, :miq_user_role => user_role) }
+
+    # include tested mixin, create user inline
+    let(:mixin) do
+      Object.new.tap do |instance|
+        instance.extend(described_class)
+        instance.define_singleton_method(:current_user) { FactoryBot.create(:user, :miq_groups => groups) }
+      end
     end
+
     # create records
     let!(:vm1) { FactoryBot.create(:vm_or_template) }
     let!(:vm2) { FactoryBot.create(:vm_or_template) }

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -8,7 +8,7 @@ describe Mixins::CheckedIdMixin do
     let!(:vm2) { FactoryBot.create(:vm_or_template) }
     let!(:vm3) { FactoryBot.create(:vm_or_template) }
 
-    subject { mixin.send(:find_records_with_rbac, model, id) }
+    subject { mixin.find_records_with_rbac(model, id) }
 
     context 'when single record is checked in show list' do
       let(:model) { VmOrTemplate }

--- a/spec/controllers/mixins/checked_id_mixin_spec.rb
+++ b/spec/controllers/mixins/checked_id_mixin_spec.rb
@@ -1,16 +1,7 @@
 describe Mixins::CheckedIdMixin do
   describe '#find_records_with_rbac' do
-    # create user role and group
-    let(:user_role) { FactoryBot.create(:miq_user_role) }
-    let(:groups) { FactoryBot.create_list(:miq_group, 2, :miq_user_role => user_role) }
-
     # include tested mixin, create user inline
-    let(:mixin) do
-      Object.new.tap do |instance|
-        instance.extend(described_class)
-        instance.define_singleton_method(:current_user) { FactoryBot.create(:user, :miq_groups => groups) }
-      end
-    end
+    let(:mixin) { Object.new.tap { |instance| instance.extend(described_class) } }
 
     # create records
     let!(:vm1) { FactoryBot.create(:vm_or_template) }


### PR DESCRIPTION
Currently the `CheckedIdMixin` specs will fail with strict partials enabled because there's no `current_user` defined on the object. As far as I can tell this method isn't required by the mixin, nor used by the specs. Removing them had no effect.

While I was here I refactored the way the object mixed in the module, and removed a gratuitous `send` call.

Part of the cleanup effort brought up at https://github.com/ManageIQ/manageiq-ui-classic/issues/6734