### PR TITLE
Carbon - add carbon scss

### DIFF
--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -7,4 +7,4 @@
 @import '~@manageiq/react-ui-components/dist/textual_summary.css';
 @import '~@manageiq/react-ui-components/dist/wooden-tree.css';
 @import '~@manageiq/ui-components/dist/css/ui-components.css';
-@import '~carbon-components/css/carbon-components.css';
+@import './carbon.scss';

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -7,3 +7,4 @@
 @import '~@manageiq/react-ui-components/dist/textual_summary.css';
 @import '~@manageiq/react-ui-components/dist/wooden-tree.css';
 @import '~@manageiq/ui-components/dist/css/ui-components.css';
+@import '~carbon-components/css/carbon-components.css';

--- a/app/stylesheet/carbon.scss
+++ b/app/stylesheet/carbon.scss
@@ -1,0 +1,15 @@
+// enable carbon UI shell
+$feature-flags: (
+  ui-shell: true,
+);
+
+// disable IBM fonts until we can override patternfly
+$css--font-face: false;
+$css--plex: false;
+
+// don't break patternfly styling
+$css--body: false;
+$css--reset: false;
+$css--default-type: false;
+
+@import '~carbon-components/scss/globals/scss/styles.scss';

--- a/app/stylesheet/carbon.scss
+++ b/app/stylesheet/carbon.scss
@@ -12,6 +12,11 @@ $css--body: false;
 $css--reset: false;
 $css--default-type: false;
 
+// Use the gray 90 theme
+@import '~@carbon/themes/scss/themes';
+$carbon--theme: $carbon--theme--g90;
+@include carbon--theme();
+
 @import '~carbon-components/scss/globals/scss/styles.scss';
 
 // ignored by patternfly, but sets the right base for carbon rem units

--- a/app/stylesheet/carbon.scss
+++ b/app/stylesheet/carbon.scss
@@ -13,3 +13,8 @@ $css--reset: false;
 $css--default-type: false;
 
 @import '~carbon-components/scss/globals/scss/styles.scss';
+
+// ignored by patternfly, but sets the right base for carbon rem units
+html {
+  font-size: 100%;
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
+    "@carbon/themes": "~10.12.0",
     "@data-driven-forms/pf3-component-mapper": "~1.30.0",
     "@data-driven-forms/react-form-renderer": "~1.30.0",
     "@manageiq/react-ui-components": "~0.11.68",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-switch": "3.3.4",
+    "carbon-components": "~10.12.0",
     "classnames": "~2.2.6",
     "codemirror": "~5.47.0",
     "connected-react-router": "~6.7.0",


### PR DESCRIPTION
(Split off from https://github.com/ManageIQ/manageiq-ui-classic/pull/6963 as it was getting too large.)

This enables carbon css without affecting anything.
This PR should cause no visual differences at all :).

ui-shell css is needed for the new menu (https://github.com/ManageIQ/manageiq-ui-classic/pull/6963),

not switching to IBM fonts globally because:
  * changing patternfly fonts should be easier after https://github.com/ManageIQ/manageiq-ui-classic/pull/5679
  * carbon loads the font from `fonts.gstatic.com`, we may need need to use a [custom join function](https://github.com/bholloway/resolve-url-loader/blob/master/packages/resolve-url-loader/README.md) to change to local urls

also https://github.com/ManageIQ/manageiq-ui-classic/pull/5679 - switching reset stylesheets can wait, and body styling and typography can change after that.

Overriding html font-size to 100% to get reasonable styling from carbon use of rem units, patternfly sets body to 12px.

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6817

cc @skateman