### PR TITLE
Sort report results by default sort column from view's yaml

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -491,12 +491,7 @@ class ReportController < ApplicationController
 
     elsif nodes.length == 5
       @sb[:selected_rep_id] = nodes[4]
-      if role_allows?(:feature => "miq_report_widget_editor")
-        # all widgets for this report
-        get_all_widgets("report", nodes[4])
-      end
       get_all_reps(nodes[4])
-
     elsif nodes.length == 6 # Report result selected.
       @sb[:miq_report_id] = nil
       report = show_saved_report(determine_report_result_id('report'))


### PR DESCRIPTION
Default sort column is improper in report results screen 

#### Before
<img width="1426" alt="Screenshot 2020-08-26 at 12 11 14" src="https://user-images.githubusercontent.com/14937244/91291402-4b700f80-e795-11ea-84fe-9a396aa2be22.png">

#### After
<img width="1418" alt="Screenshot 2020-08-26 at 12 07 41" src="https://user-images.githubusercontent.com/14937244/91291408-4e6b0000-e795-11ea-87a8-0c1354b39ee2.png">

Related yaml for that screen is [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/product/views/MiqReportResult.yaml)


There is [code](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/report_controller/widgets.rb#L223) in method `get_all_widgets ` which set default sort column to `0` (it is first column from column list(`col_order[0]`) of view's yaml) and this default sort column is used also for sorting report results.

So this is probably OK for widget's lists but we want to control default sort column from related yaml of view's list.


so I was thinking about removing [code]([code](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/report_controller/widgets.rb#L223)) and then I found calling method `get_all_widgets` is not needed. (widgets list is obtained in `get_all_reps` method [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/3fce7b476be7b8352c16ba06be1dfb78916ae444/app/controllers/report_controller/reports.rb#L138))


@miq-bot assign @mzazrivec 
@miq-bot add_label bug


