### PR TITLE
CustomLoader - load from all Engines' .menu

### DIFF
--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -5,6 +5,10 @@ module Menu
         @cache ||= sections_items
       end
 
+      def unload
+        @cache = nil
+      end
+
       def engines
         Vmdb::Plugins.all
       end

--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -1,20 +1,30 @@
 module Menu
   module CustomLoader
-    @sections = []
-    @items = []
-
     class << self
       def load
-        [@sections, @items]
+        @cache ||= sections_items
       end
 
-      def register(item)
-        case item
-        when Menu::Section
-          @sections << item
-        when Menu::Item
-          @items << item
+      def engines
+        Vmdb::Plugins.all
+      end
+
+      def sections_items
+        sections = []
+        items = []
+
+        engines.map do |engine|
+          engine.try(:menu)
+        end.compact.flatten.each do |item|
+          case item
+          when Menu::Section
+            sections << item
+          when Menu::Item
+            items << item
+          end
         end
+
+        [sections, items]
       end
     end
   end

--- a/spec/presenters/menu/custom_loader_spec.rb
+++ b/spec/presenters/menu/custom_loader_spec.rb
@@ -4,10 +4,21 @@ describe Menu::CustomLoader do
     Singleton.__init__(Menu::CustomLoader)
   end
 
+  def register(item)
+    engine = Object.new.tap do |engine|
+      allow(engine).to receive(:menu).and_return([ item ])
+    end
+
+    allow(Vmdb::Plugins).to receive(:all).and_return([ engine ])
+
+    Menu::CustomLoader.unload
+    Menu::Manager.instance.send(:initialize)
+  end
+
   context '.register' do
     it 'loads custom menu items' do
       # create custom section with 2 custom items
-      described_class.register(
+      register(
         Menu::Section.new(:spike, 'Plugin', 'fa fa-map-pin', [
                             Menu::Item.new('plug1', 'Test', 'miq_report', {:feature => 'miq_report', :any => true}, '/plug'),
                             Menu::Item.new('plug2', 'Demo', 'miq_report', {:feature => 'miq_report', :any => true}, '/demo')
@@ -20,7 +31,7 @@ describe Menu::CustomLoader do
 
     it 'loads a custom menu item under an existing section' do
       # create custom item placed in an existing section 'vi' (Overview)
-      described_class.register(
+      register(
         Menu::Item.new('plug3', 'Plug Item', 'miq_report', {:feature => 'miq_report', :any => true}, '/demo', :default, :vi)
       )
 
@@ -31,7 +42,7 @@ describe Menu::CustomLoader do
 
     it 'loads a custom menu section and places it before an existing section' do
       # create custom section and place it before existing section 'compute' (Compute)
-      described_class.register(
+      register(
         Menu::Section.new(:spike3, 'Plugin 2', 'fa fa-map-pin', [
                             Menu::Item.new('plug4', 'Demo', 'miq_report', {:feature => 'miq_report', :any => true}, '/demo')
                           ], :default, :compute)
@@ -48,7 +59,7 @@ describe Menu::CustomLoader do
 
     it 'loads a custom menu section and places it at a given position in inside an existing section' do
       # create custom section and place it inside an existing section 'compute' (Compute), before existing subsection 'clo' (Cloud)
-      described_class.register(
+      register(
         Menu::Section.new(:spike3, 'Nested section after', 'fa fa-map-pin', [
                             Menu::Item.new('plug5', 'Test item', 'miq_report', {:feature => 'miq_report', :any => true}, '/demo')
                           ], :default, :clo, :default, nil, :compute)

--- a/spec/presenters/menu/custom_loader_spec.rb
+++ b/spec/presenters/menu/custom_loader_spec.rb
@@ -4,13 +4,19 @@ describe Menu::CustomLoader do
     Singleton.__init__(Menu::CustomLoader)
   end
 
+  after do
+    clean
+  end
+
   def register(item)
-    engine = Object.new.tap do |engine|
-      allow(engine).to receive(:menu).and_return([ item ])
-    end
+    engine = double("Rails Engine")
+    allow(engine).to receive(:menu).and_return([item])
+    allow(Vmdb::Plugins).to receive(:all).and_return([engine])
 
-    allow(Vmdb::Plugins).to receive(:all).and_return([ engine ])
+    clean
+  end
 
+  def clean
     Menu::CustomLoader.unload
     Menu::Manager.instance.send(:initialize)
   end
@@ -72,6 +78,15 @@ describe Menu::CustomLoader do
       spike_index = compute_section.items.find_index { |i| i.id == :spike3 }
       clo_index   = compute_section.items.find_index { |i| i.id == :clo }
       expect(spike_index).to eq(clo_index - 1)
+    end
+
+    it 'survives plugins without menus' do
+      engine = double("Rails Engine")
+      allow(Vmdb::Plugins).to receive(:all).and_return([engine])
+
+      clean
+
+      expect(Menu::Manager.items).to be
     end
   end
 end


### PR DESCRIPTION
instead of relying on initializers calling `register`,
and failing after code reload in development

This changes how plugins register menus:

```diff
diff --git a/lib/manageiq/v2v/engine.rb b/lib/manageiq/v2v/engine.rb
index f725e8de..dd092f7e 100644
--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -14,14 +14,14 @@ module ManageIQ::V2V
       app.config.filter_parameters += %i[conversion_host_ssh_private_key openstack_tls_ca_certs vmware_ssh_private_key]
     end
 
-    initializer 'plugin-migration-menu' do
-      Menu::CustomLoader.register(
+    def self.menu
+      [
         Menu::Section.new(:migration, N_("Migration"), 'pficon pficon-migration', [
           Menu::Item.new('plans', N_("Migration Plans"), 'migration', {:feature => 'migration', :any => true}, '/migration#/plans'),
           Menu::Item.new('mappings', N_("Infrastructure Mappings"), 'mappings', {:feature => 'mappings', :any => true}, '/migration#/mappings'),
           Menu::Item.new('settings', N_("Migration Settings"), 'migration_settings', {:feature => 'migration_settings', :any => true}, '/migration#/settings')
-        ], nil, :con) # Place Migration before Control (after the various Provider kinds)
-      )
+        ], nil, :con), # Place Migration before Control (after the various Provider kinds)
+      ]
     end
 
     def self.plugin_name
```

(Tests will go green once https://github.com/ManageIQ/manageiq-v2v/pull/1135 is in.)