### PR TITLE
a11y: Make the main menu items accessible using the keyboard

### DIFF
--- a/app/javascript/menu/side-nav-menu-link.jsx
+++ b/app/javascript/menu/side-nav-menu-link.jsx
@@ -24,10 +24,7 @@ export const SideNavMenuLink = ({
 
   return (
     <SideNavItem id={id}>
-      <Link
-        className={className}
-        onClick={onClick}
-      >
+      <Link className={className} onClick={onClick} onKeyPress={onClick} tabIndex="0">
         {IconElement && (
           <SideNavIcon small>
             <IconElement />


### PR DESCRIPTION
There was no way to access the main menu sections without using the mouse. The problem was the missing `tabindex` property and the lack of the `onKeyDown` didn't allow further expansion of the menu. After this change you should be able to focus on each menu item by hitting <TAB> and expand the menu by hitting <ENTER>.

@kavyanekkalapu delivering this as promised
@himdel there's a minor linting issue in the file that I was not able to figure out, even before my changes

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7253