### PR TITLE
Correctly render orch. template after content after page refresh

### DIFF
--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -39,11 +39,10 @@
 %hr
 #form_div
   = text_area_tag("template_content", @record.content, :style => "display:none;")
-  - if params[:action] != "explorer"
-    = render :partial => "/layouts/my_code_mirror",
-      :locals => {:text_area_id => "template_content",
-                  :mode         => "yaml",
-                  :line_numbers => true,
-                  :read_only    => true}
-    :javascript
-      ManageIQ.editor.refresh();
+  = render :partial => "/layouts/my_code_mirror",
+    :locals => {:text_area_id => "template_content",
+                :mode         => "yaml",
+                :line_numbers => true,
+                :read_only    => true}
+  :javascript
+    ManageIQ.editor.refresh();


### PR DESCRIPTION
1. navigate to orchestration template details page, notice the screen contains template content
2. hit browser refresh (full page reload), notice the screen no longer contains template content

Before (after page reload):
![Screenshot from 2020-07-02 15-07-14](https://user-images.githubusercontent.com/6648365/86362640-e0fb9100-bc75-11ea-8a68-8bb5f76e5761.png)

After (after page reload):
![Screenshot from 2020-07-02 15-06-58](https://user-images.githubusercontent.com/6648365/86362652-e5c04500-bc75-11ea-9134-5c9db1fb2c1a.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1760510