### PR TITLE
Fix missing tags on Group form

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1116,6 +1116,7 @@ module OpsController::OpsRbac
     if params[:use_filter_expression]
       @edit[:new][:use_filter_expression] = params[:use_filter_expression]
       @group = MiqGroup.find_by(:id => @edit[:group_id])
+      @sb[:active_rbac_group_tab] = 'rbac_customer_tags' # may not be set correctly because of lazy loading
       rbac_group_right_tree(@edit[:new][:belongsto].keys)
       if params[:use_filter_expression] == 'false'
         @edit[:new][:use_filter_expression] = false

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -541,7 +541,7 @@ describe OpsController do
              :description           => "Test",
              :role                  => @role.id,
              :belongsto             => {},
-             :filters               => {'managed/env' => '/managed/env'}}
+             :filters               => {'managed/department' => '/managed/department/tag1'}}
       allow(controller).to receive(:replace_right_cell)
       controller.params = {:use_filter_expression => "true", :id => "new"}
 


### PR DESCRIPTION
set `@sb[:active_rbac_group_tab`] as it may not be set correctly because of lazy loading

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/5817

- Go to Configuration > Access Control > Groups > Create/Edit a Group
- make sure My Company Tags is set to `Tags based on expression`
- click My Company Tags and other tabs so they no longer fire request `rbac_group_load_tab` (spinner no longer shows up)
- click My Company Tags and select `Specific Tags` for `This user is limited to` 

Steps to reproduce:

*Before:*
<img width="1047" alt="Screenshot 2020-06-29 at 13 28 06" src="https://user-images.githubusercontent.com/9210860/85999434-624feb00-ba0c-11ea-9a09-9284dd613074.png">
Console log:
```
miq_debug.self-1351f771c2cd2fab0d83069fd3f62aadbb7effc11a01ed4942f52308793453be.js?body=1:30 TypeError: Cannot read property 'tags' of null
    at initialize (reducers.js:76)
    at taggingApp (index.js:14)
    at combination (redux.js:459)
    at dispatch (redux.js:213)
    at index.js:93
    at index.js:11
    at middleware.js:16
    at middleware.js:22
    at Object.loadState (taggingWrapper.jsx:115)
    at TaggingWrapper.loadState (taggingWrapper.jsx:42)
```
*After:*
<img width="1045" alt="Screenshot 2020-06-29 at 13 22 22" src="https://user-images.githubusercontent.com/9210860/85999367-464c4980-ba0c-11ea-906c-940a8f006fb8.png">

@miq-bot add_label bug, settings

@lpichler please try it out in UI as you know the specific of this issue. Thanks :)