### PR TITLE
Fix volumes boolean fields in '_prov_dialog_volume_fieldset.html.haml'

### DIFF
--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -43,7 +43,8 @@
               - else
                 = options[:"#{key}_#{counter}"]
             - elsif workflow.get_field(key, dialog)[:data_type] == :boolean
-              %input{:checked           => options[:"#{key}_#{counter}"],
+              - isChecked = [nil, 'null'].exclude?(options[:"#{key}_#{counter}"])
+              %input{:checked           => isChecked,
                      :type              => "checkbox",
                      :id                => "volumes__#{key}_#{counter}",
                      :required          => workflow.get_field(key, dialog)[:required],


### PR DESCRIPTION
If a boolean field is checked, unchecked and then checked again,
then its value is set to 'null' *string*. A string however
evaluates to a 'true' value and thus the checkbox gets a sticky
'checked' state