### PR TITLE
Fix i18n labels in Persistent Volume page

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -176,7 +176,8 @@ module PersistentVolumeHelper::TextualSummary
   end
 
   def textual_volume_path
-    @record.common_path
+    {:label => _("Volume path"),
+     :value => @record.common_path}
   end
 
   def textual_fs_type
@@ -222,6 +223,7 @@ module PersistentVolumeHelper::TextualSummary
   end
 
   def textual_desired_access_modes
-    @claim.desired_access_modes.join(',')
+    {:label => _("Desired access modes"),
+     :value => @claim.desired_access_modes.join(',')}
   end
 end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7025

How reproducible:
Always

Steps to Reproduce:

- Log into MIQ UI with non en_US locale
- Navigate to Compute - Containers - Volumes and click on any list item
- `Volume path` and  `Desired access modes` are in English

Before:
<img width="518" alt="Screenshot 2020-05-04 at 11 39 25" src="https://user-images.githubusercontent.com/9210860/80953504-f67e4700-8dfb-11ea-975b-8e47c6f2d233.png">
After:
It's translated.

@miq-bot add_label bug, internationalization

@miq-bot assign @mzazrivec 