### PR TITLE
Moved 'Firmware Registries' under 'Physical Infrastructure' menu

### DIFF
--- a/app/controllers/firmware_registry_controller.rb
+++ b/app/controllers/firmware_registry_controller.rb
@@ -10,7 +10,7 @@ class FirmwareRegistryController < ApplicationController
   include Mixins::GenericShowMixin
   include Mixins::BreadcrumbsMixin
 
-  menu_section :firmware_registry
+  menu_section :phy
   toolbar :firmware_registry
 
   def self.display_methods
@@ -42,7 +42,7 @@ class FirmwareRegistryController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _('Compute')},
-        {:title => _('Infrastructure')},
+        {:title => _('Physical Infrastructure')},
         {:title => _('Firmware Registries'), :url => controller_url},
       ],
     }

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -99,7 +99,6 @@ module Menu
           Menu::Item.new('resource_pool',     N_('Resource Pools'),    'resource_pool',              {:feature => 'resource_pool_show_list'},         '/resource_pool/show_list'),
           Menu::Item.new('storage',           N_('Datastores'),        'storage',                    {:feature => 'storage_show_list'},               '/storage/explorer'),
           Menu::Item.new('pxe',               N_('PXE'),               'pxe',                        {:feature => 'pxe', :any => true},               '/pxe/explorer'),
-          Menu::Item.new('firmware_registry', N_('Firmware Registry'), 'firmware_registry',          {:feature => 'firmware_registry', :any => true}, '/firmware_registry/show_list'),
           Menu::Item.new('switch',            N_('Networking'),        'infra_networking',           {:feature => 'infra_networking', :any => true},  '/infra_networking/explorer'),
           Menu::Item.new('infra_topology',    N_('Topology'),          'infra_topology',             {:feature => 'infra_topology', :any => true},    '/infra_topology/show')
         ])
@@ -114,6 +113,7 @@ module Menu
           Menu::Item.new('physical_server',         N_('Servers'),   'physical_server',         {:feature => 'physical_server_show_list'},             '/physical_server/show_list'),
           Menu::Item.new('physical_storage',        N_('Storages'),  'physical_storage',        {:feature => 'physical_storage_show_list'},            '/physical_storage/show_list'),
           Menu::Item.new('physical_switch',         N_('Switches'),  'physical_switch',         {:feature => 'physical_switch_show_list'},             '/physical_switch/show_list'),
+          Menu::Item.new('firmware_registry',       N_('Firmware Registry'), 'firmware_registry', {:feature => 'firmware_registry', :any => true},     '/firmware_registry/show_list'),
           Menu::Item.new('physical_infra_topology', N_('Topology'),  'physical_infra_topology', {:feature => 'physical_infra_topology', :any => true}, '/physical_infra_topology/show'),
         ])
       end

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -24,7 +24,7 @@ describe Menu::DefaultMenu do
     it "shows correct titles for Hosts & Clusters" do
       menu = Menu::DefaultMenu.infrastructure_menu_section.items.map(&:name)
       result = ["Providers", "Clusters", "Hosts", "Virtual Machines", "Resource Pools",
-                "Datastores", "PXE", "Firmware Registry", "Networking", "Topology"]
+                "Datastores", "PXE", "Networking", "Topology"]
       expect(menu).to eq(result)
     end
   end


### PR DESCRIPTION
Fixes #7206

before
![Screenshot from 2020-07-16 15-08-42](https://user-images.githubusercontent.com/3450808/87712169-4a02fe80-c776-11ea-9b8c-531ded7078b9.png)

![Screenshot from 2020-07-16 14-56-06](https://user-images.githubusercontent.com/3450808/87711632-8a15b180-c775-11ea-949b-34604d3b19dc.png)

after
![Screenshot from 2020-07-16 14-57-37](https://user-images.githubusercontent.com/3450808/87711626-871ac100-c775-11ea-95fc-52493b12cba2.png)

![Screenshot from 2020-07-16 14-57-51](https://user-images.githubusercontent.com/3450808/87711616-84b86700-c775-11ea-9923-46820e2d32f6.png)
