### PR TITLE
Remove unnecessary post_check from tenants tree under catalogs

### DIFF
--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -17,7 +17,6 @@ class TreeBuilderTenants < TreeBuilder
       :check_url  => "/catalog/#{cat_item_or_bundle}/",
       :open_all   => false,
       :oncheck    => @selectable ? tenant_tree_or_generic : false,
-      :post_check => true
     }
   end
 


### PR DESCRIPTION
The `post_check` only makes sense if `three_checks` is set on the tree, this is probably a badly copy-pasted piece of code.

@miq-bot add_label cleanup, trees