### PR TITLE
Call `allowed_for_policies` method to avoid infinite loop

### DIFF
--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -85,7 +85,7 @@ module MiqPolicyController::Events
     end
 
     @edit[:choices_true] = {}                      # Build a new choices list for true actions
-    MiqAction.all.each do |a|                      # Build a hash for the true choices
+    MiqAction.allowed_for_policies(policy.mode).each do |a|                      # Build a hash for the true choices
       @edit[:choices_true][a.description] = a.id
     end
     @edit[:new][:actions_true].each do |as|
@@ -93,7 +93,7 @@ module MiqPolicyController::Events
     end
 
     @edit[:choices_false] = {}                      # Build a new choices list for false actions
-    MiqAction.all.each do |a|                       # Build a hash for the false choices
+    MiqAction.allowed_for_policies(policy.mode).each do |a|                       # Build a hash for the false choices
       @edit[:choices_false][a.description] = a.id
     end
     @edit[:new][:actions_false].each do |as|


### PR DESCRIPTION
Fixes ManageIQ/manageiq#20405

before
![Screenshot from 2020-08-12 13-07-25](https://user-images.githubusercontent.com/3450808/90045274-cbc64900-dc9c-11ea-8082-bf25139cadeb.png)

after
![Screenshot from 2020-08-12 13-07-07](https://user-images.githubusercontent.com/3450808/90045291-d1239380-dc9c-11ea-8933-86e27d416485.png)

@lfu pls review