### PR TITLE
Fix breadcrumbs for Dashboard Widgets

### DIFF
--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -260,6 +260,7 @@ module ReportController::Widgets
       @right_cell_text = _(RIGHT_CELL_TEXTS[@sb[:nodes][1]].first)
     else
       @record = @widget = MiqWidget.find(@sb[:nodes].last)
+      params[:text] = @widget.name unless params[:text].present?
       @widget_running = true if %w[running queued].include?(@widget.status.downcase)
       @right_cell_text = _(RIGHT_CELL_TEXTS[WIDGET_CONTENT_TYPE.invert[@widget.content_type]].second) % {:name => @widget.title}
       @right_cell_div  = "widget_list"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1805847

Go to Overview => Reports => Dashboard Widgets => click at a Menu via GTL

Expected result:
Breadcrumbs should be `Overview > Reports > Dashboard Widgets > [name of a menu]`
Actual result:
Breadcrumbs is `Overview > Reports > Dashboard Widgets > Menus`

Before:
<img width="685" alt="Screenshot 2020-05-21 at 14 30 00" src="https://user-images.githubusercontent.com/9210860/82559246-91eb1800-9b6f-11ea-97aa-0f5136407802.png">

After:
<img width="698" alt="Screenshot 2020-05-21 at 14 24 59" src="https://user-images.githubusercontent.com/9210860/82558854-de822380-9b6e-11ea-9afe-3fc08a1aeaeb.png">

It goes for all leaf nodes under `Dashboard Widgets `

@miq-bot add_label bug, ivanchuk/yes, jansa/yes, breadcrumbs

@h-kataria please have a look, thanks :)
