### PR TITLE
Replace old angular ansible tower form with a react based DDF

### DIFF
--- a/app/views/automation_manager/_form.html.haml
+++ b/app/views/automation_manager/_form.html.haml
@@ -1,2 +1,5 @@
-= render :partial => 'configuration_manager/shared_form', :locals => {:url => "/automation_manager", :model => "automationManagerModel"}
-
+- if @ems
+  -# FIXME: the redirect URL cannot be determined due to the explorer screen, but after a de-explorerization it should be possible to fix
+  = react('ProviderForm', :providerId => @ems.id.to_s, :redirect => automation_manager_path, :kind => 'automation', :title => ui_lookup(:model => 'ManageIQ::Providers::AutomationManager'))
+- else
+  = react('ProviderForm', :redirect => automation_manager_path, :kind => 'automation', :title => ui_lookup(:model => 'ManageIQ::Providers::AutomationManager'))

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -134,14 +134,6 @@ describe AutomationManagerController do
       expect(right_cell_text).to eq("Edit Provider")
     end
 
-    it "should display the zone field" do
-      new_zone = FactoryBot.create(:zone)
-      controller.instance_variable_set(:@provider, automation_provider1)
-      post :edit, :params => { :id => @automation_manager1.id }
-      expect(response.status).to eq(200)
-      expect(response.body).to include("option value=\\\"#{new_zone.name}\\\"")
-    end
-
     it "should save the zone field" do
       new_zone = FactoryBot.create(:zone)
       controller.instance_variable_set(:@provider, automation_provider1)


### PR DESCRIPTION
As this provider screen is explorer-based, it has some issues with redirects after creating/editing. The redirect after an API call requires a permalink to a given provider, which is not doable here. Therefore, as long as this screen is not de-explorerized, any operation will redirect back to the providers list screen.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818
Depends on: https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/228 https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/229