### PR TITLE
Void @sb[:action] before accordion_switch()

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -169,6 +169,7 @@ module ApplicationController::Explorer
   # Accordion selected in explorer
   def accordion_select(node_info = false)
     @lastaction = "explorer"
+    @sb[:action] = nil if @sb
     self.x_active_accord = params[:id].sub(/_accord$/, '')
     self.x_active_tree   = "#{x_active_accord}_tree"
 


### PR DESCRIPTION
1. Navigate to summary screen of a cloud instance with a snapshot
2. Click on `Snapshots` in the summary screen to view instance's snapshots
3. Switch to `Images` accordion
4. See the following rails error:

```
FATAL -- : Error caught: [NoMethodError] undefined method `supports_snapshot_create?' for nil:NilClass
app/helpers/application_helper/button/vm_snapshot_add.rb:5:in `disabled?'
app/helpers/application_helper/button/basic.rb:54:in `calculate_properties'
app/helpers/application_helper/toolbar_builder.rb:141:in `apply_common_props'
app/helpers/application_helper/toolbar_builder.rb:73:in `toolbar_button'
app/helpers/application_helper/toolbar_builder.rb:148:in `build_normal_button'
app/helpers/application_helper/toolbar_builder.rb:182:in `build_button'
app/helpers/application_helper/toolbar_builder.rb:446:in `block (2 levels) in build_toolbar_from_class'
app/helpers/application_helper/toolbar_builder.rb:445:in `each'
app/helpers/application_helper/toolbar_builder.rb:445:in `block in build_toolbar_from_class'
app/helpers/application_helper/toolbar_builder.rb:440:in `each'
app/helpers/application_helper/toolbar_builder.rb:440:in `each_with_index'
app/helpers/application_helper/toolbar_builder.rb:440:in `build_toolbar_from_class'
app/helpers/application_helper/toolbar_builder.rb:16:in `build_toolbar'
app/helpers/application_helper.rb:440:in `build_toolbar'
app/controllers/vm_common.rb:1130:in `replace_right_cell'
app/controllers/application_controller/explorer.rb:181:in `accordion_select'
```

The previous action (navigating to instance's snapshot screen) sets `@sb[:action]` to `snapshot_info` and subsequently confuses `replace_right_cell()` to think it should again render the snapshot screen. Therefore, I'm voiding the sandbox variable here.

https://bugzilla.redhat.com/show_bug.cgi?id=1771637
