### PR TITLE
Allow all providers in tag mapping screen

### DIFF
--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -223,24 +223,21 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)
+    error = nil
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
-    if label_exists
-      flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
-      return
-    end
+    error = :unique_mapping if label_exists
 
     if entity == ALL_ENTITIES
       category = classification_lookup_with_cash_by(cat_description)
       # Should not create a new category if "All entities". The chosen category should exist
-      if category.nil?
-        flash_message_on_validation_error_for(:tag_not_found, entity, label_name, cat_description)
-        return
-      end
+      error = :tag_not_found unless category
     else
-      if find_prefixed_category_for_mapping_by(cat_description, entity, label_name)
-        flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
-        return
-      end
+      error = :unique_mapping if find_prefixed_category_for_mapping_by(cat_description, entity, label_name)
+    end
+
+    if error
+      flash_message_on_validation_error_for(error, entity, label_name, cat_description)
+      return
     end
 
     begin

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -196,7 +196,7 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def classification_lookup_with_cash_by(cat_description)
-    @classification = {}
+    @classification ||= {}
     @classification[cat_description] ||= Classification.lookup_by_name(cat_description)
   end
 
@@ -223,7 +223,8 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def validate_mapping(cat_description, entity, label_name)
-    return :unique_mapping if ContainerLabelTagMapping.where(:label_name => label_name).exists?
+    tag = classification_lookup_with_cash_by(cat_description)&.tag
+    return :unique_mapping if tag && ContainerLabelTagMapping.where(:label_name => label_name, :tag => tag).exists?
 
     if entity == ALL_ENTITIES
       :tag_not_found unless classification_lookup_with_cash_by(cat_description)

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -197,7 +197,7 @@ module OpsController::Settings::LabelTagMapping
 
   def classification_lookup_with_cache_by(cat_description)
     @classification ||= {}
-    @classification[cat_description] ||= Classification.lookup_by_name(cat_description)
+    @classification[cat_description] ||= Classification.lookup_category_by_description(cat_description)
   end
 
   def category_for_mapping(cat_description, entity, label_name)
@@ -263,7 +263,7 @@ module OpsController::Settings::LabelTagMapping
     update_category.description = cat_description_with_prefix(mapping.labeled_resource_type, cat_description)
     begin
       if mapping.labeled_resource_type == ALL_ENTITIES
-        update_category = Classification.lookup_by_name(cat_description)
+        update_category = classification_lookup_with_cache_by(cat_description)
         # Should not create a new category if "All entities". The chosen category should exist
         if update_category.nil?
           flash_message_on_validation_error_for(:tag_not_found, mapping.labeled_resource_type, mapping.label_name, cat_description)

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -195,27 +195,39 @@ module OpsController::Settings::LabelTagMapping
     javascript_flash
   end
 
+  def classification_lookup_with_cash_by(cat_description)
+    @classification = {}
+    @classification[cat_description] ||= Classification.lookup_by_name(cat_description)
+  end
+
   def label_tag_mapping_add(entity, label_name, cat_description)
     cat_prefix = MAPPABLE_ENTITIES[entity].prefix
     cat_name_from_label = cat_prefix.to_s + Classification.sanitize_name(label_name.tr("/", ":"))
 
-    # UI currently can't allow 2 mappings for same (entity, label).
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
-    category_exists = cat_prefix && Classification.is_category.read_only.where(:single_value => true, :description => cat_description).exists?
-    if category_exists || label_exists || Classification.lookup_by_name(cat_name_from_label)
-      flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
-      return
+    if entity == ALL_ENTITIES
+      category = classification_lookup_with_cash_by(cat_description)
+      # Should not create a new category if "All entities". The chosen category should exist
+      if category.nil?
+        flash_message_on_validation_error_for(:tag_not_found, entity, label_name, cat_description)
+        return
+      end
+
+      if label_exists
+        flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
+        return
+      end
+    else
+      # UI currently can't allow 2 mappings for same (entity, label).
+      category = Classification.is_category.read_only.find_by(:single_value => true, :description => cat_description)
+      if category || label_exists || Classification.lookup_by_name(cat_name_from_label)
+        flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
+        return
+      end
     end
 
     begin
       ActiveRecord::Base.transaction do
-        category = Classification.lookup_by_name(cat_description) unless cat_prefix
-        # Should not create a new category if "All entities". The chosen category should exist
-        if entity == ALL_ENTITIES && category.nil?
-          flash_message_on_validation_error_for(:tag_not_found, entity, label_name, cat_description)
-          return
-        end
-
         category ||= Classification.create_category!(:name => cat_name_from_label,
                                                      :description  => cat_description_with_prefix(entity, cat_description),
                                                      :single_value => true,

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -195,14 +195,14 @@ module OpsController::Settings::LabelTagMapping
     javascript_flash
   end
 
-  def classification_lookup_with_cash_by(cat_description)
+  def classification_lookup_with_cache_by(cat_description)
     @classification ||= {}
     @classification[cat_description] ||= Classification.lookup_by_name(cat_description)
   end
 
   def category_for_mapping(cat_description, entity, label_name)
     if entity == ALL_ENTITIES
-      classification_lookup_with_cash_by(cat_description)
+      classification_lookup_with_cache_by(cat_description)
     else
       Classification.create_category!(:name         => category_name_from_label(entity, label_name),
                                       :description  => cat_description_with_prefix(entity, cat_description),
@@ -223,11 +223,11 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def validate_mapping(cat_description, entity, label_name)
-    tag = classification_lookup_with_cash_by(cat_description)&.tag
+    tag = classification_lookup_with_cache_by(cat_description)&.tag
     return :unique_mapping if tag && ContainerLabelTagMapping.where(:label_name => label_name, :tag => tag).exists?
 
     if entity == ALL_ENTITIES
-      :tag_not_found unless classification_lookup_with_cash_by(cat_description)
+      :tag_not_found unless classification_lookup_with_cache_by(cat_description)
     elsif find_prefixed_category_for_mapping_by(cat_description, entity, label_name)
       :unique_mapping
     end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -218,6 +218,10 @@ module OpsController::Settings::LabelTagMapping
 
   def label_tag_mapping_add(entity, label_name, cat_description)
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
+    if label_exists
+      flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
+      return
+    end
 
     if entity == ALL_ENTITIES
       category = classification_lookup_with_cash_by(cat_description)
@@ -226,15 +230,10 @@ module OpsController::Settings::LabelTagMapping
         flash_message_on_validation_error_for(:tag_not_found, entity, label_name, cat_description)
         return
       end
-
-      if label_exists
-        flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
-        return
-      end
     else
       # UI currently can't allow 2 mappings for same (entity, label).
       category = Classification.is_category.read_only.find_by(:single_value => true, :description => cat_description)
-      if category || label_exists || Classification.lookup_by_name(category_name_from_label(entity, label_name))
+      if category || Classification.lookup_by_name(category_name_from_label(entity, label_name))
         flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
         return
       end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -216,6 +216,12 @@ module OpsController::Settings::LabelTagMapping
     cat_prefix.to_s + Classification.sanitize_name(label_name.tr("/", ":"))
   end
 
+  def find_prefixed_category_for_mapping_by(cat_description, entity, label_name)
+    # UI currently can't allow 2 mappings for same (entity, label).
+    category = Classification.is_category.read_only.find_by(:single_value => true, :description => cat_description)
+    category || Classification.lookup_by_name(category_name_from_label(entity, label_name))
+  end
+
   def label_tag_mapping_add(entity, label_name, cat_description)
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
     if label_exists
@@ -231,9 +237,7 @@ module OpsController::Settings::LabelTagMapping
         return
       end
     else
-      # UI currently can't allow 2 mappings for same (entity, label).
-      category = Classification.is_category.read_only.find_by(:single_value => true, :description => cat_description)
-      if category || Classification.lookup_by_name(category_name_from_label(entity, label_name))
+      if find_prefixed_category_for_mapping_by(cat_description, entity, label_name)
         flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
         return
       end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -12,7 +12,7 @@ module OpsController::Settings::LabelTagMapping
   # In any case, this requires different providers use disjoint sets of strings.
   MappableEntity = Struct.new(:prefix, :model)
 
-  ALL_ENTITIES = "_all_entities_".freeze
+  ALL_ENTITIES = "_all_entities_"
 
   MAPPABLE_ENTITIES = {
     # TODO: support per-provider "All Amazon" etc?
@@ -233,7 +233,7 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def label_tag_mapping_add(entity, label_name, cat_description)
-    if error = validate_mapping(cat_description, entity, label_name)
+    if (error = validate_mapping(cat_description, entity, label_name))
       flash_message_on_validation_error_for(error, entity, label_name, cat_description)
       return
     end
@@ -295,14 +295,14 @@ module OpsController::Settings::LabelTagMapping
 
     deleted = false
     ActiveRecord::Base.transaction do
-      if mapping.labeled_resource_type == ALL_ENTITIES
-        # Don't delete the category in this case because it was created outside of tag mapping
-        # Note: As a side effect, taggings of this category will not be removed from resources that had this mapping
-        deleted = mapping.destroy
-      else
-        # delete mapping and category - will indirectly delete tags
-        deleted = mapping.destroy && category.destroy
-      end
+      deleted = if mapping.labeled_resource_type == ALL_ENTITIES
+                  # Don't delete the category in this case because it was created outside of tag mapping
+                  # Note: As a side effect, taggings of this category will not be removed from resources that had this mapping
+                  mapping.destroy
+                else
+                  # delete mapping and category - will indirectly delete tags
+                  mapping.destroy && category.destroy
+                end
     end
 
     if deleted

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -53,7 +53,7 @@ module OpsController::Settings::LabelTagMapping
       if !@lt_map || @lt_map.id.blank?
         add_flash(_("Add of new Container Label Tag Mapping was cancelled by the user"))
       else
-        add_flash(_("Edit of Container Label Tag Mapping \"%{name}\" was cancelled by the user"))
+        add_flash(_("Edit of Container Label Tag Mapping \"%{name}\" was cancelled by the user") % {:name => @lt_map.label_name})
       end
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -280,8 +280,6 @@ module OpsController::Settings::LabelTagMapping
 
   def label_tag_mapping_update(id, cat_description)
     mapping = ProviderTagMapping.find(id)
-    update_category = mapping.tag.classification
-    update_category.description = cat_description_with_prefix(mapping.labeled_resource_type, cat_description)
     begin
       if mapping.labeled_resource_type == ALL_ENTITIES
         update_category = classification_lookup_with_cache_by(cat_description)
@@ -291,7 +289,6 @@ module OpsController::Settings::LabelTagMapping
           return
         end
         mapping.tag = update_category.tag
-
         mapping.save!
       else
         update_category             = mapping.tag.classification
@@ -357,7 +354,7 @@ module OpsController::Settings::LabelTagMapping
     def tag_category_parameters_for_haml
       {:lt_map       => @lt_map,
        :categories   => categories_for_select,
-       :category     => @edit[:new][:category],
+       :category     => @edit[:new][:category] || categories_for_select.first,
        :all_entities => @edit[:new][:entity] == ALL_ENTITIES}
     end
   end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -120,12 +120,15 @@ module OpsController::Settings::LabelTagMapping
     # This renders into label_tag_mapping_form view, fields are different from other
     # functions here, notably `:entity` is the translated ui name.
     @lt_mapping = []
+    @single_value_category_is_present = false
     mappings.each do |m|
       lt_map = {}
       lt_map[:id] = m.id
       lt_map[:entity] = entity_ui_name_or_all(m.labeled_resource_type)
       lt_map[:label_name] = m.label_name
-      lt_map[:category] = cat_description_without_prefix(m.tag.classification.description)
+      tag_classification = m.tag.classification
+      lt_map[:category] = cat_description_without_prefix(tag_classification.description)
+      @single_value_category_is_present = true if tag_classification.single_value && m.labeled_resource_type == ALL_ENTITIES
       @lt_mapping.push(lt_map)
     end
   end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -182,6 +182,19 @@ module OpsController::Settings::LabelTagMapping
     copy_params_if_present(@edit[:new], params, %i[entity label_name category])
   end
 
+  def flash_message_on_validation_error_for(validation_error, entity, label_name, cat_description)
+    entity_name = entity_ui_name_or_all(entity)
+    variables = {:entity => entity_name, :label => label_name, :cat_description => cat_description}
+    message = if validation_error == :unique_mapping
+                _("Mapping for \"%{entity}\", Label \"%{label}\" and Tag Category \"%{cat_description}\" already exists") % variables
+              else
+                _("Mapping for \"%{entity}\", Label \"%{label}\": Tag Category \"%{cat_description}\" must exist") % variables
+              end
+
+    add_flash(message, :error)
+    javascript_flash
+  end
+
   def label_tag_mapping_add(entity, label_name, cat_description)
     cat_prefix = MAPPABLE_ENTITIES[entity].prefix
     cat_name_from_label = cat_prefix.to_s + Classification.sanitize_name(label_name.tr("/", ":"))
@@ -190,9 +203,7 @@ module OpsController::Settings::LabelTagMapping
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
     category_exists = cat_prefix && Classification.is_category.read_only.where(:single_value => true, :description => cat_description).exists?
     if category_exists || label_exists || Classification.lookup_by_name(cat_name_from_label)
-      add_flash(_("Mapping for %{entity}, Label \"%{label}\" already exists") %
-              {:entity => entity_ui_name_or_all(entity), :label => label_name}, :error)
-        javascript_flash
+      flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
       return
     end
 
@@ -201,9 +212,7 @@ module OpsController::Settings::LabelTagMapping
         category = Classification.lookup_by_name(cat_description) unless cat_prefix
         # Should not create a new category if "All entities". The chosen category should exist
         if entity == ALL_ENTITIES && category.nil?
-          add_flash(_("Mapping for %{entity}, Label \"%{label}\", tag must already exist") %
-                      {:entity => entity_ui_name_or_all(entity), :label => label_name}, :error)
-          javascript_flash
+          flash_message_on_validation_error_for(:tag_not_found, entity, label_name, cat_description)
           return
         end
 
@@ -236,9 +245,7 @@ module OpsController::Settings::LabelTagMapping
         update_category = Classification.lookup_by_name(cat_description)
         # Should not create a new category if "All entities". The chosen category should exist
         if update_category.nil?
-          add_flash(_("Mapping for %{entity}, Label \"%{label}\", tag must already exist") %
-                      {:entity => entity_ui_name_or_all(mapping.labeled_resource_type), :label => mapping.label_name}, :error)
-          javascript_flash
+          flash_message_on_validation_error_for(:tag_not_found, mapping.labeled_resource_type, mapping.label_name, cat_description)
           return
         end
         mapping.tag = update_category.tag

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -120,7 +120,7 @@ module OpsController::Settings::LabelTagMapping
     # This renders into label_tag_mapping_form view, fields are different from other
     # functions here, notably `:entity` is the translated ui name.
     @lt_mapping = []
-    @single_value_category_is_present = false
+    @any_mapping_is_all_entities = false
     mappings.each do |m|
       lt_map = {}
       lt_map[:id] = m.id
@@ -128,7 +128,7 @@ module OpsController::Settings::LabelTagMapping
       lt_map[:label_name] = m.label_name
       tag_classification = m.tag.classification
       lt_map[:category] = cat_description_without_prefix(tag_classification.description)
-      @single_value_category_is_present = true if tag_classification.single_value && m.labeled_resource_type == ALL_ENTITIES
+      @any_mapping_is_all_entities = true if m.labeled_resource_type == ALL_ENTITIES
       @lt_mapping.push(lt_map)
     end
   end

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -51,9 +51,9 @@ module OpsController::Settings::LabelTagMapping
     when "cancel"
       @lt_map = session[:edit][:lt_map] if session[:edit] && session[:edit][:lt_map]
       if !@lt_map || @lt_map.id.blank?
-        add_flash(_("Add of new Container Label Tag Mapping was cancelled by the user"))
+        add_flash(_("Add of new Provider Tag Mapping was cancelled by the user"))
       else
-        add_flash(_("Edit of Container Label Tag Mapping \"%{name}\" was cancelled by the user") % {:name => @lt_map.label_name})
+        add_flash(_("Edit of Provider Tag Mapping \"%{name}\" was cancelled by the user") % {:name => @lt_map.label_name})
       end
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
@@ -271,7 +271,7 @@ module OpsController::Settings::LabelTagMapping
       add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)
       javascript_flash
     else
-      add_flash(_("Container Label Tag Mapping \"%{name}\" was added") % {:name => label_name})
+      add_flash(_("Provider Tag Mapping \"%{name}\" was added") % {:name => label_name})
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
       replace_right_cell(:nodetype => "root")
@@ -300,7 +300,7 @@ module OpsController::Settings::LabelTagMapping
       add_flash(_("Error during 'save': %{message}") % {:message => bang.message}, :error)
       javascript_flash
     else
-      add_flash(_("Container Label Tag Mapping \"%{name}\" was saved") % {:name => mapping.label_name})
+      add_flash(_("Provider Tag Mapping \"%{name}\" was saved") % {:name => mapping.label_name})
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
       replace_right_cell(:nodetype => "root")
@@ -325,7 +325,7 @@ module OpsController::Settings::LabelTagMapping
     end
 
     if deleted
-      add_flash(_("Container Label Tag Mapping \"%{name}\": Delete successful") % {:name => label_name})
+      add_flash(_("Provider Tag Mapping \"%{name}\": Delete successful") % {:name => label_name})
       label_tag_mapping_get_all
       render :update do |page|
         page << javascript_prologue

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -273,9 +273,9 @@ module OpsController::Settings::LabelTagMapping
 
         mapping.save!
       else
-        update_category = mapping.tag.classification
+        update_category             = mapping.tag.classification
+        update_category.name        = category_name_from_description(mapping.labeled_resource_type, cat_description)
         update_category.description = cat_description_with_prefix(mapping.labeled_resource_type, cat_description)
-
         update_category.save!
       end
     rescue StandardError => bang

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -245,7 +245,7 @@ module OpsController::Settings::LabelTagMapping
 
   def validate_mapping(cat_description, entity, label_name)
     tag = classification_lookup_with_cache_by(cat_description)&.tag
-    return :unique_mapping if tag && ContainerLabelTagMapping.where(:label_name => label_name, :tag => tag).exists?
+    return :unique_mapping if tag && ProviderTagMapping.where(:label_name => label_name, :tag => tag).exists?
 
     if entity == ALL_ENTITIES
       :tag_not_found unless classification_lookup_with_cache_by(cat_description)

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -162,12 +162,7 @@ module OpsController::Settings::LabelTagMapping
   end
 
   def categories_for_select
-    categories = Classification.categories.sort_by(&:description)
-    categories.each_with_object([]) do |category, result|
-      next if category.read_only?
-
-      result << category.description
-    end
+    Classification.categories.reject(&:read_only?).sort_by(&:description).map(&:description)
   end
 
   # AJAX driven routine to check for changes in ANY field on the user form

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -200,11 +200,25 @@ module OpsController::Settings::LabelTagMapping
     @classification[cat_description] ||= Classification.lookup_by_name(cat_description)
   end
 
-  def label_tag_mapping_add(entity, label_name, cat_description)
-    cat_prefix = MAPPABLE_ENTITIES[entity].prefix
-    cat_name_from_label = cat_prefix.to_s + Classification.sanitize_name(label_name.tr("/", ":"))
+  def category_for_mapping(cat_description, entity, label_name)
+    if entity == ALL_ENTITIES
+      classification_lookup_with_cash_by(cat_description)
+    else
+      Classification.create_category!(:name         => category_name_from_label(entity, label_name),
+                                      :description  => cat_description_with_prefix(entity, cat_description),
+                                      :single_value => true,
+                                      :read_only    => true)
+    end
+  end
 
+  def category_name_from_label(entity, label_name)
+    cat_prefix = MAPPABLE_ENTITIES[entity].prefix
+    cat_prefix.to_s + Classification.sanitize_name(label_name.tr("/", ":"))
+  end
+
+  def label_tag_mapping_add(entity, label_name, cat_description)
     label_exists = ContainerLabelTagMapping.where(:label_name => label_name).exists?
+
     if entity == ALL_ENTITIES
       category = classification_lookup_with_cash_by(cat_description)
       # Should not create a new category if "All entities". The chosen category should exist
@@ -220,7 +234,7 @@ module OpsController::Settings::LabelTagMapping
     else
       # UI currently can't allow 2 mappings for same (entity, label).
       category = Classification.is_category.read_only.find_by(:single_value => true, :description => cat_description)
-      if category || label_exists || Classification.lookup_by_name(cat_name_from_label)
+      if category || label_exists || Classification.lookup_by_name(category_name_from_label(entity, label_name))
         flash_message_on_validation_error_for(:unique_mapping, entity, label_name, cat_description)
         return
       end
@@ -228,14 +242,10 @@ module OpsController::Settings::LabelTagMapping
 
     begin
       ActiveRecord::Base.transaction do
-        category ||= Classification.create_category!(:name => cat_name_from_label,
-                                                     :description  => cat_description_with_prefix(entity, cat_description),
-                                                     :single_value => true,
-                                                     :read_only    => true)
-
-              ProviderTagMapping.create!(:labeled_resource_type => entity,
-                                         :label_name            => label_name,
-                                         :tag                   => category.tag)
+        category = category_for_mapping(cat_description, entity, label_name)
+        ProviderTagMapping.create!(:labeled_resource_type => entity,
+                                   :label_name            => label_name,
+                                   :tag                   => category.tag)
       end
     rescue StandardError => bang
       add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)

--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -30,16 +30,12 @@
                        :disabled          => disabled,
                        "data-miq_observe" => {:interval => '.5',
                                               :url      => url}.to_json)
-  %h3= _("Enter tag category to map to")
-  .form-group
-    %label.col-md-2.control-label
-      = _("Tag Category")
-    .col-md-8
-      = text_field_tag("category", @edit[:new][:category],
-                       :maxlength         => 50,
-                       :class             => "form-control",
-                       "data-miq_observe" => {:interval => '.5',
-                                              :url      => url}.to_json)
+
+  #tag_category_div
+    - if @lt_map
+      = render :partial => "ops/label_tag_mapping/tag_category",
+               :locals => tag_category_parameters_for_haml
+
   .form-group
     %label.col-md-2.control-label
     .col-md-8

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -29,3 +29,6 @@
             :title   => _("Click to delete this mapping")}
             %button.btn.btn-default.btn-block.btn-sm
               = _("Delete")
+- if @single_value_category_is_present
+  .note
+    %b= _("Warning: Mappings with Resource Entity 'All-Entities' could cause overwriting existing tags on resources with mapped provider labels.")

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -1,4 +1,10 @@
 - if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_label_tag_mapping"
+  - if @single_value_category_is_present
+    #form_div
+      .alert.alert-warning
+        %span.pficon.pficon-warning-triangle-o
+        %strong
+          = _("Caution: Mappings with Resource Entity 'All-Entities' could cause overwriting existing tags on resources with mapped provider labels.")
   %table.table.table-striped.table-bordered.table-hover
     %thead
       %tr
@@ -29,6 +35,3 @@
             :title   => _("Click to delete this mapping")}
             %button.btn.btn-default.btn-block.btn-sm
               = _("Delete")
-- if @single_value_category_is_present
-  .note
-    %b= _("Warning: Mappings with Resource Entity 'All-Entities' could cause overwriting existing tags on resources with mapped provider labels.")

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -1,5 +1,5 @@
 - if @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_label_tag_mapping"
-  - if @single_value_category_is_present
+  - if @any_mapping_is_all_entities
     #form_div
       .alert.alert-warning
         %span.pficon.pficon-warning-triangle-o

--- a/app/views/ops/label_tag_mapping/_tag_category.html.haml
+++ b/app/views/ops/label_tag_mapping/_tag_category.html.haml
@@ -1,0 +1,21 @@
+- url = url_for_only_path(:action => 'label_tag_mapping_field_changed', :id => (lt_map&.id || "new")&.to_s)
+#tag_category_div
+  %h3= _("Enter tag category to map to")
+  - if all_entities
+    .form-group
+      %label.col-md-2.control-label
+        = _("Tag Category")
+      .col-md-8
+        = select_tag('category', options_for_select(categories, category), "data-live-search" => "true", :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent('category', "#{url}")
+  - else
+    .form-group
+      %label.col-md-2.control-label
+        = _("Tag Category")
+      .col-md-8
+        = text_field_tag("category", @edit[:new][:category], :maxlength         => 50,
+                                                             :class             => "form-control",
+                                                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -209,6 +209,7 @@ describe OpsController do
 
       controller.instance_variable_set :@flash_array, nil
       post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s, :button => 'save' }
+      expect(mapping.tag.name).to eq('/managed/amazon:vm:edited_again_amazon')
       expect(mapping.tag.classification.description).to eq('amazon:vm|Edited Again Amazon')
     end
   end

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -25,10 +25,10 @@ describe OpsController do
 
     def use_form_to_create_all_entities_mapping(label_name, category)
       post :label_tag_mapping_edit
-      post :label_tag_mapping_field_changed, :params => { :id => 'new', :entity => '_all_entities_' }
-      post :label_tag_mapping_field_changed, :params => { :id => 'new', :label_name => label_name }
-      post :label_tag_mapping_field_changed, :params => { :id => 'new', :category => category  }
-      post :label_tag_mapping_edit, :params => { :button => 'add' }
+      post :label_tag_mapping_field_changed, :params => {:id => 'new', :entity => '_all_entities_'}
+      post :label_tag_mapping_field_changed, :params => {:id => 'new', :label_name => label_name}
+      post :label_tag_mapping_field_changed, :params => {:id => 'new', :category => category}
+      post :label_tag_mapping_edit, :params => {:button => 'add'}
     end
 
     it "creates new mapping on save" do
@@ -57,20 +57,20 @@ describe OpsController do
 
     it "doesn't create mapping for all entities when label is already mapped" do
       use_form_to_create_all_entities_mapping(label_name, classification_department.name)
-      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       controller.instance_variable_set(:@flash_array, nil)
 
       use_form_to_create_all_entities_mapping(label_name, classification_department.name)
-      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
       expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
     end
 
     it "doesn't create mapping for all entities when category name doesn't exist" do
       use_form_to_create_all_entities_mapping(label_name, "XXX")
 
-      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
       expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\": Tag Category \"XXX\" must exist")
     end
 
@@ -78,13 +78,13 @@ describe OpsController do
 
     it "doesn't create mapping for all entities when tag from label is already created" do
       use_form_to_create_all_entities_mapping(label_name, classification_department.name)
-      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       controller.instance_variable_set(:@flash_array, nil)
 
       use_form_to_create_all_entities_mapping(label_name, classification_department.name)
-      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
       expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
     end
 
@@ -92,7 +92,7 @@ describe OpsController do
       use_form_to_create_all_entities_mapping(label_name, classification_department.name)
 
       mapping = ContainerLabelTagMapping.last
-      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
       expect(mapping.labeled_resource_type).to eq(all_entities)
       expect(mapping.label_name).to eq(label_name)
@@ -109,11 +109,11 @@ describe OpsController do
 
       controller.instance_variable_set(:@flash_array, nil)
 
-      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s }
-      post :label_tag_mapping_field_changed, :params => { :id => mapping.id.to_s, :category => classification_cost_center.name }
-      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s, :button => 'save' }
+      post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s}
+      post :label_tag_mapping_field_changed, :params => {:id => mapping.id.to_s, :category => classification_cost_center.name}
+      post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s, :button => 'save'}
 
-      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       mapping.reload
@@ -129,9 +129,9 @@ describe OpsController do
 
       expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_truthy
 
-      post :label_tag_mapping_delete, :params => { :id => mapping.id.to_s }
+      post :label_tag_mapping_delete, :params => {:id => mapping.id.to_s}
 
-      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_falsey
@@ -144,11 +144,11 @@ describe OpsController do
 
       controller.instance_variable_set(:@flash_array, nil)
 
-      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s }
-      post :label_tag_mapping_field_changed, :params => { :id => mapping.id.to_s, :category => 'XXX' }
-      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s, :button => 'save' }
+      post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s}
+      post :label_tag_mapping_field_changed, :params => {:id => mapping.id.to_s, :category => 'XXX'}
+      post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s, :button => 'save'}
 
-      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
       expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\": Tag Category \"XXX\" must exist")
     end
 

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -56,15 +56,15 @@ describe OpsController do
     let(:all_entities) { '_all_entities_' }
 
     it "doesn't create mapping for all entities when label is already mapped" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       controller.instance_variable_set(:@flash_array, nil)
 
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
-      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.description}\" already exists")
     end
 
     it "doesn't create mapping for all entities when category name doesn't exist" do
@@ -77,19 +77,19 @@ describe OpsController do
     let!(:classification_department) { FactoryBot.create(:classification_department_with_tags) }
 
     it "doesn't create mapping for all entities when tag from label is already created" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
       controller.instance_variable_set(:@flash_array, nil)
 
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       error_message = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }.first[:message]
-      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.description}\" already exists")
     end
 
     it "creates new mapping for all entities on save" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
 
       mapping = ContainerLabelTagMapping.last
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
@@ -104,13 +104,13 @@ describe OpsController do
     let(:classification_cost_center) { FactoryBot.create(:classification_cost_center) }
 
     it "can edit an existing mapping for all entities" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       mapping = ContainerLabelTagMapping.last
 
       controller.instance_variable_set(:@flash_array, nil)
 
       post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s}
-      post :label_tag_mapping_field_changed, :params => {:id => mapping.id.to_s, :category => classification_cost_center.name}
+      post :label_tag_mapping_field_changed, :params => {:id => mapping.id.to_s, :category => classification_cost_center.description}
       post :label_tag_mapping_edit, :params => {:id => mapping.id.to_s, :button => 'save'}
 
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
@@ -122,7 +122,7 @@ describe OpsController do
     end
 
     it "deletes mapping but it doesn't delete classifications and taggins for all entities" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       controller.instance_variable_set(:@flash_array, nil)
 
       mapping = ContainerLabelTagMapping.last
@@ -139,7 +139,7 @@ describe OpsController do
     end
 
     it "cannot set category name of tag which does not exist on an existing mapping for all entities" do
-      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       mapping = ContainerLabelTagMapping.last
 
       controller.instance_variable_set(:@flash_array, nil)

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -23,6 +23,14 @@ describe OpsController do
       post :label_tag_mapping_edit, :params => { :button => 'add' }
     end
 
+    def use_form_to_create_all_entities_mapping(label_name, category)
+      post :label_tag_mapping_edit
+      post :label_tag_mapping_field_changed, :params => { :id => 'new', :entity => '_all_entities_' }
+      post :label_tag_mapping_field_changed, :params => { :id => 'new', :label_name => label_name }
+      post :label_tag_mapping_field_changed, :params => { :id => 'new', :category => category  }
+      post :label_tag_mapping_edit, :params => { :button => 'add' }
+    end
+
     it "creates new mapping on save" do
       use_form_to_create_mapping
       mapping = ProviderTagMapping.last
@@ -41,6 +49,107 @@ describe OpsController do
       expect(mapping.label_value).to be nil
       expect(mapping.tag.classification.category?).to be true
       expect(mapping.tag.classification.description).to eq('amazon:vm|Amazon Vms')
+    end
+
+    let!(:classification_department) { FactoryBot.create(:classification_department_with_tags) }
+    let(:label_name) { 'some-amazon-label' }
+    let(:all_entities) { '_all_entities_' }
+
+    it "doesn't create mapping for all entities when label is already mapped" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      expect(errors).to be_empty
+
+      controller.instance_variable_set(:@flash_array, nil)
+
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
+    end
+
+    it "doesn't create mapping for all entities when category name doesn't exist" do
+      use_form_to_create_all_entities_mapping(label_name, "XXX")
+
+      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\": Tag Category \"XXX\" must exist")
+    end
+
+    let!(:classification_department) { FactoryBot.create(:classification_department_with_tags) }
+
+    it "doesn't create mapping for all entities when tag from label is already created" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      expect(errors).to be_empty
+
+      controller.instance_variable_set(:@flash_array, nil)
+
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\" and Tag Category \"#{classification_department.name}\" already exists")
+    end
+
+    it "creates new mapping for all entities on save" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+
+      mapping = ContainerLabelTagMapping.last
+      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      expect(errors).to be_empty
+      expect(mapping.labeled_resource_type).to eq(all_entities)
+      expect(mapping.label_name).to eq(label_name)
+      expect(mapping.label_value).to be nil
+      expect(mapping.tag.classification.category?).to be true
+      expect(mapping.tag.classification.description).to eq(classification_department.description)
+    end
+
+    let(:classification_cost_center) { FactoryBot.create(:classification_cost_center) }
+
+    it "can edit an existing mapping for all entities" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      mapping = ContainerLabelTagMapping.last
+
+      controller.instance_variable_set(:@flash_array, nil)
+
+      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s }
+      post :label_tag_mapping_field_changed, :params => { :id => mapping.id.to_s, :category => classification_cost_center.name }
+      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s, :button => 'save' }
+
+      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      expect(errors).to be_empty
+
+      mapping.reload
+
+      expect(mapping.tag.id).to eq(classification_cost_center.tag.id)
+    end
+
+    it "deletes mapping but it doesn't delete classifications and taggins for all entities" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      controller.instance_variable_set(:@flash_array, nil)
+
+      mapping = ContainerLabelTagMapping.last
+
+      expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_truthy
+
+      post :label_tag_mapping_delete, :params => { :id => mapping.id.to_s }
+
+      errors = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }
+      expect(errors).to be_empty
+
+      expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_falsey
+      expect(Classification.lookup_by_name(classification_department.name).name).to eq(classification_department.name)
+    end
+
+    it "cannot set category name of tag which does not exist on an existing mapping for all entities" do
+      use_form_to_create_all_entities_mapping(label_name, classification_department.name)
+      mapping = ContainerLabelTagMapping.last
+
+      controller.instance_variable_set(:@flash_array, nil)
+
+      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s }
+      post :label_tag_mapping_field_changed, :params => { :id => mapping.id.to_s, :category => 'XXX' }
+      post :label_tag_mapping_edit, :params => { :id => mapping.id.to_s, :button => 'save' }
+
+      error_message = controller.instance_variable_get(:@flash_array).select{|x| x[:level] == :error }.first[:message]
+      expect(error_message).to eq("Mapping for \"All Entities\", Label \"#{label_name}\": Tag Category \"XXX\" must exist")
     end
 
     it "can edit an existing mapping" do

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -91,7 +91,7 @@ describe OpsController do
     it "creates new mapping for all entities on save" do
       use_form_to_create_all_entities_mapping(label_name, classification_department.description)
 
-      mapping = ContainerLabelTagMapping.last
+      mapping = ProviderTagMapping.last
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
       expect(mapping.labeled_resource_type).to eq(all_entities)
@@ -105,7 +105,7 @@ describe OpsController do
 
     it "can edit an existing mapping for all entities" do
       use_form_to_create_all_entities_mapping(label_name, classification_department.description)
-      mapping = ContainerLabelTagMapping.last
+      mapping = ProviderTagMapping.last
 
       controller.instance_variable_set(:@flash_array, nil)
 
@@ -125,22 +125,22 @@ describe OpsController do
       use_form_to_create_all_entities_mapping(label_name, classification_department.description)
       controller.instance_variable_set(:@flash_array, nil)
 
-      mapping = ContainerLabelTagMapping.last
+      mapping = ProviderTagMapping.last
 
-      expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_truthy
+      expect(ProviderTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_truthy
 
       post :label_tag_mapping_delete, :params => {:id => mapping.id.to_s}
 
       errors = controller.instance_variable_get(:@flash_array).select { |x| x[:level] == :error }
       expect(errors).to be_empty
 
-      expect(ContainerLabelTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_falsey
+      expect(ProviderTagMapping.where(:label_name => label_name, :tag => classification_department.tag).exists?).to be_falsey
       expect(Classification.lookup_by_name(classification_department.name).name).to eq(classification_department.name)
     end
 
     it "cannot set category name of tag which does not exist on an existing mapping for all entities" do
       use_form_to_create_all_entities_mapping(label_name, classification_department.description)
-      mapping = ContainerLabelTagMapping.last
+      mapping = ProviderTagMapping.last
 
       controller.instance_variable_set(:@flash_array, nil)
 

--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -22,10 +22,6 @@ describe 'ops/_label_tag_mapping_form.html.haml' do
       expect(render).to have_selector('input#label_name')
     end
 
-    it 'renders the category name text box' do
-      expect(render).to have_selector('input#category')
-    end
-
     it 'entity should be enabled when adding a new mapping' do
       expect(response.body).to include('<select name="entity" id="entity" class="selectpicker">')
     end
@@ -33,14 +29,22 @@ describe 'ops/_label_tag_mapping_form.html.haml' do
     it 'label should be enabled when adding a new mapping' do
       expect(response.body).to include('<input type="text" name="label_name" id="label_name" maxlength="25" class="form-control" data-miq_observe')
     end
-
-    it 'category should be enabled when adding a new mapping' do
-      expect(response.body).to include('<input type="text" name="category" id="category" maxlength="50" class="form-control" data-miq_observe')
-    end
   end
 
   context 'edit existing mapping' do
+    let(:tag_category_parameters_for_haml) do
+      {:lt_map       => @lt_map,
+       :categories   => [],
+       :category     => nil,
+       :all_entities => false}
+    end
+
     before do
+      set_controller_for_view("ops")
+      set_controller_for_view_to_be_nonrestful
+
+      allow(view).to receive(:tag_category_parameters_for_haml).and_return(tag_category_parameters_for_haml)
+
       @lt_map = FactoryBot.create(:tag_mapping_with_category)
       @edit = {:id  => nil,
                :new => {:options    => [["<All>", nil]],


### PR DESCRIPTION
This PR along with the [core PR](https://github.com/ManageIQ/manageiq/pull/20289) enables the following new functions:
- Allows mapping a label to existing managed tags categories
- Allows mapping labels of all provider types  and resource types to managed tag categories
- As a side effect of the above, it allows referencing mapped managed tag categories and entries in policies, rate assignments, reports, expressions, filters, etc.

The representation of this concept is presented externally in the UI and the supporting code as **All Entities**. Internally, `All Entities` is implemented as a tag category without the `<provider-type>:<resource-type>:` prefix, which is what effectively opens mapping up to regular managed tag categories.
![image](https://user-images.githubusercontent.com/76593/93347771-76350d00-f803-11ea-86d1-1d7bf37bb848.png)

Opening up label mapping to managed tag categories presents a number of challenges and edge cases that add some new behavior. One of which is having to support both single-value and multi-value categories. We think we've identified and addresses all edge cases and have implemented tests in both PRs to cover them.

## UI
![bB70F7KfBe](https://user-images.githubusercontent.com/14937244/94283238-0d5f3a80-ff51-11ea-81d8-05b9e3fefc0f.gif)


## Summarization of behavior

### Specific Entity (Provider,... ) - tags/classifications contain prefixes

#### Used Values in UI form:
- Entity: `Instance(Amazon)`
- Resource Label: `environment`
- Tag Category:  `NewCategory` (this category does not have to exist)

Actions:
- create:
  - Tag Mapping:
```
ContainerLabelTagMapping.last
=>

#<ContainerLabelTagMapping:0x00007fb3377cc1c0> {
                       :id => 9,
    :labeled_resource_type => "Vm",
               :label_name => "environment",
              :label_value => nil,
                   :tag_id => 215,
               :created_at => Thu, 20 Aug 2020 14:45:37 UTC +00:00,
               :updated_at => Thu, 20 Aug 2020 14:45:37 UTC +00:00
}
```
Tag created with mapping:

```
ContainerLabelTagMapping.last.tag
=>
#<Tag:0x00007fb31d1e4740> {
      :id => 215,
    :name => "/managed/amazon:vm:newcategory"
}
```
and classification

```
ContainerLabelTagMapping.last.tag.classification
=>
#<Classification:0x00007fb32e6d3330> {
              :id => 215,
     :description => "amazon:vm|NewCategory",
            :icon => nil,
       :read_only => true,
          :syntax => "string",
    :single_value => true,
    :example_text => nil,
          :tag_id => 215,
       :parent_id => nil,
            :show => true,
         :default => nil,
     :perf_by_tag => nil
}
```

- update:
   Tag and classification of mapping is updated correctly.

- delete:
   Tags/Classifications/Taggings are deleted from resources (Vms..) when mapping is deleted.

### All Entities(All Providers,...) 
-  mapped tags/classifications are visible and usable in UI(expression editor, policy,... ) and mapped to existing category


#### Used Values in UI form:
- Entity: `All Entities`
- Resource Label: `environment`
- Tag Category:  `Department ` (this category have to exist)

Actions:
- create:
```
ContainerLabelTagMapping.last
=>

#<ContainerLabelTagMapping:0x00007fb33a935d60> {
                       :id => 12,
    :labeled_resource_type => "_all_entities_",
               :label_name => "environment",
              :label_value => nil,
                   :tag_id => 40,
               :created_at => Fri, 21 Aug 2020 07:53:26 UTC +00:00,
               :updated_at => Fri, 21 Aug 2020 07:53:26 UTC +00:00
}
```

```
# existing tag 
ContainerLabelTagMapping.last.tag 
=>

#<Tag:0x00007fb33b1bcf88> {
      :id => 40,
    :name => "/managed/department"
}
```

```
# existing classification 
ContainerLabelTagMapping.last.tag.classification
=>
#<Classification:0x00007fb33b4fb028> {
              :id => 40,
     :description => "Department",
            :icon => nil,
       :read_only => false,
          :syntax => "string",
    :single_value => false,
    :example_text => "The department the resource is assigned to, such as HR, Accounting, or Sales.",
          :tag_id => 40,
       :parent_id => nil,
            :show => true,
         :default => true,
     :perf_by_tag => nil
}
```

- update Tag Category:
 Tags/Classifications/Taggings **remain** to connected with previous Tag Category and tag:

 Mapping to Tag Category: `Department`
```
Vm.first.tags
=>

[
    [0] #<Tag:0x00007fb33b5d2640> {
          :id => 209,
        :name => "/managed/department/production"
    }
]
```
When Tag Category on the mapping is changed to the `Environment`:


```
Vm.first.tags
=>

[
    [0] #<Tag:0x00007fb33b5d2780> {
          :id => 208,
        :name => "/managed/environment/production"
    },
    [1] #<Tag:0x00007fb33b5d2640> {
          :id => 209,
        :name => "/managed/department/production".  ## <-- From Previous Tag Category
    }
]
```

- delete mapping:
 Tags/Classifications/Taggings created by mapping process **are not deleted** on resources.

### Links
Addresses https://github.com/ManageIQ/manageiq/issues/20409
Required Core PR - ManageIQ/manageiq#20289