### PR TITLE
Fixed display of `Expression` on the screen.

### DIFF
--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -165,15 +165,12 @@
                     %div
                       %table
                         - unless c.applies_to_exp.blank?
-                          %tr
-                            %td= _("Scope")
+                          %tr{:colspan => "2"}
                             %td
-                              = h(MiqExpression.to_human(c.applies_to_exp))
-                        %tr
+                              = "#{_("Scope")} #{MiqExpression.to_human(c.applies_to_exp)}"
+                        %tr{:colspan => "2"}
                           %td
-                            = _("Expression")
-                          %td
-                            = h(MiqExpression.to_human(c.expression))
+                            = "#{_("Expression")} #{MiqExpression.to_human(c.expression)}"
         %hr
 
       -# Events for this policy


### PR DESCRIPTION
When screen size was made smaller, text was going to the next line, making it difficult to read.

Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/11668

before
![b02d6385-da7e-4a7c-97e3-0e32b7dc55dc](https://user-images.githubusercontent.com/3450808/88930661-c5ba7c00-d249-11ea-8cbd-309663b6218e.png)

after
![Screenshot from 2020-07-30 09-41-24](https://user-images.githubusercontent.com/3450808/88930558-a3286300-d249-11ea-8b0e-6ac31f080077.png)

