### PR TITLE
[WIP] Move wooden-tree css from react-ui-components, fix alignment

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -5,5 +5,5 @@
 @import '~@pf3/timeline/style.css';
 @import '~@manageiq/react-ui-components/dist/quadicon.css';
 @import '~@manageiq/react-ui-components/dist/textual_summary.css';
-@import '~@manageiq/react-ui-components/dist/wooden-tree.css';
 @import '~@manageiq/ui-components/dist/css/ui-components.css';
+@import './wooden-tree.scss';

--- a/app/stylesheet/wooden-tree.scss
+++ b/app/stylesheet/wooden-tree.scss
@@ -1,0 +1,36 @@
+.react-tree-view {
+  ul {
+    padding-left: 0;
+  }
+
+  li > :first-child {
+    display: inline-block;
+  }
+
+  i.icon {
+    width: calc(1em + 3px);
+    padding: 2px;
+    padding-right: 1px;
+    margin-right: 4px;
+  }
+
+  .dirty {
+    color: #39A5DC;
+  }
+
+  .selected {
+    background-color: #349ad3;
+    color: #FFFFFF;
+  }
+
+  $indentSize: "1em";
+  $chevronSize: "1em + 7px";
+  @for $i from 0 through 5 {
+    .indent-#{$i} {
+      padding-left: calc(#{$indentSize} * #{$i}) !important;
+      &.no-open-button {
+        padding-left: calc(#{$indentSize} * #{$i} + #{$chevronSize}) !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
converts `i.icon` to `border-box`,
adds `.indent-N` overrides to fit the icon width

and no longer uses the react-ui-components css, only the react-wooden-tree css and local css.

(WIP - this fixes the tree alignment issue, but waiting for input on the possibility of making the changes in react-wooden-tree. (https://github.com/ManageIQ/manageiq-ui-classic/pull/6413#issuecomment-631796459))