### PR TITLE
Don't render empty cd-rom table in VM reconfigure screen

### DIFF
--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -403,7 +403,7 @@
   %hr
 
   - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
-    %div
+    %div{"ng-if" => "vm.reconfigureModel.vmCDRoms"}
       %h3
         = _('CD/DVD Drives')
       %table.table.table-striped.table-condensed.table-bordered
@@ -448,7 +448,7 @@
                                                      "ng-if"    => "cdRom.connect_disconnect == 'disconnect'",
                                                      "ng-click" => "vm.cancelCDRomConnectDisconnect(cdRom)"}= _('Cancel Disconnect')
 
-    %hr
+    %hr{"ng-if" => "vm.reconfigureModel.vmCDRoms"}
 
 
   %table{:width => "100%", :align => "bottom"}


### PR DESCRIPTION
Before
![Screenshot from 2020-06-09 12-13-53](https://user-images.githubusercontent.com/6648365/84135805-b2114700-aa4a-11ea-844c-ab3a49e6b976.png)


After
![Screenshot from 2020-06-09 12-13-28](https://user-images.githubusercontent.com/6648365/84135814-b6d5fb00-aa4a-11ea-8f22-33cf8068c3e8.png)


Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7096