### PR TITLE
/dashboard/logout: don't remember logout as start_url when session invalid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -892,7 +892,8 @@ class ApplicationController < ActionController::Base
     timed_out = PrivilegeCheckerService.new.user_session_timed_out?(session, current_user) if timed_out.nil?
     reset_session
 
-    session[:start_url] = request.url if request.method == "GET"
+    # remember for after login, but make sure we don't redirect to logout, or POST actions
+    session[:start_url] = request.url if request.method == "GET" && !request.url.include?('/logout')
 
     respond_to do |format|
       format.html do

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -26,6 +26,12 @@ describe "Login process" do
       expect(session[:start_url]).to eq('http://www.example.com/report/explorer')
     end
 
+    it "redirects to 'login' and skips start_url for logout" do
+      get '/dashboard/logout'
+      expect(response).to redirect_to(:controller => 'dashboard', :action => 'login')
+      expect(session[:start_url]).to be_nil
+    end
+
     it "allows login with correct password" do
       post '/dashboard/authenticate', :params => { :user_name => user.userid, :user_password => 'smartvm' }
       expect(response.status).to eq(200)


### PR DESCRIPTION
check_privileges is skipped for logout,
but none of the other before actions are,
and get_global_session_data can still trigger handle_invalid_session,
which would remember logout as start_url,
leading to a (counterproductive) redirect to logout right after logging in.

This may have happened recently :point_up: [September 29, 2020 9:09 PM](https://gitter.im/ManageIQ/manageiq?at=5f73a287aaff36059b6575de), I'm not sure that was caused by this, but it seems possible.