### PR TITLE
Move TreeBuilder.group_id under TreeBuilderBelongsToHac

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -142,10 +142,6 @@ class TreeBuilder
     )
   end
 
-  def group_id
-    @group.present? && @group.id.present? ? @group.id : 'new'
-  end
-
   def set_locals_for_render
     {
       :tree_id         => "#{@name}box",

--- a/app/presenters/tree_builder_belongs_to_hac.rb
+++ b/app/presenters/tree_builder_belongs_to_hac.rb
@@ -32,6 +32,10 @@ class TreeBuilderBelongsToHac < TreeBuilder
     }
   end
 
+  def group_id
+    @group.present? && @group.id.present? ? @group.id : 'new'
+  end
+
   def x_get_tree_roots
     count_only_or_objects(false, ExtManagementSystem.assignable)
   end


### PR DESCRIPTION
This is the only callsite, there's no need to have it globally for all trees.

@miq-bot add_label cleanup, trees