### PR TITLE
Allow chaining method calls built from report columns in layouts/item

### DIFF
--- a/app/views/layouts/_item.html.haml
+++ b/app/views/layouts/_item.html.haml
@@ -6,7 +6,7 @@
       %label.control-label.col-md-2
         = _(@view.headers[@view.col_order.index(item)])
       .col-md-8
-        - item_data = @item.send(item)
+        - item_data = item.split('.').inject(@item) { |obj, met| obj.send(met) }
         - if %w(data name).include?(@view.headers[i].downcase)
           - if item_data.respond_to?(:scan)
             - item_data.scan(/.{1,125}/).each do |data_part|


### PR DESCRIPTION
Bumped into this randomly while hunting down something else. When you go the `Infrastructure -> Networking` and select a `Switch` in the left side tree, you can access the related `Hosts` through the summary screen. However, this throws an undefined method error on `ext_management_system.name`.

The page to be rendered is being created from a report, more specifically the column headers of a report. So while reporting allows us to reach for fields in further tables using a dotted notation (see above), the `send` method we're using in the view is not capable of doing so.

As a workaround I implemented a chaining send after splitting the column headers. The solution is not ideal but it gets us where we should be. The problem might happen on other pages where we use the same file for rendering and the report definition is complex enough.

@miq-bot add_label bug