### PR TITLE
help_documentation: use product_documentation_website

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -279,8 +279,14 @@ module Menu
       end
 
       def help_documentation
+        # note these can still be overriden via Settings.help_menu
+        href = if ::Settings.docs.product_documentation_direct_link
+                 ::Settings.docs.product_documentation_website
+               else
+                 '/support/index?support_tab=about'
+               end
         help_menu_item(:documentation, :title => N_('Documentation'),
-                                       :href  => '/support/index?support_tab=about')
+                                       :href  => href)
       end
 
       def help_product

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,10 +1,2 @@
-:docs:
-  :ansible_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#adding-an-ansible-tower-provider
-  :cloud_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#cloud_providers
-  :configuration_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#configuration_management_providers
-  :container_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#containers-providers
-  :infra_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#infrastructure_providers
-  :network_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#network_providers
-  :physical_infra_provider: https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/#infrastructure_providers
 :ui:
   :custom_button_count: 3


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20320
Fixes: https://github.com/ManageIQ/manageiq-documentation/issues/557

when `Settings.docs.product_documentation_direct_link` is true (default),
the documentation link goes to `Settings.docs.product_documentation_website`

false (and previous behavior) goes to the local PDFs screen in SupportController (which is empty without any local documentation PDFs).

This also moves provider documentation links to core, to keep `Settings.docs` in one place.

Cc @Fryguy 