### PR TITLE
Fixed button text to be consistent with others in the toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_center.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonCenter < Applicat
         button(
           :custom_button_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Custom Button from Inventory'),
+          N_('Remove this Button from Inventory'),
           :confirm => N_("Warning: This Button will be permanently removed!"),
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonDelete
         )

--- a/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition_button_group_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::GenericObjectDefinitionButtonGroupCenter < App
         button(
           :custom_button_set_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Custom Button Group from Inventory'),
+          N_('Remove this Button Group from Inventory'),
           :confirm => N_("Warning: This Custom Button Group will be permanently removed!"),
           :klass   => ApplicationHelper::Button::GenericObjectDefinitionButtonButtonGroupDelete,
         ),


### PR DESCRIPTION
Changed button text in custom button group and custom button toolbar to be consistent with others in same toolbar and to the one that exists in translated files.

before
![Screenshot from 2020-06-30 19-09-29](https://user-images.githubusercontent.com/3450808/86185818-4e3be480-bb05-11ea-9a5f-697c329b1272.png)
![Screenshot from 2020-06-30 19-09-51](https://user-images.githubusercontent.com/3450808/86185821-509e3e80-bb05-11ea-842f-e2a870b7564c.png)

after
![after](https://user-images.githubusercontent.com/3450808/86185751-1c2a8280-bb05-11ea-88a9-d59028c8feac.png)

![Screenshot from 2020-06-30 19-06-25](https://user-images.githubusercontent.com/3450808/86185755-1e8cdc80-bb05-11ea-927b-304a93ad37b9.png)
