### PR TITLE
[IVANCHUK] Support for ovirt native console

### DIFF
--- a/app/helpers/application_helper/button/vm_native_console.rb
+++ b/app/helpers/application_helper/button/vm_native_console.rb
@@ -1,0 +1,16 @@
+class ApplicationHelper::Button::VmNativeConsole < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.vendor == 'redhat'
+  end
+
+  def disabled?
+    begin
+      @record.validate_native_console_support
+    rescue MiqException::RemoteConsoleNotSupportedError => err
+      @error_message = _('VM Native Console error: %{error}') % {:error => err}
+    end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -270,6 +270,15 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :confirm => N_("Opening a VMRC console requires that VMRC is installed and pre-configured to work in your browser. Are you sure?"),
           :klass   => ApplicationHelper::Button::VmVmrcConsole),
         button(
+          :vm_native_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a native console for this VM'),
+          N_('Native Console'),
+          :keepSpinner => true,
+          :url         => "native_console",
+          :klass       => ApplicationHelper::Button::VmNativeConsole
+        ),
+        button(
           :cockpit_console,
           'pficon pficon-screen fa-lg',
           N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3098,6 +3098,7 @@ Rails.application.routes.draw do
         right_size_print
         launch_html5_console
         launch_vmrc_console
+        launch_native_console
         perf_chart_chooser
         policies
         protect
@@ -3159,6 +3160,7 @@ Rails.application.routes.draw do
         vm_pre_prov
         vm_vdi
         html5_console
+        native_console
         wait_for_task
         win32_services
         ownership_update
@@ -3186,6 +3188,7 @@ Rails.application.routes.draw do
         explorer
         launch_html5_console
         launch_vmrc_console
+        launch_native_console
         retirement_info
         reconfigure_form_fields
         policies
@@ -3257,6 +3260,7 @@ Rails.application.routes.draw do
         vm_pre_prov
         vmrc_console
         html5_console
+        native_console
         wait_for_task
         win32_services
         x_button

--- a/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
@@ -1,0 +1,34 @@
+describe ApplicationHelper::Button::VmNativeConsole do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:ems) { FactoryBot.create(:ems_redhat) }
+  let(:record) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
+  let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#calculate_properties' do
+    before(:each) do
+      remote_console_validation
+      button.calculate_properties
+    end
+
+    context 'and remote control is supported' do
+      let(:remote_console_validation) do
+        allow(record).to receive(:validate_native_console_support).and_return(true)
+      end
+      it_behaves_like 'an enabled button'
+    end
+    context 'and remote control is not supported' do
+      let(:err_msg) { 'Remote console is not supported' }
+      let(:remote_console_validation) do
+        allow(record).to receive(:validate_native_console_support)
+          .and_raise(MiqException::RemoteConsoleNotSupportedError, err_msg)
+      end
+      it_behaves_like 'a disabled button', "VM Native Console error: Remote console is not supported"
+    end
+  end
+end


### PR DESCRIPTION
This is ivanchuk-specific version of https://github.com/ManageIQ/manageiq-ui-classic/pull/6574 (cherry picked from commit 4503228192a8f5522da28e8d28721eb2265da381).

This PR implements UI support for ovirt native console. With these changes in place a new button on ovirt VM summary screen will show:
![Screenshot from 2020-10-01 20-09-58](https://user-images.githubusercontent.com/6648365/94848352-2cb00900-0424-11eb-9761-d45f3e17f6ec.png)

Clicking on the above button will download a `console.vv` file to your computer:
![Screenshot from 2020-10-01 20-10-58](https://user-images.githubusercontent.com/6648365/94848429-481b1400-0424-11eb-95f5-499a7c74f0e8.png)

Open the `console.vv` file using `remote-viewer` [1] utility:
![Screenshot from 2020-10-01 20-11-23](https://user-images.githubusercontent.com/6648365/94848480-59fcb700-0424-11eb-98ea-6443355aad5e.png)

The `remote-viewer` utility will render the remote console:
![Screenshot from 2020-10-01 20-13-56](https://user-images.githubusercontent.com/6648365/94848521-6aad2d00-0424-11eb-9509-abd3f3c057eb.png)

Optionally, you may configure your browser to open the `console.vv` file automatically using the `remote-viewer` utility.

[1] https://virt-manager.org/download/