### PR TITLE
nix the all_vm_or_templates callers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1403,7 +1403,7 @@ class ApplicationController < ActionController::Base
 
   def get_db_view(db, options = {})
     if %w[ManageIQ_Providers_InfraManager_Template ManageIQ_Providers_InfraManager_Vm]
-       .include?(db) && options[:association] == "all_vms_and_templates"
+       .include?(db) && options[:association] == "vms_and_templates"
       options[:association] = nil
     end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1019,7 +1019,7 @@ module VmCommon
                          end
     else
       rec = TreeBuilder.get_model_for_prefix(@nodetype).constantize.find(node_id)
-      options[:association] = @nodetype == 'az' ? 'vms' : 'all_vms_and_templates'
+      options[:association] = @nodetype == 'az' ? 'vms' : 'vms_and_templates'
       options[:parent] = rec
       options[:named_scope] << :active
 


### PR DESCRIPTION
fixes `ManageIQ::Providers::Google::CloudManager Inst Including Associations (0.1ms - 1rows)
[----] F, [2020-06-17T13:58:28.726000 #394303:ae790] FATAL -- : Error caught: [NoMethodError] undefined method 'all_vms_and_templates'` from https://github.com/ManageIQ/manageiq/issues/20284

@miq-bot add_label bug

broken in https://github.com/ManageIQ/manageiq/pull/20149

@agrare this better? 