### PR TITLE
Change to support simplified direct link for assignments

### DIFF
--- a/app/controllers/chargeback_assignment_controller.rb
+++ b/app/controllers/chargeback_assignment_controller.rb
@@ -13,7 +13,7 @@ class ChargebackAssignmentController < ApplicationController
 
   def index
     @title = _("Chargeback Assignments")
-    @tabform = "Compute"
+    @tabform = ChargebackRate::VALID_CB_RATE_TYPES.include?(params[:tab]) ? params[:tab] : "Compute"
     session[:changed] = @changed = false
     build_tabs
     set_form_vars


### PR DESCRIPTION
With this change, direct links such as http://localhost:3000/chargeback_assignment?type=Compute,                       http://localhost:3000/chargeback_assignment?type=Storage should work.

