### PR TITLE
Implementing add new block storage manager functionality

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -384,6 +384,7 @@ module Mixins
           ems_container_recheck_auth_status
           ems_infra_recheck_auth_status
           ems_physical_infra_recheck_auth_status
+          ems_storage_recheck_auth_status
         ].include?(params[:pressed])
           if params[:id]
             table_key = :table

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -82,6 +82,7 @@ module ApplicationHelper::PageLayouts
       ems_infra
       ems_network
       ems_physical_infra
+      ems_block_storage
     ].include?(controller_name) &&
       action_name == 'show_list' &&
       controller.class.model.none?

--- a/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
@@ -15,8 +15,16 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :send_checked => true,
                        :confirm      => N_("Refresh relationships and power states for all items related to the selected Block Storage Managers?"),
                        :enabled      => false,
-                       :onwhen       => "1+"),
+                       :onwhen       => "1+"
+                     ),
                      separator,
+                     button(
+                       :ems_block_storage_new,
+                       'pficon pficon-add-circle-o fa-lg',
+                       t = N_('Add a New Block Storage Manager'),
+                       t,
+                       :url => "/new"
+                     ),
                      button(
                        :ems_block_storage_delete,
                        'pficon pficon-delete fa-lg',
@@ -26,7 +34,8 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :send_checked => true,
                        :confirm      => N_("Warning: The selected Block Storage Managers and ALL of their components will be permanently removed!"),
                        :enabled      => false,
-                       :onwhen       => "1+"),
+                       :onwhen       => "1+"
+                     ),
                    ]
                  ),
                ])
@@ -47,7 +56,8 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :url_parms    => "main_div",
                        :send_checked => true,
                        :enabled      => false,
-                       :onwhen       => "1+"),
+                       :onwhen       => "1+"
+                     ),
                      button(
                        :ems_block_storage_tag,
                        'pficon pficon-edit fa-lg',
@@ -56,7 +66,30 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :url_parms    => "main_div",
                        :send_checked => true,
                        :enabled      => false,
-                       :onwhen       => "1+"),
+                       :onwhen       => "1+"
+                     ),
+                   ]
+                 ),
+               ])
+  button_group('ems_storage_authentication', [
+                 select(
+                   :ems_storage_authentication_choice,
+                   nil,
+                   t = N_('Authentication'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :ems_storage_recheck_auth_status,
+                       'fa fa-search fa-lg',
+                       N_('Re-check Authentication Status for the selected block storage manager'),
+                       N_('Re-check Authentication Status'),
+                       :url_parms    => "main_div",
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => "1+"
+                     ),
                    ]
                  ),
                ])

--- a/app/views/ems_block_storage/new.html.haml
+++ b/app/views/ems_block_storage/new.html.haml
@@ -1,0 +1,3 @@
+= react('ProviderForm', :redirect => ems_block_storage_path,
+  :kind => 'storage',
+  :title => ui_lookup(:model => 'ManageIQ::Providers::StorageManager'))

--- a/app/views/ems_block_storage/show_list.html.haml
+++ b/app/views/ems_block_storage/show_list.html.haml
@@ -1,1 +1,7 @@
-#main_div= render :partial => "layouts/gtl"
+#main_div
+  - if ManageIQ::Providers::StorageManager.any?
+    = render :partial => 'layouts/gtl'
+  - else
+    = render :partial => 'layouts/empty',
+             :locals => {:add_message => _("Add a new Block Storage Manager"),
+                         :documentation => ::Settings.docs.storage_manager}

--- a/app/views/ems_storage/show.html.haml
+++ b/app/views/ems_storage/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2209,6 +2209,7 @@ Rails.application.routes.draw do
         tagging_edit
       ),
       :post => %w(
+        new
         button
         dynamic_checkbox_refresh
         dynamic_radio_button_refresh
@@ -3145,6 +3146,7 @@ Rails.application.routes.draw do
     ems_network
     ems_physical_infra
     ems_physical_infra_dashboard
+    ems_storage
     miq_ae_customization
     pxe
   ].freeze
@@ -3202,7 +3204,7 @@ Rails.application.routes.draw do
   # prevent No route matches [GET] "/favicon.ico"
   get '/favicon.ico' => 'static#favicon', :format => false
 
-  %w[ems_cloud ems_infra ems_physical_infra ems_container ems_network].each do |resource|
+  %w[ems_cloud ems_infra ems_physical_infra ems_container ems_network ems_storage ems_block_storage].each do |resource|
     resources(resource.to_sym, :as => resource.pluralize.to_sym, :except => %i[create update destroy])
   end
 end


### PR DESCRIPTION
As part of the storage modifications (see #7282 for the entire modifications details. This PR is a partial split from #7282) we added a new functionality and now block storage manager can be added directly. This add-on allow us to add the new storage manager, AutoSDE directly.

<img width="957" alt="5" src="https://user-images.githubusercontent.com/53213107/94357028-ebbf9980-009d-11eb-9448-d91f58c62ec8.png">

Links
----------------
in order to successfully implement the new storage functionalities and storage manager type (autosde) we made additional changes in other relevant repositories and opened PR which may be linked to this PR:
- manageiq-schema: https://github.com/ManageIQ/manageiq-schema/pull/505 (all done!) 
- manageiq-provider-autosde: https://github.com/Autosde/manageiq-providers-autosde/
- manageiq-decorators: https://github.com/ManageIQ/manageiq-decorators/pull/33
- manageiq (core) - https://github.com/ManageIQ/manageiq/pull/20629 
