### PR TITLE
Allow to select whole hour in dialog sample screen

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -51,7 +51,7 @@
                           &nbsp;
                           = select_tag("start_hour", options_for_select(Array.new(24) { |i| i }, time.hour))
                           \:
-                          = select_tag("start_min", options_for_select(Array.new(12)  { |i| i * 5 }, time.min))
+                          = select_tag("start_min", options_for_select(Array.new(60) { |i| i }, time.min))
 
                       - when "DialogFieldTextAreaBox"
                         = text_area_tag(field.id, field.sample_text, :size => "50x6", :disabled => true)


### PR DESCRIPTION
When creating a service dialog with timepicker, it is possible to select a default date / time for the input. Though when we render the dialog sample screen, we only allow every fifth minute to be selected and rendered.

This change allows to select and render every minute in an hour in the datepicker element.

https://bugzilla.redhat.com/show_bug.cgi?id=1706848

For the above bz to be properly addressed in ivanchuk, we need the following PR https://github.com/ManageIQ/ui-components/pull/373 to be cherry-picked into ivanchuk.