### PR TITLE
Container project dashboard - add missing dataAvailable

### DIFF
--- a/app/services/container_service_mixin.rb
+++ b/app/services/container_service_mixin.rb
@@ -50,6 +50,7 @@ module ContainerServiceMixin
   def create_delete_data(create_trend, delete_trend)
     if create_trend.any?
       {
+        :dataAvailable => true,
         :xData    => create_trend.keys,
         :yCreated => create_trend.values.map(&:round),
         :yDeleted => delete_trend.values.map(&:round)
@@ -71,6 +72,7 @@ module ContainerServiceMixin
   def trend_data(trend)
     if trend.any?
       {
+        :dataAvailable => true,
         :xData => trend.keys,
         :yData => trend.values.map { |value| (value || 0).round }
       }
@@ -154,6 +156,7 @@ module ContainerServiceMixin
 
     if used_cpu.any?
       {
+        :dataAvailable => true,
         :interval_name => "realtime",
         :xy_data       => utilization_data(used_cpu, total_cpu, used_mem, total_mem)
       }
@@ -173,6 +176,7 @@ module ContainerServiceMixin
 
     if used_cpu.any?
       {
+        :dataAvailable => true,
         :interval_name => "hourly",
         :xy_data       => utilization_data(used_cpu, total_cpu, used_mem, total_mem)
       }
@@ -192,6 +196,7 @@ module ContainerServiceMixin
 
     if used_cpu.any?
       {
+        :dataAvailable => true,
         :interval_name => "daily",
         :xy_data       => utilization_data(used_cpu, total_cpu, used_mem, total_mem)
       }

--- a/app/services/dashboard_service.rb
+++ b/app/services/dashboard_service.rb
@@ -16,6 +16,7 @@ class DashboardService
 
   def format_cpu(used, total)
     {
+      :dataAvailable => true,
       :used  => cpu_num(used.values.last).round(display_precision),
       :total => cpu_num(total.values.last).round(0),
       :xData => used.keys,
@@ -29,6 +30,7 @@ class DashboardService
 
   def format_memory(used, total)
     {
+      :dataAvailable => true,
       :used  => mem_num(used.values.last).round(display_precision),
       :total => mem_num(total.values.last).round(0),
       :xData => used.keys,

--- a/spec/services/container_dashboard_service_spec.rb
+++ b/spec/services/container_dashboard_service_spec.rb
@@ -77,12 +77,14 @@ describe ContainerDashboardService do
 
       expect(node_utilization_single_provider).to eq(
         :cpu    => {
+          :dataAvailable => true,
           :used  => 2,
           :total => 2,
           :xData => [current_date],
           :yData => [2]
         },
         :memory => {
+          :dataAvailable => true,
           :used  => 1,
           :total => 2,
           :xData => [current_date],
@@ -92,12 +94,14 @@ describe ContainerDashboardService do
 
       expect(node_utilization_all_providers).to eq(
         :cpu    => {
+          :dataAvailable => true,
           :used  => 3,
           :total => 3,
           :xData => [current_date],
           :yData => [3.0]
         },
         :memory => {
+          :dataAvailable => true,
           :used  => 2,
           :total => 3,
           :xData => [current_date],
@@ -382,11 +386,13 @@ describe ContainerDashboardService do
       daily_network_trends_single_provider = described_class.new(ems_openshift.id, controller).network_metrics[:xy_data]
 
       expect(daily_network_trends_single_provider).to eq(
+        :dataAvailable => true,
         :xData => [previous_date, current_date],
         :yData => [2000, 1000]
       )
 
       expect(daily_network_trends).to eq(
+        :dataAvailable => true,
         :xData => [previous_date, current_date],
         :yData => [2000, 2500]
       )
@@ -443,15 +449,16 @@ describe ContainerDashboardService do
       ems_kubernetes.metric_rollups << nil_fields_metric.dup
 
       hourly_network_trends = described_class.new(nil, controller).network_metrics[:xy_data]
-      hourly_network_trends_single_provider =
-        described_class.new(ems_openshift.id, controller).network_metrics[:xy_data]
+      hourly_network_trends_single_provider = described_class.new(ems_openshift.id, controller).network_metrics[:xy_data]
 
       expect(hourly_network_trends_single_provider).to eq(
+        :dataAvailable => true,
         :xData => [previous_date.beginning_of_hour.utc, current_date.beginning_of_hour.utc],
         :yData => [2000, 1000]
       )
 
       expect(hourly_network_trends).to eq(
+        :dataAvailable => true,
         :xData => [previous_date.beginning_of_hour.utc, current_date.beginning_of_hour.utc],
         :yData => [2000, 2500]
       )


### PR DESCRIPTION
Fixes #7186

Compute > Containers > Projects
pick a project, switch to dashboard view

Add `dataAvailable` to a couple of places in dashboard services.
Otherwise, the container project dashboard doesn't display anything,
because `loadingDone` is true (no spinner),
`dataAvailable` is not false (no empty message),
or true (no chart).

I suspect the `dataAvailable` logic somehow changed in the other dashboards and this one was never updated, but I don't see the commit. 

@h-kataria any ideas? Or, does this make sense as is?

---

Before:

![before](https://user-images.githubusercontent.com/289743/86831659-b1d68c80-c086-11ea-96d2-8a1c22e4a6a3.png)


After:

![after](https://user-images.githubusercontent.com/289743/86831667-b4d17d00-c086-11ea-96fc-6e9adb471eca.png)

---

Testing: you can use https://github.com/yaacov/miq-scripts/blob/master/set-miq-metric.rb to generate data, as long as you have at least one container project.