### PR TITLE
[JANSA] Add missing routes for OpsController actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2474,6 +2474,7 @@ Rails.application.routes.draw do
         rbac_user_field_changed
         rbac_users_list
         region_edit
+        region_form_field_changed
         repo_default_name
         restart_server
         rhn_buttons
@@ -2498,6 +2499,7 @@ Rails.application.routes.draw do
         upload_favicon
         wait_for_task
         x_button
+        x_show
         zone_edit
         zone_field_changed
       ) + exp_post + dialog_runner_post


### PR DESCRIPTION
Reproducer:
Click on Settings -> Regions (tree) -> Regions(list) - error displayed

caused by [this](https://github.com/ManageIQ/manageiq-ui-classic/pull/7117)  but according to this [comment](https://github.com/ManageIQ/manageiq-ui-classic/pull/7117#issuecomment-644787637)  we should not backport the PR to jansa.


other removed routes from [the PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/7117) or haml can stay removed.


@miq-bot assign @skateman 

@miq-bot add_label bug

cc @gtanzillo 
