### PR TITLE
only set `object_ids` if in a form.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1216,7 +1216,7 @@ class ApplicationController < ActionController::Base
     if !fetch_data && @report_data_additional_options.nil?
       process_show_list_options(options, db)
     end
-    unless @edit.nil?
+    if @in_a_form && @edit.present?
       object_ids = @edit[:object_ids] unless @edit[:object_ids].nil?
       object_ids = @edit[:pol_items] unless @edit[:pol_items].nil?
     end


### PR DESCRIPTION
When clicking on a breadcrumb link while in a form without cancelling out of the form, code was setting `object_ids` from previously stored data in `@edit` causing not to load correct records in the list view.

Fixes #5383