### PR TITLE
Marked Strings For Translation in Reports -> Formatting

### DIFF
--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -40,7 +40,7 @@
             - ci = MiqReport.get_col_info(f.last.split("__").first)
             - unless ci[:available_formats].blank?
               -# need to gsub the period out of the field name for pull down or observe doesn't work, replacing with "__"
-              - opts = [["<#{_('None')}>", "_none_"], ["<#{_('Reset to Default')}>", nil]] + Array(ci[:available_formats].invert).sort_by(&:first)
+              - opts = [["<#{_('None')}>", "_none_"], ["<#{_('Reset to Default')}>", nil]] + Array(ci[:available_formats].invert).sort_by(&:first).map{|format| _(format[0])}
               = select_tag("fmt_#{f.last.gsub(".", "___")}",
                 options_for_select(opts, @edit[:new][:col_formats][f.last] || ci[:default_format]),
                 "data-miq_sparkle_on" => true,


### PR DESCRIPTION
Found in Overview->Reports->Add a new Report->Formatting

Fixes: [#8665](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/8665)

Preview:
<img src="https://user-images.githubusercontent.com/64800041/96635671-29ed5900-12ea-11eb-9da7-d7de805a2b38.png" width="1000">
<img src="https://user-images.githubusercontent.com/64800041/96635831-6456f600-12ea-11eb-9bb9-1a89f9e88c6f.png" width="1000">