### PR TITLE
Add reconfigureMode parameter to dialog-user

### DIFF
--- a/app/views/shared/dialogs/_reconfigure_dialog.html.haml
+++ b/app/views/shared/dialogs/_reconfigure_dialog.html.haml
@@ -3,7 +3,7 @@
     .spinner{'ng-show' => "!vm.dialogLoaded"}
 
     .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
-      %dialog-user{"dialog" =>"vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)"}
+      %dialog-user{"dialog" => "vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)", "reconfigure-mode" => true}
 
       .clearfix
       .pull-right.button-group{'ng-show' => "vm.dialogLoaded"}


### PR DESCRIPTION
This needs to be tested / go in with https://github.com/ManageIQ/ui-components/pull/440

1. Create a service dialog, have a field in it marked as non-reconfigurable
2. Create a catalog item using the above dialog
3. Order the above created service
4. Once the service is deployed, reconfigure it

Previously, all input fields in the dialog being reconfigure could be edited. This fix adds a `reconfigureMode` flag to the `dialog-user` component, which then enabled / disables the respective inputs accordingly.

@himdel @tinaafitz @billfitzgerald0120 

https://bugzilla.redhat.com/show_bug.cgi?id=1837410