### PR TITLE
maintain consistent rails versions across repos

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", ">= 5.0.0.1", "< 5.3"
+  s.add_dependency "rails", "~>5.2.4"
 
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.5"


### PR DESCRIPTION
this is what we're running in schema and I feel like it should be consistent especially since the `5.0.0.1` format makes travis super unhappy, capische? 

honestly I'm not sure the schema one's right, but it'd better anyway that we're at least consistently wrong so... maybe LJ will have a better idea than this