### PR TITLE
Get rid of the no longer used @miq_after_onload

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -108,9 +108,6 @@ module Mixins
         self.x_active_tree   = "#{params[:accordion]}_tree"
         self.x_active_accord = params[:accordion]
       end
-      if params[:button]
-        @miq_after_onload = "miqAjax('/#{controller_name}/x_button?pressed=#{params[:button]}');"
-      end
 
       build_accordions_and_trees
 

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -21,9 +21,6 @@ module VmShowMixin
       self.x_active_tree   = "#{params[:accordion]}_tree"
       self.x_active_accord = params[:accordion]
     end
-    if params[:button]
-      @miq_after_onload = "miqAjax('/#{controller_name}/x_button?pressed=#{params[:button]}');"
-    end
 
     # Build the Explorer screen from scratch
     allowed_features = build_accordions_and_trees_only

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -19,8 +19,3 @@
 
 = render :partial => "layouts/spinner"
 = render :partial => "layouts/lightbox_panel"
-
--# if set by controller, set up to run as JS after onload is done
-- if @miq_after_onload
-  :javascript
-    ManageIQ.afterOnload = '#{j @miq_after_onload}';


### PR DESCRIPTION
We found out with @h-kataria that this piece of code is no longer used, so we're removing it. Apparently it was related to VM chart context menus, but it got somehow refactored. Also the code has been copy-pasted to other controllers unnecessarily.

Follow-up on https://github.com/ManageIQ/manageiq-ui-classic/pull/6957

@miq-bot add_label cleanup, technical debt
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @h-kataria  
