### PR TITLE
Skip dynamic vm_or_template specs where the method isn't supported

### DIFF
--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -22,6 +22,10 @@ describe VmOrTemplateController do
         actual_method = %i(s1 s2).include?(method) ? actual_action : method.to_s
 
         it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
+          unless controller.respond_to?(actual_method.to_sym)
+            skip "method #{actual_action} not defined for #{controller.controller_name}"
+          end
+
           expect(controller).to receive(actual_method)
           get :x_button, :params => { :id => nil, :pressed => actual_action }
         end


### PR DESCRIPTION
Within the specs for `VmOrTemplateController` there are a series of dynamically generated methods that are tested that start with "image_" or "instance_" based on ApplicationController::Explorer::X_BUTTON_ALLOWED_ACTIONS.

However, with strict partial validation enabled, about half these fail because the dynamic method in question isn't actually defined, e.g. image_rename, image_drift, and so on.

This modifies the specs so that it skips the spec if the method isn't actually defined on the controller.

Continuation of #6738