### PR TITLE
Implemented missing `onItemButtonClick` method for Order Service button

### DIFF
--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -393,6 +393,13 @@ const GtlView = ({
   const inEditMode = () => additionalOptions.in_a_form;
   const noCheckboxes = () => additionalOptions.no_checkboxes;
 
+  const onItemButtonClick = (item, ev) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+    miqOrderService(item.id);
+    return false;
+  };
+
   const onItemClick = (item, event) => {
     // no need to set targetUrl if custom_action is set i.e. for pre prov screen
     let targetUrl = (additionalOptions && additionalOptions.custom_action) ? undefined : showUrl;
@@ -472,6 +479,7 @@ const GtlView = ({
           onPageSet={onPageSet}
           onPerPageSelect={onPerPageSelect}
           onItemSelect={onItemSelect}
+          onItemButtonClick={onItemButtonClick}
           onItemClick={onItemClick}
           onSort={onSort}
           onSelectAll={onSelectAll}

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -155,7 +155,7 @@ export const DataTable = ({
                   disabled={row.cells[columnKey].disabled}
                   title={row.cells[columnKey].title}
                   alt={row.cells[columnKey].title}
-                  onClick={ev => onItemButtonClick(row.cells[columnKey], ev)}
+                  onClick={ev => onItemButtonClick(row, ev)}
                 >
                   {row.cells[columnKey].text}
                 </button>

--- a/app/javascript/components/gtl/StaticGTLView.jsx
+++ b/app/javascript/components/gtl/StaticGTLView.jsx
@@ -13,6 +13,7 @@ export const StaticGTLView = ({
   total,
   settings,
   pagination,
+  onItemButtonClick,
   onItemClick,
   onItemSelect,
   onSort,
@@ -34,7 +35,7 @@ export const StaticGTLView = ({
       onSelectAll={onSelectAll}
       onItemClick={onItemClick}
       onItemSelect={onItemSelect}
-      onItemButtonClick={() => console.log('onItemButtonClick')}
+      onItemButtonClick={onItemButtonClick}
       onPageSet={onPageSet}
       onPerPageSelect={onPerPageSelect}
     />
@@ -48,6 +49,7 @@ StaticGTLView.defaultProps = {
   onSort: (headerId, isAscending) => console.log('onSort', headerId, isAscending),
   onPerPageSelect: foo => console.log('onPerPageSelect', foo),
   onPageSet: foo => console.log('onPageSet', foo),
+  onItemButtonClick: foo => console.log('onItemButtonClick', foo),
   onItemClick: foo => console.log('onItemClick', foo),
   onItemSelect: foo => console.log('onItemSelect', foo),
   total: 128,
@@ -65,6 +67,7 @@ StaticGTLView.propTypes = {
     perPage: PropTypes.number,
     perPageOptions: PropTypes.arrayOf(PropTypes.number),
   }),
+  onItemButtonClick: PropTypes.func,
   onItemSelect: PropTypes.func,
   onRowClick: PropTypes.func,
   onSort: PropTypes.func,


### PR DESCRIPTION
Missed handling case where List view has an Order service button. Issue was introduced in REact list view conversion in https://github.com/ManageIQ/manageiq-ui-classic/pull/7188

