### PR TITLE
Fix failing tree_builder_sections_spec

### DIFF
--- a/spec/presenters/tree_builder_sections_spec.rb
+++ b/spec/presenters/tree_builder_sections_spec.rb
@@ -76,15 +76,15 @@ describe TreeBuilderSections do
                             :tip        => "Properties",
                             :image      => false,
                             :selectable => false,
-                            :nodes      => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
+                            :nodes      => [{:name => :_model_, :header => "File", :group => "Properties"}]}])
     end
 
     it 'sets children correctly' do
       root = @sections_tree.send(:x_get_tree_roots).first
       kids = @sections_tree.send(:x_get_tree_hash_kids, root, false)
       expect(kids).to eq([{:id         => "group_Properties:_model_",
-                           :text       => "Filesystem",
-                           :tip        => "Filesystem",
+                           :text       => "File",
+                           :tip        => "File",
                            :image      => false,
                            :selectable => false,
                            :checked    => true,


### PR DESCRIPTION
This is to fix the following CI failure:
```
1) TreeBuilderSections TreeBuilderSections sets roots correctly
     Failure/Error:
       expect(roots).to eq([{:id         => "group_Properties",
                             :text       => "Properties",
                             :tip        => "Properties",
                             :image      => false,
                             :selectable => false,
                             :nodes      => [{:name => :_model_, :header => "Filesystem", :group => "Properties"}]}])
     
       expected: [{:id=>"group_Properties", :image=>false, :nodes=>[{:group=>"Properties", :header=>"Filesystem", :name=>:_model_}], :selectable=>false, :text=>"Properties", :tip=>"Properties"}]
            got: [{:id=>"group_Properties", :image=>false, :nodes=>[{:group=>"Properties", :header=>"File", :name=>:_model_}], :selectable=>false, :text=>"Properties", :tip=>"Properties"}]
     
       (compared using ==)
     
       Diff:
       @@ -1,6 +1,6 @@
        [{:id=>"group_Properties",
          :image=>false,
       -  :nodes=>[{:group=>"Properties", :header=>"Filesystem", :name=>:_model_}],
       +  :nodes=>[{:group=>"Properties", :header=>"File", :name=>:_model_}],
          :selectable=>false,
          :text=>"Properties",
          :tip=>"Properties"}]
       
     # ./spec/presenters/tree_builder_sections_spec.rb:74:in `block (3 levels) in <top (required)>'
  2) TreeBuilderSections TreeBuilderSections sets children correctly
     Failure/Error:
       expect(kids).to eq([{:id         => "group_Properties:_model_",
                            :text       => "Filesystem",
                            :tip        => "Filesystem",
                            :image      => false,
                            :selectable => false,
                            :checked    => true,
                            :nodes      => []}])
     
       expected: [{:checked=>true, :id=>"group_Properties:_model_", :image=>false, :nodes=>[], :selectable=>false, :text=>"Filesystem", :tip=>"Filesystem"}]
            got: [{:checked=>true, :id=>"group_Properties:_model_", :image=>false, :nodes=>[], :selectable=>false, :text=>"File", :tip=>"File"}]
     
       (compared using ==)
     
       Diff:
       @@ -3,6 +3,6 @@
          :image=>false,
          :nodes=>[],
          :selectable=>false,
       -  :text=>"Filesystem",
       -  :tip=>"Filesystem"}]
       +  :text=>"File",
       +  :tip=>"File"}]
       
     # ./spec/presenters/tree_builder_sections_spec.rb:85:in `block (3 levels) in <top (required)>'
```

coming from https://github.com/ManageIQ/manageiq/pull/20361