### PR TITLE
implement edit storage manager functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1350,6 +1350,8 @@ class ApplicationController < ActionController::Base
       javascript_redirect(edit_ems_network_path(params[:id]))
     elsif params[:pressed] == "ems_physical_infra_edit" && params[:id]
       javascript_redirect(edit_ems_physical_infra_path(params[:id]))
+    elsif params[:pressed] == "ems_storage_edit" && params[:id]
+      javascript_redirect(edit_ems_storage_path(params[:id]))
     else
       javascript_redirect(:action => @refresh_partial, :id => @redirect_id)
     end

--- a/app/controllers/ems_block_storage_controller.rb
+++ b/app/controllers/ems_block_storage_controller.rb
@@ -4,6 +4,7 @@ class EmsBlockStorageController < ApplicationController
   include Mixins::EmsCommon
   include Mixins::GenericSessionMixin
   include Mixins::BreadcrumbsMixin
+  include Mixins::StorageCommonMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_object_storage_controller.rb
+++ b/app/controllers/ems_object_storage_controller.rb
@@ -4,6 +4,7 @@ class EmsObjectStorageController < ApplicationController
   include Mixins::EmsCommon
   include Mixins::GenericSessionMixin
   include Mixins::BreadcrumbsMixin
+  include Mixins::StorageCommonMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -4,6 +4,7 @@ class EmsStorageController < ApplicationController
   include Mixins::EmsCommon
   include Mixins::GenericSessionMixin
   include Mixins::BreadcrumbsMixin
+  include Mixins::StorageCommonMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/mixins/storage_common_mixin.rb
+++ b/app/controllers/mixins/storage_common_mixin.rb
@@ -1,0 +1,10 @@
+module Mixins
+  module StorageCommonMixin
+    def model_feature_for_action(action)
+      case action
+      when :edit
+        :ems_storage_new
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_block_storages_center.rb
@@ -26,6 +26,16 @@ class ApplicationHelper::Toolbar::EmsBlockStoragesCenter < ApplicationHelper::To
                        :url => "/new"
                      ),
                      button(
+                       :ems_block_storage_edit,
+                       'pficon pficon-edit fa-lg',
+                       N_('Select a single Storage Manager to edit'),
+                       N_('Edit Selected Storage Manager'),
+                       :url_parms    => "main_div",
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => "1"
+                     ),
+                     button(
                        :ems_block_storage_delete,
                        'pficon pficon-delete fa-lg',
                        N_('Remove selected Block Storage Managers from Inventory'),

--- a/app/helpers/application_helper/toolbar/ems_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_storage_center.rb
@@ -19,6 +19,12 @@ class ApplicationHelper::Toolbar::EmsStorageCenter < ApplicationHelper::Toolbar:
                        :confirm => N_("Refresh relationships and power states for all items related to this Storage Manager?")),
                      separator,
                      button(
+                       :ems_storage_edit,
+                       'pficon pficon-edit fa-lg',
+                       t = N_('Edit this Storage Manager'),
+                       t
+                     ),
+                     button(
                        :ems_storage_delete,
                        'pficon pficon-delete fa-lg',
                        t = N_('Remove this Storage Manager from Inventory'),

--- a/app/helpers/ems_storage_helper.rb
+++ b/app/helpers/ems_storage_helper.rb
@@ -1,3 +1,7 @@
 module EmsStorageHelper
   include_concern 'TextualSummary'
+
+  def edit_redirect_path(lastaction, ems)
+    lastaction == 'show_list' ? ems_block_storage_path : ems_block_storage_path(ems)
+  end
 end

--- a/app/views/ems_block_storage/edit.html.haml
+++ b/app/views/ems_block_storage/edit.html.haml
@@ -1,0 +1,5 @@
+= react('ProviderForm', :providerId => @ems.id.to_s,
+  :redirect => @lastaction == 'show_list' ? ems_block_storage_path : ems_block_storage_path(@ems),
+  :kind => 'storage',
+  :title => ui_lookup(:model => 'ManageIQ::Providers::StorageManager'))
+

--- a/app/views/ems_storage/_edit_storage.html.haml
+++ b/app/views/ems_storage/_edit_storage.html.haml
@@ -1,0 +1,19 @@
+- url = url_for_only_path(:controller => 'ems_storage', :action => 'update', :id => (@ems.id || 'new'))
+= form_for(@ems,
+           :url    => url,
+           :method => :post,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "update-url"      => url,
+                       "form-fields-url" => "/#{controller_name}/ems_storage_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "save"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+  = render :partial => "shared/views/ems_common/angular/form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());
+

--- a/app/views/ems_storage/edit.html.haml
+++ b/app/views/ems_storage/edit.html.haml
@@ -1,19 +1,7 @@
-- url = url_for_only_path(:controller => 'ems_storage', :action => 'update', :id => (@ems.id || 'new'))
-= form_for(@ems,
-           :url    => url,
-           :method => :post,
-           :html   => {"ng-controller"   => "emsCommonFormController",
-                       "name"            => "angularForm",
-                       "ng-show"         => "afterGet",
-                       "update-url"      => url,
-                       "form-fields-url" => "/#{controller_name}/ems_storage_form_fields/",
-                       "novalidate"      => true}) do |f|
-  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
-  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "save"}
-  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
-  = render :partial => "shared/views/ems_common/angular/form"
-
-:javascript
-  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
-  miq_bootstrap($('#form_id').val());
+#main_div
+  -if @ems.supports?(:block_storage)
+    :javascript
+      window.location.href = "#{url_for_only_path(:controller => 'ems_block_storage', :action => 'edit', :id => params[:id])}"
+  -else
+    = render :partial => "edit_storage"
 


### PR DESCRIPTION
As part of the storage modifications (see #7282 for the entire modifications details. This PR is a partial split from #7282) we added the ability to edit storage manager. storage manager can only be edited if it was created directly (see https://github.com/ManageIQ/manageiq-ui-classic/pull/7345 for the new add block storage manager functionality). Storage managers that were added indirectly (e.g. cinder storage manager created indirectly if we add openstack cloud manager) can  NOT be edited from the storage edit button.

<img width="628" alt="1" src="https://user-images.githubusercontent.com/53213107/94655665-a30b1900-0307-11eb-9343-8613f9540be2.png">
<img width="650" alt="2" src="https://user-images.githubusercontent.com/53213107/94655708-ae5e4480-0307-11eb-9ddd-0f139486b175.png">


Links
----------------
in order to successfully implement the new storage functionalities and storage manager type (autosde) we made additional changes in other relevant repositories and opened PR which may be linked to this PR:
- manageiq-schema: https://github.com/ManageIQ/manageiq-schema/pull/505 (all done!) 
- manageiq-provider-autosde: https://github.com/Autosde/manageiq-providers-autosde/
- manageiq-decorators: https://github.com/ManageIQ/manageiq-decorators/pull/33
- manageiq (core) - https://github.com/ManageIQ/manageiq/pull/20629 