### PR TITLE
[WIP] workers-form: generate schema from list of workers, don't blow up on missing workers

### DIFF
--- a/app/javascript/components/workers-form/__snapshots__/workers.schema.test.js.snap
+++ b/app/javascript/components/workers-form/__snapshots__/workers.schema.test.js.snap
@@ -136,7 +136,7 @@ Object {
               ],
             },
           ],
-          "name": "genericWorkers",
+          "name": "generic_worker",
           "title": "Generic Workers",
         },
         Object {
@@ -269,7 +269,7 @@ Object {
               ],
             },
           ],
-          "name": "priorityWorkers",
+          "name": "priority_worker",
           "title": "Priority Workers",
         },
       ],
@@ -408,7 +408,7 @@ Object {
               ],
             },
           ],
-          "name": "cuCollectors",
+          "name": "ems_metrics_collector_worker.defaults",
           "title": "C & U Data Collectors",
         },
         Object {
@@ -521,11 +521,11 @@ Object {
               ],
             },
           ],
-          "name": "cuProccesors",
+          "name": "ems_metrics_processor_worker",
           "title": "C & U Data Processors",
         },
       ],
-      "name": "group3",
+      "name": "group2",
     },
     Object {
       "component": "dual-group",
@@ -701,7 +701,7 @@ Object {
               ],
             },
           ],
-          "name": "eventMonitor",
+          "name": "event_catcher",
           "title": "Event Monitor",
         },
         Object {
@@ -903,11 +903,11 @@ Object {
               ],
             },
           ],
-          "name": "refresh",
+          "name": "ems_refresh_worker.defaults",
           "title": "Refresh",
         },
       ],
-      "name": "group4",
+      "name": "group3",
     },
     Object {
       "component": "dual-group",
@@ -1082,11 +1082,65 @@ Object {
               ],
             },
           ],
-          "name": "vmAnalysisCollectors",
+          "name": "smart_proxy_worker",
           "title": "VM Analysis Collectors",
         },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "remote_console_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+          ],
+          "name": "remote_console_worker",
+          "title": "Remote Console Workers",
+        },
       ],
-      "name": "group5",
+      "name": "group4",
     },
     Object {
       "component": "dual-group",
@@ -1143,7 +1197,7 @@ Object {
               ],
             },
           ],
-          "name": "uiWorker",
+          "name": "ui_worker",
           "title": "UI Worker",
         },
         Object {
@@ -1152,7 +1206,7 @@ Object {
             Object {
               "component": "select-field",
               "label": "Count",
-              "name": "remote_console_worker.count",
+              "name": "web_service_worker.count",
               "options": Array [
                 Object {
                   "label": "0",
@@ -1196,12 +1250,91 @@ Object {
                 },
               ],
             },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "web_service_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
           ],
-          "name": "remoteWorkers",
-          "title": "Remote Console Workers",
+          "name": "web_service_worker",
+          "title": "Web Service Workers",
         },
       ],
-      "name": "group6",
+      "name": "group5",
     },
     Object {
       "component": "dual-group",
@@ -1336,144 +1469,11 @@ Object {
               ],
             },
           ],
-          "name": "reportingWorkers",
+          "name": "reporting_worker",
           "title": "Reporting Workers",
         },
-        Object {
-          "component": "sub-form",
-          "fields": Array [
-            Object {
-              "component": "select-field",
-              "label": "Count",
-              "name": "web_service_worker.count",
-              "options": Array [
-                Object {
-                  "label": "0",
-                  "value": 0,
-                },
-                Object {
-                  "label": "1",
-                  "value": 1,
-                },
-                Object {
-                  "label": "2",
-                  "value": 2,
-                },
-                Object {
-                  "label": "3",
-                  "value": 3,
-                },
-                Object {
-                  "label": "4",
-                  "value": 4,
-                },
-                Object {
-                  "label": "5",
-                  "value": 5,
-                },
-                Object {
-                  "label": "6",
-                  "value": 6,
-                },
-                Object {
-                  "label": "7",
-                  "value": 7,
-                },
-                Object {
-                  "label": "8",
-                  "value": 8,
-                },
-                Object {
-                  "label": "9",
-                  "value": 9,
-                },
-              ],
-            },
-            Object {
-              "component": "select-field",
-              "label": "Memory threshold",
-              "name": "web_service_worker.memory_threshold",
-              "options": Array [
-                Object {
-                  "label": "200 MB",
-                  "value": 209715200,
-                },
-                Object {
-                  "label": "250 MB",
-                  "value": 262144000,
-                },
-                Object {
-                  "label": "300 MB",
-                  "value": 314572800,
-                },
-                Object {
-                  "label": "350 MB",
-                  "value": 367001600,
-                },
-                Object {
-                  "label": "400 MB",
-                  "value": 419430400,
-                },
-                Object {
-                  "label": "450 MB",
-                  "value": 471859200,
-                },
-                Object {
-                  "label": "500 MB",
-                  "value": 524288000,
-                },
-                Object {
-                  "label": "550 MB",
-                  "value": 576716800,
-                },
-                Object {
-                  "label": "600 MB",
-                  "value": 629145600,
-                },
-                Object {
-                  "label": "700 MB",
-                  "value": 734003200,
-                },
-                Object {
-                  "label": "800 MB",
-                  "value": 838860800,
-                },
-                Object {
-                  "label": "900 MB",
-                  "value": 943718400,
-                },
-                Object {
-                  "label": "1 GB",
-                  "value": 1073741824,
-                },
-                Object {
-                  "label": "1.1 GB",
-                  "value": 1181116006.4,
-                },
-                Object {
-                  "label": "1.2 GB",
-                  "value": 1288490188.8,
-                },
-                Object {
-                  "label": "1.3 GB",
-                  "value": 1395864371.2,
-                },
-                Object {
-                  "label": "1.4 GB",
-                  "value": 1503238553.6,
-                },
-                Object {
-                  "label": "1.5 GB",
-                  "value": 1610612736,
-                },
-              ],
-            },
-          ],
-          "name": "webServiceWorkers",
-          "title": "Web Service Workers",
-        },
       ],
-      "name": "group7",
+      "name": "group6",
     },
   ],
 }

--- a/app/javascript/components/workers-form/__snapshots__/workers.schema.test.js.snap
+++ b/app/javascript/components/workers-form/__snapshots__/workers.schema.test.js.snap
@@ -1,0 +1,1480 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schema generates correctly 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "generic_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "generic_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "genericWorkers",
+          "title": "Generic Workers",
+        },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "priority_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "priority_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "priorityWorkers",
+          "title": "Priority Workers",
+        },
+      ],
+      "name": "group1",
+    },
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "ems_metrics_collector_worker.defaults.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "ems_metrics_collector_worker.defaults.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "cuCollectors",
+          "title": "C & U Data Collectors",
+        },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "ems_metrics_processor_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "ems_metrics_processor_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "cuProccesors",
+          "title": "C & U Data Processors",
+        },
+      ],
+      "name": "group3",
+    },
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "event_catcher.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+                Object {
+                  "label": "1.6 GB",
+                  "value": 1717986918.4,
+                },
+                Object {
+                  "label": "1.7 GB",
+                  "value": 1825361100.8,
+                },
+                Object {
+                  "label": "1.8 GB",
+                  "value": 1932735283.2,
+                },
+                Object {
+                  "label": "1.9 GB",
+                  "value": 2040109465.6,
+                },
+                Object {
+                  "label": "2 GB",
+                  "value": 2147483648,
+                },
+                Object {
+                  "label": "2.1 GB",
+                  "value": 2254857830.4,
+                },
+                Object {
+                  "label": "2.2 GB",
+                  "value": 2362232012.8,
+                },
+                Object {
+                  "label": "2.3 GB",
+                  "value": 2469606195.2,
+                },
+                Object {
+                  "label": "2.4 GB",
+                  "value": 2576980377.6,
+                },
+                Object {
+                  "label": "2.5 GB",
+                  "value": 2684354560,
+                },
+                Object {
+                  "label": "2.6 GB",
+                  "value": 2791728742.4,
+                },
+                Object {
+                  "label": "2.7 GB",
+                  "value": 2899102924.8,
+                },
+                Object {
+                  "label": "2.8 GB",
+                  "value": 3006477107.2,
+                },
+                Object {
+                  "label": "2.9 GB",
+                  "value": 3113851289.6,
+                },
+                Object {
+                  "label": "3 GB",
+                  "value": 3221225472,
+                },
+                Object {
+                  "label": "3.5 GB",
+                  "value": 3758096384,
+                },
+                Object {
+                  "label": "4 GB",
+                  "value": 4294967296,
+                },
+                Object {
+                  "label": "4.5 GB",
+                  "value": 4831838208,
+                },
+                Object {
+                  "label": "5 GB",
+                  "value": 5368709120,
+                },
+                Object {
+                  "label": "5.5 GB",
+                  "value": 5905580032,
+                },
+                Object {
+                  "label": "6 GB",
+                  "value": 6442450944,
+                },
+                Object {
+                  "label": "6.5 GB",
+                  "value": 6979321856,
+                },
+                Object {
+                  "label": "7 GB",
+                  "value": 7516192768,
+                },
+                Object {
+                  "label": "7.5 GB",
+                  "value": 8053063680,
+                },
+                Object {
+                  "label": "8 GB",
+                  "value": 8589934592,
+                },
+                Object {
+                  "label": "8.5 GB",
+                  "value": 9126805504,
+                },
+                Object {
+                  "label": "9 GB",
+                  "value": 9663676416,
+                },
+                Object {
+                  "label": "9.5 GB",
+                  "value": 10200547328,
+                },
+                Object {
+                  "label": "10 GB",
+                  "value": 10737418240,
+                },
+              ],
+            },
+          ],
+          "name": "eventMonitor",
+          "title": "Event Monitor",
+        },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "ems_refresh_worker.defaults.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+                Object {
+                  "label": "1.6 GB",
+                  "value": 1717986918.4,
+                },
+                Object {
+                  "label": "1.7 GB",
+                  "value": 1825361100.8,
+                },
+                Object {
+                  "label": "1.8 GB",
+                  "value": 1932735283.2,
+                },
+                Object {
+                  "label": "1.9 GB",
+                  "value": 2040109465.6,
+                },
+                Object {
+                  "label": "2 GB",
+                  "value": 2147483648,
+                },
+                Object {
+                  "label": "2.1 GB",
+                  "value": 2254857830.4,
+                },
+                Object {
+                  "label": "2.2 GB",
+                  "value": 2362232012.8,
+                },
+                Object {
+                  "label": "2.3 GB",
+                  "value": 2469606195.2,
+                },
+                Object {
+                  "label": "2.4 GB",
+                  "value": 2576980377.6,
+                },
+                Object {
+                  "label": "2.5 GB",
+                  "value": 2684354560,
+                },
+                Object {
+                  "label": "2.6 GB",
+                  "value": 2791728742.4,
+                },
+                Object {
+                  "label": "2.7 GB",
+                  "value": 2899102924.8,
+                },
+                Object {
+                  "label": "2.8 GB",
+                  "value": 3006477107.2,
+                },
+                Object {
+                  "label": "2.9 GB",
+                  "value": 3113851289.6,
+                },
+                Object {
+                  "label": "3 GB",
+                  "value": 3221225472,
+                },
+                Object {
+                  "label": "3.5 GB",
+                  "value": 3758096384,
+                },
+                Object {
+                  "label": "4 GB",
+                  "value": 4294967296,
+                },
+                Object {
+                  "label": "4.5 GB",
+                  "value": 4831838208,
+                },
+                Object {
+                  "label": "5 GB",
+                  "value": 5368709120,
+                },
+                Object {
+                  "label": "5.5 GB",
+                  "value": 5905580032,
+                },
+                Object {
+                  "label": "6 GB",
+                  "value": 6442450944,
+                },
+                Object {
+                  "label": "6.5 GB",
+                  "value": 6979321856,
+                },
+                Object {
+                  "label": "7 GB",
+                  "value": 7516192768,
+                },
+                Object {
+                  "label": "7.5 GB",
+                  "value": 8053063680,
+                },
+                Object {
+                  "label": "8 GB",
+                  "value": 8589934592,
+                },
+                Object {
+                  "label": "8.5 GB",
+                  "value": 9126805504,
+                },
+                Object {
+                  "label": "9 GB",
+                  "value": 9663676416,
+                },
+                Object {
+                  "label": "9.5 GB",
+                  "value": 10200547328,
+                },
+                Object {
+                  "label": "10 GB",
+                  "value": 10737418240,
+                },
+              ],
+            },
+          ],
+          "name": "refresh",
+          "title": "Refresh",
+        },
+      ],
+      "name": "group4",
+    },
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "smart_proxy_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "smart_proxy_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+                Object {
+                  "label": "1.6 GB",
+                  "value": 1717986918.4,
+                },
+                Object {
+                  "label": "1.7 GB",
+                  "value": 1825361100.8,
+                },
+                Object {
+                  "label": "1.8 GB",
+                  "value": 1932735283.2,
+                },
+                Object {
+                  "label": "1.9 GB",
+                  "value": 2040109465.6,
+                },
+                Object {
+                  "label": "2 GB",
+                  "value": 2147483648,
+                },
+                Object {
+                  "label": "2.1 GB",
+                  "value": 2254857830.4,
+                },
+                Object {
+                  "label": "2.2 GB",
+                  "value": 2362232012.8,
+                },
+                Object {
+                  "label": "2.3 GB",
+                  "value": 2469606195.2,
+                },
+                Object {
+                  "label": "2.4 GB",
+                  "value": 2576980377.6,
+                },
+                Object {
+                  "label": "2.5 GB",
+                  "value": 2684354560,
+                },
+                Object {
+                  "label": "2.6 GB",
+                  "value": 2791728742.4,
+                },
+                Object {
+                  "label": "2.7 GB",
+                  "value": 2899102924.8,
+                },
+                Object {
+                  "label": "2.8 GB",
+                  "value": 3006477107.2,
+                },
+                Object {
+                  "label": "2.9 GB",
+                  "value": 3113851289.6,
+                },
+              ],
+            },
+          ],
+          "name": "vmAnalysisCollectors",
+          "title": "VM Analysis Collectors",
+        },
+      ],
+      "name": "group5",
+    },
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "helperText": "Changing the UI Workers Count will immediately restart the webserver",
+              "label": "Count",
+              "name": "ui_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+          ],
+          "name": "uiWorker",
+          "title": "UI Worker",
+        },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "remote_console_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+          ],
+          "name": "remoteWorkers",
+          "title": "Remote Console Workers",
+        },
+      ],
+      "name": "group6",
+    },
+    Object {
+      "component": "dual-group",
+      "fields": Array [
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "reporting_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "reporting_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "reportingWorkers",
+          "title": "Reporting Workers",
+        },
+        Object {
+          "component": "sub-form",
+          "fields": Array [
+            Object {
+              "component": "select-field",
+              "label": "Count",
+              "name": "web_service_worker.count",
+              "options": Array [
+                Object {
+                  "label": "0",
+                  "value": 0,
+                },
+                Object {
+                  "label": "1",
+                  "value": 1,
+                },
+                Object {
+                  "label": "2",
+                  "value": 2,
+                },
+                Object {
+                  "label": "3",
+                  "value": 3,
+                },
+                Object {
+                  "label": "4",
+                  "value": 4,
+                },
+                Object {
+                  "label": "5",
+                  "value": 5,
+                },
+                Object {
+                  "label": "6",
+                  "value": 6,
+                },
+                Object {
+                  "label": "7",
+                  "value": 7,
+                },
+                Object {
+                  "label": "8",
+                  "value": 8,
+                },
+                Object {
+                  "label": "9",
+                  "value": 9,
+                },
+              ],
+            },
+            Object {
+              "component": "select-field",
+              "label": "Memory threshold",
+              "name": "web_service_worker.memory_threshold",
+              "options": Array [
+                Object {
+                  "label": "200 MB",
+                  "value": 209715200,
+                },
+                Object {
+                  "label": "250 MB",
+                  "value": 262144000,
+                },
+                Object {
+                  "label": "300 MB",
+                  "value": 314572800,
+                },
+                Object {
+                  "label": "350 MB",
+                  "value": 367001600,
+                },
+                Object {
+                  "label": "400 MB",
+                  "value": 419430400,
+                },
+                Object {
+                  "label": "450 MB",
+                  "value": 471859200,
+                },
+                Object {
+                  "label": "500 MB",
+                  "value": 524288000,
+                },
+                Object {
+                  "label": "550 MB",
+                  "value": 576716800,
+                },
+                Object {
+                  "label": "600 MB",
+                  "value": 629145600,
+                },
+                Object {
+                  "label": "700 MB",
+                  "value": 734003200,
+                },
+                Object {
+                  "label": "800 MB",
+                  "value": 838860800,
+                },
+                Object {
+                  "label": "900 MB",
+                  "value": 943718400,
+                },
+                Object {
+                  "label": "1 GB",
+                  "value": 1073741824,
+                },
+                Object {
+                  "label": "1.1 GB",
+                  "value": 1181116006.4,
+                },
+                Object {
+                  "label": "1.2 GB",
+                  "value": 1288490188.8,
+                },
+                Object {
+                  "label": "1.3 GB",
+                  "value": 1395864371.2,
+                },
+                Object {
+                  "label": "1.4 GB",
+                  "value": 1503238553.6,
+                },
+                Object {
+                  "label": "1.5 GB",
+                  "value": 1610612736,
+                },
+              ],
+            },
+          ],
+          "name": "webServiceWorkers",
+          "title": "Web Service Workers",
+        },
+      ],
+      "name": "group7",
+    },
+  ],
+}
+`;

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -243,26 +243,26 @@ export const parseSettings = ({ workers: { worker_base: wb } }) => {
   const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
   const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
 
-  const selectCount = value => (typeof value === 'number' ? value : countDefault);
+  const count = (worker) => ((worker && worker.count && (typeof worker.count === 'number')) ? worker.count : countDefault);
 
   return {
     generic_worker: {
       memory_threshold: parseWorker(wb.queue_worker_base.generic_worker).bytes || baseMemDefault,
-      count: selectCount(wb.queue_worker_base.generic_worker.count),
+      count: count(wb.queue_worker_base.generic_worker),
     },
     priority_worker: {
       memory_threshold: parseWorker(wb.queue_worker_base.priority_worker).bytes || baseMemDefault,
-      count: selectCount(wb.queue_worker_base.priority_worker.count),
+      count: count(wb.queue_worker_base.priority_worker),
     },
     ems_metrics_collector_worker: {
       defaults: {
         memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_collector_worker.defaults).bytes || baseMemDefault,
-        count: selectCount(wb.queue_worker_base.ems_metrics_collector_worker.defaults.count),
+        count: count(wb.queue_worker_base.ems_metrics_collector_worker.defaults),
       },
     },
     ems_metrics_processor_worker: {
       memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_processor_worker).bytes || baseMemDefault,
-      count: selectCount(wb.queue_worker_base.ems_metrics_processor_worker.count),
+      count: count(wb.queue_worker_base.ems_metrics_processor_worker),
     },
     event_catcher: {
       memory_threshold: parseWorker(wb.event_catcher).bytes || monitorDefault,
@@ -274,21 +274,21 @@ export const parseSettings = ({ workers: { worker_base: wb } }) => {
     },
     smart_proxy_worker: {
       memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || baseMemDefault,
-      count: selectCount(wb.queue_worker_base.smart_proxy_worker.count),
+      count: count(wb.queue_worker_base.smart_proxy_worker),
     },
     ui_worker: {
-      count: selectCount(wb.ui_worker.count),
+      count: count(wb.ui_worker),
     },
     reporting_worker: {
       memory_threshold: parseWorker(wb.queue_worker_base.reporting_worker).bytes || baseMemDefault,
-      count: selectCount(wb.queue_worker_base.reporting_worker.count),
+      count: count(wb.queue_worker_base.reporting_worker),
     },
     web_service_worker: {
       memory_threshold: parseWorker(wb.web_service_worker).bytes || memDefault,
-      count: selectCount(wb.web_service_worker.count),
+      count: count(wb.web_service_worker),
     },
     remote_console_worker: {
-      count: selectCount(wb.remote_console_worker.count),
+      count: count(wb.remote_console_worker),
     },
   };
 };

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -230,53 +230,56 @@ export const parseSettings = ({ workers: { worker_base: wb } }) => {
   const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
   const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
 
-  const count = (worker) => ((worker && worker.count && (typeof worker.count === 'number')) ? worker.count : countDefault);
-  const bytes = (worker, defaultValue) => (worker && toBytes(worker.memory_threshold) || defaultValue);
+  const workerCount = (worker) => (typeof worker.count === 'number') && worker.count;
+  const workerBytes = (worker) => toBytes(worker.memory_threshold);
+
+  const count = (path) => (_.get(wb, path) && workerCount(_.get(wb, path)) || countDefault);
+  const bytes = (path, defaultValue) => (_.get(wb, path) && workerBytes(_.get(wb, path)) || defaultValue);
 
   return {
     generic_worker: {
-      memory_threshold: bytes(wb.queue_worker_base.generic_worker, baseMemDefault),
-      count: count(wb.queue_worker_base.generic_worker),
+      memory_threshold: bytes('queue_worker_base.generic_worker', baseMemDefault),
+      count: count('queue_worker_base.generic_worker'),
     },
     priority_worker: {
-      memory_threshold: bytes(wb.queue_worker_base.priority_worker, baseMemDefault),
-      count: count(wb.queue_worker_base.priority_worker),
+      memory_threshold: bytes('queue_worker_base.priority_worker', baseMemDefault),
+      count: count('queue_worker_base.priority_worker'),
     },
     ems_metrics_collector_worker: {
       defaults: {
-        memory_threshold: bytes(wb.queue_worker_base.ems_metrics_collector_worker.defaults, baseMemDefault),
-        count: count(wb.queue_worker_base.ems_metrics_collector_worker.defaults),
+        memory_threshold: bytes('queue_worker_base.ems_metrics_collector_worker.defaults', baseMemDefault),
+        count: count('queue_worker_base.ems_metrics_collector_worker.defaults'),
       },
     },
     ems_metrics_processor_worker: {
-      memory_threshold: bytes(wb.queue_worker_base.ems_metrics_processor_worker, baseMemDefault),
-      count: count(wb.queue_worker_base.ems_metrics_processor_worker),
+      memory_threshold: bytes('queue_worker_base.ems_metrics_processor_worker', baseMemDefault),
+      count: count('queue_worker_base.ems_metrics_processor_worker'),
     },
     event_catcher: {
-      memory_threshold: bytes(wb.event_catcher, monitorDefault),
+      memory_threshold: bytes('event_catcher', monitorDefault),
     },
     ems_refresh_worker: {
       defaults: {
-        memory_threshold: bytes(wb.queue_worker_base.ems_refresh_worker.defaults, baseMemDefault),
+        memory_threshold: bytes('queue_worker_base.ems_refresh_worker.defaults', baseMemDefault),
       },
     },
     smart_proxy_worker: {
-      memory_threshold: bytes(wb.queue_worker_base.smart_proxy_worker, baseMemDefault),
-      count: count(wb.queue_worker_base.smart_proxy_worker),
+      memory_threshold: bytes('queue_worker_base.smart_proxy_worker', baseMemDefault),
+      count: count('queue_worker_base.smart_proxy_worker'),
     },
     ui_worker: {
-      count: count(wb.ui_worker),
+      count: count('ui_worker'),
     },
     reporting_worker: {
-      memory_threshold: bytes(wb.queue_worker_base.reporting_worker, baseMemDefault),
-      count: count(wb.queue_worker_base.reporting_worker),
+      memory_threshold: bytes('queue_worker_base.reporting_worker', baseMemDefault),
+      count: count('queue_worker_base.reporting_worker'),
     },
     web_service_worker: {
-      memory_threshold: bytes(wb.web_service_worker, memDefault),
-      count: count(wb.web_service_worker),
+      memory_threshold: bytes('web_service_worker', memDefault),
+      count: count('web_service_worker'),
     },
     remote_console_worker: {
-      count: count(wb.remote_console_worker),
+      count: count('remote_console_worker'),
     },
   };
 };

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -235,3 +235,60 @@ export const injectOption = (options, initialValue, isCount = false) => {
   }
   return options;
 };
+
+// parse /api/servers/:id/settings output
+export const parseSettings = ({ workers: { worker_base: wb } }) => {
+  const countDefault = wb.defaults.count;
+  const memDefault = toBytes(wb.defaults.memory_threshold);
+  const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
+  const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
+
+  const selectCount = value => (typeof value === 'number' ? value : countDefault);
+
+  return {
+    generic_worker: {
+      memory_threshold: parseWorker(wb.queue_worker_base.generic_worker).bytes || baseMemDefault,
+      count: selectCount(wb.queue_worker_base.generic_worker.count),
+    },
+    priority_worker: {
+      memory_threshold: parseWorker(wb.queue_worker_base.priority_worker).bytes || baseMemDefault,
+      count: selectCount(wb.queue_worker_base.priority_worker.count),
+    },
+    ems_metrics_collector_worker: {
+      defaults: {
+        memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_collector_worker.defaults).bytes || baseMemDefault,
+        count: selectCount(wb.queue_worker_base.ems_metrics_collector_worker.defaults.count),
+      },
+    },
+    ems_metrics_processor_worker: {
+      memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_processor_worker).bytes || baseMemDefault,
+      count: selectCount(wb.queue_worker_base.ems_metrics_processor_worker.count),
+    },
+    event_catcher: {
+      memory_threshold: parseWorker(wb.event_catcher).bytes || monitorDefault,
+    },
+    ems_refresh_worker: {
+      defaults: {
+        memory_threshold: parseWorker(wb.queue_worker_base.ems_refresh_worker.defaults).bytes || baseMemDefault,
+      },
+    },
+    smart_proxy_worker: {
+      memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || baseMemDefault,
+      count: selectCount(wb.queue_worker_base.smart_proxy_worker.count),
+    },
+    ui_worker: {
+      count: selectCount(wb.ui_worker.count),
+    },
+    reporting_worker: {
+      memory_threshold: parseWorker(wb.queue_worker_base.reporting_worker).bytes || baseMemDefault,
+      count: selectCount(wb.queue_worker_base.reporting_worker.count),
+    },
+    web_service_worker: {
+      memory_threshold: parseWorker(wb.web_service_worker).bytes || memDefault,
+      count: selectCount(wb.web_service_worker.count),
+    },
+    remote_console_worker: {
+      count: selectCount(wb.remote_console_worker.count),
+    },
+  };
+};

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -223,7 +223,7 @@ export const injectOption = (options, initialValue, isCount = false) => {
 };
 
 // parse /api/servers/:id/settings output
-export const parseSettings = ({ workers: { worker_base: wb } }) => {
+export const parseSettings = (workersDef) => ({ workers: { worker_base: wb } }) => {
   const workerCount = (worker) => (typeof worker.count === 'number') && worker.count;
   const workerBytes = (worker) => toBytes(worker.memory_threshold);
 

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -102,20 +102,6 @@ export const buildPatch = (parent) => {
 };
 
 /**
- * Parse worker object.
- *
- * @param {object} parent Worker object obtained from API.
- * @return {object} Object with all values in different formats.
- */
-export const parseWorker = ({ count, memory_threshold }) => ({
-  count,
-  memory_threshold,
-  human_size: toHumanSize(memory_threshold),
-  rubyMethod: toRubyMethod(memory_threshold),
-  bytes: toBytes(memory_threshold),
-});
-
-/**
  * Create number range options.
  *
  * @param {number} length 0 .. lenght.
@@ -239,52 +225,54 @@ export const injectOption = (options, initialValue, isCount = false) => {
 // parse /api/servers/:id/settings output
 export const parseSettings = ({ workers: { worker_base: wb } }) => {
   const countDefault = wb.defaults.count;
+
   const memDefault = toBytes(wb.defaults.memory_threshold);
   const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
   const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
 
   const count = (worker) => ((worker && worker.count && (typeof worker.count === 'number')) ? worker.count : countDefault);
+  const bytes = (worker, defaultValue) => (worker && toBytes(worker.memory_threshold) || defaultValue);
 
   return {
     generic_worker: {
-      memory_threshold: parseWorker(wb.queue_worker_base.generic_worker).bytes || baseMemDefault,
+      memory_threshold: bytes(wb.queue_worker_base.generic_worker, baseMemDefault),
       count: count(wb.queue_worker_base.generic_worker),
     },
     priority_worker: {
-      memory_threshold: parseWorker(wb.queue_worker_base.priority_worker).bytes || baseMemDefault,
+      memory_threshold: bytes(wb.queue_worker_base.priority_worker, baseMemDefault),
       count: count(wb.queue_worker_base.priority_worker),
     },
     ems_metrics_collector_worker: {
       defaults: {
-        memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_collector_worker.defaults).bytes || baseMemDefault,
+        memory_threshold: bytes(wb.queue_worker_base.ems_metrics_collector_worker.defaults, baseMemDefault),
         count: count(wb.queue_worker_base.ems_metrics_collector_worker.defaults),
       },
     },
     ems_metrics_processor_worker: {
-      memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_processor_worker).bytes || baseMemDefault,
+      memory_threshold: bytes(wb.queue_worker_base.ems_metrics_processor_worker, baseMemDefault),
       count: count(wb.queue_worker_base.ems_metrics_processor_worker),
     },
     event_catcher: {
-      memory_threshold: parseWorker(wb.event_catcher).bytes || monitorDefault,
+      memory_threshold: bytes(wb.event_catcher, monitorDefault),
     },
     ems_refresh_worker: {
       defaults: {
-        memory_threshold: parseWorker(wb.queue_worker_base.ems_refresh_worker.defaults).bytes || baseMemDefault,
+        memory_threshold: bytes(wb.queue_worker_base.ems_refresh_worker.defaults, baseMemDefault),
       },
     },
     smart_proxy_worker: {
-      memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || baseMemDefault,
+      memory_threshold: bytes(wb.queue_worker_base.smart_proxy_worker, baseMemDefault),
       count: count(wb.queue_worker_base.smart_proxy_worker),
     },
     ui_worker: {
       count: count(wb.ui_worker),
     },
     reporting_worker: {
-      memory_threshold: parseWorker(wb.queue_worker_base.reporting_worker).bytes || baseMemDefault,
+      memory_threshold: bytes(wb.queue_worker_base.reporting_worker, baseMemDefault),
       count: count(wb.queue_worker_base.reporting_worker),
     },
     web_service_worker: {
-      memory_threshold: parseWorker(wb.web_service_worker).bytes || memDefault,
+      memory_threshold: bytes(wb.web_service_worker, memDefault),
       count: count(wb.web_service_worker),
     },
     remote_console_worker: {

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -224,17 +224,17 @@ export const injectOption = (options, initialValue, isCount = false) => {
 
 // parse /api/servers/:id/settings output
 export const parseSettings = ({ workers: { worker_base: wb } }) => {
-  const countDefault = wb.defaults.count;
-
-  const memDefault = toBytes(wb.defaults.memory_threshold);
-  const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
-  const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
-
   const workerCount = (worker) => (typeof worker.count === 'number') && worker.count;
   const workerBytes = (worker) => toBytes(worker.memory_threshold);
 
+  const countDefault = wb.defaults.count;
   const count = (path) => (_.get(wb, path) && workerCount(_.get(wb, path)) || countDefault);
-  const bytes = (path, defaultValue) => (_.get(wb, path) && workerBytes(_.get(wb, path)) || defaultValue);
+
+  const memDefault = toBytes(wb.defaults.memory_threshold);
+  const bytes = (path, defaultValue = memDefault) => (_.get(wb, path) && workerBytes(_.get(wb, path)) || defaultValue);
+
+  const baseMemDefault = bytes('queue_worker_base.defaults');
+  const monitorDefault = bytes('event_catcher.defaults');
 
   return {
     generic_worker: {

--- a/app/javascript/components/workers-form/helpers.js
+++ b/app/javascript/components/workers-form/helpers.js
@@ -236,50 +236,25 @@ export const parseSettings = (workersDef) => ({ workers: { worker_base: wb } }) 
   const baseMemDefault = bytes('queue_worker_base.defaults');
   const monitorDefault = bytes('event_catcher.defaults');
 
-  return {
-    generic_worker: {
-      memory_threshold: bytes('queue_worker_base.generic_worker', baseMemDefault),
-      count: count('queue_worker_base.generic_worker'),
-    },
-    priority_worker: {
-      memory_threshold: bytes('queue_worker_base.priority_worker', baseMemDefault),
-      count: count('queue_worker_base.priority_worker'),
-    },
-    ems_metrics_collector_worker: {
-      defaults: {
-        memory_threshold: bytes('queue_worker_base.ems_metrics_collector_worker.defaults', baseMemDefault),
-        count: count('queue_worker_base.ems_metrics_collector_worker.defaults'),
-      },
-    },
-    ems_metrics_processor_worker: {
-      memory_threshold: bytes('queue_worker_base.ems_metrics_processor_worker', baseMemDefault),
-      count: count('queue_worker_base.ems_metrics_processor_worker'),
-    },
-    event_catcher: {
-      memory_threshold: bytes('event_catcher', monitorDefault),
-    },
-    ems_refresh_worker: {
-      defaults: {
-        memory_threshold: bytes('queue_worker_base.ems_refresh_worker.defaults', baseMemDefault),
-      },
-    },
-    smart_proxy_worker: {
-      memory_threshold: bytes('queue_worker_base.smart_proxy_worker', baseMemDefault),
-      count: count('queue_worker_base.smart_proxy_worker'),
-    },
-    ui_worker: {
-      count: count('ui_worker'),
-    },
-    reporting_worker: {
-      memory_threshold: bytes('queue_worker_base.reporting_worker', baseMemDefault),
-      count: count('queue_worker_base.reporting_worker'),
-    },
-    web_service_worker: {
-      memory_threshold: bytes('web_service_worker', memDefault),
-      count: count('web_service_worker'),
-    },
-    remote_console_worker: {
-      count: count('remote_console_worker'),
-    },
+  const defaultThresholds = {
+    'defaults': memDefault,
+    'queue_worker_base': baseMemDefault,
+    'event_catcher': monitorDefault,
   };
+
+  const out = {};
+  workersDef.forEach((worker) => {
+    const path = _.compact([worker.prefix, worker.name]).join('.');
+
+    const obj = {};
+    if (worker.options.count) {
+      obj.count = count(path);
+    }
+    if (worker.options.memory_threshold) {
+      obj.memory_threshold = bytes(path, defaultThresholds[worker.options.default_threshold]);
+    }
+
+    _.set(out, worker.name, obj); // no prefix
+  });
+  return out;
 };

--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from 'patternfly-react';
 import { get } from 'lodash';
-import addSchema from './workers.schema';
+import { addSchema, workers } from './workers.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { API } from '../../http_api';
 import {
@@ -19,7 +19,7 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
   useEffect(() => {
     miqSparkleOn();
     API.get(`/api/servers/${id}/settings`)
-      .then(parseSettings)
+      .then(parseSettings(workers))
       .then((parsedValues) => {
         setInitialValues(parsedValues);
         setSchema(() => addSchema(parsedValues));

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -98,7 +98,7 @@ const countField = ({ name, options: { count: range, countHelperText: helperText
   name: `${name}.count`,
   options: injectOption(range, _.get(formValues, `${name}.count`), true),
   label: __('Count'),
-  helperText,
+  ...(helperText ? { helperText } : {}),  // helperText: helperText, but not there if undefined
 });
 
 const memoryThresholdField = ({ name, options: { memory_threshold: mtOptions } }, formValues) => ({

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -19,30 +19,37 @@ const memoryThresholds = {
 export const workers = [
   {
     name: 'generic_worker',
+    prefix: 'queue_worker_base',
     title: __('Generic Workers'),
     options: {
       count: 'range9',
       memory_threshold: 'basic',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'ems_metrics_collector_worker.defaults',  // .defaults?
+    prefix: 'queue_worker_base',
     title: __('C & U Data Collectors'),
     options: {
       count: 'range9',
       memory_threshold: 'basic',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'event_catcher',
     title: __('Event Monitor'),
     options: {
       memory_threshold: 'event_catcher',
+      default_threshold: 'event_catcher',
     },
   }, {
     name: 'smart_proxy_worker',
+    prefix: 'queue_worker_base',
     title: __('VM Analysis Collectors'),
     options: {
       count: 'range5',
       memory_threshold: 'smart_proxy',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'ui_worker',
@@ -53,30 +60,38 @@ export const workers = [
     },
   }, {
     name: 'reporting_worker',
+    prefix: 'queue_worker_base',
     title: __('Reporting Workers'),
     options: {
       count: 'range9',
       memory_threshold: 'basic',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'priority_worker',
+    prefix: 'queue_worker_base',
     title: __('Priority Workers'),
     options: {
       count: 'range9',
       memory_threshold: 'basic',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'ems_metrics_processor_worker',
+    prefix: 'queue_worker_base',
     title: __('C & U Data Processors'),
     options: {
       count: 'range4',
       memory_threshold: 'basic',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'ems_refresh_worker.defaults',  // .defaults?
+    prefix: 'queue_worker_base',
     title: __('Refresh'),
     options: {
       memory_threshold: 'ems_refresh',
+      default_threshold: 'queue_worker_base',
     },
   }, {
     name: 'remote_console_worker',
@@ -90,6 +105,7 @@ export const workers = [
     options: {
       count: 'range9',
       memory_threshold: 'basic',
+      default_threshold: 'defaults',
     },
   }
 ];

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -3,219 +3,142 @@ import {
   injectOption, generateBasicOptions, generateRange, generateRefreshOptions,
 } from './helpers';
 
-function addSchema(formValues) {
-  const basicOptions = generateBasicOptions();
-  const rangeNine = generateRange(10);
-  const rangeFour = generateRange(5);
-  const rangeFive = generateRange(6);
+// worker counts
+const range4 = generateRange(5); // 0..4
+const range5 = generateRange(6); // 0..5
+const range9 = generateRange(10); // 0..9
 
-  const fields = [{
-    component: 'dual-group',
-    name: 'group1',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'genericWorkers',
-        title: __('Generic Workers'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'generic_worker.count',
-            options: injectOption(rangeNine, formValues.generic_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'generic_worker.memory_threshold',
-            options: injectOption(basicOptions, formValues.generic_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
-        name: 'priorityWorkers',
-        title: __('Priority Workers'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'priority_worker.count',
-            options: injectOption(rangeNine, formValues.priority_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'priority_worker.memory_threshold',
-            options: injectOption(basicOptions, formValues.priority_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      },
-    ],
-  }, {
-    component: 'dual-group',
-    name: 'group3',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'cuCollectors',
-        title: __('C & U Data Collectors'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'ems_metrics_collector_worker.defaults.count',
-            options: injectOption(rangeNine, formValues.ems_metrics_collector_worker.defaults.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'ems_metrics_collector_worker.defaults.memory_threshold',
-            options: injectOption(basicOptions, formValues.ems_metrics_collector_worker.defaults.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
-        name: 'cuProccesors',
-        title: __('C & U Data Processors'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'ems_metrics_processor_worker.count',
-            options: injectOption(rangeFour, formValues.ems_metrics_processor_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'ems_metrics_processor_worker.memory_threshold',
-            options: injectOption(basicOptions, formValues.ems_metrics_processor_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      },
-    ],
-  }, {
-    component: 'dual-group',
-    name: 'group4',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'eventMonitor',
-        title: __('Event Monitor'),
-        fields: [{
-          component: componentTypes.SELECT,
-          name: 'event_catcher.memory_threshold',
-          options: injectOption(generateRefreshOptions(false, 100, 500), formValues.event_catcher.memory_threshold),
-          label: __('Memory threshold'),
-        },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
-        name: 'refresh',
-        title: __('Refresh'),
-        fields: [{
-          component: componentTypes.SELECT,
-          name: 'ems_refresh_worker.defaults.memory_threshold',
-          options: injectOption(generateRefreshOptions(), formValues.ems_refresh_worker.defaults.memory_threshold),
-          label: __('Memory threshold'),
-        },
-        ],
-      },
-    ],
-  },
+// memory thresholds
+const mtBasic = generateBasicOptions(); // 200M, 250M ... 500M, 600M ... 1.5G
+const mtEventCatcher = generateRefreshOptions(false, 100, 500); // 500M, 600M ... 3G, 3.5G ... 10G
+const mtEmsRefresh = generateRefreshOptions(); // 200M, 250M ... 600M, 700M ... 3G, 3.5G ... 10G
+const mtSmartProxy = generateRefreshOptions(true); // 200M, 250M ... 600M, 700M ... 1.9G
+
+const workers = [
   {
-    component: 'dual-group',
-    name: 'group5',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'vmAnalysisCollectors',
-        title: __('VM Analysis Collectors'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'smart_proxy_worker.count',
-            options: injectOption(rangeFive, formValues.smart_proxy_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'smart_proxy_worker.memory_threshold',
-            options: injectOption(generateRefreshOptions(true), formValues.smart_proxy_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      },
-    ],
-  },
-  {
-    component: 'dual-group',
-    name: 'group6',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'uiWorker',
-        title: __('UI Worker'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'ui_worker.count',
-            options: injectOption(rangeNine, formValues.ui_worker.count, true),
-            label: __('Count'),
-            helperText: __('Changing the UI Workers Count will immediately restart the webserver'),
-          },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
-        name: 'remoteWorkers',
-        title: __('Remote Console Workers'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'remote_console_worker.count',
-            options: injectOption(rangeNine, formValues.remote_console_worker.count, true),
-            label: __('Count'),
-          },
-        ],
-      },
-    ],
+    name: 'generic_worker',
+    title: __('Generic Workers'),
+    options: {
+      count: range9,
+      memory_threshold: mtBasic,
+    },
   }, {
-    component: 'dual-group',
-    name: 'group7',
-    fields: [
-      {
-        component: componentTypes.SUB_FORM,
-        name: 'reportingWorkers',
-        title: __('Reporting Workers'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'reporting_worker.count',
-            options: injectOption(rangeNine, formValues.reporting_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'reporting_worker.memory_threshold',
-            options: injectOption(basicOptions, formValues.reporting_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      }, {
-        component: componentTypes.SUB_FORM,
-        name: 'webServiceWorkers',
-        title: __('Web Service Workers'),
-        fields: [
-          {
-            component: componentTypes.SELECT,
-            name: 'web_service_worker.count',
-            options: injectOption(rangeNine, formValues.web_service_worker.count, true),
-            label: __('Count'),
-          }, {
-            component: componentTypes.SELECT,
-            name: 'web_service_worker.memory_threshold',
-            options: injectOption(basicOptions, formValues.web_service_worker.memory_threshold),
-            label: __('Memory threshold'),
-          },
-        ],
-      },
-    ],
-  },
-  ];
-  return { fields };
+    name: 'ems_metrics_collector_worker.defaults',  // .defaults?
+    title: __('C & U Data Collectors'),
+    options: {
+      count: range9,
+      memory_threshold: mtBasic,
+    },
+  }, {
+    name: 'event_catcher',
+    title: __('Event Monitor'),
+    options: {
+      memory_threshold: mtEventCatcher,
+    },
+  }, {
+    name: 'smart_proxy_worker',
+    title: __('VM Analysis Collectors'),
+    options: {
+      count: range5,
+      memory_threshold: mtSmartProxy,
+    },
+  }, {
+    name: 'ui_worker',
+    title: __('UI Worker'),
+    options: {
+      count: range9,
+      countHelperText: __('Changing the UI Workers Count will immediately restart the webserver'),
+    },
+  }, {
+    name: 'reporting_worker',
+    title: __('Reporting Workers'),
+    options: {
+      count: range9,
+      memory_threshold: mtBasic,
+    },
+  }, {
+    name: 'priority_worker',
+    title: __('Priority Workers'),
+    options: {
+      count: range9,
+      memory_threshold: mtBasic,
+    },
+  }, {
+    name: 'ems_metrics_processor_worker',
+    title: __('C & U Data Processors'),
+    options: {
+      count: range4,
+      memory_threshold: mtBasic,
+    },
+  }, {
+    name: 'ems_refresh_worker.defaults',  // .defaults?
+    title: __('Refresh'),
+    options: {
+      memory_threshold: mtEmsRefresh,
+    },
+  }, {
+    name: 'remote_console_worker',
+    title: __('Remote Console Workers'),
+    options: {
+      count: range9,
+    },
+  }, {
+    name: 'web_service_worker',
+    title: __('Web Service Workers'),
+    options: {
+      count: range9,
+      memory_threshold: mtBasic,
+    },
+  }
+];
+
+
+const countField = ({ name, options: { count: range, countHelperText: helperText } }, formValues) => ({
+  component: componentTypes.SELECT,
+  name: `${name}.count`,
+  options: injectOption(range, _.get(formValues, `${name}.count`), true),
+  label: __('Count'),
+  helperText,
+});
+
+const memoryThresholdField = ({ name, options: { memory_threshold: mtOptions } }, formValues) => ({
+  component: componentTypes.SELECT,
+  name: `${name}.memory_threshold`,
+  options: injectOption(mtOptions, _.get(formValues, `${name}.memory_threshold`)),
+  label: __('Memory threshold'),
+});
+
+
+const workerSubForm = (worker, formValues) => ({
+  component: componentTypes.SUB_FORM,
+  name: worker.name,
+  title: worker.title,
+  fields: _.compact([
+    worker.options.count && countField(worker, formValues),
+    worker.options.memory_threshold && memoryThresholdField(worker, formValues),
+  ]),
+});
+
+// [ a, b, c, d, e ] -> [ [ a, d ], [ b, e ], [ c, undefined ] ]
+const pairs = (array) => {
+  let [left, right] = _.chunk(array, Math.ceil(array.length / 2));
+  return _.zip(left, right);
+};
+
+const pairGroup = (fields, groupOptions) => ({
+  component: 'dual-group',
+  name: `group${groupOptions.index++}`,
+  fields,
+});
+
+function addSchema(formValues) {
+  const groupOptions = {
+    index: 1,
+  };
+  const workerForms = workers.map((worker) => workerSubForm(worker, formValues));
+  const dualGroups = pairs(workerForms).map((pair) => pairGroup(_.compact(pair), groupOptions));
+
+  return { fields: dualGroups };
 }
 
 export default addSchema;

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -14,7 +14,7 @@ const mtEventCatcher = generateRefreshOptions(false, 100, 500); // 500M, 600M ..
 const mtEmsRefresh = generateRefreshOptions(); // 200M, 250M ... 600M, 700M ... 3G, 3.5G ... 10G
 const mtSmartProxy = generateRefreshOptions(true); // 200M, 250M ... 600M, 700M ... 1.9G
 
-const workers = [
+export const workers = [
   {
     name: 'generic_worker',
     title: __('Generic Workers'),
@@ -131,7 +131,7 @@ const pairGroup = (fields, groupOptions) => ({
   fields,
 });
 
-function addSchema(formValues) {
+export function addSchema(formValues) {
   const groupOptions = {
     index: 1,
   };
@@ -140,5 +140,3 @@ function addSchema(formValues) {
 
   return { fields: dualGroups };
 }
-
-export default addSchema;

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -3,91 +3,93 @@ import {
   injectOption, generateBasicOptions, generateRange, generateRefreshOptions,
 } from './helpers';
 
-// worker counts
-const range4 = generateRange(5); // 0..4
-const range5 = generateRange(6); // 0..5
-const range9 = generateRange(10); // 0..9
+const workerCounts = {
+  'range4': generateRange(5), // 0..4
+  'range5': generateRange(6), // 0..5
+  'range9': generateRange(10), // 0..9
+};
 
-// memory thresholds
-const mtBasic = generateBasicOptions(); // 200M, 250M ... 500M, 600M ... 1.5G
-const mtEventCatcher = generateRefreshOptions(false, 100, 500); // 500M, 600M ... 3G, 3.5G ... 10G
-const mtEmsRefresh = generateRefreshOptions(); // 200M, 250M ... 600M, 700M ... 3G, 3.5G ... 10G
-const mtSmartProxy = generateRefreshOptions(true); // 200M, 250M ... 600M, 700M ... 1.9G
+const memoryThresholds = {
+  'basic': generateBasicOptions(), // 200M, 250M ... 500M, 600M ... 1.5G
+  'event_catcher': generateRefreshOptions(false, 100, 500), // 500M, 600M ... 3G, 3.5G ... 10G
+  'ems_refresh': generateRefreshOptions(), // 200M, 250M ... 600M, 700M ... 3G, 3.5G ... 10G
+  'smart_proxy': generateRefreshOptions(true), // 200M, 250M ... 600M, 700M ... 1.9G
+};
 
 export const workers = [
   {
     name: 'generic_worker',
     title: __('Generic Workers'),
     options: {
-      count: range9,
-      memory_threshold: mtBasic,
+      count: 'range9',
+      memory_threshold: 'basic',
     },
   }, {
     name: 'ems_metrics_collector_worker.defaults',  // .defaults?
     title: __('C & U Data Collectors'),
     options: {
-      count: range9,
-      memory_threshold: mtBasic,
+      count: 'range9',
+      memory_threshold: 'basic',
     },
   }, {
     name: 'event_catcher',
     title: __('Event Monitor'),
     options: {
-      memory_threshold: mtEventCatcher,
+      memory_threshold: 'event_catcher',
     },
   }, {
     name: 'smart_proxy_worker',
     title: __('VM Analysis Collectors'),
     options: {
-      count: range5,
-      memory_threshold: mtSmartProxy,
+      count: 'range5',
+      memory_threshold: 'smart_proxy',
     },
   }, {
     name: 'ui_worker',
     title: __('UI Worker'),
     options: {
-      count: range9,
+      count: 'range9',
       countHelperText: __('Changing the UI Workers Count will immediately restart the webserver'),
     },
   }, {
     name: 'reporting_worker',
     title: __('Reporting Workers'),
     options: {
-      count: range9,
-      memory_threshold: mtBasic,
+      count: 'range9',
+      memory_threshold: 'basic',
     },
   }, {
     name: 'priority_worker',
     title: __('Priority Workers'),
     options: {
-      count: range9,
-      memory_threshold: mtBasic,
+      count: 'range9',
+      memory_threshold: 'basic',
     },
   }, {
     name: 'ems_metrics_processor_worker',
     title: __('C & U Data Processors'),
     options: {
-      count: range4,
-      memory_threshold: mtBasic,
+      count: 'range4',
+      memory_threshold: 'basic',
     },
   }, {
     name: 'ems_refresh_worker.defaults',  // .defaults?
     title: __('Refresh'),
     options: {
-      memory_threshold: mtEmsRefresh,
+      memory_threshold: 'ems_refresh',
     },
   }, {
     name: 'remote_console_worker',
     title: __('Remote Console Workers'),
     options: {
-      count: range9,
+      count: 'range9',
     },
   }, {
     name: 'web_service_worker',
     title: __('Web Service Workers'),
     options: {
-      count: range9,
-      memory_threshold: mtBasic,
+      count: 'range9',
+      memory_threshold: 'basic',
     },
   }
 ];
@@ -96,7 +98,7 @@ export const workers = [
 const countField = ({ name, options: { count: range, countHelperText: helperText } }, formValues) => ({
   component: componentTypes.SELECT,
   name: `${name}.count`,
-  options: injectOption(range, _.get(formValues, `${name}.count`), true),
+  options: injectOption(workerCounts[range], _.get(formValues, `${name}.count`), true),
   label: __('Count'),
   ...(helperText ? { helperText } : {}),  // helperText: helperText, but not there if undefined
 });
@@ -104,7 +106,7 @@ const countField = ({ name, options: { count: range, countHelperText: helperText
 const memoryThresholdField = ({ name, options: { memory_threshold: mtOptions } }, formValues) => ({
   component: componentTypes.SELECT,
   name: `${name}.memory_threshold`,
-  options: injectOption(mtOptions, _.get(formValues, `${name}.memory_threshold`)),
+  options: injectOption(memoryThresholds[mtOptions], _.get(formValues, `${name}.memory_threshold`)),
   label: __('Memory threshold'),
 });
 

--- a/app/javascript/components/workers-form/workers.schema.test.js
+++ b/app/javascript/components/workers-form/workers.schema.test.js
@@ -11,8 +11,6 @@ it('schema generates correctly', () => {
           },
         },
         queue_worker_base: {
-          ems_metrics_collector_worker: {},
-          ems_refresh_worker: {},
           defaults: {
             memory_threshold: "500.megabytes",
           },

--- a/app/javascript/components/workers-form/workers.schema.test.js
+++ b/app/javascript/components/workers-form/workers.schema.test.js
@@ -1,4 +1,4 @@
-import addSchema from './workers.schema.js';
+import { addSchema } from './workers.schema.js';
 import { parseSettings } from './helpers.js';
 
 it('schema generates correctly', () => {

--- a/app/javascript/components/workers-form/workers.schema.test.js
+++ b/app/javascript/components/workers-form/workers.schema.test.js
@@ -1,0 +1,32 @@
+import addSchema from './workers.schema.js';
+import { parseSettings } from './helpers.js';
+
+it('schema generates correctly', () => {
+  const response = {
+    workers: {
+      worker_base: {
+        event_catcher: {
+          defaults: {
+            memory_threshold: "2.gigabytes",
+          },
+        },
+        queue_worker_base: {
+          ems_metrics_collector_worker: {},
+          ems_refresh_worker: {},
+          defaults: {
+            memory_threshold: "500.megabytes",
+          },
+        },
+        defaults: {
+          count: 1,
+          memory_threshold: "400.megabytes",
+        },
+      },
+    },
+  };
+
+  const parsed = parseSettings(response);
+  const schema = addSchema(parsed)
+
+  expect(schema).toMatchSnapshot();
+});

--- a/app/javascript/components/workers-form/workers.schema.test.js
+++ b/app/javascript/components/workers-form/workers.schema.test.js
@@ -5,19 +5,9 @@ it('schema generates correctly', () => {
   const response = {
     workers: {
       worker_base: {
-        event_catcher: {
-          defaults: {
-            memory_threshold: "2.gigabytes",
-          },
-        },
-        queue_worker_base: {
-          defaults: {
-            memory_threshold: "500.megabytes",
-          },
-        },
         defaults: {
           count: 1,
-          memory_threshold: "400.megabytes",
+          memory_threshold: "500.megabytes",
         },
       },
     },

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -4,6 +4,7 @@ require('@babel/polyfill');
 
 window.Rx = require('rxjs');
 window.$ = require('jquery');
+window._ = require('lodash');
 window.__ = (x) => x;
 window.n__ = (x) => x;
 


### PR DESCRIPTION
(
more todo (from https://github.com/ManageIQ/manageiq-ui-classic/pull/6767) figure out why it offers floating point values for memory thresholds in megabytes (human size display looks good
\+ move to api?)
)

---

Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/6767,
⚙ > accordion Settings > Server > tab Workers

---

The form schema was hardcoded with the list of workers and settings

* removing a worker created a free space in the form because it didn't realign
* the only schema differences were really the field name, form group title, and whether the worker only allows setting counts (and how many), memory thresholds (which values), or both. And a helper text for UI worker.

=> moving those into a data definition object,
creating a shared `countField`, `memoryThreshholdField`, `workerSubForm` helpers,
and generating the schema from that.

=> The list of workers gets automatically aligned to put the first half in the left column and the rest in the right column.

:-1: The list is still hardcoded in UI (just separated from form details), will need further API changes for that to change.

Added a snapshot test to ensure the schema stays consistent.

---

Parsing the output of the `/api/server/123/settings` endpoint would throw when a worker is removed, leading to a nondescript error (https://github.com/ManageIQ/manageiq-ui-classic/issues/6758).

Moved to a separate `parseSettings` function, which now only requires `workers.worker_base.defaults` to be present, and will deal with missing workers,
or incomplete settings.

And made that function use the same list of workers to find out which workers to look for and where.

---

Before:

![](https://user-images.githubusercontent.com/289743/76766708-5196a480-6790-11ea-9a0c-0ad92930a54a.png)

After:

![after](https://user-images.githubusercontent.com/289743/76777866-c8d43480-67a0-11ea-82f8-b152ac382761.png)