### PR TITLE
Redirect to proper screen after succesful update of a Cloud Tenant in a list

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -156,20 +156,15 @@ class CloudTenantController < ApplicationController
     tenant_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Cloud Tenant \"%{name}\" updated") % {
+      flash_and_redirect(_("Cloud Tenant \"%{name}\" updated") % {
         :name => tenant_name
       })
     else
-      add_flash(_("Unable to update Cloud Tenant \"%{name}\": %{details}") % {
+      flash_and_redirect(_("Unable to update Cloud Tenant \"%{name}\": %{details}") % {
         :name    => tenant_name,
         :details => task.message
       }, :error)
     end
-
-    @breadcrumbs&.pop
-    session[:edit] = nil
-    flash_to_session
-    javascript_redirect(:action => "show", :id => tenant_id)
   end
 
   def cloud_tenant_form_fields

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -210,6 +210,32 @@ describe CloudTenantController do
     end
   end
 
+  describe '#update_finished' do
+    let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'ok', :message => 'some message') }
+
+    before do
+      allow(MiqTask).to receive(:find).with(123).and_return(miq_task)
+      allow(controller).to receive(:session).and_return(:async => {:params => {:task_id => 123, :name => tenant.name}})
+    end
+
+    it 'calls flash_and_redirect with appropriate arguments for succesful updating of a Cloud Tenant' do
+      expect(controller).to receive(:flash_and_redirect).with(_("Cloud Tenant \"%{name}\" updated") % {:name => tenant.name})
+      controller.send(:update_finished)
+    end
+
+    context 'unsuccesful updating of a Cloud Tenant' do
+      let(:miq_task) { double("MiqTask", :state => 'Finished', :status => 'Error', :message => 'some message') }
+
+      it 'calls flash_and_redirect with appropriate arguments' do
+        expect(controller).to receive(:flash_and_redirect).with(_("Unable to update Cloud Tenant \"%{name}\": %{details}") % {
+          :name    => tenant.name,
+          :details => miq_task.message
+        }, :error)
+        controller.send(:update_finished)
+      end
+    end
+  end
+
   describe "#delete" do
     let(:task_options) do
       {


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6967

We don't want always to redirect to the dashboard (or textual summary) of selected Tenant (after editing it). We want to end up in the same screen as before the action (Edit). Redirecting to the previous screen url solves the problem, instead of always calling `show` method. And it works universally, no matter where we are - in a list or also dashboard/summary of the Tenant.

`javascript_redirect(previous_breadcrumb_url)` instead of
`javascript_redirect(:action => "show", :id => tenant_id)` - that's the only change here. Everything else remains the same. I just used the existing `flash_and_redirect` method to achieve this. We end up with less code in `update_finish` method + it's working for all of the possible cases.

---

**Before:**
![tenant_before](https://user-images.githubusercontent.com/13417815/78900494-32312580-7a77-11ea-8092-b10fbd4a9fb7.png)

**After:**
![tenant_after1](https://user-images.githubusercontent.com/13417815/78900511-36f5d980-7a77-11ea-8ffc-26dec9d210ea.png)
![tenant_after2](https://user-images.githubusercontent.com/13417815/78900526-3bba8d80-7a77-11ea-835d-371e6acc76b5.png)
After editing selected Tenant in a list in _Compute > Clouds > Tenants_:
![tenant_after3](https://user-images.githubusercontent.com/13417815/78900899-d3b87700-7a77-11ea-9532-aa794823313f.png)
