### PR TITLE
Simplified checkedness of 🌳🌳 on compare screens, enabled post_check

### DIFF
--- a/app/presenters/tree_builder_sections.rb
+++ b/app/presenters/tree_builder_sections.rb
@@ -16,6 +16,7 @@ class TreeBuilderSections < TreeBuilder
       :full_ids     => true,
       :checkboxes   => true,
       :three_checks => true,
+      :post_check   => true,
       :oncheck      => "miqOnCheckSections",
       :check_url    => "/#{@controller_name}/sections_field_changed/"
     }
@@ -31,22 +32,11 @@ class TreeBuilderSections < TreeBuilder
                    :text       => section[:group] == "Categories" ? _("%{current_tenant} Tags") % {:current_tenant => @current_tenant} : _(section[:group]),
                    :tip        => _(section[:group]),
                    :image      => false,
-                   :checked    => true,
                    :selectable => false,
                    :nodes      => [section])
       else
         nodes.last[:nodes].push(section)
       end
-    end
-    nodes.each do |node|
-      checked = node[:nodes].count { |kid| @data.include[kid[:name]][:checked] } # number of checked kids
-      node[:checked] = if checked.zero?
-                         false
-                       elsif checked < node[:nodes].size
-                         'undefined'
-                       else
-                         true
-                       end
     end
     count_only_or_objects(false, nodes)
   end

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -58,6 +58,7 @@ describe TreeBuilderSections do
         :full_ids     => true,
         :checkboxes   => true,
         :three_checks => true,
+        :post_check   => true,
         :oncheck      => "miqOnCheckSections",
         :check_url    => "/controller_name/sections_field_changed/"
       )
@@ -74,7 +75,6 @@ describe TreeBuilderSections do
                             :text       => "Properties",
                             :tip        => "Properties",
                             :image      => false,
-                            :checked    => true,
                             :selectable => false,
                             :nodes      => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
     end


### PR DESCRIPTION
The checkedness on compare screens is implemented explicitly in a little crazy way and partial checking never worker. So we decided with @brumik to utilize `post_check` on the tree. This allowed me to :scissors: delete :skull: some code and fix the issue.

**Before:**
![Screenshot from 2020-04-10 09-39-01](https://user-images.githubusercontent.com/649130/78972914-21cc8980-7b0f-11ea-84bb-5e3818f6777c.png)

**After:**
![Screenshot from 2020-04-10 09-37-04](https://user-images.githubusercontent.com/649130/78972868-0f525000-7b0f-11ea-9a8b-958452fb6ec5.png)

@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label trees, bug, cleanup
