### PR TITLE
Fix Policy Simulation breadcrumbs when coming from Provider page

### DIFF
--- a/app/controllers/vm_controller.rb
+++ b/app/controllers/vm_controller.rb
@@ -19,6 +19,30 @@ class VmController < ApplicationController
     process_show_list(options)
   end
 
+  def breadcrumbs_options
+    if params["action"] == "policy_sim"
+      if @breadcrumbs.first[:url].include?("ems_infra")
+        {:breadcrumbs => [
+          {:title => _("Compute")},
+          {:title => _("Infrastructure")},
+          {:title => _("Providers"), :url => "/ems_infra/show_list"},
+          {:title => @breadcrumbs[1][:name], :url => @breadcrumbs[1][:url]}
+        ]}
+      elsif @breadcrumbs.first[:url].include?("ems_cloud")
+        {:breadcrumbs => [
+          {:title => _("Compute")},
+          {:title => _("Clouds")},
+          {:title => _("Providers"), :url => "/ems_cloud/show_list"},
+          {:title => @breadcrumbs[1][:name], :url => @breadcrumbs[1][:url]}
+        ]}
+      else
+        super
+      end
+    else
+      super
+    end
+  end
+
   private ####
 
   def get_session_data


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1720712

Go to Compute -> Clouds/Infrastracture -> Providers -> click to a Provider -> click on VMs/Instances -> check one or more -> Policy -> Policy Simulation -> see breadcrumbs

Before:
<img width="1402" alt="Screenshot 2020-06-22 at 16 25 30" src="https://user-images.githubusercontent.com/9210860/85298978-0255c380-b4a5-11ea-95bd-10de7c6d81b9.png">

After:
<img width="1412" alt="Screenshot 2020-06-22 at 16 14 25" src="https://user-images.githubusercontent.com/9210860/85297767-75f6d100-b4a3-11ea-9678-7e2ad2bfada4.png">


@miq-bot add_label ivanchuk/yes, jansa/yes, bug, breadcrumbs