### PR TITLE
Remove Generic Item Modal

### DIFF
--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -31,8 +31,6 @@ class AnsibleCredentialController < ApplicationController
       javascript_redirect(:action => 'new')
     when 'embedded_automation_manager_credentials_edit'
       javascript_redirect(:action => 'edit', :id => params[:miq_grid_checks])
-    when 'embedded_automation_manager_credentials_delete'
-      delete_credentials
     when 'ansible_credential_tag'
       tag(self.class.model)
     when "ansible_repository_tag" # repositories from nested list
@@ -68,19 +66,6 @@ class AnsibleCredentialController < ApplicationController
     [%i[properties relationships options smart_management]]
   end
   helper_method :textual_group_list
-
-  def delete_credentials
-    checked = find_checked_items
-    checked[0] = params[:id] if checked.blank? && params[:id]
-    ManageIQ::Providers::EmbeddedAutomationManager::Authentication.where(:id => checked).each do |auth|
-      auth.delete_in_provider_queue
-      add_flash(_("Deletion of Credential \"%{name}\" was successfully initiated.") % {:name => auth.name})
-    rescue StandardError => ex
-      add_flash(_("Unable to delete Credential \"%{name}\": %{details}") % {:name => auth.name, :details => ex}, :error)
-    end
-    session[:flash_msgs] = @flash_array
-    javascript_redirect(:action => 'show_list')
-  end
 
   def breadcrumbs_options
     {

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -36,8 +36,6 @@ class AnsibleRepositoryController < ApplicationController
       javascript_redirect(:action => 'edit', :id => id)
     when "embedded_configuration_script_source_add"
       javascript_redirect(:action => 'new')
-    when "embedded_configuration_script_source_delete"
-      delete_repositories
     when "ansible_repositories_reload"
       show_list
       render :update do |page|
@@ -64,22 +62,6 @@ class AnsibleRepositoryController < ApplicationController
     else
       super
     end
-  end
-
-  def delete_repositories
-    assert_privileges('embedded_configuration_script_source_delete')
-    checked = find_checked_items
-    checked[0] = params[:id] if checked.blank? && params[:id]
-    AnsibleRepositoryController.model.where(:id => checked).each do |repo|
-      repo.delete_in_provider_queue
-      add_flash(_("Delete of Repository \"%{name}\" was successfully initiated.") % {:name => repo.name})
-    rescue StandardError => ex
-      add_flash(_("Unable to delete Repository \"%{name}\": %{details}") % {:name    => repo.name,
-                                                                            :details => ex},
-                :error)
-    end
-    session[:flash_msgs] = @flash_array
-    javascript_redirect(:action => 'show_list')
   end
 
   def edit

--- a/app/helpers/application_helper/toolbar/ansible_credential_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credential_center.rb
@@ -19,8 +19,14 @@ class ApplicationHelper::Toolbar::AnsibleCredentialCenter < ApplicationHelper::T
           t = N_('Remove this Credential from Inventory'),
           t,
           :klass => ApplicationHelper::Button::EmbeddedAnsible,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: The selected Credential will be permanently removed!")),
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:controller     => 'provider_dialogs',
+                                         :modal_title    => N_('Delete Credential'),
+                                         :modal_text     => N_('Are you sure you want to delete the following credential?'),
+                                         :api_url        => 'authentications',
+                                         :async_delete   => true,
+                                         :redirect_url   => '/ansible_credential/show_list',
+                                         :component_name => 'RemoveGenericItemModal'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_credentials_center.rb
@@ -34,7 +34,14 @@ class ApplicationHelper::Toolbar::AnsibleCredentialsCenter < ApplicationHelper::
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+",
-          :confirm      => N_("Warning: The selected Credentials will be permanently removed!")),
+          :data         => {'function'      => 'sendDataWithRx',
+                            'function-data' => {:controller     => 'provider_dialogs',
+                                                :modal_title    => N_('Delete Credentials'),
+                                                :modal_text     => N_('Are you sure you want to delete the following credentials?'),
+                                                :api_url        => 'authentications',
+                                                :async_delete   => true,
+                                                :redirect_url   => '/ansible_credential/show_list',
+                                                :component_name => 'RemoveGenericItemModal'}}),
       ]
     )
   ])

--- a/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repositories_center.rb
@@ -53,11 +53,17 @@ class ApplicationHelper::Toolbar::AnsibleRepositoriesCenter < ApplicationHelper:
           t = N_('Remove selected Repositories from Inventory'),
           t,
           :klass        => ApplicationHelper::Button::EmbeddedAnsible,
-          :url_parms    => "unused_div",
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1+",
-          :confirm      => N_("Warning: The selected Repository will be permanently removed!")),
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:controller     => 'provider_dialogs',
+                                         :modal_title    => N_('Delete Repositories'),
+                                         :modal_text     => N_('Are you sure you want to delete the following repositories?'),
+                                         :api_url        => 'configuration_script_sources',
+                                         :async_delete   => true,
+                                         :redirect_url   => '/ansible_repository/show_list',
+                                         :component_name => 'RemoveGenericItemModal'}}),
       ]
     )
   ])

--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -39,9 +39,15 @@ class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::T
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Repository from Inventory'),
           t,
-          :klass     => ApplicationHelper::Button::EmbeddedAnsible,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: The selected Repository will be permanently removed!")),
+          :klass => ApplicationHelper::Button::EmbeddedAnsible,
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:controller     => 'provider_dialogs',
+                                         :modal_title    => N_('Delete Repository'),
+                                         :modal_text     => N_('Are you sure you want to delete the following repository?'),
+                                         :api_url        => 'configuration_script_sources',
+                                         :async_delete   => true,
+                                         :redirect_url   => '/ansible_repository/show_list',
+                                         :component_name => 'RemoveGenericItemModal'}}),
       ]
     ),
   ])

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Modal, Spinner } from 'patternfly-react';
+import { API } from '../http_api';
+
+const parseApiError = (error) => {
+  if (error.hasOwnProperty('data')) {
+    return error.data.error.message;
+  } else if (error.hasOwnProperty('message')) {
+    return error.message;
+  }
+};
+
+export const removeItems = (items, apiUrl, asyncDelete, redirectUrl) => {
+  let apiPromises = [];
+  const deleteMessage = asyncDelete ? __('Deletion of item %s has been successfuly initiated') : __('The item "%s" has been successfully deleted');
+
+  miqSparkleOn();
+  items.forEach(item => {
+    apiPromises.push(API.post(`/api/${apiUrl}/${item.id}`, {action: 'delete'}, {skipErrors: [400, 500]})
+                       .then((apiResult) => ({result: apiResult.success ? 'success' : 'error', data: apiResult, name: item.name}))
+                       .catch((apiResult) => ({result: 'error', data: apiResult, name: item.name})))
+  });
+  Promise.all(apiPromises)
+    .then((apiData) => {
+      if (items.length === 1 && apiData[0].result === 'error') {
+        add_flash(sprintf(__('Error deleting item "%s": %s'), apiData[0].name, parseApiError(apiData[0].data)), 'error');
+        miqSparkleOff();
+      } else {
+        apiData.forEach(item => {
+          if (item.result === 'success') {
+            miqFlashLater({message: sprintf(deleteMessage, item.name)});
+          } else if (item.result === 'error' && items.length > 1) {
+            miqFlashLater({message: sprintf(__('Error deleting item "%s": %s'), item.name, parseApiError(item.data)), level: 'error'});
+          }
+        });
+      }
+      return apiData;
+    })
+    .then((apiData) => {
+      if (items.length > 1 || (items.length === 1 && apiData[0].result === 'success')) {
+        window.location.href = redirectUrl; // '/catalog/explorer?report_deleted=true';
+        miqSparkleOff();
+      }
+    });
+};
+
+class RemoveGenericItemModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: [],
+      loaded: false
+    };
+  }
+
+  componentDidMount() {
+    let apiPromises = [];
+    const itemsIds = this.props.recordId ? [this.props.recordId] : this.props.gridChecks;
+
+    // Load modal data from API
+    itemsIds.forEach(item => apiPromises.push(API.get(`/api/${this.props.modalData.api_url}/${item}`)));
+    Promise.all(apiPromises)
+      .then(apiData => apiData.map(item => (
+        {id:   item.id,
+         name: item.name})))
+      .then(data => this.setState({data: data, loaded: true}))
+      .then(() => this.props.dispatch({
+        type: 'FormButtons.saveable',
+        payload: true
+      }));
+
+    // Buttons setup
+    this.props.dispatch({
+      type: 'FormButtons.init',
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => removeItems(this.state.data, this.props.modalData.api_url, this.props.modalData.async_delete, this.props.modalData.redirect_url)
+      }
+    });
+    this.props.dispatch({
+      type: "FormButtons.customLabel",
+      payload: __('Delete'),
+    });
+  }
+
+  render () {
+    const renderSpinner = (spinnerOn) => {
+      if (spinnerOn) {
+        return <Spinner loading size="lg" />;
+      }
+    };
+
+    return (
+      <Modal.Body className="warning-modal-body">
+        {renderSpinner(!this.state.loaded)}
+        {this.state.loaded &&
+          <div>
+             <h4>{__(this.props.modalData.modal_text)}</h4>
+             <ul>
+               {this.state.data.map(item => (
+                 <li key={item.id}><h4><strong>{item.name}</strong></h4></li>
+               ))}
+             </ul>
+          </div>
+        }
+      </Modal.Body>
+    );
+  }
+}
+
+RemoveGenericItemModal.propTypes = {
+  dispatch: PropTypes.func.isRequired
+};
+
+export default connect()(RemoveGenericItemModal);

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -27,6 +27,7 @@ import OrcherstrationTemplateForm from '../components/orchestration-template/orc
 import PxeServersForm from '../components/pxe-servers-form/pxe-server-form';
 import { Quadicon } from '@manageiq/react-ui-components/dist/quadicon';
 import RemoveCatalogItemModal from '../components/remove-catalog-item-modal';
+import RemoveGenericItemModal from '../components/remove-generic-item-modal';
 import ReportDataTable from '../components/report-data-table';
 import ServiceDialogFromForm from '../components/service-dialog-from-form/service-dialog-from';
 import ServiceForm from '../components/service-form';
@@ -75,6 +76,7 @@ ManageIQ.component.addReact('OrcherstrationTemplateForm', OrcherstrationTemplate
 ManageIQ.component.addReact('PxeServersForm', PxeServersForm);
 ManageIQ.component.addReact('Quadicon', Quadicon);
 ManageIQ.component.addReact('RemoveCatalogItemModal', RemoveCatalogItemModal);
+ManageIQ.component.addReact('RemoveGenericItemModal', RemoveGenericItemModal);
 ManageIQ.component.addReact('ReportDataTable', ReportDataTable);
 ManageIQ.component.addReact('navbar.RightSection', navbar.RightSection);
 ManageIQ.component.addReact('ServiceDialogFromForm', ServiceDialogFromForm);

--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -49,7 +49,8 @@ ManageIQ.angular.app.component('providerDialogUser', {
 function reactModal(buttonData) {
   const props = {
     recordId: ManageIQ.record.recordId,
-    gridChecks: ManageIQ.gridChecks
+    gridChecks: ManageIQ.gridChecks,
+    modalData: buttonData
   };
 
   const Component = ManageIQ.component.getReact(buttonData.component_name);

--- a/app/javascript/spec/remove-generic-item-modal/__snapshots__/remove-generic-item-modal.spec.js.snap
+++ b/app/javascript/spec/remove-generic-item-modal/__snapshots__/remove-generic-item-modal.spec.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RemoveGenericItemModal should correctly render modal for multiple items 1`] = `
+<ModalBody
+  bsClass="modal-body"
+  className="warning-modal-body"
+  componentClass="div"
+>
+  <div>
+    <h4>
+      TEXT
+    </h4>
+    <ul>
+      <li
+        key="123"
+      >
+        <h4>
+          <strong>
+            name123
+          </strong>
+        </h4>
+      </li>
+      <li
+        key="456"
+      >
+        <h4>
+          <strong>
+            name456
+          </strong>
+        </h4>
+      </li>
+    </ul>
+  </div>
+</ModalBody>
+`;
+
+exports[`RemoveGenericItemModal should correctly render modal for single item 1`] = `
+<ModalBody
+  bsClass="modal-body"
+  className="warning-modal-body"
+  componentClass="div"
+>
+  <div>
+    <h4>
+      TEXT
+    </h4>
+    <ul>
+      <li
+        key="123"
+      >
+        <h4>
+          <strong>
+            name123
+          </strong>
+        </h4>
+      </li>
+    </ul>
+  </div>
+</ModalBody>
+`;

--- a/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
+++ b/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import fetchMock from 'fetch-mock';
+import { mount, shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import RemoveGenericItemModal from '../../components/remove-generic-item-modal';
+import { removeItems } from '../../components/remove-generic-item-modal';
+import '../helpers/addFlash';
+import '../helpers/miqFlashLater';
+import '../helpers/miqSparkle';
+import '../helpers/sprintf';
+
+describe('RemoveGenericItemModal', () => {
+  const item1 = 123;
+  const item2 = 456;
+  const url1 = `/api/authentications/${item1}`;
+  const url2 = `/api/authentications/${item2}`;
+  const apiResponse1 = {id: item1, name: 'name123'};
+  const apiResponse2 = {id: item2, name: 'name456'};
+  const store = configureStore()({});
+  const dispatchMock = jest.spyOn(store, 'dispatch');
+  const modalData = {api_url: 'authentications', async_delete: true, redirect_url: '/go/home', modal_text: 'TEXT'};
+
+  beforeEach(() => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "location", {
+        value: {
+           href: 'http://example.com'
+        },
+        writable: true
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  it('should correctly set component state for single item', (done) => {
+    fetchMock.getOnce(url1, apiResponse1);
+    const component = mount(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />);
+    expect(fetchMock.called(url1)).toBe(true);
+
+    setImmediate(() => {
+      component.update();
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1], loaded: true});
+      done();
+    });
+  });
+
+  it('should correctly set component state for multiple items', (done) => {
+    fetchMock.getOnce(url1, apiResponse1).getOnce(url2, apiResponse2);
+    const component = mount(<RemoveGenericItemModal store={store} gridChecks={[item1, item2]} modalData={modalData} />);
+    expect(fetchMock.called(url1)).toBe(true);
+    expect(fetchMock.called(url2)).toBe(true);
+
+    setImmediate(() => {
+      component.update();
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1, apiResponse2], loaded: true});
+      done();
+    });
+  });
+
+  it('should correctly render modal for single item', (done) => {
+    fetchMock.getOnce(url1, apiResponse1);
+    const component = shallow(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />).dive();
+
+    setImmediate(() => {
+      component.update();
+      expect(toJson(component)).toMatchSnapshot();
+      done();
+    });
+  });
+
+  it('should correctly render modal for multiple items', (done) => {
+    fetchMock.getOnce(url1, apiResponse1).getOnce(url2, apiResponse2);
+    const component = shallow(<RemoveGenericItemModal store={store} gridChecks={[item1, item2]} modalData={modalData} />).dive();
+
+    setImmediate(() => {
+      component.update();
+      expect(toJson(component)).toMatchSnapshot();
+      done();
+    });
+  });
+
+  it ('correctly initializes buttons', (done) => {
+    fetchMock.getOnce(url1, apiResponse1);
+    const component = mount(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />);
+
+    setImmediate(() => {
+      component.update();
+      expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.init', payload: {"addClicked": expect.anything(), "newRecord": true, "pristine": true}});
+      expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.customLabel', payload: 'Delete'});
+      expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.saveable', payload: true});
+      done();
+    });
+  });
+
+  it ('removeItems() works correctly', (done) => {
+    const postUrl = `/api/authentications/${item1}`;
+    fetchMock.getOnce(url1, apiResponse1);
+    fetchMock.postOnce(postUrl, {action: 'delete'});
+    const component = mount(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />);
+
+    setImmediate(() => {
+      removeItems(component.childAt(0).state().data, modalData.api_url, modalData.async_delete, modalData.redirect_url);
+      expect(fetchMock.called(url1)).toBe(true);
+      expect(fetchMock.called(postUrl)).toBe(true);
+      done();
+    });
+  });
+});

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -55,15 +55,6 @@ describe AnsibleCredentialController do
       end
     end
 
-    context 'deleting one or more ansible credentials from inventory' do
-      let(:params) { {:pressed => "embedded_automation_manager_credentials_delete"} }
-
-      it 'calls delete_credentials method' do
-        expect(controller).to receive(:delete_credentials)
-        controller.send(:button)
-      end
-    end
-
     context 'tagging one or more ansible credentials' do
       let(:params) { {:pressed => "ansible_credential_tag"} }
 

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -75,15 +75,6 @@ describe AnsibleRepositoryController do
       end
     end
 
-    context 'deleting one or more repositories from inventory' do
-      let(:params) { {:pressed => "embedded_configuration_script_source_delete"} }
-
-      it 'calls delete_repositories method' do
-        expect(controller).to receive(:delete_repositories)
-        controller.send(:button)
-      end
-    end
-
     context 'refreshing selected ansible repositories' do
       let(:params) { {:pressed => "ansible_repositories_reload"} }
 


### PR DESCRIPTION
This PR implements a new react / patternfly component to remove misc. (generic) items using rest api. The component renders a modal window with a confirmation text / question and a list of items to be removed.

The PR also modifies the UI code to use the new modal to delete emb. ansible repositories and credentials.

Before:
![delete-before-01](https://user-images.githubusercontent.com/6648365/77549539-41797600-6eb0-11ea-9d51-1a9732603996.png)
![delete-before-02](https://user-images.githubusercontent.com/6648365/77549546-44746680-6eb0-11ea-9385-2d2437decfa3.png)

After:
![delete-after-02](https://user-images.githubusercontent.com/6648365/77549565-4a6a4780-6eb0-11ea-8688-052b18ad07a1.png)
![delete-after-01](https://user-images.githubusercontent.com/6648365/77549562-49d1b100-6eb0-11ea-9772-fca983f49177.png)