### PR TITLE
Display labels for Infra VMs

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -7,7 +7,7 @@ module VmCommon
 
   def textual_group_list
     [
-      %i[properties multi_region lifecycle relationships vmsafe normal_operating_ranges miq_custom_attributes ems_custom_attributes],
+      %i[properties multi_region lifecycle relationships vmsafe normal_operating_ranges miq_custom_attributes ems_custom_attributes labels],
       %i[compliance power_management security configuration datastore_allocation datastore_usage diagnostics tags]
     ]
   end


### PR DESCRIPTION
Labels should be shown for Infra VMs not just Cloud VMs.

![Screenshot from 2020-09-17 11-09-30](https://user-images.githubusercontent.com/12851112/93493988-8370fb00-f8da-11ea-9c72-7320a1a27b12.png)

https://github.com/ManageIQ/manageiq-providers-vmware/pull/626 adds the collection code

https://github.com/ManageIQ/manageiq-providers-vmware/issues/539