### PR TITLE
Cross reference the webpack manifest with the actual node_modules

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -4,8 +4,11 @@
 
 const merge = require('webpack-merge');
 const CompressionPlugin = require('compression-webpack-plugin');
-const { StatsWriterPlugin } = require('webpack-stats-plugin');
 const sharedConfig = require('./shared.js');
+
+const { StatsWriterPlugin } = require('webpack-stats-plugin');
+const fs = require('fs');
+const sortBy = require('lodash/sortBy');
 
 module.exports = merge(sharedConfig, {
   mode: 'production',
@@ -24,12 +27,44 @@ module.exports = merge(sharedConfig, {
 
       transform(data) {
         // recursively flatten nested modules
-        const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name;
+        const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name.split("!").pop();
         const transformModules = ms => ms.flatMap(m => transformModule(m));
 
-        var modules = transformModules(data.modules).sort();
+        var modules = transformModules(data.modules)
         modules = [...new Set(modules)]; // uniq
-        return JSON.stringify(modules, null, 2);
+
+        // find the package.json file for each module
+        modules = modules.filter(m => m.includes("node_modules"));
+        var packagePaths = modules.map(m => {
+          var match = m.match(/(.*node_modules\/)([^\/]+)(\/[^\/]+)?/);
+          var path = [
+            `${match[1]}${match[2]}/package.json`,
+            `${match[1]}${match[2]}${match[3]}/package.json`,
+          ].find(p => fs.existsSync(p));
+
+          if (path == null) {
+            console.warn(`[webpack-manifest] WARN: Unable to find a package.json for ${m}`);
+          }
+
+          return path;
+        })
+        packagePaths = packagePaths.filter(p => p != null);
+        packagePaths = [...new Set(packagePaths)]; // uniq
+
+        // extract relevant package data from the package.json
+        var packages = packagePaths.map(p => {
+          var content = fs.readFileSync(p);
+          var package = JSON.parse(content);
+          return {
+            name: package.name,
+            license: package.license,
+            version: package.version,
+            location: p
+          }
+        });
+        packages = sortBy(packages, ['name', 'version']);
+
+        return JSON.stringify(packages, null, 2);
       }
     })
   ],


### PR DESCRIPTION
Part of #7289

With this change (based on the Ruby code in #7289) the webpack-modules-manifest.json now looks like this:

```json
[
  {
    "name": "@babel/runtime",
    "license": "MIT",
    "version": "7.11.0",
    "location": "/Users/jfrey/.gem/ruby/2.6.5/bundler/gems/manageiq-v2v-d17c2571ae48/node_modules/@babel/runtime/package.json"
  },
  {
    "name": "@babel/runtime",
    "license": "MIT",
    "version": "7.11.2",
    "location": "./node_modules/@babel/runtime/package.json"
  },
  {
    "name": "@babel/runtime-corejs2",
    "license": "MIT",
    "version": "7.11.2",
    "location": "./node_modules/@babel/runtime-corejs2/package.json"
  },
  {
    "name": "@carbon/icon-helpers",
    "license": "Apache-2.0",
    "version": "10.9.0",
    "location": "./node_modules/@carbon/icon-helpers/package.json"
  },
  {
    "name": "@carbon/icons-react",
    "license": "Apache-2.0",
    "version": "10.11.0",
    "location": "./node_modules/@carbon/icons-react/package.json"
  },
  {
    "name": "@carbon/icons-react",
    "license": "Apache-2.0",
    "version": "10.17.0",
    "location": "./node_modules/carbon-components-react/node_modules/@carbon/icons-react/package.json"
  },
```

@himdel Please review.  cc @simaishi 