### PR TITLE
[JANSA] Update ui-components to 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@data-driven-forms/pf3-component-mapper": "~1.18.0",
     "@data-driven-forms/react-form-renderer": "~1.18.0",
     "@manageiq/react-ui-components": "~0.11.57",
-    "@manageiq/ui-components": "~1.3.3",
+    "@manageiq/ui-components": "~1.3.4",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",
     "angular": "~1.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,10 +1252,10 @@
     redux-form-validators "^2.7.0"
     redux-mock-store "^1.5.1"
 
-"@manageiq/ui-components@~1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.3.3.tgz#349ec945574253fac9f49fb56a87a859fbb97f4f"
-  integrity sha512-rYa1Neu2sPikizzW/pjvsj1CuC2HXQo/yQqE1LrIzxPq//SZUqgPNA2wFac5TvYBV7zq1jk5KFJKVz+5Ldho4w==
+"@manageiq/ui-components@~1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.3.4.tgz#8fa1007591cfac45fdd12e6423a0774bd7822c50"
+  integrity sha512-BxNTy6qexmc1Us+XowgFDGvB6l460X7EbooZ6TUxghNQRlr7JgJjJNzbVzv2SjvA46IdTdpsnT2s3JvIWERYjg==
   dependencies:
     angular-bootstrap-switch "^0.5.1"
     angular-dragdrop "^1.0.13"


### PR DESCRIPTION
To fix the failing CI, we need to backport the following 2 PRs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/7051
https://github.com/ManageIQ/manageiq-ui-classic/pull/7052