### PR TITLE
Improve automate namespace query performance.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -378,7 +378,7 @@ class MiqAeClassController < ApplicationController
     when "MiqAeClass"
       cls = "aec"
       glyphicon = "ff ff-class"
-    when "MiqAeNamespace"
+    when "MiqAeNamespace", "MiqAeDomain"
       cls = "aen"
       glyphicon = "pficon pficon-folder-open"
     when "MiqAeInstance"

--- a/app/presenters/tree_builder_automate_catalog.rb
+++ b/app/presenters/tree_builder_automate_catalog.rb
@@ -31,7 +31,6 @@ class TreeBuilderAutomateCatalog < TreeBuilderAutomate
   def filter_ae_objects(objects)
     return objects unless @sb[:cached_waypoint_ids]
     klass_name = objects.first.class.name
-    prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
-    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{prefix}::#{obj.id}") }
+    objects.select { |obj| @sb[:cached_waypoint_ids].include?("#{klass_name}::#{obj.id}") }
   end
 end

--- a/spec/helpers/application_helper/buttons/miq_ae_class_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_class_copy_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationHelper::Button::MiqAeClassCopy do
   before { login_as FactoryBot.create(:user, :with_miq_edit_features) }
 
   describe '#visible?' do
-    let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
+    let(:record) { FactoryBot.create(:miq_ae_class, :domain => domain) }
     context 'when there are no editable domains' do
       let(:domain) { FactoryBot.create(:miq_ae_domain_user_locked) }
       it { expect(subject.visible?).to be_falsey }

--- a/spec/helpers/application_helper/buttons/miq_ae_default_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_default_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::MiqAeDefault do
   let(:session) { {} }
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
+  let(:record) { FactoryBot.create(:miq_ae_class, :domain => domain) }
   let(:subject) { described_class.new(view_context, {}, {'record' => record}, {:child_id => 'miq_ae_class_edit'}) }
 
   before { login_as FactoryBot.create(:user, :with_miq_edit_features) }

--- a/spec/helpers/application_helper/buttons/miq_ae_instance_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_instance_copy_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::MiqAeInstanceCopy do
   let(:session) { {} }
   let(:view_context) { setup_view_context_with_sandbox({}) }
-  let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
+  let(:record) { FactoryBot.create(:miq_ae_class, :domain => domain) }
   let(:domain) { FactoryBot.create(:miq_ae_domain_disabled) }
   subject { described_class.new(view_context, {}, {'record' => record}, {:child_id => child_id}) }
 
@@ -21,7 +21,7 @@ describe ApplicationHelper::Button::MiqAeInstanceCopy do
       end
       context 'and button is miq_ae_method_copy with method record' do
         let(:child_id) { 'miq_ae_method_copy' }
-        let(:klass) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => domain) }
+        let(:klass) { FactoryBot.create(:miq_ae_class, :domain => domain) }
         let(:record) do
           FactoryBot.create(:miq_ae_method, :scope => 'class', :language => 'ruby',
                                           :location => 'builtin', :ae_class => klass)

--- a/spec/helpers/application_helper/buttons/miq_ae_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_ae_spec.rb
@@ -18,7 +18,7 @@ describe ApplicationHelper::Button::MiqAe do
         it { expect(subject.visible?).to be_falsey }
       end
       context 'when editable domains available' do
-        let(:record) { FactoryBot.create(:miq_ae_class, :of_domain, :domain => FactoryBot.create(:miq_ae_domain)) }
+        let(:record) { FactoryBot.create(:miq_ae_class) }
         it { expect(subject.visible?).to be_truthy }
       end
     end

--- a/spec/helpers/application_helper/toolbar_chooser_spec.rb
+++ b/spec/helpers/application_helper/toolbar_chooser_spec.rb
@@ -29,7 +29,7 @@ describe ApplicationHelper, "ToolbarChooser" do
       end
 
       it "should return namespaces toolbar on domain node" do
-        n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :priority => 10)
+        n1 = FactoryBot.create(:miq_ae_domain, :name => 'ns1', :priority => 10)
         x_node_set("aen-#{n1.id}", :ae_tree)
         expect(_toolbar_chooser.send(:center_toolbar_filename_automate)).to eq("miq_ae_domain_center_tb")
       end


### PR DESCRIPTION
New columns `domain_id` and `relative_path` have been added to `MiqAeNamespaces/MiqAeClass/MiqAeInstance/MiqAeMethod` tables.
So namespace can be queried based on these two columns instead of loop thru the namespace fqname.

Part of https://github.com/ManageIQ/manageiq/pull/20050.
cross repo tests: ManageIQ/manageiq-cross_repo-tests#112

ManageIQ/manageiq-automation_engine#410
