### PR TITLE
Clean up dead index routes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -19,6 +19,11 @@ class CatalogController < ApplicationController
     @table_name ||= "service_template"
   end
 
+  def index
+    flash_to_session
+    redirect_to(:action => 'explorer')
+  end
+
   CATALOG_X_BUTTON_ALLOWED_ACTIONS = {
     'ab_button_new'                 => :ab_button_new,
     'ab_button_edit'                => :ab_button_edit,

--- a/app/controllers/consumption_controller.rb
+++ b/app/controllers/consumption_controller.rb
@@ -4,5 +4,7 @@ class ConsumptionController < ApplicationController
     @showtype   = "consumption"
   end
 
+  alias_method :index, :show
+
   menu_section :cons
 end

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -24,6 +24,8 @@ class InfraNetworkingController < ApplicationController
     redirect_to(:action => 'explorer')
   end
 
+  alias_method :index, :show_list
+
   def tagging_explorer_controller?
     @explorer
   end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -22,6 +22,11 @@ class MiqPolicyController < ApplicationController
     @title = _("Policies")
   end
 
+  def index
+    flash_to_session
+    redirect_to(:action => 'explorer')
+  end
+
   def export
     @breadcrumbs = []
     @layout = "miq_policy_export"

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -91,6 +91,8 @@ class ServiceController < ApplicationController
     redirect_to(:action => 'explorer')
   end
 
+  alias_method :index, :show_list
+
   def explorer
     @explorer   = true
     @lastaction = "explorer"

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -38,6 +38,8 @@ class StorageController < ApplicationController
     redirect_to(:action => 'explorer')
   end
 
+  alias_method :index, :show_list
+
   def init_show
     return unless super
     if !@explorer && @display == "main"

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -13,6 +13,11 @@ class VmCloudController < ApplicationController
     @table_name ||= "vm_cloud"
   end
 
+  def index
+    flash_to_session
+    redirect_to(:action => 'explorer')
+  end
+
   def attach
     assert_privileges("instance_attach")
     @volume_choices = {}

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -14,6 +14,11 @@ class VmInfraController < ApplicationController
     @table_name ||= "vm_infra"
   end
 
+  def index
+    flash_to_session
+    redirect_to(:action => 'explorer')
+  end
+
   private
 
   def features

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -9,6 +9,11 @@ class VmOrTemplateController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def index
+    flash_to_session
+    redirect_to(:action => 'explorer')
+  end
+
   private
 
   def features

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3114,6 +3114,20 @@ Rails.application.routes.draw do
     },
   }
 
+  routes_without_index = %i[
+    cloud_tenant_dashboard
+    ems_cloud
+    ems_cloud_dashboard
+    ems_container
+    ems_infra
+    ems_infra_dashboard
+    ems_network
+    ems_physical_infra
+    ems_physical_infra_dashboard
+    miq_ae_customization
+    pxe
+  ].freeze
+
   root :to => 'dashboard#login'
 
   # Let's serve pictures directly from the DB
@@ -3127,9 +3141,7 @@ Rails.application.routes.draw do
 
   controller_routes.each do |controller_name, controller_actions|
     # Default route with no action to controller's index action
-    unless [
-      :ems_cloud, :ems_infra, :ems_physical_infra, :ems_container, :ems_network
-    ].include?(controller_name)
+    unless routes_without_index.include?(controller_name)
       match controller_name.to_s, :controller => controller_name, :action => :index, :via => :get
     end
 


### PR DESCRIPTION
Some dead `index` routes are completely unnecessary, these have been added to the list of skipped routes in the configuration. The other group of these is routed to controllers that can directly map to a model. In order to keep the `url_for_only_path` helper method functioning, these routes have not been removed, but I introduced the missing methods that redirect them to the `show_list` or `explorer` actions. This pattern already existed in our codebase for some controllers.