### PR TITLE
subtree_arranged of_type is a string, not a Class

### DIFF
--- a/app/presenters/tree_builder_alert_profile_assign.rb
+++ b/app/presenters/tree_builder_alert_profile_assign.rb
@@ -9,7 +9,7 @@ class TreeBuilderAlertProfileAssign < TreeBuilder
   def x_get_tree_roots
     roots = ExtManagementSystem.assignable.each_with_object({}) do |ems, nodes|
       subtree = ems.children.flat_map(&:folders).each_with_object({}) do |folder, obj|
-        obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE))
+        obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE.name))
       end
 
       nodes.merge!(ems => subtree) if subtree.any?


### PR DESCRIPTION
With rails 5.2, where clauses will no longer cast Class objects as Strings.
We need to explicitly pass String objects.

Similar to https://github.com/ManageIQ/manageiq/pull/19016

Fixes errors of this variety on rails 5.2 (in a rails 5.1 backward compatible
way):

```
  6) TreeBuilderEmsFolders#x_get_tree_roots redhat provider with folders returns with a single root
     Failure/Error: obj.merge!(folder.subtree_arranged(:of_type => self.class::ANCESTRY_TYPE))

     TypeError:
       can't cast Class
     # /home/travis/build/jrafanie/manageiq-cross_repo-tests/repos/jrafanie/manageiq@5d620a6e51f3204b2d023e1c6f1c436690e69766/app/models/mixins/relationship_mixin.rb:387:in `subtree_rels_arranged'
     # /home/travis/build/jrafanie/manageiq-cross_repo-tests/repos/jrafanie/manageiq@5d620a6e51f3204b2d023e1c6f1c436690e69766/app/models/mixins/relationship_mixin.rb:397:in `subtree_arranged'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:12:in `block (2 levels) in x_get_tree_roots'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:11:in `each'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:11:in `each_with_object'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:11:in `block in x_get_tree_roots'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:10:in `each_with_object'
     # ./app/presenters/tree_builder_alert_profile_assign.rb:10:in `x_get_tree_roots'
     # ./spec/presenters/tree_builder_ems_folders_spec.rb:39:in `block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # TypeError:
     #   TypeError
     #   /home/travis/build/jrafanie/manageiq-cross_repo-tests/repos/jrafanie/manageiq@5d620a6e51f3204b2d023e1c6f1c436690e69766/app/models/mixins/relationship_mixin.rb:387:in `subtree_rels_arranged'
```