### PR TITLE
Do not mount the index route on ContainerDashboardController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3091,6 +3091,7 @@ Rails.application.routes.draw do
 
   routes_without_index = %i[
     cloud_tenant_dashboard
+    container_dashboard
     ems_cloud
     ems_cloud_dashboard
     ems_container


### PR DESCRIPTION
This is the only remaining dead route which I kept from https://github.com/ManageIQ/manageiq-ui-classic/pull/7131 to demonstrate the correctness of https://github.com/ManageIQ/manageiq-ui-classic/pull/7138