### PR TITLE
Use constants for component/validator types in cloud tenant form

### DIFF
--- a/app/javascript/components/cloud-tenant-form/create-form.schema.js
+++ b/app/javascript/components/cloud-tenant-form/create-form.schema.js
@@ -1,13 +1,15 @@
+import { componentTypes, validatorTypes } from '@@ddf';
+
 /**
  * @param {Boolean} renderEmsChoices
  * @param {Object} emsChoices
  */
 function createSchema(renderEmsChoices, emsChoices) {
   let fields = [{
-    component: 'text-field',
+    component: componentTypes.TEXT_FIELD,
     name: 'name',
     validate: [{
-      type: 'required-validator',
+      type: validatorTypes.REQUIRED,
     }],
     label: __('Tenant Name'),
     maxLength: 128,
@@ -15,14 +17,14 @@ function createSchema(renderEmsChoices, emsChoices) {
   }];
   if (!renderEmsChoices) {
     fields = [{
-      component: 'select-field',
+      component: componentTypes.SELECT,
       name: 'ems_id',
       menuPlacement: 'bottom',
       label: __('Cloud Provider/Parent Cloud Tenant'),
       placeholder: `<${__('Choose')}>`,
       validateOnMount: true,
       validate: [{
-        type: 'required-validator',
+        type: validatorTypes.REQUIRED,
       }],
       options: Object.keys(emsChoices).map(key => ({
         value: emsChoices[key],


### PR DESCRIPTION
Strings are so 2019, let's use constants here :laughing: also helps with some DDFv2 issues