### PR TITLE
Mixin the TextualSummaryHelper to fix invalid partials, part 3

### DIFF
--- a/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_tenant_helper/textual_summary_spec.rb
@@ -1,4 +1,6 @@
 describe CloudTenantHelper::TextualSummary do
+  include TextualSummaryHelper
+
   before do
     instance_variable_set(:@record, FactoryBot.create(:cloud_tenant))
     allow(@record).to receive_message_chain(:cloud_resource_quotas, :order).and_return([])

--- a/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb
@@ -1,4 +1,6 @@
 describe EmsPhysicalInfraHelper::TextualSummary do
+  include TextualSummaryHelper
+
   before do
     instance_variable_set(:@record, FactoryBot.create(:ems_infra))
     allow(@record).to receive(:authentication_userid_passwords).and_return([])


### PR DESCRIPTION
At the moment with strict partials enabled you will see several errors like this:

```
1) EmsPhysicalInfraHelper::TextualSummary#textual_group Relationships
     Failure/Error: allow(self).to receive(:textual_authentications).and_return([])
       #<RSpec::ExampleGroups::EmsPhysicalInfraHelperTextualSummary::TextualGroup_3 "Relationships" (./spec/shared/helpers/textual_summary_helper_methods.rb:24)> does not implement: textual_authentications
     Shared Example Group: "textual_group" called from ./spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb:14
     # ./spec/helpers/ems_physical_infra_helper/textual_summary_spec.rb:7:in `block (2 levels) in <top (required)>'
```
Followup to #6750, but this one applies to the ems_physical_infra_helper instead of the host_helper.

Edit: Did the same for the cloud tenant helper while I was here.