### PR TITLE
Fix Chargeback Assignments for Datastores

### DIFF
--- a/app/controllers/chargeback_assignment_controller.rb
+++ b/app/controllers/chargeback_assignment_controller.rb
@@ -184,7 +184,11 @@ class ChargebackAssignmentController < ApplicationController
                                      "#{@edit[:current_assignment][0][:label][1]}-labels"
                                    end
                                  else
-                                   @edit[:current_assignment][0][:object].class.name.downcase
+                                   if @edit[:current_assignment][0][:object].class.name.split("::").last.downcase == "storage"
+                                     "storage"
+                                   else
+                                     @edit[:current_assignment][0][:object].class.name.downcase
+                                   end
                                  end
     end
     if @edit[:new][:cbshow_typ]&.ends_with?("-tags")


### PR DESCRIPTION
Go to Overview -> Chargeback -> Assignments -> Storage -> select Selected Datastores -> make a change and `Save`

Before:
It ends with an error
<img width="1444" alt="Screenshot 2020-05-21 at 16 21 53" src="https://user-images.githubusercontent.com/9210860/82568500-332d9a80-9b7f-11ea-805d-c8d3724a4478.png">

```
FATAL -- : Error caught: [ArgumentError] Received: manageiq::providers::redhat::inframanager::storage, expected one of ["enterprise", "storage", "ext_management_system", "ems_cluster", "tenant", "ems_container"]
/manageiq-ui-classic/app/controllers/chargeback_assignment_controller.rb:286:in `get_cis_all'
manageiq-ui-classic/app/controllers/chargeback_assignment_controller.rb:211:in `cb_assign_set_form_vars'
manageiq-ui-classic/app/controllers/chargeback_assignment_controller.rb:98:in `get_node_info'
manageiq-ui-classic/app/controllers/chargeback_assignment_controller.rb:72:in `cb_assign_update'
```
After:
<img width="1443" alt="Screenshot 2020-05-21 at 16 08 03" src="https://user-images.githubusercontent.com/9210860/82568299-e0ec7980-9b7e-11ea-99da-e95380bc1f35.png">

@lpichler please have a look, thanks :)

@miq-bot add_label bug