### PR TITLE
eslintrc: import/no-unresolved: ignore @@ddf alias

### DIFF
--- a/app/javascript/.eslintrc.json
+++ b/app/javascript/.eslintrc.json
@@ -28,6 +28,9 @@
     }],
     "func-names": 0,
     "implicit-arrow-linebreak": "off",
+    "import/no-unresolved": [ "error", {
+      "ignore": ["^@@ddf"]
+    }],
     "import/prefer-default-export": "off",
     "indent": [ "error", 2, {
       "SwitchCase": 1,


### PR DESCRIPTION
Cc @skateman 

Before..

```
/home/himdel/manageiq-ui-classic/app/javascript/components/select/index.jsx
   6:29  error  Unable to resolve path to module '@@ddf'                         import/no-unresolved
```

now, no error, `@@ddf` is assumed to exist.