### PR TITLE
Add gettext to title of a tab

### DIFF
--- a/app/views/layouts/_tabs.html.haml
+++ b/app/views/layouts/_tabs.html.haml
@@ -62,4 +62,4 @@
             = safe_right_cell_text
       - else
         %h1
-          = @title
+          = _(@title)


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7023

Steps to Reproduce:

- Log into MIQ UI with non en_US locale
- Navigate to Storage -> Block Storage -> Volume Types
- Observe `Cloud Volume Types` is in English.

Before:
<img width="1449" alt="Screenshot 2020-05-06 at 13 43 33" src="https://user-images.githubusercontent.com/9210860/81173215-fd45bf00-8f9f-11ea-86b9-3607aed0f7e3.png">
After:
<img width="1436" alt="Screenshot 2020-05-06 at 13 43 59" src="https://user-images.githubusercontent.com/9210860/81173211-fb7bfb80-8f9f-11ea-88a6-c95b9fc54683.png">

@miq-bot add_label bug, jansa/no, internationalization

@miq-bot assign @mzazrivec 