### PR TITLE
[url_validation.js] Allow for file:// urls

### DIFF
--- a/app/assets/javascripts/directives/url_validation.js
+++ b/app/assets/javascripts/directives/url_validation.js
@@ -18,7 +18,9 @@ ManageIQ.angular.app.directive('urlValidation', ['nodeValidator', function(nodeV
         allow_protocol_relative_urls: true,
       };
       var validUrl = function(url) {
-        return nodeValidator.isURL(url, options) || url.match(/^[-\w:.]+@.*:/);
+        return nodeValidator.isURL(url, options) ||
+               url.match(/^file:\/\/\/.+/)       ||
+               url.match(/^[-\w:.]+@.*:/);
       };
     },
   };

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -47,7 +47,7 @@
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.required"}
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.urlValidation"}
-          = _("URL must include a protocol (http:// or https://) or be a valid SSH path (user@server:path or ssh://user@address:port/path)")
+          = _("URL must include a protocol (http://, https:// or file://) or be a valid SSH path (user@server:path or ssh://user@address:port/path)")
     .form-group
       %label.col-md-2.control-label
         = _('SCM credentials')


### PR DESCRIPTION
This is already allowed in the backend:

https://github.com/ManageIQ/manageiq/blob/cf751304/app/models/git_repository.rb#L12

So this should just be enforcing this in the same fashion on the frontend as we do in the backend.


Links
-----

* Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1845281
* Link to chat in `gitter`: https://gitter.im/ManageIQ/manageiq/ui?at=5ed96f049da05a060a509a2f
* Simlar to what was done previously:  https://github.com/ManageIQ/manageiq-ui-classic/pull/3694
* Info about `file:///` format:  https://en.wikipedia.org/wiki/File_URI_scheme
* Implementation of `isUrl`:  https://github.com/gkaimakas/angular.validators/blob/cc0204498bb57333082b0a70f2fd71beee86db4f/angular.validators.js#L316-L376


Steps for Testing/QA
--------------------

### Before

Can't enter valid `file:///` protocol urls:

<img width="929" alt="Screen Shot 2020-06-04 at 4 54 44 PM" src="https://user-images.githubusercontent.com/314014/84057996-2d58f700-a97e-11ea-9cb5-06d3f57ed848.png">


### After

Are allowed to enter valid `file:///` protocol urls (but only with 3 slashes):

<img width="901" alt="Screen Shot 2020-06-08 at 11 52 32 AM" src="https://user-images.githubusercontent.com/314014/84058256-92145180-a97e-11ea-9b08-27a63757250b.png">

<img width="947" alt="Screen Shot 2020-06-08 at 11 51 05 AM" src="https://user-images.githubusercontent.com/314014/84058113-5f6a5900-a97e-11ea-9401-996c67d532df.png">

<img width="910" alt="Screen Shot 2020-06-08 at 11 52 25 AM" src="https://user-images.githubusercontent.com/314014/84058270-96d90580-a97e-11ea-9c78-b944f6749406.png">

