### PR TITLE
Fix popover hiding under menu

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -714,3 +714,8 @@ fieldset {
 table.c3-tooltip td {
   background-color: #393f44;
 }
+
+/* popovers should go over menu, but under .miq-main-menu-overlay */
+#popover {
+  z-index: 9999;
+}


### PR DESCRIPTION
popovers need to go over the menu but under the menu overlay.

Prevents `/ems_configuration/new` Username popover (amongst others) from being cut off by the menu.

Before:

![bad](https://user-images.githubusercontent.com/289743/92144587-71855780-ee06-11ea-9099-d8b48dffe408.png)


After:

![good](https://user-images.githubusercontent.com/289743/92144599-74804800-ee06-11ea-9602-08f8f23af766.png)

Cc @h-kataria 