### PR TITLE
Display all added/saved volume data in UI.

### DIFF
--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -54,7 +54,7 @@
       %hr
       %div
     - counter += 1
-    - draw_fields = !options[:"name_#{counter}"].blank? && !options[:"size_#{counter}"].blank?
+    - draw_fields = options.has_key?(:"name_#{counter}") || options.has_key?(:"size_#{counter}")
 
 :javascript
   (function(){


### PR DESCRIPTION
Changed line of code that was only displaying volume data if both name & size fields were populated even though the data was there in `@edit` hash.

fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7400

/cc @iv1111 please test, validation for these fields should be done by backend.