### PR TITLE
Test against all possible subclasses for checkedness in VAT tree

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1098,8 +1098,8 @@ module OpsController::OpsRbac
       else # Belongsto tag checked
         class_prefix, id = parse_nodetype_and_id(params[:id])
         klass = TreeBuilder.get_model_for_prefix(class_prefix)
-        # If ExtManagementSystem/Host is returned get specific class
-        if %w[ExtManagementSystem Host].include?(klass)
+        # If ExtManagementSystem/Host/EmsFolder is returned get specific class
+        if %w[ExtManagementSystem Host EmsFolder].include?(klass)
           klass = find_record_with_rbac(klass.constantize, id).class.to_s
         end
         if params[:check] == "0" #   unchecked

--- a/app/presenters/tree_builder_belongs_to_vat.rb
+++ b/app/presenters/tree_builder_belongs_to_vat.rb
@@ -8,7 +8,11 @@ class TreeBuilderBelongsToVat < TreeBuilderBelongsToHac
     else
       node.hide_checkbox = true
     end
-    node.checked = @selected_nodes&.include?("EmsFolder_#{object[:id]}")
+
+    node.checked = @selected_nodes&.one? do |s|
+      prefix, id = s.split('_') # The prefix can be any subclass of EmsFolder
+      prefix.safe_constantize < EmsFolder && id.to_i == object[:id].to_i
+    end
   end
 
   def x_get_tree_datacenter_kids(parent, count_only)


### PR DESCRIPTION
When editing a group under `Configuration -> Access control`, the tree on the 3rd tab in Assigned Filters doesn't check the nodes properly after editing a group. The problem is that `EmsFolder` has STI subclasses and the tree doesn't know about them. To avoid this problem, I am testing against all subclasses when determining the checkedness of a node in this tree.

@miq-bot add_label bug, jansa/yes?
@miq-bot add_reviewer @h-kataria 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1818005