### PR TITLE
Rename the TEXTAREA_FIELD to TEXTAREA in the VM snapshot form

### DIFF
--- a/app/javascript/components/vm-snapshot-form/vm-snapshot-form.schema.js
+++ b/app/javascript/components/vm-snapshot-form/vm-snapshot-form.schema.js
@@ -25,7 +25,7 @@ const createSchema = (hideName, showMemory, descriptionRequired) => {
   const fields = [
     ...(hideName ? [] : [nameField]),
     {
-      component: componentTypes.TEXTAREA_FIELD,
+      component: componentTypes.TEXTAREA,
       id: 'description',
       name: 'description',
       label: __('Description'),


### PR DESCRIPTION
Missed this during the DDFv2 conversions :see_no_evil: fixing :pick: 