### PR TITLE
Added new provisioning fields for the "IBM Power Virtual Servers" Provider

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,6 +73,7 @@ class ApplicationController < ActionController::Base
   include_concern 'ReportDownloads'
   include_concern 'SessionSize'
   include_concern 'SysprepAnswerFile'
+  include_concern 'UserScriptFile'
   include_concern 'Tags'
   include_concern 'Tenancy'
   include_concern 'Timelines'

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -711,6 +711,13 @@ module ApplicationController::MiqRequestMethods
               @edit[:new][f.to_sym] = []
               params[key].split(",").each { |v| @edit[:new][f.to_sym].push(v.to_i) }
             end
+          elsif f == "cloud_volumes"
+            if params[key] == ""
+              @edit[:new][f.to_sym] = [nil]
+            else
+              @edit[:new][f.to_sym] = []
+              params[key].split(",").each { |v| @edit[:new][f.to_sym].push(v) }
+            end
           else
             @edit[:new][f.to_sym] = [val, field[:values][val]] # Save [value, description]
           end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -205,7 +205,6 @@ module ApplicationController::MiqRequestMethods
     end
   end
 
-  # Add/edit a provision request
   def prov_edit
     if params[:button] == "cancel"
       req = MiqRequest.find(session[:edit][:req_id]) if session[:edit] && session[:edit][:req_id]
@@ -227,6 +226,12 @@ module ApplicationController::MiqRequestMethods
       @layout = layout_from_tab_name(params[:org_controller])
       if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
         upload_sysprep_file
+        @tabactive = "customize"
+      elsif params[:commit] == 'Upload Script'
+        upload_user_script
+        @tabactive = "customize"
+      elsif params[:commit] == "Clear Script"
+        clear_user_script
         @tabactive = "customize"
       else
         if params[:req_id]

--- a/app/controllers/application_controller/user_script_file.rb
+++ b/app/controllers/application_controller/user_script_file.rb
@@ -1,0 +1,32 @@
+class ApplicationController
+  module UserScriptFile
+    def upload_user_script
+      @_params.delete(:commit)
+      @upload_user_script = true
+      @edit = session[:edit]
+      build_grid
+
+      if params.fetch_path(:upload, :file).respond_to?(:read)
+        @edit[:new][:user_script] = params[:upload][:file].original_filename
+        begin
+          @edit[:new][:user_script_text] = params[:upload][:file].read
+          msg = _('User script "%{params}" upload was successful') % {:params => params[:upload][:file].original_filename}
+          add_flash(msg)
+        rescue StandardError => bang
+          @edit[:new][:user_script] = nil
+          msg = _("Error during User Script \"%{params}\" file upload: %{message}") % {:params => params[:upload][:file].original_filename, :message => bang.message}
+          add_flash(msg, :error)
+        end
+      end
+    end
+
+    def clear_user_script
+      @_params.delete(:commit)
+      @upload_user_script = false
+      @edit = session[:edit]
+      build_grid
+
+      @edit[:new][:user_script_text] = nil
+    end
+  end
+end

--- a/app/controllers/application_controller/user_script_file.rb
+++ b/app/controllers/application_controller/user_script_file.rb
@@ -22,7 +22,7 @@ class ApplicationController
 
     def clear_user_script
       @_params.delete(:commit)
-      @upload_user_script = false
+      @upload_user_script = true
       @edit = session[:edit]
       build_grid
 

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -31,19 +31,26 @@ module VmShowMixin
     if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
       upload_sysprep_file
       set_form_locals_for_sysprep
+    elsif params[:commit] == 'Upload Script'
+      upload_user_script
+      set_form_locals_for_file_upload
+    elsif params[:commit] == "Clear Script"
+      clear_user_script
+      set_form_locals_for_file_upload
     end
+
     if params[:id]
       # if you click on a link to VM on a dashboard widget that will redirect you
       # to explorer with params[:id] and you get into the true branch
       redirected = set_elements_and_redirect_unauthorized_user
     else
-      set_active_elements(allowed_features.first) unless @upload_sysprep_file
+      set_active_elements(allowed_features.first) unless (@upload_sysprep_file || @upload_user_script)
     end
 
     render :layout => "application" unless redirected
   end
 
-  def set_form_locals_for_sysprep
+  def set_form_locals_for_file_upload
     _partial, action, @right_cell_text = set_right_cell_vars
     locals = {:submit_button => true,
               :no_reset      => true,

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -30,7 +30,7 @@ module VmShowMixin
 
     if params[:commit] == "Upload" && session.fetch_path(:edit, :new, :sysprep_enabled, 1) == "Sysprep Answer File"
       upload_sysprep_file
-      set_form_locals_for_sysprep
+      set_form_locals_for_file_upload
     elsif params[:commit] == 'Upload Script'
       upload_user_script
       set_form_locals_for_file_upload
@@ -44,7 +44,7 @@ module VmShowMixin
       # to explorer with params[:id] and you get into the true branch
       redirected = set_elements_and_redirect_unauthorized_user
     else
-      set_active_elements(allowed_features.first) unless (@upload_sysprep_file || @upload_user_script)
+      set_active_elements(allowed_features.first) unless @upload_sysprep_file || @upload_user_script
     end
 
     render :layout => "application" unless redirected

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -72,7 +72,7 @@
         - if @edit && field_hash[:required] && field_hash[:display] == :edit
           *
       -# Text fields
-      - if [:cpu_limit, :cpu_reserve, :dns_servers, :dns_suffixes, :gateway,
+      - if [:cpu_limit, :cpu_reserve, :entitled_processors, :dns_servers, :dns_suffixes, :gateway,
             :hostname, :ip_addr, :linux_host_name, :linux_domain_name,
             :mac_address, :owner_address, :owner_city, :owner_company,
             :owner_country, :owner_department, :owner_email,

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -505,9 +505,21 @@
         .col-md-8
           - path = Rails.application.routes.recognize_path request.referer
           - if path[:controller] == "miq_request"
-            = form_tag({:action    => "prov_edit"},
-                        :multipart => true,
-                        :method    => :post) do
+            = form_tag({:action    => "prov_edit",
+                         :req_id    => @edit[:req_id]&.to_s}.compact,
+                         :multipart => true,
+                         :method    => :post) do
+              .form-group
+                .col-md-4
+                  = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
+                .col-md-6
+                  = submit_tag(_("Upload Script"), :class => "upload btn btn-default")
+                  = submit_tag(_("Clear Script"),  :class => "upload btn btn-default")
+          - else
+            = form_tag({:controller => path[:controller],
+                        :action     => "explorer"},
+                        :multipart  => true,
+                        :method     => :post) do
               .form-group
                 .col-md-4
                   = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -191,7 +191,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:customization_template_script, :sysprep_upload_text].include?(field)
+      - elsif [:customization_template_script, :sysprep_upload_text, :user_script_text].include?(field)
         -# text Area field to display uploaded file contents
         .col-md-8
           = text_area_tag(field_id, options[field],
@@ -501,3 +501,16 @@
                   = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
                 .col-md-6
                   = submit_tag(_("Upload"), :class => "upload btn btn-default")
+      - elsif [:user_script].include?(field)
+        .col-md-8
+          - path = Rails.application.routes.recognize_path request.referer
+          - if path[:controller] == "miq_request"
+            = form_tag({:action    => "prov_edit"},
+                        :multipart => true,
+                        :method    => :post) do
+              .form-group
+                .col-md-4
+                  = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
+                .col-md-6
+                  = submit_tag(_("Upload Script"), :class => "upload btn btn-default")
+                  = submit_tag(_("Clear Script"),  :class => "upload btn btn-default")

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -243,7 +243,7 @@
                :vm_maximum_memory, :boot_disk_size, :subnet].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
-        - multiple = field == :security_groups || field == :cloud_volumes
+        - multiple = %i[security_groups cloud_volumes].include?(field)
         - td_class = field == :security_groups ? "wider" : "wide"
         .col-md-8{:class => td_class}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]
@@ -501,7 +501,7 @@
                   = render :partial => "shared/file_chooser", :locals => {:object_name => "upload", :method => "file"}
                 .col-md-6
                   = submit_tag(_("Upload"), :class => "upload btn btn-default")
-      - elsif [:user_script].include?(field)
+      - elsif field == :user_script
         .col-md-8
           - path = Rails.application.routes.recognize_path request.referer
           - if path[:controller] == "miq_request"

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -243,7 +243,7 @@
                :vm_maximum_memory, :boot_disk_size, :subnet].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
-        - multiple = field == :security_groups
+        - multiple = field == :security_groups || field == :cloud_volumes
         - td_class = field == :security_groups ? "wider" : "wide"
         .col-md-8{:class => td_class}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -233,7 +233,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:instance_type, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
+      - elsif [:instance_type, :sys_type, :pin_policy, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
                :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8,
                :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
                :retirement_warn, :cloud_network, :network_port, :cloud_subnet,
@@ -407,7 +407,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:linked_clone, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid, :seal_template,
+      - elsif [:linked_clone, :migratable, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid, :seal_template,
                :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible].include?(field)
         -# ### Checkbox fields
         .col-md-8{:style => "vertical-align: top;"}

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -233,7 +233,7 @@
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]
-      - elsif [:instance_type, :sys_type, :pin_policy, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
+      - elsif [:instance_type, :sys_type, :storage_type, :cloud_volumes, :pin_policy, :guest_access_key_pair, :security_groups, :monitoring, :vm_tag_1,
                :vm_tag_2, :vm_tag_3, :vm_tag_4, :vm_tag_5, :vm_tag_6, :vm_tag_7, :vm_tag_8,
                :vm_tag_9, :vm_tag_10, :provision_type, :network_adapters, :retirement,
                :retirement_warn, :cloud_network, :network_port, :cloud_subnet,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -142,7 +142,7 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
   - when :hardware
-    - keys = [:instance_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
+    - keys = [:instance_type, :sys_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
@@ -183,6 +183,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :customize
+
     - if select_check?(wf)
       - edit_or_options = (@edit && @edit[:new] && @edit[:new][:sysprep_enabled]) || (@options && @options[:sysprep_enabled]) || []
       - keys = [:sysprep_enabled]
@@ -401,6 +402,13 @@
               :prefix                     => "/miq_request/",
               :keys                       => keys})
     - else
+      - keys = [:migratable, :pin_policy]
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
+        :locals         => {:workflow => wf,
+           :dialog                    => dialog,
+           :label                     => _("Other"),
+           :prefix                    => "/miq_request/",
+           :keys                      => keys})
       - keys = [:root_username, :root_password]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -142,7 +142,7 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
   - when :hardware
-    - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
+    - keys = [:instance_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -402,6 +402,24 @@
               :prefix                     => "/miq_request/",
               :keys                       => keys})
     - else
+      - if (@edit && @edit[:new] && @edit[:new][:user_script_text]) || (@options && @options[:user_script_text])
+        - file_name = (@edit && @edit[:new]) ? @edit[:new][:user_script] : @options[:user_script]
+        - label = _("Uploaded File '%{filename}'") % {:filename => file_name}
+        - keys = [:user_script_text]
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
+            :locals         => {:workflow => wf,
+              :dialog                     => dialog,
+              :label                      => label,
+              :prefix                     => "/miq_request/",
+              :keys                       => keys})
+      - if @edit && @edit[:new]
+        - keys = [:user_script]
+        = render(:partial => "/miq_request/prov_dialog_fieldset",
+            :locals         => {:workflow => wf,
+              :dialog                     => dialog,
+              :label                      => _("Upload File"),
+              :prefix                     => "/miq_request/",
+              :keys                       => keys})
       - keys = [:migratable, :pin_policy]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -405,7 +405,7 @@
       - if (@edit && @edit[:new] && @edit[:new][:user_script_text]) || (@options && @options[:user_script_text])
         - file_name = (@edit && @edit[:new]) ? @edit[:new][:user_script] : @options[:user_script]
         - label = _("Uploaded File '%{filename}'") % {:filename => file_name}
-        - keys = [:user_script_text]
+        - keys = %i[user_script_text]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
             :locals         => {:workflow => wf,
               :dialog                     => dialog,
@@ -420,7 +420,7 @@
               :label                      => _("Upload File"),
               :prefix                     => "/miq_request/",
               :keys                       => keys})
-      - keys = [:migratable, :pin_policy]
+      - keys = %i[migratable, pin_policy]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
            :dialog                    => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -142,7 +142,7 @@
             :prefix                     => "/miq_request/",
             :keys                       => keys})
   - when :hardware
-    - keys = [:instance_type, :sys_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
+    - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")

--- a/app/views/vm_cloud/explorer.html.haml
+++ b/app/views/vm_cloud/explorer.html.haml
@@ -12,6 +12,10 @@
       = render(:partial => "layouts/tl_show_async")
     - else
       = render :partial => "layouts/textual_groups_generic"
+- elsif @upload_user_script
+  #main_div
+    = render(:partial => 'miq_request/prov_edit')
+    - @upload_user_script = false
 - else
   -# Showing a list of VMs
   #main_div


### PR DESCRIPTION
Adding fields supported by the IBM PVS but missing in the MIQ

New fields added to the IBM Power Virtual Servers provisioning form.
* pull-down fields: "pin_policy, system_type, storage_type"
* multiselect field: "cloud_volumes"
* read-only text field: "user_script_text" on two different UI paths (miq_prov and explorer)
* checkbox field: 'migratable' boolean value
* fileupload: "user_script" for two different UI paths (miq_prov and explorer)
* added "Customization" Tab, which contains the fileupload, file content text-box, and "IP v4" fields.
  (the tab was already supported by MIQ)

See API field meanings: https://cloud.ibm.com/apidocs/power-cloud#pcloud-pvminstances-post
See related PR in the IBM Cloud repository: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/19