### PR TITLE
Removed redundant line of code

### DIFF
--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -100,7 +100,6 @@ module Mixins
     def edit
       assert_privileges("#{privilege_prefix}_edit_provider")
       @explorer = true if explorer_controller?
-      @server_zones = Zone.visible.in_my_region.order('lower(description)').pluck(:description, :name)
       @server_zones = Zone.visible.in_my_region.order(Zone.arel_table[:name].lower).pluck(:description, :name)
       case params[:button]
       when "cancel"


### PR DESCRIPTION
this line was added in https://github.com/ManageIQ/manageiq-ui-classic/pull/6782, should keep the next line that uses `arel_table`

Marking `jansa/no` because https://github.com/ManageIQ/manageiq-ui-classic/pull/6970 is not backported.

