### PR TITLE
Menu - pre-carbon cleanups

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1029,8 +1029,9 @@ module OpsController::Settings::Common
         @in_a_form = true
         @edit = {:new => {}, :key => 'customize_help_menu'}
         @edit[:new] = Settings.help_menu.to_h
-        help_menu_items.each do |item|
-          @edit[:new][item] = Settings.help_menu.try(item).try(:to_h) || {}
+        Menu::DefaultMenu.help_menu_items.each do |item|
+          id = item.id.to_sym
+          @edit[:new][id] = Settings.help_menu.try(id).try(:to_h) || {}
         end
         @edit[:current] = copy_hash(@edit[:new])
         session[:edit] = @edit

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -35,13 +35,14 @@ module OpsController::Settings::HelpMenu
   def help_menu_form_field_changed
     return unless load_edit('customize_help_menu')
 
-    help_menu_items.each do |item|
+    Menu::DefaultMenu.help_menu_items.each do |item|
+      id = item.id.to_sym
       %i[title href type].map do |field|
-        param = params["#{item}_#{field}"]
+        param = params["#{id}_#{field}"]
         next if param.nil?
 
-        @edit[:new][item][field] = param
-        @edit[:new][item].delete(field) if param.empty?
+        @edit[:new][id][field] = param
+        @edit[:new][id].delete(field) if param.empty?
       end
     end
 

--- a/app/helpers/application_helper/navbar.rb
+++ b/app/helpers/application_helper/navbar.rb
@@ -1,13 +1,9 @@
 module ApplicationHelper
   module Navbar
     def menu_to_json(placement = :default)
-      structure = []
-      Menu::Manager.menu(placement) do |menu_section|
-        next unless menu_section.visible?
-
-        structure << item_to_hash(menu_section)
-      end
-      structure
+      Menu::Manager.menu(placement).map do |menu_section|
+        item_to_hash(menu_section) if menu_section.visible?
+      end.compact
     end
 
     def item_to_hash(item)

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -63,14 +63,6 @@ module OpsHelper
     end
   end
 
-  def help_menu_items
-    items = []
-    Menu::Manager.menu(:help) do |menu|
-      items = menu.items.map { |item| item.id.to_sym }
-    end
-    items
-  end
-
   def server_zones
     @server_zones ||= Zone.visible.in_my_region.pluck(:name)
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -2,6 +2,22 @@
 module Menu
   class DefaultMenu
     class << self
+      def default_menu
+        [
+          overview_menu_section,
+          services_menu_section,
+          compute_menu_section,
+          network_menu_section,
+          storage_menu_section,
+          configuration_menu_section,
+          automation_menu_section,
+          control_menu_section,
+          monitor_menu_section,
+          settings_menu_section,
+          help_menu_section,
+        ].compact
+      end
+
       def compute_menu_section
         Menu::Section.new(:compute, N_("Compute"), 'pficon pficon-cpu', [
           clouds_menu_section,
@@ -273,22 +289,6 @@ module Menu
         end
 
         Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', menu, :help)
-      end
-
-      def default_menu
-        [
-          overview_menu_section,
-          services_menu_section,
-          compute_menu_section,
-          network_menu_section,
-          storage_menu_section,
-          configuration_menu_section,
-          automation_menu_section,
-          control_menu_section,
-          monitor_menu_section,
-          settings_menu_section,
-          help_menu_section,
-        ].compact
       end
 
       private

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -266,34 +266,44 @@ module Menu
         ], :top_right)
       end
 
-      def help_menu_section
-        menu = {
-          :documentation => {
-            :title => N_('Documentation'),
-            :href  => '/support/index?support_tab=about'
-          },
-          :product       => {
-            :title => ::Settings.docs.product_support_website_text,
-            :href  => ::Settings.docs.product_support_website
-          },
-          :about         => {
-            :title => N_('About')
-          }
-        }.map do |key, value|
-          Menu::Item.new(key,
-                         help_menu_field(key, :title, value[:title]),
-                         key.to_s,
-                         {:feature => key.to_s},
-                         help_menu_field(key, :href, value[:href]),
-                         help_menu_field(key, :type, value[:type]),
-                         nil,
-                         value)
-        end
+      def help_documentation
+        help_menu_item(:documentation, :title => N_('Documentation'),
+                                       :href  => '/support/index?support_tab=about')
+      end
 
-        Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', menu, :help)
+      def help_product
+        help_menu_item(:product, :title => ::Settings.docs.product_support_website_text,
+                                 :href  => ::Settings.docs.product_support_website)
+      end
+
+      def help_about
+        help_menu_item(:about, :title => N_('About'))
+      end
+
+      def help_menu_items
+        [
+          help_documentation,
+          help_product,
+          help_about,
+        ]
+      end
+
+      def help_menu_section
+        Menu::Section.new(:help, N_('Help'), 'pficon pficon-help', help_menu_items, :help)
       end
 
       private
+
+      def help_menu_item(key, value)
+        Menu::Item.new(key,
+                       help_menu_field(key, :title, value[:title]),
+                       key.to_s,
+                       {:feature => key.to_s},
+                       help_menu_field(key, :href, value[:href]),
+                       help_menu_field(key, :type, value[:type]),
+                       nil,
+                       value)
+      end
 
       def help_menu_field(key, item, default)
         lambda do

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -23,7 +23,7 @@ module Menu
           clouds_menu_section,
           infrastructure_menu_section,
           physical_infrastructure_menu_section,
-          container_menu_section
+          container_menu_section,
         ].compact)
       end
 
@@ -48,7 +48,7 @@ module Menu
       end
 
       def consumption_menu_section
-        Menu::Section.new(:cons, N_("Consumption"), 'fa fa-plus', [
+        Menu::Section.new(:cons, N_("Consumption"), nil, [
           Menu::Item.new('consumption', N_('Dashboard'), 'consumption', {:feature => 'consumption', :any => true}, '/consumption/show')
         ])
       end
@@ -63,7 +63,7 @@ module Menu
       end
 
       def chargeback_menu_section
-        Menu::Section.new(:chargeback, N_("Chargeback"), 'fa fa-plus', [
+        Menu::Section.new(:chargeback, N_("Chargeback"), nil, [
           Menu::Item.new('chargeback_report',     N_('Reports'),     'chargeback_reports',     {:feature => 'chargeback_reports',         :any => true}, '/chargeback_report/explorer'),
           Menu::Item.new('chargeback_rate',       N_('Rates'),       'chargeback_rates',       {:feature => 'chargeback_rates_show_list', :any => true}, '/chargeback_rate/show_list'),
           Menu::Item.new('chargeback_assignment', N_('Assignments'), 'chargeback_assignments', {:feature => 'chargeback_assignments'},                   '/chargeback_assignment/explorer'),
@@ -71,7 +71,7 @@ module Menu
       end
 
       def clouds_menu_section
-        Menu::Section.new(:clo, N_("Clouds"), 'fa fa-plus', [
+        Menu::Section.new(:clo, N_("Clouds"), nil, [
           Menu::Item.new('ems_cloud',           N_('Providers'),          'ems_cloud',           {:feature => 'ems_cloud_show_list'},             '/ems_cloud/show_list'),
           Menu::Item.new('availability_zone',   N_('Availability Zones'), 'availability_zone',   {:feature => 'availability_zone_show_list'},     '/availability_zone/show_list'),
           Menu::Item.new('host_aggregate',      N_('Host Aggregates'),    'host_aggregate',      {:feature => 'host_aggregate_show_list'},        '/host_aggregate/show_list'),
@@ -85,7 +85,7 @@ module Menu
       end
 
       def infrastructure_menu_section
-        Menu::Section.new(:inf, N_("Infrastructure"), 'fa fa-plus', [
+        Menu::Section.new(:inf, N_("Infrastructure"), nil, [
           Menu::Item.new('ems_infra',         N_('Providers'),         'ems_infra',                  {:feature => 'ems_infra_show_list'},             '/ems_infra/show_list'),
           Menu::Item.new('ems_cluster',       N_("Clusters"),          'ems_cluster',                {:feature => 'ems_cluster_show_list'},           '/ems_cluster/show_list'),
           Menu::Item.new('host',              N_("Hosts"),             'host',                       {:feature => 'host_show_list'},                  '/host/show_list'),
@@ -100,7 +100,7 @@ module Menu
       end
 
       def physical_infrastructure_menu_section
-        Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
+        Menu::Section.new(:phy, N_("Physical Infrastructure"), nil, [
           Menu::Item.new('physical_infra_overview', N_('Overview'),  'physical_infra_overview', {:feature => 'physical_infra_overview'},               '/physical_infra_overview/show'),
           Menu::Item.new('ems_physical_infra',      N_('Providers'), 'ems_physical_infra',      {:feature => 'ems_physical_infra_show_list'},          '/ems_physical_infra/show_list'),
           Menu::Item.new('physical_chassis',        N_('Chassis'),   'physical_chassis',        {:feature => 'physical_chassis_show_list'},            '/physical_chassis/show_list'),
@@ -113,7 +113,7 @@ module Menu
       end
 
       def container_menu_section
-        Menu::Section.new(:cnt, N_("Containers"), 'fa fa-plus', [
+        Menu::Section.new(:cnt, N_("Containers"), nil, [
           Menu::Item.new('container_dashboard',      N_('Overview'),            'container_dashboard',      {:feature => 'container_dashboard'},                       '/container_dashboard/show'),
           Menu::Item.new('ems_container',            N_('Providers'),           'ems_container',            {:feature => 'ems_container_show_list'},                   '/ems_container/show_list'),
           Menu::Item.new('container_project',        N_('Projects'),            'container_project',        {:feature => 'container_project_show_list'},               '/container_project/show_list'),
@@ -147,13 +147,13 @@ module Menu
 
       def storage_menu_section
         Menu::Section.new(:sto, N_("Storage"), 'fa fa-database', [
-                            block_storage_menu_section,
-                            object_storage_menu_section,
-                          ])
+          block_storage_menu_section,
+          object_storage_menu_section,
+        ])
       end
 
       def block_storage_menu_section
-        Menu::Section.new(:bst, N_("Block Storage"), 'fa fa-database', [
+        Menu::Section.new(:bst, N_("Block Storage"), nil, [
                             Menu::Item.new('ems_block_storage',
                                            N_('Managers'),
                                            'ems_block_storage',
@@ -183,7 +183,7 @@ module Menu
       end
 
       def object_storage_menu_section
-        Menu::Section.new(:ost, N_("Object Storage"), 'fa fa-database', [
+        Menu::Section.new(:ost, N_("Object Storage"), nil, [
                             Menu::Item.new('ems_object_storage',
                                            N_('Managers'),
                                            'ems_object_storage',
@@ -215,19 +215,19 @@ module Menu
         Menu::Section.new(:aut, N_("Automation"), 'pficon pficon-automation', [
           ansible_menu_section,
           automation_manager_menu_section,
-          automate_menu_section
+          automate_menu_section,
         ])
       end
 
       def automation_manager_menu_section
-        Menu::Section.new(:at, N_("Ansible Tower"), 'fa fa-cog', [
+        Menu::Section.new(:at, N_("Ansible Tower"), nil, [
           Menu::Item.new('automation_manager', N_('Explorer'), 'automation_manager', {:feature => 'automation_manager', :any => true}, '/automation_manager/explorer'),
           Menu::Item.new('configuration_job',  N_('Jobs'),     'configuration_job',  {:feature => 'configuration_job_show_list'},      '/configuration_job/show_list')
         ])
       end
 
       def ansible_menu_section
-        Menu::Section.new(:ansible, N_("Ansible"), 'pficon pficon-automation', [
+        Menu::Section.new(:ansible, N_("Ansible"), nil, [
           Menu::Item.new('ansible_playbooks', N_('Playbooks'), 'embedded_configuration_script_payload', {:feature => 'embedded_configuration_script_payload', :any => true}, '/ansible_playbook/show_list'),
           Menu::Item.new('ansible_repositories', N_('Repositories'), 'embedded_configuration_script_source', {:feature => 'embedded_configuration_script_source', :any => true}, '/ansible_repository/show_list'),
           Menu::Item.new('ansible_credentials', N_('Credentials'), 'embedded_automation_manager_credentials', {:feature => 'embedded_automation_manager_credentials', :any => true}, '/ansible_credential/show_list'),
@@ -235,7 +235,7 @@ module Menu
       end
 
       def automate_menu_section
-        Menu::Section.new(:automate, N_("Automate"), 'pficon pficon-automation', [
+        Menu::Section.new(:automate, N_("Automate"), nil, [
           Menu::Item.new('miq_ae_class',         N_('Explorer'),        'miq_ae_class_explorer',         {:feature => 'miq_ae_domain_view'},            '/miq_ae_class/explorer'),
           Menu::Item.new('miq_ae_tools',         N_('Simulation'),      'miq_ae_class_simulation',       {:feature => 'miq_ae_class_simulation'},       '/miq_ae_tools/resolve'),
           Menu::Item.new('generic_object_definition', N_('Generic Objects'), 'generic_object_definition', {:feature => 'generic_object_definition'},   '/generic_object_definition/show_list'),
@@ -247,14 +247,16 @@ module Menu
       end
 
       def alerts_menu_section
-        Menu::Section.new(:monitor_alerts, N_("Alerts"), 'fa fa-bullhorn-o fa-2x', [
+        Menu::Section.new(:monitor_alerts, N_("Alerts"), nil, [
                             Menu::Item.new('monitor_alerts_overview', N_('Overview'), 'monitor_alerts_overview', {:feature => 'monitor_alerts_overview', :any => true}, '/alerts_overview/show'),
                             Menu::Item.new('monitor_alerts_list', N_('All Alerts'), 'monitor_alerts_list', {:feature => 'monitor_alerts_list', :any => true}, '/alerts_list/show'),
                           ])
       end
 
       def monitor_menu_section
-        Menu::Section.new(:monitor, N_("Monitor"), 'fa fa-heartbeat fa-2x', [alerts_menu_section])
+        Menu::Section.new(:monitor, N_("Monitor"), 'fa fa-heartbeat', [
+          alerts_menu_section,
+        ])
       end
 
       def settings_menu_section

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -4,18 +4,23 @@ module Menu
     class << self
       def default_menu
         [
+          # user, group switcher & find are NOT part of the menu
           overview_menu_section,
           services_menu_section,
+
+          # items with Providers
           compute_menu_section,
           network_menu_section,
           storage_menu_section,
           configuration_menu_section,
           automation_menu_section,
+
           control_menu_section,
           monitor_menu_section,
+
           settings_menu_section,
           help_menu_section,
-        ].compact
+        ]
       end
 
       def compute_menu_section
@@ -24,7 +29,7 @@ module Menu
           infrastructure_menu_section,
           physical_infrastructure_menu_section,
           container_menu_section,
-        ].compact)
+        ])
       end
 
       def configuration_menu_section
@@ -44,7 +49,7 @@ module Menu
           Menu::Item.new('miq_capacity_utilization', N_('Utilization'), 'utilization', {:feature => 'utilization'}, '/utilization'),
           chargeback_menu_section,
           Menu::Item.new('optimization', N_('Optimization'), 'optimization', {:feature => 'optimization'}, '/optimization'),
-        ].compact)
+        ])
       end
 
       def consumption_menu_section
@@ -243,7 +248,7 @@ module Menu
           Menu::Item.new('miq_ae_export',        N_('Import / Export'), 'miq_ae_class_import_export',    {:feature => 'miq_ae_class_import_export'},    '/miq_ae_tools/import_export'),
           Menu::Item.new('miq_ae_logs',          N_('Log'),             'miq_ae_class_log',              {:feature => 'miq_ae_class_log'},              '/miq_ae_tools/log'),
           Menu::Item.new('miq_request_ae',       N_('Requests'),        'ae_miq_request',                {:feature => 'ae_miq_request_show_list'},      '/miq_request/show_list?typ=ae')
-        ].compact)
+        ])
       end
 
       def alerts_menu_section

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -35,7 +35,7 @@ module Menu
     def visible?
       return true if rbac_feature.nil?
 
-      ApplicationHelper.role_allows?(rbac_feature)
+      rbac_feature.nil? || ApplicationHelper.role_allows?(rbac_feature)
     end
 
     def link_params

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -33,6 +33,8 @@ module Menu
     end
 
     def visible?
+      return true if rbac_feature.nil?
+
       ApplicationHelper.role_allows?(rbac_feature)
     end
 

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -15,9 +15,9 @@ module Menu
     end
 
     def menu(placement = :default)
-      @menu.each do |menu_section|
-        yield menu_section if menu_section.placement == placement
-      end
+      @menu.select do |menu_section|
+        menu_section.placement == placement
+      end.compact
     end
 
     def items

--- a/app/presenters/menu/section.rb
+++ b/app/presenters/menu/section.rb
@@ -16,6 +16,8 @@ module Menu
       self.placement ||= :default
       self.type ||= :default
 
+      self.items.compact!
+
       @parent = nil
       items.each { |el| el.parent = self }
     end

--- a/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_dashboard_no_listnav.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/vertical_navbar"
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%;"}
   #breadcrumbs
     = render :partial => "layouts/breadcrumbs"

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/vertical_navbar"
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden !important; height: 100%;"}
   #breadcrumbs
     = render :partial => "layouts/breadcrumbs"

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -1,4 +1,3 @@
-= render :partial => "layouts/vertical_navbar"
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.max-height{:style => "overflow: hidden !important"}
   #breadcrumbs
     = render :partial => "layouts/breadcrumbs"

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -1,10 +1,8 @@
 - if big_iframe
-  = render :partial => "layouts/vertical_navbar"
   .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.max-height{:style => "overflow: hidden !important"}
     .row.max-height
       = yield
 - elsif inner_layout_present?
-  = render :partial => "layouts/vertical_navbar"
   .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.max-height{:style => "overflow: hidden !important"}
     #breadcrumbs
       = render :partial => "layouts/breadcrumbs"
@@ -58,7 +56,6 @@
           #custom_left_cell
 
 - elsif layout_full_center
-  = render :partial => "layouts/vertical_navbar"
   = render :partial => layout_full_center
 - else
   #center_div{:style => "height: 100%;"}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -19,3 +19,5 @@
 
 = render :partial => "layouts/spinner"
 = render :partial => "layouts/lightbox_panel"
+
+= react('MainMenu', { :menu => menu_to_json })

--- a/app/views/layouts/_vertical_navbar.html.haml
+++ b/app/views/layouts/_vertical_navbar.html.haml
@@ -1,1 +1,0 @@
-= react('MainMenu', { :menu => menu_to_json })

--- a/app/views/ops/_settings_help_menu_tab.html.haml
+++ b/app/views/ops/_settings_help_menu_tab.html.haml
@@ -16,31 +16,29 @@
         %th
           = _('Open in')
 
-      - Menu::Manager.menu(:help) do |menu|
-        - menu.items.each do |item|
-          %tr
-            - val = @edit[:new][item.id.to_sym].try(:[], :type) || item.defaults[:type]
-            %td
-              = text_field_tag("#{item.id}_title", @edit[:new][item.id.to_sym].try(:[], :title),
-                               :placeholder       => item.defaults[:title],
-                               :class             => 'form-control',
-                               'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
-            %td
-              = text_field_tag("#{item.id}_href", @edit[:new][item.id.to_sym].try(:[], :href),
-                               :placeholder => item.defaults[:href],
-                               :class => 'form-control',
-                               'data-miq_observe' => {:interval => '.5', :url => url}.to_json,
-                               :disabled => val.to_s == 'modal')
-            %td
-              = select_tag("#{item.id}_type", options_for_select([[_("Current Window"), 'default'],
-                                                                 [_("New Window"), "new_window"],
-                                                                 [_("About Modal"),  "modal"]], val.to_s),
-                          :class             => 'selectpicker')
+      - Menu::DefaultMenu.help_menu_items.each do |item|
+        %tr
+          - val = @edit[:new][item.id.to_sym].try(:[], :type) || item.defaults[:type]
+          %td
+            = text_field_tag("#{item.id}_title", @edit[:new][item.id.to_sym].try(:[], :title),
+                             :placeholder => item.defaults[:title],
+                             :class => 'form-control',
+                             'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
+          %td
+            = text_field_tag("#{item.id}_href", @edit[:new][item.id.to_sym].try(:[], :href),
+                             :placeholder => item.defaults[:href],
+                             :class => 'form-control',
+                             'data-miq_observe' => {:interval => '.5', :url => url}.to_json,
+                             :disabled => val.to_s == 'modal')
+          %td
+            = select_tag("#{item.id}_type", options_for_select([[_("Current Window"), 'default'],
+                                                                [_("New Window"), 'new_window'],
+                                                                [_("About Modal"), 'modal']], val.to_s),
+                         :class => 'selectpicker')
 
-          - Settings.help_menu.try(item.id.to_s).try(:title).nil?
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent("#{item.id}_type", '#{url}')
-            $("##{item.id}_type").on('change', function() {
-              $("##{item.id}_href").prop('disabled', $(this).val() == 'modal');
-            });
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("#{item.id}_type", '#{url}')
+          $("##{item.id}_type").on('change', function() {
+            $("##{item.id}_href").prop('disabled', $(this).val() == 'modal');
+          });

--- a/spec/presenters/menu/menu_manager_spec.rb
+++ b/spec/presenters/menu/menu_manager_spec.rb
@@ -15,7 +15,7 @@ describe Menu::Manager do
 
     it "loads custom menu items" do
       expect(Menu::YamlLoader).to receive(:load).and_call_original
-      Menu::Manager.menu {}
+      Menu::Manager.menu
     end
   end
 
@@ -27,7 +27,7 @@ describe Menu::Manager do
         expect(Dir).to receive(:glob).and_return([temp_file2.path, temp_file.path])
 
         section = nil
-        Menu::Manager.menu do |a_section|
+        Menu::Manager.menu.each do |a_section|
           section = a_section if a_section.name == 'Red Hat'
         end
         expect(section).to be_truthy
@@ -43,7 +43,7 @@ describe Menu::Manager do
     it "knows about custom items from settings" do
       ::Settings.ui.custom_menu = settings_custom_items
       count = 0
-      Menu::Manager.menu do |item|
+      Menu::Manager.menu.each do |item|
         count += 1 if item.kind_of?(Menu::Item) && item.name =~ /^Custom Item/
       end
       expect(count).to eq(2)


### PR DESCRIPTION
(Split off from #6963 as it was getting too large.)

This should not change anything, especially to do with menus :).

* move menu partial + invocations from every layout to a single header invocation
* moved `compact` from sections and items to the common code
* allowed menu item without rbac - logout can't require rbac
* removed icons from second & 3rd level sections - only first level sections have icons
* split help items so that the future user settings menu can reorder them, and editing still works

Cc @skateman 