### PR TITLE
Change availability Zones field to non-mandatory

### DIFF
--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -40,14 +40,11 @@
     %select{"name"        => "availability_zone_id",
             "ng-model"    => "vm.cloudVolumeModel.availability_zone_id",
             "ng-options"  => "az.ems_ref as az.name for az in vm.availabilityZoneChoices",
-            "required"    => "",
             "ng-disabled" => "!vm.newRecord",
             :checkchange  => true,
             "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
-        = "<#{_('Choose')}>"
-    %span.help-block{"ng-show" => "angularForm.availability_zone_id.$error.required"}
-      = _("Required")
+        = "<#{_('None')}>"
 
 .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
   %label.col-md-2.control-label


### PR DESCRIPTION
MIQ UI volume create form should not require availability zone as a mandatory field. Openstack API also have this field as optional.
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1859388