### PR TITLE
[IVANCHUK] header fix

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -4,8 +4,8 @@ $navbar-pf-navbar-navbar-brand-min-width:   270px;
 $navbar-pf-navbar-navbar-brand-padding:     8px 0 2px;
 $dropdown-link-hover-bg:                    #d4edfa;  // sets dropdown link hover
 $link-color:                                #0099d3;  // sets link (also accordion hover, selected table cell) color globally
-$navbar-pf-vertical-border-color:           #3c69a3;  // sets 3px border color at top of screen
-$navbar-pf-alt-bg-color:                    #3c69a3;  // sets background color of navigation bar
+$navbar-pf-vertical-border-color:           #166aa3;  // sets 3px border color at top of screen
+$navbar-pf-alt-bg-color:                    #166aa3;  // sets background color of navigation bar
 $nav-pf-vertical-width:                     225px;    // sets width of primary navigation
 $navbar-pf-alt-navbar-toggle-icon-bar-hover-bg: #fff;
 $img-bg-navbar:                             "layout/navbar.png"; // sets a custom background image in the header


### PR DESCRIPTION
This PR adjusts the masthead background color to match the header image on the right. (The header image is not necessary for the default branding, but has been left in for users who continue to rebrand the header with an image like was used in the previous design.)

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6983

Old
![Screen Shot 2020-04-23 at 10 00 22 AM](https://user-images.githubusercontent.com/1287144/80108118-ee93ec80-8549-11ea-8a7b-b122b874c7ad.png)

New
![Screen Shot 2020-04-23 at 10 00 03 AM](https://user-images.githubusercontent.com/1287144/80108113-edfb5600-8549-11ea-9a10-737814833508.png)

