### PR TITLE
copy catalog - add info notice about copy not being in catalog by default

### DIFF
--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -14,6 +14,7 @@ class CopyCatalogForm extends Component {
   }
 
   componentDidMount() {
+    add_flash(__("The copied item will not be displayed in the catalog by default"), 'info');
     this.setState(() => ({
       schema: createSchema(),
       initialValues: {

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -20,6 +20,9 @@ ManageIQ.angular.rxSubject = rxSubject;
 window.sendDataWithRx = sendDataWithRx;
 window.listenToRx = listenToRx;
 
+// mock miq_application helpers
+window.add_flash = (x) => true;
+
 // configure enzyme adapter
 import Enzyme from 'enzyme';
 import EnzymeAdapter from 'enzyme-adapter-react-16';


### PR DESCRIPTION
Services > Catalogs >> Catalog Items
toolbar Configuration > Copy

After:

![20200715140735](https://user-images.githubusercontent.com/289743/87555317-d0e7a680-c6a4-11ea-8414-1dc627a70c01.png)

This adds the flash message when copying a catalog item.

This is to make it explicit that copying a catalog item will clear the "Display in catalog" checkbox.
(That part happens during `ServiceTemplate::Copy#template_copy` and is intentional.)

Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10828