### PR TITLE
Add access for Configured System console

### DIFF
--- a/app/controllers/configured_system_controller.rb
+++ b/app/controllers/configured_system_controller.rb
@@ -30,6 +30,19 @@ class ConfiguredSystemController < ApplicationController
     process_show_list(options)
   end
 
+  def launch_configured_system_console
+    record = self.class.model.find(params[:id])
+    unless record.console_url
+      add_flash(_("Configured System console access failed: Task start failed"), :error)
+    end
+
+    if @flash_array
+      javascript_flash(:spinner_off => true)
+    else
+      javascript_open_window(record.console_url)
+    end
+  end
+
   private
 
   def textual_group_list

--- a/app/helpers/application_helper/button/configured_system_console.rb
+++ b/app/helpers/application_helper/button/configured_system_console.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ConfiguredSystemConsole < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.supports_console?
+  end
+end

--- a/app/helpers/application_helper/toolbar/configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_center.rb
@@ -14,4 +14,22 @@ class ApplicationHelper::Toolbar::ConfiguredSystemCenter < ApplicationHelper::To
       ]
     ),
   ])
+  button_group('access', [
+    select(
+      :access_choice,
+      nil,
+      N_('Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :configured_system_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open the Configured System console'),
+          N_('Configured System console'),
+          :url   => "launch_configured_system_console",
+          :klass => ApplicationHelper::Button::ConfiguredSystemConsole
+        ),
+      ]
+    ),
+  ])
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2537,6 +2537,7 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         wait_for_task
+        launch_configured_system_console
       ] +
         adv_search_post +
         dialog_runner_post +


### PR DESCRIPTION
This **enhancement** adds a button to Access **Configured System console** 

<img width="1865" alt="Configured_System_Access_Console" src="https://user-images.githubusercontent.com/41962815/95890905-5f2a0200-0d52-11eb-9147-e2e11cbc1bee.png">

Corresponding RBAC PR - https://github.com/ManageIQ/manageiq/pull/20686