### PR TITLE
Enabling textual_summary to work with nil asset_detail

### DIFF
--- a/app/helpers/physical_chassis_helper/textual_summary.rb
+++ b/app/helpers/physical_chassis_helper/textual_summary.rb
@@ -39,19 +39,19 @@ module PhysicalChassisHelper::TextualSummary
   end
 
   def textual_product_name
-    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+    {:label => _("Product Name"), :value => @record.asset_detail&.product_name}
   end
 
   def textual_manufacturer
-    {:label => _("Manufacturer"), :value => @record.asset_detail["manufacturer"] }
+    {:label => _("Manufacturer"), :value => @record.asset_detail&.manufacturer}
   end
 
   def textual_serial_number
-    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+    {:label => _("Serial Number"), :value => @record.asset_detail&.serial_number}
   end
 
   def textual_part_number
-    {:label => _("Part Number"), :value => @record.asset_detail["part_number"] }
+    {:label => _("Part Number"), :value => @record.asset_detail&.part_number}
   end
 
   def textual_health_state
@@ -63,11 +63,11 @@ module PhysicalChassisHelper::TextualSummary
   end
 
   def textual_description
-    {:label => _("Description"), :value => @record.asset_detail["description"]}
+    {:label => _("Description"), :value => @record.asset_detail&.description}
   end
 
   def textual_location_led_state
-    {:label => _("Identify LED State"), :value => @record.asset_detail['location_led_state']}
+    {:label => _("Identify LED State"), :value => @record.asset_detail&.location_led_state}
   end
 
   #

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -86,19 +86,19 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_product_name
-    {:label => _("Product Name"), :value => @record.asset_detail['product_name'] }
+    {:label => _("Product Name"), :value => @record.asset_detail&.product_name}
   end
 
   def textual_manufacturer
-    {:label => _("Manufacturer"), :value => @record.asset_detail['manufacturer'] }
+    {:label => _("Manufacturer"), :value => @record.asset_detail&.manufacturer}
   end
 
   def textual_machine_type
-    {:label => _("Machine Type"), :value => @record.asset_detail['machine_type'] }
+    {:label => _("Machine Type"), :value => @record.asset_detail&.machine_type}
   end
 
   def textual_serial_number
-    {:label => _("Serial Number"), :value => @record.asset_detail['serial_number'] }
+    {:label => _("Serial Number"), :value => @record.asset_detail&.serial_number}
   end
 
   def textual_ems_ref
@@ -106,7 +106,7 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_model
-    {:label => _("Model"), :value => @record.asset_detail['model']}
+    {:label => _("Model"), :value => @record.asset_detail&.model}
   end
 
   def textual_capacity
@@ -165,31 +165,31 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_loc_led_state
-    {:label => _("Identify LED State"), :value => @record.asset_detail['location_led_state']}
+    {:label => _("Identify LED State"), :value => @record.asset_detail&.location_led_state}
   end
 
   def textual_support_contact
-    {:label => _("Support contact"), :value => @record.asset_detail['contact']}
+    {:label => _("Support contact"), :value => @record.asset_detail&.contact}
   end
 
   def textual_description
-    {:label => _("Description"), :value => @record.asset_detail['description']}
+    {:label => _("Description"), :value => @record.asset_detail&.description}
   end
 
   def textual_location
-    {:label => _("Location"), :value => @record.asset_detail['location']}
+    {:label => _("Location"), :value => @record.asset_detail&.location}
   end
 
   def textual_room
-    {:label => _("Room"), :value => @record.asset_detail['room']}
+    {:label => _("Room"), :value => @record.asset_detail&.room}
   end
 
   def textual_rack_name
-    {:label => _("Rack name"), :value => @record.asset_detail['rack_name']}
+    {:label => _("Rack name"), :value => @record.asset_detail&.rack_name}
   end
 
   def textual_lowest_rack_unit
-    {:label => _("Lowest rack name"), :value => @record.asset_detail['lowest_rack_unit']}
+    {:label => _("Lowest rack name"), :value => @record.asset_detail&.lowest_rack_unit}
   end
 
   def textual_health_state

--- a/app/helpers/physical_storage_helper/textual_summary.rb
+++ b/app/helpers/physical_storage_helper/textual_summary.rb
@@ -43,11 +43,11 @@ module PhysicalStorageHelper::TextualSummary
   end
 
   def textual_product_name
-    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+    {:label => _("Product Name"), :value => @record.asset_detail&.product_name}
   end
 
   def textual_serial_number
-    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+    {:label => _("Serial Number"), :value => @record.asset_detail&.serial_number}
   end
 
   def textual_health_state
@@ -67,34 +67,34 @@ module PhysicalStorageHelper::TextualSummary
   end
 
   def textual_description
-    {:label => _("Description"), :value => @record.asset_detail["description"]}
+    {:label => _("Description"), :value => @record.asset_detail&.description}
   end
 
   def textual_machine_type
-    {:label => _("Machine Type"), :value => @record.asset_detail["machine_type"]}
+    {:label => _("Machine Type"), :value => @record.asset_detail&.machine_type}
   end
 
   def textual_model
-    {:label => _("Model"), :value => @record.asset_detail["model"]}
+    {:label => _("Model"), :value => @record.asset_detail&.model}
   end
 
   def textual_contact
-    {:label => _("Contact"), :value => @record.asset_detail["contact"]}
+    {:label => _("Contact"), :value => @record.asset_detail&.contact}
   end
 
   def textual_location
-    {:label => _("Location"), :value => @record.asset_detail["location"]}
+    {:label => _("Location"), :value => @record.asset_detail&.location}
   end
 
   def textual_room
-    {:label => _("Room"), :value => @record.asset_detail["room"]}
+    {:label => _("Room"), :value => @record.asset_detail&.room}
   end
 
   def textual_rack_name
-    {:label => _("Rack Name"), :value => @record.asset_detail["rack_name"]}
+    {:label => _("Rack Name"), :value => @record.asset_detail&.rack_name}
   end
 
   def textual_lowest_rack_unit
-    {:label => _("Lowest Rack Unit"), :value => @record.asset_detail["lowest_rack_unit"]}
+    {:label => _("Lowest Rack Unit"), :value => @record.asset_detail&.lowest_rack_unit}
   end
 end

--- a/app/helpers/physical_switch_helper/textual_summary.rb
+++ b/app/helpers/physical_switch_helper/textual_summary.rb
@@ -57,19 +57,19 @@ module PhysicalSwitchHelper::TextualSummary
   end
 
   def textual_product_name
-    {:label => _("Product Name"), :value => @record.asset_detail["product_name"] }
+    {:label => _("Product Name"), :value => @record.asset_detail&.product_name}
   end
 
   def textual_manufacturer
-    {:label => _("Manufacturer"), :value => @record.asset_detail["manufacturer"] }
+    {:label => _("Manufacturer"), :value => @record.asset_detail&.manufacturer}
   end
 
   def textual_serial_number
-    {:label => _("Serial Number"), :value => @record.asset_detail["serial_number"] }
+    {:label => _("Serial Number"), :value => @record.asset_detail&.serial_number}
   end
 
   def textual_part_number
-    {:label => _("Part Number"), :value => @record.asset_detail["part_number"] }
+    {:label => _("Part Number"), :value => @record.asset_detail&.part_number}
   end
 
   def textual_health_state
@@ -81,7 +81,7 @@ module PhysicalSwitchHelper::TextualSummary
   end
 
   def textual_description
-    {:label => _("Description"), :value => @record.asset_detail["description"]}
+    {:label => _("Description"), :value => @record.asset_detail&.description}
   end
 
   def textual_power_state


### PR DESCRIPTION
We introduced new storage provider, AutoSDE, which also uses miq physical storages controller. physical storages under autosde dont have all of the information (mostly the asset_detail fields) that currently avaliable under miq physical storage and that cause a crash once we entered into the physical storage summary page. It is allowed to have an empty field but a bug in the code prevented empty fields for asset_detail, and that was fixed in this PR.

<img width="799" alt="1" src="https://user-images.githubusercontent.com/53213107/95430024-da0aab80-0953-11eb-8f27-3e13912ff3f0.png">


links
-------
https://github.com/ManageIQ/manageiq-providers-autosde/pull/25
