### PR TITLE
Remove the no longer used ownership_field_changed route

### DIFF
--- a/spec/routing/service_routing_spec.rb
+++ b/spec/routing/service_routing_spec.rb
@@ -22,13 +22,6 @@ describe 'routes for ServiceController' do
     end
   end
 
-  describe "#ownership_field_changed" do
-    it "routes with POST" do
-      expect(post("/service/ownership_field_changed"))
-        .to route_to("service#ownership_field_changed")
-    end
-  end
-
   describe "#ownership_update" do
     it "routes with POST" do
       expect(post("/service/ownership_update")).to route_to("service#ownership_update")

--- a/spec/routing/shared_examples/vm_common_examples.rb
+++ b/spec/routing/shared_examples/vm_common_examples.rb
@@ -141,14 +141,6 @@ shared_examples_for 'A controller that has vm_common routes' do
     end
   end
 
-  describe '#ownership_field_changed' do
-    it 'routes with POST' do
-      expect(
-        post("/#{controller_name}/ownership_field_changed")
-      ).to route_to("#{controller_name}#ownership_field_changed")
-    end
-  end
-
   describe '#ownership_update' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/ownership_update")).to route_to("#{controller_name}#ownership_update")

--- a/spec/routing/vm_or_template_routing_spec.rb
+++ b/spec/routing/vm_or_template_routing_spec.rb
@@ -70,7 +70,6 @@ describe VmOrTemplateController do
     guest_applications
     kernel_drivers
     linux_initprocesses
-    ownership_field_changed
     ownership_update
     patches
     perf_chart_chooser

--- a/spec/routing/vm_routing_spec.rb
+++ b/spec/routing/vm_routing_spec.rb
@@ -26,7 +26,6 @@ describe VmOrTemplateController do
     edit_vm
     form_field_changed
     ownership
-    ownership_field_changed
     ownership_update
     policy_sim
     policy_sim_add


### PR DESCRIPTION
The method for this route has been removed when we converted it to react, however, the route definition and specs remained. :scissors: 

