### PR TITLE
Rename Category and Label in Label Tag Mapping Screen

### DIFF
--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -22,7 +22,7 @@
       miqSelectPickerEvent('entity', "#{url}")
   .form-group
     %label.col-md-2.control-label
-      = _("Label")
+      = _("Resource Label")
     .col-md-8
       = text_field_tag("label_name", @edit[:new][:label_name],
                        :maxlength         => 25,
@@ -33,7 +33,7 @@
   %h3= _("Enter tag category to map to")
   .form-group
     %label.col-md-2.control-label
-      = _("Category")
+      = _("Tag Category")
     .col-md-8
       = text_field_tag("category", @edit[:new][:category],
                        :maxlength         => 50,


### PR DESCRIPTION
Make fields Category and Label consistent in with list of mappings:

<img width="1049" alt="Screenshot 2020-08-21 at 10 59 10" src="https://user-images.githubusercontent.com/14937244/90872935-a40e6980-e39d-11ea-8303-9da56a9d8ffb.png">

Change is in Label Tag Mapping form:

### Before
<img width="962" alt="Screenshot 2020-08-21 at 10 45 05" src="https://user-images.githubusercontent.com/14937244/90872999-b688a300-e39d-11ea-99c7-447b58628fd2.png">


### After
<img width="885" alt="Screenshot 2020-08-21 at 11 03 36" src="https://user-images.githubusercontent.com/14937244/90873187-05ced380-e39e-11ea-9d76-6e9ac9b80e3f.png">

cc @gtanzillo 

@miq-bot assign @h-kataria 
@miq-bot add_label bug
