### PR TITLE
Implement support for adding physical storages

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -265,6 +265,7 @@ module Mixins
         when "storage_delete"                   then deletestorages
         when "storage_scan"                     then scanstorage
         when "storage_tag"                      then tag(Storage)
+        when "physical_storage_new"             then javascript_redirect(:action => 'new', :controller => 'physical_storage', :storage_manager_id => block_storage_manager_id(params[:id]))
         # Edit Tags for Network Manager Relationship pages
         when "availability_zone_tag"            then tag(AvailabilityZone)
         when "cloud_network_tag"                then tag(CloudNetwork)

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -4,11 +4,20 @@ class PhysicalStorageController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::MoreShowActions
   include Mixins::BreadcrumbsMixin
+  include Mixins::GenericButtonMixin
 
   before_action :check_privileges
   before_action :session_data
   after_action :cleanup_action
   after_action :set_session_data
+
+  toolbar :physical_storage, :physical_storages
+
+  def new
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Add New %{table}") % {:table => ui_lookup(:table => table_name)},
+                    :url  => "/#{controller_name}/new")
+  end
 
   def self.table_name
     @table_name ||= "physical_storages"
@@ -44,5 +53,17 @@ class PhysicalStorageController < ApplicationController
         {:title => _("Storages"), :url => controller_url},
       ],
     }
+  end
+
+  private
+
+  def specific_buttons(pressed)
+    case pressed
+    when 'physical_storage_new'
+      javascript_redirect(:action => 'new')
+    else
+      return false
+    end
+    true
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -738,6 +738,7 @@ module ApplicationHelper
   def display_adv_search?
     %w[auth_key_pair_cloud
        storage_resource
+       physical_storage
        availability_zone
        automation_manager
        cloud_network

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   module Listnav
     def render_listnav_filename
       common_layouts = %w[
-        storage_resource
+        physical_storage
         auth_key_pair_cloud
         availability_zone
         cloud_network

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -180,7 +180,6 @@ module ApplicationHelper::PageLayouts
 
   def show_adv_search?
     show_search = %w[
-      storage_resource
       auth_key_pair_cloud
       availability_zone
       automation_manager
@@ -229,12 +228,14 @@ module ApplicationHelper::PageLayouts
       orchestration_stack
       persistent_volume
       physical_server
+      physical_storage
       resource_pool
       retired
       security_group
       security_policy
       security_policy_rule
       service
+      storage_resource
       templates
       vm
     ]

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -19,6 +19,13 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             :confirm => N_("Refresh relationships and power states for all items related to these Physical Storages?"),
             :options => {:feature => :refresh}
           ),
+          button(
+            :physical_storage_new,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Attach a new storage system'),
+            t,
+            :url => "/new"
+          ),
         ]
       ),
     ]

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -86,4 +86,8 @@ module EmsStorageHelper::TextualSummary
   def textual_storage_resources
     textual_link(@record.try(:storage_resources), :label => _('Storage Resources (Pools)'))
   end
+
+  def textual_physical_storages
+    textual_link(@record.try(:physical_storages), :label => _('Storage Systems'))
+  end
 end

--- a/app/javascript/components/physical-storage-form/index.jsx
+++ b/app/javascript/components/physical-storage-form/index.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import MiqFormRenderer from '@@ddf';
+import createSchema from './physical-storage-form.schema';
+import miqRedirectBack from '../../helpers/miq-redirect-back';
+
+const PhysicalStorageForm = ({ redirect }) => {
+  const state = useState(undefined);
+
+  const onSubmit = async(values) => {
+    miqSparkleOn();
+    const message = __('Physical storage added');
+    API.post('/api/physical_storages', { action: 'create', resource: values })
+      .then(() => miqRedirectBack(message, 'success', redirect)).catch(miqSparkleOff);
+  };
+
+  const onCancel = () => {
+    const message = __('Adding of physical storage was cancelled by the user');
+    miqRedirectBack(message, 'success', redirect);
+  };
+
+  return (
+    <MiqFormRenderer
+      schema={createSchema(...state)}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      buttonsLabels={{
+        submitLabel: __('Add'),
+        cancelLabel: __('Cancel'),
+      }}
+    />
+  );
+};
+
+PhysicalStorageForm.propTypes = {
+  redirect: PropTypes.string.isRequired,
+};
+
+export default PhysicalStorageForm;

--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -1,0 +1,79 @@
+import { componentTypes, validatorTypes } from '@@ddf';
+
+const loadProviders = () =>
+  API.get(
+    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true',
+  ).then(({ resources }) =>
+    resources.map(({ id, name }) => ({ value: id, label: name })));
+
+const loadFamilies = id => API.get(`/api/providers/${id}?attributes=type,physical_storage_families`)
+  // eslint-disable-next-line camelcase
+  .then(({ physical_storage_families }) => physical_storage_families.map(({ name, id }) => ({
+    label: name,
+    value: id,
+  })));
+
+const createSchema = (emsId, setEmsId) => ({
+  fields: [
+    {
+      component: componentTypes.SELECT,
+      name: 'ems_id',
+      key: 'ems_id',
+      id: 'ems_id',
+      label: __('Provider:'),
+      isRequired: true,
+      loadOptions: loadProviders,
+      onChange: value => setEmsId(value),
+      validate: [{ type: validatorTypes.REQUIRED }],
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'name',
+      id: 'name',
+      label: __('Name:'),
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
+    },
+    {
+      component: componentTypes.SELECT,
+      name: 'physical_storage_family_id',
+      id: 'physical_storage_family_id',
+      label: __('System Type:'),
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
+      loadOptions: () => (emsId ? loadFamilies(emsId) : Promise.resolve([])),
+      key: emsId,
+      condition: {
+        when: 'ems_id',
+        isNotEmpty: true,
+      },
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'management_ip',
+      id: 'management_ip',
+      label: __('Management IP:'),
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'user',
+      id: 'user',
+      label: __('User:'),
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'password',
+      type: 'password',
+      id: 'physical_storage_password',
+      label: __('Password:'),
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
+    },
+  ],
+});
+
+export default createSchema;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -43,6 +43,7 @@ import TextualSummaryWrapper from '../react/textual_summary_wrapper';
 import VmServerRelationshipForm from '../components/vm-server-relationship-form';
 import VmSnapshotForm from '../components/vm-snapshot-form/vm-snapshot-form';
 import WorkersForm from '../components/workers-form/workers-form';
+import PhysicalStorageForm from '../components/physical-storage-form';
 
 /**
 * Add component definitions to this file.
@@ -95,3 +96,4 @@ ManageIQ.component.addReact('Toolbar', Toolbar);
 ManageIQ.component.addReact('VmServerRelationshipForm', VmServerRelationshipForm);
 ManageIQ.component.addReact('VmSnapshotForm', VmSnapshotForm);
 ManageIQ.component.addReact('WorkersForm', WorkersForm);
+ManageIQ.component.addReact('PhysicalStorageForm', PhysicalStorageForm);

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -192,6 +192,11 @@ module Menu
                                            'storage_resource',
                                            {:feature => 'storage_resource_show_list'},
                                            '/storage_resource/show_list'),
+                            Menu::Item.new('physical_storage',
+                                           N_('Storages'),
+                                           'physical_storage',
+                                           {:feature => 'physical_storage_show_list'},
+                                           '/physical_storage/show_list'),
                           ])
       end
 

--- a/app/views/physical_storage/new.html.haml
+++ b/app/views/physical_storage/new.html.haml
@@ -1,0 +1,3 @@
+= react('PhysicalStorageForm',
+         :redirect => previous_breadcrumb_url)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1320,17 +1320,19 @@ Rails.application.routes.draw do
       )
     },
 
-    :physical_storage    => {
-      :get  => %w(
+    :physical_storage   => {
+      :get  => %w[
         download_data
-        show_list
+        download_summary_pdf
         show
-      ),
-
-      :post  => %w(
         show_list
+        new
+      ],
+      :post => %w[
+        listnav_search_selected
         quick_search
-      ) + adv_search_post + save_post,
+        show_list
+      ] + adv_search_post + save_post + exp_post
     },
 
     :physical_chassis    => {

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -58,7 +58,7 @@ describe Menu::DefaultMenu do
 
     it "shows correct content for Block Storage submenu" do
       menu = Menu::DefaultMenu.block_storage_menu_section.items.map(&:name)
-      result = ["Managers", "Volumes", "Volume Snapshots", "Volume Backups", "Volume Types", "Storage Resources"]
+      result = ["Managers", "Volumes", "Volume Snapshots", "Volume Backups", "Volume Types", "Storage Resources", "Storages"]
       expect(menu).to eq(result)
     end
   end


### PR DESCRIPTION
As part of the storage modifications (see ManageIQ/manageiq-ui-classic#7282 for the entire modifications details.) , we added the ability of directly adding physical storage for supporting storage managers.