### PR TITLE
Sort the webpack modules for consistent output

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -15,7 +15,7 @@ const uniqueWebpackModules = (data) => {
   const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name.split("!").pop();
   const transformModules = ms => ms.flatMap(m => transformModule(m));
 
-  var modules = transformModules(data.modules);
+  var modules = transformModules(data.modules).sort();
   modules = [...new Set(modules)]; // uniq
 
   return modules;


### PR DESCRIPTION
@himdel Please review.  We had sorted it originally, but when we switched to generating the packages only it was irrelevant.  So when we added back the modules list it was unsorted.