### PR TITLE
Policy detail - Conditions - replace nested Scopes/Expressions table with divs

### DIFF
--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -162,18 +162,17 @@
                   %td
                     = c.description
                   %td
+                    - if c.applies_to_exp.present?
+                      %strong
+                        = _("Scope")
+                      %div
+                        = h(MiqExpression.to_human(c.applies_to_exp))
+                      %br
+
+                    %strong
+                      = _("Expression")
                     %div
-                      %table
-                        - unless c.applies_to_exp.blank?
-                          %tr
-                            %td= _("Scope")
-                            %td
-                              = h(MiqExpression.to_human(c.applies_to_exp))
-                        %tr
-                          %td
-                            = _("Expression")
-                          %td
-                            = h(MiqExpression.to_human(c.expression))
+                      = h(MiqExpression.to_human(c.expression))
         %hr
 
       -# Events for this policy


### PR DESCRIPTION
Control > Explorer >> Policies/Policy Profiles
open policy detail, see table of Conditions

when an expression is too long, the nested table in the Scopes/Expression column wraps both the "Expression" column, and the actual expression, leading to weirdly looking text

updated to just use newlines to separate the type from the expression

(Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/11668)

---

Before:

![before3](https://user-images.githubusercontent.com/289743/88595572-c0dfa780-d052-11ea-86cb-18436d8e208d.png)

note the vertical "Expression" text that's *not* part of the regex :)


After:

![after3](https://user-images.githubusercontent.com/289743/88595597-cdfc9680-d052-11ea-9222-476f793ef64d.png)

---

With both scope and expression, before:

![before](https://user-images.githubusercontent.com/289743/88595651-f08eaf80-d052-11ea-98e8-83aa750716ae.png)

After:

![after](https://user-images.githubusercontent.com/289743/88595661-f5ebfa00-d052-11ea-8ab9-161ca76a4ab0.png)
