### PR TITLE
Disable the option to select LDAP and LDAPS

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -50,10 +50,6 @@ module OpsHelper
 
   def auth_mode_name
     case ::Settings.authentication.mode.downcase
-    when 'ldap'
-      _('LDAP')
-    when 'ldaps'
-      _('LDAPS')
     when 'amazon'
       _('Amazon')
     when 'httpd'

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -27,94 +27,12 @@
         = _("Mode")
       .col-md-8
         = select_tag('authentication_mode',
-                      options_for_select([[_("Database"), "database"], [_("LDAP"), "ldap"], [_("LDAPS"), "ldaps"],
-                      [_("Amazon"), "amazon"], [_("External (httpd)"), "httpd"]],
+                      options_for_select([[_("Database"), "database"], [_("Amazon"), "amazon"], [_("External (httpd)"), "httpd"]],
                       @edit[:new][:authentication][:mode]),
                       :class    => "selectpicker")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('authentication_mode', "#{url}")
-  %hr
-  = hidden_div_if(!%w(ldap ldaps).include?(@edit[:new][:authentication][:mode]), :id => "ldap_div") do
-    %h3= _("LDAP Settings")
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _("LDAP Host Names")
-        .col-md-8
-          = text_field_tag("authentication_ldaphost_1",
-                            @edit[:new][:authentication][:ldaphost][0],
-                            :maxlength => 50,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %br/
-          = text_field_tag("authentication_ldaphost_2",
-                            @edit[:new][:authentication][:ldaphost][1],
-                            :maxlength => 50,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %br/
-          = text_field_tag("authentication_ldaphost_3",
-                            @edit[:new][:authentication][:ldaphost][2],
-                            :maxlength => 50,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      .form-group
-        %label.col-md-2.control-label
-          = _("LDAP Port")
-        .col-md-8
-          = text_field_tag("authentication_ldapport",
-                            @edit[:new][:authentication][:ldapport],
-                            :maxlength => 6,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      .form-group
-        %label.col-md-2.control-label
-          = _("User Type")
-        .col-md-8
-          = select_tag('authentication_user_type',
-                      options_for_select([["User Principal Name", "userprincipalname"],
-                      ["E-mail Address", "mail"],
-                      ["Distinguished Name (CN=<user>)", "dn-cn"],
-                      ["Distinguished Name (UID=<user>)", "dn-uid"],
-                      ["SAM Account Name", "samaccountname"]],
-                      @edit[:new][:authentication][:user_type]),
-                      :class    => "selectpicker",
-                      "data-miq_observe" => {:url => url}.to_json)
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('authentication_user_type', "#{url}")
-
-      .form-group
-        %label.col-md-2.control-label
-          = _("Domain Prefix: <domain>\\<user>")
-        .col-md-8
-          = text_field_tag("authentication_domain_prefix",
-                            @edit[:new][:authentication][:domain_prefix],
-                            :maxlength => 255,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      .form-group
-        %label.col-md-2.control-label
-          = _("User Suffix:")
-          - if @edit[:new][:authentication][:user_type] == "dn-cn"
-            %span#upn-mail_prefix{:style => "display:none"}= h("<user>@")
-            %span#dn-cn_prefix= h("CN=<user>,")
-            %span#dn-uid_prefix{:style => "display:none"}= h("UID=<user>,")
-          - elsif @edit[:new][:authentication][:user_type] == "dn-uid"
-            %span#upn-mail_prefix{:style => "display:none"}= h("<user>@")
-            %span#dn-cn_prefix{:style => "display:none"}= h("CN=<user>,")
-            %span#dn-uid_prefix= h("UID=<user>,")
-          - else
-            %span#upn-mail_prefix= h("<user>@")
-            %span#dn-cn_prefix{:style => "display:none"}= h("CN=<user>,")
-            %span#dn-uid_prefix{:style => "display:none"}= h("UID=<user>,")
-        .col-md-8
-          = text_field_tag("authentication_user_suffix",
-                            @edit[:new][:authentication][:user_suffix],
-                            :maxlength => 255,
-                            :class => "form-control",
-                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     %hr
   = hidden_div_if(@edit[:new][:authentication][:mode] != "amazon", :id => "amazon_div") do
     %h3= _("Amazon Primary AWS Account Settings for IAM")
@@ -138,79 +56,6 @@
                                 :class => "form-control",
                                 "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     %hr
-  = hidden_div_if(!%w(ldap ldaps).include?(@edit[:new][:authentication][:mode]), :id => "ldap_role_div") do
-    %h3
-      = _("Role Settings")
-    .form-horizontal
-      .form-group
-        %label.col-md-2.control-label
-          = _("Get User Groups from LDAP")
-        .col-md-8
-          = check_box_tag("ldap_role", "1",
-                          @edit[:new][:authentication][:ldap_role],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-    = hidden_div_if(@edit[:new][:authentication][:ldap_role], :id => "ldap_default_group_div") do
-      .form-horizontal
-        .form-group
-          %label.col-md-2.control-label
-            = _("Default Group for Users")
-          .col-md-8
-            = select_tag('authentication_default_group_for_users',
-                          options_for_select([["<No Default Group>", nil]] + MiqGroup.pluck(:description).sort,
-                          @edit[:new][:authentication][:default_group_for_users]),
-                          :class    => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('authentication_default_group_for_users', "#{url}")
-    = hidden_div_if(!@edit[:new][:authentication][:ldap_role], :id => "ldap_role_details_div") do
-      .form-horizontal
-        .form-group#get_roles_now{:style => @edit[:new][:authentication][:user_proxies].blank? ? "display: none" : ""}
-          %label.col-md-2.control-label
-            = _("Get Groups from Home Forest")
-          .col-md-8
-            = check_box_tag("get_direct_groups", "1",
-                            @edit[:new][:authentication][:get_direct_groups],
-                            "data-miq_observe_checkbox" => {:url => url}.to_json)
-        .form-group
-          %label.col-md-2.control-label
-            = _("Follow Referrals")
-          .col-md-8
-            = check_box_tag("follow_referrals", "1",
-                            @edit[:new][:authentication][:follow_referrals],
-                            "data-miq_observe_checkbox" => {:url => url}.to_json)
-        .form-group
-          %label.col-md-2.control-label
-            = _("Base DN")
-          .col-md-8
-            = text_field_tag("authentication_basedn",
-                                @edit[:new][:authentication][:basedn],
-                                :maxlength => 255,
-                                :class => "form-control",
-                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        .form-group
-          %label.col-md-2.control-label
-            = _("Bind DN")
-          .col-md-8
-            = text_field_tag("authentication_bind_dn",
-                                @edit[:new][:authentication][:bind_dn],
-                                :maxlength => 255,
-                                :class => "form-control",
-                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        .form-group
-          %label.col-md-2.control-label
-            = _("Bind Password")
-          .col-md-8
-            = password_field_tag("authentication_bind_pwd", '',
-                                :maxlength         => 128,
-                                :placeholder       => placeholder_if_present(@edit[:new][:authentication][:bind_pwd]),
-                                :class => "form-control",
-                                "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        .form-group
-          .col-md-10{:align => "right"}
-            = render :partial => 'ldap_verify_button', :locals => {:id => "#{@sb[:active_tab].split('_').last}"}
-
-  = hidden_div_if(!@edit[:new][:authentication][:ldap_role], :id => "user_proxies_div") do
-    = render :partial => 'ldap_forest_entries', :locals => {:entry => nil, :edit => false}
 
   = hidden_div_if(@edit[:new][:authentication][:mode] != "amazon", :id => "amazon_role_div") do
     %h3

--- a/spec/helpers/ops_helper_spec.rb
+++ b/spec/helpers/ops_helper_spec.rb
@@ -1,7 +1,7 @@
 describe OpsHelper do
   describe '#auth_mode_name' do
-    modes = %w(ldap ldaps amazon httpd database)
-    modes_pretty = %w(LDAP LDAPS Amazon External\ Authentication Database)
+    modes = %w(amazon httpd database)
+    modes_pretty = %w(Amazon External\ Authentication Database)
 
     modes.zip modes_pretty.each do |mode, mode_pretty|
       it "Returns #{mode_pretty} when mode is #{mode}" do

--- a/spec/helpers/ops_helper_spec.rb
+++ b/spec/helpers/ops_helper_spec.rb
@@ -1,7 +1,7 @@
 describe OpsHelper do
   describe '#auth_mode_name' do
-    modes = %w(amazon httpd database)
-    modes_pretty = %w(Amazon External\ Authentication Database)
+    modes = %w[amazon httpd database]
+    modes_pretty = %w[Amazon External\ Authentication Database]
 
     modes.zip modes_pretty.each do |mode, mode_pretty|
       it "Returns #{mode_pretty} when mode is #{mode}" do

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -34,20 +34,6 @@ describe 'ops/_rbac_group_details.html.haml' do
                                               :selected_nodes => {})
     end
 
-    it 'should show "Look up groups" checkbox and label for auth mode ldap' do
-      stub_settings(:authentication => { :mode => 'ldap' }, :server => {})
-      render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup')
-      expect(rendered).to include('Look up LDAP Groups')
-    end
-
-    it 'should show "Look up groups" checkbox and label for auth mode ldaps' do
-      stub_settings(:authentication => { :mode => 'ldaps' }, :server => {})
-      render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup')
-      expect(rendered).to include('Look up LDAPS Groups')
-    end
-
     it 'should not show "Look up groups" checkbox and label for auth mode amazon' do
       stub_settings(:authentication => { :mode => 'amazon' }, :server => {})
       render :partial => 'ops/rbac_group_details'


### PR DESCRIPTION
This PR will disable the option to select options LDAP and LDAPS from the authentication page,
which is how the deprecated MiqLdap is configured.

The plan is to disable the option to select LDAP and LDAPS from the UI first.
Then remove MiqLdap from the back end a release later.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7227




Links
----------------
* The associated back end issue is: [20017](https://github.com/ManageIQ/manageiq/issues/20017)


Steps for Testing/QA [Optional]
-------------------------------

To test navigate to the authentication page, Settings -> Server -> Authentication
Then confirm `LDAP` and `LDAPS` are no longer valid options in the `Mode` pull down.
 
