### PR TITLE
Fix html5 console button identifier

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -99,7 +99,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
         N_('Access'),
         :items => [
           included_class.button(
-            :vm_vnc_console,
+            :vm_html5_console,
             'pficon pficon-screen fa-lg',
             N_('Open a web-based HTML5 console for this VM'),
             N_('VM Console'),


### PR DESCRIPTION
1. create a user role with access to html5 console: `All VM and Instance Access Rules > VM Access Rules > Operate > Console using HTML5`
2. create a user group and a user using the above role
3. log in as the above user
4. attemt to connect to cloud instance console

Before:
![Screenshot from 2020-08-28 13-27-34](https://user-images.githubusercontent.com/6648365/91556165-91160f00-e932-11ea-9a7f-69d853abcce0.png)


After:
![Screenshot from 2020-08-28 13-20-02](https://user-images.githubusercontent.com/6648365/91556178-94a99600-e932-11ea-8a69-761cfef8ce53.png)

The role identifier for the html5 console feature is `vm_html5_console` and the button identifier in UI needs to match this role identifier, otherwise the feature will never work properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1873418