### PR TITLE
Add console link to Configuration Profile

### DIFF
--- a/app/controllers/configuration_profile_controller.rb
+++ b/app/controllers/configuration_profile_controller.rb
@@ -37,6 +37,19 @@ class ConfigurationProfileController < ApplicationController
     process_show_list(opts)
   end
 
+  def launch_configuration_profile_console
+    record = self.class.model.find(params[:id])
+    unless record.console_url
+      add_flash(_("Configuration Profile console access failed: Task start failed"), :error)
+    end
+
+    if @flash_array
+      javascript_flash(:spinner_off => true)
+    else
+      javascript_open_window(record.console_url)
+    end
+  end
+
   private
 
   def breadcrumbs_options

--- a/app/helpers/application_helper/button/configuration_profile_console.rb
+++ b/app/helpers/application_helper/button/configuration_profile_console.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ConfigurationProfileConsole < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.supports_console?
+  end
+end

--- a/app/helpers/application_helper/toolbar/configuration_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_profile_center.rb
@@ -1,0 +1,20 @@
+class ApplicationHelper::Toolbar::ConfigurationProfileCenter < ApplicationHelper::Toolbar::Basic
+  button_group('access', [
+    select(
+      :access_choice,
+      nil,
+      N_('Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :configuration_profile_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open the Configuration Profile console'),
+          N_('Configuration Profile console'),
+          :url   => "launch_configuration_profile_console",
+          :klass => ApplicationHelper::Button::ConfigurationProfileConsole
+        ),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -489,6 +489,8 @@ class ApplicationHelper::ToolbarChooser
 
         return @lastaction == 'show_list' ? "#{@layout.pluralize}_center_tb" : "#{@layout}_center_tb"
 
+      elsif @layout == "configuration_profile"
+        return "configuration_profile_center_tb"
       elsif @layout == "configuration" && @tabform == "ui_4"
         return "time_profiles_center_tb"
       elsif @layout == "diagnostics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2498,6 +2498,7 @@ Rails.application.routes.draw do
         show
         show_list
         tagging_edit
+        launch_configuration_profile_console
       ]
     },
 


### PR DESCRIPTION
This **enhancement** adds Access to the IBM Terraform template console

<img width="1179" alt="Configuration_Profile_Details_Access" src="https://user-images.githubusercontent.com/41962815/94854310-b8ad3b00-03fa-11eb-85ca-e1ab458b80ba.png">

