### PR TITLE
 Always display the error message upon authentication from the backend

### DIFF
--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -94,12 +94,7 @@ class UserValidationService
       user_or_taskid = User.authenticate(user[:name], user[:password], request, authenticate_options)
     rescue MiqException::MiqEVMLoginError => err
       user[:name] = nil
-      err_message = if err.message.present? && authenticate_options[:require_user]
-                      err.message
-                    else
-                      _("Sorry, the username or password you entered is incorrect.")
-                    end
-      return ValidateResult.new(:fail, err_message)
+      return ValidateResult.new(:fail, err.message)
     end
 
     if user_or_taskid.kind_of?(User)


### PR DESCRIPTION
Displaying a message upon a login attempt when a user's account has been locked:
![Screenshot from 2020-04-22 16-57-22](https://user-images.githubusercontent.com/649130/79997959-687c9500-84ba-11ea-8bfe-30345f89afbd.png)

Parent issue: https://github.com/ManageIQ/manageiq/issues/20043
Depends on: https://github.com/ManageIQ/manageiq/pull/20087

@miq-bot add_label enhancement