### PR TITLE
remove reference to unused dialog field type

### DIFF
--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -91,8 +91,6 @@
                           - else
                             = h(field.values[0].last) unless field.values.empty?
 
-                      - when "DialogFieldButton"
-                        = button_tag(_('Save'), :disabled => true)
                       - when "DialogFieldTagControl"
                         - select_attrs = {:class => 'selectpicker'}
                         - select_attrs[:multiple] = '' if field.multiselect?


### PR DESCRIPTION
Remove reference to unused dialog field button. 

related:
https://github.com/ManageIQ/manageiq/pull/20421 and https://github.com/ManageIQ/manageiq/pull/20459