### PR TITLE
Check for container template instantiation support

### DIFF
--- a/app/helpers/application_helper/toolbar/container_template_center.rb
+++ b/app/helpers/application_helper/toolbar/container_template_center.rb
@@ -10,7 +10,10 @@ class ApplicationHelper::Toolbar::ContainerTemplateCenter < ApplicationHelper::T
           :service_dialog_from_ct,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Create Service Dialog from Container Template'),
-          t),
+          t,
+          :options => {:feature => :instantiate},
+          :klass   => ApplicationHelper::Button::GenericFeatureButtonWithDisable
+        ),
       ]
     ),
   ])


### PR DESCRIPTION
Add checks for the instantiation supports_feature and disable the button if it isn't supported.

Fix for https://github.com/ManageIQ/manageiq-ui-classic/pull/7156