### PR TITLE
Add ability for displaying Search bar in the screens without listnav

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1358,7 +1358,7 @@ function miqHideSearchClearButton(explorer) {
     $(this).prev('.form-control').val('').focus();
     $(this).hide();
     // Clear Search text values as well
-    var url = '/' + ManageIQ.controller + '/adv_search_text_clear' + '?in_explorer=' + explorer;
+    var url = '/' + ManageIQ.controller + '/search_clear' + '?in_explorer=' + explorer;
     miqJqueryRequest(url);
   });
 }

--- a/app/controllers/ansible_credential_controller.rb
+++ b/app/controllers/ansible_credential_controller.rb
@@ -25,6 +25,10 @@ class AnsibleCredentialController < ApplicationController
     nested_list(ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource)
   end
 
+  def show_searchbar?
+    true
+  end
+
   def button
     case params[:pressed]
     when 'embedded_automation_manager_credentials_add'

--- a/app/controllers/ansible_playbook_controller.rb
+++ b/app/controllers/ansible_playbook_controller.rb
@@ -17,6 +17,10 @@ class AnsiblePlaybookController < ApplicationController
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook
   end
 
+  def show_searchbar?
+    true
+  end
+
   def button
     if params[:pressed] == "embedded_configuration_script_payload_tag"
       tag(self.class.model)

--- a/app/controllers/ansible_repository_controller.rb
+++ b/app/controllers/ansible_repository_controller.rb
@@ -25,6 +25,10 @@ class AnsibleRepositoryController < ApplicationController
     ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   end
 
+  def show_searchbar?
+    true
+  end
+
   def title
     _("Repository")
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -551,11 +551,12 @@ class ApplicationController < ActionController::Base
     send_data(fs.contents, :filename => fs.name)
   end
 
-  def adv_search_text_clear
+  # Clear the Search and display original list of items
+  def search_clear
     @search_text = @sb[:search_text] = nil
     if params[:in_explorer] == "true"
       reload
-    else
+    else # non-explorer screens
       javascript_redirect(last_screen_url)
     end
   end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -861,7 +861,7 @@ class MiqPolicyController < ApplicationController
       @search_text = params[:search_text].strip
       @sb[:pol_search_text][x_active_tree] = @search_text unless @search_text.nil?
     else
-      @sb[:pol_search_text].delete(x_active_tree) if params[:action] == 'adv_search_text_clear'
+      @sb[:pol_search_text].delete(x_active_tree) if params[:action] == 'search_clear'
       @search_text = @sb[:pol_search_text][x_active_tree]
     end
   end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -165,6 +165,11 @@ module ApplicationHelper::PageLayouts
     @sb[:pages] && @html && %i[reports_tree savedreports_tree cb_reports_tree].include?(x_active_tree)
   end
 
+  def show_search?
+    # Layouts with Advanced Search have the Search, too
+    controller.try(:show_searchbar?) || display_adv_search?
+  end
+
   def show_advanced_search?
     x_tree && ((tree_with_advanced_search? && !@record) || @show_adv_search)
   end

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -10,9 +10,14 @@
             = miq_toolbar toolbar_from_hash
       .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
         .col-md-12
-        - if layout_uses_tabs?
-          .col-md-12
-            = render :partial => 'layouts/tabs'
+          .row
+            .col-md-7
+              - if layout_uses_tabs?
+                = render :partial => 'layouts/tabs'
+            .col-md-5
+              - if show_search?
+                %br
+                = render :partial => 'layouts/searchbar'
         .col-md-12
           = yield
       .row#paging_div{:style => (layout_uses_paging? && !@in_a_form) ? '' : 'display: none'}

--- a/app/views/layouts/_searchbar.html.haml
+++ b/app/views/layouts/_searchbar.html.haml
@@ -1,5 +1,5 @@
-- if @lastaction == "show_list" && !session[:menu_click] && display_adv_search? && !@in_a_form
-  = render :partial => 'layouts/quick_search'
+- if @lastaction == 'show_list' && !session[:menu_click] && !@in_a_form
+  = render :partial => 'layouts/quick_search' if display_adv_search?
   #searchbox
     = form_tag({:action => 'show_list'},
                :class  => "search-pf has-button form-group pull-right",
@@ -23,7 +23,7 @@
       .form-group
         %button.btn.btn-default{:type => "submit"}
           %span.fa.fa-search
-        - if @lastaction == "show_list" && !session[:menu_click] && display_adv_search? && !@in_a_form
+        - if display_adv_search?
           %button{"type"          => "button",
                   :class          => "btn btn-default",
                   "data-toggle"   => "modal",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2043,6 +2043,7 @@ Rails.application.routes.draw do
         tagging_edit
       ),
       :post => %w(
+        search_clear
         button
         show_list
         tag_edit_form_field_changed
@@ -2059,6 +2060,7 @@ Rails.application.routes.draw do
         tagging_edit
       ),
       :post => %w(
+        search_clear
         button
         show_list
         tag_edit_form_field_changed
@@ -2077,6 +2079,7 @@ Rails.application.routes.draw do
         tagging_edit
       ),
       :post => %w(
+        search_clear
         button
         edit
         new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     adv_search_load_choice
     adv_search_name_typed
     adv_search_toggle
-    adv_search_text_clear
+    search_clear
   )
 
   button_post = %w(

--- a/spec/controllers/ansible_credential_controller_spec.rb
+++ b/spec/controllers/ansible_credential_controller_spec.rb
@@ -82,9 +82,7 @@ describe AnsibleCredentialController do
     let(:action) { 'show' }
     subject { controller.send(:toolbar) }
 
-    before do
-      controller.instance_variable_set(:@lastaction, action)
-    end
+    before { controller.instance_variable_set(:@lastaction, action) }
 
     context 'displaying list of credentials' do
       let(:action) { 'show_list' }
@@ -101,13 +99,17 @@ describe AnsibleCredentialController do
     end
 
     context 'displaying nested list of repositories' do
-      before do
-        controller.instance_variable_set(:@display, 'repositories')
-      end
+      before { controller.instance_variable_set(:@display, 'repositories') }
 
       it 'returns proper toolbar filename' do
         expect(subject).to eq('ansible_repositories_center')
       end
+    end
+  end
+
+  describe '#show_searchbar?' do
+    it 'renders true to allow displaying Search bar' do
+      expect(controller.send(:show_searchbar?)).to eq(true)
     end
   end
 end

--- a/spec/controllers/ansible_playbook_controller_spec.rb
+++ b/spec/controllers/ansible_playbook_controller_spec.rb
@@ -56,9 +56,7 @@ describe AnsiblePlaybookController do
     let(:action) { 'show' }
     subject { controller.send(:toolbar) }
 
-    before do
-      controller.instance_variable_set(:@lastaction, action)
-    end
+    before { controller.instance_variable_set(:@lastaction, action) }
 
     context 'displaying list of playbooks' do
       let(:action) { 'show_list' }
@@ -72,6 +70,12 @@ describe AnsiblePlaybookController do
       it 'returns proper toolbar filename' do
         expect(subject).to eq('ansible_playbook_center')
       end
+    end
+  end
+
+  describe '#show_searchbar?' do
+    it 'renders true to allow displaying Search bar' do
+      expect(controller.send(:show_searchbar?)).to eq(true)
     end
   end
 end

--- a/spec/controllers/ansible_repository_controller_spec.rb
+++ b/spec/controllers/ansible_repository_controller_spec.rb
@@ -122,9 +122,7 @@ describe AnsibleRepositoryController do
     let(:action) { 'show' }
     subject { controller.send(:toolbar) }
 
-    before do
-      controller.instance_variable_set(:@lastaction, action)
-    end
+    before { controller.instance_variable_set(:@lastaction, action) }
 
     context 'displaying list of repositories' do
       let(:action) { 'show_list' }
@@ -141,13 +139,17 @@ describe AnsibleRepositoryController do
     end
 
     context 'displaying nested list of playbooks' do
-      before do
-        controller.instance_variable_set(:@display, 'playbooks')
-      end
+      before { controller.instance_variable_set(:@display, 'playbooks') }
 
       it 'returns proper toolbar filename' do
         expect(subject).to eq('ansible_playbooks_center')
       end
+    end
+  end
+
+  describe '#show_searchbar?' do
+    it 'renders true to allow displaying Search bar' do
+      expect(controller.send(:show_searchbar?)).to eq(true)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -473,7 +473,7 @@ describe ApplicationController do
     end
   end
 
-  describe '#adv_search_text_clear' do
+  describe '#search_clear' do
     before do
       controller.instance_variable_set(:@breadcrumbs, [{:url => 'last url'}])
       controller.instance_variable_set(:@sb, :search_text => 'Search text')
@@ -481,14 +481,14 @@ describe ApplicationController do
 
     it 'sets @search_text and @sb[:search_text] to nil' do
       allow(controller).to receive(:javascript_redirect)
-      controller.send(:adv_search_text_clear)
+      controller.send(:search_clear)
       expect(controller.instance_variable_get(:@search_text)).to be_nil
       expect(controller.instance_variable_get(:@sb)[:search_text]).to be_nil
     end
 
     it 'calls javascript_redirect for non-explorer' do
       expect(controller).to receive(:javascript_redirect).with('last url')
-      controller.send(:adv_search_text_clear)
+      controller.send(:search_clear)
     end
 
     context 'explorer screen' do
@@ -496,7 +496,7 @@ describe ApplicationController do
 
       it 'calls reload' do
         expect(controller).to receive(:reload)
-        controller.send(:adv_search_text_clear)
+        controller.send(:search_clear)
       end
     end
   end

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -268,7 +268,7 @@ describe MiqPolicyController do
       let(:tree) { :any_tree }
 
       before do
-        controller.params = {:action => 'adv_search_text_clear'}
+        controller.params = {:action => 'search_clear'}
         controller.instance_variable_set(:@sb, :active_tree => tree, :pol_search_text => {tree => search})
         controller.instance_variable_set(:@search_text, search)
       end

--- a/spec/helpers/application_helper/page_layouts_spec.rb
+++ b/spec/helpers/application_helper/page_layouts_spec.rb
@@ -9,4 +9,16 @@ describe ApplicationHelper::PageLayouts do
       end
     end
   end
+
+  describe '#show_search?' do
+    it 'returns true if displaying Advanced Search' do
+      allow(helper).to receive(:display_adv_search?).and_return(true)
+      expect(helper.show_search?).to eq(true)
+    end
+
+    it 'returns true if displaying Search for appropriate controller' do
+      allow(controller).to receive(:show_searchbar?).and_return(true)
+      expect(helper.show_search?).to eq(true)
+    end
+  end
 end

--- a/spec/views/layouts/_center_div_no_listnav.html.haml_spec.rb
+++ b/spec/views/layouts/_center_div_no_listnav.html.haml_spec.rb
@@ -1,0 +1,17 @@
+describe "layouts/_center_div_no_listnav.html.haml" do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    allow(view).to receive(:calculate_toolbars).and_return(:center_tb => 'ansible_playbooks_center')
+    allow(view).to receive(:show_search?).and_return(true)
+    allow(view).to receive(:taskbar_in_header?).and_return(true)
+    allow(view).to receive(:url_for)
+    assign(:lastaction, 'show_list')
+    login_as user
+  end
+
+  it 'renders Search bar' do
+    render
+    expect(rendered).to include('Search by Name within results')
+  end
+end

--- a/spec/views/layouts/_searchbar.html.haml_spec.rb
+++ b/spec/views/layouts/_searchbar.html.haml_spec.rb
@@ -1,0 +1,19 @@
+describe "layouts/_searchbar.html.haml" do
+  before do
+    allow(view).to receive(:url_for)
+    assign(:lastaction, 'show_list')
+  end
+
+  it 'renders Search bar and not quick search' do
+    render
+    expect(rendered).to include('Search by Name within results')
+    expect(rendered).not_to include('quicksearchbox')
+  end
+
+  it 'renders Advanced Search and quick search' do
+    allow(view).to receive(:display_adv_search?).and_return(true)
+    render
+    expect(rendered).to include('quicksearchbox')
+    expect(rendered).to include('Advanced Search')
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6765

This PR:
- renames `adv_search_text_clear` to `search_clear`
  -  we will have `search_clear` and `adv_search_clear` now so we will be able to distinguish easily what's related to _Advanced Search_ and what to regular _Search_, no misleading name of the method
- makes small improvements in _searchbar.html.haml_
   - it does not make sense to check if the screen supports displaying Adv. Search if we want only Search to be displayed (line 1; and if the same check for displaying Adv Seach is present "later" in the haml), also it does not make sense to check the same conditions twice (conditions in line 1 and 26 were totally the same!)
   - also quick search makes sense to be rendered only if there's Advanced Search support
  - test these changes in other screens (not only without listnav)
- adds ability for displaying _Search_ bar also in the screens without listnav, generally
- uses the ability for displaying _Search_ in Automation _Ansible Playbooks/Credentials/Repositories_ screens (see the [related issue](https://github.com/ManageIQ/manageiq-ui-classic/issues/6765)), which are now without the listnav (see the [recently merged PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/6789))

---

**Before:**
![play_before](https://user-images.githubusercontent.com/13417815/78162605-6721f480-7447-11ea-9909-dcd7436f058d.png)

**After:**
![play_after](https://user-images.githubusercontent.com/13417815/78162614-6b4e1200-7447-11ea-88d5-4fef0c340bab.png)
