### PR TITLE
EmsContainerController: use allows instead of expect

### DIFF
--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -71,7 +71,7 @@ describe EmsContainerController do
         EvmSpecHelper.create_guid_miq_server_zone
         # set kubeclient to return a mock route.
         allow(Kubeclient::Client).to receive(:new).and_return(mock_client)
-        expect(mock_client).to receive(:discover).at_least(:once)
+        allow(mock_client).to receive(:discover)
       end
 
       it "detects openshift hawkular metric route" do


### PR DESCRIPTION
Probably a better fix for https://github.com/ManageIQ/manageiq-ui-classic/pull/7051

