### PR TITLE
Remove unused routes from auth_key_pair cloud_controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,6 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
-        tag_edit_form_field_changed
         ems_form_choices
         download_private_key
         ownership
@@ -145,7 +144,6 @@ Rails.application.routes.draw do
         button
         create
         dynamic_checkbox_refresh
-        form_field_changed
         listnav_search_selected
         ownership_form_fields
         ownership_update


### PR DESCRIPTION

@miq-bot add_label technical debt
@miq-bot assign @skateman 

I am not able to find usage and also do some testing in UI after removal, it seems that it can be removed 👍 
(form_field_changed can be removed because you cannot create or edit key pair)