### PR TITLE
Correct typo and allow adding new and displaying details page of a Group

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -904,7 +904,7 @@ module OpsController::OpsRbac
     case @sb[:active_rbac_group_tab]
     when 'rbac_customer_tags'
       cats = Classification.categories.select do |c|
-        c.show || !%w[folder_path_blue folder_path_yellow].include?(c.name) && !(c.read_only? || c.entries.empty)
+        c.show || !%w[folder_path_blue folder_path_yellow].include?(c.name) && !(c.read_only? || c.entries.empty?)
       end
       cats.sort_by! { |t| t.description.try(:downcase) } # Get the categories, sort by description
       tags = cats.map do |cat|


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1813375

This PR corrects the typo and with the fix, it allows adding new and displaying details page of a Group, when there is a Category with **_Show in Console_** option set to **_No_**.

---

**Before:** Trying to add a new group, nothing happens in the UI:
![add_before](https://user-images.githubusercontent.com/13417815/76904135-aaa12e00-689f-11ea-8cee-6b78dcc37199.png)

**After:**
![add_after](https://user-images.githubusercontent.com/13417815/76904025-7299eb00-689f-11ea-9177-dc1fb34e0e96.png)
