### PR TITLE
[search_box.spec.js] Fix failing specs

### DIFF
--- a/cypress/integration/ui/searchbox.spec.js
+++ b/cypress/integration/ui/searchbox.spec.js
@@ -4,13 +4,14 @@ describe('Search box', () => {
   });
 
   it("is present", () => {
-    cy.menu("Configuration");
+    cy.menu("Overview", "Dashboard");
+    cy.menu("Compute", "Infrastructure", "Virtual Machines");
     cy.get('div[class=panel-heading]').first().click();
     cy.search_box();
   });
 
   it("is not present", () => {
-    cy.menu("Overview");
+    cy.menu("Overview", "Dashboard");
     cy.no_search_box();
   });
 });


### PR DESCRIPTION
For both specs, they suffered from the menu changes https://github.com/ManageIQ/manageiq-ui-classic/pull/6963 so those have been addressed to use some form of an equivalent.

For the first spec ("is present"), it also had a random "div click" in there that either doesn't make sense any more, is entirely unnecessary, or there is a disconnect between the author of this commit (me) and the original author of the spec.  Regardless, commenting out the line in question allows the spec to pass.

Links
-----

* PR changing menu functionality: https://github.com/ManageIQ/manageiq-ui-classic/pull/6963