### PR TITLE
Delete the unused users route form AutomationManagerController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,7 +187,6 @@ Rails.application.routes.draw do
         tree_autoload
         tree_select
         cs_form_field_changed
-        users
         wait_for_task
       ) +
         adv_search_post +


### PR DESCRIPTION
I think this is a dead route, just a biproduct of some copy-paste.