### PR TITLE
[IVANCHUK] Allow selecting whole tenant subtree in catalog item creation

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1292,13 +1292,16 @@ class CatalogController < ApplicationController
 
   def checked_tenants
     new_id = params[:id].split('-').pop.to_i if params[:id].starts_with?('tn')
+    tenant = Tenant.find(new_id)
+    new_ids = [new_id] + tenant.descendants.pluck(:id)
     tenant_ids = @edit[:new][:tenant_ids]
     if params[:check] == '1' # Adding/checking Tenant(s) in the tree for the Catalog Item
-      tenant_ids += [new_id] if tenant_ids.exclude?(new_id)
+      tenant_ids += new_ids
     elsif params[:check] == '0' # Unchecking selected Tenant(s)
-      tenant_ids.delete(new_id)
+      new_ids += tenant.ancestors.pluck(:id)
+      new_ids.each { |t| tenant_ids.delete(t) }
     end
-    @edit[:new][:tenant_ids] = tenant_ids.sort
+    @edit[:new][:tenant_ids] = tenant_ids.sort.uniq
   end
 
   def available_container_managers

--- a/app/presenters/tree_builder_tenants.rb
+++ b/app/presenters/tree_builder_tenants.rb
@@ -13,11 +13,12 @@ class TreeBuilderTenants < TreeBuilder
 
   def tree_init_options
     {
-      :checkboxes => true,
-      :check_url  => "/catalog/#{cat_item_or_bundle}/",
-      :open_all   => false,
-      :oncheck    => @selectable ? tenant_tree_or_generic : false,
-      :post_check => true
+      :checkboxes   => true,
+      :check_url    => "/catalog/#{cat_item_or_bundle}/",
+      :open_all     => false,
+      :oncheck      => @selectable ? tenant_tree_or_generic : false,
+      :post_check   => true,
+      :three_checks => true
     }
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1126,9 +1126,11 @@ describe CatalogController do
   end
 
   describe '#get_form_vars' do
+    let(:tenant) { FactoryBot.create(:tenant) }
+
     before do
       controller.instance_variable_set(:@edit, :new => {:tenant_ids => []}, :key => 'prov_edit__new')
-      controller.params = {:id => 'tn-1', :check => '1'}
+      controller.params = {:id => "tn-#{tenant.id}", :check => '1'}
       controller.instance_variable_set(:@sb, {})
     end
 
@@ -1156,18 +1158,21 @@ describe CatalogController do
 
     it 'gets tenant id of newly checked Tenant in the tree' do
       controller.send(:get_form_vars)
-      expect(subject).to eq([1])
+      expect(subject).to eq([tenant.id])
     end
 
     context 'unchecking Tenant in the tree' do
+      let(:tenant1) { FactoryBot.create(:tenant) }
+      let(:tenant2) { FactoryBot.create(:tenant) }
+
       before do
-        controller.instance_variable_set(:@edit, :new => {:tenant_ids => [1, 2]}, :key => 'prov_edit__new')
-        controller.params = {:id => 'tn-2', :check => '0'}
+        controller.instance_variable_set(:@edit, :new => {:tenant_ids => [tenant1.id, tenant2.id]}, :key => 'prov_edit__new')
+        controller.params = {:id => "tn-#{tenant2.id}", :check => '0'}
       end
 
       it 'removes Tenant id from @edit' do
         controller.send(:get_form_vars)
-        expect(subject).to eq([1])
+        expect(subject).to eq([tenant1.id])
       end
     end
 


### PR DESCRIPTION
This is ivanchuk version of https://github.com/ManageIQ/manageiq-ui-classic/pull/7142

This enhancement allows for selecting / deselecting whole tenant subtree during catalog item creation and editing. This would mean that the customer would no longer have to select all individual projects & tenants (although that is still possible), but can just select root of the desired tenant subtree.

![Screenshot from 2020-06-18 14-59-10](https://user-images.githubusercontent.com/6648365/85023401-f8665480-b174-11ea-961e-d36c098a73b2.png)

The presenter change simply modifies the rendered tree to allow for selection / deselection of the while subtree. The controller change automatically adds all descendants & removes all ancestors during addition / deletion.

https://bugzilla.redhat.com/show_bug.cgi?id=1838704