### PR TITLE
Remove exotic DDF components from the componentMapper

### DIFF
--- a/app/javascript/components/catalog-form/catalog-form.schema.js
+++ b/app/javascript/components/catalog-form/catalog-form.schema.js
@@ -41,9 +41,6 @@ function createSchema(options, catalogId) {
       maxLength: 60,
     }],
   }, {
-    component: 'hr',
-    name: 'hr',
-  }, {
     component: componentTypes.SUB_FORM,
     title: __('Assign Catalog Items'),
     id: 'assign-catalog-items',

--- a/app/javascript/components/code-editor/index.js
+++ b/app/javascript/components/code-editor/index.js
@@ -6,6 +6,7 @@ import {
   ControlLabel,
   Radio,
   HelpBlock,
+  FieldLevelHelp,
 } from 'patternfly-react';
 
 // editor modes
@@ -90,11 +91,13 @@ const CodeGroup = ({
   meta: { error },
   label,
   isRequired,
+  helperText,
   ...props
 }) => (
   <FormGroup name={name} validationState={error && 'error'}>
     <ControlLabel>
       {isRequired ? <RequiredLabel label={label} /> : label }
+      {helperText && <FieldLevelHelp content={helperText} />}
     </ControlLabel>
     <CodeEditor
       onChange={(_editor, _data, value) => onChange(value)}

--- a/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
+++ b/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
@@ -102,12 +102,6 @@ const orchestrationFormSchema = (isEditing = false, isCopying = false, initialVa
     id: 'form-separator',
     name: 'form-separator',
   }, {
-    component: 'note',
-    id: 'form-note',
-    name: 'form-note',
-    label: __('Note: Select format type below to apply syntax highlighting for better readability'),
-    className: '',
-  },{
     component: 'code-editor',
     id: 'content',
     name: 'content',
@@ -115,6 +109,7 @@ const orchestrationFormSchema = (isEditing = false, isCopying = false, initialVa
     mode: setFormat(initialValues),
     modes: ['yaml', 'json'],
     validateOnMount: true,
+    helperText: __('Select the format type below to apply syntax highlighting for better readability'),
     isRequired: true,
     validate: [{
       type: validatorTypes.REQUIRED,

--- a/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
+++ b/app/javascript/components/orchestration-template/orchestration-template-form.schema.js
@@ -98,22 +98,23 @@ const orchestrationFormSchema = (isEditing = false, isCopying = false, initialVa
     label: __('Draft'),
     component: componentTypes.CHECKBOX,
   }, {
-    component: 'hr',
-    id: 'form-separator',
-    name: 'form-separator',
-  }, {
-    component: 'code-editor',
-    id: 'content',
-    name: 'content',
-    label: __('Content'),
-    mode: setFormat(initialValues),
-    modes: ['yaml', 'json'],
-    validateOnMount: true,
-    helperText: __('Select the format type below to apply syntax highlighting for better readability'),
-    isRequired: true,
-    validate: [{
-      type: validatorTypes.REQUIRED,
-    }, value => validateCopyContent(value, initialValues, isCopying)],
+    component: componentTypes.SUB_FORM,
+    id: 'code-section',
+    name: 'code-section',
+    fields: [{
+      component: 'code-editor',
+      id: 'content',
+      name: 'content',
+      label: __('Content'),
+      mode: setFormat(initialValues),
+      modes: ['yaml', 'json'],
+      validateOnMount: true,
+      helperText: __('Select the format type below to apply syntax highlighting for better readability'),
+      isRequired: true,
+      validate: [{
+        type: validatorTypes.REQUIRED,
+      }, value => validateCopyContent(value, initialValues, isCopying)],
+    }],
   }],
 });
 

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.schema.js
@@ -123,9 +123,6 @@ const createSchema = isEditing => ({
       },
       ...basicInformationCommonFields,
     ],
-  }, {
-    component: 'hr',
-    name: 'form-divider',
   },
   ...imageMenusSubForm,
   ],

--- a/app/javascript/forms/mappers/componentMapper.jsx
+++ b/app/javascript/forms/mappers/componentMapper.jsx
@@ -18,8 +18,6 @@ const mapper = {
   'field-array': FieldArray,
   'dual-group': DualGroup,
   'dual-list-select': DualListSelect,
-  hr: () => <hr />,
-  note: props => <div className={props.className} role="alert">{props.label}</div>,
   'password-field': PasswordField,
   'validate-credentials': AsyncCredentials,
   [componentTypes.SELECT]: Select,

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -45,10 +45,6 @@ exports[`Catalog form component should render add variant form 1`] = `
             "title": "Basic Info",
           },
           Object {
-            "component": "hr",
-            "name": "hr",
-          },
-          Object {
             "component": "sub-form",
             "fields": Array [
               Object {
@@ -139,10 +135,6 @@ exports[`Catalog form component should render edit variant form 1`] = `
             "id": "basic-info",
             "name": "basic-info",
             "title": "Basic Info",
-          },
-          Object {
-            "component": "hr",
-            "name": "hr",
           },
           Object {
             "component": "sub-form",

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -124,10 +124,6 @@ exports[`PxeServersForm should render correctly 1`] = `
             "title": "Basic Information",
           },
           Object {
-            "component": "hr",
-            "name": "form-divider",
-          },
-          Object {
             "component": "sub-form",
             "fields": Array [
               Object {


### PR DESCRIPTION
The `hr` component used to separate form parts has been replaced with the `sub-form` component. If the fields are too close to each other, we should probably update the styling, but IMO they are good as they are. The catalog, the orchestration template and the PXE forms were affected:

**Before:**
![Screenshot from 2020-09-30 12-35-41](https://user-images.githubusercontent.com/649130/94675139-8d9eea80-0319-11eb-9648-1cb4f7b308ae.png)
![Screenshot from 2020-09-30 12-37-05](https://user-images.githubusercontent.com/649130/94675257-bde68900-0319-11eb-9b95-a9fa84d247a9.png)


**After:**
![Screenshot from 2020-09-30 12-35-26](https://user-images.githubusercontent.com/649130/94675148-92639e80-0319-11eb-946f-17f0a24610c6.png)
![Screenshot from 2020-09-30 12-37-31](https://user-images.githubusercontent.com/649130/94675262-c0e17980-0319-11eb-92c0-effc433b6ffc.png)


The `note` component is completely replaceable with the `helperText` attribute on the right component, which was not implemented on the `code-editor` component. The only affected page here is the orchestration templates form.

**Before:**
![Screenshot from 2020-09-30 12-29-10](https://user-images.githubusercontent.com/649130/94675402-f71ef900-0319-11eb-87c1-d7857b8606ac.png)

**After:**
![Screenshot from 2020-09-30 12-28-24](https://user-images.githubusercontent.com/649130/94675416-fc7c4380-0319-11eb-90bc-91dff8dfca9c.png)

This allows me to remove the `hr` and `note` components from the DDF mapper.