### PR TITLE
Removed leftover settings for Chargeback Rates

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -42,7 +42,6 @@ module Sandbox
     automation_manager_providers_tree
     automation_manager_cs_filter_tree
     cb_assignments_tree
-    cb_rates_tree
     cb_reports_tree
     cluster_tree
     configuration_scripts_tree
@@ -113,7 +112,6 @@ module Sandbox
     automation_manager_cs_filter
     automation_manager_configuration_scripts
     cb_assignments
-    cb_rates
     cb_reports
     configuration_scripts
     condition

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -315,8 +315,6 @@ class TreeBuilder
     ## Chargeback
     ### Reports
     :cb_reports                      => "TreeBuilderChargebackReports",
-    ### Rates
-    :cb_rates                        => "TreeBuilderChargebackRates",
     ### Assignments
     :cb_assignments                  => "TreeBuilderChargebackAssignments",
 


### PR DESCRIPTION
Missed removal of these in https://github.com/ManageIQ/manageiq-ui-classic/pull/7039

