### PR TITLE
Add IBM PowerVS to Cloud Volume create form

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -283,6 +283,8 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
       vm.volumeTypes = data.cloud_volume_types;
     } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::Amazon::StorageManager::Ebs') {
       loadEBSVolumeTypes();
+    } else if (vm.cloudVolumeModel.emstype === 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager') {
+      vm.volumeTypes = data.cloud_volume_types;
     }
     miqService.sparkleOff();
   };

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -573,6 +573,8 @@ class CloudVolumeController < ApplicationController
       options.merge!(cinder_manager_options)
     when "ManageIQ::Providers::Amazon::StorageManager::Ebs"
       options.merge!(aws_ebs_options)
+    when "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager"
+      options.merge!(ibmcloud_powervs_options)
     end
     options
   end
@@ -598,6 +600,14 @@ class CloudVolumeController < ApplicationController
     options[:encrypted] = params[:aws_encryption]
 
     # Get the storage manager.
+    storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
+    options[:ems] = find_record_with_rbac(ExtManagementSystem, storage_manager_id)
+    options
+  end
+
+  def ibmcloud_powervs_options
+    options = {}
+    options[:volume_type] = params[:volume_type] if params[:volume_type]
     storage_manager_id = params[:storage_manager_id] if params[:storage_manager_id]
     options[:ems] = find_record_with_rbac(ExtManagementSystem, storage_manager_id)
     options

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -90,6 +90,19 @@
       %option{"value" => ""}
         = "<#{_('None')}>"
 
+.form-group{"ng-class" => "{'has-error': angularForm.volume_type.$invalid}",
+            "ng-if"    => "vm.cloudVolumeModel.emstype == 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager'"}
+  %label.col-md-2.control-label
+    = _('Cloud Volume Type')
+  .col-md-8
+    %select{"name"        => "volume_type",
+            "ng-model"    => "vm.cloudVolumeModel.volume_type",
+            "ng-options"  => "voltype.name as voltype.name for voltype in vm.volumeTypes",
+            "ng-disabled" => "!vm.newRecord",
+            "pf-select"   => true}
+      %option{"value" => ""}
+        = "<#{_('None')}>"
+
 .form-group{"ng-class" => "{'has-error': angularForm.size.$invalid}"}
   %label.col-md-2.control-label
     = _('Size (in gigabytes)')


### PR DESCRIPTION
Add support for loading IBM Cloud Power Virtual Servers
'CloudVolumeTypes' within the Cloud Volume create forms.

This depends on the backend PR ManageIQ/manageiq-providers-ibm_cloud#53
