### PR TITLE
Fix constantizing CloudVolume for disable? check

### DIFF
--- a/app/helpers/application_helper/button/cloud_volume_backup_create.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_create.rb
@@ -1,8 +1,7 @@
 class ApplicationHelper::Button::CloudVolumeBackupCreate < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
     ManageIQ::Providers::CloudManager.none? do |ems|
-      Module.const_defined?("#{ems.class}::CloudVolume") &&
-        ems.class::CloudVolume.supports?(:backup_create)
+      "#{ems.class}::CloudVolume".safe_constantize&.supports?(:backup_create)
     end
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
+++ b/app/helpers/application_helper/button/cloud_volume_backup_restore.rb
@@ -1,8 +1,7 @@
 class ApplicationHelper::Button::CloudVolumeBackupRestore < ApplicationHelper::Button::ButtonNewDiscover
   def disabled?
     ManageIQ::Providers::CloudManager.none? do |ems|
-      Module.const_defined?("#{ems.class}::CloudVolume") &&
-        ems.class::CloudVolume.supports?(:backup_restore)
+      "#{ems.class}::CloudVolume".safe_constantize&.supports?(:backup_restore)
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/cloud_volume_backup_create_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_volume_backup_create_spec.rb
@@ -1,0 +1,28 @@
+describe ApplicationHelper::Button::CloudVolumeBackupCreate do
+  describe "#disabled?" do
+    let(:view_context) { setup_view_context_with_sandbox({}) }
+    let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+    context "with no providers" do
+      it "the button is disabled" do
+        expect(button.disabled?).to be true
+      end
+    end
+
+    context "with an OpenStack CloudManager supporting backup_create" do
+      before { FactoryBot.create(:ems_openstack) }
+
+      it "the button is enabled" do
+        expect(button.disabled?).to be false
+      end
+    end
+
+    context "with an Amazon CloudManager not supporting backup_create" do
+      before { FactoryBot.create(:ems_amazon) }
+
+      it "the button is disabled" do
+        expect(button.disabled?).to be true
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/cloud_volume_backup_restore_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_volume_backup_restore_spec.rb
@@ -1,0 +1,28 @@
+describe ApplicationHelper::Button::CloudVolumeBackupRestore do
+  describe "#disabled?" do
+    let(:view_context) { setup_view_context_with_sandbox({}) }
+    let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+    context "with no providers" do
+      it "the button is disabled" do
+        expect(button.disabled?).to be true
+      end
+    end
+
+    context "with an OpenStack CloudManager supporting backup_restore" do
+      before { FactoryBot.create(:ems_openstack) }
+
+      it "the button is enabled" do
+        expect(button.disabled?).to be false
+      end
+    end
+
+    context "with an Amazon CloudManager not supporting backup_restore" do
+      before { FactoryBot.create(:ems_amazon) }
+
+      it "the button is disabled" do
+        expect(button.disabled?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some environments `Module.const_defined?("Namespace::CloudVolume")` returns `::CloudVolume` so this check doesn't work.

`Module.const_defined?("ManageIQ::Providers::Amazon::CloudManager::CloudVolume")` returns `true` then invoking `.supports?()` on that class raises a `NameError`.

`String#safe_constantize` is a more reliable way of determining if a class exists.