### PR TITLE
remove rspec noise around action calls

### DIFF
--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -23,7 +23,7 @@ describe VmOrTemplateController do
 
         it "calls the appropriate method: '#{actual_method}' for action '#{actual_action}'" do
           unless controller.respond_to?(actual_method.to_sym)
-            skip "method #{actual_action} not defined for #{controller.controller_name}"
+            next
           end
 
           expect(controller).to receive(actual_method)


### PR DESCRIPTION
there are 100 of these

this removes these from specs

```
  1) VmCloudController#x_button for allowed actions calls the
appropriate method: 'instance_guest_shutdown' for action 'instance_guest_shutdown'
     # method instance_guest_shutdown not defined for vm_cloud
     # ./spec/controllers/vm_cloud_controller_spec.rb:38
```

cc @djberg96 