### PR TITLE
Fix translation for consolidation column dropdown

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -18,7 +18,7 @@ module ReportHelper
     :miq_rpt_gray_bg     => _("Gray Background")
   }.freeze
 
-  NOTHING_STRING = "<<< #{_('Nothing')} >>>".freeze
+  NOTHING_STRING = N_("<<<Nothing>>>").freeze
 
   def visibility_options(widget)
     typ = widget.visibility.keys.first

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -8,7 +8,7 @@
         = _('Column 1')
       .col-md-8
         = select_tag('chosen_pivot1',
-          options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options1, @pivot.by1),
+          options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options1, @pivot.by1),
           :multiple             => false,
           :class                => "selectpicker")
         :javascript
@@ -20,7 +20,7 @@
           = _('Column 2')
         .col-md-8
           = select_tag('chosen_pivot2',
-            options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options2, @pivot.by2),
+            options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options2, @pivot.by2),
             :multiple             => false,
             :class                => "selectpicker")
           :javascript
@@ -32,7 +32,7 @@
             = _('Column 3')
           .col-md-8
             = select_tag('chosen_pivot3',
-              options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options3, @pivot.by3),
+              options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options3, @pivot.by3),
               :multiple             => false,
               :class                => "selectpicker")
             :javascript

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -12,7 +12,7 @@
         - else
           - sortby1 = @sortby1
         = select_tag('chosen_sort1',
-          options_for_select([ReportHelper::NOTHING_STRING] + @sort1, sortby1),
+          options_for_select([_(ReportHelper::NOTHING_STRING)] + @sort1, sortby1),
           :multiple              => false,
           :class                 => "selectpicker")
         :javascript
@@ -87,7 +87,7 @@
           - else
             - sortby2 = @sortby2
           = select_tag('chosen_sort2',
-            options_for_select([ReportHelper::NOTHING_STRING] + @sort2, sortby2),
+            options_for_select([_(ReportHelper::NOTHING_STRING)] + @sort2, sortby2),
             :multiple              => false,
             :class                 => "selectpicker")
           :javascript

--- a/app/views/report/_widget_columns.html.haml
+++ b/app/views/report/_widget_columns.html.haml
@@ -5,7 +5,7 @@
       *
     = _('Column 1')
   .col-md-8
-    = select_tag("chosen_pivot1", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options1, @pivot.by1),
+    = select_tag("chosen_pivot1", options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options1, @pivot.by1),
       :multiple             => false,
       :class                => "selectpicker",
       :disabled             => @edit[:read_only])
@@ -19,7 +19,7 @@
         *
       = _('Column 2')
     .col-md-8
-      = select_tag("chosen_pivot2", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options2, @pivot.by2),
+      = select_tag("chosen_pivot2", options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options2, @pivot.by2),
         :multiple             => false,
         :class                => "selectpicker",
         :disabled             => @edit[:read_only])
@@ -33,7 +33,7 @@
           *
         = _('Column 3')
       .col-md-8
-        = select_tag("chosen_pivot3", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options3, @pivot.by3),
+        = select_tag("chosen_pivot3", options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options3, @pivot.by3),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only])
@@ -47,7 +47,7 @@
           *
         = _('Column 4')
       .col-md-8
-        = select_tag("chosen_pivot4", options_for_select([ReportHelper::NOTHING_STRING] + @pivot.options4, @pivot.by4),
+        = select_tag("chosen_pivot4", options_for_select([_(ReportHelper::NOTHING_STRING)] + @pivot.options4, @pivot.by4),
           :multiple             => false,
           :class                => "selectpicker",
           :disabled             => @edit[:read_only],


### PR DESCRIPTION
## Issue Summary
English string occurs in Overview - Reports - Reports - Configuration - Add a new report - Consolidation

## Issue Details
### Steps to reproduce


1. Click Overview -> Reports
2. Click Reports
3. Click Configuration Management -> Virtual Machines -> Account Groups - Linux
4. Click Configuration
5. Click Add a new report
6. Click Available Fields and select at one item
7. Click ![image](https://media.github.ibm.com/user/30329/files/b1fd4b80-9f62-11ea-949b-092afacf868c) icon
8. Click Consolidation
9. Select the fields you just selected at column 1

### Expected behavior
translated string will occur

### What really happened/Before
English string occurs
![image](https://media.github.ibm.com/user/30329/files/e83acb00-9f62-11ea-9a13-876dcd110468)

### After Fix:
<img width="858" alt="Screen Shot 2020-09-17 at 3 45 12 PM" src="https://user-images.githubusercontent.com/37085529/93520746-f8edc300-f8fc-11ea-8944-e17ee880c6b0.png">


