### PR TITLE
Let individual provider to determine its own textual summary.

### DIFF
--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -64,6 +64,11 @@ class EmsStorageController < ApplicationController
   end
 
   def textual_group_list
+    # Try to get the groups names from the manager
+    group_list = @record.try(:textual_group_list)
+    return group_list if group_list
+
+    # If manager doesn't have its own group names use defaults.
     [
       %i[properties status],
       %i[relationships topology smart_management]


### PR DESCRIPTION
Providers of the same kind may have different sets of summary properties.
Example for block storage provider:
Openstack doesn't have storage systems, but Autosde has. 
Autosde provider doesn't have parent ems cloud, but Openstack provider has.

If we don't want to show permanent zero or empty values for non supported properties by the provider, we need to allow each provider to determine its own textual summary.