### PR TITLE
Add I18N support to expression type in alerts.

### DIFF
--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -93,7 +93,7 @@
                   -# Expression is an MiqExpression
                   = _('Expression')
                 - else
-                  = h(MiqAlert.expression_types(@alert.db)[@alert.expression[:eval_method]])
+                  = h(_(MiqAlert.expression_types(@alert.db)[@alert.expression[:eval_method]]))
 
         -# Expression driving event
         - if @edit
@@ -181,7 +181,7 @@
         - else
           - if @alert.expression[:eval_method] != "nothing"
             %h3
-              = h(MiqAlert.expression_types(@alert.db)[@alert.expression[:eval_method]])
+              = h(_(MiqAlert.expression_types(@alert.db)[@alert.expression[:eval_method]]))
               = _('Parameters')
             .form-horizontal
               - MiqAlert.expression_options(@alert.expression[:eval_method]).each do |eo|


### PR DESCRIPTION
<img width="625" alt="Screen Shot 2020-07-16 at 3 11 31 PM" src="https://user-images.githubusercontent.com/2593270/87712443-a6661e00-c776-11ea-8f44-d031ba1f019c.png">

@miq-bot add_label bug, jansa/yes, internationalization