### PR TITLE
Merge default button labels properly with the custom ones in DDF

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -14,14 +14,8 @@ Validators.messages = {
   required: __('Required'),
 };
 
-const buttonLabels = {
-  submitLabel: __('Save'),
-  resetLabel: __('Reset'),
-  cancelLabel: __('Cancel'),
-};
-
 const MiqFormRenderer = ({
-  className, setPristine, onStateUpdate, formFieldsMapper, ...props
+  className, setPristine, onStateUpdate, formFieldsMapper, buttonsLabels, ...props
 }) => (
   <FormRender
     formFieldsMapper={formFieldsMapper}
@@ -39,7 +33,12 @@ const MiqFormRenderer = ({
         onStateUpdate(formOptions);
       }
     }}
-    {...buttonLabels}
+    buttonsLabels={{
+      submitLabel: __('Save'),
+      resetLabel: __('Reset'),
+      cancelLabel: __('Cancel'),
+      ...buttonsLabels,
+    }}
     {...props}
   />
 );
@@ -49,12 +48,14 @@ MiqFormRenderer.propTypes = {
   onStateUpdate: PropTypes.func,
   setPristine: PropTypes.func.isRequired,
   formFieldsMapper: PropTypes.any,
+  buttonsLabels: PropTypes.any,
 };
 
 MiqFormRenderer.defaultProps = {
   className: 'form-react',
   onStateUpdate: undefined,
   formFieldsMapper: defaultFormFieldsMapper,
+  buttonsLabels: {},
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators({ setPristine }, dispatch);


### PR DESCRIPTION
The `buttonsLabels` property is not set in the `MiqFormRenderer` component, so the default button labels come straight from DDF without any i18n. There's a splatted `buttonLabels` prop on the component, but its contents are not caught by the `FormRenderer` component.

I changed the dataflow so the default button labels have now i18n calls and they are being merged with the additional ones coming as props.

@miq-bot add_label i18n, bug, react
@miq-bot assign @mzazrivec 