### PR TITLE
render_exception: use error modal

### DIFF
--- a/app/assets/javascripts/controllers/error_modal_controller.js
+++ b/app/assets/javascripts/controllers/error_modal_controller.js
@@ -41,6 +41,9 @@ function ErrorModalController($timeout) {
     } else if (source === '$http') {
       $ctrl.contentType = err.headers('content-type');
       $ctrl.url = err.config.url;
+    } else if (source === 'server') {
+      $ctrl.contentType = null;
+      $ctrl.url = err.url;
     }
 
     $ctrl.error = err;
@@ -54,7 +57,9 @@ function ErrorModalController($timeout) {
       $ctrl.data = findError($ctrl.data);
     }
 
-    $ctrl.status = (err.status !== -1) ? err.status + ' ' + err.statusText : 'Server not responding';
+    if (source !== 'server') {
+      $ctrl.status = (err.status !== -1) ? err.status + ' ' + err.statusText : 'Server not responding';
+    }
   };
 
   $ctrl.close = function() {
@@ -92,19 +97,19 @@ angular.module('miq.error', [])
       '              </strong>',
       '              {{$ctrl.url}}',
       '            </p>',
-      '            <p>',
+      '            <p ng-if="$ctrl.status">',
       '              <strong>',
       '                Status',
       '              </strong>',
       '              {{$ctrl.status}}',
       '            </p>',
-      '            <p>',
+      '            <p ng-if="$ctrl.contentType">',
       '              <strong>',
       '                Content-Type',
       '              </strong>',
       '              {{$ctrl.contentType}}',
       '            </p>',
-      '            <p>',
+      '            <p ng-if="$ctrl.data">',
       '              <strong>',
       '                Data',
       '              </strong>',

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -273,8 +273,21 @@ class ApplicationController < ActionController::Base
       format.js do
         render :update do |page|
           page << javascript_prologue
-          page.replace_html("center_div", :partial => "layouts/exception_contents", :locals => {:message => msg})
-          page << "miqSparkle(false);"
+
+          message = msg + " [#{params[:controller]}/#{params[:action]}]"
+
+          page << "
+            sendDataWithRx({
+              serverError: {
+                data: '#{j_str message}',
+                url: '#{j_str request.url}',
+              },
+              source: 'server',
+            });
+
+            miqSparkle(false);
+          "
+
           page << javascript_hide_if_exists("adv_searchbox_div")
         end
       end


### PR DESCRIPTION
Fixes #485 

When a rails exception occurs during an AJAX request, we try to render the exception screen inside center_div.

Depending on the screen, it may not be there at all, or may be positioned wrong.
This changes the mechanism to cause the error modal to pop up even for old-style ajax requests (it already did that for angular).

It means we no longer show the whole exception_contents layout partial, only the actual error message, but that's where the error is.

For exceptions during full-page render, neither issue is present, so those stay the same:

![error_reload](https://user-images.githubusercontent.com/289743/86039681-4bbc8a80-ba32-11ea-8e38-234d0f829326.png)

But for AJAX exceptions:

![modal](https://user-images.githubusercontent.com/289743/86039697-524b0200-ba32-11ea-8c10-76b8f1956787.png)

(Content-type and Status are normally also displayed, but for these responses, it's always 200 OK and javascript.)

