### PR TITLE
Added gettext calls to MiqReport::GROUPINGS for options select

### DIFF
--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -145,7 +145,7 @@
                 - col = field_to_col(f.last)
                 - selected = @edit[:new][:col_options][col] && @edit[:new][:col_options][col][:grouping] ? @edit[:new][:col_options][col][:grouping] : []
                 = select_tag(field_name,
-                    options_for_select(MiqReport::GROUPINGS.map(&:reverse), selected),
+                    options_for_select(MiqReport::GROUPINGS.map(&:reverse).map { |key, value| [_(key), value] }, selected),
                     :class    => "selectpicker show-tick",
                     :multiple => true,
                     "title"   => "Check Option")


### PR DESCRIPTION
Issue: English string occurs in Overview -> Reports -> Reports -> Configuration -> Add a new report -> Summary 

Links 
----------------
* [Core Dependency PR - #20537 ](https://github.com/ManageIQ/manageiq/pull/20537)

Steps for Testing/QA
-------------------------------
1. Change language in settings
2. Click Overview -> Reports
3. Click Reports
4. Click Configuration Management -> Virtual Machines -> Account Groups - Linux
5. Click Configuration
6. Click Add a new report
7. Click Availiable Fields and select at one item
8. Click icon
9. Click Formatting
10. Click Summary
11. Select Descending at Sort Order
12. Select Yes at Show Sort Breaks

Original Issue
------------------
English string occured
![error](https://user-images.githubusercontent.com/71033910/92791372-9c2d5e00-f37a-11ea-86fd-74e999812776.png)

Result
-----------------------
<img width="1126" alt="Screen Shot 2020-09-09 at 2 28 53 PM" src="https://user-images.githubusercontent.com/71033910/92638766-cb739a80-f2a8-11ea-82fa-5bd99a42b53d.png">

