### PR TITLE
Remove obsolete big_iframe logic

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,6 @@
     = miq_favicon_link_tag
     = stylesheet_link_tag 'application'
     = stylesheet_link_tag '/custom.css'
-    = render :partial => "stylesheets/template50"
     = javascript_dependencies
     - if Rails.env.development?
       = javascript_include_tag 'miq_debug'

--- a/app/views/stylesheets/_template50.html.haml
+++ b/app/views/stylesheets/_template50.html.haml
@@ -1,5 +1,0 @@
-- if big_iframe
-  :css
-    @media (min-width: 1080px) {
-      .navbar-pf ul > li.active { margin-bottom: 0 !important; }
-      .navbar-nav ul > li > ul { display:none }


### PR DESCRIPTION
big_iframe used to be the layout without menu,
that changed in https://github.com/ManageIQ/manageiq/pull/8114,

therefore we should no longer adjust big_iframe margins as if the menu wasn't there
removing

Cc @skateman 