### PR TITLE
Fix issue during return from Set Ownership Screen to summary page of Service

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -30,7 +30,6 @@ module Mixins
 
           recs = session[:checked_items] || checked_or_params
 
-          @edit[:object_ids] = recs
           if recs.empty?
             add_flash(_("One or more %{model} must be selected to Set Ownership") % {
               :model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)
@@ -109,7 +108,7 @@ module Mixins
 
           @groups = {} # Create new entries hash (2nd pulldown)
           Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
-          @edit[:object_ids] = @ownershipitems
+
           @view = get_db_view(klass, :clickable => false) # Instantiate the MIQ Report view object
           session[:edit] = @edit
         end

--- a/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
@@ -9,6 +9,31 @@ describe Mixins::Actions::VmActions::Ownership do
     allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
   end
 
+  describe "#set_ownership" do
+    let(:controller)      { ServiceController.new }
+    let(:service)         { FactoryBot.create(:service) }
+    let(:request)         { ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=service' }
+
+    before do
+      allow(controller).to receive(:assert_privileges)
+      allow(request).to receive(:parameters).and_return(:controller => 'service')
+      allow(controller).to receive(:drop_breadcrumb)
+      allow(controller).to receive(:get_db_view)
+
+      request.session =  {:checked_items => [service.id] }
+      controller.instance_variable_set(:@_request, request)
+    end
+
+    it "cleans :object_ids in session when action method is called" do
+      controller.instance_variable_set(:@sb, {})
+      controller.instance_variable_set(:@explorer, true)
+      controller.instance_variable_set(:@_params, {:pressed => ''})
+
+      controller.send(:set_ownership)
+      expect(controller.instance_variable_get(:@edit)[:object_ids]).to be_nil
+    end
+  end
+
   describe '#build_ownership_info' do
     before do
       allow(controller).to receive(:session).and_return(:userid => user.userid)

--- a/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
@@ -20,14 +20,14 @@ describe Mixins::Actions::VmActions::Ownership do
       allow(controller).to receive(:drop_breadcrumb)
       allow(controller).to receive(:get_db_view)
 
-      request.session =  {:checked_items => [service.id] }
+      request.session = {:checked_items => [service.id]}
       controller.instance_variable_set(:@_request, request)
     end
 
     it "cleans :object_ids in session when action method is called" do
       controller.instance_variable_set(:@sb, {})
       controller.instance_variable_set(:@explorer, true)
-      controller.instance_variable_set(:@_params, {:pressed => ''})
+      controller.instance_variable_set(:@_params, :pressed => '')
 
       controller.send(:set_ownership)
       expect(controller.instance_variable_get(:@edit)[:object_ids]).to be_nil

--- a/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
+++ b/spec/controllers/mixins/actions/vm_actions/ownership_spec.rb
@@ -1,13 +1,16 @@
 describe Mixins::Actions::VmActions::Ownership do
-  describe '#build_ownership_info' do
-    let(:user_role) { FactoryBot.create(:miq_user_role) }
-    let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
-    let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
+  let(:user_role) { FactoryBot.create(:miq_user_role) }
+  let(:group) { FactoryBot.create(:miq_group, :miq_user_role => user_role) }
+  let(:user) { FactoryBot.create(:user, :miq_groups => [group]) }
 
+  before do
+    EvmSpecHelper.local_miq_server
+    login_as user
+    allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
+  end
+
+  describe '#build_ownership_info' do
     before do
-      EvmSpecHelper.local_miq_server
-      login_as user
-      allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
       allow(controller).to receive(:session).and_return(:userid => user.userid)
     end
 
@@ -16,11 +19,7 @@ describe Mixins::Actions::VmActions::Ownership do
       let(:cat_item) { FactoryBot.create(:service_template) }
 
       before do
-        EvmSpecHelper.local_miq_server
-        login_as user
         allow(controller).to receive(:find_records_with_rbac).and_return([cat_item])
-        allow(MiqGroup).to receive(:non_tenant_groups).and_return([group])
-        allow(controller).to receive(:session).and_return(:userid => user.userid)
         controller.params = {:controller => 'catalog'}
       end
 


### PR DESCRIPTION
When `Set Ownership Screen` is opened then `@edit[:objects_ids]` is filled up with objects which are displayed in **Affected Items** section.

When buttons "Save" or "Cancel" are pressed , content of `@edit[:objects_ids]` persist in session and when we return to summary page of Service then `@edit[:objects_ids]` is populated from session and it causes that there is error in `get_view` method.

Source for `Affected Items` list in Set Ownership Screen is now based on [build_target_hash method](https://github.com/ManageIQ/manageiq-ui-classic/blob/1913facee1e86607d95885b609936384e4450c8b/app/controllers/mixins/actions/vm_actions/ownership.rb#L96).




Steps for Testing/QA
-------------------------------
Scenario
![EGUyifUAcM](https://user-images.githubusercontent.com/14937244/93463881-ae624b80-f8e8-11ea-9413-44abd2150593.gif)


1. Go to `Services -> My Service`
2. Find service without VMs (with VMs is don't display vms )
3. Go to `Set Ownership Screen`
4. Press button `Cancel` or `Save`, this error will appear.


```
Error caught: [NoMethodError] undefined method `where' for []:Array
Did you mean?  when
/Users/lpichler/projects/manageiq/manageiq/app/models/miq_report/search.rb:113:in `paged_view_search'
/Users/lpichler/projects/manageiq/manageiq/plugins/manageiq-ui-classic/app/controllers/application_controller.rb:1238:in `get_view'
/Users/lpichler/projects/manageiq/manageiq/plugins/manageiq-ui-classic/app/controllers/application_controller.rb:359:in `report_data'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/abstract_controller/base.rb:194:in `process_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/action_controller/metal/rendering.rb:30:in `process_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/callbacks.rb:132:in `run_callbacks'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/abstract_controller/callbacks.rb:41:in `process_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/action_controller/metal/rescue.rb:22:in `process_action'
/Users/lpichler/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/actionpack-5.2.4.3/lib/action_controller/metal/instrumentat
```

@miq-bot add_label bug

Note: Similar issue is in policy screen but it is for standalone PR.
