### PR TITLE
Remove listnav from Ansible Credentials/Playbooks/Repositories list screens

### DIFF
--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -2,6 +2,8 @@ module ApplicationHelper::PageLayouts
   def layout_uses_listnav?
     return false if show_list_with_no_provider?
 
+    return false if show_list_ansible?
+
     return false if @in_a_form
 
     return false if %w[
@@ -55,6 +57,15 @@ module ApplicationHelper::PageLayouts
     return false if controller.action_name.end_with?("tagging_edit")
 
     true
+  end
+
+  def show_list_ansible?
+    %w[
+      ansible_credential
+      ansible_playbook
+      ansible_repository
+    ].include?(controller_name) &&
+      action_name == 'show_list'
   end
 
   def show_list_with_no_provider?

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -20,9 +20,9 @@ describe AnsibleCredentialController do
     subject { get :show_list, :params => {} }
     render_views
 
-    it "renders correct template and listnav" do
+    it "renders correct template and does not render listnav" do
       is_expected.to render_template(:partial => "layouts/_gtl")
-      is_expected.to render_template(:partial => "layouts/listnav/_show_list")
+      is_expected.not_to render_template(:partial => "layouts/listnav/_show_list")
       is_expected.to have_http_status 200
     end
 

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -25,9 +25,9 @@ describe AnsiblePlaybookController do
     subject { get :show_list }
     render_views
 
-    it "renders correct template and listnav" do
+    it "renders correct template and does not render listnav" do
       is_expected.to render_template(:partial => "layouts/_gtl")
-      is_expected.to render_template(:partial => "layouts/listnav/_show_list")
+      is_expected.not_to render_template(:partial => "layouts/listnav/_show_list")
       is_expected.to have_http_status 200
     end
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -31,10 +31,10 @@ describe AnsibleRepositoryController do
     describe "#show_list" do
       subject { get :show_list, :params => {} }
 
-      it "render list of repositories with a toolbar and listnav" do
+      it "render list of repositories with a toolbar and without listnav" do
         expect(ApplicationHelper::Toolbar::AnsibleRepositoriesCenter).to receive(:definition).and_call_original
         is_expected.to render_template(:partial => "layouts/_gtl")
-        is_expected.to render_template(:partial => "layouts/listnav/_show_list")
+        is_expected.not_to render_template(:partial => "layouts/listnav/_show_list")
         is_expected.to have_http_status 200
       end
     end

--- a/spec/helpers/application_helper/page_layouts_spec.rb
+++ b/spec/helpers/application_helper/page_layouts_spec.rb
@@ -1,0 +1,12 @@
+describe ApplicationHelper::PageLayouts do
+  describe '#layout_uses_listnav?' do
+    before { allow(helper).to receive(:action_name).and_return('show_list') }
+
+    %w[ansible_credential ansible_playbook ansible_repository].each do |ctrl_name|
+      it 'returns false for Automation Ansible list screens not to render listnav' do
+        allow(helper).to receive(:controller_name).and_return(ctrl_name)
+        expect(helper.layout_uses_listnav?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6765

**Ansible Credentials/Playbooks/Repositories** list screens don't have _Advanced Search_ so the presence of listnav with _"No filters defined"_ in accordion is misleading. This PR removes the listnav from such screens. Note that after clicking on any item in the list, the listnav will be present, as expected.

---

**Before:**
Ansible Credentials screen (similarly for Playbooks/Repositories screens):
![ansible_before](https://user-images.githubusercontent.com/13417815/77469226-0b37ea00-6e0f-11ea-931b-f2ec96e51496.png)

**After:**
![ansible_after](https://user-images.githubusercontent.com/13417815/77470469-007e5480-6e11-11ea-9d5f-698c608f4de7.PNG)
