### PR TITLE
Fix provisioning dialog ':migratable' symbol ref

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -420,7 +420,7 @@
               :label                      => _("Upload File"),
               :prefix                     => "/miq_request/",
               :keys                       => keys})
-      - keys = %i[migratable, pin_policy]
+      - keys = %i[migratable pin_policy]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,
            :dialog                    => dialog,


### PR DESCRIPTION
When using '%[]' for an array of symbols whitespace is used as a
delimiter, not commas.

Small bug that prevents the 'migratable' checkbox from showing up in provisioning forms. Looks like just a typo when moving to the %i[] notation - https://github.com/ManageIQ/manageiq-ui-classic/pull/7297#discussion_r490223813.