### PR TITLE
Fix invalid login message

### DIFF
--- a/spec/controllers/dashboard_controller/verify_user_spec.rb
+++ b/spec/controllers/dashboard_controller/verify_user_spec.rb
@@ -66,14 +66,14 @@ describe DashboardController do
     it 'fails for an existing user with wrong password' do
       validation = controller.send(:validate_user, invalid_password, nil)
       expect(validation.result).to eq(:fail)
-      expect(validation.flash_msg).to eq("Sorry, the username or password you entered is incorrect.")
+      expect(validation.flash_msg).to eq("The username or password you entered is incorrect.")
       expect(validation.url).to be_nil
     end
 
     it 'fails for an invalid user' do
       validation = controller.send(:validate_user, invalid_user, nil)
       expect(validation.result).to eq(:fail)
-      expect(validation.flash_msg).to eq("Sorry, the username or password you entered is incorrect.")
+      expect(validation.flash_msg).to eq("The username or password you entered is incorrect.")
       expect(validation.url).to be_nil
     end
 


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq/pull/20087

Fixes test failure on master:
```
Failed examples:
rspec ./spec/controllers/dashboard_controller/verify_user_spec.rb:73 # DashboardController validate_user fails for an invalid user
rspec ./spec/controllers/dashboard_controller/verify_user_spec.rb:66 # DashboardController validate_user fails for an existing user with wrong password
```

@miq-bot add-label jansa/no

ping @skateman 