### PR TITLE
Implemented FieldArray component and added it to the DDF mapper

### DIFF
--- a/app/javascript/components/field-array/field-array-item.jsx
+++ b/app/javascript/components/field-array/field-array-item.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Col, Button } from 'patternfly-react';
+
+const FieldArrayItem = ({
+  FieldProvider,
+  fields,
+  fieldIndex,
+  name,
+  value,
+  formOptions,
+  remove,
+  colsize,
+}) => {
+  return (
+    <div className="field-array-item">
+      { fields.map(({ label: _label, ...field }, index) => (
+        <Col xs={colsize} key={index}>{ formOptions.renderForm([field]) }</Col>
+      )) }
+      <Col xs={2}>
+        <Button className="field-array-item-remove" onClick={() => remove(fieldIndex)}>
+          { __('Remove') }
+        </Button>
+      </Col>
+    </div>
+  );
+};
+
+FieldArrayItem.propTypes = {
+  FieldProvider: PropTypes.oneOfType([PropTypes.element.isRequired, PropTypes.func]).isRequired,
+  fields: PropTypes.any.isRequired,
+  fieldIndex: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.any,
+  formOptions: PropTypes.shape({
+    getState: PropTypes.func.isRequired,
+    change: PropTypes.func.isRequired,
+    renderForm: PropTypes.func.isRequired,
+  }).isRequired,
+  remove: PropTypes.func.isRequired,
+  colsize: PropTypes.number.isRequired,
+};
+
+export default FieldArrayItem;

--- a/app/javascript/components/field-array/index.jsx
+++ b/app/javascript/components/field-array/index.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col, Button, FormGroup } from 'patternfly-react';
+
+import FieldArrayItem from './field-array-item';
+
+const FieldArray = ({
+  FieldProvider,
+  FieldArrayProvider,
+  arrayValidator,
+  label,
+  fields,
+  itemDefault,
+  formOptions,
+  addText,
+  ...rest
+}) => {
+  const { name } = rest.input;
+  const colsize = Math.floor(10 / fields.length);
+
+  const header = (
+    <Row>
+      <div className="field-array-header">
+        { fields.map(({ label }, index) => (
+          <Col xs={colsize} key={index}><label>{ label }</label></Col>
+        )) }
+        <Col xs={2}><label>{ __('Actions') }</label></Col>
+      </div>
+    </Row>
+  );
+
+  return (
+    <FieldArrayProvider name={name} validate={arrayValidator}>
+      { ({ fields: { length, map, value, push, remove } }) => (
+        <div className="field-array">
+          <h3>{ label }</h3>
+          { length && length > 0 && header }
+          {
+            map((option, index) => (
+              <Row key={index}>
+                <FieldArrayItem
+                  name={option}
+                  fields={fields}
+                  value={value[index].value}
+                  fieldIndex={index}
+                  formOptions={formOptions}
+                  FieldProvider={FieldProvider}
+                  remove={remove}
+                  colsize={colsize}
+                />
+              </Row>
+            ))
+          }
+          <FormGroup>
+            <Button bsStyle="primary" className="field-array-item-add pull-right" onClick={() => push(itemDefault)}>
+              { addText }
+            </Button>
+            <div className="clearfix" />
+          </FormGroup>
+        </div>
+      )}
+    </FieldArrayProvider>
+  );
+};
+
+FieldArray.propTypes = {
+  FieldProvider: PropTypes.oneOfType([PropTypes.element.isRequired, PropTypes.func]).isRequired,
+  FieldArrayProvider: PropTypes.oneOfType([PropTypes.element.isRequired, PropTypes.func]).isRequired,
+  arrayValidator: PropTypes.func,
+  label: PropTypes.string,
+  fields: PropTypes.any.isRequired,
+  itemDefault: PropTypes.any,
+  formOptions: PropTypes.shape({
+    getState: PropTypes.func.isRequired,
+    change: PropTypes.func.isRequired,
+    renderForm: PropTypes.func.isRequired,
+  }).isRequired,
+  addText: PropTypes.string,
+};
+
+FieldArray.defaultProps = {
+  arrayValidator: undefined,
+  label: undefined,
+  addText: __('New option'),
+  itemDefault: {},
+};
+
+export default FieldArray;

--- a/app/javascript/forms/mappers/formFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formFieldsMapper.jsx
@@ -9,6 +9,7 @@ import EditPasswordField from '../../components/async-credentials/edit-password-
 import InputWithDynamicPrefix from '../input-with-dynamic-prefix';
 import PasswordField from '../../components/async-credentials/password-field';
 import { DataDrivenFormCodeEditor } from '../../components/code-editor';
+import FieldArray from '../../components/field-array';
 
 const fieldsMapper = {
   ...formFieldsMapper,
@@ -21,6 +22,7 @@ const fieldsMapper = {
   'password-field': PasswordField,
   'validate-credentials': AsyncCredentials,
   'validate-provider-credentials': AsyncProviderCredentials,
+  'field-array': FieldArray,
 };
 
 export default fieldsMapper;


### PR DESCRIPTION
In some forms we have a set of key-value pairs, the ones I found were for automate attributes in generic objects. DDF provides a [Field Array](https://data-driven-forms.org/renderer/dynamic-fields#heading-usingfieldarray) component but without implementation for PF3, so I created one for our purposes.

![Screenshot from 2020-04-27 15-49-10](https://user-images.githubusercontent.com/649130/80379663-adc80a80-889e-11ea-9922-d4290428008c.png)

To test this component, use the diff below (feel free to tweak), go to a VM's summary screen and initiate *Set Ownership* from the *Configuration* toolbar button.
```diff
diff --git a/app/javascript/components/set-ownership-form/ownership-form.schema.js b/app/javascript/components/set-ownership-form/ownership-form.schema.js
index 61cbf51b0..394f43ef4 100644
--- a/app/javascript/components/set-ownership-form/ownership-form.schema.js
+++ b/app/javascript/components/set-ownership-form/ownership-form.schema.js
@@ -13,6 +13,22 @@ const createSchema = (ownerOptions, groupOptions) => ({
     id: 'group_name',
     label: __('Select a Group:'),
     options: groupOptions,
+  }, {
+    name: 'options',
+    label: 'Options',
+    component: componentTypes.FIELD_ARRAY,
+    fields: [
+      {
+        component: componentTypes.TEXT_FIELD,
+        label: 'foo',
+        name: 'key',
+      },
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'value',
+        label: 'bar',
+      },
+    ],
   }],
 });
```

@miq-bot add_label enhancement, react

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7002
Resolves https://github.com/ManageIQ/manageiq-ui-classic/issues/6988