### PR TITLE
Make sure custom button doesn't need to be checked when on summary page

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -189,14 +189,11 @@ class ApplicationHelper::ToolbarBuilder
   end
 
   def cb_send_checked_list
-    @display.present? && custom_button_appliable_class?(@display.camelize.singularize)
+    @display.present? && custom_button_appliable_class?(@display.camelize.singularize) && @view_context.params[:id] == @record.id.to_s
   end
 
   def cb_enabled_value_for_nested
-    if @display == 'generic_objects'
-      return false if @lastaction == 'generic_objects'
-      return true if @lastaction == 'generic_object'
-    end
+    @display == 'generic_objects' && @view_context.params[:id] == @record.id.to_s
   end
 
   def create_custom_button(input, model, record)


### PR DESCRIPTION
Note: You may need https://github.com/ManageIQ/manageiq-api/pull/812 to create CustomButton correctly

Steps to reproduce:
- Automation -> Generic Objects -> Add Custom Button Group to a Generic Object -> Add Custom Buttons to this group or Add just a Custom Button
- Services -> My Services -> click to a Service that has an Instance of that Generic Object
- click on Instances
- click on one Instance
- see buttons 

Before:
<img width="1669" alt="Screenshot 2020-04-27 at 13 32 52" src="https://user-images.githubusercontent.com/9210860/80367610-b531e880-888b-11ea-8a38-07447e0f8f93.png">

After:
<img width="1662" alt="Screenshot 2020-04-27 at 13 15 59" src="https://user-images.githubusercontent.com/9210860/80367580-a51a0900-888b-11ea-95d0-258dba903825.png">

@miq-bot add_label wip, bug, jansa/yes