### PR TITLE
Add 'public_network' provisioning checkbox field

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -408,7 +408,7 @@
             -# Display notes if available
             = field_hash[:notes]
       - elsif [:linked_clone, :migratable, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid, :seal_template,
-               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible].include?(field)
+               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible, :public_network].include?(field)
         -# ### Checkbox fields
         .col-md-8{:style => "vertical-align: top;"}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -174,7 +174,7 @@
           :prefix                     => "/miq_request/",
           :keys                       => keys})
   - when :network
-    - keys = [:vlan, :mac_address]
+    - keys = [:vlan, :mac_address, :public_network]
     - keys << :subnet if wf.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow)
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,


### PR DESCRIPTION
This is implemented to enable attaching a VM to a public network during
provisioning.