### PR TITLE
Correctly render add provider screen after accordion switch

### DIFF
--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -403,6 +403,10 @@ class AutomationManagerController < ApplicationController
       presenter.hide(:form_buttons_div)
       presenter.update(:main_div, r[:partial => "configuration_script",
                                     :locals  => {:controller => controller_name}])
+    elsif concrete_model.none? && x_active_tree == :automation_manager_providers_tree
+      presenter.update(:main_div, r[:partial => "layouts/empty",
+                                    :locals  => {:add_message   => _("Add a new Ansible Tower Provider"),
+                                                 :documentation => ::Settings.docs.ansible_provider}])
     else
       presenter.update(:main_div, r[:partial => 'layouts/x_gtl'])
     end


### PR DESCRIPTION
1. make sure you have no Ansible Tower provider
2. navigate to Ansible Tower explorer
3. switch accordion to `Configured Systems` and then back to `Providers`

Before:
![Screenshot from 2020-08-17 12-30-26](https://user-images.githubusercontent.com/6648365/90386913-88e1e800-e085-11ea-96ee-f65bb53b993c.png)


After:
![Screenshot from 2020-08-17 12-28-31](https://user-images.githubusercontent.com/6648365/90386923-8c756f00-e085-11ea-8cd9-f71285561126.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1860033