### PR TITLE
[Gemfile] Remove "second" source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-source 'https://rubygems.org'
-
 gemspec
 
 #


### PR DESCRIPTION
Since we inherit the `Gemfile` from `ManageIQ/manageiq` in this repo, there is now a deprecation warning when running `bundler` v2.1.4:

```
[DEPRECATED] Your Gemfile contains multiple primary sources. Using
`source` more than once without a block is a security risk...
```

This is because there is a duplicate source when evaling the `Gemfile` from `ManageIQ/manageiq`.  Since that one needs to stay, removing this one allows `bundle update` and friends to continue to work without the deprecation warning.

Links
-----

* **Before**: [Example warning on `travis` prior to this fix](https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/354577492#L240)
* **After**: [`travis` run for this PR](https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/354631147#L263-L268) (no deprecation warning in `bin/setup`)