### PR TITLE
autoprefixer, browserslist: update, move to package.json

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,11 +1,7 @@
 // note that every package mentioned here has to be explicitly required (require/import, not a string name)
 // if not, this fails if babel runs in a plugin repo before it manages to load them
 
-const browsers = [
-  "> 3%",
-  "last 2 versions",
-  "Firefox ESR",
-];
+const browsers = require('./package.json').browserslist;
 
 module.exports = {
   presets: [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "1.0.0",
   "description": "ManageIQ Cloud Management Platform",
   "main": "index.js",
+  "browserslist": [
+    "> 3%",
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "not IE 11"
+  ],
   "scripts": {
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --headless --browser chrome",
@@ -102,7 +109,7 @@
     "@babel/register": "~7.9.0",
     "@babel/runtime-corejs3": "~7.9.0",
     "angular-mocks": "~1.6.9",
-    "autoprefixer": "~6.7.7",
+    "autoprefixer": "~9.8.0",
     "babel-eslint": "~10.1.0",
     "babel-jest": "~25.1.0",
     "babel-loader": "~8.1.0",
@@ -147,8 +154,8 @@
     "resolve-url-loader": "~3.1.1",
     "sass-loader": "~8.0.2",
     "style-loader": "~1.1.3",
-    "stylelint": "^8.2.0",
-    "stylelint-config-standard": "^17.0.0",
+    "stylelint": "~13.5.0",
+    "stylelint-config-standard": "~20.0.0",
     "webpack": "~4.42.0",
     "webpack-cli": "~3.3.11",
     "webpack-dev-server": "~3.10.3",


### PR DESCRIPTION
we're using old autoprefixer which depends on browserslist 1.7, which doesn't know "not dead" - updating autoprefixer, and stylelint because that depends on an older version too

then moving our browserslist from babel config to global config,
so that autoprefixer picks it up automatically,
and doesn't generate IE CSS.

Prevents errors when requiring carbon:

    (9155:3) IE supports only grid-row with / and span. You should add grid: false option to Autoprefixer and use some JS grid polyfill for full spec support
    @ ./app/stylesheet/application-webpack.scss 2:26-264
    @ ./app/javascript/packs/application-common.js

cc @skateman 