### PR TITLE
remove-generic-item-modal: fix typeof==undefined bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,9 @@
     "no-unreachable": 2,
     "use-isnan": 2,
     "valid-jsdoc": 2,
-    "valid-typeof": 2,
+    "valid-typeof": [2, {
+      "requireStringLiterals": true
+    }],
     "dot-notation": [2, {
       "allowKeywords": true
     }],

--- a/app/javascript/.eslintrc.json
+++ b/app/javascript/.eslintrc.json
@@ -55,6 +55,9 @@
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": [1, "always"],
     "semi": [2, "always"],
-    "space-before-function-paren": [2, "never"]
+    "space-before-function-paren": [2, "never"],
+    "valid-typeof": [2, {
+      "requireStringLiterals": true
+    }]
   }
 }

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -43,7 +43,7 @@ export const removeItems = (items, apiUrl, asyncDelete, redirectUrl, treeSelect)
     })
     .then((apiData) => {
       if (items.length > 1 || (items.length === 1 && apiData[0].result === 'success')) {
-        if (typeof(treeSelect) == undefined) {
+        if (!treeSelect) {
           window.location.href = redirectUrl;
           miqSparkleOff();
         } else {


### PR DESCRIPTION
`typeof(treeSelect) == undefined` is always false, typeof returns a string

This lead to buttons without tree_select trying to do tree_select instead of redirect_url.

Cc @mzazrivec, @h-kataria 