### PR TITLE
[IVANCHUK] Add support for Service Telemetry Framework

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -138,6 +138,10 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_api_port                = data.default_api_port !== undefined && data.default_api_port !== '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.metrics_port                    = data.metrics_port !== undefined && data.metrics_port !== '' ? data.metrics_port.toString() : '443';
       $scope.emsCommonModel.amqp_api_port                   = data.amqp_api_port !== undefined && data.amqp_api_port !== '' ? data.amqp_api_port.toString() : '5672';
+      $scope.emsCommonModel.stf_api_port                    = data.stf_api_port !== undefined && data.stf_api_port !== '' ? data.stf_api_port.toString() : '5666';
+      $scope.emsCommonModel.stf_hostname                    = data.stf_hostname
+      $scope.emsCommonModel.stf_security_protocol           = data.stf_security_protocol
+      $scope.emsCommonModel.stf_auth_status                 = data.stf_auth_status
       $scope.emsCommonModel.metrics_database_name           = data.metrics_database_name !== undefined && data.metrics_database_name !== '' ? data.metrics_database_name : data.metrics_default_database_name;
       $scope.emsCommonModel.api_version                     = data.api_version;
       $scope.emsCommonModel.default_security_protocol       = data.default_security_protocol;
@@ -246,6 +250,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
       $scope.emsCommonModel.default_api_port                = '';
       $scope.emsCommonModel.amqp_api_port                   = '5672';
+      $scope.emsCommonModel.stf_api_port                    = '5666';
       $scope.emsCommonModel.alerts_selection                = data.alerts_selection;
       $scope.emsCommonModel.prometheus_alerts_api_port      = '443';
       $scope.emsCommonModel.prometheus_alerts_auth_status   = data.prometheus_alerts_auth_status;
@@ -345,6 +350,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       ($scope.emsCommonModel.amqp_hostname) &&
       ($scope.emsCommonModel.amqp_userid !== '' && $scope.angularForm.amqp_userid !== undefined && $scope.angularForm.amqp_userid.$valid &&
        $scope.emsCommonModel.amqp_password !== '' && $scope.angularForm.amqp_password !== undefined && $scope.angularForm.amqp_password.$valid)) {
+      return true;
+    } else if ($scope.currentTab === 'amqp' && $scope.emsCommonModel.event_stream_selection === 'stf' && $scope.emsCommonModel.stf_hostname &&
+      $scope.emsCommonModel.stf_security_protocol && $scope.emsCommonModel.stf_api_port) {
       return true;
     } else if (($scope.currentTab === 'console') &&
       ($scope.emsCommonModel.console_userid !== '' && $scope.angularForm.console_userid !== undefined &&
@@ -741,7 +749,11 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.updateAuthStatus = function(updatedValue) {
-    $scope.angularForm[$scope.currentTab + '_auth_status'].$setViewValue(updatedValue);
+    if ($scope.currentTab === 'amqp' && $scope.emsCommonModel.event_stream_selection == "stf") {
+      $scope.angularForm['stf_auth_status'].$setViewValue(updatedValue);
+    } else {
+      $scope.angularForm[$scope.currentTab + '_auth_status'].$setViewValue(updatedValue);
+    }
   };
 
   $scope.updateHostname = function(value) {
@@ -763,6 +775,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.amqp_security_protocol = $scope.postValidationModel.amqp.amqp_security_protocol;
         $scope.emsCommonModel.amqp_userid = $scope.postValidationModel.amqp.amqp_userid;
         $scope.emsCommonModel.amqp_password = $scope.postValidationModel.amqp.amqp_password;
+        $scope.emsCommonModel.stf_security_protocol = $scope.postValidationModel.amqp.stf_security_protocol;
+        $scope.emsCommonModel.stf_hostname = $scope.postValidationModel.amqp.stf_hostname;
+        $scope.emsCommonModel.stf_api_port = $scope.postValidationModel.amqp.stf_api_port;
       }
       $scope.$broadcast('clearErrorOnTab', {tab: 'amqp'});
     }

--- a/app/controllers/mixins/ems_common/angular.rb
+++ b/app/controllers/mixins/ems_common/angular.rb
@@ -273,6 +273,10 @@ module Mixins
         kubevirt_tls_ca_certs = ""
         kubevirt_password = ""
         kubevirt_tls_verify = false
+        stf_hostname = ""
+        stf_api_port = ""
+        stf_security_protocol = ""
+        stf_auth_status = ""
 
         provider_options = @ems.options || {}
 
@@ -280,6 +284,13 @@ module Mixins
           amqp_hostname = @ems.connection_configurations.amqp.endpoint.hostname
           amqp_port = @ems.connection_configurations.amqp.endpoint.port
           amqp_security_protocol = @ems.connection_configurations.amqp.endpoint.security_protocol || 'ssl'
+        end
+
+        if @ems.connection_configurations.stf.try(:endpoint)
+          stf_hostname = @ems.connection_configurations.stf.endpoint.hostname
+          stf_api_port = @ems.connection_configurations.stf.endpoint.port
+          stf_security_protocol = @ems.connection_configurations.stf.endpoint.security_protocol || 'ssl'
+          stf_auth_status = @ems.authentication_status_ok?(:stf) if @ems.has_authentication_type?(:stf)
         end
 
         if @ems.has_authentication_type?(:amqp)
@@ -432,7 +443,11 @@ module Mixins
                            :amqp_fallback_hostname1         => amqp_fallback_hostname1 ? amqp_fallback_hostname1 : "",
                            :amqp_fallback_hostname2         => amqp_fallback_hostname2 ? amqp_fallback_hostname2 : "",
                            :default_url                     => @ems.endpoints.first.url,
-                           :assume_role                     => assume_role}
+                           :assume_role                     => assume_role,
+                           :stf_hostname                    => stf_hostname,
+                           :stf_security_protocol           => stf_security_protocol,
+                           :stf_api_port                    => stf_api_port,
+                           :stf_auth_status                 => stf_auth_status}
         end
 
         if controller_name == "ems_infra"
@@ -573,6 +588,9 @@ module Mixins
         amqp_fallback_hostname2 = params[:amqp_fallback_hostname2].strip if params[:amqp_fallback_hostname2]
         amqp_port = params[:amqp_api_port].strip if params[:amqp_api_port]
         amqp_security_protocol = params[:amqp_security_protocol].strip if params[:amqp_security_protocol]
+        stf_hostname = params[:stf_hostname].strip if params[:stf_hostname]
+        stf_security_protocol = params[:stf_security_protocol].strip if params[:stf_security_protocol]
+        stf_api_port = params[:stf_api_port].strip if params[:stf_api_port]
         metrics_hostname = params[:metrics_hostname].strip if params[:metrics_hostname]
         metrics_port = params[:metrics_api_port].strip if params[:metrics_api_port]
         metrics_database_name = params[:metrics_database_name].strip if params[:metrics_database_name]
@@ -591,6 +609,7 @@ module Mixins
         amqp_endpoint = {}
         amqp_fallback_endpoint1 = {}
         amqp_fallback_endpoint2 = {}
+        stf_endpoint = {}
         ceilometer_endpoint = {}
         ssh_keypair_endpoint = {}
         metrics_endpoint = {}
@@ -604,6 +623,8 @@ module Mixins
           ems.keystone_v3_domain_id = params[:keystone_v3_domain_id]
           if params[:event_stream_selection] == "amqp"
             amqp_endpoint = {:role => :amqp, :hostname => amqp_hostname, :port => amqp_port, :security_protocol => amqp_security_protocol}
+          elsif params[:event_stream_selection] == "stf"
+            stf_endpoint = {:role => :stf, :hostname => stf_hostname, :port => stf_api_port, :security_protocol => stf_security_protocol}
           else
             ceilometer_endpoint = {:role => :ceilometer}
           end
@@ -745,6 +766,7 @@ module Mixins
         endpoints = {:default           => default_endpoint,
                      :ceilometer        => ceilometer_endpoint,
                      :amqp              => amqp_endpoint,
+                     :stf               => stf_endpoint,
                      :console           => default_endpoint,
                      :smartstate_docker => default_endpoint,
                      :amqp_fallback1    => amqp_fallback_endpoint1,
@@ -771,7 +793,7 @@ module Mixins
         authentications = build_credentials(ems, mode)
         configurations = []
 
-        %i[default ceilometer amqp amqp_fallback1 amqp_fallback2 console smartstate_docker ssh_keypair metrics hawkular prometheus prometheus_alerts kubevirt].each do |role|
+        %i[default ceilometer amqp amqp_fallback1 amqp_fallback2 stf console smartstate_docker ssh_keypair metrics hawkular prometheus prometheus_alerts kubevirt].each do |role|
           configurations << build_configuration(ems, authentications, endpoints, role)
         end
 
@@ -863,6 +885,7 @@ module Mixins
       end
 
       def retrieve_event_stream_selection
+        return 'stf' if @ems.connection_configurations.stf&.endpoint&.hostname&.present?
         return 'amqp' if @ems.connection_configurations.amqp&.endpoint&.hostname&.present?
         return 'ceilometer' if @ems.connection_configurations.ceilometer&.endpoint&.hostname&.present?
         @ems.kind_of?(ManageIQ::Providers::Openstack::CloudManager) || @ems.kind_of?(ManageIQ::Providers::Openstack::InfraManager) ? 'ceilometer' : 'none'

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -270,10 +270,16 @@
               %input{:type         => "radio",
                      :name         => "event_stream_selection",
                      :id           => "amqp_radio",
-                     "ng-checked"  => "emsCommonModel.event_stream_selection == amqp",
                      :value        => "amqp",
                      "ng-model"    => "emsCommonModel.event_stream_selection",
                      "checkchange" => ""} AMQP
+            %label.radio-inline.control-label{"for" => "stf_radio", "ng-show" => "#{ng_model}.emstype == 'openstack'"}
+              %input{:type         => "radio",
+                     :name         => "event_stream_selection",
+                     :id           => "stf_radio",
+                     :value        => "stf",
+                     "ng-model"    => "emsCommonModel.event_stream_selection",
+                     "checkchange" => ""} STF
             %hr
 
             %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}
@@ -293,6 +299,28 @@
                                     :id                => record.id,
                                     :prefix            => "amqp",
                                     :basic_info_needed => true}
+            %div{"ng-if" => "emsCommonModel.event_stream_selection == 'stf'"}
+              = render :partial => "layouts/angular-bootstrap/endpoints_angular",
+                       :locals  => {:ng_show                => true,
+                                    :ng_model               => "#{ng_model}",
+                                    :id                     => record.id,
+                                    :prefix                 => "stf",
+                                    :ng_reqd_hostname       => "true",
+                                    :ng_reqd_api_port       => "true"}
+              = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                       :locals  => {:ng_show           => true,
+                                    :ng_show_userid    => "false",
+                                    :ng_show_password  => "false",
+                                    :ng_reqd_userid    => "false",
+                                    :ng_reqd_password  => "false",
+                                    :verify_title_off  => _('Server information is required to perform verification.'),
+                                    :verify_title_on   => _('Validate provided server information.'),
+                                    :ng_model          => "#{ng_model}",
+                                    :validate_url      => validate_url,
+                                    :id                => record.id,
+                                    :prefix            => "stf",
+                                    :basic_info_needed => true}
+
         .form-group
           .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra'"}
             %span{:style => "color:black"}
@@ -300,6 +328,10 @@
                 = _("Used to authenticate with OpenStack AMQP Messaging Bus for event handling. Configure AMQP if eventing is not enabled on Ceilometer.")
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'ceilometer'"}
                 = _("Select Ceilometer if eventing is not enabled on AMQP.")
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack'"}
+            %span{:style => "color:black"}
+              %div{"ng-if" => "emsCommonModel.event_stream_selection == 'stf'"}
+                = _("Used to authenticate with OpenStack Service Telemetry Framework for event handling.")
           .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'vmware_cloud'"}
             %span{:style => "color:black"}
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}


### PR DESCRIPTION
This enhancement allows to create Service Telemetry Framework (event collection) endpoint for OpenStack cloud provider.

![Screenshot from 2020-06-29 20-28-12](https://user-images.githubusercontent.com/6648365/86042210-1e2e0c00-ba47-11ea-82b6-73c8b336c027.png)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7000