### PR TITLE
Display title on nested Policy Simulation screen.

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -468,6 +468,7 @@ module VmCommon
       @in_a_form = true
       replace_right_cell(:action => 'policy_sim', :refresh_breadcrumbs => false)
     else
+      @right_cell_text = _("%{vm_or_template} Policy Simulation") % {:vm_or_template => ui_lookup(:table => vm_or_instance(@record))}
       @sb[:explorer] = nil
       render :template => 'vm/show'
     end

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -50,6 +50,7 @@ module ApplicationHelper::PageLayouts
       consumption
       dashboard
       dialog_provision
+      policies
       topology
     ].include?(@showtype)
 

--- a/app/views/vm_common/_policy_options.html.haml
+++ b/app/views/vm_common/_policy_options.html.haml
@@ -1,6 +1,10 @@
 - url = {:url => url_for_only_path(:action => 'policy_options', :id => @record.id)}.to_json
 - url2 = {:url => url_for_only_path(:action => 'policy_show_options', :id => @record.id)}.to_json
 #policy_options_div
+  - unless @explorer
+    %h1#explorer_title
+      %span#explorer_title_text
+        = safe_right_cell_text
   %h3
     = _('Options')
   .form-horizontal


### PR DESCRIPTION
Go to Cloud Provider summary screen. Click on Instances link, then from the list select one or more Instance(s), Press Policy Simulation button for one or more selected instance(s). On the Policy Simulation screen, Add a Policy Profile and then click on one of the Instances to see results of Policy simulation - Notice missing title on screen and an extra listnav on the left side. This fix removes the extra layout from the screen and adds the title on the Policy simulation result screen. Title was missing when going to the screen thru relationships(non-explorer style screen)

before
![Screenshot from 2020-06-30 18-17-16](https://user-images.githubusercontent.com/3450808/86182681-6a885300-bafe-11ea-8167-4dd96165b4f8.png)

after
![Screenshot from 2020-06-30 18-11-36](https://user-images.githubusercontent.com/3450808/86182689-6e1bda00-bafe-11ea-9f95-24e045e0fcf7.png)
