### PR TITLE
a11y: Allow the user to exit the menu when unfocusing or ESC

### DIFF
--- a/app/javascript/menu/main-menu.jsx
+++ b/app/javascript/menu/main-menu.jsx
@@ -38,6 +38,7 @@ export const MainMenu = ({
 
   const appearExpanded = expanded || !!activeSection || !!searchResults;
   const hideSecondary = () => setSection(null);
+  const hideSecondaryEscape = e => e.keyCode === 27 && hideSecondary();
 
   useEffect(() => {
     // persist expanded state
@@ -67,7 +68,7 @@ export const MainMenu = ({
 
   return (
     <>
-      <div onClick={hideSecondary} id="main-menu-primary">
+      <div onClick={hideSecondary} onKeyDown={hideSecondaryEscape} role="navigation" id="main-menu-primary">
         <Navbar
           isSideNavExpanded={expanded}
           onClickSideNavExpand={() => setExpanded(!expanded)}
@@ -125,6 +126,7 @@ export const MainMenu = ({
             <MenuCollapse
               expanded={expanded /* not appearExpanded */}
               toggle={() => setExpanded(!expanded)}
+              onFocus={hideSecondary}
             />
           )}
         </SideNav>
@@ -132,9 +134,18 @@ export const MainMenu = ({
       { activeSection && (
         <>
           <SideNav aria-label={__('Secondary Menu')} className="secondary" isChildOfHeader={false} expanded>
-            <SecondLevel menu={activeSection.items} hideSecondary={hideSecondary} />
+            <div onKeyDown={hideSecondaryEscape} role="navigation">
+              <SecondLevel menu={activeSection.items} hideSecondary={hideSecondary} />
+            </div>
           </SideNav>
-          <div className="miq-main-menu-overlay" onClick={hideSecondary} />
+          <div
+            className="miq-main-menu-overlay"
+            role="navigation"
+            tabIndex="0"
+            onClick={hideSecondary}
+            onFocus={hideSecondary}
+            onKeyDown={hideSecondary}
+          />
         </>
       )}
     </>

--- a/app/javascript/menu/menu-collapse.jsx
+++ b/app/javascript/menu/menu-collapse.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ChevronLeft20, ChevronRight20 } from '@carbon/icons-react';
 import { SideNavItem } from 'carbon-components-react/es/components/UIShell';
 
-const MenuCollapse = ({ expanded, toggle }) => (
+const MenuCollapse = ({ expanded, toggle, onFocus }) => (
   <SideNavItem className="menu-collapse">
     <div
       role="button"
@@ -11,6 +11,7 @@ const MenuCollapse = ({ expanded, toggle }) => (
       className="menu-collapse-button"
       onClick={toggle}
       onKeyPress={toggle}
+      onFocus={onFocus}
       aria-expanded={expanded}
       aria-controls="main-menu-primary"
       aria-haspopup="true"


### PR DESCRIPTION
I set an `onKeyDown` event on both menu levels, if the ESC key is pressed, the second level of the menu gets collapsed. I also made the overlay focusable, so if the user goes through the menu, it gets collapsed before the user can enter the main content area.

With the current implementation there's one catch though: if the user expands the second level and starts moving on the menu items with the keyboard backwards (SHIFT+TAB), it can go around and can get to the main content area without collapsing. I have a few ideas about how this could be solved:
* detect if the focus left the browser's active area with `window.onblur` and collapse the menu (alt+tab would also collapse the menu)
* collapse the second level if the user gets back to the first (might make navigation less comfortable)
* leave as it is and let's hope for common sense :pray: :rofl: 

Parent issue https://github.com/ManageIQ/manageiq-ui-classic/issues/7358