### PR TITLE
[WIP] - add console link to the configuration profile

### DIFF
--- a/app/helpers/configuration_profile_helper/textual_summary.rb
+++ b/app/helpers/configuration_profile_helper/textual_summary.rb
@@ -8,7 +8,12 @@ module ConfigurationProfileHelper::TextualSummary
   end
 
   def textual_configuration_profile_name
-    {:label => _("Name"), :value => @record.name}
+    h = {:label => _("Name"), :value => @record.name}
+    if @record.supports_console?
+      h[:link] = @record.console_url
+      h[:title] = _("Go to Configuration Profile's console")
+    end
+    h
   end
 
   def textual_configuration_profile_description


### PR DESCRIPTION
This is an enhancement for https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28. 

In the Confguration Profile details page, we want to add a console link back to the CAM UI where the user can review the template source, versions, parameters, etc.

Here's a screenshot with the new configuration profile details page. The user can click on the profile name. 

<img width="585" alt="Screen Shot 2020-09-30 at 10 00 53 AM" src="https://user-images.githubusercontent.com/22264185/94696240-d4361a00-0304-11eb-9141-c61b90b0b6e7.png">


Depends on: https://github.com/ManageIQ/manageiq/pull/20613 and https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/32