### PR TITLE
Fixed to translate strings in UI

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -292,7 +292,7 @@ module MiqPolicyController::Alerts
     # Build hash of arrays of all events by event type
     @edit[:events] = {}
     MiqEventDefinition.all_control_events.each do |e|
-      @edit[:events][e.id] = (e.etype.description + ": " + e.description)
+      @edit[:events][e.id] = (_(e.etype.description) + ": " + _(e.description))
     end
 
     # Build hash of all mgmt systems by id

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -242,7 +242,7 @@ module MiqPolicyController::Policies
         next if excluded_event?(e)
 
         @edit[:allevents][e.etype.description] ||= []
-        @edit[:allevents][e.etype.description].push([e.description, e.id.to_s])
+        @edit[:allevents][e.etype.description].push([_(e.description), e.id.to_s])
       end
     else # Editing basic information and policy scope
       build_expression(@policy, @edit[:new][:towhat])

--- a/app/helpers/application_helper/toolbar/miq_policies_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policies_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::MiqPoliciesCenter < ApplicationHelper::Toolbar
           t = proc do
               _('Add a New %{model} %{mode} Policy') % {
                 :model => ui_lookup(:model => @sb[:nodeid].camelize),
-                :mode  => @sb[:mode].capitalize
+                :mode  => _(@sb[:mode]).capitalize
               }
           end,
           t,

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -171,7 +171,7 @@
             .form-horizontal
               .form-group
                 %label.col-md-3.control-label
-                  = h(k)
+                  = h(_(k))
                 .col-md-8
                   - @edit[:allevents][k].sort_by(&:first).each do |e|
                     - checked = @edit[:new][:events].include?(e.last) ? true : false


### PR DESCRIPTION
@mzazrivec please review if this is the right way to fix these. I have noticed some of these strings are missing from translations

before
![56c85a80-9f5c-11ea-8503-c2d879d25d15](https://user-images.githubusercontent.com/3450808/87470695-2495b980-c5eb-11ea-98d6-1c7e593a470d.png)

![e07c2600-9f64-11ea-9233-05902e5cf70b](https://user-images.githubusercontent.com/3450808/87470706-26f81380-c5eb-11ea-8cbd-df8fb7c998d2.png)

![Screenshot from 2020-07-14 17-05-01](https://user-images.githubusercontent.com/3450808/87478510-e3f06d00-c5f7-11ea-89bf-90dcc972f883.png)

after
![Screenshot from 2020-07-14 15-57-21](https://user-images.githubusercontent.com/3450808/87470627-0c259f00-c5eb-11ea-8f1e-2c23c2ce104c.png)

![Screenshot from 2020-07-14 15-56-46](https://user-images.githubusercontent.com/3450808/87470618-08921800-c5eb-11ea-8490-fb5f1ac49d4a.png)

![Screenshot from 2020-07-14 17-07-33](https://user-images.githubusercontent.com/3450808/87478508-e0f57c80-c5f7-11ea-94c3-c41cea68d187.png)

