### PR TITLE
Add noreferrer noopener to external links

### DIFF
--- a/app/javascript/react/textual_summary_click.js
+++ b/app/javascript/react/textual_summary_click.js
@@ -6,7 +6,7 @@ export default function textualSummaryGenericClick(item, event) {
   }
 
   if (item.external) {
-    window.open(item.link, '_blank');
+    window.open(item.link, '_blank', 'noopener,noreferrer');
   } else if (item.explorer) {
     const tokenElement = document.querySelector("meta[name=csrf-token]");
     // FIXME: jQuery is necessary here as it communicates with the old world

--- a/app/views/layouts/_empty.html.haml
+++ b/app/views/layouts/_empty.html.haml
@@ -8,6 +8,7 @@
   %p
     = _("Learn more about this")
     %a{:href => documentation,
+       :rel => 'noopener noreferrer',
        :target => '_blank'}
       = _("in the documentation.")
   .blank-slate-pf-main-action

--- a/app/views/shared/views/_alerts_list.html.haml
+++ b/app/views/shared/views/_alerts_list.html.haml
@@ -67,7 +67,10 @@
       %list-expanded-content
         .row
           .col-md-12
-            %a{"ng-href" => '{{$parent.$parent.item.sopLink}}', "target" => "_blank", "ng-if" => "$parent.item.sopLink"}
+            %a{"ng-href" => '{{$parent.$parent.item.sopLink}}',
+               "target" => "_blank",
+               "ng-if" => "$parent.item.sopLink",
+               :rel => 'noopener noreferrer'}
               = _("View SOP")
         .row
           .col-md-12


### PR DESCRIPTION
We only really have external links to documentation and provider UIs,
but better make sure they all have the right `rel` attributes set.

Cc @Fryguy 