### PR TITLE
Do not display second level menu if that has no visible items.

### DIFF
--- a/app/helpers/application_helper/navbar.rb
+++ b/app/helpers/application_helper/navbar.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
         :type    => item.type,
         :visible => item.visible?,
         :active  => item_active?(item),
-        :items   => item.items.to_a.map(&method(:item_to_hash))
+        :items   => item.items.to_a.select(&:visible?).map(&method(:item_to_hash))
       }
     end
 


### PR DESCRIPTION
If a second level menu has no visible items for logged in user role, second level menu tab should not be visible on the vertical navbar.

Steps to recreate:
1. Create a new user role, assign this role product features shown in the `Allowed features for new role` screenshot below.
2. Assign newly created role to a user and log in to CF with this user. 
3. Check the vertical navbar, second level menus appear with empty third level menus. 
4. After the fix second level menus with no visible items is not visible in the menus.

Allowed features for new role
![menu_bug_features_Access](https://user-images.githubusercontent.com/3450808/81629327-e30d4600-93d0-11ea-8aea-3c74706be13a.png)

before
![menus_before_fix](https://user-images.githubusercontent.com/3450808/81629261-b822f200-93d0-11ea-9f73-847a80f953b5.png)

after
![menus_after_fix](https://user-images.githubusercontent.com/3450808/81629267-bc4f0f80-93d0-11ea-9456-7c684856d9db.png)
