### PR TITLE
output the stack trace of the error to the page.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -187,6 +187,7 @@ class ApplicationController < ActionController::Base
             e.message
           end
 
+    msg = "#{msg}\n#{e.backtrace.join("\n")}" unless MiqEnvironment::Command.is_production?
     render_exception(msg)
   end
   private :error_handler


### PR DESCRIPTION
Minor change for outputing the stack trace of the error to the page, but only in dev mode.