### PR TITLE
Use collection name form API yaml configuration in setownership screen 

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -7,7 +7,7 @@ module Mixins
         def ownership_items_hash
           return [] unless @ownershipitems
 
-          @ownershipitems.map {|item| {:id => item.id.to_s, :kind => item.class.to_s.demodulize.underscore.pluralize} }
+          @ownershipitems.map { |item| {:id => item.id.to_s, :kind => Api::CollectionConfig.new.name_for_subclass(item.class)} }
         end
 
         included do

--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -2,6 +2,18 @@ module Mixins
   module Actions
     module VmActions
       module Ownership
+        extend ActiveSupport::Concern
+
+        def ownership_items_hash
+          return [] unless @ownershipitems
+
+          @ownershipitems.map {|item| {:id => item.id.to_s, :kind => item.class.to_s.demodulize.underscore.pluralize} }
+        end
+
+        included do
+          helper_method :ownership_items_hash
+        end
+
         # Set Ownership selected db records
         def set_ownership
           assert_privileges(params[:pressed])

--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -2,9 +2,9 @@
 
 %h3
   = _('Changes')
--# Possible values for item kind are: vms, templates, services
-= react('SetOwnershipForm', { :ownershipItems => @ownershipitems.map {|item| {:id => item.id.to_s, :kind => item.class.to_s.demodulize.underscore.pluralize} }})
+-# Possible values for item kind are: vms, templates, services, service_templates
 
+= react('SetOwnershipForm', { :ownershipItems => ownership_items_hash })
 
 %hr
 %h3


### PR DESCRIPTION
When you click on set ownership screen toolbar menu on catalog item with ansible you will get this error:

<img width="1466" alt="Screenshot 2020-07-24 at 20 57 05" src="https://user-images.githubusercontent.com/14937244/88425763-3f88da80-cdf0-11ea-9852-17363f136bf1.png">

Issue is that collection name is improperly determined from service template record what this record had was more special) model class(ServiceTemplateAnsibleTower).

I used API yaml configuration to get proper collection name and I added helper method.

@miq-bot assign @h-kataria 