### PR TITLE
Introducing a new test suite that checks the aliveness of routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ addons:
 env:
   matrix:
   - TEST_SUITE=spec
+  - TEST_SUITE=spec:routes
   - TEST_SUITE=spec:javascript
   - TEST_SUITE=spec:compile
   - TEST_SUITE=spec:jest
   - TEST_SUITE=spec:debride
 matrix:
   exclude:
+  - rvm: 2.5.7
+    env: TEST_SUITE=spec:routes
   - rvm: 2.5.7
     env: TEST_SUITE=spec:javascript
   - rvm: 2.5.7

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
   RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
     spec_dir = File.expand_path("spec", __dir__)
     EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
-    t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
+    t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb').exclude(spec_dir + '/routes_spec.rb')
   end
 end
 
@@ -44,6 +44,13 @@ if ENV["BUNDLE_GEMFILE"].nil? || ENV["BUNDLE_GEMFILE"] == File.expand_path("../G
 end
 
 namespace :spec do
+  desc "Run all routing specs"
+  RSpec::Core::RakeTask.new(:routes => 'app:test:initialize') do |t|
+    spec_dir = File.expand_path("spec", __dir__)
+    EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
+    t.pattern = FileList[File.expand_path('spec/routes_spec.rb', __dir__)]
+  end
+
   desc "Run all javascript specs"
   task :javascript => ["app:test:initialize", :environment, "jasmine:ci"]
 

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -1,0 +1,24 @@
+routes = Rails.application.routes.routes.each_with_object({}) do |route, obj|
+  controller, action = route.defaults.values_at(:controller, :action)
+
+  next if controller.nil? || controller.starts_with?('api/') || controller.starts_with?('rails/')
+
+  klass = "#{controller}_controller".camelize.constantize
+
+  obj[klass] ||= []
+  obj[klass] << action
+end
+
+describe 'Application routes' do
+  routes.each do |controller, actions|
+    describe controller do
+      actions.uniq.each do |action|
+        describe "##{action}" do
+          it 'method defined' do
+            expect(subject.respond_to?(action)).to be_truthy
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I created a spec that runs through all routes and checks if the method to be called when the route is accessed exists on the given controller. This test should warn us about remaining routes and possibly dead code when moving our UI towards an API-driven single page application.

Right now it takes a minute to run all the tests, however, the pattern can and will allow us to write other kinds of global tests. These new tests I'm currently working on can run up to 10 minutes, so I just created a separate suite for this in Travis. Locally you can run it using:
```sh
bundle exec rake spec:routes
```

On the CI results you can see that the `spec` suite [ignores](https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/350792788) the new specs, while the `spec:routes` suite [fails](https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/350792789) on a single dead route that is fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/7139.
