### PR TITLE
Add New Subnet without Cloud Tenant

### DIFF
--- a/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
+++ b/app/views/static/cloud_subnet/cloud-subnet-form.html.haml
@@ -31,7 +31,7 @@
                             'maxlength' => 128,
                             'ng-model'  => 'vm.cloudSubnetModel.ext_management_system.name'}
     .form-group{'ng-class' => '{"has-error": angularForm.cloud_tenant_id.$invalid}',
-                'ng-if' => 'vm.cloudSubnetModel.ems_id'}
+                'ng-if' => 'vm.cloudSubnetModel.ems_id && vm.available_tenants.length'}
       %label.col-md-2.control-label
         = _('Cloud Tenant Placement')
       .col-md-8{'ng-if' => 'vm.newRecord'}


### PR DESCRIPTION
In Network > Subnets > Add New Subnet form only show and require 'Cloud
Tenant Placement' field if tenants are defined. The field is already
hidden before selecting a Network Manager. This addition to the 'ng-if'
statement prevents it from appearing if the selected Network Manager has
no available tenants defined.

Form without any Network Manager selected. 'Cloud Tenant Placement' is not visible:
![image](https://user-images.githubusercontent.com/1637291/94970064-769efa80-04c9-11eb-8466-a7d471eb0fc8.png)

Form with `Openstack::NetworkManager` type Network Manager selected. 'Cloud Tenant Placement' is shown and required:
![image](https://user-images.githubusercontent.com/1637291/94970023-5ec77680-04c9-11eb-86a6-2b97ea49f917.png)

Form with `IbmCloud::PowerVirtualServers` type Network Manager selected, 'Clout Tenant Placement' is not visible and is not required to submit 'Add' action:
![image](https://user-images.githubusercontent.com/1637291/94970237-d3021a00-04c9-11eb-8938-cc592f3e38c6.png)