### PR TITLE
Redirect to proper screen after reconfiguring, migrating, evacuating Instances in a nested list

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/evacuate.rb
+++ b/app/controllers/mixins/actions/vm_actions/evacuate.rb
@@ -40,6 +40,7 @@ module Mixins
 
           @sb[:action] = nil
           if @sb[:explorer]
+            @sb[:explorer] = nil
             replace_right_cell
           else
             flash_to_session

--- a/app/controllers/mixins/actions/vm_actions/live_migrate.rb
+++ b/app/controllers/mixins/actions/vm_actions/live_migrate.rb
@@ -84,6 +84,7 @@ module Mixins
           end
           @sb[:action] = nil
           if @sb[:explorer]
+            @sb[:explorer] = nil
             replace_right_cell
           else
             flash_to_session

--- a/app/controllers/mixins/actions/vm_actions/resize.rb
+++ b/app/controllers/mixins/actions/vm_actions/resize.rb
@@ -99,6 +99,7 @@ module Mixins
             @sb[:action] = nil
           end
           if @sb[:explorer] && !(@breadcrumbs.length >= 2 && previous_breadcrumb_url.include?('miq_request'))
+            @sb[:explorer] = nil
             replace_right_cell
           else
             flash_to_session

--- a/spec/controllers/mixins/actions/vm_actions/evacuate_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/evacuate_spec.rb
@@ -1,0 +1,17 @@
+describe Mixins::Actions::VmActions::Evacuate do
+  describe '#evacuate_vm' do
+    let(:controller) { VmCloudController.new }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@sb, :explorer => true)
+      controller.params = {}
+    end
+
+    it 'sets @sb[:explorer] back to nil after canceling/submitting evacuating selected Instances' do
+      controller.send(:evacuate_vm)
+      expect(controller.instance_variable_get(:@sb)[:explorer]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/mixins/actions/vm_actions/live_migrate_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/live_migrate_spec.rb
@@ -1,0 +1,17 @@
+describe Mixins::Actions::VmActions::LiveMigrate do
+  describe '#live_migrate_vm' do
+    let(:controller) { VmCloudController.new }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@sb, :explorer => true)
+      controller.params = {}
+    end
+
+    it 'sets @sb[:explorer] to nil after migration of selected Instances' do
+      controller.send(:live_migrate_vm)
+      expect(controller.instance_variable_get(:@sb)[:explorer]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/mixins/actions/vm_actions/resize_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/resize_spec.rb
@@ -1,0 +1,19 @@
+describe Mixins::Actions::VmActions::Resize do
+  describe '#resize_vm' do
+    let(:controller) { VmCloudController.new }
+    let(:instance) { FactoryBot.create(:vm_cloud) }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@sb, :explorer => true)
+      controller.instance_variable_set(:@breadcrumbs, [])
+      controller.params = {:objectId => instance}
+    end
+
+    it 'sets @sb[:explorer] back to nil after reconfiguring selected Instances' do
+      controller.send(:resize_vm)
+      expect(controller.instance_variable_get(:@sb)[:explorer]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6959

The first commit fixes wrong redirect if we evacuated Instances displayed in a non-explorer screen (nested list) after we provided the same action on Instances in an explorer screen ( (_Compute > Clouds > Instances_). We need to set `@sb[:explorer]` back to `nil`. It was `nil` before Evacuate action, originally, **even if we were in an explorer screen**.

If we don't set `@sb[:explorer]` back to `nil` right after the Evacuate action, `true` value will be [saved](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1877) in `session[:sandboxes]['vm_cloud'][:explorer]` from `@sb[:explorer]` "forever", and later, when submitting/canceling Evacuate action in non explorer screen, the `controller_name` will be, when setting or getting global session data, the same as before in explorer screen (`'vm_cloud'`) - and we end up with a wrong value of `@sb[:explorer]` later exactly [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L1724) when setting `@sb` from `session[:sandboxes]`.

The exactly same issue (with redirecting to the proper screen after the action) is fixed in this PR also for reconfiguring and live migrating Instances displayed in a nested list.

Some related comments [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/6759#discussion_r404489457).

_Note:_ 
It will not be possible to finish Evacuate action when reproducing the issue, until the [fix](https://github.com/ManageIQ/manageiq-ui-classic/pull/6759) will be merged but this issue is related to Evacuate action, too, for sure (you can try it with that fix and you will see).

---

**Before:** (after canceling reconfiguring Instances in a nested list, for example)
![before](https://user-images.githubusercontent.com/13417815/78792240-29761c00-79b1-11ea-92c7-8ef0e7e2ee55.png)

**After:**
![after](https://user-images.githubusercontent.com/13417815/78792250-2e3ad000-79b1-11ea-9dcb-d9be84de699f.png)

