### PR TITLE
Fix header in Set Ownership Screen

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -102,6 +102,27 @@ module Mixins
           session[:edit] = @edit
         end
 
+        def header_for_ownership
+          raise _("Items are required for Set Ownership screen") if @ownershipitems.nil? || @ownershipitems.count == 0
+
+          if @ownershipitems.count == 1
+            case @ownershipitems.first
+            when ManageIQ::Providers::InfraManager::Vm
+              _('Set Ownership for Virtual Machine')
+            when ManageIQ::Providers::CloudManager::Vm
+              _('Set Ownership for Instance')
+            when ManageIQ::Providers::InfraManager::Template
+              _('Set Ownership for Template')
+            when ManageIQ::Providers::CloudManager::Template
+              _('Set Ownership for Image')
+            else
+              _('Set Ownership')
+            end
+          else
+            _('Set Ownership for selected items')
+          end
+        end
+
         def valid_items_for(klass, param_ids)
           scope = klass.respond_to?(:with_ownership) ? klass.with_ownership : klass
           checked_ids = Rbac.filtered(scope.where(:id => param_ids)).pluck(:id)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1484,7 +1484,7 @@ module VmCommon
       action = "prov_edit"
     when "ownership"
       partial = "shared/views/ownership"
-      header = _("Set Ownership for %{vms_or_templates}") % {:vms_or_templates => ui_lookup(:table => table)}
+      header = header_for_ownership
       action = "ownership_update"
     when "performance"
       partial = "layouts/performance"

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -204,6 +204,38 @@ describe VmOrTemplateController do
       expect(presenter[:update_partials]).to have_key(:form_buttons_div)
     end
 
+    context 'set ownership screen' do
+      let(:vm_openstack) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
+
+      before do
+        allow(controller).to receive(:render)
+        controller.instance_variable_set(:@sb, :action => 'ownership')
+        request.parameters[:controller] = 'vm_or_template'
+      end
+
+      it 'displays header for instance' do
+        controller.instance_variable_set(:@ownershipitems, [vm_openstack])
+        controller.send(:replace_right_cell)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Set Ownership for Instance')
+      end
+
+      let(:vm_vmware) { FactoryBot.create(:vm_vmware) }
+
+      it 'displays header for virtual machine' do
+        controller.instance_variable_set(:@ownershipitems, [vm_vmware])
+        controller.send(:replace_right_cell)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Set Ownership for Virtual Machine')
+      end
+
+      let(:template) { FactoryBot.create(:template_infra) }
+
+      it 'displays header for virtual machine and template' do
+        controller.instance_variable_set(:@ownershipitems, [vm_vmware, template])
+        controller.send(:replace_right_cell)
+        expect(controller.instance_variable_get(:@right_cell_text)).to eq('Set Ownership for selected items')
+      end
+    end
+
     context 'Instance policy simulation' do
       let(:vm_openstack) { FactoryBot.create(:vm_openstack, :ext_management_system => FactoryBot.create(:ems_openstack)) }
 


### PR DESCRIPTION
There was displayed only "Instance" or "Virtual Machine" regardless real type of resource. In other words it never display "Image" or "Template" in header. 

I added method which return string header according to model of passed record.

## Template

#### before

<img width="628" alt="Screenshot 2020-08-24 at 16 05 48" src="https://user-images.githubusercontent.com/14937244/91053970-e77a0980-e623-11ea-9f5b-ca180705584a.png">

#### after

<img width="595" alt="Screenshot 2020-08-24 at 16 04 31" src="https://user-images.githubusercontent.com/14937244/91053961-e47f1900-e623-11ea-9cc2-8fa879edf5d0.png">



Links
-------



@miq-bot assign @mzazrivec 
@miq-bot add_label bug

