### PR TITLE
Display vendor for configured systems

### DIFF
--- a/app/helpers/configured_system_helper/textual_summary.rb
+++ b/app/helpers/configured_system_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module ConfiguredSystemHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i[hostname ipmi_present ipaddress mac_address zone]
+      %i[hostname ipmi_present ipaddress mac_address vendor zone]
     )
   end
 
@@ -26,6 +26,12 @@ module ConfiguredSystemHelper::TextualSummary
 
   def textual_mac_address
     {:label => _("Mac address"), :value => @record.mac_address}
+  end
+
+  def textual_vendor
+    return nil if @record.vendor.blank?
+
+    {:label => _("Vendor"), :value => @record.vendor}
   end
 
   def textual_zone


### PR DESCRIPTION
This is an enhancement required for https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28. We want to display the vendor for configured systems. This improves user experience and allows the user to determine which vendor/cloud provider the configured system is deployed to.

<img width="593" alt="Screen Shot 2020-09-25 at 8 30 45 AM" src="https://user-images.githubusercontent.com/22264185/94267420-8d61b200-ff09-11ea-8668-85a308324a45.png">
