### PR TITLE
Allow cut & paste in automate entry point input

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -250,6 +250,11 @@ class CatalogController < ApplicationController
         if params[:display]
           page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"
         end
+        %w[fqname reconfigure_fqname retire_fqname].each do |name|
+          if params[name.to_sym] && @edit[:new][name.to_sym].present?
+            page << "$('##{name}_remove').attr('disabled', false);"
+          end
+        end
         if changed != session[:changed]
           page << javascript_for_miq_button_visibility(changed)
           session[:changed] = changed
@@ -575,7 +580,7 @@ class CatalogController < ApplicationController
       x_node_set(@edit[:active_id], :automate_catalog_tree)
       page << javascript_hide("ae_tree_select_div")
       page << javascript_hide("blocker_div")
-      page << javascript_hide("#{ae_tree_key}_div")
+      page << "$('##{ae_tree_key}_remove').attr('disabled', true);"
       page << "$('##{ae_tree_key}').val('#{@edit[:new][ae_tree_key]}');"
       page << "$('##{ae_tree_key}').prop('title', '#{@edit[:new][ae_tree_key]}');"
       @edit[:ae_tree_select] = false

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1690,6 +1690,7 @@ class MiqAeClassController < ApplicationController
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page.replace("form_div", :partial => "copy_objects_form") if params[:domain] || params[:override_source]
+      page << "$('#namespace_remove').attr('disabled', #{@edit[:new][:namespace].blank?});"
       page << javascript_for_miq_button_visibility(@changed)
     end
   end
@@ -1704,6 +1705,21 @@ class MiqAeClassController < ApplicationController
       @edit[:namespace] = @edit[:new][:namespace]
     end
 
+    session[:edit] = @edit
+  end
+
+  def ae_tree_select_discard
+    @edit = session[:edit]
+    @edit[:new][:namespace] = @edit[:namespace] = nil
+    @changed = (@edit[:new] != @edit[:current])
+    render :update do |page|
+      page << javascript_prologue
+      page << javascript_hide("ae_tree_select_div")
+      page << javascript_hide("blocker_div")
+      page << "$('#namespace').val('#{@edit[:new][:namespace]}');"
+      page << "$('#namespace_remove').attr('disabled', true);"
+      page << javascript_for_miq_button_visibility(@changed)
+    end
     session[:edit] = @edit
   end
 

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -68,7 +68,7 @@ module AutomateTreeHelper
       case params[:button]
       when 'submit'
         @edit[:new][@edit[:ae_field_typ]] = @edit[:active_id]
-        page << set_element_visible("#{edit_key}_div", true)
+        page << "$('##{edit_key}_remove').attr('disabled', false);"
 
         if @edit[:include_domain_prefix] != true && MiqAeDatastore.path_includes_domain?(@edit[:automate_tree_selected_path])
           selected_path = @edit[:automate_tree_selected_path]

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -166,19 +166,18 @@
         .input-group
           = text_field_tag("fqname",
                            @edit[:new][:fqname],
-                           :class   => "form-control",
-                           :onFocus => 'miqShowAE_Tree("provision");miqButtons("hide", "automate");')
+                           :class             => "form-control",
+                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
           %span.input-group-btn
-            #fqname_div{:style => @edit[:new][:fqname] != "" ? "" : "display:none"}
-              = link_to({:action => 'ae_tree_select_discard',
-                         :typ => "provision"},
-                        "data-miq_sparkle_on"  => true,
-                        "data-miq_sparkle_off" => true,
-                        "data-confirm"         => _("Are you sure you want to remove this Provisioning Entry Point?"),
-                        "data-method"          => :post,
-                        :remote                => true,
-                        :class                 => "btn btn-default",
-                        :title                 => _("Remove this Provisioning Entry Point")) do
+            #fqname_div
+              %button.btn.btn-default{"onclick" => "miqShowAE_Tree('provision'); miqButtons('hide', 'automate');",
+                                      "title"   => _('Click to select Provisioning Entry Point')}
+                %i.ff.ff-load-balancer
+              %button.btn.btn-default{"id"           => "fqname_remove",
+                                      "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'provision')}');",
+                                      "title"        => _('Remove this Provisioning Entry Point'),
+                                      "data-confirm" => _("Are you sure you want to remove this Provisioning Entry Point?"),
+                                      "disabled"     => @edit[:new][:fqname].nil?}
                 %i.pficon.pficon-close
           %span.input-group-addon{:style => "visibility:hidden"}
     - unless @edit[:new][:st_prov_type] == 'generic_container_template'
@@ -190,22 +189,19 @@
             = text_field_tag("reconfigure_fqname",
                              @edit[:new][:reconfigure_fqname],
                              :class             => "form-control",
-                             :onFocus           => 'miqShowAE_Tree("reconfigure");miqButtons("hide", "automate");',
                              "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %span.input-group-btn
-              #reconfigure_fqname_div{:style => @edit[:new][:reconfigure_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "reconfigure"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm"         => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                          "data-method"          => :post,
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Reconfigure Entry Point")) do
+              #reconfigure_fqname_div
+                %button.btn.btn-default{"onclick" => "miqShowAE_Tree('reconfigure'); miqButtons('hide', 'automate');",
+                                        "title"   => _('Click to select Reconfigure Entry Point')}
+                  %i.ff.ff-load-balancer
+                %button.btn.btn-default{"id"           => "reconfigure_fqname_remove",
+                                        "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'reconfigure')}');",
+                                        "title"        => _('Remove this Reconfigure Entry Point'),
+                                        "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                                        "disabled"     => @edit[:new][:reconfigure_fqname].nil?}
                   %i.pficon.pficon-close
             %span.input-group-addon{:style => "visibility:hidden"}
-
       .form-group
         %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
           = _('Retirement Entry Point')
@@ -213,19 +209,18 @@
           .input-group
             = text_field_tag("retire_fqname",
                              @edit[:new][:retire_fqname],
-                             :class   => "form-control",
-                             :onFocus => 'miqShowAE_Tree("retire");miqButtons("hide", "automate");')
+                             :class             => "form-control",
+                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             %span.input-group-btn
-              #retire_fqname_div{:style => @edit[:new][:retire_fqname] != "" ? "" : "display:none"}
-                = link_to({:action => 'ae_tree_select_discard',
-                           :typ => "retire"},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          "data-confirm"         => _("Are you sure you want to remove this Retirement Entry Point?"),
-                          "data-method"          => :post,
-                          :remote                => true,
-                          :class                 => "btn btn-default",
-                          :title                 => _("Remove this Retirement Entry Point")) do
+              #retire_fqname_div
+                %button.btn.btn-default{"onclick" => "miqShowAE_Tree('retire'); miqButtons('hide', 'automate');",
+                                        "title"   => _('Click to select Retirement Entry Point')}
+                  %i.ff.ff-load-balancer
+                %button.btn.btn-default{"id"           => "retire_fqname_remove",
+                                        "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'retire')}');",
+                                        "title"        => _('Remove this Retirement Entry Point'),
+                                        "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),
+                                        "disabled"     => @edit[:new][:retire_fqname].nil?}
                   %i.pficon.pficon-close
             %span.input-group-addon{:style => "visibility:hidden"}
     - if role_allows?(:feature => 'rbac_tenant_view')

--- a/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -61,9 +61,20 @@
         %label.col-md-2.control-label
           = _('Namespace')
         .col-md-8
-          = text_field_tag("namespace",
-                           @edit[:new][:namespace],
-                           :onFocus => 'miqShowAE_Tree("namespace");miqButtons("hide");')
+          .input-group
+            = text_field_tag("namespace",
+                             @edit[:new][:namespace],
+                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+                             :class             => 'form-control')
+            %span.input-group-btn
+              %button.btn.btn-default{"onclick" => "miqShowAE_Tree('namespace'); miqButtons('hide', 'automate');",
+                                      "title"   => _('Click to select Provisioning Entry Point')}
+                %i.ff.ff-load-balancer
+              %button.btn.btn-default{'id'       => 'namespace_remove',
+                                      'onclick'  => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'provision')}');",
+                                      'title'    => _('Remove this Namespace'),
+                                      'disabled' => @edit[:new][:namespace].nil?}
+                %i.pficon.pficon-close
   %p
     %table.table.table-striped.table-bordered
       %thead

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1972,6 +1972,7 @@ Rails.application.routes.draw do
       :post => %w(
         add_update_method
         ae_tree_select
+        ae_tree_select_discard
         ae_tree_select_toggle
         change_tab
         copy_objects


### PR DESCRIPTION
2 screens containing input for automate endpoint have been modified so that the input would allow cut & paste of the desired string (automate endpoint). The modified input would also contain two buttons: one for opening the automate tree selector and another button for removing entered text.

Catalog item screen:
![Screenshot from 2020-07-03 17-16-30](https://user-images.githubusercontent.com/6648365/86481891-25a82a80-bd51-11ea-8e2a-1a6bcd32403a.png)

Copy automate namespace screen:
![Screenshot from 2020-07-03 17-17-09](https://user-images.githubusercontent.com/6648365/86481895-26d95780-bd51-11ea-9134-1b9de61f35c2.png)



https://bugzilla.redhat.com/show_bug.cgi?id=1740397