### PR TITLE
Display success flash message after canceling adding/removing Security Group

### DIFF
--- a/app/assets/javascripts/components/vm_cloud/vm-cloud-add-security-group.js
+++ b/app/assets/javascripts/components/vm_cloud/vm-cloud-add-security-group.js
@@ -48,7 +48,7 @@ function vmCloudAddSecurityGroupFormController(API, miqService, $q) {
 
   vm.cancelClicked = function() {
     miqService.sparkleOn();
-    miqService.redirectBack(sprintf(__('Addition of security group was canceled by the user.')), 'warning', vm.redirectUrl);
+    miqService.redirectBack(sprintf(__('Addition of security group was canceled by the user.')), 'success', vm.redirectUrl);
   };
 
   vm.addClicked = function() {

--- a/app/assets/javascripts/components/vm_cloud/vm-cloud-remove-security-group.js
+++ b/app/assets/javascripts/components/vm_cloud/vm-cloud-remove-security-group.js
@@ -33,7 +33,7 @@ function vmCloudRemoveSecurityGroupFormController(API, miqService) {
 
   vm.cancelClicked = function() {
     miqService.sparkleOn();
-    miqService.redirectBack(sprintf(__('Removal of security group was canceled by the user.')), 'warning', vm.redirectUrl);
+    miqService.redirectBack(sprintf(__('Removal of security group was canceled by the user.')), 'success', vm.redirectUrl);
   };
 
   vm.saveClicked = function() {


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6786

Warning flash message was displayed after canceling adding/removing Security Group from an Instance. This was inconsistent with displaying flash messages after canceling other actions in this or in all other screens. This very simple PR makes it consistent again.

---

**Before:**
After adding Security Group to an Instance:
![sec_before](https://user-images.githubusercontent.com/13417815/77439402-49211800-6de7-11ea-9627-359933bbfc3e.png)
After removing Security Group from an Instance:
![removal_before](https://user-images.githubusercontent.com/13417815/77468715-438af880-6e0e-11ea-9469-b0e2192aa4af.png)

**After:**
![sec_after](https://user-images.githubusercontent.com/13417815/77439409-4c1c0880-6de7-11ea-88dc-e319b7eca5e1.png)
![removal_after](https://user-images.githubusercontent.com/13417815/77468731-484fac80-6e0e-11ea-8802-7c7c973e904d.png)
