### PR TITLE
[JANSA] Translated "choose" string in URL selector in PXE server form

### DIFF
--- a/app/javascript/forms/input-with-dynamic-prefix.jsx
+++ b/app/javascript/forms/input-with-dynamic-prefix.jsx
@@ -63,6 +63,7 @@ const DataDrivenInputWithPrefix = ({
           <div className="dynamic-prefix-input">
             <rawComponents.Select
               classNamePrefix="ddorg__pf3-component-mapper__select"
+              placeholder={`${__('Choose')}`}
               invalid={isRequired && !prefix}
               id={`dynamic-prefix-select-${rest.name}`}
               input={{

--- a/app/javascript/spec/forms/__snapshots__/input-with-dynamic-prefix.spec.js.snap
+++ b/app/javascript/spec/forms/__snapshots__/input-with-dynamic-prefix.spec.js.snap
@@ -41,6 +41,7 @@ exports[`DataDrivenInputWithPrefix should render correctly 1`] = `
           },
         ]
       }
+      placeholder="Choose"
       simpleValue={true}
     />
   </div>


### PR DESCRIPTION
Fixes: [#9230](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/9230)

Before: 
<img src="https://user-images.githubusercontent.com/64800041/92617492-5777c900-f28d-11ea-96c9-ef2a03cd3a67.png" width="500">

After:
<img src="https://user-images.githubusercontent.com/64800041/92620167-572cfd00-f290-11ea-8f44-697617941af1.png" width="500">