### PR TITLE
Expose the API global in the jest testing context

### DIFF
--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -64,3 +64,7 @@ Object.defineProperty(Array.prototype, 'flat', {
  * unfortunately this cannot be mocked in some helper file it will only work in global setup
  */
 jest.mock('../app/javascript/helpers/miq-redirect-back', () => jest.fn());
+
+// Loading the API global to the test context
+import { API } from '../app/javascript/http_api';
+window.API = API;


### PR DESCRIPTION
We have the `API` function exposed on `window` globally, but the tests can't deal with that. I hope I'm putting it to the right location...

FYI @Maria-Cordero-ibm 