### PR TITLE
Set form data after Reset or Save button are pressed

### DIFF
--- a/app/controllers/chargeback_assignment_controller.rb
+++ b/app/controllers/chargeback_assignment_controller.rb
@@ -46,7 +46,6 @@ class ChargebackAssignmentController < ApplicationController
     return unless load_edit("cbassign_edit__#{params[:id]}", "index")
     case params[:button]
     when "reset"
-      set_form_vars
       flash_to_session(_("All changes have been reset"), :warning)
     when "save"
       set_record_vars
@@ -59,6 +58,7 @@ class ChargebackAssignmentController < ApplicationController
         flash_to_session(_("Rate Assignments saved"))
       end
     end
+    set_form_vars
     render :update do |page|
       page << javascript_prologue
       prefix = @edit[:new][:type].downcase


### PR DESCRIPTION
Since we stay on the form screen even after pressing Save button on screen, moved call to `set_form_vars` outside case statement, we should set form data for when either of save or reset buttons are pressed. Existing code only did that when Reset was pressed.

Fixes https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/11283

