### PR TITLE
[WIP] Enable conditional validation of fields in DDF forms

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import defaultComponentMapper from './mappers/componentMapper';
+import validatorMapper from './mappers/validatorMapper';
 import SpyField from './spy-field';
 
 Validators.messages = {
@@ -60,6 +61,7 @@ const MiqFormRenderer = ({
   return (
     <FormRender
       componentMapper={{ ...componentMapper, 'spy-field': SpyField }}
+      validatorMapper={validatorMapper}
       FormTemplate={MiqFormTemplate}
       schema={{ fields: [...fields, { component: 'spy-field', name: 'spy-field', initialize }], ...schema }}
       {...props}

--- a/app/javascript/forms/mappers/validatorMapper.jsx
+++ b/app/javascript/forms/mappers/validatorMapper.jsx
@@ -1,0 +1,12 @@
+import { parseCondition, validatorMapper } from '@data-driven-forms/react-form-renderer';
+
+const conditionalValidator = fn => ({ condition, ...schema }) => (value, allValues, meta) => (
+  !condition || parseCondition(condition, allValues).result ? fn(schema)(value, allValues, meta) : undefined
+);
+
+const mapper = Object.keys(validatorMapper).reduce((obj, key) => ({
+  ...obj,
+  [key]: conditionalValidator(validatorMapper[key]),
+}), {});
+
+export default mapper;

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@carbon/icons-react": "~10.11.0",
     "@carbon/themes": "~10.12.0",
-    "@data-driven-forms/pf3-component-mapper": "~2.8.13",
-    "@data-driven-forms/react-form-renderer": "~2.8.13",
+    "@data-driven-forms/pf3-component-mapper": "~2.8.23",
+    "@data-driven-forms/react-form-renderer": "~2.8.23",
     "@manageiq/react-ui-components": "~0.11.70",
     "@manageiq/ui-components": "~1.4.3",
     "@pf3/select": "~1.12.6",


### PR DESCRIPTION
This is the implementation of the idea proposed [here](https://github.com/data-driven-forms/react-forms/issues/149#issuecomment-539401224), basically allowing to use the same [`condition`](https://data-driven-forms.org/schema/condition-schema#heading-conditionschema) syntax that is already available when displaying/hiding fields. It is wrapping each validator in the [`validatorMapper`](https://data-driven-forms.org/mappers/validator-mapper) with the condition parsing that has been [exposed for external usage](https://github.com/data-driven-forms/react-forms/pull/807).

```js
[
  {
    component: componentTypes.SELECT,
    name: "country",
    label: "Country",
    options: [
      { value: "us", label: "United States" },
      { value: "xx", label: "Other" },
    ],
  },
  {
    component: componentTypes.TEXT_FIELD,
    name: "state",
    label: "State/province",
    validate: [
      {
        type: validatorTypes.REQUIRED,
        condition: {
          when: "country",
          is: "us"
        }
      }
    ],
  }
]
```

This would (partially) solve an [issue](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/15#discussion_r488052818) in the IBM Cloud provider form where some fields would be not required if a dropdown is set to the right value. However, it doesn't deal with the visibility of `*` and some other aspects, so I am also considering to create a specialized wrapper component (with a `fields` attribute similarly to the validator) that would solve all the issues by altering the schema of the fields beneath. 

Even if I go with the other solution, this might be useful in other areas and so I'm leaving it here for discussion as a draft.