### PR TITLE
Disable privilege escalation when machine credential doesn't support it

### DIFF
--- a/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
+++ b/app/assets/javascripts/controllers/catalog/catalog_item_form_controller.js
@@ -521,6 +521,10 @@ ManageIQ.angular.app.controller('catalogItemFormController', ['$scope', '$timeou
     angular.element('#confirmationModal').modal('hide');
   };
 
+  vm.enablePrivilegeEscalation = function(credential) {
+    return (credential.options && credential.options.become_method && credential.options.become_method !== "");
+  };
+
   $scope.dialogNameValidation = function() {
     miqService.miqFlashClear();
     $scope.angularForm.$setValidity('unchanged', true);

--- a/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
+++ b/app/assets/javascripts/controllers/playbook-reusable-code-mixin.js
@@ -183,7 +183,7 @@ function playbookReusableCodeMixin(API, $q, miqService) {
     );
 
     // list of machine credentials
-    getCredentialsForType('machine', '/api/authentications?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential&expand=resources&attributes=id,name', vm);
+    getCredentialsForType('machine', '/api/authentications?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential&expand=resources&attributes=id,name,options', vm);
 
     // list of vault credentials
     getCredentialsForType('vault', '/api/authentications?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential&expand=resources&attributes=id,name', vm);

--- a/app/views/layouts/angular/_ansible_form_options_angular.html.haml
+++ b/app/views/layouts/angular/_ansible_form_options_angular.html.haml
@@ -182,7 +182,7 @@
                 'ng-options'  => 'v as k for (v, k) in vm.log_output_types',
                 "checkchange" => "",
                 'miq-select'  => true}
-    #escalate_privilege{"ng-if" => "(#{ng_model}.location === 'playbook' && #{ng_model}.#{prefix}_become_enabled!=null || vm.retirement_playbook_selected('#{prefix}'))"}
+    #escalate_privilege{"ng-if" => "(#{ng_model}.location === 'playbook' && #{ng_model}.#{prefix}_become_enabled!=null || vm.retirement_playbook_selected('#{prefix}')) && vm._#{prefix}_machine_credential && vm.enablePrivilegeEscalation(vm._#{prefix}_machine_credential)"}
       .form-group
         %label.col-md-3.control-label
           = _("Escalate Privilege")


### PR DESCRIPTION
1. Attempt to create a Ansible Playbook service
2. Select repository and a playbook
3. Select a machine credential without privilege escalation method
4. Select a different machine credential with privilege escalation method

In both cases (3 & 4) the `Privilege Escalation` switch stays visible & usable. In truth, the switch should be enabled only for machine credentials actually supporting privilege escalation.

When selected a machine credential that supports privilege escalation:
![Screenshot from 2020-06-02 16-10-43](https://user-images.githubusercontent.com/6648365/83530448-09179900-a4ec-11ea-9edb-88ed06deb1c7.png)

When selected a machine credential that doesn't support privilege escalation:
![Screenshot from 2020-06-02 16-11-09](https://user-images.githubusercontent.com/6648365/83530451-0a48c600-a4ec-11ea-882b-da0efbab960c.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1810477