### PR TITLE
Include modules manifest

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -10,6 +10,52 @@ const { StatsWriterPlugin } = require('webpack-stats-plugin');
 const fs = require('fs');
 const sortBy = require('lodash/sortBy');
 
+const uniqueWebpackModules = (data) => {
+  // recursively flatten nested modules
+  const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name.split("!").pop();
+  const transformModules = ms => ms.flatMap(m => transformModule(m));
+
+  var modules = transformModules(data.modules);
+  modules = [...new Set(modules)]; // uniq
+
+  return modules;
+}
+
+const packagesFromModules = (modules) => {
+  // find the package.json file for each module
+  modules = modules.filter(m => m.includes("node_modules"));
+  var packagePaths = modules.map(m => {
+    var match = m.match(/(.*node_modules\/)([^/]+)(\/[^/]+)?/);
+    var path = [
+      `${match[1]}${match[2]}/package.json`,
+      `${match[1]}${match[2]}${match[3]}/package.json`,
+    ].find(p => fs.existsSync(p));
+
+    if (path == null) {
+      console.warn(`[webpack-manifest] WARN: Unable to find a package.json for ${m}`);
+    }
+
+    return path;
+  })
+  packagePaths = packagePaths.filter(p => p != null);
+  packagePaths = [...new Set(packagePaths)]; // uniq
+
+  // extract relevant package data from the package.json
+  var packages = packagePaths.map(p => {
+    var content = fs.readFileSync(p);
+    var pkg = JSON.parse(content);
+    return {
+      name: pkg.name,
+      license: pkg.license,
+      version: pkg.version,
+      location: p
+    }
+  });
+  packages = sortBy(packages, ['name', 'version']);
+
+  return packages;
+}
+
 module.exports = merge(sharedConfig, {
   mode: 'production',
   devtool: 'source-map',
@@ -20,50 +66,25 @@ module.exports = merge(sharedConfig, {
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf)$/,
     }),
 
-    // Write out dependencies list for audit purposes
+    // Write out dependent modules list for audit purposes
     new StatsWriterPlugin({
-      filename: "webpack-modules-manifest.json",
+      filename: "webpack_modules_manifest.json",
       fields: ["modules"],
 
       transform(data) {
-        // recursively flatten nested modules
-        const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name.split("!").pop();
-        const transformModules = ms => ms.flatMap(m => transformModule(m));
+        var modules = uniqueWebpackModules(data);
+        return JSON.stringify(modules, null, 2);
+      }
+    }),
 
-        var modules = transformModules(data.modules)
-        modules = [...new Set(modules)]; // uniq
+    // Write out dependent packages list for audit purposes
+    new StatsWriterPlugin({
+      filename: "webpack_packages_manifest.json",
+      fields: ["modules"],
 
-        // find the package.json file for each module
-        modules = modules.filter(m => m.includes("node_modules"));
-        var packagePaths = modules.map(m => {
-          var match = m.match(/(.*node_modules\/)([^\/]+)(\/[^\/]+)?/);
-          var path = [
-            `${match[1]}${match[2]}/package.json`,
-            `${match[1]}${match[2]}${match[3]}/package.json`,
-          ].find(p => fs.existsSync(p));
-
-          if (path == null) {
-            console.warn(`[webpack-manifest] WARN: Unable to find a package.json for ${m}`);
-          }
-
-          return path;
-        })
-        packagePaths = packagePaths.filter(p => p != null);
-        packagePaths = [...new Set(packagePaths)]; // uniq
-
-        // extract relevant package data from the package.json
-        var packages = packagePaths.map(p => {
-          var content = fs.readFileSync(p);
-          var package = JSON.parse(content);
-          return {
-            name: package.name,
-            license: package.license,
-            version: package.version,
-            location: p
-          }
-        });
-        packages = sortBy(packages, ['name', 'version']);
-
+      transform(data) {
+        var modules = uniqueWebpackModules(data);
+        var packages = packagesFromModules(modules);
         return JSON.stringify(packages, null, 2);
       }
     })


### PR DESCRIPTION
We previously switched the manifest generator to only output the
packages that were affected, but it's still useful to know which modules
within those packages are actually used. This commit puts back the
modules manifest generator alongside the packages manifest generator.

@himdel Please review. cc @simaishi @bhadrim 