### PR TITLE
[WIP] Implemented the NestedProvider component for provider forms

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -153,6 +153,7 @@ const ProviderForm = ({ providerId, kind, title, redirect }) => {
 
   const componentMapper = {
     ...mapper,
+    'nested-provider': NestedProvider,
     'protocol-selector': ProtocolSelector,
     'provider-select-field': ProviderSelectField,
     'provider-credentials': ProviderCredentials,

--- a/app/javascript/components/provider-form/nested-provider.jsx
+++ b/app/javascript/components/provider-form/nested-provider.jsx
@@ -1,0 +1,29 @@
+import React, { useState, useContext } from 'react';
+
+import { EditingContext } from './index';
+import Select from '../select';
+import { useFormApi, validatorTypes } from '@@ddf';
+
+// Recursively omits the required validator and the isRequired attribute
+const override = fields => fields.map(({
+  fields, validate, isRequired: _isRequired, ...field
+}) => ({
+  ...field,
+  validate: validate.filter(({ type }) => type !== validatorTypes.REQUIRED),
+  ...(fields ? { fields: override(fields) } : {}),
+}));
+
+const NestedProvider = ({ fields, ...props }) => {
+  const { providerId } = useContext(EditingContext);
+  const [{ edit, require }, setState] = useState(() => ({ edit: !!providerId, require: !props.initialValue }));
+  const formOptions = useFormApi();
+
+  return (
+    <>
+      { edit && formOptions.renderForm(require ? fields : override(fields)) }
+      <Select onChange={value => setState(state => ({ ...state, require: !value }))} {...props} />
+    </>
+  );
+};
+
+export default NestedProvider;


### PR DESCRIPTION
This component acts as a dropdown and also exposes underlying fields similarly to the `protocol-selector` or the `validate-provider-credentials`. The idea is to allow a provider (manager) to pull in credentials from another provider and render the underlying fields conditionally if this happens.

> In edit mode the underlying fields are always rendered, but if there's something selected in the dropdown, they are not required. Basically an `override` function removes the `REQUIRED` validator from the list of validators and also sets the `isRequired` attribute to `false`. 

When editing an existing provider that is not linked to another one, the credentials should be always required, because otherwise the provider would not be accessible. However, when editing a linked provider, the credentials are just optional to allow modification of the linked credentials.

> If the form is not in edit mode, the underlying fields are not overridden but only rendered when the is nothing selected in the dropdown.

When adding a new provider, we want to give the user the opportunity to link it to a different provider of the same family. If this happens, the user should not enter any credentials as those will be pulled from the linked provider.

This is an alternative (but not necessarily a replacement) solution of the same thing as https://github.com/ManageIQ/manageiq-ui-classic/pull/7312

Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7311