### PR TITLE
Fix Save & Cancel launched from StorageController (Datastores)

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -263,6 +263,7 @@ class StorageController < ApplicationController
   end
 
   def explorer
+    @showtype = nil
     @breadcrumbs = []
     @explorer = true
     @lastaction = "explorer"
@@ -463,7 +464,7 @@ class StorageController < ApplicationController
   end
 
   def tagging_explorer_controller?
-    @explorer
+    @explorer && @showtype.nil?
   end
 
   # called by explorer.rb x_button


### PR DESCRIPTION
1. Infrastructure > Datastores > Select a datastore > in the summary screen, click on VMs
2. In the rendered list, check a VM
3. Launch Tagging screen
4. Hit `Cancel` button

Before, the `Cancel` or even `Save` button would take you back to the datastore summary screen:
![Screenshot from 2020-09-14 17-18-05](https://user-images.githubusercontent.com/6648365/93104547-46c0bc00-f6ae-11ea-9bf8-71bd62e7c670.png)

With this fix, the `Cancel` button would take you back to the list of VMs running on that datastore:
![Screenshot from 2020-09-14 16-58-22](https://user-images.githubusercontent.com/6648365/93104574-53451480-f6ae-11ea-9ed7-11648032cb45.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1741115