### PR TITLE
Round GB Tenant Quota to compensate precision loss

### DIFF
--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -108,7 +108,7 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
         var quota =  vm.tenantQuotaModel.quotas[key];
         if (quota.value) {
           if (quota.unit === 'bytes') {
-            quota.value = quota.value / GIGABYTE;
+            quota.value = Math.round(quota.value / GIGABYTE);
           }
           quota.enforced = true;
         } else {

--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -174,7 +174,7 @@ module OpsHelper::TextualSummary
                 when "general_number_precision_0"
                   value.to_i
                 when "gigabytes_human"
-                  value.to_f / 1.0.gigabyte
+                  (value.to_f / 1.0.gigabyte).round(1)
                 else
                   value.to_f
                 end


### PR DESCRIPTION
Tenant Quotas are stored as bytes using datatype 'float'. This results in precision loss for values exceeding 931322 GB i.e. 99999723552768 bytes. The maximum precision of the 'float' datatype is 15 digits. When values exceeding 931322 GB are used as Tenant Quotas, the displayed result should be rounded (precision 1) to show the correct number of GB. At the edit page (Manage quotas for Tenant) the number of GB should be rounded too (precision 0).

N.B. The 'gigabyte_human' format is defined as having precision:1 at [manageiq/db/fixtures/miq_report_formats.yml](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_report_formats.yml).

The 'Tenant Quota' page when having entered 931323 GB Storage Quota:
![2020-09-09_14h16_49](https://user-images.githubusercontent.com/23237514/92597312-8438da00-f2a7-11ea-8dcb-22e418761020.png)

The 'Manage quotas for Tenant' page when having entered 931323 GB Storage Quota and Memory Quota (revisit after save):
![2020-09-09_16h25_06](https://user-images.githubusercontent.com/23237514/92611429-12698c00-f2b9-11ea-99b7-0ae13ad4fd39.png)

This PR is cosmetically fixing the precision loss for large numbers of GB (larger than 931322 GB) displayed at the Tenant Quota pages.





