### PR TITLE
Display the provider's name in the flash when cancelling edit

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -105,7 +105,13 @@ const ProviderForm = ({ providerId, kind, title, redirect }) => {
   }, [providerId]);
 
   const onCancel = () => {
-    const message = sprintf(providerId ? __('Edit of %s was cancelled by the user') : __('Add of %s was cancelled by the user'), title);
+    const message = sprintf(
+      providerId
+        ? __('Edit of %s "%s" was cancelled by the user')
+        : __('Add of %s was cancelled by the user'),
+      title,
+      initialValues && initialValues.name,
+    );
     miqRedirectBack(message, 'success', redirect);
   };
 


### PR DESCRIPTION
When we introduced DDF, the provider name was missed from the flash message when cancelling the edit of a provider.

**Before:**
![Screenshot from 2020-08-07 08-05-09](https://user-images.githubusercontent.com/649130/89614446-bdcf8d00-d884-11ea-8aa5-e01e350ed1b8.png)

**After:**
![Screenshot from 2020-08-07 08-01-53](https://user-images.githubusercontent.com/649130/89614453-c0ca7d80-d884-11ea-8a0b-96cee2d1e63e.png)

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818
Fixes #7244