### PR TITLE
Control > Explorer - use RemoveGenericItemModal + API for deletions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -550,6 +550,7 @@ class ApplicationController < ActionController::Base
   # to reload currently displayed summary screen in explorer
   def reload
     @_params[:id] = x_node
+    @report_deleted = true if params[:deleted].present?
     tree_select
   end
 

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -90,29 +90,23 @@ class MiqPolicyController < ApplicationController
   end
 
   POLICY_X_BUTTON_ALLOWED_ACTIONS = {
-    'action_delete'          => :action_delete,
     'action_edit'            => :action_edit,
     'action_new'             => :action_edit,
-    'alert_delete'           => :alert_delete,
     'alert_edit'             => :alert_edit,
     'alert_copy'             => :alert_edit,
     'alert_new'              => :alert_edit,
     'alert_profile_assign'   => :alert_profile_assign,
-    'alert_profile_delete'   => :alert_profile_delete,
     'alert_profile_edit'     => :alert_profile_edit,
     'alert_profile_new'      => :alert_profile_edit,
-    'condition_delete'       => :condition_delete,
     'condition_edit'         => :condition_edit,
     'condition_copy'         => :condition_edit,
     'condition_policy_copy'  => :condition_edit,
     'condition_new'          => :condition_edit,
     'condition_remove'       => :condition_remove,
     'event_edit'             => :event_edit,
-    'profile_delete'         => :profile_delete,
     'profile_edit'           => :profile_edit,
     'profile_new'            => :profile_edit,
     'policy_copy'            => :policy_copy,
-    'policy_delete'          => :policy_delete,
     'policy_edit'            => :policy_edit,
     'policy_new'             => :policy_edit,
     'policy_edit_conditions' => :policy_edit,
@@ -481,13 +475,6 @@ class MiqPolicyController < ApplicationController
     end
     reload_trees_by_presenter(presenter, trees)
 
-    if params[:action].ends_with?('_delete') &&
-       !x_node.starts_with?('p') &&
-       !x_node.starts_with?('co')
-      nodes = x_node.split('_')
-      nodes.pop
-      self.x_node = nodes.join("_")
-    end
     presenter[:osf_node] = x_node
 
     @changed = session[:changed] if @edit # to get save/reset buttons to highlight when fields are moved left/right

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -129,23 +129,6 @@ module MiqPolicyController::AlertProfiles
     end
   end
 
-  def alert_profile_delete
-    alert_profiles = []
-    # showing 1 alert set, delete it
-    if params[:id].nil? || !MiqAlertSet.exists?(params[:id])
-      add_flash(_("Alert Profile no longer exists"), :error)
-    else
-      alert_profiles.push(params[:id])
-      alert_profile_get_info(MiqAlertSet.find(params[:id]))
-    end
-    process_alert_profiles(alert_profiles, "destroy") unless alert_profiles.empty?
-    nodes = x_node.split("_")
-    nodes.pop
-    self.x_node = nodes.join("_")
-    get_node_info(x_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => %i[alert_profile])
-  end
-
   def alert_profile_field_changed
     return unless load_edit("alert_profile_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -184,10 +167,6 @@ module MiqPolicyController::AlertProfiles
   end
 
   private
-
-  def process_alert_profiles(alert_profiles, task)
-    process_elements(alert_profiles, MiqAlertSet, task)
-  end
 
   def alert_profile_get_assign_to_objects_empty?
     return true if @assign[:new][:assign_to].blank?

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -65,26 +65,6 @@ module MiqPolicyController::Alerts
     end
   end
 
-  def alert_delete
-    assert_privileges("alert_delete")
-    alerts = []
-    # showing 1 alert, delete it
-
-    if params[:id].nil? || !MiqAlert.exists?(params[:id])
-      add_flash(_("Alert no longer exists"), :error)
-    elsif MiqAlert.find(params[:id]).read_only
-      add_flash(_("Alert can not be deleted"), :error)
-    else
-      alerts.push(params[:id])
-    end
-    @alert = MiqAlert.find(params[:id])
-
-    process_alerts(alerts, "destroy") unless alerts.empty?
-    @new_alert_node = self.x_node = "root"
-    get_node_info(x_node)
-    replace_right_cell(:nodetype => "root", :replace_trees => %i[alert_profile alert])
-  end
-
   def alert_field_changed
     return unless load_edit("alert_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -233,10 +213,6 @@ module MiqPolicyController::Alerts
   def display_driving_event?
     (@edit[:new][:expression][:eval_method] && @edit[:new][:expression][:eval_method] != "nothing") ||
       %w[ContainerNode ContainerProject].include?(@edit[:new][:db])
-  end
-
-  def process_alerts(alerts, task)
-    process_elements(alerts, MiqAlert, task)
   end
 
   def alert_build_edit_screen

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -118,22 +118,6 @@ module MiqPolicyController::Conditions
     replace_right_cell(:nodetype => "p", :replace_trees => %i[policy_profile policy])
   end
 
-  def condition_delete
-    assert_privileges("condition_delete")
-    conditions = []
-    # showing 1 condition, delete it
-    con = Condition.find(params[:id])
-    if params[:id].nil? || con.nil?
-      add_flash(_("Condition no longer exists"), :error)
-    else
-      conditions.push(params[:id])
-      @new_condition_node = "xx-#{con.towhat.camelize(:lower)}"
-    end
-    process_conditions(conditions, "destroy") unless conditions.empty?
-    get_node_info(@new_condition_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => %i[condition])
-  end
-
   def condition_field_changed
     return unless load_edit("condition_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -146,10 +130,6 @@ module MiqPolicyController::Conditions
   end
 
   private
-
-  def process_conditions(conditions, task)
-    process_elements(conditions, Condition, task)
-  end
 
   def condition_build_edit_screen
     @edit = {}

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -67,21 +67,6 @@ module MiqPolicyController::MiqActions
     end
   end
 
-  def action_delete
-    assert_privileges("action_delete")
-    actions = []
-    # showing 1 action, delete it
-    if params[:id].nil? || !MiqAction.exists?(params[:id])
-      add_flash(_("Action no longer exists"), :error)
-    else
-      actions.push(params[:id])
-    end
-    process_actions(actions, "destroy") unless actions.empty?
-    @new_action_node = self.x_node = "root"
-    get_node_info(x_node)
-    replace_right_cell(:nodetype => "root", :replace_trees => %i[action])
-  end
-
   def action_field_changed
     return unless load_edit("action_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -172,10 +157,6 @@ module MiqPolicyController::MiqActions
   end
 
   private
-
-  def process_actions(actions, task)
-    process_elements(actions, MiqAction, task)
-  end
 
   def action_build_snmp_variables
     @edit[:new][:options][:snmp_version] = "v1" if @edit[:new][:action_type] == "snmp_trap" && @edit[:new][:options][:snmp_version].blank?

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -138,27 +138,6 @@ module MiqPolicyController::Policies
     end
   end
 
-  def policy_delete
-    assert_privileges("policy_delete")
-    policies = []
-    # showing 1 policy, delete it
-    pol = MiqPolicy.find_by(:id => params[:id])
-    if params[:id].nil? || pol.nil?
-      add_flash(_("Policy no longer exists"), :error)
-    else
-      if pol.read_only
-        add_flash(_("Policy is read only"), :error)
-      else
-        policies.push(params[:id])
-      end
-      self.x_node = @new_policy_node = policies_node(pol.mode, pol.towhat)
-    end
-    process_policies(policies, "destroy") unless policies.empty?
-    add_flash(_("The selected Policies were deleted")) if @flash_array.nil?
-    get_node_info(@new_policy_node)
-    replace_right_cell(:nodetype => "xx", :replace_trees => %i[policy policy_profile])
-  end
-
   def policy_field_changed
     return unless load_edit("policy_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -201,10 +180,6 @@ module MiqPolicyController::Policies
   end
 
   private
-
-  def process_policies(policies, task)
-    process_elements(policies, MiqPolicy, task)
-  end
 
   def policy_build_edit_screen(edit_type = nil)
     @edit = {}

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -73,22 +73,6 @@ module MiqPolicyController::PolicyProfiles
     end
   end
 
-  def profile_delete
-    assert_privileges("profile_delete")
-    profiles = []
-    # showing 1 policy set, delete it
-    if params[:id].nil? || MiqPolicySet.find(params[:id]).nil?
-      add_flash(_("Policy Profile no longer exists"), :error)
-    else
-      profiles.push(params[:id])
-    end
-    process_profiles(profiles, "destroy") unless profiles.empty?
-    add_flash(_("The selected Policy Profile was deleted")) if @flash_array.nil?
-    self.x_node = @new_profile_node = 'root'
-    get_node_info('root')
-    replace_right_cell(:nodetype => 'root', :replace_trees => %i[policy_profile])
-  end
-
   def profile_field_changed
     return unless load_edit("profile_edit__#{params[:id]}", "replace_cell__explorer")
 
@@ -101,10 +85,6 @@ module MiqPolicyController::PolicyProfiles
   end
 
   private
-
-  def process_profiles(profiles, task)
-    process_elements(profiles, MiqPolicySet, task)
-  end
 
   def profile_build_edit_screen
     @edit = {}

--- a/app/helpers/application_helper/button/condition.rb
+++ b/app/helpers/application_helper/button/condition.rb
@@ -1,13 +1,5 @@
 class ApplicationHelper::Button::Condition < ApplicationHelper::Button::ReadOnly
-  needs :@sb, :@condition
-
   def role_allows_feature?
     @view_context.x_active_tree == :condition_tree && role_allows?(:feature => self[:child_id])
-  end
-
-  def disabled?
-    @error_message = _('Conditions assigned to Policies can not be deleted') if !@condition.miq_policies.empty? &&
-                                                                                self[:child_id].include?('delete')
-    @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/condition_delete.rb
+++ b/app/helpers/application_helper/button/condition_delete.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::ConditionDelete < ApplicationHelper::Button::Co
   end
 
   def disabled?
-    @error_message = _('Conditions assigned to Policies can not be deleted') if !@record.miq_policies.empty?
+    @error_message = _('Conditions assigned to Policies can not be deleted') if @record.miq_policies.present?
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/condition_delete.rb
+++ b/app/helpers/application_helper/button/condition_delete.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::ConditionDelete < ApplicationHelper::Button::Condition
+  needs :@record
+
+  def data(data)
+    t = {:condition_type => ui_lookup(:model => @record.towhat)}
+    data['function-data']['modal_title'] = _('Delete %{condition_type} Condition') % t
+    data['function-data']['modal_text'] = _("Are you sure you want to delete this %{condition_type} Condition?") % t
+    data
+  end
+
+  def disabled?
+    @error_message = _('Conditions assigned to Policies can not be deleted') if !@record.miq_policies.empty?
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/policy_delete.rb
+++ b/app/helpers/application_helper/button/policy_delete.rb
@@ -1,4 +1,13 @@
 class ApplicationHelper::Button::PolicyDelete < ApplicationHelper::Button::PolicyButton
+  needs :@record
+
+  def data(data)
+    t = {:policy_type => ui_lookup(:model => @record.towhat)}
+    data['function-data']['modal_title'] = _('Delete %{policy_type} Policy') % t
+    data['function-data']['modal_text'] = _("Are you sure you want to delete this %{policy_type} Policy?") % t
+    data
+  end
+
   def disabled?
     super
     @error_message ||= _('Policies that belong to Profiles can not be deleted') unless @policy.memberof.empty?

--- a/app/helpers/application_helper/toolbar/condition_center.rb
+++ b/app/helpers/application_helper/toolbar/condition_center.rb
@@ -37,10 +37,12 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
             _('Delete this %{condition_type} Condition') % {:condition_type => ui_lookup(:model => @condition.towhat)}
           end,
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :klass        => ApplicationHelper::Button::Condition,
-          :confirm      => proc { _("Are you sure you want to delete this %{condition_type} Condition?") % {:condition_type => ui_lookup(:model => @condition.towhat)} }),
+          :klass => ApplicationHelper::Button::ConditionDelete,
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:api_url        => 'conditions',
+                                         :component_name => 'RemoveGenericItemModal',
+                                         :controller     => 'provider_dialogs',
+                                         :tree_select    => 'root'}}),
         button(
           :condition_remove,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/condition_center.rb
+++ b/app/helpers/application_helper/toolbar/condition_center.rb
@@ -43,7 +43,7 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
                                          :display_field  => 'description',
-                                         :tree_select    => 'root'}}),
+                                         :ajax_reload    => true}}),
         button(
           :condition_remove,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/condition_center.rb
+++ b/app/helpers/application_helper/toolbar/condition_center.rb
@@ -42,6 +42,7 @@ class ApplicationHelper::Toolbar::ConditionCenter < ApplicationHelper::Toolbar::
                      'function-data' => {:api_url        => 'conditions',
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
+                                         :display_field  => 'description',
                                          :tree_select    => 'root'}}),
         button(
           :condition_remove,

--- a/app/helpers/application_helper/toolbar/miq_action_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_action_center.rb
@@ -23,6 +23,7 @@ class ApplicationHelper::Toolbar::MiqActionCenter < ApplicationHelper::Toolbar::
                      'function-data' => {:api_url        => 'actions',
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
+                                         :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Action?"),
                                          :modal_title    => N_("Delete Action"),
                                          :tree_select    => 'root'}}),

--- a/app/helpers/application_helper/toolbar/miq_action_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_action_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqActionCenter < ApplicationHelper::Toolbar::
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Action?"),
                                          :modal_title    => N_("Delete Action"),
-                                         :tree_select    => 'root'}}),
+                                         :ajax_reload    => true}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_action_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_action_center.rb
@@ -18,10 +18,14 @@ class ApplicationHelper::Toolbar::MiqActionCenter < ApplicationHelper::Toolbar::
           'pficon pficon-delete fa-lg',
           t = N_('Delete this Action'),
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Are you sure you want to delete this Action?"),
-          :klass        =>  ApplicationHelper::Button::MiqActionDelete),
+          :klass => ApplicationHelper::Button::MiqActionDelete,
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:api_url        => 'actions',
+                                         :component_name => 'RemoveGenericItemModal',
+                                         :controller     => 'provider_dialogs',
+                                         :modal_text     => N_("Are you sure you want to delete this Action?"),
+                                         :modal_title    => N_("Delete Action"),
+                                         :tree_select    => 'root'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_alert_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_center.rb
@@ -25,10 +25,14 @@ class ApplicationHelper::Toolbar::MiqAlertCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-delete fa-lg',
           t = N_('Delete this Alert'),
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Are you sure you want to delete this Alert?"),
-          :klass        => ApplicationHelper::Button::MiqAlertDelete),
+          :klass => ApplicationHelper::Button::MiqAlertDelete,
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:api_url        => 'alerts', # TODO missing delete action
+                                         :component_name => 'RemoveGenericItemModal',
+                                         :controller     => 'provider_dialogs',
+                                         :modal_text     => N_("Are you sure you want to delete this Alert?"),
+                                         :modal_title    => N_("Delete Alert"),
+                                         :tree_select    => 'root'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_alert_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_center.rb
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::MiqAlertCenter < ApplicationHelper::Toolbar::B
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Alert?"),
                                          :modal_title    => N_("Delete Alert"),
-                                         :tree_select    => 'root'}}),
+                                         :ajax_reload    => true}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_alert_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_center.rb
@@ -30,6 +30,7 @@ class ApplicationHelper::Toolbar::MiqAlertCenter < ApplicationHelper::Toolbar::B
                      'function-data' => {:api_url        => 'alerts', # TODO missing delete action
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
+                                         :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Alert?"),
                                          :modal_title    => N_("Delete Alert"),
                                          :tree_select    => 'root'}}),

--- a/app/helpers/application_helper/toolbar/miq_alert_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::MiqAlertCenter < ApplicationHelper::Toolbar::B
           t,
           :klass => ApplicationHelper::Button::MiqAlertDelete,
           :data  => {'function'      => 'sendDataWithRx',
-                     'function-data' => {:api_url        => 'alerts', # TODO missing delete action
+                     'function-data' => {:api_url        => 'alert_definitions',
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
                                          :display_field  => 'description',

--- a/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
@@ -29,6 +29,7 @@ class ApplicationHelper::Toolbar::MiqAlertProfileCenter < ApplicationHelper::Too
                      'function-data' => {:api_url        => 'alert_profiles',  # TODO missing collection
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
+                                         :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Alert Profile?"),
                                          :modal_title    => N_("Delete Alert Profile"),
                                          :tree_select    => 'root'}}),

--- a/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::MiqAlertProfileCenter < ApplicationHelper::Too
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Alert Profile?"),
                                          :modal_title    => N_("Delete Alert Profile"),
-                                         :tree_select    => 'root'}}),
+                                         :ajax_reload    => true}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::MiqAlertProfileCenter < ApplicationHelper::Too
           t = N_('Delete this Alert Profile'),
           t,
           :data  => {'function'      => 'sendDataWithRx',
-                     'function-data' => {:api_url        => 'alert_profiles',  # TODO missing collection
+                     'function-data' => {:api_url        => 'alert_definition_profiles',
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
                                          :display_field  => 'description',

--- a/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_alert_profile_center.rb
@@ -25,9 +25,13 @@ class ApplicationHelper::Toolbar::MiqAlertProfileCenter < ApplicationHelper::Too
           'pficon pficon-delete fa-lg',
           t = N_('Delete this Alert Profile'),
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :confirm      => N_("Are you sure you want to delete this Alert Profile?")),
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:api_url        => 'alert_profiles',  # TODO missing collection
+                                         :component_name => 'RemoveGenericItemModal',
+                                         :controller     => 'provider_dialogs',
+                                         :modal_text     => N_("Are you sure you want to delete this Alert Profile?"),
+                                         :modal_title    => N_("Delete Alert Profile"),
+                                         :tree_select    => 'root'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -40,11 +40,13 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
             _('Delete this %{policy_type} Policy') % {:policy_type => ui_lookup(:model => @policy.towhat)}
           end,
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :klass        => ApplicationHelper::Button::PolicyDelete,
-          :confirm      => proc { _("Are you sure you want to delete this %{policy_type} Policy?") % {:policy_type => ui_lookup(:model => @policy.towhat)} },
-          :options      => {:feature => 'policy_delete'}),
+          :klass   => ApplicationHelper::Button::PolicyDelete,
+          :options => {:feature => 'policy_delete'},
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => {:api_url        => 'policies',
+                                           :component_name => 'RemoveGenericItemModal',
+                                           :controller     => 'provider_dialogs',
+                                           :tree_select    => 'root'}}),
         button(
           :condition_edit,
           'pficon pficon-add-circle-o fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -47,7 +47,7 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
                                            :component_name => 'RemoveGenericItemModal',
                                            :controller     => 'provider_dialogs',
                                            :display_field  => 'description',
-                                           :tree_select    => 'root'}}),
+                                           :ajax_reload    => true}}),
         button(
           :condition_edit,
           'pficon pficon-add-circle-o fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -46,6 +46,7 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
                        'function-data' => {:api_url        => 'policies',
                                            :component_name => 'RemoveGenericItemModal',
                                            :controller     => 'provider_dialogs',
+                                           :display_field  => 'description',
                                            :tree_select    => 'root'}}),
         button(
           :condition_edit,

--- a/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
@@ -19,10 +19,14 @@ class ApplicationHelper::Toolbar::MiqPolicyProfileCenter < ApplicationHelper::To
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Policy Profile'),
           t,
-          :url_parms    => "main_div",
-          :send_checked => true,
           :klass        => ApplicationHelper::Button::ReadOnly,
-          :confirm      => N_("Are you sure you want to remove this Policy Profile?")),
+          :data  => {'function'      => 'sendDataWithRx',
+                     'function-data' => {:api_url        => 'policy_profiles',
+                                         :component_name => 'RemoveGenericItemModal',
+                                         :controller     => 'provider_dialogs',
+                                         :modal_text     => N_("Are you sure you want to delete this Policy Profile?"),
+                                         :modal_title    => N_("Delete Policy Profile"),
+                                         :tree_select    => 'root'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::MiqPolicyProfileCenter < ApplicationHelper::To
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Policy Profile?"),
                                          :modal_title    => N_("Delete Policy Profile"),
-                                         :tree_select    => 'root'}}),
+                                         :ajax_reload    => true}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_profile_center.rb
@@ -24,6 +24,7 @@ class ApplicationHelper::Toolbar::MiqPolicyProfileCenter < ApplicationHelper::To
                      'function-data' => {:api_url        => 'policy_profiles',
                                          :component_name => 'RemoveGenericItemModal',
                                          :controller     => 'provider_dialogs',
+                                         :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Policy Profile?"),
                                          :modal_title    => N_("Delete Policy Profile"),
                                          :tree_select    => 'root'}}),

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -64,19 +64,22 @@ class RemoveGenericItemModal extends React.Component {
   }
 
   componentDidMount() {
-    let apiPromises = [];
     const itemsIds = this.props.recordId ? [this.props.recordId] : _.uniq(this.props.gridChecks);
+    const { api_url, display_field = 'name' } = this.props.modalData;
 
     // Load modal data from API
-    itemsIds.forEach(item => apiPromises.push(API.get(`/api/${this.props.modalData.api_url}/${item}`)));
-    Promise.all(apiPromises)
-      .then(apiData => apiData.map(item => (
-        {id:   item.id,
-         name: item.name})))
-      .then(data => this.setState({data: data, loaded: true}))
+    Promise.all(itemsIds.map((item) => API.get(`/api/${api_url}/${item}`)))
+      .then((apiData) => apiData.map((item) => ({
+        id: item.id,
+        name: item[display_field],
+      })))
+      .then((data) => this.setState({
+        data,
+        loaded: true,
+      }))
       .then(() => this.props.dispatch({
         type: 'FormButtons.saveable',
-        payload: true
+        payload: true,
       }));
 
     // Buttons setup

--- a/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
+++ b/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
@@ -102,7 +102,11 @@ describe('RemoveGenericItemModal', () => {
     const component = mount(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />);
 
     setImmediate(() => {
-      removeItems(component.childAt(0).state().data, modalData.api_url, modalData.async_delete, modalData.redirect_url);
+      removeItems(component.childAt(0).state().data, {
+        apiUrl: modalData.api_url,
+        asyncDelete: modalData.async_delete,
+        redirectUrl: modalData.redirect_url,
+      });
       expect(fetchMock.called(url1)).toBe(true);
       expect(fetchMock.called(postUrl)).toBe(true);
       done();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2105,12 +2105,10 @@ Rails.application.routes.draw do
         accordion_select
         action_edit
         action_field_changed
-        alert_delete
         alert_edit
         alert_field_changed
         alert_profile_assign
         alert_profile_assign_changed
-        alert_profile_delete
         alert_profile_edit
         alert_profile_field_changed
         button

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -51,27 +51,6 @@ describe MiqPolicyController do
       end
     end
 
-    context '#alert_profile_delete' do
-      before do
-        @ap = FactoryBot.create(:miq_alert_set)
-        controller.instance_variable_set(:@sb, :trees => {:alert_profile_tree => {:active_node => "xx-Vm_ap-#{@ap.id}"}}, :active_tree => :alert_profile_tree)
-        allow(controller).to receive(:replace_right_cell)
-      end
-
-      it 'Refuses to delete a non-existent profile' do
-        controller.params = {:id => @ap.id + 1, :button => 'delete'}
-        controller.alert_profile_delete
-        expect(assigns(:flash_array).first[:message]).to include("Alert Profile no longer exists")
-      end
-
-      it 'Deletes an existing profile' do
-        controller.params = {:id => @ap.id, :button => 'delete'}
-        expect(controller).to receive(:process_alert_profiles).with([@ap.id], 'destroy').and_return(nil)
-        controller.alert_profile_delete
-        expect(controller.send(:flash_errors?)).not_to be_truthy
-      end
-    end
-
     context "#alert_profile_edit" do
       before do
         controller.instance_variable_set(:@sb,

--- a/spec/controllers/miq_policy_controller/alerts_spec.rb
+++ b/spec/controllers/miq_policy_controller/alerts_spec.rb
@@ -1,25 +1,5 @@
 describe MiqPolicyController do
   context "::Alerts" do
-    describe '#alert_delete' do
-      let(:alert) { FactoryBot.create(:miq_alert, :read_only => readonly) }
-
-      before { login_as FactoryBot.create(:user, :features => "alert_delete") }
-
-      context 'read only alert' do
-        let(:readonly) { true }
-
-        it 'renders a flash message' do
-          controller.params[:id] = alert.id
-          controller.instance_variable_set(:@sb, {})
-          expect(controller).to receive(:x_node)
-          expect(controller).to receive(:get_node_info)
-          expect(controller).to receive(:replace_right_cell)
-          expect(controller).not_to receive(:process_alerts)
-          controller.send(:alert_delete)
-        end
-      end
-    end
-
     context "alert edit" do
       before do
         login_as FactoryBot.create(:user, :features => "alert_admin")

--- a/spec/helpers/application_helper/buttons/condition_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/condition_delete_spec.rb
@@ -1,4 +1,4 @@
-describe ApplicationHelper::Button::Condition do
+describe ApplicationHelper::Button::ConditionDelete do
   describe "#role_allows_feature?" do
     let(:session) { {} }
     before do
@@ -23,7 +23,7 @@ describe ApplicationHelper::Button::Condition do
       @condition = FactoryBot.create(:condition)
       sandbox = {:active_tree => :condition_tree}
       @view_context = setup_view_context_with_sandbox(sandbox)
-      @button = described_class.new(@view_context, {}, {'condition' => @condition}, {:child_id => "condition_delete"})
+      @button = described_class.new(@view_context, {}, {'record' => @condition}, {:child_id => "condition_delete"})
     end
 
     it "will be disabled" do

--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -52,6 +52,7 @@ describe TreeBuilderSections do
                                                :controller_name => @controller_name,
                                                :current_tenant  => @current_tenant)
     end
+
     it 'set init options correctly' do
       tree_options = @sections_tree.send(:tree_init_options)
       expect(tree_options).to eq(
@@ -63,12 +64,14 @@ describe TreeBuilderSections do
         :check_url    => "/controller_name/sections_field_changed/"
       )
     end
+
     it 'set locals for render correctly' do
       locals = @sections_tree.send(:set_locals_for_render)
       expect(locals[:check_url]).to eq("/#{@controller_name}/sections_field_changed/")
       expect(locals[:oncheck]).to eq("miqOnCheckSections")
       expect(locals[:hierarchical_check]).to eq(true)
     end
+
     it 'sets roots correctly' do
       roots = @sections_tree.send(:x_get_tree_roots)
       expect(roots).to eq([{:id         => "group_Properties",

--- a/spec/routing/miq_policy_routing_spec.rb
+++ b/spec/routing/miq_policy_routing_spec.rb
@@ -44,12 +44,6 @@ describe 'routes for MiqPolicyController' do
     end
   end
 
-  describe '#alert_profile_delete' do
-    it 'routes with POST' do
-      expect(post("/#{controller_name}/alert_profile_delete")).to route_to("#{controller_name}#alert_profile_delete")
-    end
-  end
-
   describe '#alert_profile_edit' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/alert_profile_edit")).to route_to("#{controller_name}#alert_profile_edit")


### PR DESCRIPTION
This changes all deletions in Control > Explorer (alert_profiles, alerts, conditions, miq_actions, policies, policy_profiles)  to use the API.

Continuing @mzazrivec 's effort (https://github.com/ManageIQ/manageiq-ui-classic/pull/6812 and others), this uses `RemoveGenericItemModal` on the UI side.

Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10722 + https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10521 by not using the uuid in `name`, but preferring the name in `description` when asking for confirmation - added a `display_field` option for `RemoveGenericItemModal` to achieve that.