### PR TITLE
workers-form: remove vim_broker_worker

### DIFF
--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -54,9 +54,6 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
               memory_threshold: parseWorker(wb.queue_worker_base.ems_refresh_worker.defaults).bytes || baseMemDefault,
             },
           },
-          vim_broker_worker: {
-            memory_threshold: parseWorker(wb.vim_broker_worker).bytes || memDefault,
-          },
           smart_proxy_worker: {
             memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || baseMemDefault,
             count: selectCount(wb.queue_worker_base.smart_proxy_worker.count),
@@ -141,9 +138,6 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
       },
       ui_worker: {
         count: isDifferent('ui_worker.count'),
-      },
-      vim_broker_worker: {
-        memory_threshold: toRubyMethod(isDifferent('vim_broker_worker.memory_threshold')),
       },
       event_catcher: {
         memory_threshold: toRubyMethod(isDifferent('event_catcher.memory_threshold')),

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -124,17 +124,6 @@ function addSchema(formValues) {
     fields: [
       {
         component: componentTypes.SUB_FORM,
-        name: 'connectionBroker',
-        title: __('Connection Broker'),
-        fields: [{
-          component: componentTypes.SELECT,
-          name: 'vim_broker_worker.memory_threshold',
-          options: injectOption(generateRefreshOptions(false, 100, 500), formValues.vim_broker_worker.memory_threshold),
-          label: __('Memory threshold'),
-        },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
         name: 'vmAnalysisCollectors',
         title: __('VM Analysis Collectors'),
         fields: [

--- a/app/javascript/spec/workers-form/workers-form.spec.js
+++ b/app/javascript/spec/workers-form/workers-form.spec.js
@@ -70,9 +70,6 @@ describe('Workers form', () => {
           ui_worker: {
             memory_threshold: '1.gigabytes', count: 1,
           },
-          vim_broker_worker: {
-            memory_threshold: 2147483648,
-          },
           web_service_worker: {
             connection_pool_size: 8, memory_threshold: 1073741824,
           },
@@ -94,7 +91,6 @@ describe('Workers form', () => {
       reporting_worker: { count: 2, memory_threshold: 524288000 },
       smart_proxy_worker: { count: 2, memory_threshold: 576716800 },
       ui_worker: { count: 1 },
-      vim_broker_worker: { memory_threshold: 2147483648 },
       web_service_worker: { count: 1, memory_threshold: 1073741824 },
     };
 


### PR DESCRIPTION
`MiqVimBrokerWorker` was removed in https://github.com/ManageIQ/manageiq-providers-vmware/issues/484

=> removing the setting

Fixes #6758 