### PR TITLE
Use DATABASE_URL friendly AR::Base.configurations

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -813,7 +813,7 @@ module OpsController::Diagnostics
   end
 
   def database_details
-    @database_details = Rails.configuration.database_configuration[Rails.env]
+    @database_details = ActiveRecord::Base.configurations[Rails.env]
     @database_display_name =
       if @database_details["host"].in?([nil, "", "localhost", "127.0.0.1"])
         _("Internal Database")


### PR DESCRIPTION
Rails.configuration.database_configuration has no knowledge of db configuration
found in the DATABASE_URL environment variable. We need to use
ActiveRecord::Base.configurations.

Related to: https://github.com/ManageIQ/manageiq/pull/20208
And: https://github.com/ManageIQ/manageiq/pull/15269