### PR TITLE
Add description/target platform to Config Profile

### DIFF
--- a/app/helpers/configuration_profile_helper/textual_summary.rb
+++ b/app/helpers/configuration_profile_helper/textual_summary.rb
@@ -1,12 +1,26 @@
 module ConfigurationProfileHelper::TextualSummary
   def textual_configuration_profile_group_properties
     %i[configuration_profile_name
+       configuration_profile_description
+       configuration_profile_target_platform
        configuration_profile_region
        configuration_profile_zone]
   end
 
   def textual_configuration_profile_name
     {:label => _("Name"), :value => @record.name}
+  end
+
+  def textual_configuration_profile_description
+    return nil if @record.description.blank?
+
+    {:label => _("Description"), :value => @record.description}
+  end
+
+  def textual_configuration_profile_target_platform
+    return nil if @record.target_platform.blank?
+
+    {:label => _("Target Platform"), :value => @record.target_platform}
   end
 
   def textual_configuration_profile_region


### PR DESCRIPTION
This [enhancement](https://github.com/ManageIQ/manageiq-ui-classic/issues/7313) displays Description and Target Platform for Configuration Profile. This is to make it easier for user to determine which Platform the Configuration Profile can be deployed to.

<img width="1918" alt="ManageIQ-Add-Description-Target-Platform-Configuration-Profile-2" src="https://user-images.githubusercontent.com/41962815/93492864-4b1ced00-f8d9-11ea-8262-25b6d91af5c6.png">
