### PR TITLE
Remove redundant 'Network' prefix from network menu items

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -143,12 +143,12 @@ module Menu
           Menu::Item.new('ems_network',      N_('Providers'),         'ems_network',      {:feature => 'ems_network_show_list'},     '/ems_network/show_list'),
           Menu::Item.new('cloud_network',    N_('Networks'),          'cloud_network',    {:feature => 'cloud_network_show_list'},   '/cloud_network/show_list'),
           Menu::Item.new('cloud_subnet',     N_('Subnets'),           'cloud_subnet',     {:feature => 'cloud_subnet_show_list'},    '/cloud_subnet/show_list'),
-          Menu::Item.new('network_router',   N_('Network Routers'),   'network_router',   {:feature => 'network_router_show_list'},  '/network_router/show_list'),
-          Menu::Item.new('network_service',  N_('Network Services'),  'network_service',  {:feature => 'network_service_show_list'}, '/network_service/show_list'),
+          Menu::Item.new('network_router',   N_('Routers'),           'network_router',   {:feature => 'network_router_show_list'},  '/network_router/show_list'),
+          Menu::Item.new('network_service',  N_('Services'),          'network_service',  {:feature => 'network_service_show_list'}, '/network_service/show_list'),
           Menu::Item.new('security_group',   N_('Security Groups'),   'security_group',   {:feature => 'security_group_show_list'},  '/security_group/show_list'),
           Menu::Item.new('security_policy',  N_('Security Policies'), 'security_policy',  {:feature => 'security_policy_show_list'}, '/security_policy/show_list'),
           Menu::Item.new('floating_ip',      N_('Floating IPs'),      'floating_ip',      {:feature => 'floating_ip_show_list'},     '/floating_ip/show_list'),
-          Menu::Item.new('network_port',     N_('Network Ports'),     'network_port',     {:feature => 'network_port_show_list'},    '/network_port/show_list'),
+          Menu::Item.new('network_port',     N_('Ports'),             'network_port',     {:feature => 'network_port_show_list'},    '/network_port/show_list'),
           Menu::Item.new('network_topology', N_('Topology'),          'network_topology', {:feature => 'network_topology'},          '/network_topology/show'),
         ])
       end


### PR DESCRIPTION
**Before:**
![Screenshot from 2020-10-06 12-27-18](https://user-images.githubusercontent.com/649130/95190245-4c9e4e80-07cf-11eb-8dfa-353eec6652ff.png)

**After:**
![Screenshot from 2020-10-06 15-52-44](https://user-images.githubusercontent.com/649130/95210754-1cb17400-07ec-11eb-970f-ed72006d8a0a.png)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7394