### PR TITLE
Added `Back` button and locked sidebar on Chargeback Preview screen.

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1159,6 +1159,8 @@ module VmCommon
         locals[:create_button] = true
       end
 
+      locals[:action_url] = nil if ['chargeback'].include?(@sb[:action])
+
       if %w[ownership protect reconfigure retire tag].include?(@sb[:action])
         locals[:multi_record] = true # need save/cancel buttons on edit screen even tho @record.id is not there
         locals[:record_id]    = @sb[:rec_id] || @edit[:object_ids][0] if @sb[:action] == "tag"
@@ -1230,7 +1232,7 @@ module VmCommon
             presenter.update(:form_buttons_div, '')
             presenter.remove_paging.hide(:form_buttons_div)
           end
-        elsif %w[reconfigure_update retire].exclude?(action) && !hide_x_edit_buttons(action)
+        elsif %w[chargeback reconfigure_update retire].exclude?(action) && !hide_x_edit_buttons(action)
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
         end
 
@@ -1447,6 +1449,8 @@ module VmCommon
       partial = @refresh_partial
       header = _('Chargeback preview for "%{vm_name}"') % { :vm_name => name }
       action = 'vm_chargeback'
+      @in_a_form = true
+      @edit = {}
     when "evm_relationship"
       partial = "vm_common/evm_relationship"
       header = _("Edit %{product} Server Relationship for %{vm_or_template} \"%{name}\"") % {:vm_or_template => ui_lookup(:table => table),

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -157,7 +157,7 @@
   - elsif record_id || export_button
     -# show button to go back
     #buttons
-      - if params[:action] == "policies" || %w(right_size).include?(@sb[:action])
+      - if params[:action] == "policies" || %w(chargeback right_size).include?(@sb[:action])
         - action = (params[:action] == "policies" ? "policy_sim" : "x_history")
         -# Button to go back to policy simulation screen from 1 VMs policies
         = button_tag(t = _('Back'),


### PR DESCRIPTION
Not having a back button and locked sidebar was causing user to make selection in the tree while on Chargeback Preview screen and running into errors in replace_right_cell call because `@sb[:action]` value was still set to `chargeback`.

Fixes #3678

before
![before](https://user-images.githubusercontent.com/3450808/86144488-b8cc3080-bac3-11ea-8546-6dfc8f72c4fd.png)

after
![after](https://user-images.githubusercontent.com/3450808/86144499-bcf84e00-bac3-11ea-93cb-2c6542b70ae7.png)
