### PR TITLE
Added a "Note" field mapping to React forms.

### DIFF
--- a/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
+++ b/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
@@ -36,6 +36,10 @@ const validateCopyContent = (value, { name, content }, copy) => {
   return undefined;
 };
 
+const setFormat = (values) => {
+  return typeof values.content !== 'undefined' && values.content[0] === '{' ? 'json' : 'yaml';
+};
+
 const orchestrationFormSchema = (isEditing = false, isCopying = false, initialValues = {}) => ({
   fields: [{
     component: componentTypes.TEXT_FIELD,
@@ -90,9 +94,14 @@ const orchestrationFormSchema = (isEditing = false, isCopying = false, initialVa
     component: 'hr',
     name: 'form-separator',
   }, {
+    component: 'note',
+    name: 'form-note',
+    label: __('Note: Select format type below to apply syntax highlighting for better readability'),
+  },{
     component: 'code-editor',
     name: 'content',
     label: __('Content'),
+    mode: setFormat(initialValues),
     modes: ['yaml', 'json'],
     validateOnMount: true,
     isRequired: true,

--- a/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
+++ b/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
@@ -97,6 +97,7 @@ const orchestrationFormSchema = (isEditing = false, isCopying = false, initialVa
     component: 'note',
     name: 'form-note',
     label: __('Note: Select format type below to apply syntax highlighting for better readability'),
+    className: '',
   },{
     component: 'code-editor',
     name: 'content',

--- a/app/javascript/forms/mappers/formFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formFieldsMapper.jsx
@@ -20,6 +20,7 @@ const fieldsMapper = {
   'dual-list-select': DualListSelect,
   'input-with-dynamic-prefix': InputWithDynamicPrefix,
   hr: () => <hr />,
+  note: props => <p>{props.label}</p>,
   'password-field': PasswordField,
   'validate-credentials': AsyncCredentials,
   [componentTypes.SELECT]: props => <components.SelectField placeholder={`<${__('Choose')}>`} {...props} />,

--- a/app/javascript/forms/mappers/formFieldsMapper.jsx
+++ b/app/javascript/forms/mappers/formFieldsMapper.jsx
@@ -20,7 +20,7 @@ const fieldsMapper = {
   'dual-list-select': DualListSelect,
   'input-with-dynamic-prefix': InputWithDynamicPrefix,
   hr: () => <hr />,
-  note: props => <p>{props.label}</p>,
+  note: props => <div className={props.className} role="alert">{props.label}</div>,
   'password-field': PasswordField,
   'validate-credentials': AsyncCredentials,
   [componentTypes.SELECT]: props => <components.SelectField placeholder={`<${__('Choose')}>`} {...props} />,


### PR DESCRIPTION
- Added a "Note" field mapping to React forms to be able to show a note on the React forms. This is to eliminate a confusion/issue on Orchestration Template edit form, where user is prompted to select a format yaml/json for the template contents, format type is not saved in the database. Selected format type is applied to show syntax highlighting to help user with better readability of contents while they are entering text in the field.
- Made a change to select format type based upon save content value.

before
![before](https://user-images.githubusercontent.com/3450808/86268674-8808fb80-bb96-11ea-8a65-4611056631ce.png)

after
![Screenshot from 2020-07-01 12-16-05](https://user-images.githubusercontent.com/3450808/86267513-d1584b80-bb94-11ea-90ef-380ad7712523.png)
