### PR TITLE
RemoveGenericItemModal: fix display_field handling

### DIFF
--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -5,8 +5,14 @@ import { Modal, Spinner } from 'patternfly-react';
 import { API } from '../http_api';
 
 const apiTransformFunctions = {
-  buttonGroup: (item) => ({id: item.id, name: item.name.split('|')[0]}),
-  default: (item) => ({id: item.id, name: item.name}),
+  buttonGroup: (item) => ({
+    id: item.id,
+    name: item.name.split('|')[0],
+  }),
+  default: (item, { display_field = 'name' }) => ({
+    id: item.id,
+    name: item[display_field],
+  }),
 };
 
 const parseApiError = (error) => {
@@ -87,11 +93,7 @@ class RemoveGenericItemModal extends React.Component {
     }
     // Load modal data from API
     Promise.all(itemsIds.map((item) => API.get(`/api/${api_url}/${item}`)))
-      .then(apiData => apiData.map(transformFn))
-      .then((apiData) => apiData.map((item) => ({
-        id: item.id,
-        name: item[display_field],
-      })))
+      .then(apiData => apiData.map((item) => transformFn(item, { display_field })))
       .then((data) => this.setState({
         data,
         loaded: true,


### PR DESCRIPTION
in #7207 a `display_field` prop was added to allow for displaying description instead of name
in #6980 a `transformFn` feature was added with a default implementation that trims the item to id & name

that broke `display_field` because there is no `description` anymore,
merging the 2 features, now the default transform respects display_field

---

Before:

![](https://user-images.githubusercontent.com/649130/93452100-4e63a900-f8d8-11ea-8663-ccf3a1abc6cb.png)

After:

![del](https://user-images.githubusercontent.com/289743/93782602-4aa68e00-fc1a-11ea-8d24-f73f817b5a25.png)
