### PR TITLE
Enabling storage-service selection when creating cloud-volume

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -136,10 +136,14 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   vm.storageManagerChanged = function(id) {
     miqService.sparkleOn();
-    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,volume_availability_zones,cloud_tenants,cloud_volume_snapshots,cloud_volume_types')
+    return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,volume_availability_zones,cloud_tenants,cloud_volume_snapshots,cloud_volume_types,storage_services,supports_storage_services')
       .then(getStorageManagerFormData)
       .catch(miqService.handleFailure);
   };
+
+  vm.StorageServiceChanged = function(id) {
+    vm.cloudVolumeModel.storage_service_id = id
+  }
 
   vm.sizeChanged = function(size) {
     if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
@@ -273,12 +277,16 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
 
   var getStorageManagerFormData = function(data) {
     vm.cloudVolumeModel.emstype = data.type;
+    vm.storageServices = data.storage_services;
     vm.cloudTenantChoices = data.cloud_tenants;
     vm.availabilityZoneChoices = data.volume_availability_zones;
     vm.baseSnapshotChoices = data.cloud_volume_snapshots;
+
     vm.supportsCinderVolumeTypes = data.supports_cinder_volume_types;
     vm.supportsVolumeResizing = data.supports_volume_resizing;
     vm.supportsVolumeAvailabilityZones = data.supports_volume_availability_zones;
+    vm.supportsStorageServices = data.supports_storage_services;
+
     if (vm.supportsCinderVolumeTypes) {
       vm.volumeTypes = data.cloud_volume_types;
     } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -583,8 +583,17 @@ class CloudVolumeController < ApplicationController
       options.merge!(aws_ebs_options)
     when "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager"
       options.merge!(ibmcloud_powervs_options)
+    when "ManageIQ::Providers::Autosde::StorageManager"
+      options.merge!(autosde_options)
     end
     options
+  end
+
+  def autosde_options
+    {
+      :ems             => ExtManagementSystem.find(params[:storage_manager_id]),
+      :storage_service => StorageService.find(params[:storage_service_id])
+    }
   end
 
   def cinder_manager_options

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -119,6 +119,27 @@
     %span.help-block{"ng-show" => "angularForm.size.$error.required"}
       = _("Required")
 
+
+.form-group{"ng-class" => "{'has-error': angularForm.storage_service_id.$invalid}",
+     "ng-if"    => "vm.supportsStorageServices"  }
+  %label.col-md-2.control-label
+    = _('Storage Service')
+  .col-md-8
+    %select{"name"        => "storage_service_id",
+            "ng-model"    => "vm.cloudVolumeModel.storage_service_id",
+            "ng-options"  => "service.id as service.name for service in vm.storageServices",
+
+            "required"    => "",
+            :checkchange  => true,
+            "miq-select"  => true}
+      %option{"value" => "", "disabled" => ""}
+        = "<#{_('Choose')}>"
+    %span.help-block{"ng-show" => "angularForm.storage_service_id.$error.required"}
+      = _("Required")
+
+
+
+
 .form-group{"ng-class" => "{'has-error': angularForm.aws_iops.$invalid}",
             "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::Amazon::StorageManager::Ebs'"}
   %label.col-md-2.control-label


### PR DESCRIPTION
As part of the storage modifications (see https://github.com/ManageIQ/manageiq-ui-classic/pull/7282 for the entire modifications details. This PR is a partial split from https://github.com/ManageIQ/manageiq-ui-classic/pull/7282) we modified the new cloud-volume form field to allow selection of storage-resources for relevant cloud volumes. This add-on allow us to add cloud volumes that are managed by the new AutoSDE storage manager.

for example (see image below) if we add cloud volume that managed by autosde storage manager we will get an additional field to fill, storage service (which is populated by storage-resources (pools) retrieved from the autosde manager)
<img width="1389" alt="6" src="https://user-images.githubusercontent.com/53213107/94359531-8de87d00-00b0-11eb-94cb-9b00e1c43608.png">

Links
----------------
in order to successfully implement the new storage functionalities and storage manager type (autosde) we made additional changes in other relevant repositories and opened PR which may be linked to this PR:
- manageiq-schema: https://github.com/ManageIQ/manageiq-schema/pull/505 (all done!) 
- manageiq-provider-autosde: https://github.com/Autosde/manageiq-providers-autosde/
- manageiq-decorators: https://github.com/ManageIQ/manageiq-decorators/pull/33
- manageiq (core) - https://github.com/ManageIQ/manageiq/pull/20629 
