### PR TITLE
Replace old angular config provider form with the new ProviderForm

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -87,7 +87,7 @@ module Mixins
     def new
       assert_privileges("#{privilege_prefix}_add_provider")
       @explorer = true if explorer_controller?
-      @provider_manager = concrete_model.new
+      @ems = @provider_manager = concrete_model.new
       @server_zones = Zone.visible.in_my_region.order(Zone.arel_table[:name].lower).pluck(:description, :name)
       @sb[:action] = params[:action]
       if @explorer
@@ -108,8 +108,8 @@ module Mixins
         add_provider
         save_provider
       else
-        manager_id            = params[:miq_grid_checks] || params[:id] || find_checked_items[0]
-        @provider_manager     = find_record(concrete_model, manager_id)
+        manager_id               = params[:miq_grid_checks] || params[:id] || find_checked_items[0]
+        @ems = @provider_manager = find_record(concrete_model, manager_id)
         @providerdisplay_type = self.class.model_to_name(@provider_manager.type)
         @sb[:action] = params[:action]
         if @explorer

--- a/app/helpers/ems_configuration_helper.rb
+++ b/app/helpers/ems_configuration_helper.rb
@@ -1,3 +1,7 @@
 module EmsConfigurationHelper
   include_concern 'TextualSummary'
+
+  def edit_redirect_path(lastaction, ems)
+    lastaction == 'show_list' ? ems_configuration_path : ems_configuration_path(ems)
+  end
 end

--- a/app/views/ems_configuration/edit.html.haml
+++ b/app/views/ems_configuration/edit.html.haml
@@ -1,2 +1,1 @@
-= render :partial => 'configuration_manager/shared_form', :locals => {:url => "/ems_configuration", :model => "configurationManagerModel"}
-
+= react('ProviderForm', :providerId => @ems.id.to_s, :redirect => edit_redirect_path(@lastaction, @ems), :kind => 'configuration', :title => ui_lookup(:model => 'ManageIQ::Providers::ConfigurationManager'))

--- a/app/views/ems_configuration/new.html.haml
+++ b/app/views/ems_configuration/new.html.haml
@@ -1,2 +1,1 @@
-= render :partial => 'configuration_manager/shared_form', :locals => {:url => "/ems_configuration", :model => "configurationManagerModel"}
-
+= react('ProviderForm', :redirect => ems_configuration_path, :kind => 'configuration', :title => ui_lookup(:model => 'ManageIQ::Providers::ConfigurationManager'))


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-providers-foreman/pull/62
Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

**Before:**
![Screenshot from 2020-05-28 21-28-38](https://user-images.githubusercontent.com/649130/83184750-3817be80-a12a-11ea-9024-a885c0f5264b.png)

**After:**
![Screenshot from 2020-05-28 21-25-06](https://user-images.githubusercontent.com/649130/83184437-c0e22a80-a129-11ea-9651-aa3963d6db0e.png)

This change will allow us to add any other configuration management provider on this form.

@miq-bot add_label pending core