### PR TITLE
Use miqOnCheckGeneric for handling checks on HAC and VAT trees

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -262,15 +262,6 @@ function miqOnClickDiagnostics(id) {
   }
 }
 
-// OnCheck handler for the belongsto tagging trees on the user edit screen
-function miqOnCheckUserFilters(node, tree_name) {
-  var tree_typ = tree_name.split('_')[0];
-  var checked = Number(node.state.checked);
-  var url = ManageIQ.tree.checkUrl + encodeURIComponent(node.key) + '?check=' + checked + '&tree_typ=' + encodeURIComponent(tree_typ);
-  miqJqueryRequest(url);
-  return true;
-}
-
 function miqMenuChangeRow(action, elem) {
   var grid = $('#folder_grid .panel-group');
   var selected = grid.find('.panel-heading.active').parent();
@@ -377,7 +368,6 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickMenuRoles',
     'miqOnCheckProtect',
     'miqOnCheckSections',
-    'miqOnCheckUserFilters',
     'miqOnClickAutomate',
     'miqOnClickAutomateCatalog',
     'miqOnClickDiagnostics',

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1122,8 +1122,6 @@ module OpsController::OpsRbac
         @edit[:use_filter_expression] = true
       end
     end
-
-    params[:tree_typ] ? params[:tree_typ] + "_tree" : nil
   end
 
   # Set form variables for group add/edit

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -27,7 +27,7 @@ class TreeBuilderBelongsToHac < TreeBuilder
     {
       :full_ids   => true,
       :checkboxes => true,
-      :oncheck    => @edit ? "miqOnCheckUserFilters" : nil,
+      :oncheck    => @edit ? "miqOnCheckGeneric" : nil,
       :check_url  => "/ops/rbac_group_field_changed/#{group_id}___"
     }
   end


### PR DESCRIPTION
The only difference between the old handler and `miqOnCheckGeneric` is the `tree_typ` attribute, which is not really necessary. The trees are available on the `Configuration -> Access Control` screen after editing a group under the 2nd and 3rd tab of `Assigned Filters`.

Note that there's a bug in the area: https://github.com/ManageIQ/manageiq-ui-classic/pull/6800

cc @brumik one more tree doing it with generic :wink: 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label cleanup, trees