### PR TITLE
Fixed width of Storage Manager select component width to fix truncation

### DIFF
--- a/app/views/cloud_object_store_container/new.html.haml
+++ b/app/views/cloud_object_store_container/new.html.haml
@@ -18,6 +18,7 @@
                 "required"    => "",
                 "disabled"    => !@storage_manager.nil?,
                 :checkchange  => true,
+                :class        => "form-control",
                 "miq-select"  => true}
           %option{"value" => "", "disabled" => ""}
             = "<#{_('Choose')}>"

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -9,6 +9,7 @@
             "required"    => "",
             "disabled"    => @storage_manager.present? || @volume.try(:id).present?,
             :checkchange  => true,
+            :class        => "form-control",
             "miq-select"  => true}
       %option{"value" => "", "disabled" => ""}
         = "<#{_('Choose')}>"


### PR DESCRIPTION
## Issue Summary
 Truncation occurs in Storage - Block Storage - Volumes - Add Cloud Volumes

## Issue Details
### Steps to reproduce


1. Click Storage -> Block Storage -> Volumes
2. In "Cloud Volumes" page
3. Click "Configuration" button
4. Click "Add a new Cloud Volumes" item
5. Select any one in "Storage Manager" drop-down list

Same issue in Storage-->Object Storage-->Object Storage Containers-->Add new, so fixed in both pages.

### Expected behavior
Select should show full text

### What really happened

<img width="1460" alt="Screen Shot 2020-10-08 at 3 12 23 PM" src="https://user-images.githubusercontent.com/37085529/95510834-895f7680-0984-11eb-95ef-3ce64ce2d931.png">

### After fixing the issue

<img width="1464" alt="Screen Shot 2020-10-08 at 3 11 40 PM" src="https://user-images.githubusercontent.com/37085529/95510884-a1cf9100-0984-11eb-8405-d8236ae15bd8.png">

