### PR TITLE
[IVANCHUK] Fix cancel, save and select_tree actions in breadcrumbs and title in PXE menu section

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -37,7 +37,7 @@ module Mixins
         end
       else
         options[:x_node] ||= x_node
-        right_cell_text = controller_options[:right_cell_text] || title_for_breadcrumbs
+        right_cell_text = controller_options[:right_cell_text] || @right_cell_text
 
         self.x_node_text = params[:text] if action_name == "tree_select" # get text of the active node
 

--- a/app/controllers/optimization_controller.rb
+++ b/app/controllers/optimization_controller.rb
@@ -31,7 +31,7 @@ class OptimizationController < ApplicationController
     }
   end
 
-  def data_for_breadcrumbs
+  def data_for_breadcrumbs(*)
     breadcrumbs_options[:breadcrumbs].compact
   end
   helper_method :data_for_breadcrumbs

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -252,7 +252,12 @@ class PxeController < ApplicationController
     presenter[:osf_node] = x_node
     presenter[:lock_sidebar] = @in_a_form && @edit
 
-    presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
+    presenter.update(:breadcrumbs, r[
+      :partial => "layouts/breadcrumbs",
+      :locals  => {
+        :right_cell_text => right_cell_text || @right_cell_text,
+      }
+    ])
 
     render :json => presenter.for_render
   end
@@ -268,7 +273,6 @@ class PxeController < ApplicationController
   end
 
   def breadcrumbs_options
-    @right_cell_text = "editing" unless @edit.nil?
     {
       :breadcrumbs => [
         {:title => _("Compute")},

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,1 +1,5 @@
-= react('Breadcrumbs', { :items => (data_for_breadcrumbs if respond_to?(:data_for_breadcrumbs)), :controllerName => controller_name, :title => @title })
+- right_cell_text ||= @right_cell_text
+= react('Breadcrumbs',
+        :items => (data_for_breadcrumbs({:right_cell_text => right_cell_text}) if respond_to?(:data_for_breadcrumbs)),
+        :controllerName => controller_name,
+        :title => @title)

--- a/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
+++ b/spec/controllers/mixins/breadcrumbs_mixin_spec.rb
@@ -82,6 +82,7 @@ describe Mixins::BreadcrumbsMixin do
       before do
         allow(subject).to receive(:x_node).and_return("xx-1")
         allow(subject).to receive(:x_node_right_cell).and_return("xx-1")
+        allow(subject).to receive(:params).and_return({})
         allow(TreeBuilderUtilization).to receive(:new).and_return(tree)
         allow(tree).to receive(:bs_tree).and_return(
           [
@@ -152,6 +153,41 @@ describe Mixins::BreadcrumbsMixin do
               {:title => service_2.name, :key => "xx-#{service_2.id}"},
             ]
           )
+        end
+      end
+
+      describe "#action_breadcrumb?" do
+        let(:options) do
+          {
+            :right_cell_text => 'Record Edit of Item 1'
+          }
+        end
+
+        before do
+          subject.instance_variable_set(:@sb, :explorer => true, :action => 'record_edit')
+          subject.instance_variable_set(:@trees, [tree])
+        end
+
+        it "returns action breadcrumb" do
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Record Edit of Item 1")
+        end
+
+        it "not return action breadcrumb if cancel button" do
+          allow(subject).to receive(:params).and_return(:button => 'cancel')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
+        end
+
+        it "not return action breadcrumb if actions is prohibited to build breadcrumb" do
+          allow(subject).to receive(:action_name).and_return('tree_select')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
+        end
+
+        it "not return action breadcrumb if save button" do
+          allow(subject).to receive(:params).and_return(:button => 'save')
+
+          expect(subject.data_for_breadcrumbs(options).last).to eq(:title => "Item 1", :key => "xx-1")
         end
       end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740405

Ivanchuk version of https://github.com/ManageIQ/manageiq-ui-classic/pull/5776

Bug:
All other breadcrumb and links seem to be working correctly, but there's a minor problem in the breadcrumb when you navigate to the page for the first time or from a different page or refresh the page.

Steps to reproduce:

There are 2 ways to reproduce - 
1) On fresh navigation to Compute > Infrastructure > PXE, breadcrumb shows `Compute > Infrastructure > PXE > PXE Servers > editing`, notice `editing` at the end.
2) Navigate to the PXE page, select an accordion, for eg "System Image Types` and refresh the page. Breadcrumb shows - `Compute > Infrastructure > PXE > System Image Types > editing`,  notice `editing` at the end.

Before:
<img width="1437" alt="Screenshot 2020-05-13 at 10 54 29" src="https://user-images.githubusercontent.com/9210860/81792356-3a620200-9508-11ea-8d1f-1787e0759b02.png">
<img width="1434" alt="Screenshot 2020-05-13 at 10 54 42" src="https://user-images.githubusercontent.com/9210860/81792361-3c2bc580-9508-11ea-8478-1b83b332b698.png">

After:
<img width="1451" alt="Screenshot 2020-05-13 at 10 25 16" src="https://user-images.githubusercontent.com/9210860/81790325-8a8b9500-9505-11ea-9047-450789924739.png">
<img width="1440" alt="Screenshot 2020-05-13 at 10 25 29" src="https://user-images.githubusercontent.com/9210860/81790313-88293b00-9505-11ea-8ee1-40ad3b54b5ce.png">

@miq-bot add_label bug, breadcrumbs

@h-kataria please have a look, thanks :)