### PR TITLE
Add javascript_tree_data helper, use instead of :javascript

### DIFF
--- a/app/helpers/js_helper.rb
+++ b/app/helpers/js_helper.rb
@@ -91,4 +91,8 @@ EOD
   def js_format_date(value)
     value.nil? ? 'undefined' : "new Date('#{value.iso8601}')"
   end
+
+  def javascript_tree_data(name, json)
+    javascript_tag("ManageIQ.tree.data['#{name}'] = #{json};")
+  end
 end

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -5,9 +5,8 @@
     - @accords.each do |accord|
       = miq_accordion_panel(accord[:title], selected == accord, accord[:container]) do
         -# Set the first tree to be rendered if there is a mismatch with the name/type
-        - tree = @trees.find(-> { @trees.first }) { |t| t.name == "#{accord[:name]}_tree".to_sym  }
-        :javascript
-          ManageIQ.tree.data['#{tree.name}'] = #{tree.locals_for_render[:bs_tree]};
+        - tree = @trees.find(-> { @trees.first }) { |t| t.name == "#{accord[:name]}_tree".to_sym }
+        = javascript_tree_data(tree.name, tree.locals_for_render[:bs_tree])
         %miq-tree-view{:name       => tree.name,
                        :data       => "vm.data['#{tree.name}']",
                        :reselect   => tree.locals_for_render[:allow_reselect],


### PR DESCRIPTION
something changed and `:javascript` tags are too eager to escape the data, leading to parse errors.

Before:

    <script>
      ManageIQ.tree.data['settings_tree'] = [{&quot;key&quot;:&quot;root&quot;,&quot;text&quot;:&quot;ManageIQ Region: Region 0 [0]&quot;,&quot;tooltip&quot;:&quot;ManageIQ Region: Region 0 [0]&quot;, ...
    </script>

Now:

    <script>
    //<![CDATA[
    ManageIQ.tree.data['settings_tree'] = [{"key":"root","text":"ManageIQ Region: Region 0 [0]", ...
    //]]>
    </script>

Fixes

    explorer:392 Uncaught SyntaxError: Unexpected token '&'
    explorer:396 Uncaught SyntaxError: Unexpected token '&'
    explorer:400 Uncaught SyntaxError: Unexpected token '&'

in ops.