### PR TITLE
Expose our DDF renderer and constants as an alias for other engines

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from 'patternfly-react';
-import FormRender, { Validators, layoutComponents } from '@data-driven-forms/react-form-renderer';
+import FormRender, { Validators, layoutComponents, componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import { layoutMapper } from '@data-driven-forms/pf3-component-mapper';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -60,4 +60,5 @@ MiqFormRenderer.defaultProps = {
 
 const mapDispatchToProps = dispatch => bindActionCreators({ setPristine }, dispatch);
 
+export { componentTypes, validatorTypes };
 export default connect(null, mapDispatchToProps)(MiqFormRenderer);

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -136,6 +136,7 @@ module.exports = {
       'bootstrap-select': '@pf3/select', // never use vanilla bootstrap-select
       '@patternfly/patternfly': resolveModule('NONEXISTENT'),
       '@patternfly/patternfly-next': resolveModule('NONEXISTENT'),
+      '@@ddf': resolve(dirname(__filename), '../../app/javascript/forms/data-driven-form'),
     },
     extensions: settings.extensions,
     modules: [],

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
     "\\.(css|scss)$": 'identity-obj-proxy',
     '^react$': '<rootDir>/node_modules/react/',
     '^moment$': resolveModule('moment'), // fix moment-strftime peerDependency issue
+    '@@ddf': '<rootDir>/app/javascript/forms/data-driven-form',
   },
 };


### PR DESCRIPTION
We have our own renderer for DDF and it would be nice to expose it for other rails engines. This would allow me to continue in getting rid of final-form components in [some provider repos](https://github.com/ManageIQ/manageiq-ui-classic/issues/6716#issuecomment-591974680) by replacing them with DDF.

The alias is set to `@@ddf`, so we could load a component like this:
```js
import MiqFormRenderer, { componentTypes, validatorTypes } from "@@ddf";
```

@miq-bot add_label enhancement, react
@miq-bot assign @himdel 