### PR TITLE
Marked Strings for Translation in Chargeback -> Rates

### DIFF
--- a/app/views/chargeback_rate/_cb_rate_show.html.haml
+++ b/app/views/chargeback_rate/_cb_rate_show.html.haml
@@ -13,7 +13,7 @@
       = _('Type')
     .col-md-8
       %p.form-control-static
-        = h(@record.rate_type)
+        = h(_(@record.rate_type))
 %hr
 %h3= _('Rate Details')
 %table.table.table-bordered
@@ -49,7 +49,7 @@
         %td{:rowspan => num_tiers}
           = h(rate_detail_group(detail.chargeable_field[:group]))
         %td{:rowspan => num_tiers}
-          = detail.chargeable_field[:description]
+          = _(detail.chargeable_field[:description])
           %br
           = Dictionary.gettext(detail.chargeable_field.metric_key, :type => :column, :notfound => :titleize)
           - if breakdown_present
@@ -60,7 +60,7 @@
         %td
           = tier.start ? tier.start : 0
         %td
-          = tier.finish ? tier.finish : Float::INFINITY.to_s
+          = tier.finish == Float::INFINITY ? _('Infinity') : tier.finish
         %td{:align => "right"}
           = tier.fixed_rate ? tier.fixed_rate : 0.0
         %td{:align => "right"}
@@ -73,7 +73,7 @@
           %td
             = tier.start
           %td
-            = tier.finish
+            = tier.finish == Float::INFINITY ? _('Infinity') : tier.finish
           %td{:align => "right"}
             = tier.fixed_rate
           %td{:align => "right"}


### PR DESCRIPTION
Found in Overview->Chargeback->Rates

Related to: ManageIQ/manageiq#20780
Fixes: [#10150](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10150)

Preview:
<img src="https://user-images.githubusercontent.com/64800041/96777942-f75e6180-13b8-11eb-8dc0-531b1adcfbec.png" width="1000">
<img src="https://user-images.githubusercontent.com/64800041/96778010-0ba25e80-13b9-11eb-8ee4-15124b0753f5.png" width="1000">