### PR TITLE
Add missing name into the Firmware Registry Form schema

### DIFF
--- a/app/javascript/components/firmware-registry/firmware-registry-form.schema.js
+++ b/app/javascript/components/firmware-registry/firmware-registry-form.schema.js
@@ -5,6 +5,7 @@ export default (TYPES) => {
     {
       component: componentTypes.SUB_FORM,
       title: __('Basic Info'),
+      name: 'basic-info',
       fields: [
         {
           component: componentTypes.SELECT_COMPONENT,


### PR DESCRIPTION
When you go to `Compute -> Infrastructure -> Firmware Registries` the form under `Configuration -> Add new Firmware Registry` is broken as the `name˙ now is a required parameter in DDF:

![Screenshot from 2020-04-30 12-50-34](https://user-images.githubusercontent.com/649130/80702343-3504c080-8ae1-11ea-9a4d-ba71fba9923b.png)

By adding the name on the `sub-form` the problem goes away:
![Screenshot from 2020-04-30 12-48-49](https://user-images.githubusercontent.com/649130/80702367-3e8e2880-8ae1-11ea-8e44-7eb7b08d6858.png)

@miq-bot add_label bug, react
@miq-bot assign @mzazrivec 