### PR TITLE
Remove form action in report editor forms

### DIFF
--- a/app/views/report/_form.html.haml
+++ b/app/views/report/_form.html.haml
@@ -2,10 +2,9 @@
 #form_div
   = render :partial => '/layouts/tabs'
   = render :partial => "layouts/flash_msg"
-  = form_tag({:action => 'create',
-              :id     => "report_basic_form"},
-             :class  => "form-horizontal",
-             :method => :post) do
+  = form_tag({:id     => "report_basic_form"},
+              :class  => "form-horizontal",
+              :method => :post) do
     %h3
       = _('Basic Report Info')
     .form-group

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -1,9 +1,8 @@
 - url = url_for_only_path(:action => 'form_field_changed', :id => (@edit[:rpt_id] || 'new'))
 #columns_div
-  = form_tag({:action => 'create',
-              :id     => "report_columns_form"},
-             :class  => "form-horizontal",
-             :method => :post) do
+  = form_tag({:id     => "report_columns_form"},
+              :class  => "form-horizontal",
+              :method => :post) do
     %h3
       = _('Configure Report Columns')
     .form-group


### PR DESCRIPTION
Route report#create was removed [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/7123) but is still used in form actions and rails are trying to generate url according to form action.

Reproducer is just open form to create or edit report.

@miq-bot add_label bug, jansa/no

@miq-bot assign @skateman 

@skateman No sure whether such issue could be also on other places - do you think that there is way how to  create script/spec which detects such places ? (I don't how to exactly recognise forms which doen't use form#action)
