### PR TITLE
Add region id to Provider summary

### DIFF
--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module EmsInfraHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i[hostname ipaddress type port cpu_resources memory_resources cpus cpu_cores guid host_default_vnc_port_range]
+      %i[hostname ipaddress type port cpu_resources memory_resources cpus cpu_cores guid host_default_vnc_port_range region]
     )
   end
 
@@ -40,6 +40,12 @@ module EmsInfraHelper::TextualSummary
   #
   # Items
   #
+
+  def textual_region
+    return nil if @record.region_id.blank?
+
+    {:label => _('Region'), :value => @record.region_id}
+  end
 
   def textual_hostname
     @record.hostname

--- a/spec/helpers/ems_infra_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_infra_helper/textual_summary_spec.rb
@@ -28,6 +28,7 @@ describe EmsInfraHelper::TextualSummary do
     cpu_cores
     guid
     host_default_vnc_port_range
+    region
   )
 
   include_examples "textual_group", "Status", %i(refresh_status refresh_date orchestration_stacks_status)


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7042

Go to Compute -> Infrastructure -> Providers -> click on one

Before:
![image](https://user-images.githubusercontent.com/9210860/83733874-7c392080-a64e-11ea-992a-8da01fba0a0d.png)

After:
![image](https://user-images.githubusercontent.com/9210860/83733781-53189000-a64e-11ea-811a-0923e4fdee5c.png)


@miq-bot add_label wip