### PR TITLE
address one of two brakeman warnings

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -155,7 +155,7 @@ module OpsController::OpsRbac
       if !params[:quotas]
         tenant.set_quotas({})
       else
-        tenant.set_quotas(params.require(:quotas).permit!.to_h.deep_symbolize_keys)
+        tenant.set_quotas(params.require(:quotas).permit(:quotas).to_h.deep_symbolize_keys)
       end
     rescue => bang
       add_flash(_("Error when saving tenant quota: %{message}") % {:message => bang.message}, :error)


### PR DESCRIPTION
We need up upgrade brakeman per https://github.com/ManageIQ/manageiq/issues/20121
We also need to run it everywhere other than core.

This addresses the following which it will complain about:
https://brakemanscanner.org/docs/warning_types/mass_assignment/
and https://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/

this only addresses the first of those because I'm not sure what to do about the second yet

see https://github.com/ManageIQ/manageiq/pull/20125


