### PR TITLE
Allow the async-credentials component and its children to be not required

### DIFF
--- a/app/javascript/components/async-credentials/async-credentials.jsx
+++ b/app/javascript/components/async-credentials/async-credentials.jsx
@@ -19,6 +19,7 @@ const AsyncCredentials = ({
   name,
   asyncValidate,
   validationDependencies,
+  isRequired,
   edit,
 }) => {
   const formOptions = useFormApi();
@@ -35,7 +36,7 @@ const AsyncCredentials = ({
   }, setState] = useState(() => ({}));
 
   const { input, meta } = useFieldApi({
-    initialValue: !!edit,
+    initialValue: !!edit || !isRequired, // The field is initially valid in edit mode or if the field is optional
     name,
     validate: [{ type: validatorTypes.REQUIRED }],
   });

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
@@ -99,6 +99,7 @@ const createSchema = isEditing => ({
           name: 'authentication.valid',
           edit: isEditing,
           validationDependencies: ['uri'],
+          isRequired: true,
           asyncValidate: formValues => new Promise((resolve, reject) => http.post('/pxe/pxe_server_async_cred_validation', {
             uri: formValues.uri,
             ...formValues.authentication,

--- a/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/async-credentials.spec.js.snap
@@ -95,10 +95,10 @@ exports[`Async credentials component should render correctly 1`] = `
   </SingleField>
   <FormGroup
     bsClass="form-group"
-    validationState="error"
+    validationState={null}
   >
     <div
-      className="form-group has-error"
+      className="form-group"
     >
       <input
         name="validate_credentials"
@@ -106,11 +106,12 @@ exports[`Async credentials component should render correctly 1`] = `
         onChange={[Function]}
         onFocus={[Function]}
         type="hidden"
-        value={false}
+        value={true}
       />
       <FormSpy
         subscription={
           Object {
+            "dirtyFields": true,
             "values": true,
           }
         }
@@ -133,15 +134,6 @@ exports[`Async credentials component should render correctly 1`] = `
             Validate
           </button>
         </Button>
-        <HelpBlock
-          bsClass="help-block"
-        >
-          <span
-            className="help-block"
-          >
-            Validation Required
-          </span>
-        </HelpBlock>
       </FormSpy>
     </div>
   </FormGroup>

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -84,6 +84,7 @@ exports[`PxeServersForm should render correctly 1`] = `
                       },
                     ],
                     "id": "authentication.valid",
+                    "isRequired": true,
                     "name": "authentication.valid",
                     "validationDependencies": Array [
                       "uri",


### PR DESCRIPTION
There was no way to set the `async-credentials` component to be optional, i.e. always demanding a validation, even if the underlying fields were never touched. The way we were checking this fact was also a little bit buggy and not very effective, so first I did some optimizations around it. Instead of saving the `initialValues` on the first render, I'm directly using the `dirtyFields` in the `FormSpy`. I also exposed an `isRequired` attribute on the component that allows us to set it valid in its initial state.

This change is just half of the solution, all the required `async-provider-credentials` components in the provider schemas should be updated with an `isRequired` attribute if they are not optional.

https://github.com/ManageIQ/manageiq-providers-amazon/pull/653
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/237
https://github.com/ManageIQ/manageiq-providers-azure/pull/412
https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/38
https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/27
https://github.com/ManageIQ/manageiq-providers-foreman/pull/71
https://github.com/ManageIQ/manageiq-providers-google/pull/156
https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/31
https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/51
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/401
https://github.com/ManageIQ/manageiq-providers-lenovo/pull/314
https://github.com/ManageIQ/manageiq-providers-nsxt/pull/19
https://github.com/ManageIQ/manageiq-providers-nuage/pull/225
https://github.com/ManageIQ/manageiq-providers-openstack/pull/639
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/525
https://github.com/ManageIQ/manageiq-providers-redfish/pull/122
https://github.com/ManageIQ/manageiq-providers-scvmm/pull/164
https://github.com/ManageIQ/manageiq-providers-vmware/pull/634