### PR TITLE
switch parent to ancestry (miq_ae_namespaces)

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -56,7 +56,7 @@ class TreeController < ApplicationController
     begin
       # Collect all the db records based on the parsed fqname
       open_nodes = namespace.split('/').each_with_object([]) do |ns, items|
-        items << MiqAeNamespace.find_by!(:name => ns, :parent => items.last)
+        items << MiqAeNamespace.find_by!(:name => ns, :ancestry => items.last)
       end
       open_nodes << MiqAeClass.find_by!(:name => klass, :namespace_id => open_nodes.last.id)
       open_nodes << MiqAeInstance.find_by!(:name => instance, :class_id => open_nodes.last.id)


### PR DESCRIPTION
Actually we used ancestry instead of parent_id
```
[----] F, [2020-08-07T08:53:02.418285 #9:2aecc843f884] FATAL -- : Error caught: [ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column miq_ae_namespaces.parent does not exist
LINE 1: ...spaces" WHERE "miq_ae_namespaces"."name" = $1 AND "miq_ae_na...
                                                             ^
: SELECT  "miq_ae_namespaces".* FROM "miq_ae_namespaces" WHERE "miq_ae_namespaces"."name" = $1 AND "miq_ae_namespaces"."parent" IS NULL LIMIT $2
/usr/share/gems/gems/activerecord-5.1.7/lib/active_record/connection_adapters/postgresql_adapter.rb:624:in `exec_params'
/usr/share/gems/gems/activerecord-5.1.7/lib/active_record/connection_adapters/postgresql_adapter.rb:624:in `block (2 levels) in exec_no_cache'
/usr/share/gems/gems/activesupport-5.1.7/lib/active_support/dependencies/interlock.rb:46:in `block in permit_concurrent_loads'
/usr/share/gems/gems/activesupport-5.1.7/lib/active_support/concurrency/share_lock.rb:185:in `yield_shares'
/usr/share/gems/gems/activesupport-5.1.7/lib/active_support/dependencies/interlock.rb:45:in `permit_concurrent_loads'
/usr/share/gems/gems/activerecord-5.1.7/lib/active_record/connection_adapters/postgresql_adapter.rb:623:in `block in exec_no_cache'
/usr/share/gems/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block (2 levels) in log'
/usr/share/ruby/monitor.rb:230:in `mon_synchronize'
````
https://github.com/ManageIQ/manageiq-schema/pull/455
