### PR TITLE
Remove some additional dead routes from the application

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -441,7 +441,10 @@ module ReportController::Schedules
     schedule.enabled = @edit[:new][:enabled]
     schedule.resource_type = "MiqReport" # Default schedules apply to MiqReport model for now
 
-    email_url_prefix = url_for_only_path(:controller => "report", :action => "show_saved") + "/"
+    # FIXME: the ReportController#show_saved route doesn't exist, it has to be reimplemented
+    # for more information see https://github.com/ManageIQ/manageiq-ui-classic/issues/7126
+    # email_url_prefix = url_for_only_path(:controller => "report", :action => "show_saved") + "/"
+    email_url_prefix = '/report/show_saved/'
     schedule_options = {
       :send_email       => @edit[:new][:send_email],
       :email_url_prefix => email_url_prefix,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2585,7 +2585,6 @@ Rails.application.routes.draw do
         schedule_edit
         schedule_form_field_changed
         show_preview
-        show_saved
         tree_autoload
         tree_select
         upload

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -654,12 +654,14 @@ Rails.application.routes.draw do
         tree_select
         tagging_edit
         listnav_search_selected
+        x_button
+        x_history
+        x_search_by_name
       ) +
                adv_search_post +
                exp_post +
                perf_post +
-               save_post +
-               x_post
+               save_post
     },
 
     :container_group          => {
@@ -1271,7 +1273,6 @@ Rails.application.routes.draw do
       :post   =>  %w(
         listnav_search_selected
         show_list
-        update
         quick_search
       ) + adv_search_post + save_post,
     },
@@ -1770,7 +1771,6 @@ Rails.application.routes.draw do
         listnav_search_selected
         quick_search
         reload
-        show
         show_list
         tagging
         tagging_edit

--- a/spec/routing/report_routing_spec.rb
+++ b/spec/routing/report_routing_spec.rb
@@ -241,12 +241,6 @@ describe "routes for ReportController" do
     end
   end
 
-  describe "#show_saved" do
-    it "routes with POST" do
-      expect(post("/report/show_saved")).to route_to("report#show_saved")
-    end
-  end
-
   describe "#tree_autoload" do
     it "routes with POST" do
       expect(post("/report/tree_autoload"))


### PR DESCRIPTION
I missed some routes from my [previous PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7123)

The `ReportController#show_saved` has been deleted and it causes a [bug](https://github.com/ManageIQ/manageiq-ui-classic/issues/7126) in e-mails generated from reporting. However, as it is dead, I'm removing it and the bugfix should reintroduce the route in the future.