### PR TITLE
Adding RSpecs for edit block storage manager

### DIFF
--- a/spec/controllers/mixins/ems_common_spec.rb
+++ b/spec/controllers/mixins/ems_common_spec.rb
@@ -333,3 +333,31 @@ describe EmsNetworkController do
     end
   end
 end
+
+describe EmsBlockStorageController do
+  context "::EmsCommon" do
+    describe "#button" do
+      before do
+        stub_user(:features => :all)
+        EvmSpecHelper.create_guid_miq_server_zone
+      end
+
+      it "when edit is pressed for unsupported block storage manager type" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        ems = FactoryBot.create(:ems_cinder)
+        get :edit, :params => {:id => ems.id}
+        expect(response.status).to eq(302)
+        expect(session['flash_msgs']).not_to be_empty
+        expect(session['flash_msgs'].first[:message]).to include('is not supported')
+      end
+
+      it "when edit is pressed for supported block storage manager type" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        ems = FactoryBot.create(:ems_autosde)
+        get :edit, :params => {:id => ems.id}
+        expect(response.status).to eq(200)
+        expect(session['flash_msgs']).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -38,6 +38,7 @@ describe TreeNode::ExtManagementSystem do
     :ems_vmware_cloud_network         => {},
     :ems_cinder                       => {},
     :ems_swift                        => {},
+    :ems_autosde                      => {},
     # :configuration_manager             => {},
     # :provisioning_manager              => {},
     # :ems_cloud                         => {},


### PR DESCRIPTION
following https://github.com/ManageIQ/manageiq-ui-classic/pull/7354, I added tests for the ability to edit supported block storage manager (storage manager can only be edited if it was created directly)

links
--------
https://github.com/ManageIQ/manageiq-ui-classic/pull/7354
