### PR TITLE
DDF: submit only fields that are registered in the schema

### DIFF
--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -29,6 +29,17 @@ const defaultLabels = {
   cancelLabel: __('Cancel'),
 };
 
+// This is a wrapper around the passed onSubmit function that filters out the values from the form
+// data that don't have corresponding fields in the declared form schema.
+const submitWrapper = (fn) => (values, formOptions, ...args) => {
+  // Get a list of all fields declared in the schema
+  const fields = formOptions.getRegisteredFields();
+
+  const filteredValues = fields.reduce((obj, field) => (_.has(values, field) ? _.set(obj, field, _.get(values, field)) : obj), {});
+  // For compatibility, we're passing all the other arguments as well
+  return fn(filteredValues, formOptions, ...args);
+};
+
 const MiqFormRenderer = ({
   className,
   componentMapper,
@@ -38,6 +49,7 @@ const MiqFormRenderer = ({
   showFormControls,
   schema: { fields, ...schema },
   initialize,
+  onSubmit,
   ...props
 }) => {
   const { current: FormWrapper } = useRef(({ children, ...props }) => (
@@ -63,6 +75,7 @@ const MiqFormRenderer = ({
       componentMapper={{ ...componentMapper, 'spy-field': SpyField }}
       FormTemplate={MiqFormTemplate}
       schema={{ fields: [...fields, { component: 'spy-field', name: 'spy-field', initialize }], ...schema }}
+      onSubmit={submitWrapper(onSubmit)}
       {...props}
     />
   );
@@ -83,6 +96,7 @@ MiqFormRenderer.propTypes = {
   canReset: PropTypes.bool,
   showFormControls: PropTypes.bool,
   initialize: PropTypes.func,
+  onSubmit: PropTypes.func,
 };
 
 MiqFormRenderer.defaultProps = {
@@ -96,6 +110,7 @@ MiqFormRenderer.defaultProps = {
   canReset: false,
   showFormControls: true,
   initialize: undefined,
+  onSubmit: () => undefined,
 };
 
 export {

--- a/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
+++ b/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
@@ -37,7 +37,7 @@ describe('Import datastore via git component', () => {
     const expectedCall = expect.arrayContaining([
       '/miq_ae_tools/retrieve_git_datastore',
       expect.objectContaining({
-        body: '{"git_verify_ssl":true,"git_url":"http://"}',
+        body: '{"git_url":"http://","git_verify_ssl":true}',
       }),
     ]);
     setImmediate(() => {


### PR DESCRIPTION
By default DDF submits any data with the form that is passed into its `initialValues`. This required us to filter out some of these values when seeding a form with data coming from the API either during the request handling or inside the `onSubmit`. It's not a big deal if you just have a couple of fields, but it can be painful when there are more of them or the schema is dynamic.

To ease this, I am proposing a global solution by filtering these values in a wrapper around the passed `onSubmit` function, so it just gets the right values and it doesn't require to change anything in the existing forms. After this change only those values will be passed to the `onSubmit` function that have a matching field in the form schema. I guess this is the standard HTML behavior, I just couldn't convince the DDF people :hand_over_mouth: 