### PR TITLE
Fix leftnav icon tooltip and showing user info in side leftnav nav.

### DIFF
--- a/app/javascript/menu/first-level.jsx
+++ b/app/javascript/menu/first-level.jsx
@@ -5,13 +5,14 @@ import SideNavMenuLink from './side-nav-menu-link';
 import { carbonizeIcon } from './icon';
 import { itemId, linkProps } from './item-type';
 
-const mapItems = (items, { activeSection, setSection }) => items.map(item => (
+const mapItems = (items, expanded, { activeSection, setSection }) => items.map(item => (
   item.items.length ? (
     <MenuSection
       key={item.id}
       {...item}
       hover={item.id === activeSection}
       setSection={setSection}
+      expanded={expanded}
     />
   ) : (
     <MenuItem key={item.id} {...item} />
@@ -44,9 +45,10 @@ MenuItem.defaultProps = {
 };
 
 const MenuSection = ({
-  active, hover, icon, id, items, title, setSection,
+  active, expanded, hover, icon, id, items, title, setSection,
 }) => (
   <SideNavMenuLink
+    expanded={expanded}
     id={itemId(id, true)}
     isActive={active}
     forceHover={hover}
@@ -59,8 +61,10 @@ const MenuSection = ({
   />
 );
 
+
 MenuSection.propTypes = {
   active: PropTypes.bool,
+  expanded: PropTypes.bool.isRequired,
   hover: PropTypes.bool,
   icon: PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -76,14 +80,17 @@ MenuSection.defaultProps = {
 };
 
 
-const FirstLevel = ({ activeSection, menu, setSection }) => (
+const FirstLevel = ({
+  activeSection, expanded, menu, setSection,
+}) => (
   <SideNavItems className="menu-items">
-    {mapItems(menu, { setSection, activeSection })}
+    {mapItems(menu, expanded, { setSection, activeSection })}
   </SideNavItems>
 );
 
 FirstLevel.propTypes = {
   activeSection: PropTypes.string,
+  expanded: PropTypes.bool.isRequired,
   menu: PropTypes.any.isRequired,
   setSection: PropTypes.func.isRequired,
 };

--- a/app/javascript/menu/group-switcher.jsx
+++ b/app/javascript/menu/group-switcher.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Dropdown from 'carbon-components-react/es/components/Dropdown';
 import SideNavItem from 'carbon-components-react/es/components/UIShell/SideNavItem';
 import { Collaborate20 } from '@carbon/icons-react';
+import TooltipIcon from 'carbon-components-react/es/components/TooltipIcon';
 
 const { miqChangeGroup } = window;
 
@@ -24,13 +25,18 @@ const GroupSwitcher = ({ miqGroups, currentGroup, expanded: isExpanded }) => {
   };
 
   const collapsed = (
-    <SideNavItem className="padded vertical-center">
-      <Collaborate20 />
+    <SideNavItem className="padded collapse_icon">
+      <TooltipIcon
+        direction="right"
+        tooltipText={`${__('Current group:')} ${currentOption.label}`}
+      >
+        <Collaborate20 />
+      </TooltipIcon>
     </SideNavItem>
   );
 
   const singleGroup = (
-    <SideNavItem className="padded vertical-center">
+    <SideNavItem className="padded collapse_icon">
       {currentOption.label}
     </SideNavItem>
   );
@@ -51,7 +57,6 @@ const GroupSwitcher = ({ miqGroups, currentGroup, expanded: isExpanded }) => {
   return (
     <div
       className="menu-group"
-      title={`${__('Current group:')} ${currentOption.label}`}
     >
       { isExpanded ? expanded : collapsed }
     </div>

--- a/app/javascript/menu/main-menu.jsx
+++ b/app/javascript/menu/main-menu.jsx
@@ -33,6 +33,7 @@ export const MainMenu = ({
   const [menu, setMenu] = useState(initialMenu);
   const [searchResults, setSearch] = useState(null);
   const [activeSection, setSection] = useState(null);
+  const [openMenu, setOpen] = useState(false);
   // code to override navbar in plugins
   const Navbar = ManageIQ.component.getReact('menu.Navbar');
 
@@ -66,20 +67,53 @@ export const MainMenu = ({
     updateActiveItem(ManageIQ.redux.store.getState().router.location);
   }, []);
 
+  const showMenu = (event) => {
+    // when focus/tab is in leftnav, if menu is not expanded, open menu
+    if (!expanded) {
+      setExpanded(true);
+      // To understand if we are opening it manually on tab
+      setOpen(true);
+    }
+    if (event.keyCode === 27) hideSecondary();
+  };
+  const hideMenu = (event) => {
+    // if we open it manually, collpase menu on blur
+    if (!event.currentTarget.contains(event.relatedTarget) && openMenu) {
+      setExpanded(false);
+      setOpen(false);
+    }
+  };
+  const toggleMenu = () => {
+    // if it is already open on tabbing, keep it open
+    if (expanded && openMenu) {
+      setOpen(false);
+    } else {
+      setExpanded(!expanded);
+    }
+  };
+
   return (
     <>
-      <div onClick={hideSecondary} onKeyDown={hideSecondaryEscape} role="navigation" id="main-menu-primary">
-        <Navbar
-          isSideNavExpanded={expanded}
-          onClickSideNavExpand={() => setExpanded(!expanded)}
-          applianceName={applianceName}
-          currentUser={currentUser}
-          brandUrl={brandUrl}
-        />
+      <Navbar
+        isSideNavExpanded={expanded}
+        open={openMenu}
+        onClickSideNavExpand={() => setExpanded(!expanded)}
+        applianceName={applianceName}
+        currentUser={currentUser}
+        brandUrl={brandUrl}
+      />
+      <div
+        onClick={hideSecondary}
+        onKeyDown={showMenu}
+        onBlur={hideMenu}
+        role="presentation"
+        id="main-menu-primary"
+      >
         <SideNav
           aria-label={__('Main Menu')}
           className="primary"
           expanded={appearExpanded}
+          addFocusListeners={false}
           isChildOfHeader={false}
         >
           {showLogo && (
@@ -109,6 +143,7 @@ export const MainMenu = ({
             menu={menu}
             expanded={appearExpanded}
             onSearch={setSearch}
+            toggle={() => setExpanded(!expanded)}
           />
 
           <hr className="bx--side-nav__hr" />
@@ -119,14 +154,16 @@ export const MainMenu = ({
               menu={menu}
               setSection={setSection}
               activeSection={activeSection && activeSection.id}
+              expanded={appearExpanded}
             />
           )}
 
           {showMenuCollapse && (
             <MenuCollapse
-              expanded={expanded /* not appearExpanded */}
-              toggle={() => setExpanded(!expanded)}
+              expanded={expanded/* not appearExpanded */}
+              toggle={toggleMenu}
               onFocus={hideSecondary}
+              open={openMenu}
             />
           )}
         </SideNav>
@@ -134,14 +171,13 @@ export const MainMenu = ({
       { activeSection && (
         <>
           <SideNav aria-label={__('Secondary Menu')} className="secondary" isChildOfHeader={false} expanded>
-            <div onKeyDown={hideSecondaryEscape} role="navigation">
+            <div onKeyDown={hideSecondaryEscape} role="presentation">
               <SecondLevel menu={activeSection.items} hideSecondary={hideSecondary} />
             </div>
           </SideNav>
           <div
             className="miq-main-menu-overlay"
-            role="navigation"
-            tabIndex="0"
+            role="presentation"
             onClick={hideSecondary}
             onFocus={hideSecondary}
             onKeyDown={hideSecondary}

--- a/app/javascript/menu/menu-collapse.jsx
+++ b/app/javascript/menu/menu-collapse.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { ChevronLeft20, ChevronRight20 } from '@carbon/icons-react';
 import { SideNavItem } from 'carbon-components-react/es/components/UIShell';
 
-const MenuCollapse = ({ expanded, toggle, onFocus }) => (
+const MenuCollapse = ({
+  expanded, toggle, onFocus, open,
+}) => (
   <SideNavItem className="menu-collapse">
     <div
       role="button"
@@ -16,7 +18,7 @@ const MenuCollapse = ({ expanded, toggle, onFocus }) => (
       aria-controls="main-menu-primary"
       aria-haspopup="true"
     >
-      {expanded ? <ChevronLeft20 /> : <ChevronRight20 />}
+      {(expanded && !open) ? <ChevronLeft20 /> : <ChevronRight20 />}
     </div>
   </SideNavItem>
 );
@@ -24,10 +26,13 @@ const MenuCollapse = ({ expanded, toggle, onFocus }) => (
 MenuCollapse.propTypes = {
   expanded: PropTypes.bool,
   toggle: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  open: PropTypes.bool,
 };
 
 MenuCollapse.defaultProps = {
   expanded: false,
+  open: false,
 };
 
 export default MenuCollapse;

--- a/app/javascript/menu/search.jsx
+++ b/app/javascript/menu/search.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Search from 'carbon-components-react/es/components/Search';
 import { Search20 } from '@carbon/icons-react';
 import { SideNavItem } from 'carbon-components-react/es/components/UIShell';
+import TooltipIcon from 'carbon-components-react/es/components/TooltipIcon';
 
 export const flatten = (menuItems = []) => {
   const flat = [];
@@ -26,11 +27,26 @@ export const flatten = (menuItems = []) => {
   return flat;
 };
 
-const MenuSearch = ({ expanded, menu, onSearch }) => {
+const MenuSearch = ({
+  expanded, menu, onSearch, toggle,
+}) => {
   if (!expanded) {
     return (
       <SideNavItem className="padded menu-search vertical-center">
-        <Search20 />
+        <div
+          tabIndex="0"
+          className="search_div"
+          role="button"
+          onClick={toggle}
+          onKeyPress={toggle}
+        >
+          <TooltipIcon
+            direction="right"
+            tooltipText={__('Find')}
+          >
+            <Search20 />
+          </TooltipIcon>
+        </div>
       </SideNavItem>
     );
   }
@@ -63,8 +79,8 @@ const MenuSearch = ({ expanded, menu, onSearch }) => {
     <SideNavItem className="padded menu-search">
       <Search
         size="sm"
-        placeHolderText={__("Find")}
-        labelText={__("Find") /* hidden in css */}
+        placeHolderText={__('Find')}
+        labelText={__('Find') /* hidden in css */}
         onChange={event => searchResults(event.target.value)}
       />
     </SideNavItem>
@@ -77,10 +93,12 @@ MenuSearch.propTypes = {
     title: PropTypes.string.isRequired,
   })).isRequired,
   onSearch: PropTypes.func,
+  toggle: PropTypes.func,
 };
 
 MenuSearch.defaultProps = {
   onSearch: () => null,
+  toggle: () => null,
 };
 
 export default MenuSearch;

--- a/app/javascript/menu/side-nav-menu-link.jsx
+++ b/app/javascript/menu/side-nav-menu-link.jsx
@@ -4,11 +4,13 @@ import { SideNavIcon, SideNavItem } from 'carbon-components-react/es/components/
 import Link from 'carbon-components-react/es/components/UIShell/Link';
 import { ChevronRight20 } from '@carbon/icons-react';
 import cx from 'classnames';
+import TooltipIcon from 'carbon-components-react/es/components/TooltipIcon';
 
 // SideNavLink with a chevron from SideNavMenu instead of SideNavLinkText
 // has an onClick, not items like SideNavMenu
 
 const SideNavMenuLink = ({
+  expanded,
   forceHover,
   id,
   isActive,
@@ -27,7 +29,15 @@ const SideNavMenuLink = ({
       <Link className={className} onClick={onClick} onKeyPress={onClick} tabIndex="0">
         {IconElement && (
           <SideNavIcon small>
-            <IconElement />
+            {expanded && (<IconElement />)}
+            {!expanded && (
+              <TooltipIcon
+                direction="right"
+                tooltipText={title}
+              >
+                <IconElement />
+              </TooltipIcon>
+            )}
           </SideNavIcon>
         )}
 
@@ -44,6 +54,7 @@ const SideNavMenuLink = ({
 };
 
 SideNavMenuLink.propTypes = {
+  expanded: PropTypes.bool.isRequired,
   forceHover: PropTypes.bool,
   id: PropTypes.string.isRequired,
   isActive: PropTypes.bool,

--- a/app/javascript/menu/username.jsx
+++ b/app/javascript/menu/username.jsx
@@ -9,14 +9,14 @@ const Username = ({ applianceName, currentUser, expanded }) => {
   return (
     <div className="menu-user" data-userid={currentUser.userid} title={title}>
       { expanded && (
-        <SideNavItem className="padded vertical-center">
+        <SideNavItem className="padded collapse_icon">
           <span>
             {currentUser.name}
           </span>
         </SideNavItem>
       )}
       { expanded || (
-        <SideNavItem className="padded vertical-center">
+        <SideNavItem className="padded collapse_icon">
           <UserAvatar20 />
         </SideNavItem>
       )}

--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -70,6 +70,18 @@
   .vertical-center {
     display: flex;
     align-items: center;
+    padding: 0 !important;
+
+    &:hover {
+      background-color: $row-active-primary-bg;
+    }
+
+    .search_div {
+      height: 32px;
+      width: 48px;
+      padding: 0 1rem;
+      padding-top: 6px;
+    }
   }
 
   .menu-user,
@@ -91,6 +103,34 @@
 
   .menu-search {
     height: 32px;
+  }
+
+  .collapse_icon {
+    display: flex;
+    align-items: center;
+  }
+  
+  .bx--side-nav__item {
+    .bx--tooltip__trigger {
+      position: fixed;
+      &::before {
+        border-color: transparent $inverse-01 transparent transparent !important;
+      }
+
+      .pficon {
+        color: #f4f4f4;
+      }
+
+      svg {
+        fill: #f4f4f4;
+      }
+
+      .bx--assistive-text {
+        background-color: $inverse-01;
+        color: $text-04;
+      }
+
+    }
   }
 }
 


### PR DESCRIPTION
In this PR, Fixed few issues.

- Added icon tooltip for menu list when menu is collapsed
- Added tooltip for search and group name when menu is collapsed
- Added tabindex for search so that search can be focused.
- Fixed bug about not showing userinfo and grouinfo (those two were still in collapsed state)when user tab into leftnav.
- Fixed showing user name info when user tab into side nav.

**Before:**
No tooltips for icons.

<img width="227" alt="Screen Shot 2020-10-11 at 5 27 49 PM" src="https://user-images.githubusercontent.com/37085529/95690627-1e61aa00-0be7-11eb-866b-4a3bc6830671.png">

**After:**
<img width="293" alt="Screen Shot 2020-10-12 at 10 35 07 PM" src="https://user-images.githubusercontent.com/37085529/95808788-3d416880-0cdb-11eb-899c-190ece0ebd99.png">

<img width="548" alt="Screen Shot 2020-10-12 at 10 35 13 PM" src="https://user-images.githubusercontent.com/37085529/95808800-429eb300-0cdb-11eb-9826-551152f982d7.png">


fyi @skateman @himdel 


Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7358