### PR TITLE
Cypress Integration Environment

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -7,12 +7,12 @@ require "yaml"
 ENV["RAILS_ENV"] ||= "development"
 RAILS_ENV = ENV["RAILS_ENV"]
 
-ENV["NODE_ENV"] ||= RAILS_ENV
+ENV["NODE_ENV"] ||= RAILS_ENV == "integration" ? "production" : RAILS_ENV
 NODE_ENV = ENV["NODE_ENV"]
 
 APP_PATH          = File.expand_path("../", __dir__)
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
-WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
+WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{RAILS_ENV}.js")
 
 unless File.exist?(WEBPACK_CONFIG)
   puts "Webpack configuration not found."

--- a/config/webpack/integration.js
+++ b/config/webpack/integration.js
@@ -1,0 +1,11 @@
+// Note: You must restart bin/webpack-dev-server for changes to take effect
+
+/* eslint global-require: 0 */
+
+const { env } = require('process')
+
+if (env.CYPRESS_DEV) {
+  module.exports = require('./development.js')
+} else {
+  module.exports = require('./production.js')
+}

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -26,5 +26,14 @@ development:
 test:
   <<: *default
 
+integration:
+  <<: *default
+
+# uncomment these to enable webpack:server
+  dev_server:
+    host: 0.0.0.0
+    port: 8080
+    https: false
+
 production:
   <<: *default

--- a/lib/tasks/manageiq/cypress.rake
+++ b/lib/tasks/manageiq/cypress.rake
@@ -1,0 +1,16 @@
+# This check ensures that we only load this task under the `app:` prefix when
+# in `manageiq-ui-classic`, and loads it normally under `manageiq`
+#
+# Without it, a few things happen:
+#
+#   - There is an error since there is no manageiq/integration file in the path
+#   - If the above is addressed, it will load this task in two contexts when
+#     loading from manageiq-ui-classic:
+#     - cypress:ui:*
+#     - app:cypress:ui:*
+#
+if Rails.root
+  require "manageiq/integration"
+
+  ManageIQ::Integration::CypressRakeTask.new(:ui)
+end

--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -88,27 +88,33 @@ namespace :webpack do
   end
 end
 
+miq_app_prefix = defined?(ENGINE_ROOT) ? "app:" : ""
+
 # compile and clobber when running assets:* tasks
-if Rake::Task.task_defined?("assets:precompile")
-  Rake::Task["assets:precompile"].enhance do
-    Rake::Task["webpack:compile"].invoke unless ENV["TRAVIS"]
+if Rake::Task.task_defined?("#{miq_app_prefix}assets:precompile")
+  unless ENV["TRAVIS"]
+    Rake::Task["#{miq_app_prefix}assets:precompile"].enhance do
+      Rake::Task["webpack:compile"].invoke
+    end
   end
 
-  Rake::Task["assets:precompile"].actions.each do |action|
+  Rake::Task["#{miq_app_prefix}assets:precompile"].actions.each do |action|
     if action.source_location[0].include?(File.join("lib", "tasks", "webpacker"))
-      Rake::Task["assets:precompile"].actions.delete(action)
+      Rake::Task["#{miq_app_prefix}assets:precompile"].actions.delete(action)
     end
   end
 end
 
-if Rake::Task.task_defined?("assets:clobber")
-  Rake::Task["assets:clobber"].enhance do
-    Rake::Task["webpack:clobber"].invoke unless ENV["TRAVIS"]
+if Rake::Task.task_defined?("#{miq_app_prefix}assets:clobber")
+  unless ENV["TRAVIS"]
+    Rake::Task["#{miq_app_prefix}assets:clobber"].enhance do
+      Rake::Task["webpack:clobber"].invoke
+    end
   end
 
-  Rake::Task["assets:clobber"].actions.each do |action|
+  Rake::Task["#{miq_app_prefix}assets:clobber"].actions.each do |action|
     if action.source_location[0].include?(File.join("lib", "tasks", "webpacker"))
-      Rake::Task["assets:clobber"].actions.delete(action)
+      Rake::Task["#{miq_app_prefix}assets:clobber"].actions.delete(action)
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "cypress:open": "cypress open",
+    "cypress:run:ci": "cypress run --headless --browser chrome --config video=false ",
     "cypress:run:chrome": "cypress run --headless --browser chrome",
     "cypress:run:firefox": "cypress run --headless --browser firefox",
     "test": "jest",


### PR DESCRIPTION
Requires https://github.com/ManageIQ/manageiq/pull/20350

Adds `rake` tasks and support for running `cypress` through the new `integration` Rails environment


Usage
-----

Can be run either from `manageiq` or `manageiq-ui-classic`

### From `manageiq-ui-classic`

1. Run `rake app:cypress:ui:seed` (first time only)
2. Run `rake app:cypress:ui:open`

### From `manageiq`

1. Run `rake cypress:ui:seed`
2. Run `rake cypress:ui:open`

To make changes to the application javascript files without having to recompile, adding `dev:` to the tasks can be used to avoid a production compile and run the server with "dev-like" assets.


Links
-----

* Core PR:  https://github.com/ManageIQ/manageiq/pull/20350
* To support cypress running on Travis.  Current PR for that effort:  https://github.com/ManageIQ/manageiq-ui-classic/pull/6683