### PR TITLE
[JANSA] Fix GOD breadcrumbs

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -290,7 +290,9 @@ class GenericObjectDefinitionController < ApplicationController
       :breadcrumbs  => [
         {:title => _("Automation")},
         {:title => _("Automate")},
-        {:title => _("Generic Objects")},
+        {:title => _("Generic Objects"), :url => url_for_only_path(:controller => 'generic_object_definition',
+                                                                   :action => 'show_list',
+                                                                   :id => 'root')},
       ],
       :record_info  => @generic_object_definition,
       :disable_tree => %w[new edit].include?(action_name),


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1719889

Makes `Generic Objects` part of breadcrumbs clickable so it's same as on master.

Before:
<img width="362" alt="Screenshot 2020-06-29 at 09 34 25" src="https://user-images.githubusercontent.com/9210860/85986032-e2b22400-b9eb-11ea-9ff1-80da99dc7c84.png">

After:
<img width="368" alt="Screenshot 2020-06-29 at 10 05 01" src="https://user-images.githubusercontent.com/9210860/85988903-070fff80-b9f0-11ea-9fbe-f0b43b0abd00.png">


@miq-bot add_label wip