### PR TITLE
Honor sorting options in dialog preview

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -75,6 +75,12 @@
                           - if field.values.length > 1
                             - val = copy_array(field.values.map {|x, y| x.nil? ? [x,_(y)] : [x, y]})
 
+                            - if field.options.key?(:sort_by)
+                              - if field.data_type == 'integer'
+                                - val = val.map { |item| item[0].nil? ? item : [item[0].to_i, item[1]] }
+                              - val = val.sort { |a, b| a[0].nil? ? -1 : field.options[:sort_by] == 'value' ? a[0] <=> b[0] : a[1] <=> b[1] }
+                              - if field.options.key?(:sort_order) && field.options[:sort_order] == 'descending'
+                                - val.reverse!
                             - if field.type == "DialogFieldDropDownList"
                               - select_attrs = {:class => 'selectpicker'}
                               - select_attrs[:multiple] = '' if field.multiselect?


### PR DESCRIPTION
This change is for service dialog preview screen to honor field sorting parameters of dropdowns & radio buttons:
* sort by key or value
* sort the values either as integers or strings

Needs to go in with https://github.com/ManageIQ/ui-components/pull/445

https://bugzilla.redhat.com/show_bug.cgi?id=1740878