### PR TITLE
Remove copy-pasted and possibly dead code from Infra Networking

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -97,24 +97,7 @@ class InfraNetworkingController < ApplicationController
     @explorer = true
     @lastaction = "explorer"
 
-    # if AJAX request, replace right cell, and return
-    if request.xml_http_request?
-      replace_right_cell
-      return
-    end
-
-    if params[:accordion]
-      self.x_active_tree   = "#{params[:accordion]}_tree"
-      self.x_active_accord = params[:accordion]
-    end
-    if params[:button]
-      @miq_after_onload = "miqAjax('/#{controller_name}/x_button?pressed=#{params[:button]}');"
-    end
-
     build_accordions_and_trees
-
-    params.instance_variable_get(:@parameters).merge!(session[:exp_parms]) if session[:exp_parms]
-    session.delete(:exp_parms)
     @in_a_form = false
 
     render :layout => "application"


### PR DESCRIPTION
I haven't found any callsite where these two pieces are being called on the given screen. My guess is that it was copy-pasted and never cleaned up.

@miq-bot assign @h-kataria 
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label cleanup