### PR TITLE
Revert "make react forms responsive"

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -711,26 +711,6 @@ fieldset {
   margin-top: -20px !important;
 }
 
-/* responsive styling for new react forms (refactor after all forms are converted )*/
-
-@media (max-width: $screen-sm){
-  .container-fluid form.form-react {
-    width: 100%;
-  }
-}
-
-@media (min-width: $screen-md) {
-  .container-fluid form.form-react {
-    width: 75%
-  }
-}
-
-@media (min-width: $screen-lg) {
-  .container-fluid form.form-react {
-    width: 50%
-  }
-}
-
 table.c3-tooltip td {
   background-color: #393f44;
 }


### PR DESCRIPTION
Required for field-array stuff which is much wider, we will do the respo differently in the future anyway.

**Before:**
![Screenshot from 2020-04-27 18-21-59](https://user-images.githubusercontent.com/649130/80396454-f38fcd80-88b4-11ea-8614-16168bfcca80.png)

**After:**
![Screenshot from 2020-04-27 18-17-29](https://user-images.githubusercontent.com/649130/80396466-f7bbeb00-88b4-11ea-8a0d-41eb0cdaa4e2.png)


This reverts commit 1df8779bdcc6c7b22c804c954050bf8ae807022d from https://github.com/ManageIQ/manageiq-ui-classic/pull/5650