### PR TITLE
Check that yarn is installed when updating

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -8,6 +8,7 @@ namespace :update do
           warn "Skipping yarn install for #{engine.name} on travis #{ENV['TEST_SUITE']}"
           next
         end
+        system("which yarn >/dev/null") || abort("\n== You have to install yarn ==")
         system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
       end
     end


### PR DESCRIPTION
If yarn isn't installed the user gets a vague "yarn failed in #{plugin}"
error which isn't obvious what failed.

We can check that the command exists prior to running yarn and thus
print a helpful error message.

Before:
```
$ rake update:ui

== yarn failed in /home/agrare/.gems/2.7.0/bundler/gems/manageiq-providers-lenovo-c1b52532c712 ==
```

After:
```
$ rake update:ui

== You have to install yarn ==
```