### PR TITLE
webpack - make dev_server config optional

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -5,33 +5,39 @@ const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
 const { env } = require('process')
 
+const {
+  https = false,
+  host = '0.0.0.0',
+  port = '8080',
+} = settings.dev_server || {};
+
 module.exports = merge(sharedConfig, {
   mode: 'development',
   devtool: 'inline-source-map',
 
   devServer: {
     clientLogLevel: 'none',
-    https: settings.dev_server && settings.dev_server.https,
-    host: settings.dev_server && settings.dev_server.host,
-    port: settings.dev_server && settings.dev_server.port,
+    https,
+    host,
+    port,
     contentBase: output.path,
     publicPath: output.publicPath,
     compress: true,
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
     watchOptions: {
-      ignored: /node_modules/
+      ignored: /node_modules/,
     },
     proxy: {
       '/': {
-        target: `http://${settings.dev_server.host}:${env.PORT || '3000'}`,
+        target: `http://${host}:${env.PORT || '3000'}`,
         secure: false,
       },
       '/ws': {
-        target: `ws://${settings.dev_server.host}:${env.WS_PORT || env.PORT || '3000'}`,
+        target: `ws://${host}:${env.WS_PORT || env.PORT || '3000'}`,
         secure: false,
         ws: true,
       },
-    }
-  }
-})
+    },
+  },
+});

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -23,12 +23,6 @@ default: &default
 development:
   <<: *default
 
-# uncomment these to enable webpack:server
-  dev_server:
-    host: 0.0.0.0
-    port: 8080
-    https: false
-
 test:
   <<: *default
 


### PR DESCRIPTION
devServer is enabled/disabled by running webpack vs webpack-dev-server
not by commenting or uncommenting the yaml config bit

this makes webpack not fail in development when dev_server config is missing,
and moves the defaults to webpack.

Cc @NickLaMuro 