### PR TITLE
Correctly render multi-tags in request details dialog

### DIFF
--- a/app/views/miq_request/_request_dialog_details.html.haml
+++ b/app/views/miq_request/_request_dialog_details.html.haml
@@ -32,6 +32,8 @@
 
     - when 'DialogFieldTagControl'
       - value = wf.value(field.name) || '' # it returns in format Clasification::id
-      - _, classification_id = value.split('::')
-      - current_classification = Classification.find_by(:id => classification_id)
-      = h(current_classification.nil? ? '' : current_classification.description)
+      - classifications = value.split(',').map { |c| Classification.find_by(:id => c.split('::').second).description }
+      - if classifications.empty?
+        = h('')
+      -else
+        = h(classifications.join(', '))


### PR DESCRIPTION
1. Create a service dialog, add a Tag control element to it
2. Make sure the selected tag in the above tag control element allows multiple choices
3. Add the above created service dialog to a catalog item (a generic catalog item for example)
4. Order the above created catalog item and select at least two tags in the presented dialog
5. Check the order request details page, see if it contains info about all selected tags

Before
![Screenshot from 2020-10-13 17-19-21](https://user-images.githubusercontent.com/6648365/95880930-52b8a000-0d78-11eb-8cf3-840f38ed2ad5.png)


After
![Screenshot from 2020-10-13 17-19-04](https://user-images.githubusercontent.com/6648365/95880950-56e4bd80-0d78-11eb-911f-b5a329c650f4.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1886887