### PR TITLE
Remove the unused show_association/show_details routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1776,7 +1776,6 @@ Rails.application.routes.draw do
         perf_top_chart
         protect
         show
-        show_association
         show_list
         start
         tagging_edit
@@ -2764,8 +2763,6 @@ Rails.application.routes.draw do
         reload
         sections_field_changed
         show
-        show_association
-        show_details
         show_list
         storage_list
         storage_pod_list

--- a/spec/routing/host_routing_spec.rb
+++ b/spec/routing/host_routing_spec.rb
@@ -207,12 +207,6 @@ describe "routes for HostController" do
     end
   end
 
-  describe "#show_association" do
-    it "routes with GET" do
-      expect(get("/host/show_association")).to route_to("host#show_association")
-    end
-  end
-
   describe "#start" do
     it "routes with GET" do
       expect(get("/host/start")).to route_to("host#start")

--- a/spec/routing/storage_routing_spec.rb
+++ b/spec/routing/storage_routing_spec.rb
@@ -85,18 +85,6 @@ describe "routes for StorageController" do
     end
   end
 
-  describe "#show_details" do
-    it "routes with POST" do
-      expect(post("/#{controller_name}/show_details")).to route_to("#{controller_name}#show_details")
-    end
-  end
-
-  describe "#show_association" do
-    it "routes with POST" do
-      expect(post("/#{controller_name}/show_association")).to route_to("#{controller_name}#show_association")
-    end
-  end
-
   describe "#snapshot_files" do
     it "routes with GET" do
       expect(get("/#{controller_name}/snapshot_files")).to route_to("#{controller_name}#snapshot_files")


### PR DESCRIPTION
The definition of these methods expect arguments, which is not possible when you want to have routes.