### PR TITLE
[JANSA] Dont walk empty child nodes for parent check

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -503,11 +503,13 @@ window.miqInitTree = function(options, tree) {
     // Process nodes bottom-to-top
     while (parents.length > 0) {
       var node = parents.pop();
-      node.state.checked = node.nodes.map(function(node) {
-        return node.state ? node.state.checked : false;
-      }).reduce(function(acc, curr) {
-        return (acc === curr) ? acc : 'undefined';
-      });
+      if (node.nodes.length > 0) {
+        node.state.checked = node.nodes.map(function(node) {
+          return node.state ? node.state.checked : false;
+        }).reduce(function(acc, curr) {
+          return (acc === curr) ? acc : 'undefined';
+        });
+      }
     }
   }
 


### PR DESCRIPTION
1. Create a role with `Everything > Services > Catalog Explorer > Catalog Items` only
2. Create a user using the above role
3. Create a service dialog and catalog item using the created dialog
4. As the newly created user, navigate to `Services > Catalogs > Catalog Items > [the above created catalog item]`
5. Observe the following error in javascript console:
```
react_devtools_backend.js:2273 TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at miqInitTree (application-8c25e4425d87073edf7151217c873f7544b8598c0754dc3e79329ecb198b661a.js:3)
    at eval (eval at globalEval (jquery.js:343), <anonymous>:1:1)
    at eval (<anonymous>)
    at Function.globalEval (jquery.js:343)
    at ye (jquery.js:5291)
    at _.fn.init.append (jquery.js:5431)
    at _.fn.init.<anonymous> (jquery.js:5525)
    at N (jquery.js:3614)
    at _.fn.init.html (jquery.js:5492)
```

This is a problem in jansa / ivanchuk, current master uses completely different implementation for tree rendering.

https://bugzilla.redhat.com/show_bug.cgi?id=1860278