### PR TITLE
Don't use ServiceTemplate::CATALOG_ITEM_TYPES

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -59,7 +59,7 @@
             %label.col-md-3.control-label
               = _('Item Type')
             .col-md-9
-              = h(_(ServiceTemplate::CATALOG_ITEM_TYPES[@record.prov_type]))
+              = h(_(ServiceTemplate.all_catalog_item_types[@record.prov_type]))
         - if @record.prov_type == "generic"
           .form-group
             %label.col-md-3.control-label

--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -69,7 +69,7 @@ class GtlFormatter
   end
 
   def self.service_template_format(value)
-    [value ? _(ServiceTemplate::CATALOG_ITEM_TYPES[value]) : '', nil]
+    [value ? _(ServiceTemplate.all_catalog_item_types[value]) : '', nil]
   end
 
   def self.timezone(view, row, col)


### PR DESCRIPTION
To allow for pluggable catalog item types, use the
ServiceTemplate.all_catalog_item_types method instead of the hard coded
set of catalog types.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/106
Core PR: https://github.com/ManageIQ/manageiq/pull/20039