### PR TITLE
Fix failing automation spec - missing name

### DIFF
--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -149,6 +149,7 @@ describe AutomationManagerController do
       post :edit, :params => { :button     => 'save',
                                :id         => @automation_manager1.id,
                                :zone       => new_zone.name,
+                               :name       => 'foobar',
                                :url        => automation_provider1.url,
                                :verify_ssl => automation_provider1.verify_ssl }
       expect(response.status).to eq(200)


### PR DESCRIPTION
related to https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/229

name is required, so providing one

Cc @agrare 

---

Fixes travis failure...

https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/364237496#L2495

```
  1) AutomationManagerController#edit should save the zone field
     Failure/Error: @provider.name       = params[:name]
     
     NoMethodError:
       undefined method `sub' for nil:NilClass
     # ./app/controllers/mixins/automation_manager_controller_mixin.rb:178:in `sync_form_to_instance'
     # ./app/controllers/mixins/manager_controller_mixin.rb:17:in `add_provider'
     # ./app/controllers/mixins/manager_controller_mixin.rb:108:in `edit'
     # ./spec/controllers/automation_manager_controller_spec.rb:150:in `block (3 levels) in <top (required)>'
```

the name is required and the test was not providing it.