### PR TITLE
Display the buttons' labels on DDF forms properly

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -50,10 +50,11 @@ const MiqFormRenderer = ({
     <FormTemplate
       {...props}
       FormWrapper={FormWrapper}
-      buttonsLabels={{ ...defaultLabels, ...buttonsLabels }}
       disableSubmit={disableSubmit}
       canReset={canReset}
       showFormControls={showFormControls}
+      {...defaultLabels}
+      {...buttonsLabels}
     />
   ));
 
@@ -69,9 +70,12 @@ const MiqFormRenderer = ({
 
 MiqFormRenderer.propTypes = {
   className: PropTypes.string,
-  buttonsLabels: PropTypes.any,
+  buttonsLabels: PropTypes.shape({
+    submitLabel: PropTypes.string,
+    resetLabel: PropTypes.string,
+    cancelLabel: PropTypes.string,
+  }),
   componentMapper: PropTypes.any,
-  buttonsLabels: PropTypes.any,
   schema: PropTypes.shape({
     fields: PropTypes.arrayOf(PropTypes.any),
   }),
@@ -85,7 +89,6 @@ MiqFormRenderer.defaultProps = {
   className: 'form-react',
   buttonsLabels: {},
   componentMapper: defaultComponentMapper,
-  buttonsLabels: {},
   schema: {
     fields: [],
   },

--- a/app/javascript/spec/forms/__snapshots__/data-driven-form.spec.js.snap
+++ b/app/javascript/spec/forms/__snapshots__/data-driven-form.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataDrivenForm should render correctly 1`] = `"<form class=\\"ddorg__pf3-layout-components__form-wrapper form-react\\"><div class=\\"form-group\\"><input name=\\"name\\" class=\\"form-control\\" value=\\"\\"></div><div class=\\"ddorg__pf3-layout-components__button-group \\"><button type=\\"submit\\" disabled=\\"\\" class=\\"btn btn-primary\\">Submit</button></div></form>"`;
+exports[`DataDrivenForm should render correctly 1`] = `"<form class=\\"ddorg__pf3-layout-components__form-wrapper form-react\\"><div class=\\"form-group\\"><input name=\\"name\\" class=\\"form-control\\" value=\\"\\"></div><div class=\\"ddorg__pf3-layout-components__button-group \\"><button type=\\"submit\\" disabled=\\"\\" class=\\"btn btn-primary\\">Save</button></div></form>"`;


### PR DESCRIPTION
The migrating guide to v2 on the DDF website has not been updated with the proper documentation for the button labels. Credit goes to @DavidResende0 for [finding the issue](https://github.com/ManageIQ/manageiq-ui-classic/pull/7324#discussion_r493865416) and @rvsia for explaining me how to set these properly.

**Before:**
![Screenshot from 2020-09-24 17-12-33](https://user-images.githubusercontent.com/649130/94164607-8a26e180-fe89-11ea-934b-4e95a2f21555.png)

**After:**
![Screenshot from 2020-09-24 17-12-11](https://user-images.githubusercontent.com/649130/94164620-8eeb9580-fe89-11ea-87a3-f5d91286ac28.png)