### PR TITLE
Fix missing partial for GOD page

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -21,6 +21,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def show_list
+    self.x_node = params[:id] if params[:id].present?
     self.x_active_tree ||= :generic_object_definitions_tree
     self.x_node ||= 'root'
     build_tree
@@ -290,7 +291,9 @@ class GenericObjectDefinitionController < ApplicationController
       :breadcrumbs  => [
         {:title => _("Automation")},
         {:title => _("Automate")},
-        {:title => _("Generic Objects")},
+        {:title => _("Generic Objects"), :url => url_for_only_path(:controller => 'generic_object_definition',
+                                                                   :action => 'show_list',
+                                                                   :id => 'root')},
       ],
       :record_info  => @generic_object_definition,
       :disable_tree => %w[new edit].include?(action_name),

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -58,6 +58,8 @@ module ApplicationHelper::PageLayouts
 
     return false if controller.action_name.end_with?("tagging_edit")
 
+    return false if controller.kind_of?(GenericObjectDefinitionController) && x_node != "root"
+
     true
   end
 

--- a/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
+++ b/app/views/layouts/listnav/_generic_object_definition_show_list_with_treeview.html.haml
@@ -1,0 +1,16 @@
+- return if @display == 'generic_objects' || @display == 'main'
+= miq_accordion_panel(_("Generic Object Definitions"), true, "god") do
+  :javascript
+    ManageIQ.tree.data['#{@tree.name}'] = #{@tree.locals_for_render[:bs_tree]};
+  %tree_div{'ng-controller' => 'treeViewController as vm'}
+    %miq-tree-view{:name       => @tree.name,
+                   :data       => "vm.data['#{@tree.name}']",
+                   :reselect   => @tree.locals_for_render[:allow_reselect],
+                   "ng-init"   => "vm.initData('#{@tree.name}', '#{@tree.locals_for_render[:select_node]}')",
+                   'on-select' => "vm.nodeSelect(node, '/#{request.parameters[:controller]}/tree_select')",
+                   'selected'  => "vm.selectedNodes['#{@tree.name}']",
+                   'persist'   => 'key',
+                   'lazy-load' => "(vm.lazyLoad(node, '#{@tree.name}', '/#{request.parameters[:controller]}/tree_autoload'))"}
+
+:javascript
+  miq_bootstrap('tree_div');


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq-ui-classic/pull/6997

Go to Automation -> Automate -> Generic Objects

Before:
<img width="1438" alt="Screenshot 2020-05-28 at 13 49 36" src="https://user-images.githubusercontent.com/9210860/83137823-1696e280-a0ea-11ea-8496-a51728434bc0.png">

After:
<img width="1447" alt="Screenshot 2020-05-28 at 16 38 23" src="https://user-images.githubusercontent.com/9210860/83155863-f96e0e00-a101-11ea-9b02-d213e48572d3.png">

<img width="741" alt="Screenshot 2020-05-28 at 16 41 06" src="https://user-images.githubusercontent.com/9210860/83155935-11de2880-a102-11ea-8910-89dc9e44eaf3.png">


@miq-bot add_label bug, jansa/no

@h-kataria please have a look. I removed listnav for summary pages that use `show_list` for some reason. And improved breadcrumbs so the navigation works a bit. I'll work on GOD breadcrumbs more in followup PR.