### PR TITLE
Remove unused route identify_catalog in OpsController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,7 +297,6 @@ Rails.application.routes.draw do
         group_form_field_changed
         group_reorder_field_changed
         group_update
-        identify_catalog
         ot_tags_edit
         ownership_update
         prov_field_changed

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -35,7 +35,6 @@ describe 'routes for CatalogController' do
     group_form_field_changed
     group_reorder_field_changed
     group_update
-    identify_catalog
     ot_tags_edit
     prov_field_changed
     reload


### PR DESCRIPTION
There is method `identify_catalog` on OpsController but I was not able to find usage of this method as action method for `identify_catalog` route.


@miq-bot assign @skateman 

@miq-bot add_label technical debt 