### PR TITLE
Implementing remove physical storage

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storage_center.rb
@@ -19,6 +19,21 @@ class ApplicationHelper::Toolbar::PhysicalStorageCenter < ApplicationHelper::Too
             :confirm => N_("Refresh relationships and power states for all items related to this Physical Storage?"),
             :options => {:feature => :refresh}
           ),
+          api_button(
+            :physical_storage_delete,
+            nil,
+            t = N_('Delete the Physical Storage'),
+            t,
+            :icon         => "pficon pficon-delete fa-lg",
+            :klass        => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options      => {:feature => :delete},
+            :api          => {
+              :action => 'delete',
+              :entity => 'physical_storages'
+            },
+            :confirm      => N_("Are you sure you want to delete this physical storage?\nNote that all of the attached services (e.g. volumes) will be unmapped."),
+            :send_checked => true
+          ),
         ]
       ),
     ]

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -26,6 +26,24 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             t,
             :url => "/new"
           ),
+          api_button(
+            :physical_storage_delete,
+            nil,
+            t = N_('Delete the Physical Storage'),
+            t,
+            :icon         => "pficon pficon-delete fa-lg",
+            :klass        => ApplicationHelper::Button::PolymorphicConditionalButton,
+            :options      => {:feature      => :delete,
+                              :parent_class => "PhysicalStorage"},
+            :api          => {
+              :action => 'delete',
+              :entity => 'physical_storages'
+            },
+            :confirm      => N_("Are you sure you want to delete this physical storage?\nNote that all of the attached services (e.g. volumes) will be unmapped."),
+            :send_checked => true,
+            :enabled      => false,
+            :onwhen       => '1+'
+          ),
         ]
       ),
     ]

--- a/app/javascript/toolbar-actions/custom-action.js
+++ b/app/javascript/toolbar-actions/custom-action.js
@@ -15,6 +15,15 @@ export function APIFunction(actionType, entity, resources) {
       } else {
         add_flash(sprintf(__('Requested %s of selected item.'), actionType), 'success');
       }
+
+      if (data.results){
+        data.results.forEach(res => {
+          if (!res.success) {
+            add_flash(sprintf(__(res.message)), 'error');
+          }
+        });
+      }
+
       return data;
     })
     .catch(data => data);


### PR DESCRIPTION
Adding functionality for deleting supported physical storages via rest-API

<img width="626" alt="22" src="https://user-images.githubusercontent.com/53213107/96684306-1098eb00-1384-11eb-96c5-c9b7be4bd357.png">
<img width="706" alt="11" src="https://user-images.githubusercontent.com/53213107/96684312-11ca1800-1384-11eb-89ed-7218befaaf56.png">


links
-----------
the following are related PRs
https://github.com/ManageIQ/manageiq/pull/20713
https://github.com/ManageIQ/manageiq-api/pull/932
https://github.com/ManageIQ/manageiq-providers-autosde/pull/38