### PR TITLE
Network controller breadcrumbs: fix menu section name: Networks -> Networks, helper

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -240,7 +240,7 @@ class CloudNetworkController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Networks"), :url => controller_url},
       ],
       :record_info => @network,

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -313,7 +313,7 @@ class CloudSubnetController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Subnets"), :url => controller_url},
       ],
     }

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -45,7 +45,7 @@ class EmsNetworkController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -215,7 +215,7 @@ class FloatingIpController < ApplicationController
     record_name = :address
     {
       :breadcrumbs  => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Floating IPs"), :url => controller_url},
       ],
       :record_info  => record_info,

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -306,7 +306,7 @@ class MiqRequestController < ApplicationController
   #   Example: '/miq_request?typ=service' --> "'service'".
   # The returned value needs to be equal to the first argument to Menu::Section.new(...)
   #   Example:  Menu::Section.new(:clo, N_("Clouds"), 'fa fa-plus', [ ... --> ":clo"
-  def menu_section_id(parms)
+  def menu_section_id(parms = {})
     parms[:typ] == 'ae' ? :automate : :svc
   end
 

--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -250,5 +250,9 @@ module Mixins
       @x_node_text ||= {}
       @x_node_text[x_active_tree] = CGI.unescape(text) if text.present?
     end
+
+    def breadcrumbs_menu_section(id = menu_section_id)
+      {:title => _(Menu::Manager.section(id)&.name)}
+    end
   end
 end

--- a/app/controllers/mixins/menu_section.rb
+++ b/app/controllers/mixins/menu_section.rb
@@ -1,7 +1,7 @@
 module Mixins::MenuSection
   extend ActiveSupport::Concern
 
-  def menu_section_id(_parms)
+  def menu_section_id(_parms = {})
     self.class.instance_eval { @section_id }
   end
 

--- a/app/controllers/network_port_controller.rb
+++ b/app/controllers/network_port_controller.rb
@@ -22,7 +22,7 @@ class NetworkPortController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Network Ports"), :url => controller_url},
       ],
       :record_info => @router,

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -392,7 +392,7 @@ class NetworkRouterController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Network Routers"), :url => controller_url},
       ],
       :record_info => @router,

--- a/app/controllers/network_service_controller.rb
+++ b/app/controllers/network_service_controller.rb
@@ -31,7 +31,7 @@ class NetworkServiceController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Network Services"), :url => controller_url},
       ]
     }

--- a/app/controllers/network_topology_controller.rb
+++ b/app/controllers/network_topology_controller.rb
@@ -8,7 +8,7 @@ class NetworkTopologyController < TopologyController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Topology")},
       ],
     }

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -291,7 +291,7 @@ class SecurityGroupController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Security Groups"), :url => controller_url},
       ],
     }

--- a/app/controllers/security_policy_controller.rb
+++ b/app/controllers/security_policy_controller.rb
@@ -32,7 +32,7 @@ class SecurityPolicyController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Security Policies"), :url => controller_url},
       ],
       :record_info => @router,

--- a/app/controllers/security_policy_rule_controller.rb
+++ b/app/controllers/security_policy_rule_controller.rb
@@ -48,7 +48,7 @@ class SecurityPolicyRuleController < ApplicationController
   def breadcrumbs_options
     {
       :breadcrumbs => [
-        {:title => _("Networks")},
+        breadcrumbs_menu_section,
         {:title => _("Security Policies")},
         {:title => _("Rules"), :url => controller_url},
       ]


### PR DESCRIPTION
the Network section was renamed from Networks in #6994, but `breadcrumbs_options` hardcode the section name in all the network controllers.

Adding a helper that uses `menu_section` to determine the right menu section, and use its name, instead of hardcoding the name

(https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10909)

Before:

![before](https://user-images.githubusercontent.com/289743/87084898-838bb500-c21e-11ea-8496-9f658c326365.png)

After:

![after](https://user-images.githubusercontent.com/289743/87084901-85557880-c21e-11ea-8be5-ee2b65671fc2.png)

