### PR TITLE
Remove extra flash message after attaching/detaching Cloud Volume from Instance

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -168,15 +168,11 @@ class CloudNetworkController < ApplicationController
     cloud_network_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Cloud Network \"%{name}\" updated") % {:name => cloud_network_name})
+      flash_and_redirect(_("Cloud Network \"%{name}\" updated") % {:name => cloud_network_name})
     else
-      add_flash(_("Unable to update Cloud Network \"%{name}\": %{details}") % {:name    => cloud_network_name,
-                                                                               :details => task.message}, :error)
+      flash_and_redirect(_("Unable to update Cloud Network \"%{name}\": %{details}") % {:name    => cloud_network_name,
+                                                                                        :details => task.message}, :error)
     end
-
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(previous_breadcrumb_url)
   end
 
   private

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -190,15 +190,11 @@ class CloudSubnetController < ApplicationController
     subnet_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Cloud Subnet \"%{name}\" updated") % {:name => subnet_name })
+      flash_and_redirect(_("Cloud Subnet \"%{name}\" updated") % {:name => subnet_name})
     else
-      add_flash(_("Unable to update Cloud Subnet \"%{name}\": %{details}") % {:name    => subnet_name,
-                                                                              :details => task.message}, :error)
+      flash_and_redirect(_("Unable to update Cloud Subnet \"%{name}\": %{details}") % {:name    => subnet_name,
+                                                                                       :details => task.message}, :error)
     end
-
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(previous_breadcrumb_url)
   end
 
   private

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -157,7 +157,7 @@ class VmCloudController < ApplicationController
 
   def flash_and_redirect(message)
     session[:edit] = nil
-    flash_to_session(message)
+    add_flash(message)
     @record = @sb[:action] = nil
     replace_right_cell
   end

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -219,6 +219,32 @@ describe CloudSubnetController do
     end
   end
 
+  describe '#update_finished' do
+    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'ok', :message => 'some message') }
+
+    before do
+      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
+      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => cloud_subnet.name}})
+    end
+
+    it 'calls flash_and_redirect with appropriate arguments for succesful updating of a Cloud Subnet' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Cloud Subnet \"%{name}\" updated") % {:name => cloud_subnet.name})
+      controller.send(:update_finished)
+    end
+
+    context 'unsuccesful updating of a Cloud Subnet' do
+      let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'Error', :message => 'some message') }
+
+      it 'calls flash_and_redirect with appropriate arguments' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Unable to update Cloud Subnet \"%{name}\": %{details}") % {
+          :name    => cloud_subnet.name,
+          :details => miq_task.message
+        }, :error)
+        controller.send(:update_finished)
+      end
+    end
+  end
+
   describe "#delete" do
     let(:task_options) do
       {

--- a/spec/controllers/host_aggregate_controller_spec.rb
+++ b/spec/controllers/host_aggregate_controller_spec.rb
@@ -350,41 +350,6 @@ describe HostAggregateController do
     end
   end
 
-  describe '#flash_and_redirect' do
-    let(:message) { 'Edit Host Aggregate' }
-
-    before do
-      allow(controller).to receive(:render)
-      allow(controller).to receive(:session).and_return(:edit => {:expression => {}})
-      controller.instance_variable_set(:@breadcrumbs, [{:url => 'previous_url'}, {:url => 'last_url'}])
-    end
-
-    it 'adds message to flash array' do
-      controller.send(:flash_and_redirect, message)
-      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => message, :level => :success}])
-    end
-
-    it 'adds error flash message to flash array' do
-      controller.send(:flash_and_redirect, message, :error)
-      expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => message, :level => :error}])
-    end
-
-    it 'sets session[:edit] to nil' do
-      controller.send(:flash_and_redirect, message)
-      expect(controller.session[:edit]).to be_nil
-    end
-
-    it 'adds flash message to session' do
-      controller.send(:flash_and_redirect, message)
-      expect(controller.session[:flash_msgs]).to eq([{:message => message, :level => :success}])
-    end
-
-    it 'calls javascript_redirect' do
-      expect(controller).to receive(:javascript_redirect).with('previous_url')
-      controller.send(:flash_and_redirect, message)
-    end
-  end
-
   describe '#button' do
     context 'Check Compliance of Last Known Configuration on Instances' do
       let(:vm_instance) { FactoryBot.create(:vm_or_template) }

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -278,8 +278,8 @@ describe VmCloudController do
       controller.instance_variable_set(:@sb, :action => 'some_action')
     end
 
-    it 'calls flash_to_session, replace_right_cell and sets session[:edit], @record and @sb[:action] to nil' do
-      expect(controller).to receive(:flash_to_session).with('Message')
+    it 'calls add_flash, replace_right_cell and sets session[:edit], @record and @sb[:action] to nil' do
+      expect(controller).to receive(:add_flash).with('Message')
       expect(controller).to receive(:replace_right_cell)
       controller.send(:flash_and_redirect, 'Message')
       expect(controller.session[:edit]).to be_nil


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6785

There was an issue with displaying an extra flash message from the previous action (attaching/detaching Cloud Volume from an Instance) in the screen of an actual action on an Instance.
The core of the problem was saving flash message to the session, when attaching/detaching Cloud Volume (to `session[:flash_msgs]` when calling `flash_to_session` in `flash_and_redirect`), so the message was kept in the session even when starting performing some other action. Then the message was saved to `@flash_array` from `session[:flash_msgs]` [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1760-L1762) and then it was rendered (see the "Before" screenshots). Clearing `@flash_array` and `session[:flash_msgs]` after the screen was rendered (after calling `redirect_to` or `replace_right_cell` methods) solves the issue and makes rendering what's expected.

Note that this issue may be present in more screens than mentioned in the issue, and this is why I've made a change exactly in `flash_and_redirect` method to achieve the expected behavior. For some actions on selected items the issue is not present - this is because for those actions, only `add_flash` is called - and this method saves flash message only to `@flash_array` and not also to the session. However, for some actions this is ok but for some other we really need to save flash messages to the session to be rendered properly.

For some other action, there's `@flash_array = nil` which works well, too, but the disadvantage is that it has to be in the code for each action. I haven't chosen this approach because it's better to clear `session[:flash_msgs]` and eventually `@flash_array` right after it is not needed anymore, and not only when it could cause a problem.

---

**Before:**
![assoc_before1](https://user-images.githubusercontent.com/13417815/77658883-a350e300-6f77-11ea-9be1-376b42bf7524.png)
![assoc_before2](https://user-images.githubusercontent.com/13417815/77658896-a8159700-6f77-11ea-91a8-474cf76c3df6.png)

**After:**
![assoc_after1](https://user-images.githubusercontent.com/13417815/77658909-ac41b480-6f77-11ea-8545-ba3dc6b87d75.png)
![assoc_after2](https://user-images.githubusercontent.com/13417815/77658914-aea40e80-6f77-11ea-9c9a-1f1b9bda1910.png)
