### PR TITLE
Remove focus tag from polymorphic_conditional_button_spec

### DIFF
--- a/spec/helpers/application_helper/buttons/polymorphic_conditional_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/polymorphic_conditional_button_spec.rb
@@ -1,4 +1,4 @@
-fdescribe ApplicationHelper::Button::PolymorphicConditionalButton do
+describe ApplicationHelper::Button::PolymorphicConditionalButton do
   let(:view_context) { setup_view_context_with_sandbox({}) }
 
   describe "#backup_create" do


### PR DESCRIPTION
I used focus in order to solve rspec issue in https://github.com/ManageIQ/manageiq-ui-classic/pull/7343 and forgot to remove it. 
