### PR TITLE
MiqFormRenderer: fix proptype error

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -48,9 +48,7 @@ MiqFormRenderer.propTypes = {
   className: PropTypes.string,
   onStateUpdate: PropTypes.func,
   setPristine: PropTypes.func.isRequired,
-  formFieldsMapper: PropTypes.shape({
-    [PropTypes.string]: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.element]).isRequired,
-  }),
+  formFieldsMapper: PropTypes.any,
 };
 
 MiqFormRenderer.defaultProps = {


### PR DESCRIPTION
```
Warning: Failed prop type: The prop `formFieldsMapper.function () { [native code] }` is marked as required in `MiqFormRenderer`, but its value is `undefined`.
    in MiqFormRenderer (created by ConnectFunction)
    in ConnectFunction (created by WorkersForm)
    in div (created by Grid)
    in Grid (created by WorkersForm)
    in WorkersForm
    in Provider
```

introduced in #6769, cc @skateman ,  @Hyperkid123 

No point in validating `formFieldsMapper` in `MiqFormRenderer`, we're just passing this unaltered to DDF FormRender, that's where that validation should happen.

The bug is that all Object field names are strings, so `{ [PropTypes.string]: 123 }` becomes `{ "function () { [native code] }": 123 }`,
that's not a valid proptype.