### PR TITLE
Customized 'volumes' tab for IBM PVS in '_prov_dialog.html.haml'

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -70,7 +70,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
-    - keys = wf.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ProvisionWorkflow) ? [:name, :size, :diskType, :shareable] : [:name, :size, :delete_on_terminate]
+    - keys = wf.keys_for_volumes
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -70,7 +70,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
-    - keys = wf.keys_for_volumes
+    - keys = wf.volume_dialog_keys
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -70,7 +70,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :volumes
-    - keys = [:name, :size, :delete_on_terminate]
+    - keys = wf.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ProvisionWorkflow) ? [:name, :size, :diskType, :shareable] : [:name, :size, :delete_on_terminate]
     = render(:partial => "/miq_request/prov_dialog_volume_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,


### PR DESCRIPTION
- IBM Power Virtual Server related change
- in case of IBM PVS provisioning form the
  following fields are shown: name, size, diskType, shareable
- types: text, text, text, checkbox (respectively)

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/20618