### PR TITLE
[Rails52] Fixes deprecated rack helpers

### DIFF
--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -242,7 +242,7 @@ describe OpsController do
     }
 
     skip "https://github.com/rails/rails/issues/23881" if Gem::Requirement.new('< 5.0.0.beta4') === Rails.gem_version
-    expect(response).to be_success
+    expect(response).to have_http_status(204)
 
     audit_event = AuditEvent.where(:target_id => schedule.id).first
     expect(audit_event.attributes['message']).to include("description changed to new_description")

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -241,7 +241,6 @@ describe OpsController do
       :timer_value => ""
     }
 
-    skip "https://github.com/rails/rails/issues/23881" if Gem::Requirement.new('< 5.0.0.beta4') === Rails.gem_version
     expect(response).to have_http_status(204)
 
     audit_event = AuditEvent.where(:target_id => schedule.id).first

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1394,7 +1394,7 @@ describe ReportController do
       post :form_field_changed, :params => {:id => 'new', :name => 'test'}
       post :form_field_changed, :params => {:button => "right", :available_fields => ["ChargebackVm-cpu_cost"]}
       resp = post :form_field_changed, :params => {:button => "left", :selected_fields => ["ChargebackVm-cpu_cost"]}
-      expect(resp.error?).to be_falsey
+      expect(resp.server_error?).to be_falsey
     end
   end
 


### PR DESCRIPTION
The following two errors were showing up in the specs:

```
DEPRECATION WARNING: The error? predicate is deprecated and will be removed in Rails 6.0. Please use server_error? as provided by Rack::Response::Helpers.
(called from block (3 levels) in <top (required)> at /Users/nicklamuro/code/redhat/manageiq-ui-classic/spec/controllers/report_controller_spec.rb:1397)
```

```
DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers.
(called from block (2 levels) in <top (required)> at /Users/nicklamuro/code/redhat/manageiq-ui-classic/spec/controllers/ops_controller_spec.rb:245)
```

This fixes those by either calling the correct method, or using a more commonly used method (`have_http_status`) that is used more commonly in our spec suite.


In addition to this, a `skip` call relic from the Rails 5.0 upgrade has also been removed.


Links
-----

* Part of the Rails 5.2 effort: https://github.com/ManageIQ/manageiq/issues/20032