### PR TITLE
Fix for Configuration Provider appearing twice

### DIFF
--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -29,12 +29,6 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-  zone:
-    columns:
-    - name
-  endpoints:
-    columns:
-    - url
 
 # Included tables and columns for query performance
 include_for_find:


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/23 where the Configuration Provider is listed twice in the UI.