### PR TITLE
[JANSA] Add scrollbar to automate entrypoint dialog

### DIFF
--- a/app/views/shared/_tree.html.haml
+++ b/app/views/shared/_tree.html.haml
@@ -1,5 +1,5 @@
 - angular ||= false
 
 %div{:id => "#{name}_div"}
-  .treeview-pf-hover.treeview-pf-select{:id => "#{name}box", :style => "overflow: hidden"}
+  .treeview-pf-hover.treeview-pf-select{:id => "#{name}box", :style => "height: 350px !important; overflow-y: auto !important"}
     = render :partial  => "layouts/tree", :locals => tree.locals_for_render.merge(:angular => angular)


### PR DESCRIPTION
This fix is to make sure the automate entrypoint selection dialog is scrollable if needed. This is jansa & ivanchuk only fix, the problem on current master has been resolved by reimplementing trees using react.

Before:
![Screenshot from 2020-09-21 14-50-46](https://user-images.githubusercontent.com/6648365/93768749-23e85780-fc1a-11ea-8fbf-31247ebbe3f4.png)


After:
![Screenshot from 2020-09-21 14-47-11](https://user-images.githubusercontent.com/6648365/93768733-1e8b0d00-fc1a-11ea-95bd-05ba6a8faae9.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1880991