### PR TITLE
Fix breadcrumb and right cell text of order service

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1812,7 +1812,7 @@ class CatalogController < ApplicationController
     @explorer = true
 
     # FIXME: make this functional
-    get_node_info(x_node) unless @tagging || @edit
+    get_node_info(x_node) unless @tagging || @edit || @in_a_form
     replace_trees   = @replace_trees   if @replace_trees    # get_node_info might set this
     right_cell_text = @right_cell_text if @right_cell_text  # get_node_info might set this too
 


### PR DESCRIPTION
This fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6394

@miq-bot add_reviewer @h-kataria 

Before:

<img width="1425" alt="Screen Shot 2020-10-02 at 4 17 31 PM" src="https://user-images.githubusercontent.com/37085529/94966194-d518a880-04ca-11eb-8af5-5533a40a2e75.png">

After:

<img width="1463" alt="Screen Shot 2020-10-02 at 4 13 24 PM" src="https://user-images.githubusercontent.com/37085529/94966213-dd70e380-04ca-11eb-8936-7a90b7db9f4e.png">
