### PR TITLE
Added gettext calls for Provider Label in playbook and repository views

### DIFF
--- a/app/helpers/ansible_playbook_helper/textual_summary.rb
+++ b/app/helpers/ansible_playbook_helper/textual_summary.rb
@@ -24,7 +24,7 @@ module AnsiblePlaybookHelper::TextualSummary
   end
 
   def textual_provider
-    @record.manager.try(:name)
+    {:label => _("Provider"), :value => @record.manager.try(:name)}
   end
 
   def textual_repository

--- a/app/helpers/ansible_repository_helper/textual_summary.rb
+++ b/app/helpers/ansible_repository_helper/textual_summary.rb
@@ -35,7 +35,7 @@ module AnsibleRepositoryHelper::TextualSummary
   end
 
   def textual_provider
-    @record.manager.try(:name)
+    {:label => _("Provider"), :value => @record.manager.try(:name)}
   end
 
   def textual_playbooks


### PR DESCRIPTION
Issue: <CloudForms_GVT>English string occurs on both Repository and Playbooks summary page.  
Found on: Automation -> Ansible -> Repositories -> { Select Repository }
Found on: Automation -> Ansible -> Playbook -> { Select Repository }

Steps to reproduce
------------------------------
1. Click Automation-> Ansible-> Repositories
2. Click one Repository
3. Verify with GVT test areas

Original Issue
------------------------------
English string occurred in both Repositories and Playbooks summaries
![error-summary](https://user-images.githubusercontent.com/71033910/93522054-ee342d80-f8fe-11ea-8c14-ba2fdd46f0d8.png)

Result
--------------------------------
<img width="1038" alt="translation-fix" src="https://user-images.githubusercontent.com/71033910/93523620-51bf5a80-f901-11ea-9694-b00540e8b555.png">

"My Company" is customer data, which cannot be translated.
