### PR TITLE
Fix TreeBuilder#post_check to actually reverse! the nodes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -131,7 +131,7 @@ class TreeBuilder
     end
 
     # Process nodes top-to-bottom
-    nodes.reverse
+    nodes.reverse!
     while nodes.any?
       parent = nodes.pop
 


### PR DESCRIPTION
My rewrite of the algorithm from JS to Ruby wasn't as good as I thought :see_no_evil: `Array#reverse` in Ruby isn't the same as `Array.prototype.reverse` in JS. It's strange how big difference a single character can make :sob: 

https://github.com/ManageIQ/manageiq-ui-classic/pull/6964/files#diff-bff4131de23ce9175827098fd726ca7aL461

@miq-bot add_label bug, trees
@miq-bot assign @h-kataria