### PR TITLE
[Rails52] Use arel to fix "Dangerous query method"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1079,7 +1079,7 @@ class ApplicationController < ActionController::Base
   def process_saved_reports(saved_reports, task)
     success_count = 0
     failure_count = 0
-    MiqReportResult.for_user(current_user).where(:id => saved_reports).order("lower(name)").each do |rep|
+    MiqReportResult.for_user(current_user).where(:id => saved_reports).order(MiqReportResult.arel_table[:name].lower).each do |rep|
       rep.public_send(task) if rep.respond_to?(task) # Run the task
     rescue StandardError
       failure_count += 1 # Push msg and error flag

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1150,7 +1150,7 @@ class CatalogController < ApplicationController
   end
 
   def fetch_zones
-    @zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :id)
+    @zones = Zone.visible.in_my_region.order(Zone.arel_table[:description].lower).pluck(:description, :id)
   end
 
   def st_set_form_vars

--- a/app/controllers/mixins/actions/host_actions/misc.rb
+++ b/app/controllers/mixins/actions/host_actions/misc.rb
@@ -5,7 +5,7 @@ module Mixins
         # Common handling of misc Host buttons
 
         def each_host(host_ids, task_name)
-          Host.where(:id => host_ids).order('lower(name)').each do |host|
+          Host.where(:id => host_ids).order(Host.arel_table[:name].lower).each do |host|
             yield host
           rescue StandardError => err
             add_flash(

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -122,7 +122,7 @@ module ContainersCommonMixin
   end
 
   def process_scan_images(ids)
-    ContainerImage.where(:id => ids).order("lower(name)").each do |image|
+    ContainerImage.where(:id => ids).order(ContainerImage.arel_table[:name].lower).each do |image|
       image_name = image.name
       begin
         image.scan
@@ -138,7 +138,7 @@ module ContainersCommonMixin
   end
 
   def process_check_compliance(model, ids)
-    model.where(:id => ids).order("lower(name)").each do |entity|
+    model.where(:id => ids).order(model.arel_table[:name].lower).each do |entity|
       entity.check_compliance
     rescue => bang
       add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': %{error}") %

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -496,7 +496,7 @@ module Mixins
     end
 
     def process_check_compliance(model, ids)
-      model.where(:id => ids).order("lower(name)").each do |entity|
+      model.where(:id => ids).order(model.arel_table[:name].lower).each do |entity|
         entity.check_compliance
       rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': %{error}") %
@@ -517,7 +517,7 @@ module Mixins
 
     def form_instance_vars
       @server_zones = []
-      zones = Zone.visible.order('lower(description)')
+      zones = Zone.visible.order(Zone.arel_table[:name].lower)
       zones.each do |zone|
         @server_zones.push([zone.description, zone.name])
       end

--- a/app/controllers/mixins/ems_common/core.rb
+++ b/app/controllers/mixins/ems_common/core.rb
@@ -2,7 +2,7 @@ module Mixins
   module EmsCommon
     module Core
       def process_emss_task_destroy(emss)
-        model.where(:id => emss).order("lower(name)").each do |ems|
+        model.where(:id => emss).order(model.arel_table[:name].lower).each do |ems|
           audit = {:event        => "ems_record_delete_initiated",
                    :message      => "[#{ems.name}] Record delete initiated",
                    :target_id    => ems.id,
@@ -23,7 +23,7 @@ module Mixins
 
       def process_emss_task_pause_resume(emss, task)
         action = task.split("_").first
-        model.where(:id => emss).order("lower(name)").each do |ems|
+        model.where(:id => emss).order(model.arel_table[:name].lower).each do |ems|
           audit = {:event        => "ems_record_#{action}_initiated",
                    :message      => "[#{ems.name}] Record #{action} initiated",
                    :target_id    => ems.id,
@@ -37,7 +37,7 @@ module Mixins
       end
 
       def process_emss_task_other(emss, task)
-        model.where(:id => emss).order("lower(name)").each do |ems|
+        model.where(:id => emss).order(model.arel_table[:name].lower).each do |ems|
           ems.send(task.to_sym) if ems.respond_to?(task) # Run the task
         rescue => bang
           add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -208,13 +208,13 @@ module Mixins
     def new
       assert_privileges("#{privilege_prefix}_add_provider")
       @provider_manager = concrete_model.new
-      @server_zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :name)
+      @server_zones = Zone.visible.in_my_region.order(Zone.arel_table[:name].lower).pluck(:description, :name)
       @sb[:action] = params[:action]
       render_form
     end
 
     def edit
-      @server_zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :name)
+      @server_zones = Zone.visible.in_my_region.order(Zone.arel_table[:name].lower).pluck(:description, :name)
       case params[:button]
       when "cancel"
         cancel_provider

--- a/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_automation_manager_configuration_scripts.rb
@@ -17,8 +17,10 @@ class TreeBuilderAutomationManagerConfigurationScripts < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots
-    objects = []
-    templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::AutomationManager.order("lower(name)"), :match_via_descendants => ConfigurationScript)
+    objects    = []
+    model      = ManageIQ::Providers::AnsibleTower::AutomationManager
+    rbac_scope = model.order(model.arel_table[:name].lower)
+    templates  = Rbac.filtered(rbac_scope, :match_via_descendants => ConfigurationScript)
 
     templates.each do |temp|
       objects.push(temp)

--- a/app/presenters/tree_builder_infra_networking.rb
+++ b/app/presenters/tree_builder_infra_networking.rb
@@ -22,7 +22,8 @@ class TreeBuilderInfraNetworking < TreeBuilder
   end
 
   def x_get_tree_roots
-    objects = Rbac.filtered(ManageIQ::Providers::Vmware::InfraManager.order("lower(name)"))
+    model   = ManageIQ::Providers::Vmware::InfraManager
+    objects = Rbac.filtered(model.order(model.arel_table[:name].lower))
     count_only_or_objects(false, objects)
   end
 

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -162,7 +162,7 @@ describe TreeBuilder do
     end
 
     it 'counts collections with order' do
-      expect(builder.count_only_or_objects(true, VmOrTemplate.distinct.order("lower(vms.name)"))).to eq(0)
+      expect(builder.count_only_or_objects(true, VmOrTemplate.distinct.order(VmOrTemplate.arel_table[:name].lower))).to eq(0)
     end
   end
 


### PR DESCRIPTION
There were multiple places (all in `.order` calls) that triggered the following warning

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as
raw SQL) called with non-attribute argument(s): "lower(name)".  Non-attribute
arguments will be disallowed in Rails 6.0. This method should not be called
with user-provided values, such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql().
```

This fixes that by instead calling to `arel_table[].lower`, which does the same thing, but uses the existing arel interface to do it, which should be safer.  It should fail earlier for non-name columns, and should be safer overall then using `Arel.sql()`.


Links
-----

* Part of the Rails 5.2 effort:  https://github.com/ManageIQ/manageiq/issues/20032
* Similar to:
  - https://github.com/ManageIQ/manageiq/pull/20036
  - https://github.com/ManageIQ/manageiq/pull/20045
  - https://github.com/ManageIQ/manageiq-providers-openstack/pull/578