### PR TITLE
Fixed `.find` call in Profile remove_member call

### DIFF
--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -43,7 +43,7 @@ module MiqPolicyController::PolicyProfiles
         policies.each { |p| current.push(p.id) } # Build an array of the current policy ids
         mems = @edit[:new][:policies].invert     # Get the ids from the member list box
         begin
-          policies.each { |c| profile.remove_member(MiqPolicy.find(c)) unless mems.include?(c.id) } # Remove any policies no longer in the members list box
+          policies.each { |c| profile.remove_member(c) unless mems.include?(c.id) } # Remove any policies no longer in the members list box
           mems.each_key { |m| profile.add_member(MiqPolicy.find(m)) unless current.include?(m) }    # Add any policies not in the set
         rescue StandardError => bang
           add_flash(_("Error during 'Policy Profile %{params}': %{messages}") %

--- a/spec/controllers/miq_policy_controller/policy_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/policy_profiles_spec.rb
@@ -1,0 +1,36 @@
+describe MiqPolicyController do
+  before do
+    stub_user(:features => :all)
+  end
+  context "::PolicyProfiles" do
+    context "#profile_edit" do
+      render_views
+
+      before do
+        @policy_profile = FactoryBot.create(:miq_policy_set, :description => "foo")
+        @policy1 = FactoryBot.create(:miq_policy, :towhat => "ContainerGroup", :mode => "compliance")
+        @policy2 = FactoryBot.create(:miq_policy, :towhat => "ContainerGroup", :mode => "compliance")
+        @policy_profile.add_member(@policy1)
+        @policy_profile.add_member(@policy2)
+      end
+
+      it "Successfully removes a Policy from a Policy Profile" do
+        new = {:description => "foo", :policies => {@policy2.name => @policy2.id}}
+        current = {:description => "foo", :policies => {@policy1.name => @policy1.id, @policy2.name => @policy2.id}}
+
+        controller.instance_variable_set(:@edit, :new        => new,
+                                                 :current    => current,
+                                                 :key        => "profile_edit__#{@policy_profile.id}",
+                                                 :profile_id => @policy_profile.id)
+        session[:edit] = assigns(:edit)
+        allow(controller).to receive(:replace_right_cell)
+        controller.params = {:button => "save", :id => @policy_profile.id}
+        expect(@policy_profile.members.count).to eq(2)
+        controller.profile_edit
+        expect(assigns(:flash_array).first[:message]).to include("Policy Profile \"#{@policy_profile.description}\" was saved")
+        @policy_profile.reload
+        expect(@policy_profile.members.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/9367

before
![before](https://user-images.githubusercontent.com/3450808/83812717-fc30ac00-a689-11ea-8a95-b94ae7502bc3.png)

after
![after](https://user-images.githubusercontent.com/3450808/83812736-03f05080-a68a-11ea-8051-246b00c26ab5.png)

cc @chessbyte 