### PR TITLE
[JANSA] Correctly set x_node for generic_object_definition_controller show_list()

### DIFF
--- a/app/controllers/generic_object_definition_controller.rb
+++ b/app/controllers/generic_object_definition_controller.rb
@@ -21,6 +21,7 @@ class GenericObjectDefinitionController < ApplicationController
   end
 
   def show_list
+    self.x_node = params[:id] if params[:id].present?
     self.x_active_tree ||= :generic_object_definitions_tree
     self.x_node ||= 'root'
     build_tree


### PR DESCRIPTION
1. Go to Generic Objects screen
2. Create a new GO class
3. Click on the new class in the left accordion
4. Click on `Generic Objects` breadcrumb link
5. See the new breadcrumb

Before:
![Screenshot from 2020-09-02 16-03-02](https://user-images.githubusercontent.com/6648365/91994144-885c7900-ed36-11ea-898f-f4965d05ca1e.png)


After:
![Screenshot from 2020-09-02 15-55-00](https://user-images.githubusercontent.com/6648365/91994155-8c889680-ed36-11ea-8d5d-d6700abc0a3c.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1719889

This fix is only for jansa & ivanchuk branches, on master branch the problem has been fixed in 85f78065b78708fc00b0399a5796af4aa4fa64f2