### PR TITLE
MiqTask to get stdout for Ansible should be owned by user who requested view

### DIFF
--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -42,7 +42,7 @@
         = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
           - if job && job.respond_to?(:raw_stdout_via_worker)
-            %ansible-raw-stdout#service_detail_ansible_tower_job{'task-id' => @record.job.raw_stdout_via_worker(nil, 'html')}
+            %ansible-raw-stdout#service_detail_ansible_tower_job{'task-id' => @record.job.raw_stdout_via_worker(User.current_user&.userid, 'html')}
             :javascript
               miq_bootstrap('#service_detail_ansible_tower_job');
 
@@ -50,14 +50,14 @@
         = miq_tab_content("provisioning", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_provisioning_group_list, :tab_id => "provisioning"}
           - if provision_job
-            %ansible-raw-stdout#service_detail_ansible_playbook{'task-id' => provision_job.raw_stdout_via_worker(nil, 'html')}
+            %ansible-raw-stdout#service_detail_ansible_playbook{'task-id' => provision_job.raw_stdout_via_worker(User.current_user&.userid, 'html')}
             :javascript
               miq_bootstrap('#service_detail_ansible_playbook');
 
         - if retirement_job
           = miq_tab_content("retirement", 'default', :class => 'cm-tab') do
             = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_retirement_group_list, :tab_id => "retirement"}
-            %ansible-raw-stdout#service_detail_job{'task-id' => retirement_job.raw_stdout_via_worker(nil, 'html')}
+            %ansible-raw-stdout#service_detail_job{'task-id' => retirement_job.raw_stdout_via_worker(User.current_user&.userid, 'html')}
             :javascript
               miq_bootstrap('#service_detail_job');
 


### PR DESCRIPTION
**ISSUE:**
Users will get error on Ansible playbook screen if they do not have product feature ```miq_task_all_ui```  since MiqTask to get Ansible playbook stdout was created for `system` account

**Solution**: 
Provide userid when creating MiqTask for grabbing stdout output from absible playbook

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/83421809-a55f7400-a3f6-11ea-91ad-962bb4310e0c.png)

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/83421353-f458d980-a3f5-11ea-8348-86a6b694d31a.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1836125

@miq-bot add-label bug, ivanchuk/yes, jansa/yes