### PR TITLE
Implementing Dashboard for storage managers

### DIFF
--- a/app/assets/javascripts/controllers/ems_storage_dashboard/heatmap_controller.js
+++ b/app/assets/javascripts/controllers/ems_storage_dashboard/heatmap_controller.js
@@ -1,0 +1,78 @@
+angular.module( 'patternfly.charts' ).controller('heatmapStorageController', ['$q', 'providerId', '$http', 'miqService', '$scope', function($q, providerId, $http, miqService, $scope) {
+  var vm = this;
+  vm.id = 'heatmap_' + providerId;
+  vm.data = {};
+
+  var init = function() {
+    ManageIQ.angular.scope = $scope;
+    // vm.timeframeLabel = __('Last 30 Days');
+    var url = '/ems_storage_dashboard/resources_capacity_data/' + providerId;
+
+    var heatmapPromise = $http.get(url)
+      .then(function(response) {
+        vm.heatmapData = response.data.data;
+      })
+      .catch(miqService.handleFailure);
+
+    $q.all([heatmapPromise]).then(function() {
+      vm.title = vm.heatmapData.heatmaps.title;
+      vm.data = processHeatmapData(vm.data, vm.heatmapData.heatmaps);
+    });
+
+    vm.dataAvailable = true;
+    vm.titleAlt = __('Utilization - Overriding Defaults');
+    vm.legendLabels = ['< 60%', '70%', '70-80%', '80-90%', '> 90%'];
+    vm.rangeTooltips = ['Memory Utilization < 70%<br\>40 Nodes', 'Memory Utilization 70-80%<br\>4 Nodes', 'Memory Utilization 80-90%<br\>4 Nodes', 'Memory Utilization > 90%<br\>4 Nodes'];
+    vm.thresholds = [0.6, 0.7, 0.8, 0.9];
+    vm.heatmapColorPattern = ['#d4f0fa', '#F9D67A', '#EC7A08', '#CE0000', '#f00'];
+    vm.showLegends = true;
+  };
+
+  var heatmapTitles = {
+    'resourceUsage': __('Resources (Pools)'),
+  };
+
+  var processHeatmapData = function(heatmapsStruct, data) {
+    heatmapsStruct.data = {};
+    var heatmapsStructData = [];
+    if (data) {
+      var keys = Object.keys(data);
+
+      var heatmapData = function(d) {
+        var percent = -1;
+        var tooltip = __('Resource: ') + d.resource + '<br>' + __('Provider: ') + d.provider;
+        if (d.percent === null) {
+          tooltip += '<br> ' + __('Usage: Unknown');
+        } else {
+          percent = d.percent;
+          tooltip += '<br>' + __('Usage: ') + sprintf(__('%d%% in use'), (percent * 100).toFixed(0));
+        }
+        return {
+          'id': keys[i] + '_' + d.id,
+          'tooltip': tooltip,
+          'value': percent,
+        };
+      };
+
+      for (var i in keys) {
+        if (keys[i] === 'title') {
+          continue;
+        }
+        if (data[keys[i]] === null) {
+          heatmapsStruct.data[heatmapTitles[keys[i]]] = [];
+          vm.dataAvailable = false;
+        } else {
+          heatmapsStructData = data[keys[i]].map(heatmapData);
+        }
+        heatmapsStruct.data[heatmapTitles[keys[i]]] = _.sortBy(heatmapsStructData, 'value').reverse();
+      }
+    } else {
+      heatmapsStruct.data = [];
+      vm.dataAvailable = false;
+    }
+
+    return heatmapsStruct.data;
+  };
+
+  init();
+}]);

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -5,6 +5,7 @@ class EmsStorageController < ApplicationController
   include Mixins::GenericSessionMixin
   include Mixins::BreadcrumbsMixin
   include Mixins::StorageCommonMixin
+  include Mixins::DashboardViewMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_storage_dashboard_controller.rb
+++ b/app/controllers/ems_storage_dashboard_controller.rb
@@ -1,0 +1,40 @@
+class EmsStorageDashboardController < ApplicationController
+  extend ActiveSupport::Concern
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def show
+    if params[:id].nil?
+      @breadcrumbs.clear
+    end
+  end
+
+  def resources_capacity_data
+    render :json => {:data => block_storage_heatmap_data(params[:id])}
+  end
+
+  def aggregate_status_data
+    render :json => {:data => aggregate_status(params[:id])}
+  end
+
+  private
+
+  def block_storage_heatmap_data(ems_id)
+    EmsStorageDashboardService.new(ems_id, self, EmsStorage).block_storage_heatmap_data
+  end
+
+  def aggregate_status(ems_id)
+    EmsStorageDashboardService.new(ems_id, self, EmsStorage).aggregate_status_data
+  end
+
+  def get_session_data
+    @layout = "ems_storage_dashboard"
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+end

--- a/app/controllers/mixins/dashboard_view_mixin.rb
+++ b/app/controllers/mixins/dashboard_view_mixin.rb
@@ -1,7 +1,7 @@
 module Mixins
   module DashboardViewMixin
     def dashboard_view
-      if @sb[:summary_mode].present?
+      if @sb and @sb[:summary_mode].present?
         @sb[:summary_mode] == 'dashboard'
       else
         mode = (@settings || {}).fetch_path(:views, :summary_mode)

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -157,7 +157,15 @@ module Mixins
           :object_type => ui_lookup(:model => model.to_s),
           :object_name => @ems.name
         }, :error)
-        return redirect_to(:action => @lastaction || "show_list")
+        # If we are inside the dashboard we need the :action to be set to show and not to the value inside @lastaction which is show_dashboard
+        redirect_args = if @lastaction == "show_dashboard"
+                          {:action => "show", :id => @ems.id}
+                        elsif @lastaction == "show"
+                          {:action => "show", :id => @ems.id}
+                        else
+                          {:action => @lastaction || "show_list"}
+                        end
+        return redirect_to(redirect_args || "show_list")
       end
       @in_a_form = true
       session[:changed] = false

--- a/app/helpers/application_helper/toolbar/ems_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_storage_center.rb
@@ -73,4 +73,23 @@ class ApplicationHelper::Toolbar::EmsStorageCenter < ApplicationHelper::Toolbar:
                    ]
                  ),
                ])
+  button_group('ems_storage_view', [
+                 twostate(
+                   :view_dashboard,
+                   'fa fa-tachometer fa-1xplus',
+                   N_('Dashboard View'),
+                   nil,
+                   :url       => "/",
+                   :url_parms => "?display=dashboard",
+                   :klass     => ApplicationHelper::Button::ViewDashboard
+                 ),
+                 twostate(
+                   :view_summary,
+                   'fa fa-th-list',
+                   N_('Summary View'),
+                   nil,
+                   :url       => "/",
+                   :url_parms => "?display=main"
+                 ),
+               ])
 end

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsStorageHelper::TextualSummary
   def textual_group_relationships
     relationships = %i[
                        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
-                       cloud_object_store_containers custom_button_events
+                       cloud_object_store_containers custom_button_events physical_storages storage_resources
       ]
     relationships.push(:cloud_volume_types) if @record.kind_of?(ManageIQ::Providers::StorageManager::CinderManager)
     TextualGroup.new(_("Relationships"), relationships)
@@ -84,6 +84,10 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_storage_resources
-    textual_link(@record.try(:storage_resources), :label => _('Storage Resources (Pools)'))
+    textual_link(@record.try(:storage_resources), :label => _('Resources (Pools)'))
+  end
+
+  def textual_physical_storages
+    textual_link(@record.try(:physical_storages), :label => _('Physical Storages'))
   end
 end

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -1,0 +1,84 @@
+class EmsStorageDashboardService < EmsDashboardService
+  def block_storage_heatmap_data
+    {
+      :heatmaps => heatmaps
+    }.compact
+  end
+
+  def aggregate_status_data
+    {
+      :aggStatus => aggregate_status
+    }.compact
+  end
+
+  def aggregate_status
+    {
+      :quadicon => @controller.instance_exec(@ems, &EmsStorageDashboardService.quadicon_calc),
+      :status   => status_data,
+      :attrData => attributes_data,
+    }
+  end
+
+  def attributes_data
+    attributes = if @ems.supports?(:block_storage)
+                   %i[physical_storages storage_resources cloud_volumes]
+                 else
+                   %i[cloud_object_store_containers cloud_object_store_objects]
+                 end
+
+    attr_icon = {
+      :physical_storages             => 'pficon pficon-container-node',
+      :storage_resources             => 'pficon pficon-resource-pool',
+      :cloud_volumes                 => 'pficon pficon-volume',
+      :cloud_object_store_containers => 'ff ff-cloud-object-store',
+      :cloud_object_store_objects    => 'fa fa-star',
+    }
+
+    attr_url = {
+      :storage_resources             => 'storage_resources',
+      :cloud_volumes                 => 'cloud_volumes',
+      :physical_storages             => 'physical_storages',
+      :cloud_object_store_containers => 'cloud_object_store_containers',
+      :cloud_object_store_objects    => 'cloud_object_store_objects',
+    }
+
+    attr_hsh = {
+      :storage_resources             => _('Resources (Pools)'),
+      :cloud_volumes                 => _('Volumes'),
+      :physical_storages             => _('Physical Storages'),
+      :cloud_object_store_containers => _('Containers'),
+      :cloud_object_store_objects    => _('Objects'),
+    }
+
+    format_data('ems_storage', attributes, attr_icon, attr_url, attr_hsh)
+  end
+
+  private
+
+  def get_physical_storages_ids
+    physical_storages_ids = []
+    @ems.physical_storages.each do |system|
+      physical_storages_ids << system.id
+    end
+  end
+
+  def heatmaps
+    resource_usage = []
+
+    @ems.physical_storages.each do |system|
+      system.storage_resources.each do |resource|
+        resource_usage << {
+          :id       => resource.id,
+          :resource => resource.name,
+          :provider => resource.ext_management_system.name,
+          :percent  => ((resource.logical_total.to_f - resource.logical_free.to_f) / resource.logical_total.to_f).round(2)
+        }
+      end
+    end
+
+    {
+      :resourceUsage => resource_usage.presence,
+      :title         => 'Used capacity [%]'
+    }
+  end
+end

--- a/app/views/ems_storage/_heatmap.html.haml
+++ b/app/views/ems_storage/_heatmap.html.haml
@@ -1,0 +1,11 @@
+.heatmap{"ng-controller" => "heatmapStorageController as vm"}
+  .card-pf.card-pf-heatmap
+    .card-pf-heading
+      %h2.card-pf-title
+        {{vm.title}}
+    .card-pf-body
+      .row
+        .col-xs-12.col-sm-12.col-md-12.col-lg-6.example-heatmap-container{"ng-repeat" => "(key, data) in vm.data"}
+          %pf-heatmap{'ng-attr-id' => "{{data[0].id}}", "chart-title" => "key", "data" => "data", "chart-data-available" => "vm.dataAvailable", "show-legend" => "vm.showLegends", "legend-labels" => "vm.legendLabels", "max-block-size" => "20", "block-padding" => "5", "heatmap-color-pattern" => "vm.heatmapColorPattern", "thresholds" => "vm.thresholds", "click-action" => "vm.clickAction", "loading-done" => true}
+          %span.trend-footer-pf
+            {{vm.timeframeLabel}}

--- a/app/views/ems_storage/_show_block_storage_dashboard.html.haml
+++ b/app/views/ems_storage/_show_block_storage_dashboard.html.haml
@@ -1,0 +1,11 @@
+= render :partial => "layouts/flash_msg"
+.container-fluid.container-tiles-pf.ems-storage-dashboard
+  .row.row-tile-pf
+    = react 'AggregateStatusCard', {:providerId => @record.id.to_s, :providerType => 'ems_storage'}
+  .row.row-tile-pf
+    .col-xs-12.col-sm-12.col-md-6
+      = render :partial => "heatmap"
+
+  :javascript
+    ManageIQ.angular.app.value('providerId', '#{@record.id}');
+    miq_bootstrap('.ems-storage-dashboard');

--- a/app/views/ems_storage/_show_object_storage_dashboard.html.haml
+++ b/app/views/ems_storage/_show_object_storage_dashboard.html.haml
@@ -1,0 +1,8 @@
+= render :partial => "layouts/flash_msg"
+.container-fluid.container-tiles-pf.ems-storage-dashboard
+  .row.row-tile-pf
+    = react 'AggregateStatusCard', {:providerId => @record.id.to_s, :providerType => 'ems_storage'}
+
+  :javascript
+    ManageIQ.angular.app.value('providerId', '#{@record.id}');
+    miq_bootstrap('.ems-storage-dashboard');

--- a/app/views/ems_storage/show_dashboard.html.haml
+++ b/app/views/ems_storage/show_dashboard.html.haml
@@ -1,0 +1,5 @@
+#main_div
+  -if @ems.supports?(:block_storage)
+    = render :partial => "show_block_storage_dashboard"
+  -else
+    = render :partial => "show_object_storage_dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,15 @@ Rails.application.routes.draw do
   )
 
   controller_routes = {
+
+    :ems_storage_dashboard      => {
+      :get => %w[
+        show
+        aggregate_status_data
+        resources_capacity_data
+      ]
+    },
+
     :auth_key_pair_cloud      => {
       :get  => %w(
         download_data
@@ -3159,6 +3168,7 @@ Rails.application.routes.draw do
     ems_cloud_dashboard
     ems_container
     ems_infra
+    ems_storage_dashboard
     ems_infra_dashboard
     ems_network
     ems_physical_infra

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -14,6 +14,8 @@ describe EmsStorageHelper::TextualSummary do
       cloud_volume_backups
       cloud_object_store_containers
       custom_button_events
+      physical_storages
+      storage_resources
     ]
 
     include_examples "textual_group", "Status", %i[refresh_status refresh_date]
@@ -34,6 +36,8 @@ describe EmsStorageHelper::TextualSummary do
       cloud_volume_backups
       cloud_object_store_containers
       custom_button_events
+      physical_storages
+      storage_resources
       cloud_volume_types
     ]
   end

--- a/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
@@ -35,10 +35,9 @@ shared_examples :shared_examples_for_ems_storage_controller do |providers|
           get :show, :params => {:id => @ems.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "Storage Managers",
-                                                :url  => "/ems_storage/show_list?page=&refresh=y"},
-                                               {:name => "Test Cloud Manager Cinder Manager (Summary)",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Test Cloud Manager Cinder Manager (Dashboard)",
                                                 :url  => "/ems_storage/show/#{@ems.id}"}])
+          is_expected.to render_template(:partial => "ems_storage/_show_block_storage_dashboard")
         end
       end
 


### PR DESCRIPTION
As part of the storage modifications (see https://github.com/ManageIQ/manageiq-ui-classic/pull/7282 for the entire modifications details. This PR is a partial split from PR-7282) we added dashboard for storage managers. 
The block storage dashboard also contains a new heatmap widget that shows resources/pools capacity

- New block storage manager dashboard
<img width="960" alt="block_storage_dashboard" src="https://user-images.githubusercontent.com/53213107/91713494-8d80c300-eb92-11ea-8f16-cb6dc8f9c6f5.png">

- New Objcet storage mananager dashboard
<img width="948" alt="object_storage_dashboard" src="https://user-images.githubusercontent.com/53213107/91713567-b1dc9f80-eb92-11ea-9355-3eb6c470dc5f.png">
