### PR TITLE
Fix snapshot toolbar button always disabled

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -76,7 +76,6 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Create a new snapshot for this VM'),
           t,
-          :onwhen => "1",
           :klass  => ApplicationHelper::Button::VmSnapshotAdd
         ),
       ]

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -112,7 +112,6 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Create a new snapshot for this Instance'),
           t,
-          :onwhen => "1",
           :klass  => ApplicationHelper::Button::VmSnapshotAdd
         ),
       ]

--- a/app/helpers/application_helper/toolbar/x_vm_snapshot_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_snapshot_center.rb
@@ -5,7 +5,6 @@ class ApplicationHelper::Toolbar::XVmSnapshotCenter < ApplicationHelper::Toolbar
       'pficon pficon-add-circle-o fa-lg',
       N_('Create a new snapshot for this VM'),
       nil,
-      :onwhen => "1",
       :klass  => ApplicationHelper::Button::VmSnapshotAdd),
     select(
       :vm_delete_snap_choice,


### PR DESCRIPTION
Compute > Cloud/Infra > VMs/Instances - pick a VM
toolbar Configuration > Create a new snapshot for this VM

the button is only accessible from a detail screen, not a list screen,
but `onwhen=>1` requires at least one item be selected in the list screen.

Which makes the button always disabled, fixing.
`onwhen` does not make sense outside list screens (and thus plural toolbars).

(There may be other buttons simiarly affected, this is likely a react toolbar conversion change, created https://github.com/ManageIQ/manageiq-ui-classic/issues/6968.)

Fixes https://github.com/ManageIQ/manageiq/issues/20059