### PR TITLE
prov_dialog customize - don't fail when no :sysprep_enabled

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -184,7 +184,7 @@
         :keys                       => keys})
   - when :customize
     - if select_check?(wf)
-      - edit_or_options = (@edit && @edit[:new] && @edit[:new][:sysprep_enabled]) || (@options && @options[:sysprep_enabled])
+      - edit_or_options = (@edit && @edit[:new] && @edit[:new][:sysprep_enabled]) || (@options && @options[:sysprep_enabled]) || []
       - keys = [:sysprep_enabled]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,


### PR DESCRIPTION
This code changed (https://github.com/ManageIQ/manageiq-ui-classic/pull/5774) from conditions like...

    - if (@edit && @edit[:new] && @edit[:new][:sysprep_enabled] && @edit[:new][:sysprep_enabled][0] == "fields") || (@options && @options[:sysprep_enabled] && @options[:sysprep_enabled][0] == "fields")

to one assignment...

    - edit_or_options = (@edit && @edit[:new] && @edit[:new][:sysprep_enabled]) || (@options && @options[:sysprep_enabled])

...and conditions like...

    - if edit_or_options[0] == "fields"

Which then crashes when trying to clone a RHV template, because `edit_or_options` is nil...

    Error caught: [ActionView::Template::Error] undefined method `[]' for nil:NilClass
    /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-d44320707dfe/app/views/shared/views/_prov_dialog.html.haml:195:in `__opt_rh_cfme_gemset_bundler_gems_cfme_ui_classic_d________dfe_app_views_shared_views__prov_dialog_html_haml___2839729305696764418_47250275323280'

The else branch doesn't look inside edit_or_options, so initializing to an empty array works as before.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1797706