### PR TITLE
Fix menu.spec.js

### DIFF
--- a/cypress/integration/ui/menu.spec.js
+++ b/cypress/integration/ui/menu.spec.js
@@ -14,24 +14,20 @@ describe('Menu', () => {
         expect(menu[2].items[1].items[3].title).to.equal('Virtual Machines');
       });
 
-    cy.menu('Overview')
+    cy.menu('Overview', 'Dashboard')
       .get('widget-wrapper');
-
-    cy.menu('Services')
-      .expect_explorer_title('Active Services');
-
-    cy.menu('Compute')
-      .expect_show_list_title('Cloud Providers');
 
     cy.menu('Overview', 'Reports')
       .expect_explorer_title('All Saved Reports');
 
+    cy.menu('Services', 'My Services')
+      .expect_explorer_title('Active Services');
+
+    cy.menu('Compute', 'Clouds', 'Providers')
+      .expect_show_list_title('Cloud Providers');
+
     cy.menu('Compute', 'Infrastructure', 'Virtual Machines')
       .expect_explorer_title('All VMs & Templates');
-
-    // test it remembers the last Overview > * screen used
-    cy.menu('Overview')
-      .expect_explorer_title('All Saved Reports');
   });
 
   it.skip("all menu items lead to non-error screens", () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -70,6 +70,7 @@ Cypress.Commands.add("menu", (...items) => {
 
 // cy.menuItems() - returns an array of top level menu items with {title, href, items (array of children)}
 Cypress.Commands.add("menuItems", () => {
+  cy.get('#main-menu nav.primary'); // Wait for menu to appear
   return cy.window().then((window) => window.ManageIQ.menu);
 });
 


### PR DESCRIPTION
Fixes two issues with the spec:

- `menuItems` was not doing any form of a "wait" before trying to fetch the items
- Fixed invalid Menu navigations (trying to click on a top level menu) after the Carbon style menu changes from https://github.com/ManageIQ/manageiq-ui-classic/pull/6963

This test file should pass now.


Links
-----

* Menu navigation changes (cause some of the failures): https://github.com/ManageIQ/manageiq-ui-classic/pull/6963