### PR TITLE
Fix csv download

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -12,7 +12,7 @@ module ApplicationController::ReportDownloads
   # Send the current report in csv format
   def render_csv
     report = report_for_rendering
-    filename = filename_timestamp(@report.title)
+    filename = filename_timestamp(report.title)
     disable_client_cache
     send_data(report.to_csv, :filename => "#{filename}.csv")
   end


### PR DESCRIPTION
Go to Overview -> Chargeback -> Reports -> select a Report -> click download CSV

Before:
<img width="1664" alt="Screenshot 2020-05-20 at 10 19 56" src="https://user-images.githubusercontent.com/9210860/82422998-79053880-9a83-11ea-91eb-ad404f952976.png">

After:
Download starts

Using `report` instead of `@report` like `render_txt` above `render_csv`.

@miq-bot add_label bug