### PR TITLE
Use onCheckGeneric for handling checked nodes in the policies tree

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -171,14 +171,6 @@ function miqTreeToggleExpand(treename, expand_mode) {
   expand_mode ? miqTreeObject(treename).expandAll() : miqTreeObject(treename).collapseAll();
 }
 
-// OnCheck handler for the Protect screen
-function miqOnCheckProtect(node, _treename) {
-  var ppid = node.key.split('_').pop();
-  var url = ManageIQ.tree.checkUrl + encodeURIComponent(ppid) + '?check=' + Number(node.state.checked);
-  miqJqueryRequest(url);
-  return true;
-}
-
 // OnClick handler for the VM Snapshot Tree
 function miqOnClickSnapshots(id) {
   var pieces = id.split(/-/);

--- a/app/controllers/application_controller/policy_support.rb
+++ b/app/controllers/application_controller/policy_support.rb
@@ -3,17 +3,17 @@ module ApplicationController::PolicySupport
 
   # Assign/unassign policies to/from a set of objects
   def protect
-    @gtl_type  = "grid"
-    @display   = nil
-    @edit      = session[:edit]
-    profile_id = params[:id].to_i
+    @gtl_type = "grid"
+    @display  = nil
+    @edit     = session[:edit]
 
     if params[:check] # Item was checked/unchecked
       @in_a_form = true
+      _, _, profile_id = TreeBuilder.extract_node_model_and_id(params[:id])
       if params[:check] == "0"
-        @edit[:new].delete(profile_id) # Unchecked, remove from new hash
+        @edit[:new].delete(profile_id.to_i) # Unchecked, remove from new hash
       else
-        @edit[:new][profile_id] = session[:pol_items].length # Added, set to all checked
+        @edit[:new][profile_id.to_i] = session[:pol_items].length # Added, set to all checked
       end
       changed = (@edit[:new] != @edit[:current])
       render :update do |page|

--- a/app/presenters/tree_builder_protect.rb
+++ b/app/presenters/tree_builder_protect.rb
@@ -12,7 +12,7 @@ class TreeBuilderProtect < TreeBuilder
     {
       :full_ids   => false,
       :checkboxes => true,
-      :oncheck    => "miqOnCheckProtect",
+      :oncheck    => "miqOnCheckGeneric",
       :check_url  => "/#{@data[:controller_name]}/protect/"
     }
   end

--- a/spec/presenters/tree_builder_protect_spec.rb
+++ b/spec/presenters/tree_builder_protect_spec.rb
@@ -28,13 +28,13 @@ describe TreeBuilderProtect do
         :full_ids   => false,
         :checkboxes => true,
         :check_url  => "/name/protect/",
-        :oncheck    => "miqOnCheckProtect"
+        :oncheck    => "miqOnCheckGeneric"
       )
     end
 
     it 'set locals for render correctly' do
       locals = @protect_tree.send(:set_locals_for_render)
-      expect(locals[:oncheck]).to eq("miqOnCheckProtect")
+      expect(locals[:oncheck]).to eq("miqOnCheckGeneric")
       expect(locals[:checkboxes]).to eq(true)
       expect(locals[:check_url]).to eq("/name/protect/")
     end


### PR DESCRIPTION
I'm trying to reduce the number of handler functions in miq_tree.js, this one was kinda trivial. Instead of altering the node's key on the client side, I'm parsing it on the server side. You can test this on any entity that supports policies, e.g. virtual machines. Simply select one and go to `Policy -> Manage Policies` and try to assign or unassign some.

@miq-bot add_label refactoring, technical debt, trees