### PR TITLE
Fix settings.spec.js

### DIFF
--- a/cypress/integration/ui/settings.spec.js
+++ b/cypress/integration/ui/settings.spec.js
@@ -4,7 +4,7 @@ describe('GTL', () => {
   });
 
   it("with data", () => {
-    cy.menu("Compute", "Infrastructure", "Virtual Machines");
-    cy.toolbar('Configuration', 'Edit this VM');
+    cy.menu("Configuration", "Providers");
+    cy.toolbar('Configuration', 'Add a new Provider');
   });
 });


### PR DESCRIPTION
Since VMs don't exist (for now) with our default state for specs, use a different screen that doesn't require data to be available.

`Configuration -> Providers` is a perfect candidate for that, since it isn't the default page we land on, and has an enabled menu item by default..


Links
-----

* Example run on CI here:  https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/150