### PR TITLE
Delete Cloud Tenants selected in a nested list

### DIFF
--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -240,7 +240,7 @@ class CloudTenantController < ApplicationController
     if task == "destroy"
       tenants.each do |tenant|
         audit = {
-          :event        => "cloud_tenant_record_delete_initiateed",
+          :event        => "cloud_tenant_record_delete_initiated",
           :message      => "[#{tenant.name}] Record delete initiated",
           :target_id    => tenant.id,
           :target_class => "CloudTenant",

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -195,18 +195,20 @@ class CloudTenantController < ApplicationController
     process_cloud_tenants(tenants_to_delete, "destroy") unless tenants_to_delete.empty?
 
     # refresh the list if applicable
-    if @lastaction == "show_list"
+    if @lastaction == "show_list" # list of Cloud Tenants
       show_list
       render_flash
       @refresh_partial = "layouts/gtl"
-    elsif @lastaction == "show" && @layout == "cloud_tenant"
-      # deleting from 'show' so we:
+    elsif %w[show show_dashboard].include?(@lastaction)
       if flash_errors? # either show the errors and stay on the 'show'
         render_flash
       else             # or (if we deleted what we were showing) we redirect to the listing
         flash_to_session
-        javascript_redirect(:action => 'show_list')
+        javascript_redirect(previous_breadcrumb_url)
       end
+    else # nested list of Cloud Tenants
+      flash_to_session
+      redirect_to(last_screen_url)
     end
   end
 

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -354,6 +354,9 @@ module Mixins
         when 'refresh_server_summary'
           javascript_redirect(:back)
           return
+        when 'custom_button'
+          custom_buttons
+          return
         end
 
         if @display && @display != 'main'
@@ -371,11 +374,13 @@ module Mixins
           end
         end
 
-        if params[:pressed] == "ems_cloud_recheck_auth_status"          ||
-           params[:pressed] == "ems_infra_recheck_auth_status"          ||
-           params[:pressed] == "ems_physical_infra_recheck_auth_status" ||
-           params[:pressed] == "ems_middleware_recheck_auth_status"     ||
-           params[:pressed] == "ems_container_recheck_auth_status"
+        if %w[
+          ems_cloud_recheck_auth_status
+          ems_container_recheck_auth_status
+          ems_infra_recheck_auth_status
+          ems_middleware_recheck_auth_status
+          ems_physical_infra_recheck_auth_status
+        ].include?(params[:pressed])
           if params[:id]
             table_key = :table
             _result, details = recheck_authentication
@@ -402,9 +407,6 @@ module Mixins
           return
         end
 
-        custom_buttons if params[:pressed] == "custom_button"
-
-        return if ["custom_button"].include?(params[:pressed]) # custom button screen, so return, let custom_buttons method handle everything
         return if ["#{table_name}_tag", "#{display_s}_tag", "#{table_name}_protect", "#{display_s}_protect", "#{table_name}_timeline"].include?(params[:pressed]) &&
                   @flash_array.nil? # Screen for Edit Tags or Manage Policies action showing, so return
 

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -419,6 +419,10 @@ module Mixins
         javascript_redirect(:controller => "cloud_tenant",
                             :action     => "edit",
                             :id         => find_record_with_rbac(CloudTenant, checked_or_params))
+      elsif params[:pressed] == 'cloud_tenant_delete'
+        javascript_redirect(:controller      => "cloud_tenant",
+                            :action          => 'delete_cloud_tenants',
+                            :miq_grid_checks => params[:miq_grid_checks])
       elsif params[:pressed] == "cloud_volume_new"
         javascript_redirect(:controller         => "cloud_volume",
                             :action             => "new",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,6 +452,7 @@ Rails.application.routes.draw do
     :cloud_tenant             => {
       :get => %w(
         cloud_tenant_form_fields
+        delete_cloud_tenants
         dialog_load
         download_data
         download_summary_pdf

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -236,6 +236,51 @@ describe CloudTenantController do
     end
   end
 
+  describe '#delete_cloud_tenants' do
+    before do
+      controller.params = {:miq_grid_checks => tenant.id.to_s}
+      controller.instance_variable_set(:@breadcrumbs, [{:url => 'previous url'}, {:url => 'last url'}])
+    end
+
+    it 'calls flash_to_session and redirect_to with proper url while displaying nested list of Cloud Tenants' do
+      expect(controller).to receive(:flash_to_session)
+      expect(controller).to receive(:redirect_to).with('last url')
+      controller.send(:delete_cloud_tenants)
+    end
+
+    context 'summary or dashboard of a Cloud Tenant' do
+      %w[show show_dashboard].each do |lastaction|
+        before { controller.instance_variable_set(:@lastaction, lastaction) }
+
+        it 'calls flash_to_session and javascript_redirect' do
+          expect(controller).to receive(:flash_to_session)
+          expect(controller).to receive(:javascript_redirect).with('previous url')
+          controller.send(:delete_cloud_tenants)
+        end
+
+        context 'flash errors' do
+          before { allow(controller).to receive(:flash_errors?).and_return(true) }
+
+          it 'calls render_flash' do
+            expect(controller).to receive(:render_flash)
+            controller.send(:delete_cloud_tenants)
+          end
+        end
+      end
+    end
+
+    context 'list of Cloud Tenants' do
+      before { controller.instance_variable_set(:@lastaction, 'show_list') }
+
+      it 'calls show_list and render_flash, sets @refresh_partial' do
+        expect(controller).to receive(:show_list)
+        expect(controller).to receive(:render_flash)
+        controller.send(:delete_cloud_tenants)
+        expect(controller.instance_variable_get(:@refresh_partial)).to eq('layouts/gtl')
+      end
+    end
+  end
+
   include_examples '#download_summary_pdf', :cloud_tenant
 
   it_behaves_like "controller with custom buttons"

--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -84,6 +84,23 @@ describe EmsCloudController do
         end
       end
 
+      context 'deleting Cloud Tenants' do
+        let(:ems) { FactoryBot.create(:ems_openstack) }
+        let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+
+        before do
+          allow(controller).to receive(:show)
+          controller.params = {:pressed => 'cloud_tenant_delete', :miq_grid_checks => tenant.id.to_s}
+        end
+
+        it 'calls javascript_redirect with appropriate arguments to delete selected Cloud Tenants' do
+          expect(controller).to receive(:javascript_redirect).with(:controller      => "cloud_tenant",
+                                                                   :action          => 'delete_cloud_tenants',
+                                                                   :miq_grid_checks => tenant.id.to_s)
+          controller.send(:button)
+        end
+      end
+
       context 'actions on Host Aggregates displayed through Cloud Provider' do
         let(:aggregate) { FactoryBot.create(:host_aggregate) }
 


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6973

There was the logic missing in _EmsCommon_ mixin regarding deleting Cloud Tenants displayed in a nested list. Only `show` method and `render_flash` were called in `button` method, and nothing related to deleting the Tenants.

In this PR, I am also fixing redirecting issue after deleting Cloud Tenants in a nested list. I almost didn't change [other cases for redirecting](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/cloud_tenant_controller.rb#L198-L210) regarding the `@lastaction` because I've found that they're needed just as they are, but with two little exceptions: 
- [this change](https://github.com/ManageIQ/manageiq-ui-classic/pull/6974/files#diff-68512128862e16616d93240055cb3a7dR207) is made because of the possibility of redirecting also to the nested list of Tenants displayed right before displaying the summary/dashboard of a specific Cloud Tenant (from the nested list)
- [this one](https://github.com/ManageIQ/manageiq-ui-classic/pull/6974/files#diff-68512128862e16616d93240055cb3a7dR202) is made because deleting Cloud Tenant is possible also from its dashboard, not just summary screen, it was missing there. Without it, the proper screen wouldn't be rendered after the action.

---

**Before:**
![delete_before](https://user-images.githubusercontent.com/13417815/78926792-feb5c180-7a9d-11ea-8fe8-cb003721911e.png)

**After:**
![tenant_after](https://user-images.githubusercontent.com/13417815/78935148-7559bb80-7aac-11ea-8f6e-ce10f33aeba3.png)

---

**Notes:**
I am also adding some very little improvements of the code in the `button` method which I consider as obvious and safe. However, the method requires a huge refactoring as there's a lot of unnecessary and unrelated code executed for some actions, and readability is not good. And, as we see, regarding this PR, there are still some bugs. And a lot of stuff there can be done via `button` method in _GenericButtonMixin_ -  and even much better. But we should provide refactoring of the `button` method very carefully as it is related to many actions and its complexity is not low.

Anyway, [this](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/cloud_tenant_controller.rb#L241) confuses me, I assume that it is a typo. Or maybe not? `...initiateed`