### PR TITLE
Fix error message for Custom Image

### DIFF
--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -24,7 +24,7 @@ module OpsController::Settings::Upload
   def upload_logos(file, field, text, type)
     if field && field[:logo] && field[:logo].respond_to?(:read)
       if field[:logo].original_filename.split(".").last.downcase != type
-        add_flash("%{image} must be a .#{type} file" % {:image => text}, :error)
+        add_flash(_("%{image} must be a .%{type} file") % {:image => text, :type => type}, :error)
       else
         File.open(file, "wb") { |f| f.write(field[:logo].read) }
         add_flash(_("%{image} \"%{name}\" uploaded") % {:image => text, :name => field[:logo].original_filename})


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7019

How reproducible:
Always

Steps to Reproduce:

- Log into MIQ UI with non en_US locale
- Navigate to Configuration icon - Settings - Custom Logos, and choose .jpg image for Custom Brand Image, click Upload.
- Observe the error message '»自定义品牌« must be a .png file' is partially translated

Before:
<img width="1053" alt="Screenshot 2020-05-04 at 15 11 54" src="https://user-images.githubusercontent.com/9210860/80969548-10c71d80-8e1a-11ea-8e35-09f2459044b4.png">

After:
It's translated.

@miq-bot add_label internationalization, bug

@miq-bot assign @mzazrivec 