### PR TITLE
Do not allow the users to switch to a group that they don't belong to

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -589,7 +589,7 @@ class DashboardController < ApplicationController
   def change_group
     # Get the user and new group and set current_group in the user record
     db_user = current_user
-    db_user.update(:current_group => MiqGroup.find_by(:id => params[:to_group]))
+    db_user.update(:current_group => db_user.miq_groups.find_by!(:id => params[:to_group]))
 
     # Rebuild the session
     session_reset


### PR DESCRIPTION
There's no check on the group ID when switching groups, basically any group ID can be looked up. However, there's a [validation on the model level](https://github.com/ManageIQ/manageiq/blob/master/app/models/user.rb#L47), so this can't cause privilege escalation. Still, this change makes the code more straightforward and prevent other people from getting jumpscared while reviewing PRs in the area :rofl: 

