### PR TITLE
bump more core extensions

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.5"
   s.add_dependency "high_voltage", "~> 3.0.0"
-  s.add_dependency "more_core_extensions", "~>3.2"
+  s.add_dependency "more_core_extensions", ">= 3.2", "< 5"
   s.add_dependency "novnc-rails", "~>0.2"
   s.add_dependency "patternfly-sass", "~> 3.59.1"
   s.add_dependency "sass-rails"


### PR DESCRIPTION
more core ext's on 4.1.0

update for update sake

https://github.com/ManageIQ/more_core_extensions/compare/179bf40..e5b4501
 - Added Ruby 2.7 support [[#79](https://github.com/ManageIQ/more_core_extensions/pull/79)]
 - Added Process#pause, Process#resume, and Process#alive? [[#73](https://github.com/ManageIQ/more_core_extensions/pull/73)]

array added * `#compact_map` - Collect non-nil results from the block
array added `#tabular_sort` - Sorts an Array of Hashes by specific columns

hierarchy added `#descendant_get` - Returns the descendant with a given name

the two breaking changes:
- **BREAKING**: Moved Object#descendant_get to Class#descendant_get [[#75](https://github.com/ManageIQ/more_core_extensions/pull/75)]
- **BREAKING**: Removed deprecated Enumerable#stable_sort_by [[#76](https://github.com/ManageIQ/more_core_extensions/pull/76)]

a minor header output change was made that hasn't been released yet to make tableize more markdown compliant

see https://github.com/ManageIQ/linux_admin/pull/221
