### PR TITLE
Fix non-unique keys error inside pf_aggregate_status_card

### DIFF
--- a/app/javascript/components/pf_aggregate_status_card.jsx
+++ b/app/javascript/components/pf_aggregate_status_card.jsx
@@ -32,8 +32,8 @@ const PfAggregateStatusCard = ({
       </h2>
       <div className="card-pf-body">
         <p className="card-pf-aggregate-status-notifications">
-          { notifications.map(notification => (
-            <span key={notification} className="card-pf-aggregate-status-notification">
+          { notifications.map((notification, i) => (
+            <span key={i} className="card-pf-aggregate-status-notification">
               <a href={notification.href}>
                 { notification.iconImage && (
                   <React.Fragment>


### PR DESCRIPTION
The following warning raised once we tried to implement new features that use the generic PfAggregateStatusCard.

Warning: Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s,[object Object], in p (created by PfAggregateStatusCard) in div (created by PfAggregateStatusCard) in div (created by PfAggregateStatusCard) in PfAggregateStatusCard (created by AggregateStatusCard) in div (created by AggregateStatusCard) in div (created by AggregateStatusCard) in AggregateStatusCard in Provider

<img width="951" alt="error" src="https://user-images.githubusercontent.com/53213107/92440050-8d954a00-f1b4-11ea-8efc-78fe7fb4aef5.PNG">

The error is because key={notification} returns string of notification with the value of object, and therefore for several objects we get the same key. we therefore suggest to change the key to the map index which is unique.
