### PR TITLE
Allow to display templates set ownership screen

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -98,7 +98,7 @@ module Mixins
           @groups = {} # Create new entries hash (2nd pulldown)
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
           @edit[:object_ids] = @ownershipitems
-          @view = get_db_view(klass == VmOrTemplate ? Vm : klass, :clickable => false) # Instantiate the MIQ Report view object
+          @view = get_db_view(klass, :clickable => false) # Instantiate the MIQ Report view object
           session[:edit] = @edit
         end
 

--- a/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
@@ -1,9 +1,17 @@
 describe Mixins::Actions::VmActions::Ownership do
   describe '#build_ownership_info' do
+    let(:user_role) { FactoryBot.create(:miq_user_role) }
+    let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
+    let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      login_as user
+      allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
+      allow(controller).to receive(:session).and_return(:userid => user.userid)
+    end
+
     context 'setting ownership of Catalog Item' do
-      let(:user_role) { FactoryBot.create(:miq_user_role) }
-      let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
-      let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
       let(:controller) { CatalogController.new }
       let(:cat_item) { FactoryBot.create(:service_template) }
 
@@ -19,6 +27,21 @@ describe Mixins::Actions::VmActions::Ownership do
       it 'makes quadicons in Affected Items section not clickable' do
         controller.send(:build_ownership_info, [cat_item.id])
         expect(controller.instance_variable_get(:@report_data_additional_options)[:clickable]).to be(false)
+      end
+    end
+
+    context 'setting ownership of VMs and Templates' do
+      let(:controller) { VmInfraController.new }
+      let(:vms_and_templates) { [FactoryBot.create(:vm_vmware), FactoryBot.create(:template_vmware)] }
+
+      before do
+        allow(controller).to receive(:find_records_with_rbac).and_return(vms_and_templates)
+        controller.params = {:controller => 'vm_infra'}
+      end
+
+      it 'is uses VmOrTemplate model to list items in Affected Items section' do
+        controller.send(:build_ownership_info, vms_and_templates.map(&:id))
+        expect(controller.instance_variable_get(:@report_data_additional_options)[:model]).to eq("VmOrTemplate")
       end
     end
   end


### PR DESCRIPTION
Templates are not displayed in set ownership screen because report data request uses always `Vm` model.
This change should be ok -` VmOrTemplate.yml` exists.

Changed condition was here before the  initial commit.

#### Before

![before](https://user-images.githubusercontent.com/14937244/91080504-f4a7f000-e645-11ea-8a3c-88a9dacfa3bf.gif)

(and when just templates are selected then it doesn't displays anything.)

#### After

![after](https://user-images.githubusercontent.com/14937244/91080518-f7a2e080-e645-11ea-8a95-9e39004fb8a2.gif)

@miq-bot add_label bug

@miq-bot assign @himdel 
