### PR TITLE
Fix propTypes for the MenuItem component

### DIFF
--- a/app/javascript/menu/first-level.jsx
+++ b/app/javascript/menu/first-level.jsx
@@ -28,13 +28,19 @@ const MenuItem = ({
   </SideNavLink>
 );
 
-MenuItem.props = {
+MenuItem.propTypes = {
   active: PropTypes.bool,
-  href: PropTypes.string.isRequired,
-  icon: PropTypes.string,
+  href: PropTypes.string,
+  icon: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+MenuItem.defaultProps = {
+  active: false,
+  href: undefined,
+  type: 'default',
 };
 
 const MenuSection = ({

--- a/app/javascript/menu/second-level.jsx
+++ b/app/javascript/menu/second-level.jsx
@@ -27,14 +27,16 @@ const MenuItem = ({
 MenuItem.propTypes = {
   active: PropTypes.bool,
   hideSecondary: PropTypes.func.isRequired,
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
+  type: PropTypes.string,
 };
 
 MenuItem.defaultProps = {
   active: false,
+  href: undefined,
+  type: 'default',
 };
 
 


### PR DESCRIPTION
There was still a missing `propTypes` for `MenuItem` and no `defaultProps` so I added them. Updated the `href` and `type` attribute to be not required and also the `type` set to `default` as the default value. It was causing me type errors on the second level of `Settings`.