### PR TITLE
Fixed width of Action type select component width to fix truncation

### DIFF
--- a/app/views/miq_policy/_action_details.html.haml
+++ b/app/views/miq_policy/_action_details.html.haml
@@ -29,7 +29,7 @@
             - if @edit
               = select_tag('miq_action_type',
                 options_for_select([["<#{_('Choose')}>", nil]] + MiqAction::TYPES.map { |k, v| [_(v), k] }.sort, @edit[:new][:action_type]),
-                :class => "selectpicker")
+                :class => "selectpicker form-control")
               :javascript
                 miqInitSelectPicker();
                 miqSelectPickerEvent('miq_action_type', '#{url}', {beforeSend: true, complete: true})


### PR DESCRIPTION
this is rebased and squashed version of #7285  

This is to fix truncation issue for Action type dropdown button width, for longer text selected especially for translations in other languages, text is being truncated.

**Steps to reproduce**
Click Control-> Explorer
Click Actions-> All Actions
Click Configuration
Click Add a new Action
Select one Action Type


**Expected behavior**
no truncation occurs

**What really happened**
truncation occurs



**Before:**
Text is truncated

<img width="1424" alt="Screen Shot 2020-09-16 at 8 38 39 AM" src="https://user-images.githubusercontent.com/37085529/93338181-14bb7100-f7f8-11ea-93a4-06c973dfed50.png">



**After:**
Button width increased  dynamically and text is not truncated anymore

<img width="1432" alt="Screen Shot 2020-09-16 at 11 01 47 AM" src="https://user-images.githubusercontent.com/37085529/93355472-1b53e380-f80c-11ea-89fc-5b0dc9e84811.png">

