### PR TITLE
Clean up the capacity and utilization selection trees 

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -271,13 +271,6 @@ function miqOnCheckUserFilters(node, tree_name) {
   return true;
 }
 
-// OnCheck handler for the C&U collection trees
-function miqOnCheckCUFilters(node, tree_name) {
-  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(node.key) + '&check=' + encodeURIComponent(node.state.checked) + '&tree_name=' + encodeURIComponent(tree_name);
-  miqJqueryRequest(url);
-  return true;
-}
-
 function miqMenuChangeRow(action, elem) {
   var grid = $('#folder_grid .panel-group');
   var selected = grid.find('.panel-heading.active').parent();
@@ -379,7 +372,6 @@ function miqSquashToggle(treeName) {
 
 function miqTreeEventSafeEval(func) {
   var whitelist = [
-    'miqOnCheckCUFilters',
     'miqOnCheckGenealogy',
     'miqOnCheckGeneric',
     'miqOnClickMenuRoles',

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -271,13 +271,6 @@ function miqOnCheckUserFilters(node, tree_name) {
   return true;
 }
 
-// OnCheck handler for Check All checkbox on C&U collection trees
-function miqCheckCUAll(cb, treename) {
-  cb.checked ? miqTreeObject(treename).checkAll({silent: true}) : miqTreeObject(treename).uncheckAll({silent: true});
-  var url = ManageIQ.tree.checkUrl + '?check_all=' + encodeURIComponent(cb.checked) + '&tree_name=' + encodeURIComponent(treename);
-  miqJqueryRequest(url);
-}
-
 // OnCheck handler for the C&U collection trees
 function miqOnCheckCUFilters(node, tree_name) {
   var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(node.key) + '&check=' + encodeURIComponent(node.state.checked) + '&tree_name=' + encodeURIComponent(tree_name);

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -156,23 +156,14 @@ module OpsController::Settings::CapAndU
     end
 
     if params[:tree_name] == 'datastore_tree'
-      datastore_tree_settings(model, id)
+      @edit[:new][:storages][id.to_i][:capture] = params[:check] == "true"
     elsif params[:tree_name] == 'cluster_tree'
       cluster_tree_settings(model, id)
     end
   end
 
   def cluster_tree_settings(model, id)
-    if params[:check_all] # to handle check/uncheck cluster all checkbox
-      @edit[:new][:clusters].each do |c| # Check each clustered host
-        @edit[:new][c[:id]].each do |h|
-          h[:capture] = params[:check_all] == "true" # Set C&U flag depending on if checkbox parm is present
-        end
-      end
-      @edit[:new][:non_cl_hosts].each do |c|
-        c[:capture] = params[:check_all] == 'true'
-      end
-    elsif id == "NonCluster" # Clicked on all non-clustered hosts
+    if id == "NonCluster" # Clicked on all non-clustered hosts
       @edit[:new][:non_cl_hosts].each { |c| c[:capture] = params[:check] == "true" }
     elsif model == "EmsCluster" # Clicked on a cluster
       @edit[:new][id.to_i].each { |h| h[:capture] = params[:check] == "true" }
@@ -189,16 +180,6 @@ module OpsController::Settings::CapAndU
           found
         end
       end
-    end
-  end
-
-  def datastore_tree_settings(_model, id)
-    if params[:check_all] # to handle check/uncheck storage all checkbox
-      @edit[:new][:storages].each do |_, s| # Check each storage
-        s[:capture] = params[:check_all] == "true" # Set C&U flag depending on if checkbox parm is present
-      end
-    else
-      @edit[:new][:storages][id.to_i][:capture] = params[:check] == "true"
     end
   end
 end

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -153,30 +153,30 @@ module OpsController::Settings::CapAndU
 
     if params[:id]
       model, id, _ = TreeBuilder.extract_node_model_and_id(params[:id])
-    end
 
-    if params[:tree_name] == 'datastore_tree'
-      @edit[:new][:storages][id.to_i][:capture] = params[:check] == "true"
-    elsif params[:tree_name] == 'cluster_tree'
-      cluster_tree_settings(model, id)
+      if model == 'Storage'
+        @edit[:new][:storages][id.to_i][:capture] = params[:check] == "1"
+      else
+        cluster_tree_settings(model, id)
+      end
     end
   end
 
   def cluster_tree_settings(model, id)
     if id == "NonCluster" # Clicked on all non-clustered hosts
-      @edit[:new][:non_cl_hosts].each { |c| c[:capture] = params[:check] == "true" }
+      @edit[:new][:non_cl_hosts].each { |c| c[:capture] = params[:check] == "1" }
     elsif model == "EmsCluster" # Clicked on a cluster
-      @edit[:new][id.to_i].each { |h| h[:capture] = params[:check] == "true" }
+      @edit[:new][id.to_i].each { |h| h[:capture] = params[:check] == "1" }
     elsif model == "Host" # Clicked on a host
       nc_host = @edit[:new][:non_cl_hosts].find { |x| x[:id] == id.to_i }
       # The host is among the non-clustered ones
-      return nc_host[:capture] = params[:check] == "true" if nc_host
+      return nc_host[:capture] = params[:check] == "1" if nc_host
 
       # The host is under a cluster, find it and change it
       @edit[:new][:clusters].find do |cl|
         @edit[:new][cl[:id]].find do |h|
           found = h[:id] == id.to_i
-          h[:capture] = params[:check] == "true" if found
+          h[:capture] = params[:check] == "1" if found
           found
         end
       end

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -1,72 +1,58 @@
 class TreeBuilderClusters < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
+  has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
-  def initialize(name, sandbox, build = true, **params)
-    @root = params[:root]
-    @data = EmsCluster.get_perf_collection_object_list
+  def initialize(name, sandbox, build = true)
+    @clusters = EmsCluster.get_perf_collection_object_list
+    @nc_hosts = ExtManagementSystem.in_my_region.map(&:non_clustered_hosts).flatten
     super(name, sandbox, build)
   end
 
   private
+
+  def override(node, object)
+    case object
+    when EmsCluster
+      node.checkable = @clusters[object.id][:ho_ids].any?
+    when Host
+      parent = @clusters[object.ems_cluster_id]
+      node.checked = parent ? parent[:ho_enabled].include?(object) : object.perf_capture_enabled?
+    end
+    node.selectable = false
+  end
 
   def tree_init_options
     {
       :full_ids     => false,
       :checkboxes   => true,
       :three_checks => true,
+      :post_check   => true,
       :oncheck      => "miqOnCheckCUFilters",
-      :check_url    => "/ops/cu_collection_field_changed/"
+      :check_url    => "/ops/cu_collection_field_changed/",
     }
   end
 
-  def non_cluster_selected
-    checked = @root[:non_cl_hosts].count { |item| item[:capture] }
-    if @root[:non_cl_hosts].size == checked
-      true
-    elsif checked == 0
-      false
-    else
-      'undefined'
-    end
-  end
-
   def x_get_tree_roots
-    nodes = @root[:clusters].map do |node|
-      { :id         => node[:id].to_s,
-        :text       => node[:name],
-        :icon       => 'pficon pficon-cluster',
-        :tip        => node[:name],
-        :checked    => node[:capture],
-        :nodes      => @data[node[:id]][:ho_enabled] + @data[node[:id]][:ho_disabled],
-        :selectable => false}
+    nodes = @clusters.map { |_, cl| cl[:cl_rec] }.sort_by(&:name)
+
+    if @nc_hosts.present?
+      nodes.push(
+        :id   => "NonCluster",
+        :text => t = _("Non-clustered Hosts"),
+        :icon => Host.decorate.fonticon,
+        :tip  => t
+      )
     end
-    if @root[:non_cl_hosts].present?
-      node = {:id         => "NonCluster",
-              :text       => _("Non-clustered Hosts"),
-              :icon       => 'pficon pficon-container-node',
-              :tip        => _("Non-clustered Hosts"),
-              :checked    => non_cluster_selected,
-              :nodes      => @root[:non_cl_hosts],
-              :selectable => false}
-      nodes.push(node)
-    end
+
     count_only_or_objects(false, nodes)
   end
 
-  def x_get_tree_hash_kids(parent, count_only)
-    hosts = parent[:nodes]
-    nodes = hosts.map do |node|
-      if @data[parent[:id].to_i]
-        value = @data[parent[:id].to_i][:ho_disabled].include?(node)
-      end
-      {:id         => "#{parent[:id]}_#{node[:id]}",
-       :text       => node[:name],
-       :tip        => _("Host: %{name}") % {:name => node[:name]},
-       :icon       => 'pficon pficon-container-node',
-       :checked    => node.kind_of?(Hash) ? node[:capture] : !value,
-       :selectable => false,
-       :nodes      => []}
-    end
+  def x_get_tree_cluster_kids(parent, count_only)
+    nodes = (@clusters[parent.id][:ho_enabled] + @clusters[parent.id][:ho_disabled]).sort_by(&:name)
     count_only_or_objects(count_only, nodes)
+  end
+
+  def x_get_tree_hash_kids(_parent, count_only)
+    count_only_or_objects(count_only, @nc_hosts)
   end
 end

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -27,7 +27,7 @@ class TreeBuilderClusters < TreeBuilder
       :checkboxes   => true,
       :three_checks => true,
       :post_check   => true,
-      :oncheck      => "miqOnCheckCUFilters",
+      :oncheck      => "miqOnCheckGeneric",
       :check_url    => "/ops/cu_collection_field_changed/",
     }
   end

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -2,8 +2,8 @@ class TreeBuilderClusters < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
-  def initialize(name, sandbox, build = true)
-    @clusters = EmsCluster.get_perf_collection_object_list
+  def initialize(name, sandbox, build = true, **params)
+    @clusters = params[:root]
     @nc_hosts = ExtManagementSystem.in_my_region.map(&:non_clustered_hosts).flatten
     super(name, sandbox, build)
   end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -1,13 +1,33 @@
 class TreeBuilderDatastores < TreeBuilder
   has_kids_for Hash, [:x_get_tree_hash_kids]
+  has_kids_for Storage, [:x_get_tree_storage_kids]
 
   def initialize(name, sandbox, build = true, **params)
     @root = params[:root]
-    @data = Storage.all.each_with_object({}) { |st, h| h[st.id] = st; }
     super(name, sandbox, build)
   end
 
   private
+
+  def override(node, object)
+    if object.kind_of?(Storage)
+      item = @root[object.id]
+
+      node.checked = item[:capture]
+
+      node.tooltip = "#{item[:name]} [#{item[:location]}]"
+      node.text = ViewHelper.capture do
+        ViewHelper.concat_tag(:strong, item[:name])
+        ViewHelper.concat(' [')
+        ViewHelper.concat(item[:location])
+        ViewHelper.concat(']')
+      end
+    else
+      node.hide_checkbox = true
+    end
+
+    node.selectable = false
+  end
 
   def tree_init_options
     {
@@ -19,42 +39,12 @@ class TreeBuilderDatastores < TreeBuilder
   end
 
   def x_get_tree_roots
-    nodes = @root.map do |node|
-      children = []
-      if @data[node[:id]].hosts.present?
-        children = @data[node[:id]].hosts.sort_by { |host| host.name.try(:downcase) }.map do |kid|
-          {:name => kid.name}
-        end
-      end
-
-      text = ViewHelper.capture do
-        ViewHelper.concat_tag(:strong, node[:name])
-        ViewHelper.concat(' [')
-        ViewHelper.concat(node[:location])
-        ViewHelper.concat(']')
-      end
-
-      { :id         => node[:id].to_s,
-        :text       => text,
-        :icon       => 'fa fa-database',
-        :tip        => "#{node[:name]} [#{node[:location]}]",
-        :checked    => node[:capture] == true,
-        :selectable => false,
-        :nodes      => children }
-    end
+    nodes = @root.map { |_, n| n[:st_rec] }
     count_only_or_objects(false, nodes)
   end
 
-  def x_get_tree_hash_kids(parent, count_only)
-    nodes = parent[:nodes].map do |node|
-      { :id           => node[:name],
-        :text         => node[:name],
-        :icon         => 'pficon pficon-container-node',
-        :tip          => node[:name],
-        :hideCheckbox => true,
-        :selectable   => false,
-        :nodes        => [] }
-    end
+  def x_get_tree_storage_kids(parent, count_only)
+    nodes = parent.hosts.sort_by { |host| host.name.try(:downcase) }
     count_only_or_objects(count_only, nodes)
   end
 end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -33,7 +33,7 @@ class TreeBuilderDatastores < TreeBuilder
     {
       :full_ids   => false,
       :checkboxes => true,
-      :oncheck    => "miqOnCheckCUFilters",
+      :oncheck    => "miqOnCheckGeneric",
       :check_url  => "/ops/cu_collection_field_changed/"
     }
   end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -3,6 +3,7 @@ class TreeBuilderDatastores < TreeBuilder
   has_kids_for Storage, [:x_get_tree_storage_kids]
 
   def initialize(name, sandbox, build = true, **params)
+    @storages = Storage.in_my_region.includes(:hosts).select(:id, :name, :location)
     @root = params[:root]
     super(name, sandbox, build)
   end
@@ -11,15 +12,13 @@ class TreeBuilderDatastores < TreeBuilder
 
   def override(node, object)
     if object.kind_of?(Storage)
-      item = @root[object.id]
+      node.checked = @root[object.id][:capture]
 
-      node.checked = item[:capture]
-
-      node.tooltip = "#{item[:name]} [#{item[:location]}]"
+      node.tooltip = "#{object.name} [#{object.location}]"
       node.text = ViewHelper.capture do
-        ViewHelper.concat_tag(:strong, item[:name])
+        ViewHelper.concat_tag(:strong, object.name)
         ViewHelper.concat(' [')
-        ViewHelper.concat(item[:location])
+        ViewHelper.concat(object.location)
         ViewHelper.concat(']')
       end
     else
@@ -39,8 +38,7 @@ class TreeBuilderDatastores < TreeBuilder
   end
 
   def x_get_tree_roots
-    nodes = @root.map { |_, n| n[:st_rec] }
-    count_only_or_objects(false, nodes)
+    count_only_or_objects(false, @storages)
   end
 
   def x_get_tree_storage_kids(parent, count_only)

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -1,7 +1,7 @@
 module TreeNode
   class Node
     attr_reader :nodes, :tree
-    attr_writer :icon, :image
+    attr_writer :icon, :image, :text
     attr_accessor :checkable, :checked, :color, :expanded, :hide_checkbox, :icon_background, :lazy, :klass, :selectable, :selected, :tooltip
 
     def initialize(object, parent_id, tree)

--- a/app/presenters/tree_node/storage.rb
+++ b/app/presenters/tree_node/storage.rb
@@ -1,4 +1,5 @@
 module TreeNode
   class Storage < Node
+    set_attribute(:text, &:name) # Even this is obvious, it's needed for additional changes in the C&U tree
   end
 end

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -28,8 +28,6 @@
                   %br/
                   %b= _("Enable Collection by Cluster")
                   %br/
-                  %input#cl_toggle{:name => "cl_toggle", :onchange => "miqCheckCUAll(this,'#{@cluster_tree.name}');", :type => "checkbox"}/
-                  = _("Check All")
                   :javascript
                     miqTreeResetState('#{j_str @cluster_tree.name}');
                   = render(:partial => 'shared/tree', :locals => {:tree => @cluster_tree, :name => @cluster_tree.name})
@@ -59,8 +57,6 @@
                   %br/
                   %b= _("Enable Collection by Datastore")
                   %br/
-                  %input#ds_toggle{:name => "ds_toggle", :onchange => "miqCheckCUAll(this,'#{@datastore_tree.name}');", :type => "checkbox"}/
-                  = _("Check All")
                   :javascript
                     miqTreeResetState('#{j_str @datastore_tree.name}');
                   = render(:partial => 'shared/tree', :locals => {:tree => @datastore_tree, :name => @datastore_tree.name})

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -15,7 +15,7 @@ describe TreeBuilderClusters do
       allow(host_2).to receive(:perf_capture_enabled?).and_return(false)
     end
 
-    subject { TreeBuilderClusters.new(:cluster_tree, {}, true) }
+    subject { TreeBuilderClusters.new(:cluster_tree, {}, true, :root => EmsCluster.get_perf_collection_object_list) }
 
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = subject.send(:tree_init_options)

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderClusters do
         :post_check   => true,
         :checkboxes   => true,
         :three_checks => true,
-        :oncheck      => "miqOnCheckCUFilters",
+        :oncheck      => "miqOnCheckGeneric",
         :check_url    => "/ops/cu_collection_field_changed/"
       )
     end

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -1,26 +1,27 @@
 describe TreeBuilderClusters do
   context 'TreeBuilderClusters' do
+    let(:cluster) { FactoryBot.create(:ems_cluster) }
+    let(:ems) { FactoryBot.create(:ext_management_system) }
+
+    let(:host_1) { FactoryBot.create(:host, :ems_cluster => cluster) }
+    let(:host_2) { FactoryBot.create(:host, :ems_cluster => cluster) }
+    let(:host_3) { FactoryBot.create(:host, :ext_management_system => ems) }
+
     before do
-      role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Clusters Group")
-      login_as FactoryBot.create(:user, :userid => 'clusters__wilma', :miq_groups => [@group])
-      @ho_enabled = [FactoryBot.create(:host)]
-      @ho_disabled = [FactoryBot.create(:host)]
-      allow(EmsCluster).to receive(:get_perf_collection_object_list).and_return(:'1'.to_i =>
-                                                                                             {:id          => 1,
-                                                                                              :name        => 'Name',
-                                                                                              :capture     => 'unsure',
-                                                                                              :ho_enabled  => @ho_enabled,
-                                                                                              :ho_disabled => @ho_disabled})
-      @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
-      @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-      @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true, :root => @cluster)
+      MiqRegion.seed
+      login_as FactoryBot.create(:user_admin)
+
+      allow(host_1).to receive(:perf_capture_enabled?).and_return(true)
+      allow(host_2).to receive(:perf_capture_enabled?).and_return(false)
     end
 
+    subject { TreeBuilderClusters.new(:cluster_tree, {}, true) }
+
     it 'sets tree to have full ids, not lazy and no root' do
-      root_options = @cluster_tree.send(:tree_init_options)
+      root_options = subject.send(:tree_init_options)
       expect(root_options).to eq(
         :full_ids     => false,
+        :post_check   => true,
         :checkboxes   => true,
         :three_checks => true,
         :oncheck      => "miqOnCheckCUFilters",
@@ -28,66 +29,36 @@ describe TreeBuilderClusters do
       )
     end
 
-    it 'sets tree to have full ids, not lazy and no root' do
-      locals = @cluster_tree.send(:set_locals_for_render)
-      expect(locals[:checkboxes]).to eq(true)
-      expect(locals[:oncheck]).to eq("miqOnCheckCUFilters")
-      expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
-    end
+    describe '#x_get_tree_roots' do
+      context 'nonclustered nodes available' do
+        before { allow(host_3).to receive(:perf_capture_enabled?).and_return(true) }
 
-    it 'set cluster nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
-      expect(cluster_nodes.first).to eq(:id         => "1",
-                                        :text       => "Name",
-                                        :icon       => 'pficon pficon-cluster',
-                                        :tip        => "Name",
-                                        :checked    => 'unsure',
-                                        :selectable => false,
-                                        :nodes      => @ho_enabled + @ho_disabled)
-      # non-cluster-node
-      expect(cluster_nodes.last).to eq(:id         => "NonCluster",
-                                       :text       => "Non-clustered Hosts",
-                                       :icon       => 'pficon pficon-container-node',
-                                       :tip        => "Non-clustered Hosts",
-                                       :checked    => true,
-                                       :selectable => false,
-                                       :nodes      => @non_cluster_hosts)
-    end
-
-    it 'sets non-cluster host nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
-      non_cluster_host = @cluster_tree.send(:x_get_tree_hash_kids, cluster_nodes.last, false)
-      expect(non_cluster_host).to eq([{:id         => "NonCluster_2",
-                                       :text       => "Non Cluster Host",
-                                       :tip        => "Host: Non Cluster Host",
-                                       :icon       => 'pficon pficon-container-node',
-                                       :checked    => true,
-                                       :selectable => false,
-                                       :nodes      => []}])
-    end
-
-    it 'sets cluster hosts nodes correctly' do
-      cluster_nodes = @cluster_tree.send(:x_get_tree_roots)
-      cluster_hosts = @cluster_tree.send(:x_get_tree_hash_kids, cluster_nodes.first, false)
-      cluster_hosts_expected = @ho_enabled.map do |node|
-        {:id         => "#{cluster_nodes.first[:id]}_#{node[:id]}",
-         :text       => node[:name],
-         :tip        => "Host: %{name}" % {:name => node[:name]},
-         :icon       => 'pficon pficon-container-node',
-         :checked    => true,
-         :selectable => false,
-         :nodes      => []}
+        it 'sets root nodes' do
+          nodes = subject.send(:x_get_tree_roots)
+          expect(nodes.length).to eq(2)
+        end
       end
-      cluster_hosts_expected += @ho_disabled.map do |node|
-        {:id         => "#{cluster_nodes.first[:id]}_#{node[:id]}",
-         :text       => node[:name],
-         :tip        => "Host: %{name}" % {:name => node[:name]},
-         :icon       => 'pficon pficon-container-node',
-         :checked    => false,
-         :selectable => false,
-         :nodes      => []}
+
+      it 'sets root nodes' do
+        nodes = subject.send(:x_get_tree_roots)
+        expect(nodes.length).to eq(1)
       end
-      expect(cluster_hosts).to eq(cluster_hosts_expected)
+    end
+
+    describe '#x_get_tree_cluster_kids' do
+      it 'sets cluster kids' do
+        nodes = subject.send(:x_get_tree_cluster_kids, cluster, false)
+        expect(nodes.length).to eq(2)
+      end
+    end
+
+    describe '#x_get_tree_hash_kids' do
+      before { allow(host_3).to receive(:perf_capture_enabled?).and_return(true) }
+
+      it 'sets nonclustered hosts' do
+        nodes = subject.send(:x_get_tree_hash_kids, {}, false)
+        expect(nodes.length).to eq(1)
+      end
     end
   end
 end

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -2,13 +2,24 @@ describe TreeBuilderDatastores do
   context 'TreeBuilderDatastores' do
     before do
       role = MiqUserRole.find_by(:name => "EvmRole-operator")
-      @group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Datastores Group")
-      login_as FactoryBot.create(:user, :userid => 'datastores_wilma', :miq_groups => [@group])
+      group = FactoryBot.create(:miq_group, :miq_user_role => role, :description => "Datastores Group")
+      login_as FactoryBot.create(:user, :userid => 'datastores_wilma', :miq_groups => [group])
       @host = FactoryBot.create(:host, :name => 'Host Name')
       storage = FactoryBot.create(:storage, :hosts => [@host])
-      @datastore = [{:id => storage.id, :name => 'Datastore', :location => 'Location', :capture => false}]
+
+      @datastore = {
+        storage.id => {
+          :id       => storage.id,
+          :st_rec   => storage,
+          :name     => 'Datastore',
+          :location => 'Location',
+          :capture  => false
+        }
+      }
+
       @datastores_tree = TreeBuilderDatastores.new(:datastore, {}, true, :root => @datastore)
     end
+
     it 'sets tree to have full ids, not lazy and no root' do
       root_options = @datastores_tree.send(:tree_init_options)
       expect(root_options).to eq(
@@ -18,27 +29,16 @@ describe TreeBuilderDatastores do
         :oncheck    => "miqOnCheckCUFilters"
       )
     end
-    it 'sets locals correctly' do
-      locals = @datastores_tree.send(:set_locals_for_render)
-      expect(locals[:checkboxes]).to eq(true)
-      expect(locals[:oncheck]).to eq("miqOnCheckCUFilters")
-      expect(locals[:check_url]).to eq("/ops/cu_collection_field_changed/")
-    end
+
     it 'sets Datastore node correctly' do
       parent = @datastores_tree.send(:x_get_tree_roots)
-      expect(parent.first[:text]).to eq("<strong>Datastore</strong> [#{@datastore.first[:location]}]")
-      expect(parent.first[:tip]).to eq("Datastore [#{@datastore.first[:location]}]")
-      expect(parent.first[:icon]).to eq('fa fa-database')
+      expect(parent.length).to eq(1)
     end
+
     it 'sets Host node correctly' do
       parent = @datastores_tree.send(:x_get_tree_roots)
-      kids = @datastores_tree.send(:x_get_tree_hash_kids, parent.first, false)
-      expect(kids.first[:text]).to eq(@host[:name])
-      expect(kids.first[:tip]).to eq(@host[:name])
-      expect(kids.first[:icon]).to eq('pficon pficon-container-node')
-      expect(kids.first[:hideCheckbox]).to eq(true)
-      expect(kids.first[:selectable]).to eq(false)
-      expect(kids.first[:nodes]).to eq([])
+      kids = @datastores_tree.send(:x_get_tree_storage_kids, parent.first, false)
+      expect(kids.length).to eq(1)
     end
   end
 end

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -26,7 +26,7 @@ describe TreeBuilderDatastores do
         :full_ids   => false,
         :checkboxes => true,
         :check_url  => "/ops/cu_collection_field_changed/",
-        :oncheck    => "miqOnCheckCUFilters"
+        :oncheck    => "miqOnCheckGeneric"
       )
     end
 

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -26,7 +26,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
       }
     }
     @datastore_tree = TreeBuilderDatastores.new(:datastore_tree, {}, true, :root => datastores)
-    @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true)
+    @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true, :root => EmsCluster.get_perf_collection_object_list)
   end
 
   it "Displays note if there are no Clusters" do

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -6,6 +6,8 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
   let(:host_2) { FactoryBot.create(:host, :ems_cluster => cluster) }
   let(:host_3) { FactoryBot.create(:host, :ext_management_system => ems) }
 
+  let(:datastore) { FactoryBot.create(:storage, :name => 'Name', :hosts => [host_1]) }
+
   before do
     assign(:sb, :active_tab => "settings_cu_collection")
 
@@ -14,14 +16,16 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
     allow(host_2).to receive(:perf_capture_enabled?).and_return(false)
     allow(host_3).to receive(:perf_capture_enabled?).and_return(true)
 
-
     @host = FactoryBot.create(:host, :name => 'Host Name')
-    FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
-    @datastore = [{:id       => 1,
-                   :name     => 'Datastore',
-                   :location => 'Location',
-                   :capture  => false}]
-    @datastore_tree = TreeBuilderDatastores.new(:datastore_tree, {}, true, :root => @datastore)
+    datastores = {
+      datastore.id => {
+        :name     => 'Datastore',
+        :location => 'Location',
+        :st_rec   => datastore,
+        :capture  => false,
+      }
+    }
+    @datastore_tree = TreeBuilderDatastores.new(:datastore_tree, {}, true, :root => datastores)
     @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true)
   end
 

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -1,6 +1,19 @@
 describe "ops/_settings_cu_collection_tab.html.haml" do
+  let(:cluster) { FactoryBot.create(:ems_cluster) }
+  let(:ems) { FactoryBot.create(:ext_management_system) }
+
+  let(:host_1) { FactoryBot.create(:host, :ems_cluster => cluster) }
+  let(:host_2) { FactoryBot.create(:host, :ems_cluster => cluster) }
+  let(:host_3) { FactoryBot.create(:host, :ext_management_system => ems) }
+
   before do
     assign(:sb, :active_tab => "settings_cu_collection")
+
+    MiqRegion.seed
+    allow(host_1).to receive(:perf_capture_enabled?).and_return(true)
+    allow(host_2).to receive(:perf_capture_enabled?).and_return(false)
+    allow(host_3).to receive(:perf_capture_enabled?).and_return(true)
+
 
     @host = FactoryBot.create(:host, :name => 'Host Name')
     FactoryBot.create(:storage, :name => 'Name', :id => 1, :hosts => [@host])
@@ -9,18 +22,7 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
                    :location => 'Location',
                    :capture  => false}]
     @datastore_tree = TreeBuilderDatastores.new(:datastore_tree, {}, true, :root => @datastore)
-
-    @ho_enabled = [FactoryBot.create(:host)]
-    @ho_disabled = [FactoryBot.create(:host)]
-    allow(EmsCluster).to receive(:get_perf_collection_object_list).and_return(:'1'.to_i =>
-                                                                                           {:id          => 1,
-                                                                                            :name        => 'Name',
-                                                                                            :capture     => 'unsure',
-                                                                                            :ho_enabled  => @ho_enabled,
-                                                                                            :ho_disabled => @ho_disabled})
-    @non_cluster_hosts = [{:id => 2, :name => 'Non Cluster Host', :capture => true}]
-    @cluster = {:clusters => [{:id => 1, :name => 'Name', :capture => 'unsure'}], :non_cl_hosts => @non_cluster_hosts}
-    @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true, :root => @cluster)
+    @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true)
   end
 
   it "Check All checkbox have unique id for Clusters trees" do

--- a/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_cu_collection_tab.html.haml_spec.rb
@@ -29,26 +29,6 @@ describe "ops/_settings_cu_collection_tab.html.haml" do
     @cluster_tree = TreeBuilderClusters.new(:cluster_tree, {}, true)
   end
 
-  it "Check All checkbox have unique id for Clusters trees" do
-    # setting up simple data to show Check All checkbox on screen
-    assign(:edit, :new => {
-             :all_clusters => false,
-             :clusters     => [{:name => "Some Cluster", :id => "Some Id", :capture => true}]
-           })
-    render
-    expect(response).to have_selector("input#cl_toggle")
-  end
-
-  it "Check All checkbox have unique id for Storage trees" do
-    # setting up simple data to show Check All checkbox on screen
-    assign(:edit, :new => {
-             :all_storages => false,
-             :storages     => [{:name => "Some Storage", :id => "Some Id", :capture => true}]
-           })
-    render
-    expect(response).to have_selector("input#ds_toggle")
-  end
-
   it "Displays note if there are no Clusters" do
     @cluster_tree = nil
     assign(:edit, :new => {:all_clusters => false})


### PR DESCRIPTION
My primary goal was to be able to use the `miqOnCheckGeneric` on these two trees. For that I had to eliminate the requirement on the posted `tree_name` attribute. I replaced the hash nodes with object-built nodes, which allowed me to use the `TreeBuilder.extract_node_model_and_id` method and determine the tree from the received model. By eliminating the `Check all` checkboxes, the `tree_name` became totally unnecessary and I was able to clean up the code a little. The data structure stored in the session is still too complex, but we can replace this in the future with an API-driven approach which eliminates the need of the session.

Note that there's a positive side-effect that the host nodes are now having their actual icons, not the generic one.

**Before:**
![Screenshot from 2020-03-26 15-56-07](https://user-images.githubusercontent.com/649130/77661010-5b7f8b00-6f7a-11ea-8240-0ba1ff954171.png)

**After:**
![Screenshot from 2020-03-26 15-55-00](https://user-images.githubusercontent.com/649130/77661019-60443f00-6f7a-11ea-8ad3-7f61b2fb21fd.png)

cc @brumik this should simplify your life with some of the trees you're converting

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/6796
Depends on: https://github.com/ManageIQ/manageiq/pull/20009