### PR TITLE
Pre-provisioning: fix button collision in explorers and missing hide deprecated in nested

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1646,7 +1646,7 @@ class ApplicationController < ActionController::Base
   alias miq_template_miq_request_new prov_redirect
 
   def template_types_for_controller
-    if %w[ems_cluster ems_infra host resource_pool storage vm_infra].include?(request.parameters[:controller])
+    if %w[ems_cluster ems_infra host resource_pool storage vm_infra].include?(params[:controller])
       'infra'
     else
       'cloud'

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1234,6 +1234,10 @@ module VmCommon
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
         end
 
+        if %w[pre_prov].include?(action)
+          presenter.update(:pre_prov_form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
+        end
+
         # Make sure the form_buttons_div is empty.
         # it would remain on the screen if prior to retire some action that uses the form_buttons_div was used
         # such as "edit tags" or "manage policies".

--- a/app/helpers/hide_partial_helper.rb
+++ b/app/helpers/hide_partial_helper.rb
@@ -1,5 +1,5 @@
 module HidePartialHelper
   def hide_x_edit_buttons(action)
-    %w[snap_vm].include?(action)
+    %w[snap_vm pre_prov].include?(action)
   end
 end

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -1,4 +1,5 @@
 = render :partial => "layouts/flash_msg"
+
 #pre_prov_div
   - typ = request.parameters[:controller] == "vm_cloud" ? ui_lookup(:table => "template_cloud") : ui_lookup(:table => "template_infra")
   %h3
@@ -11,5 +12,10 @@
              :checked => @edit[:hide_deprecated_templates]}
         = _('Hide deprecated')
   = render :partial => "layouts/x_gtl"
+
+  #pre_prov_form_buttons_div.pull-right
+    = render :partial => 'layouts/x_edit_buttons', :locals => {:action_url      => 'pre_prov',
+                                                               :continue_button => true,
+                                                               :no_reset        => true}
   :javascript
     $(provisioningListenToRx);

--- a/app/views/miq_request/pre_prov.html.haml
+++ b/app/views/miq_request/pre_prov.html.haml
@@ -1,8 +1,1 @@
 = render :partial => "pre_prov"
-%br
-- unless @edit[:explorer]
-  = render(:partial => 'layouts/edit_form_buttons',
-    :locals         => {:action_url => "pre_prov",
-      :ajax_buttons                 => true,
-      :continue_button              => true,
-      :noreset                      => true})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -160,7 +160,7 @@ describe ApplicationController do
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
       login_as user
-      controller.request.parameters[:pressed] = "vm_migrate"
+      controller.params[:pressed] = "vm_migrate"
     end
 
     it "returns flash message when Migrate button is pressed with list containing SCVMM VM" do
@@ -192,7 +192,7 @@ describe ApplicationController do
     before do
       login_as FactoryBot.create(:user, :features => "image_miq_request_new")
       allow(User).to receive(:server_timezone).and_return("UTC")
-      controller.request.parameters[:pressed] = "image_miq_request_new"
+      controller.params[:pressed] = "image_miq_request_new"
       controller.instance_variable_set(:@explorer, true)
     end
 
@@ -240,7 +240,7 @@ describe ApplicationController do
             allow(controller).to receive(:assert_privileges)
             allow(controller).to receive(:performed?)
             allow(controller).to receive(:template_types_for_controller).and_call_original
-            allow(request).to receive(:parameters).and_return(:controller => ctrl, :pressed => 'vm_miq_request_new')
+            controller.params = {:controller => ctrl, :pressed => 'vm_miq_request_new'}
           end
 
           it 'returns proper template type while provisioning VMs' do
@@ -256,7 +256,7 @@ describe ApplicationController do
             allow(controller).to receive(:assert_privileges)
             allow(controller).to receive(:performed?)
             allow(controller).to receive(:template_types_for_controller).and_call_original
-            allow(request).to receive(:parameters).and_return(:controller => ctrl, :pressed => 'vm_miq_request_new')
+            controller.params = {:controller => ctrl, :pressed => 'vm_miq_request_new'}
           end
 
           it 'returns proper template type while provisioning instances' do


### PR DESCRIPTION
Fixes #7011
Fixes #6543 

Before:

explorer versions of pre-provisioning (Compute > Infra/Cloud > VMs/Instances .. Lifecycle > Provision)
still have the Continue/Cancel buttons as part of the bottom toolbar,
which collides with paging toolbar when in using lower screen widths

non-explorer versions (Compute > I/C > Providers > click one, Instances/VMs .. Lifecycle > Provision)
have the buttons in the right place,
but don't show the Hide deprecated checkbox, because only the controller is checked now, and it's the wrong one

After:

both versions use the same form buttons, outside the bottom toolbar
hide deprecated works whenever cloud templates are shown