### PR TITLE
Toolbar overrides: don't overwrite existing groups

### DIFF
--- a/app/helpers/application_helper/toolbar/override.rb
+++ b/app/helpers/application_helper/toolbar/override.rb
@@ -1,3 +1,14 @@
 class ApplicationHelper::Toolbar::Override < ApplicationHelper::Toolbar::Base
-  # For now this class is empty. However we want the provider toolbar extentions to inherit from here.
+  # the provider toolbar extensions inherit from here
+
+  # prevent overriding existing buttons from toolbar overrides
+  def button_group(name, buttons)
+    super("#{id_prefix}#{name}", buttons)
+  end
+
+  private
+
+  def id_prefix
+    self.class.name + "."
+  end
 end


### PR DESCRIPTION
Right now, a plugin toolbar override can replace entire ui-classic button groups by accidentally using the same name.
If multiple plugins do that for the same entity, a random plugin would win.

By prefixing button group ids for groups from plugins, each plugin gets a unique namespace within the toolbar,
so it can still add selects and buttons, just not replace existing ones.

(I would like to solve the labeling clashes too, by prefixing plugin buttons with the plugin name, but I don't see a way of doing "class.source_engine", so without guessing from the class name, or explicitly adding the name in each override, I don't see a nice way, so we may need to solve it plugin-side.)

(It might also be nice to merge dropdowns, but not very realistic, as then we would need the buttons to have unique ids, and ids are tied to rbac features)

Example:

https://github.com/ManageIQ/manageiq-providers-nsxt/blob/master/app/helper/manageiq/providers/nsxt/toolbar_overrides/cloud_network_center.rb#L6

overrides the whole Configuration toolbar section for CloudNetworks, including in the show_list screen, even when no NSXT provider is added.

But we actually have a ui-classic Configuration toolbar, with our own Add button, the only one which works for the other providers :).


Before:

![before](https://user-images.githubusercontent.com/289743/89348805-b5b4f900-d69c-11ea-9aea-42fd6d5ef165.png)

After:

![after](https://user-images.githubusercontent.com/289743/89348822-ba79ad00-d69c-11ea-99d8-946d6935dc4c.png) ![after2](https://user-images.githubusercontent.com/289743/89348829-bcdc0700-d69c-11ea-8886-8cc488d676a8.png)

(the first Configuration is ours, the second from the provider)