### PR TITLE
Don't use the cloud_volume ems.parent_manager

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -136,7 +136,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,parent_manager.volume_availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
+    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,volume_availability_zones,cloud_tenants,cloud_volume_snapshots,cloud_volume_types')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
@@ -273,14 +273,14 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   var getStorageManagerFormData = function(data) {
     vm.cloudVolumeModel.emstype = data.type;
-    vm.cloudTenantChoices = data.parent_manager.cloud_tenants;
-    vm.availabilityZoneChoices = data.parent_manager.volume_availability_zones;
-    vm.baseSnapshotChoices = data.parent_manager.cloud_volume_snapshots;
+    vm.cloudTenantChoices = data.cloud_tenants;
+    vm.availabilityZoneChoices = data.volume_availability_zones;
+    vm.baseSnapshotChoices = data.cloud_volume_snapshots;
     vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
     vm.supportsVolumeResizing = data.supports_volume_resizing;
     vm.supportsVolumeAvailabilityZones = data.supports_volume_availability_zones;
     if (vm.supportsCinderVolumeTypes) {
-      vm.volumeTypes = data.parent_manager.cloud_volume_types;
+      vm.volumeTypes = data.cloud_volume_types;
     } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
       loadEBSVolumeTypes();
     }


### PR DESCRIPTION
Not all cloud volumes belong to a StorageManager, most (OpenStack and GCE) belong to the main CloudManager.

Asking for cloud_volume.ext_management_system.parent_manager will fail in these cases because the parent_manager association doesn't exist on the "main" manager class.

Instead we can use delegates to be able to access what is needed from the AWS storage_manager, thus allowing the provider plugin to define how different collections are accessed rather than encoding this in the UI.

Before (GCE):
![Screenshot from 2020-06-16 16-28-37](https://user-images.githubusercontent.com/12851112/84824829-8532d600-afee-11ea-94df-5bedf021f7e3.png)

After (GCE):
![Screenshot from 2020-06-16 15-32-19](https://user-images.githubusercontent.com/12851112/84824860-911e9800-afee-11ea-908a-87de5c52e817.png)

After (AWS):
![Screenshot from 2020-06-16 15-30-48](https://user-images.githubusercontent.com/12851112/84824893-9bd92d00-afee-11ea-9562-e2960980d87a.png)


Depends on: https://github.com/ManageIQ/manageiq-providers-amazon/pull/631 https://github.com/ManageIQ/manageiq-providers-openstack/pull/607