### PR TITLE
Remove edit tags button from the genealogy screen

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_vmtree_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_vmtree_center.rb
@@ -1,11 +1,6 @@
 class ApplicationHelper::Toolbar::XVmVmtreeCenter < ApplicationHelper::Toolbar::Basic
   button_group('vmtree_tasks', [
     button(
-      :vm_tag,
-      'pficon pficon-edit fa-lg',
-      N_('Edit Tags for this VM'),
-      nil),
-    button(
       :vm_compare,
       'ff ff-compare-same fa-lg',
       N_('Compare selected VMs'),


### PR DESCRIPTION
I don't really see the point of this button here, you can only edit the tags of a single VM and you can do it much easier without even getting to this page. But feel free to close this PR if you disagree.

**Before:**
![Screenshot from 2020-03-30 15-05-49](https://user-images.githubusercontent.com/649130/77915704-33ed3300-7298-11ea-8694-2f069e0b312e.png)
**After:**
![Screenshot from 2020-03-30 15-07-21](https://user-images.githubusercontent.com/649130/77915718-394a7d80-7298-11ea-95a0-31683a308097.png)

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @h-kataria 
@miq-bot add_label cleanup