### PR TITLE
Rename the features_tree when not in edit mode under Access Control

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -969,7 +969,8 @@ module OpsController::OpsRbac
   def build_rbac_feature_tree
     @role = @sb[:typ] == "copy" ? @record.dup : @record if @role.nil? # if on edit screen use @record
     @role.miq_product_features = @record.miq_product_features if @sb[:typ] == "copy"
-    TreeBuilderOpsRbacFeatures.new("features_tree", @sb, true, :role => @role, :editable => @edit.present?)
+    # The edit/noedit tree should have a different name due to a collision between RJS and Redux
+    TreeBuilderOpsRbacFeatures.new(@edit.present? ? "features_tree" : "features_tree_noedit", @sb, true, :role => @role, :editable => @edit.present?)
   end
 
   # Set form variables for user edit


### PR DESCRIPTION
When re-rendering a react/redux-based tree using RJS, the reducers would be added multiple times. In order to prevent this from happening, @brumik [created a safeguard](https://github.com/ManageIQ/manageiq-ui-classic/commit/87f53cc230609215a72e5b0c3b6295da69fc3f34) that doesn't allow to add the reducers on the same tree twice. It relies on the (non)existence of the tree's name in the redux space, which can cause problems if we re-render a tree with the same name but with a different set of reducers. 

There's such [issue](https://github.com/ManageIQ/manageiq-ui-classic/pull/6413#issuecomment-642783675) on the `Access Control -> Roles` screen when first displaying and then editing a role. My quick and easy solution for this problem to rename the tree when not in edit mode. I would rather keep the name for the edit mode as it has more moving parts. The long-term solution is to get rid of RJS page reloads :wink: 