### PR TITLE
Add role_allows? interface to TextualSummaryHelper

### DIFF
--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -1,4 +1,8 @@
 module TextualSummaryHelper
+  def role_allows?(_options = {})
+    raise NotImplementedError, _("role_allows? must be implemented in including class")
+  end
+
   def textual_link(target, **opts, &blk)
     case target
     when ActiveRecord::Relation, Array

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -1,8 +1,4 @@
 module TextualSummaryHelper
-  def role_allows?(_options = {})
-    raise NotImplementedError, _("role_allows? must be implemented in including class")
-  end
-
   def textual_link(target, **opts, &blk)
     case target
     when ActiveRecord::Relation, Array

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -1,5 +1,5 @@
 describe EmsCloudHelper::TextualSummary do
-  include TextualSummaryHelper
+  include ApplicationHelper
 
   context "#textual_instances and #textual_images" do
     before do

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -1,9 +1,10 @@
 describe EmsCloudHelper::TextualSummary do
+  include TextualSummaryHelper
+
   context "#textual_instances and #textual_images" do
     before do
       @record = FactoryBot.create(:ems_openstack)
       allow(self).to receive(:role_allows?).and_return(true)
-      allow(controller).to receive(:restful?).and_return(true)
       allow(controller).to receive(:controller_name).and_return("ems_cloud")
     end
 


### PR DESCRIPTION
With strict partials enabled you will see failures from the `EmsCloudHelper::TextualSummary` specs like this:

```
1) EmsCloudHelper::TextualSummary#textual_groups textual_group_smart_management Smart management
     Failure/Error: allow(self).to receive(:textual_authentications).and_return([])
       #<RSpec::ExampleGroups::EmsCloudHelperTextualSummary::TextualGroups::TextualGroupSmartManagement "Smart management" (./spec/shared/helpers/textual_summary_helper_methods.rb:13)> does not implement: textual_authentications
     Shared Example Group: "textual_group_smart_management" called from ./spec/helpers/ems_cloud_helper/textual_summary_spec.rb:57
     # ./spec/helpers/ems_cloud_helper/textual_summary_spec.rb:32:in `block (3 levels) in <top (required)>'
```

~~Here I decided to add an interface method in the `TextualSummary` module. Since there is no internal logic checking for its definition, it should be safe. I also `include` the TextualSummary module and remove an unused partial.~~

Update: dropped this, and just mixin the `ApplicationHelper` instead.

Part of the cleanup effort at https://github.com/ManageIQ/manageiq-ui-classic/issues/6734