### PR TITLE
Add name to Configuration Profile

### DIFF
--- a/product/views/ConfigurationProfile.yaml
+++ b/product/views/ConfigurationProfile.yaml
@@ -19,6 +19,7 @@ db: ConfigurationProfile
 
 # Columns to fetch from the main table
 cols:
+- name
 - description
 - total_configured_systems
 - configuration_environment_name
@@ -31,6 +32,7 @@ cols:
 
 # Order of columns (from all tables)
 col_order:
+- name
 - description
 - total_configured_systems
 - configuration_environment_name
@@ -39,6 +41,7 @@ col_order:
 
 # Column titles, in order
 headers:
+- Name
 - Description
 - Total Configured Systems
 - Environment


### PR DESCRIPTION
This **enhancement** adds a **Name** column to the Configuration Profile page.

<img width="1225" alt="Configuration_Profiles_Overview" src="https://user-images.githubusercontent.com/41962815/94589207-fbccaa00-0252-11eb-9079-23cc9a273d89.png">

