### PR TITLE
Get rid of the NTP servers from the Zone and Server screens

### DIFF
--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -20,12 +20,6 @@
         .col-md-8
           %p.form-control-static
             = @selected_zone.settings.key?(:proxy_server_ip) ? @selected_zone.settings[:proxy_server_ip] : ''
-      .form-group
-        %label.col-md-2.control-label
-          = _("NTP Servers")
-        .col-md-8
-          %p.form-control-static
-            = @ntp_servers
 
       .form-group
         %label.col-md-2.control-label

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -121,33 +121,6 @@
         miqSelectPickerEvent('repository_scanning_defaultsmartproxy', "#{url}")
   %hr
   %h3
-    = _("NTP Servers")
-  .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
-        = _("Servers")
-      .col-md-8
-        = text_field_tag("ntp_server_1",
-                          @edit.fetch_path(:new, :ntp, :server, 0),
-                          :maxlength => ViewHelper::MAX_NAME_LEN,
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        %br/
-        = text_field_tag("ntp_server_2",
-                          @edit.fetch_path(:new, :ntp, :server, 1),
-                          :maxlength => ViewHelper::MAX_NAME_LEN,
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        %br/
-        = text_field_tag("ntp_server_3",
-                          @edit.fetch_path(:new, :ntp, :server, 2),
-                          :maxlength => ViewHelper::MAX_NAME_LEN,
-                          :class => "form-control",
-                          "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  .note
-    = _("Specified NTP settings applied here will override Zone NTP settings.")
-  %hr
-  %h3
     = _("Outgoing SMTP E-mail Server")
   .form-horizontal
     .form-group

--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -38,32 +38,6 @@
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
       - if @zone.id && @zone.name.downcase == "default"
         = javascript_tag(javascript_focus('proxy_server_ip'))
-%hr
-%h3
-  = _("NTP Servers")
-.form-horizontal
-  .form-group
-    %label.control-label.col-md-2
-      = _("Servers")
-    .col-md-8
-      = text_field_tag("ntp_server_1",
-                        @edit.fetch_path(:new, :ntp, :server, 0),
-                        :maxlength => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      %br/
-      = text_field_tag("ntp_server_2",
-                        @edit.fetch_path(:new, :ntp, :server, 1),
-                        :maxlength => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-      %br/
-      = text_field_tag("ntp_server_3",
-                        @edit.fetch_path(:new, :ntp, :server, 2),
-                        :maxlength => ViewHelper::MAX_NAME_LEN,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-= _("* Specified NTP settings apply to this zone only and are not global.")
 
 %hr
 %h3

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -168,21 +168,6 @@ describe OpsController do
       end
     end
 
-    describe '#settings_get_form_vars_sync_ntp' do
-      before do
-        controller.params = {'ntp_server_2' => '1'}
-        controller.instance_variable_set(:@edit, :current => {:ntp => {:server => ['0', '1', '2']}},
-                                                 :new     => {:ntp => {:server => ['0', '1', '2'], 'ntp_server_2' => ''}})
-      end
-
-      subject { controller.instance_variable_get(:@edit) }
-
-      it 'removes unnecessary key from @edit[:new][:ntp]' do
-        controller.send(:settings_get_form_vars_sync_ntp)
-        expect(subject[:new]).to eq(subject[:current])
-      end
-    end
-
     describe "#pglogical_save_subscriptions" do
       before { allow(controller).to receive(:javascript_flash) }
 
@@ -251,17 +236,6 @@ describe OpsController do
           controller.instance_variable_set(:@sb, :active_tab => 'settings_help_menu')
           controller.send(:settings_get_info, 'root-0')
           expect(edit[:new]).to eq(edit[:current])
-        end
-      end
-
-      context 'zone node' do
-        it 'sets ntp server info for display' do
-          _guid, miq_server, zone = EvmSpecHelper.local_guid_miq_server_zone
-          controller.instance_variable_set(:@sb, :active_tab => 'settings_zone')
-          controller.instance_variable_set(:@edit, :new => {:ntp => {:server => ["1.example.com", "2.example.com"]}})
-          controller.send(:zone_save_ntp_server_settings, zone)
-          controller.send(:settings_get_info, "z-#{zone.id}")
-          expect(assigns(:ntp_servers)).to eq("1.example.com, 2.example.com")
         end
       end
 

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -149,8 +149,7 @@ describe OpsController do
                    :action => "zone_edit",
                    :button => "add"}
         edit = {:new => {:name        => @zone.name,
-                         :description => "description02",
-                         :ntp         => {}}}
+                         :description => "description02"}}
         controller.instance_variable_set(:@edit, edit)
         controller.params = @params
         seed_session_trees('ops', :settings_tree)

--- a/spec/views/ops/_settings_evm_servers_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_evm_servers_tab.html.haml_spec.rb
@@ -2,7 +2,7 @@ describe "ops/_settings_evm_servers_tab.html.haml" do
   before do
     assign(:sb, :active_tab => "settings_evm_servers")
     @selected_zone = FactoryBot.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
-                                                {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0, :ntp => {:server => ['Server 1']}})
+                                                {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0})
     @servers = []
   end
 
@@ -12,7 +12,6 @@ describe "ops/_settings_evm_servers_tab.html.haml" do
       expect(response.body).to include('Name')
       expect(response.body).to include('Description')
       expect(response.body).to include('SmartProxy Server IP')
-      expect(response.body).to include('NTP Servers')
       expect(response.body).to include('Max active VM Scans')
     end
   end

--- a/spec/views/ops/_zone_form.html.haml_spec.rb
+++ b/spec/views/ops/_zone_form.html.haml_spec.rb
@@ -2,7 +2,7 @@ describe "ops/_zone_form.html.haml" do
   before do
     assign(:sb, :active_tab => "settings_evm_servers")
     @selected_zone = FactoryBot.create(:zone, :name => 'One Zone', :description => " One Description", :settings =>
-                                                {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0, :ntp => {:server => ['Server 1']}})
+                                                {:proxy_server_ip => '1.2.3.4', :concurrent_vm_scans => 0})
     @servers = []
   end
 
@@ -16,16 +16,14 @@ describe "ops/_zone_form.html.haml" do
                                           :concurrent_vm_scans => '0',
                                           :userid              => nil,
                                           :password            => nil,
-                                          :verify              => nil,
-                                          :ntp                 => {:server =>[]}},
+                                          :verify              => nil},
                :current               => {:name                => nil,
                                           :description         => nil,
                                           :proxy_server_ip     => nil,
                                           :concurrent_vm_scans => '0',
                                           :userid              => nil,
                                           :password            => nil,
-                                          :verify              => nil,
-                                          :ntp                 => { :server => []}},
+                                          :verify              => nil},
                :key                   => 'zone_edit__new',
                :default_verify_status => true}
     end
@@ -34,7 +32,6 @@ describe "ops/_zone_form.html.haml" do
       expect(response.body).to include('Name')
       expect(response.body).to include('Description')
       expect(response.body).to include('SmartProxy Server IP')
-      expect(response.body).to include('NTP Servers')
       expect(response.body).to include('Max Active VM Scans')
     end
 


### PR DESCRIPTION
Just following https://github.com/ManageIQ/manageiq/pull/20623 and removing it from here. @Maria-Cordero-ibm if this gets in sooner than yours, it might cause a merge conflict. It should be easy to resolve because you're deleting the stuff I deleted too.
