### PR TITLE
Fix i18n security group

### DIFF
--- a/app/views/security_group/new.html.haml
+++ b/app/views/security_group/new.html.haml
@@ -22,6 +22,7 @@
                 'ng-model'   => "vm.securityGroupModel.ems_id",
                 'ng-options' => 'ems.id as ems.name for ems in vm.ems',
                 'miq-select' => true,
+                "selectpicker-for-select-tag" => "",
                 'required'   => ''}
           %option{:value => ""}
             = "<#{_('Choose')}>"


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7022

How reproducible:
Always

Steps to Reproduce:

- Log into MIQ ui with non en_US locale
- Navigate to Networks - Security Groups - Configuration and click on `Add a new security group`
-  Observe `Network Manager` drop-down menu and mouse hover on `Security Group Name` text box.
- `Nothing selected` and `Please fill out this field.` are in English.

Before:
<img width="1432" alt="Screenshot 2020-05-04 at 14 44 13" src="https://user-images.githubusercontent.com/9210860/80966913-bf1c9400-8e15-11ea-917a-983df4848b2f.png">

After:
<img width="1438" alt="Screenshot 2020-05-04 at 13 51 26" src="https://user-images.githubusercontent.com/9210860/80966642-2d148b80-8e15-11ea-82c8-8975a3e2967e.png">

WON'T FIX:
`Please fill out this field` effects every single required text field and is a build-in browser thing. It should be in a language the browser is set to. Leaving as is.

@miq-bot add_label wip, bug, internationalization 
