### PR TITLE
Allow i18n in datetimepicker component

### DIFF
--- a/app/helpers/application_helper/form_tags.rb
+++ b/app/helpers/application_helper/form_tags.rb
@@ -24,9 +24,7 @@ module ApplicationHelper
     def datetimepicker_input_tag(name, value = nil, options = {})
       datepicker_options = {
         "datetimepicker"  => true,
-        # FIXME: currently, not all locales (e.g. Japanese) are supported
-        # by the datepicker widget and would throw an ugly javascript error
-        # "datetime-locale" => FastGettext.locale,
+        "datetime-locale" => FastGettext.locale,
         # FIXME: in the future, this should honor l10n preferences. Here we need
         # to supply a format that moment.js understands.
         "datetime-format" => 'MM/DD/YYYY HH:mm'


### PR DESCRIPTION
Before:
![Screenshot from 2020-10-23 17-03-17](https://user-images.githubusercontent.com/6648365/97020423-d4b38080-1551-11eb-8f57-0067b7d583c5.png)


After:
![Screenshot from 2020-10-23 17-04-20](https://user-images.githubusercontent.com/6648365/97020434-d8470780-1551-11eb-902e-bf6f6370f390.png)

I tested it with all currently supported locales as well as the locales that are to be added in the near future (de, en, es, fr, it, ja, ko, pt_BR, zh_CN, zh_TW).