### PR TITLE
Webpack - remove settings we no longer need, fix production build

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -9,14 +9,6 @@ module.exports = merge(sharedConfig, {
   mode: 'development',
   devtool: 'inline-source-map',
 
-  stats: {
-    errorDetails: true
-  },
-
-  output: {
-    pathinfo: true
-  },
-
   devServer: {
     clientLogLevel: 'none',
     https: settings.dev_server && settings.dev_server.https,
@@ -36,9 +28,7 @@ module.exports = merge(sharedConfig, {
         secure: false,
       },
       '/ws': {
-        target: `ws://${settings.dev_server.host}:${env.WS_PORT ||
-          env.PORT ||
-          '3000'}`,
+        target: `ws://${settings.dev_server.host}:${env.WS_PORT || env.PORT || '3000'}`,
         secure: false,
         ws: true,
       },

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -11,14 +11,8 @@ module.exports = merge(sharedConfig, {
   devtool: 'source-map',
   stats: 'normal',
 
-  optimization: {
-    minimize: true,
-  },
-
   plugins: [
     new CompressionPlugin({
-      asset: '[path].gz[query]',
-      algorithm: 'gzip',
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf)$/,
     }),
   ],

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -55,6 +55,7 @@ const notShims = (module) => (!SplitChunksPlugin.checkTest(/shims/, module));
 
 let plugins = [
   new webpack.DefinePlugin({
+    // used only by v2v code now
     'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || 'development'),
   }),
 


### PR DESCRIPTION
Follow-up to/fix of: https://github.com/ManageIQ/manageiq-ui-classic/pull/6784

`stats.errorDetails` [defaults](https://webpack.js.org/configuration/stats/#statserrordetails) to `true`,
`output.pathinfo` [defaults](https://webpack.js.org/configuration/output/#outputpathinfo) to `true` in development mode,
`optimization.minimize` [defaults](https://webpack.js.org/configuration/optimization/#optimizationminimize) to `true` in production mode,
`CompressionPlugin.algorithm` [defaults](https://webpack.js.org/plugins/compression-webpack-plugin/#algorithm) to `gzip`,
`CompressionPlugin.asset` was renamed to `filename`, but [defaults](https://webpack.js.org/plugins/compression-webpack-plugin/#filename) to `[path].gz[query]` as of 2.0 (https://github.com/webpack-contrib/compression-webpack-plugin/releases?after=v3.0.0).

The last item is what broke schema validation for production builds, removing the `asset` param fixes it.

Cc @simaishi 