### PR TITLE
Throw an error if the API or http objects are being interchanged

### DIFF
--- a/app/javascript/http_api/api.js
+++ b/app/javascript/http_api/api.js
@@ -24,11 +24,20 @@ const API = {
 
 export default API;
 
+function apiOnly(url) {
+  const path = new URL(url, document.location.href);
+  if (!path.pathname.match(/^\/api($|\/)/)) {
+    throw new Error(`${url} is not a valid API endpoint URL, try using 'http' instead of 'API'`);
+  }
+
+  return url;
+}
+
 function urlOnly(method) {
   return (url, options) => miqFetch({
     ...options,
     method,
-    url,
+    url: apiOnly(url),
     backendName: __('API'),
     cookieAndCsrf: true,
   }, null);
@@ -38,7 +47,7 @@ function withData(method) {
   return (url, data, options) => miqFetch({
     ...options,
     method,
-    url,
+    url: apiOnly(url),
     backendName: __('API'),
     cookieAndCsrf: true,
   }, data);

--- a/app/javascript/http_api/http.js
+++ b/app/javascript/http_api/http.js
@@ -5,10 +5,18 @@ export default {
   post,
 };
 
+function nonApiOnly(url) {
+  if (url.match(/^[^/]|(\/api($|\/))/)) {
+    throw new Error(`${url} is an API endpoint URL, try using 'API' instead of 'http'`);
+  }
+
+  return url;
+}
+
 function get(url, options = {}) {
   return miqFetch({
     ...options,
-    url,
+    url: nonApiOnly(url),
     method: 'GET',
     backendName: __('http'),
     cookieAndCsrf: true,
@@ -22,7 +30,7 @@ function post(url, data, { headers, ...options } = {}) {
       'Content-Type': 'application/json',
       ...headers,
     },
-    url,
+    url: nonApiOnly(url),
     method: 'POST',
     backendName: __('http'),
     cookieAndCsrf: true,


### PR DESCRIPTION
The functions under the `API` object allowed any URL to be passed to them, analogously the `http` object also allows requests to our API endpoints. This doesn't help the understanding of the separation of the true API endpoints and the endpoints defined in our Rails controllers. As we are moving towards an API-driven single page application, the controller endpoints should slowly disappear and it is easier to track what component is firing what kind of requests if the correct objects are being used for the correct endpoints.

To enforce this as a rule, I created a regexp matching on the methods defined in both objects to allow URLs from only from the API or non-API worlds. So far I couldn't find any example of the wrong usage, so I guess if the tests pass, this change should not break anything.

FYI @kavyanekkalapu 