### PR TITLE
Remove extra *_xen reference from specs

### DIFF
--- a/spec/presenters/tree_node/vm_or_template_spec.rb
+++ b/spec/presenters/tree_node/vm_or_template_spec.rb
@@ -15,7 +15,6 @@ describe TreeNode::VmOrTemplate do
     template_microsoft
     template_redhat
     template_vmware
-    template_xen
   ).each do |factory|
     context(factory.to_s) do
       let(:object) { FactoryBot.create(factory, :name => "template", :template => true) }
@@ -45,7 +44,6 @@ describe TreeNode::VmOrTemplate do
     vm_microsoft
     vm_redhat
     vm_vmware
-    vm_xen
   ).each do |factory|
     context(factory.to_s) do
       let(:object) { FactoryBot.create(factory) }


### PR DESCRIPTION
follow-up to ManageIQ/manageiq#20250

Should fix `uninitialized constant VmXen` on UI travis:
https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/349739834#L2470-L2502