### PR TITLE
Prefer MiqProductFeature cache invalidation explicitly via backend

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -22,11 +22,6 @@ module OpsController::OpsRbac
     super(options)
   end
 
-  def invalidate_miq_product_feature_caches
-    MiqProductFeature.invalidate_caches
-    render :json => {}
-  end
-
   # Edit user or group tags
   def rbac_tags_edit
     case params[:button]

--- a/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
+++ b/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
@@ -40,7 +40,6 @@ const OpsTenantForm = ({
   const save = (values, method, url, message) => {
     miqSparkleOn();
     return API[method](url, values, { skipErrors: [400] })
-      .then(() => http.post('/ops/invalidate_miq_product_feature_caches', {}))
       .then(() => miqRedirectBack(message, 'success', redirectUrl))
       .catch((...args) => {
         miqSparkleOff();

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -176,7 +176,6 @@ describe('OpstTenantForm', () => {
       resources: [],
     });
     fetchMock.postOnce('/api/tenants', {});
-    fetchMock.postOnce('/ops/invalidate_miq_product_feature_caches', {});
     const wrapper = mount(<OpsTenantForm {...initialProps} />);
     wrapper.find('input').at(0).simulate('change', { target: { value: 'foo' } });
     wrapper.find('input').at(1).simulate('change', { target: { value: 'bar' } });
@@ -210,7 +209,6 @@ describe('OpstTenantForm', () => {
       resources: [],
     });
     fetchMock.putOnce('/api/tenants/123', {});
-    fetchMock.postOnce('/ops/invalidate_miq_product_feature_caches', {});
     let wrapper;
     await act(async() => {
       wrapper = mount(<OpsTenantForm {...initialProps} recordId={123} />);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2366,7 +2366,6 @@ Rails.application.routes.draw do
         forest_form_field_changed
         forest_select
         help_menu_form_field_changed
-        invalidate_miq_product_feature_caches
         label_tag_mapping_delete
         label_tag_mapping_edit
         label_tag_mapping_update

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -9,13 +9,6 @@ describe OpsController do
       allow(controller).to receive(:data_for_breadcrumbs).and_return([{:title => "title", :action => "action", :key => "key"}])
     end
 
-    it 'confirms existence of route and action with name invalidate_miq_product_feature_caches ' do
-      EvmSpecHelper.local_miq_server
-
-      post :invalidate_miq_product_feature_caches
-      expect(response.status).to eq(200)
-    end
-
     describe "#rbac_edit_tags_reset" do
       let(:admin_user) { FactoryBot.create(:user, :role => "super_administrator") }
       let(:another_tenant) { FactoryBot.create(:tenant) }


### PR DESCRIPTION
The cache invalidation should be done implicitly when saving a `Tenant` record...

Depends on ~~https://github.com/ManageIQ/manageiq/pull/20708~~ https://github.com/ManageIQ/manageiq/pull/20772