### PR TITLE
a11y: Make the menu expand/collapse accessible via keyboard

### DIFF
--- a/app/javascript/menu/main-menu.jsx
+++ b/app/javascript/menu/main-menu.jsx
@@ -63,7 +63,7 @@ export const MainMenu = ({
 
   return (
     <>
-      <div onClick={hideSecondary}>
+      <div onClick={hideSecondary} id="main-menu-primary">
         <SideNav
           aria-label={__("Main Menu")}
           className="primary"

--- a/app/javascript/menu/menu-collapse.jsx
+++ b/app/javascript/menu/menu-collapse.jsx
@@ -6,8 +6,14 @@ import { SideNavItem } from 'carbon-components-react/es/components/UIShell';
 const MenuCollapse = ({ expanded, toggle }) => (
   <SideNavItem className="menu-collapse">
     <div
+      role="button"
+      tabIndex="0"
       className="menu-collapse-button"
       onClick={toggle}
+      onKeyPress={toggle}
+      aria-expanded={expanded}
+      aria-controls="main-menu-primary"
+      aria-haspopup="true"
     >
       {expanded ? <ChevronLeft20 /> : <ChevronRight20 />}
     </div>


### PR DESCRIPTION
I added the right `role`, `aria` and `tabindex` values on this element. The highlighting around the element is only visible from one side, because the right side is white and the top-bottom are covered by other elements. I'm not sure how should we fix it, increasing the z-index didn't really help.

**Before:**
![Screenshot from 2020-10-02 13-22-23](https://user-images.githubusercontent.com/649130/94918179-557edf80-04b2-11eb-8a4e-18f8974aa257.png)


**After:**
![Screenshot from 2020-10-02 13-21-09](https://user-images.githubusercontent.com/649130/94918155-4ac44a80-04b2-11eb-9799-71d8cf0def28.png)
