### PR TITLE
Filter network providers supporting security group creation

### DIFF
--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -24,7 +24,7 @@ ManageIQ.angular.app.controller('securityGroupFormController', ['securityGroupFo
       vm.afterGet = true;
       vm.modelCopy = angular.copy( vm.securityGroupModel );
 
-      miqService.networkProviders()
+      miqService.networkProviders({filter_security_group_creation: true})
         .then(function(providers) {
           vm.ems = providers;
         });

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -86,6 +86,10 @@ ManageIQ.angular.app.service('miqService', ['$q', 'API', '$window', function($q,
       url += '&attributes=' + options.attributes.map(encodeURIComponent).join(',');
     }
 
+    if (options.filter_security_group_creation) {
+      url += '&filter[]=supports_create_security_group=true';
+    }
+
     return API.get(url)
       .then(function(response) {
         return response.resources || [];


### PR DESCRIPTION
1. Go to Network > Security Groups > Create a new Security Group
2. See the Network Manager dropdown list.

Before this fix, it would list all available network managers.
![Screenshot from 2020-08-25 17-47-37](https://user-images.githubusercontent.com/6648365/91196968-157e4d00-e6fb-11ea-9f4b-e11ef77fba81.png)

With this fix, it would only list network providers that support security group creation.
![Screenshot from 2020-08-25 17-47-15](https://user-images.githubusercontent.com/6648365/91196989-1adb9780-e6fb-11ea-9458-e8a4ee0c2dbb.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1740656

Depends on https://github.com/ManageIQ/manageiq/pull/20482