### PR TITLE
Remove unused routes from the miq_policy_controller

### DIFF
--- a/app/views/miq_policy/_action_list.html.haml
+++ b/app/views/miq_policy/_action_list.html.haml
@@ -1,2 +1,2 @@
 #action_list_div
-  = render :partial => 'layouts/gtl', :locals  => {:action_url => "action_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals  => {:button_div => 'policy_bar'}

--- a/app/views/miq_policy/_alert_list.html.haml
+++ b/app/views/miq_policy/_alert_list.html.haml
@@ -1,2 +1,2 @@
 #alert_list_div
-  = render :partial => 'layouts/gtl', :locals  => {:action_url => "alert_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals  => {:button_div => 'policy_bar'}

--- a/app/views/miq_policy/_policy_list.html.haml
+++ b/app/views/miq_policy/_policy_list.html.haml
@@ -1,2 +1,2 @@
 #policy_list_div
-  = render :partial => 'layouts/gtl', :locals => {:action_url => "policy_get_all", :button_div => 'policy_bar'}
+  = render :partial => 'layouts/gtl', :locals => {:button_div => 'policy_bar'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2257,12 +2257,9 @@ Rails.application.routes.draw do
         accordion_select
         action_edit
         action_field_changed
-        action_get_all
-        action_tag_pressed
         alert_delete
         alert_edit
         alert_field_changed
-        alert_get_all
         alert_profile_assign
         alert_profile_assign_changed
         alert_profile_delete
@@ -2276,7 +2273,6 @@ Rails.application.routes.draw do
         export_field_changed
         import
         policy_edit
-        policy_get_all
         policy_field_changed
         profile_edit
         profile_field_changed

--- a/spec/routing/miq_policy_routing_spec.rb
+++ b/spec/routing/miq_policy_routing_spec.rb
@@ -18,18 +18,6 @@ describe 'routes for MiqPolicyController' do
     end
   end
 
-  describe '#action_get_all' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/action_get_all")).to route_to("#{controller_name}#action_get_all")
-    end
-  end
-
-  describe '#action_tag_pressed' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/action_tag_pressed")).to route_to("#{controller_name}#action_tag_pressed")
-    end
-  end
-
   describe '#alert_edit' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/alert_edit")).to route_to("#{controller_name}#alert_edit")
@@ -39,12 +27,6 @@ describe 'routes for MiqPolicyController' do
   describe '#alert_field_changed' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/alert_field_changed")).to route_to("#{controller_name}#alert_field_changed")
-    end
-  end
-
-  describe '#alert_get_all' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/alert_get_all")).to route_to("#{controller_name}#alert_get_all")
     end
   end
 
@@ -169,12 +151,6 @@ describe 'routes for MiqPolicyController' do
   describe '#policy_field_changed' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/policy_field_changed")).to route_to("#{controller_name}#policy_field_changed")
-    end
-  end
-
-  describe '#policy_get_all' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/policy_get_all")).to route_to("#{controller_name}#policy_get_all")
     end
   end
 


### PR DESCRIPTION
The `_get_all` routes are no longer used as the `action_url` local variable is not being used in the `layouts/gtl` anymore. There's a callsite to each method though, from `tree_select` methods, so I kept the method definitions. The `action_tag_pressed` method has been probably deleted when we started using the new tagging screen. 