### PR TITLE
Enable 'Save' button after successful RHN credentials validation

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -667,7 +667,7 @@ module OpsController::Settings::Common
           @edit[:new][:server_url] = MiqDatabase.registration_default_values[:registration_server]
         end
       end
-      @changed = (new != @edit[:current])
+      @changed = (new.except(:customer_userid, :customer_password, :customer_verify) != @edit[:current].except(:customer_userid, :customer_password, :customer_verify))
     when "settings_server"                                                # Server Settings tab
       if !params[:smtp_test_to].nil? && params[:smtp_test_to] != ""
         @sb[:new_to] = params[:smtp_test_to]

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -28,7 +28,6 @@ module OpsController::Settings::RHN
     private(:rhn_save_subscription)
     private(:rhn_credentials_from_edit)
     private(:rhn_fire_available_organizations)
-    private(:rhn_load_session)
     private(:rhn_gather_checks)
 
     helper_method(:rhn_subscription_types)
@@ -186,12 +185,6 @@ module OpsController::Settings::RHN
     end
   end
 
-  def rhn_load_session
-    @edit = session[:edit] || {}
-    @edit[:new] ||= {}
-    @edit[:new][:servers] ||= {}
-  end
-
   # collect checkboxes coming in with a button
   def rhn_gather_checks
     @edit[:new][:servers] = {}
@@ -259,7 +252,7 @@ module OpsController::Settings::RHN
   end
 
   def rhn_validate
-    rhn_load_session
+    @edit = session[:edit] || {}
     rhn_fire_available_organizations do |organizations|
       if @edit[:new][:register_to] == 'rhn_satellite6'
         # Hash of display names to key names
@@ -277,9 +270,9 @@ module OpsController::Settings::RHN
       render :update do |page|
         @changed = (@edit[:new] != @edit[:current])
         page << javascript_prologue
+        page << javascript_for_miq_button_visibility(@changed) unless flash_errors?
         if @edit[:new][:register_to] == 'rhn_satellite6'
           page.replace_html('settings_rhn', :partial => 'settings_rhn_edit_tab')
-          page << javascript_for_miq_button_visibility(@changed) unless flash_errors?
         else
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -150,7 +150,8 @@ describe OpsController do
             :server_url        => "example.com",
             :repo_name         => "example_repo_name",
             :use_proxy         => 0
-          }
+          },
+          :current       => {}
         }
         controller.instance_variable_set(:@_response, ActionDispatch::TestResponse.new)
         controller.instance_variable_set(:@sb, :trees       =>


### PR DESCRIPTION
This fix is to make sure the `Save` button in Red Hat Updates form will be enabled after successful credentials validation.

Credential validation failed: `Save` button is disabled
![Screenshot from 2020-08-13 16-42-24](https://user-images.githubusercontent.com/6648365/90148945-369e7f80-dd84-11ea-971f-46cc7de02af2.png)


Credential validation passed: `Save` button will become enabled
![Screenshot from 2020-08-13 16-42-56](https://user-images.githubusercontent.com/6648365/90148948-37cfac80-dd84-11ea-90ba-3adf6d28f9e2.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1740698