### PR TITLE
React - override id, component; convert Breadcrumbs to functional

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,6 +1,6 @@
 module ReactjsHelper
   def react(name, data = {}, attributes = {}, element = 'div')
-    uid = unique_html_id('react')
+    uid = attributes[:id] || unique_html_id('react')
     capture do
       concat(content_tag(element, nil, attributes.merge(:id => uid)))
       concat(javascript_tag("ManageIQ.component.componentFactory('#{j(name)}', '##{j(uid)}', #{data.to_json})"))

--- a/app/javascript/components/breadcrumbs/index.jsx
+++ b/app/javascript/components/breadcrumbs/index.jsx
@@ -45,7 +45,7 @@ const renderItems = ({ items, controllerName }) => {
 };
 
 const Breadcrumbs = ({ items, title, controllerName }) => (
-  <Breadcrumb>
+  <Breadcrumb style={{ marginBottom: 0 }}>
     {items && renderItems({ items, controllerName })}
     <Breadcrumb.Item active>
       <strong>

--- a/app/javascript/components/breadcrumbs/index.jsx
+++ b/app/javascript/components/breadcrumbs/index.jsx
@@ -1,81 +1,69 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import { unescape } from 'lodash';
 
 import { onClickTree, onClick, onClickToExplorer } from './on-click-functions';
 
+// FIXME: don't parse html here
 const parsedText = text => unescape(text).replace(/<[/]{0,1}strong>/g, '');
 
-class Breadcrumbs extends Component {
-  renderItems = () => {
-    const { items, controllerName } = this.props;
-    return items.filter((_item, index) => index !== (items.length - 1)).map((item, index) => {
+const renderItems = ({ items, controllerName }) => {
+  return items
+    .filter((_item, index) => index !== (items.length - 1))
+    .map((item, index) => {
       const text = parsedText(item.title);
-      if ((item.url || item.key || item.to_explorer) && !item.action) {
-        if (item.key || item.to_explorer) {
-          return (
-            <Breadcrumb.Item
-              key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
-              onClick={e =>
-                (item.to_explorer
-                  ? onClickToExplorer(e, controllerName, item.to_explorer)
-                  : onClickTree(e, controllerName, item))
-                }
-            >
-              {text}
-            </Breadcrumb.Item>
-          );
-        }
+      if (item.action || (!item.url && !item.key && !item.to_explorer)) {
+        return <li key={index}>{text}</li>; // eslint-disable-line react/no-array-index-key
+      }
+
+      if (item.key || item.to_explorer) {
         return (
           <Breadcrumb.Item
-            key={item.url || index}
-            href={item.url}
-            onClick={e => onClick(e, item.url)}
+            key={`${item.key}-${index}`} // eslint-disable-line react/no-array-index-key
+            onClick={e =>
+              (item.to_explorer
+                ? onClickToExplorer(e, controllerName, item.to_explorer)
+                : onClickTree(e, controllerName, item))
+              }
           >
             {text}
           </Breadcrumb.Item>
         );
       }
-      return <li key={index}>{text}</li>; // eslint-disable-line react/no-array-index-key
-    });
-  };
 
-  render() {
-    const {
-      items, title, controllerName, ...rest // eslint-disable-line no-unused-vars
-    } = this.props;
-
-    return (
-      <Breadcrumb style={{ marginBottom: 0 }} {...rest}>
-        {items && this.renderItems()}
-        <Breadcrumb.Item active>
-          <strong>
-            {items && items.length > 0 ? parsedText(items[items.length - 1].title) : parsedText(title)}
-          </strong>
+      return (
+        <Breadcrumb.Item
+          key={item.url || index}
+          href={item.url}
+          onClick={e => onClick(e, item.url)}
+        >
+          {text}
         </Breadcrumb.Item>
-      </Breadcrumb>
-    );
-  }
-}
-
-Breadcrumbs.propTypes = {
-  items: PropTypes.arrayOf(PropTypes.shape(
-    {
-      title: PropTypes.string.isRequired,
-      url: PropTypes.string,
-      action: PropTypes.string,
-      key: PropTypes.string,
-    },
-  )),
-  title: PropTypes.string,
-  controllerName: PropTypes.string,
+      );
+    });
 };
 
-Breadcrumbs.defaultProps = {
-  items: undefined,
-  title: undefined,
-  controllerName: undefined,
+const Breadcrumbs = ({ items, title, controllerName }) => (
+  <Breadcrumb>
+    {items && renderItems({ items, controllerName })}
+    <Breadcrumb.Item active>
+      <strong>
+        {items && items.length > 0 ? parsedText(items[items.length - 1].title) : parsedText(title)}
+      </strong>
+    </Breadcrumb.Item>
+  </Breadcrumb>
+);
+
+Breadcrumbs.propTypes = {
+  controllerName: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    action: PropTypes.string,
+    key: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string,
+  })),
+  title: PropTypes.string,
 };
 
 export default Breadcrumbs;

--- a/app/javascript/miq-component/helpers.js
+++ b/app/javascript/miq-component/helpers.js
@@ -1,8 +1,8 @@
 import * as registry from './registry.js';
 import reactBlueprint from './react-blueprint.jsx';
 
-export function addReact(name, component) {
-  return registry.define(name, reactBlueprint(component));
+export function addReact(name, component, options = {}) {
+  return registry.define(name, reactBlueprint(component), options);
 }
 
 export function componentFactory(blueprintName, selector, props) {

--- a/app/javascript/miq-component/registry.js
+++ b/app/javascript/miq-component/registry.js
@@ -46,10 +46,13 @@ export function validateInstance(instance, definition) {
 /**
  * Implementation of the `ComponentApi.define` method.
  */
-export function define(name, blueprint = {}, instances = null) {
+export function define(name, blueprint = {}, options = {}) {
   // validate inputs
-  if (typeof name !== 'string' || isDefined(name)) {
-    return;
+  if (typeof name !== 'string') {
+    throw `Registry.define: non-string name: ${name}`;
+  }
+  if (isDefined(name) && !options.override) {
+    throw `Registry.define: component already exists: ${name} (use { override: true } ?)`;
   }
 
   // add new definition to the registry
@@ -57,8 +60,8 @@ export function define(name, blueprint = {}, instances = null) {
   registry.set(newDefinition, new Set());
 
   // add existing instances to the registry
-  if (Array.isArray(instances)) {
-    instances.filter((instance) => !!instance)
+  if (Array.isArray(options.instances)) {
+    options.instances.filter((instance) => !!instance)
       .forEach((instance) => {
         sanitizeAndFreezeInstanceId(instance, newDefinition);
         validateInstance(instance, newDefinition);

--- a/app/javascript/spec/miq-component/helpers.spec.js
+++ b/app/javascript/spec/miq-component/helpers.spec.js
@@ -24,7 +24,7 @@ describe('Helpers', () => {
       },
     ];
 
-    define('FooComponent', {}, testInstances);
+    define('FooComponent', {}, { instances: testInstances });
 
     cleanVirtualDom();
     expect(destroy1).not.toHaveBeenCalled();

--- a/app/javascript/spec/miq-component/miq-component.spec.js
+++ b/app/javascript/spec/miq-component/miq-component.spec.js
@@ -77,7 +77,7 @@ describe('Component API', () => {
 
   it('when passing existing instances, define method ensures a sane instance id', () => {
     const testInstances = [
-      { id: 'first' }, { id: 123 }, {},
+      { id: 'first' }, {}, {},
     ];
 
     define('FooComponent', {}, { instances: testInstances });
@@ -203,7 +203,7 @@ describe('Component API', () => {
     define('FooComponent', {
       create: jest.fn().mockName('testBlueprint.create')
         .mockImplementationOnce(() => ({ id: 'first', elementId: mountId }))
-        .mockImplementationOnce(() => ({ id: 123, elementId: mountId }))
+        .mockImplementationOnce(() => ({ elementId: mountId }))
         .mockImplementationOnce(() => ({ elementId: mountId })),
     });
 
@@ -434,7 +434,7 @@ describe('Component API', () => {
 
   it('sanitizeAndFreezeInstanceId ensures the instance id is sane and cannot be changed', () => {
     const testInstances = [
-      { id: 'first' }, { id: 123 }, {},
+      { id: 'first' }, {}, {},
     ];
 
     define('FooComponent', {});

--- a/app/javascript/spec/miq-component/miq-component.spec.js
+++ b/app/javascript/spec/miq-component/miq-component.spec.js
@@ -43,14 +43,24 @@ describe('Component API', () => {
     expect(getComponentNames()).toEqual(['FooComponent', 'BarComponent']);
   });
 
-  it('define method does nothing if the component name is already taken', () => {
+  it('define method throws if the component name is already taken', () => {
     define('FooComponent', {});
+    expect(() => {
+      define('FooComponent', {});
+    }).toThrow();
+    expect(getComponentNames()).toEqual(['FooComponent']);
+  });
+
+  it('define method passes twice with override option', () => {
     define('FooComponent', {});
+    define('FooComponent', {}, { override: true });
     expect(getComponentNames()).toEqual(['FooComponent']);
   });
 
   it('define method does nothing if the component name is not a string', () => {
-    define(123, {});
+    expect(() => {
+      define(123, {});
+    }).toThrow();
     expect(isDefined(123)).toBe(false);
     expect(getComponentNames()).toEqual([]);
   });
@@ -60,7 +70,7 @@ describe('Component API', () => {
       { id: 'first' }, { id: 'second' },
     ];
 
-    define('FooComponent', {}, testInstances);
+    define('FooComponent', {}, { instances: testInstances });
     expect(getInstance('FooComponent', 'first')).toBe(testInstances[0]);
     expect(getInstance('FooComponent', 'second')).toBe(testInstances[1]);
   });
@@ -70,7 +80,7 @@ describe('Component API', () => {
       { id: 'first' }, { id: 123 }, {},
     ];
 
-    define('FooComponent', {}, testInstances);
+    define('FooComponent', {}, { instances: testInstances });
 
     const registeredInstances = getComponentInstances('FooComponent');
     expect(registeredInstances).toHaveLength(3);
@@ -84,7 +94,7 @@ describe('Component API', () => {
       { id: 'first' },
     ];
 
-    define('FooComponent', {}, testInstances);
+    define('FooComponent', {}, { instances: testInstances });
     expect(() => {
       testInstances[0].id = 'second';
     }).toThrow();
@@ -95,7 +105,7 @@ describe('Component API', () => {
       false, '', null, undefined, {},
     ];
 
-    define('FooComponent', {}, testInstances);
+    define('FooComponent', {}, { instances: testInstances });
 
     const registeredInstances = getComponentInstances('FooComponent');
     expect(registeredInstances).toHaveLength(1);
@@ -106,7 +116,7 @@ describe('Component API', () => {
     const testInstance = { id: 'first' };
 
     expect(() => {
-      define('FooComponent', {}, [testInstance, testInstance]);
+      define('FooComponent', {}, { instances: [testInstance, testInstance] });
     }).toThrow();
   });
 
@@ -116,7 +126,7 @@ describe('Component API', () => {
     ];
 
     expect(() => {
-      define('FooComponent', {}, testInstances);
+      define('FooComponent', {}, { instances: testInstances });
     }).toThrow();
   });
 

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -63,6 +63,16 @@ let plugins = [
     publicPath: output.publicPath,
     writeToFileEmit: true,
   }),
+
+  // plugin to output timestamp after compilation (useful for --watch)
+  {
+    apply(compiler) {
+      compiler.hooks.done.tap('done timestamp', () => {
+        // setTimeout to append instead of prepend the date
+        setTimeout(() => console.log('webpack: done', new Date()));
+      });
+    },
+  },
 ];
 
 if (env.WEBPACK_VERBOSE) {


### PR DESCRIPTION
(Split off from #6963 as it was getting too large.)

This allows for overriding react component ids when calling `= react`,
overriding component registry components from plugins via `addReact(name, component, { override: true })`,
adds a webpack plugin to output timestamp of the last build (scss rebuilds take a few seconds),

and converts Breadcrumbs to a functional component, without further changes

Cc @skateman 