### PR TITLE
Show the helperText on the password-field component properly

### DIFF
--- a/app/javascript/components/async-credentials/edit-password-field.jsx
+++ b/app/javascript/components/async-credentials/edit-password-field.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormGroup,
-  ControlLabel,
-  InputGroup,
-  FormControl,
   Button,
+  ControlLabel,
+  FieldLevelHelp,
+  FormControl,
+  FormGroup,
   HelpBlock,
+  InputGroup,
 } from 'patternfly-react';
 
 import { useFieldApi } from '@@ddf';
@@ -32,6 +33,7 @@ const EditPasswordField = ({ ...props }) => {
     <FormGroup validationState={meta.error ? 'error' : null}>
       <ControlLabel>
         {isRequired ? <RequiredLabel label={label} /> : label }
+        {helperText && <FieldLevelHelp content={helperText} />}
       </ControlLabel>
       <InputGroup>
         <FormControl
@@ -48,7 +50,7 @@ const EditPasswordField = ({ ...props }) => {
           <Button type="button" onClick={setEditMode}>{buttonLabel}</Button>
         </InputGroup.Button>
       </InputGroup>
-      {(meta.error || helperText) && <HelpBlock>{ meta.error || helperText }</HelpBlock>}
+      {meta.error && <HelpBlock>{ meta.error }</HelpBlock>}
     </FormGroup>
   );
 };

--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -2,11 +2,12 @@ import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
-  FormGroup,
   ControlLabel,
-  InputGroup,
+  FieldLevelHelp,
   FormControl,
+  FormGroup,
   HelpBlock,
+  InputGroup,
 } from 'patternfly-react';
 import { componentTypes, useFormApi } from '@@ddf';
 import { checkValidState } from './helper';
@@ -49,6 +50,7 @@ const PasswordField = ({
         <FormGroup>
           <ControlLabel>
             {rest.isRequired ? <RequiredLabel label={rest.label} /> : rest.label }
+            {helperText && <FieldLevelHelp content={helperText} />}
           </ControlLabel>
           <InputGroup>
             <FormControl
@@ -63,7 +65,6 @@ const PasswordField = ({
               <Button type="button" onClick={() => setEditMode(editMode => !editMode)}>{changeEditLabel}</Button>
             </InputGroup.Button>
           </InputGroup>
-          { helperText && <HelpBlock>{ helperText }</HelpBlock> }
         </FormGroup>
       )}
       {!edit && formOptions.renderForm([secretField], formOptions)}


### PR DESCRIPTION
@DavidResende0 found out that the `PasswordField` and the underlying `EditPasswordField` components were displaying the `helperText` under the form field instead of having a popover as in any other component.

For now we we don't have a reproducing example in our codebase, but we will [soon](https://github.com/ManageIQ/manageiq-ui-classic/pull/7324). Until then these changes are necessary to test this in the Compute -> Infra -> PXE (edit) form:
```diff
diff --git a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
index 3f290a8485..7a1c33c436 100644
--- a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
@@ -109,6 +109,7 @@ const createSchema = isEditing => ({
             name: 'authentication.userid',
             label: __('Username'),
             isRequired: true,
+            helperText: 'foo',
             validate: [{ type: validatorTypes.REQUIRED }],
           }, {
             component: 'password-field',
@@ -116,6 +117,7 @@ const createSchema = isEditing => ({
             name: 'authentication.password',
             label: __('Password'),
             isRequired: true,
+            helperText: 'foo',
             validate: [{ type: validatorTypes.REQUIRED }],
           }],
         }],

```

**Before:**
![Screenshot from 2020-09-24 08-20-07](https://user-images.githubusercontent.com/649130/94108453-a00fb480-fe3f-11ea-84a6-f83fceeabb1c.png)

**After:**
![Screenshot from 2020-09-24 08-18-41](https://user-images.githubusercontent.com/649130/94108461-a4d46880-fe3f-11ea-8a59-9e50c5bdfd11.png)
![Screenshot from 2020-09-24 08-20-38](https://user-images.githubusercontent.com/649130/94108478-ab62e000-fe3f-11ea-855d-5658578527c5.png)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7335

@miq-bot add_label bug, react
@miq-bot add_reviewer @DavidResende0 
@miq-bot add_reviewer @himdel 