### PR TITLE
Skip dynamic vm_cloud specs where the method isn't supported

### DIFF
--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -36,7 +36,7 @@ describe VmCloudController do
           actual_method = %i(s1 s2).include?(method) ? actual_action : method.to_s
 
           it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
-            unless controller.methods.include?(actual_method.to_sym)
+            unless controller.respond_to?(actual_method.to_sym)
               skip "method #{actual_action} not defined for #{controller.controller_name}"
             end
 

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -36,6 +36,10 @@ describe VmCloudController do
           actual_method = %i(s1 s2).include?(method) ? actual_action : method.to_s
 
           it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
+            unless controller.methods.include?(actual_method.to_sym)
+              skip "method #{actual_action} not defined for #{controller.controller_name}"
+            end
+
             expect(controller).to receive(actual_method)
 
             # Instead of calling the get below:


### PR DESCRIPTION
Within the specs for `VmCloudController` there are a series of dynamically generated methods that are tested that start with "image_" or "instance_" based on `ApplicationController::Explorer::X_BUTTON_ALLOWED_ACTIONS`.

However, with strict partial validation enabled, about half these fail because the dynamic method in question isn't actually defined, e.g. `image_rename`, `image_drift`, and so on.

This modifies the specs so that it skips the spec if the method isn't actually defined on the controller.

Note that I used `skip` inside the example here because all of my attempts to break out of the loop before the example resulted in `no block given` errors, keeping in mind that Rails has redefined `respond_to` for controllers. If anyone has a better way I'm listening, but this will work at least.

Addresses https://github.com/ManageIQ/manageiq-ui-classic/issues/6738