### PR TITLE
Updated ProtocolSelector component to use SelectWithOnChange

### DIFF
--- a/app/javascript/components/provider-form/protocol-selector.jsx
+++ b/app/javascript/components/provider-form/protocol-selector.jsx
@@ -1,11 +1,9 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import { get } from 'lodash';
 
-import componentMapper from '../../forms/mappers/componentMapper';
-import { useFormApi, useFieldApi, componentTypes } from '@@ddf';
+import { useFormApi } from '@@ddf';
 import EditingContext from './editing-context';
-
-const Select = componentMapper[componentTypes.SELECT];
+import SelectWithOnChange from '../select';
 
 const filter = (items, toDelete) => Object.keys(items).filter(key => !toDelete.includes(key)).reduce((obj, key) => ({
   ...obj,
@@ -26,41 +24,43 @@ const ProtocolSelector = ({ initialValue: defaultValue, options, ...props }) => 
   const preSelected = !!providerId && options.find(({ pivot }) => get(formOptions.getState().values, pivot));
   const initialValue = preSelected ? preSelected.value : defaultValue;
 
-  const { input: { value } } = useFieldApi({ options, initialValue, ...props });
-  useEffect(() => {
-    if (value) {
-      setTimeout(() => {
-        // Load the initial and current values for the endpoints/authentications after the field value has been changed
-        const {
-          initialValues: {
-            endpoints: initialEndpoints = {},
-            authentications: initialAuthentications = {},
-          },
-          values: {
-            endpoints: currentEndpoints = {},
-            authentications: currentAuthentications = {},
-          },
-        } = formOptions.getState();
+  const onChange = value => setTimeout(() => {
+    // Load the initial and current values for the endpoints/authentications after the field value has been changed
+    const {
+      initialValues: {
+        endpoints: initialEndpoints = {},
+        authentications: initialAuthentications = {},
+      },
+      values: {
+        endpoints: currentEndpoints = {},
+        authentications: currentAuthentications = {},
+      },
+    } = formOptions.getState();
 
-        // Map the values of all possible options into an array
-        const optionValues = options.map(({ value }) => value);
-        // Determine which endpoint/authentication pair has to be removed from the form state
-        const toDelete = optionValues.filter(option => option !== value);
+    // Map the values of all possible options into an array
+    const optionValues = options.map(({ value }) => value);
+    // Determine which endpoint/authentication pair has to be removed from the form state
+    const toDelete = optionValues.filter(option => option !== value);
 
-        // Adjust the endpoints/authentications and pass them to the form state
-        formOptions.change('endpoints', {
-          ...filter(initialEndpoints, toDelete),
-          ...filter(currentEndpoints, optionValues),
-        });
-        formOptions.change('authentications', {
-          ...filter(initialAuthentications, toDelete),
-          ...filter(currentAuthentications, optionValues),
-        });
-      });
-    }
-  }, [value]);
+    // Adjust the endpoints/authentications and pass them to the form state
+    formOptions.change('endpoints', {
+      ...filter(initialEndpoints, toDelete),
+      ...filter(currentEndpoints, optionValues),
+    });
+    formOptions.change('authentications', {
+      ...filter(initialAuthentications, toDelete),
+      ...filter(currentAuthentications, optionValues),
+    });
+  });
 
-  return <Select options={options} {...props} />;
+  return (
+    <SelectWithOnChange
+      onChange={onChange}
+      options={options}
+      initialValue={initialValue}
+      {...props}
+    />
+  );
 };
 
 export default ProtocolSelector;

--- a/app/javascript/components/select/index.jsx
+++ b/app/javascript/components/select/index.jsx
@@ -1,4 +1,3 @@
-
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { components } from '@data-driven-forms/pf3-component-mapper';

--- a/app/javascript/spec/provider-form/__snapshots__/protocol-selector.spec.js.snap
+++ b/app/javascript/spec/provider-form/__snapshots__/protocol-selector.spec.js.snap
@@ -1,0 +1,1398 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProtocolSelector component should match the snapshot 1`] = `
+<ProtocolSelector
+  component="protocol-selector"
+  label="Type"
+  name="type"
+  options={
+    Array [
+      Object {
+        "label": "STF",
+        "pivot": "endpoints.stf.host",
+        "value": "stf",
+      },
+      Object {
+        "label": "AMQP",
+        "pivot": "endponts.amqp.host",
+        "value": "amqp",
+      },
+    ]
+  }
+>
+  <SelectWithOnChange
+    component="protocol-selector"
+    label="Type"
+    name="type"
+    options={
+      Array [
+        Object {
+          "label": "STF",
+          "pivot": "endpoints.stf.host",
+          "value": "stf",
+        },
+        Object {
+          "label": "AMQP",
+          "pivot": "endponts.amqp.host",
+          "value": "amqp",
+        },
+      ]
+    }
+  >
+    <Select
+      component="protocol-selector"
+      label="Type"
+      name="type"
+      options={
+        Array [
+          Object {
+            "label": "STF",
+            "pivot": "endpoints.stf.host",
+            "value": "stf",
+          },
+          Object {
+            "label": "AMQP",
+            "pivot": "endponts.amqp.host",
+            "value": "amqp",
+          },
+        ]
+      }
+      placeholder="<Choose>"
+    >
+      <Pf3FormGroup
+        label="Type"
+        meta={
+          Object {
+            "active": false,
+            "data": Object {},
+            "dirty": false,
+            "dirtySinceLastSubmit": false,
+            "error": undefined,
+            "initial": undefined,
+            "invalid": false,
+            "length": undefined,
+            "modified": false,
+            "modifiedSinceLastSubmit": false,
+            "pristine": true,
+            "submitError": undefined,
+            "submitFailed": false,
+            "submitSucceeded": false,
+            "submitting": false,
+            "touched": false,
+            "valid": true,
+            "validating": false,
+            "visited": false,
+          }
+        }
+      >
+        <FormGroup
+          bsClass="form-group"
+          validationState={null}
+        >
+          <div
+            className="form-group"
+          >
+            <ControlLabel
+              bsClass="control-label"
+              srOnly={false}
+            >
+              <label
+                className="control-label"
+              >
+                Type
+              </label>
+            </ControlLabel>
+            <div>
+              <Select
+                classNamePrefix="ddorg__pf3-component-mapper__select"
+                input={
+                  Object {
+                    "checked": undefined,
+                    "name": "type",
+                    "onBlur": [Function],
+                    "onChange": [Function],
+                    "onFocus": [Function],
+                    "value": "",
+                  }
+                }
+                invalid={false}
+                loadingMessage="Loading..."
+                options={
+                  Array [
+                    Object {
+                      "label": "STF",
+                      "pivot": "endpoints.stf.host",
+                      "value": "stf",
+                    },
+                    Object {
+                      "label": "AMQP",
+                      "pivot": "endponts.amqp.host",
+                      "value": "amqp",
+                    },
+                  ]
+                }
+                placeholder="<Choose>"
+                updatingMessage="Loading data"
+              >
+                <Select
+                  SelectComponent={[Function]}
+                  className="ddorg__pf3-component-mapper__select"
+                  classNamePrefix="ddorg__pf3-component-mapper__select"
+                  components={
+                    Object {
+                      "ClearIndicator": [Function],
+                      "DropdownIndicator": [Function],
+                      "Option": [Function],
+                    }
+                  }
+                  invalid={false}
+                  isClearable={false}
+                  isSearchable={false}
+                  loadOptionsChangeCounter={1}
+                  loadingMessage="Loading..."
+                  name="type"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "label": "STF",
+                        "pivot": "endpoints.stf.host",
+                        "value": "stf",
+                      },
+                      Object {
+                        "label": "AMQP",
+                        "pivot": "endponts.amqp.host",
+                        "value": "amqp",
+                      },
+                    ]
+                  }
+                  placeholder="<Choose>"
+                  pluckSingleValue={true}
+                  simpleValue={true}
+                  updatingMessage="Loading data"
+                  value=""
+                >
+                  <StateManager
+                    className="ddorg__pf3-component-mapper__select"
+                    classNamePrefix="ddorg__pf3-component-mapper__select"
+                    closeMenuOnSelect={true}
+                    components={
+                      Object {
+                        "ClearIndicator": [Function],
+                        "DropdownIndicator": [Function],
+                        "Option": [Function],
+                      }
+                    }
+                    defaultInputValue=""
+                    defaultMenuIsOpen={false}
+                    defaultValue={null}
+                    hideSelectedOptions={false}
+                    isClearable={false}
+                    isFetching={false}
+                    isSearchable={false}
+                    name="type"
+                    noOptionsMessage={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInputChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "label": "STF",
+                          "pivot": "endpoints.stf.host",
+                          "value": "stf",
+                        },
+                        Object {
+                          "label": "AMQP",
+                          "pivot": "endponts.amqp.host",
+                          "value": "amqp",
+                        },
+                      ]
+                    }
+                    placeholder="<Choose>"
+                    value={Array []}
+                  >
+                    <Select
+                      backspaceRemovesValue={true}
+                      blurInputOnSelect={true}
+                      captureMenuScroll={false}
+                      className="ddorg__pf3-component-mapper__select"
+                      classNamePrefix="ddorg__pf3-component-mapper__select"
+                      closeMenuOnScroll={false}
+                      closeMenuOnSelect={true}
+                      components={
+                        Object {
+                          "ClearIndicator": [Function],
+                          "DropdownIndicator": [Function],
+                          "Option": [Function],
+                        }
+                      }
+                      controlShouldRenderValue={true}
+                      escapeClearsValue={false}
+                      filterOption={[Function]}
+                      formatGroupLabel={[Function]}
+                      getOptionLabel={[Function]}
+                      getOptionValue={[Function]}
+                      hideSelectedOptions={false}
+                      inputValue=""
+                      isClearable={false}
+                      isDisabled={false}
+                      isFetching={false}
+                      isLoading={false}
+                      isMulti={false}
+                      isOptionDisabled={[Function]}
+                      isRtl={false}
+                      isSearchable={false}
+                      loadingMessage={[Function]}
+                      maxMenuHeight={300}
+                      menuIsOpen={false}
+                      menuPlacement="bottom"
+                      menuPosition="absolute"
+                      menuShouldBlockScroll={false}
+                      menuShouldScrollIntoView={true}
+                      minMenuHeight={140}
+                      name="type"
+                      noOptionsMessage={[Function]}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInputChange={[Function]}
+                      onMenuClose={[Function]}
+                      onMenuOpen={[Function]}
+                      openMenuOnClick={true}
+                      openMenuOnFocus={false}
+                      options={
+                        Array [
+                          Object {
+                            "label": "STF",
+                            "pivot": "endpoints.stf.host",
+                            "value": "stf",
+                          },
+                          Object {
+                            "label": "AMQP",
+                            "pivot": "endponts.amqp.host",
+                            "value": "amqp",
+                          },
+                        ]
+                      }
+                      pageSize={5}
+                      placeholder="<Choose>"
+                      screenReaderStatus={[Function]}
+                      styles={Object {}}
+                      tabIndex="0"
+                      tabSelectsValue={true}
+                      value={Array []}
+                    >
+                      <SelectContainer
+                        className="ddorg__pf3-component-mapper__select"
+                        clearValue={[Function]}
+                        cx={[Function]}
+                        getStyles={[Function]}
+                        getValue={[Function]}
+                        hasValue={false}
+                        innerProps={
+                          Object {
+                            "id": undefined,
+                            "onKeyDown": [Function],
+                          }
+                        }
+                        isDisabled={false}
+                        isFocused={false}
+                        isMulti={false}
+                        isRtl={false}
+                        options={
+                          Array [
+                            Object {
+                              "label": "STF",
+                              "pivot": "endpoints.stf.host",
+                              "value": "stf",
+                            },
+                            Object {
+                              "label": "AMQP",
+                              "pivot": "endponts.amqp.host",
+                              "value": "amqp",
+                            },
+                          ]
+                        }
+                        selectOption={[Function]}
+                        selectProps={
+                          Object {
+                            "backspaceRemovesValue": true,
+                            "blurInputOnSelect": true,
+                            "captureMenuScroll": false,
+                            "checked": undefined,
+                            "className": "ddorg__pf3-component-mapper__select",
+                            "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                            "closeMenuOnScroll": false,
+                            "closeMenuOnSelect": true,
+                            "components": Object {
+                              "ClearIndicator": [Function],
+                              "DropdownIndicator": [Function],
+                              "Option": [Function],
+                            },
+                            "controlShouldRenderValue": true,
+                            "escapeClearsValue": false,
+                            "filterOption": [Function],
+                            "formatGroupLabel": [Function],
+                            "getOptionLabel": [Function],
+                            "getOptionValue": [Function],
+                            "hideSelectedOptions": false,
+                            "inputValue": "",
+                            "isClearable": false,
+                            "isDisabled": false,
+                            "isFetching": false,
+                            "isLoading": false,
+                            "isMulti": false,
+                            "isOptionDisabled": [Function],
+                            "isRtl": false,
+                            "isSearchable": false,
+                            "loadingMessage": [Function],
+                            "maxMenuHeight": 300,
+                            "menuIsOpen": false,
+                            "menuPlacement": "bottom",
+                            "menuPosition": "absolute",
+                            "menuShouldBlockScroll": false,
+                            "menuShouldScrollIntoView": true,
+                            "minMenuHeight": 140,
+                            "name": "type",
+                            "noOptionsMessage": [Function],
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "onInputChange": [Function],
+                            "onMenuClose": [Function],
+                            "onMenuOpen": [Function],
+                            "openMenuOnClick": true,
+                            "openMenuOnFocus": false,
+                            "options": Array [
+                              Object {
+                                "label": "STF",
+                                "pivot": "endpoints.stf.host",
+                                "value": "stf",
+                              },
+                              Object {
+                                "label": "AMQP",
+                                "pivot": "endponts.amqp.host",
+                                "value": "amqp",
+                              },
+                            ],
+                            "pageSize": 5,
+                            "placeholder": "<Choose>",
+                            "screenReaderStatus": [Function],
+                            "styles": Object {},
+                            "tabIndex": "0",
+                            "tabSelectsValue": true,
+                            "value": Array [],
+                          }
+                        }
+                        setValue={[Function]}
+                        theme={
+                          Object {
+                            "borderRadius": 4,
+                            "colors": Object {
+                              "danger": "#DE350B",
+                              "dangerLight": "#FFBDAD",
+                              "neutral0": "hsl(0, 0%, 100%)",
+                              "neutral10": "hsl(0, 0%, 90%)",
+                              "neutral20": "hsl(0, 0%, 80%)",
+                              "neutral30": "hsl(0, 0%, 70%)",
+                              "neutral40": "hsl(0, 0%, 60%)",
+                              "neutral5": "hsl(0, 0%, 95%)",
+                              "neutral50": "hsl(0, 0%, 50%)",
+                              "neutral60": "hsl(0, 0%, 40%)",
+                              "neutral70": "hsl(0, 0%, 30%)",
+                              "neutral80": "hsl(0, 0%, 20%)",
+                              "neutral90": "hsl(0, 0%, 10%)",
+                              "primary": "#2684FF",
+                              "primary25": "#DEEBFF",
+                              "primary50": "#B2D4FF",
+                              "primary75": "#4C9AFF",
+                            },
+                            "spacing": Object {
+                              "baseUnit": 4,
+                              "controlHeight": 38,
+                              "menuGutter": 8,
+                            },
+                          }
+                        }
+                      >
+                        <ForwardRef(render)
+                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                          className="ddorg__pf3-component-mapper__select"
+                          css={
+                            Object {
+                              "boxSizing": "border-box",
+                              "direction": null,
+                              "label": "container",
+                              "pointerEvents": null,
+                              "position": "relative",
+                            }
+                          }
+                          onKeyDown={[Function]}
+                        >
+                          <div
+                            className="ddorg__pf3-component-mapper__select css-2b097c-container"
+                            onKeyDown={[Function]}
+                          >
+                            <Control
+                              clearValue={[Function]}
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              getValue={[Function]}
+                              hasValue={false}
+                              innerProps={
+                                Object {
+                                  "onMouseDown": [Function],
+                                  "onTouchEnd": [Function],
+                                }
+                              }
+                              innerRef={[Function]}
+                              isDisabled={false}
+                              isFocused={false}
+                              isMulti={false}
+                              isRtl={false}
+                              menuIsOpen={false}
+                              options={
+                                Array [
+                                  Object {
+                                    "label": "STF",
+                                    "pivot": "endpoints.stf.host",
+                                    "value": "stf",
+                                  },
+                                  Object {
+                                    "label": "AMQP",
+                                    "pivot": "endponts.amqp.host",
+                                    "value": "amqp",
+                                  },
+                                ]
+                              }
+                              selectOption={[Function]}
+                              selectProps={
+                                Object {
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "checked": undefined,
+                                  "className": "ddorg__pf3-component-mapper__select",
+                                  "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": true,
+                                  "components": Object {
+                                    "ClearIndicator": [Function],
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideSelectedOptions": false,
+                                  "inputValue": "",
+                                  "isClearable": false,
+                                  "isDisabled": false,
+                                  "isFetching": false,
+                                  "isLoading": false,
+                                  "isMulti": false,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": false,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "bottom",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "name": "type",
+                                  "noOptionsMessage": [Function],
+                                  "onBlur": [Function],
+                                  "onChange": [Function],
+                                  "onFocus": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [
+                                    Object {
+                                      "label": "STF",
+                                      "pivot": "endpoints.stf.host",
+                                      "value": "stf",
+                                    },
+                                    Object {
+                                      "label": "AMQP",
+                                      "pivot": "endponts.amqp.host",
+                                      "value": "amqp",
+                                    },
+                                  ],
+                                  "pageSize": 5,
+                                  "placeholder": "<Choose>",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {},
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": Array [],
+                                }
+                              }
+                              setValue={[Function]}
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
+                            >
+                              <ForwardRef(render)
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                className="ddorg__pf3-component-mapper__select__control"
+                                css={
+                                  Object {
+                                    "&:hover": Object {
+                                      "borderColor": "hsl(0, 0%, 70%)",
+                                    },
+                                    "alignItems": "center",
+                                    "backgroundColor": "hsl(0, 0%, 100%)",
+                                    "borderColor": "hsl(0, 0%, 80%)",
+                                    "borderRadius": 4,
+                                    "borderStyle": "solid",
+                                    "borderWidth": 1,
+                                    "boxShadow": null,
+                                    "boxSizing": "border-box",
+                                    "cursor": "default",
+                                    "display": "flex",
+                                    "flexWrap": "wrap",
+                                    "justifyContent": "space-between",
+                                    "label": "control",
+                                    "minHeight": 38,
+                                    "outline": "0 !important",
+                                    "position": "relative",
+                                    "transition": "all 100ms",
+                                  }
+                                }
+                                onMouseDown={[Function]}
+                                onTouchEnd={[Function]}
+                              >
+                                <div
+                                  className="ddorg__pf3-component-mapper__select__control css-yk16xz-control"
+                                  onMouseDown={[Function]}
+                                  onTouchEnd={[Function]}
+                                >
+                                  <ValueContainer
+                                    clearValue={[Function]}
+                                    cx={[Function]}
+                                    getStyles={[Function]}
+                                    getValue={[Function]}
+                                    hasValue={false}
+                                    isDisabled={false}
+                                    isMulti={false}
+                                    isRtl={false}
+                                    options={
+                                      Array [
+                                        Object {
+                                          "label": "STF",
+                                          "pivot": "endpoints.stf.host",
+                                          "value": "stf",
+                                        },
+                                        Object {
+                                          "label": "AMQP",
+                                          "pivot": "endponts.amqp.host",
+                                          "value": "amqp",
+                                        },
+                                      ]
+                                    }
+                                    selectOption={[Function]}
+                                    selectProps={
+                                      Object {
+                                        "backspaceRemovesValue": true,
+                                        "blurInputOnSelect": true,
+                                        "captureMenuScroll": false,
+                                        "checked": undefined,
+                                        "className": "ddorg__pf3-component-mapper__select",
+                                        "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                        "closeMenuOnScroll": false,
+                                        "closeMenuOnSelect": true,
+                                        "components": Object {
+                                          "ClearIndicator": [Function],
+                                          "DropdownIndicator": [Function],
+                                          "Option": [Function],
+                                        },
+                                        "controlShouldRenderValue": true,
+                                        "escapeClearsValue": false,
+                                        "filterOption": [Function],
+                                        "formatGroupLabel": [Function],
+                                        "getOptionLabel": [Function],
+                                        "getOptionValue": [Function],
+                                        "hideSelectedOptions": false,
+                                        "inputValue": "",
+                                        "isClearable": false,
+                                        "isDisabled": false,
+                                        "isFetching": false,
+                                        "isLoading": false,
+                                        "isMulti": false,
+                                        "isOptionDisabled": [Function],
+                                        "isRtl": false,
+                                        "isSearchable": false,
+                                        "loadingMessage": [Function],
+                                        "maxMenuHeight": 300,
+                                        "menuIsOpen": false,
+                                        "menuPlacement": "bottom",
+                                        "menuPosition": "absolute",
+                                        "menuShouldBlockScroll": false,
+                                        "menuShouldScrollIntoView": true,
+                                        "minMenuHeight": 140,
+                                        "name": "type",
+                                        "noOptionsMessage": [Function],
+                                        "onBlur": [Function],
+                                        "onChange": [Function],
+                                        "onFocus": [Function],
+                                        "onInputChange": [Function],
+                                        "onMenuClose": [Function],
+                                        "onMenuOpen": [Function],
+                                        "openMenuOnClick": true,
+                                        "openMenuOnFocus": false,
+                                        "options": Array [
+                                          Object {
+                                            "label": "STF",
+                                            "pivot": "endpoints.stf.host",
+                                            "value": "stf",
+                                          },
+                                          Object {
+                                            "label": "AMQP",
+                                            "pivot": "endponts.amqp.host",
+                                            "value": "amqp",
+                                          },
+                                        ],
+                                        "pageSize": 5,
+                                        "placeholder": "<Choose>",
+                                        "screenReaderStatus": [Function],
+                                        "styles": Object {},
+                                        "tabIndex": "0",
+                                        "tabSelectsValue": true,
+                                        "value": Array [],
+                                      }
+                                    }
+                                    setValue={[Function]}
+                                    theme={
+                                      Object {
+                                        "borderRadius": 4,
+                                        "colors": Object {
+                                          "danger": "#DE350B",
+                                          "dangerLight": "#FFBDAD",
+                                          "neutral0": "hsl(0, 0%, 100%)",
+                                          "neutral10": "hsl(0, 0%, 90%)",
+                                          "neutral20": "hsl(0, 0%, 80%)",
+                                          "neutral30": "hsl(0, 0%, 70%)",
+                                          "neutral40": "hsl(0, 0%, 60%)",
+                                          "neutral5": "hsl(0, 0%, 95%)",
+                                          "neutral50": "hsl(0, 0%, 50%)",
+                                          "neutral60": "hsl(0, 0%, 40%)",
+                                          "neutral70": "hsl(0, 0%, 30%)",
+                                          "neutral80": "hsl(0, 0%, 20%)",
+                                          "neutral90": "hsl(0, 0%, 10%)",
+                                          "primary": "#2684FF",
+                                          "primary25": "#DEEBFF",
+                                          "primary50": "#B2D4FF",
+                                          "primary75": "#4C9AFF",
+                                        },
+                                        "spacing": Object {
+                                          "baseUnit": 4,
+                                          "controlHeight": 38,
+                                          "menuGutter": 8,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <ForwardRef(render)
+                                      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                      className="ddorg__pf3-component-mapper__select__value-container"
+                                      css={
+                                        Object {
+                                          "WebkitOverflowScrolling": "touch",
+                                          "alignItems": "center",
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flex": 1,
+                                          "flexWrap": "wrap",
+                                          "overflow": "hidden",
+                                          "padding": "2px 8px",
+                                          "position": "relative",
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="ddorg__pf3-component-mapper__select__value-container css-1hwfws3"
+                                      >
+                                        <Placeholder
+                                          clearValue={[Function]}
+                                          cx={[Function]}
+                                          getStyles={[Function]}
+                                          getValue={[Function]}
+                                          hasValue={false}
+                                          isDisabled={false}
+                                          isFocused={false}
+                                          isMulti={false}
+                                          isRtl={false}
+                                          key="placeholder"
+                                          options={
+                                            Array [
+                                              Object {
+                                                "label": "STF",
+                                                "pivot": "endpoints.stf.host",
+                                                "value": "stf",
+                                              },
+                                              Object {
+                                                "label": "AMQP",
+                                                "pivot": "endponts.amqp.host",
+                                                "value": "amqp",
+                                              },
+                                            ]
+                                          }
+                                          selectOption={[Function]}
+                                          selectProps={
+                                            Object {
+                                              "backspaceRemovesValue": true,
+                                              "blurInputOnSelect": true,
+                                              "captureMenuScroll": false,
+                                              "checked": undefined,
+                                              "className": "ddorg__pf3-component-mapper__select",
+                                              "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                              "closeMenuOnScroll": false,
+                                              "closeMenuOnSelect": true,
+                                              "components": Object {
+                                                "ClearIndicator": [Function],
+                                                "DropdownIndicator": [Function],
+                                                "Option": [Function],
+                                              },
+                                              "controlShouldRenderValue": true,
+                                              "escapeClearsValue": false,
+                                              "filterOption": [Function],
+                                              "formatGroupLabel": [Function],
+                                              "getOptionLabel": [Function],
+                                              "getOptionValue": [Function],
+                                              "hideSelectedOptions": false,
+                                              "inputValue": "",
+                                              "isClearable": false,
+                                              "isDisabled": false,
+                                              "isFetching": false,
+                                              "isLoading": false,
+                                              "isMulti": false,
+                                              "isOptionDisabled": [Function],
+                                              "isRtl": false,
+                                              "isSearchable": false,
+                                              "loadingMessage": [Function],
+                                              "maxMenuHeight": 300,
+                                              "menuIsOpen": false,
+                                              "menuPlacement": "bottom",
+                                              "menuPosition": "absolute",
+                                              "menuShouldBlockScroll": false,
+                                              "menuShouldScrollIntoView": true,
+                                              "minMenuHeight": 140,
+                                              "name": "type",
+                                              "noOptionsMessage": [Function],
+                                              "onBlur": [Function],
+                                              "onChange": [Function],
+                                              "onFocus": [Function],
+                                              "onInputChange": [Function],
+                                              "onMenuClose": [Function],
+                                              "onMenuOpen": [Function],
+                                              "openMenuOnClick": true,
+                                              "openMenuOnFocus": false,
+                                              "options": Array [
+                                                Object {
+                                                  "label": "STF",
+                                                  "pivot": "endpoints.stf.host",
+                                                  "value": "stf",
+                                                },
+                                                Object {
+                                                  "label": "AMQP",
+                                                  "pivot": "endponts.amqp.host",
+                                                  "value": "amqp",
+                                                },
+                                              ],
+                                              "pageSize": 5,
+                                              "placeholder": "<Choose>",
+                                              "screenReaderStatus": [Function],
+                                              "styles": Object {},
+                                              "tabIndex": "0",
+                                              "tabSelectsValue": true,
+                                              "value": Array [],
+                                            }
+                                          }
+                                          setValue={[Function]}
+                                          theme={
+                                            Object {
+                                              "borderRadius": 4,
+                                              "colors": Object {
+                                                "danger": "#DE350B",
+                                                "dangerLight": "#FFBDAD",
+                                                "neutral0": "hsl(0, 0%, 100%)",
+                                                "neutral10": "hsl(0, 0%, 90%)",
+                                                "neutral20": "hsl(0, 0%, 80%)",
+                                                "neutral30": "hsl(0, 0%, 70%)",
+                                                "neutral40": "hsl(0, 0%, 60%)",
+                                                "neutral5": "hsl(0, 0%, 95%)",
+                                                "neutral50": "hsl(0, 0%, 50%)",
+                                                "neutral60": "hsl(0, 0%, 40%)",
+                                                "neutral70": "hsl(0, 0%, 30%)",
+                                                "neutral80": "hsl(0, 0%, 20%)",
+                                                "neutral90": "hsl(0, 0%, 10%)",
+                                                "primary": "#2684FF",
+                                                "primary25": "#DEEBFF",
+                                                "primary50": "#B2D4FF",
+                                                "primary75": "#4C9AFF",
+                                              },
+                                              "spacing": Object {
+                                                "baseUnit": 4,
+                                                "controlHeight": 38,
+                                                "menuGutter": 8,
+                                              },
+                                            }
+                                          }
+                                        >
+                                          <ForwardRef(render)
+                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                            className="ddorg__pf3-component-mapper__select__placeholder"
+                                            css={
+                                              Object {
+                                                "boxSizing": "border-box",
+                                                "color": "hsl(0, 0%, 50%)",
+                                                "label": "placeholder",
+                                                "marginLeft": 2,
+                                                "marginRight": 2,
+                                                "position": "absolute",
+                                                "top": "50%",
+                                                "transform": "translateY(-50%)",
+                                              }
+                                            }
+                                          >
+                                            <div
+                                              className="ddorg__pf3-component-mapper__select__placeholder css-1wa3eu0-placeholder"
+                                            >
+                                              &lt;Choose&gt;
+                                            </div>
+                                          </ForwardRef(render)>
+                                        </Placeholder>
+                                        <DummyInput
+                                          disabled={false}
+                                          id="react-select-2-input"
+                                          innerRef={[Function]}
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          readOnly={true}
+                                          tabIndex="0"
+                                          value=""
+                                        >
+                                          <ForwardRef(render)
+                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="input"
+                                            css={
+                                              Object {
+                                                "name": "62g3xt-dummyInput",
+                                                "next": undefined,
+                                                "styles": "label:dummyInput;background:0;border:0;font-size:inherit;outline:0;padding:0;width:1px;color:transparent;left:-100px;opacity:0;position:relative;transform:scale(0);",
+                                              }
+                                            }
+                                            disabled={false}
+                                            id="react-select-2-input"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onFocus={[Function]}
+                                            readOnly={true}
+                                            tabIndex="0"
+                                            value=""
+                                          >
+                                            <input
+                                              className="css-62g3xt-dummyInput"
+                                              disabled={false}
+                                              id="react-select-2-input"
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              readOnly={true}
+                                              tabIndex="0"
+                                              value=""
+                                            />
+                                          </ForwardRef(render)>
+                                        </DummyInput>
+                                      </div>
+                                    </ForwardRef(render)>
+                                  </ValueContainer>
+                                  <IndicatorsContainer
+                                    clearValue={[Function]}
+                                    cx={[Function]}
+                                    getStyles={[Function]}
+                                    getValue={[Function]}
+                                    hasValue={false}
+                                    isDisabled={false}
+                                    isMulti={false}
+                                    isRtl={false}
+                                    options={
+                                      Array [
+                                        Object {
+                                          "label": "STF",
+                                          "pivot": "endpoints.stf.host",
+                                          "value": "stf",
+                                        },
+                                        Object {
+                                          "label": "AMQP",
+                                          "pivot": "endponts.amqp.host",
+                                          "value": "amqp",
+                                        },
+                                      ]
+                                    }
+                                    selectOption={[Function]}
+                                    selectProps={
+                                      Object {
+                                        "backspaceRemovesValue": true,
+                                        "blurInputOnSelect": true,
+                                        "captureMenuScroll": false,
+                                        "checked": undefined,
+                                        "className": "ddorg__pf3-component-mapper__select",
+                                        "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                        "closeMenuOnScroll": false,
+                                        "closeMenuOnSelect": true,
+                                        "components": Object {
+                                          "ClearIndicator": [Function],
+                                          "DropdownIndicator": [Function],
+                                          "Option": [Function],
+                                        },
+                                        "controlShouldRenderValue": true,
+                                        "escapeClearsValue": false,
+                                        "filterOption": [Function],
+                                        "formatGroupLabel": [Function],
+                                        "getOptionLabel": [Function],
+                                        "getOptionValue": [Function],
+                                        "hideSelectedOptions": false,
+                                        "inputValue": "",
+                                        "isClearable": false,
+                                        "isDisabled": false,
+                                        "isFetching": false,
+                                        "isLoading": false,
+                                        "isMulti": false,
+                                        "isOptionDisabled": [Function],
+                                        "isRtl": false,
+                                        "isSearchable": false,
+                                        "loadingMessage": [Function],
+                                        "maxMenuHeight": 300,
+                                        "menuIsOpen": false,
+                                        "menuPlacement": "bottom",
+                                        "menuPosition": "absolute",
+                                        "menuShouldBlockScroll": false,
+                                        "menuShouldScrollIntoView": true,
+                                        "minMenuHeight": 140,
+                                        "name": "type",
+                                        "noOptionsMessage": [Function],
+                                        "onBlur": [Function],
+                                        "onChange": [Function],
+                                        "onFocus": [Function],
+                                        "onInputChange": [Function],
+                                        "onMenuClose": [Function],
+                                        "onMenuOpen": [Function],
+                                        "openMenuOnClick": true,
+                                        "openMenuOnFocus": false,
+                                        "options": Array [
+                                          Object {
+                                            "label": "STF",
+                                            "pivot": "endpoints.stf.host",
+                                            "value": "stf",
+                                          },
+                                          Object {
+                                            "label": "AMQP",
+                                            "pivot": "endponts.amqp.host",
+                                            "value": "amqp",
+                                          },
+                                        ],
+                                        "pageSize": 5,
+                                        "placeholder": "<Choose>",
+                                        "screenReaderStatus": [Function],
+                                        "styles": Object {},
+                                        "tabIndex": "0",
+                                        "tabSelectsValue": true,
+                                        "value": Array [],
+                                      }
+                                    }
+                                    setValue={[Function]}
+                                    theme={
+                                      Object {
+                                        "borderRadius": 4,
+                                        "colors": Object {
+                                          "danger": "#DE350B",
+                                          "dangerLight": "#FFBDAD",
+                                          "neutral0": "hsl(0, 0%, 100%)",
+                                          "neutral10": "hsl(0, 0%, 90%)",
+                                          "neutral20": "hsl(0, 0%, 80%)",
+                                          "neutral30": "hsl(0, 0%, 70%)",
+                                          "neutral40": "hsl(0, 0%, 60%)",
+                                          "neutral5": "hsl(0, 0%, 95%)",
+                                          "neutral50": "hsl(0, 0%, 50%)",
+                                          "neutral60": "hsl(0, 0%, 40%)",
+                                          "neutral70": "hsl(0, 0%, 30%)",
+                                          "neutral80": "hsl(0, 0%, 20%)",
+                                          "neutral90": "hsl(0, 0%, 10%)",
+                                          "primary": "#2684FF",
+                                          "primary25": "#DEEBFF",
+                                          "primary50": "#B2D4FF",
+                                          "primary75": "#4C9AFF",
+                                        },
+                                        "spacing": Object {
+                                          "baseUnit": 4,
+                                          "controlHeight": 38,
+                                          "menuGutter": 8,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <ForwardRef(render)
+                                      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                      className="ddorg__pf3-component-mapper__select__indicators"
+                                      css={
+                                        Object {
+                                          "alignItems": "center",
+                                          "alignSelf": "stretch",
+                                          "boxSizing": "border-box",
+                                          "display": "flex",
+                                          "flexShrink": 0,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="ddorg__pf3-component-mapper__select__indicators css-1wy0on6"
+                                      >
+                                        <IndicatorSeparator
+                                          clearValue={[Function]}
+                                          cx={[Function]}
+                                          getStyles={[Function]}
+                                          getValue={[Function]}
+                                          hasValue={false}
+                                          isDisabled={false}
+                                          isFocused={false}
+                                          isMulti={false}
+                                          isRtl={false}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "label": "STF",
+                                                "pivot": "endpoints.stf.host",
+                                                "value": "stf",
+                                              },
+                                              Object {
+                                                "label": "AMQP",
+                                                "pivot": "endponts.amqp.host",
+                                                "value": "amqp",
+                                              },
+                                            ]
+                                          }
+                                          selectOption={[Function]}
+                                          selectProps={
+                                            Object {
+                                              "backspaceRemovesValue": true,
+                                              "blurInputOnSelect": true,
+                                              "captureMenuScroll": false,
+                                              "checked": undefined,
+                                              "className": "ddorg__pf3-component-mapper__select",
+                                              "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                              "closeMenuOnScroll": false,
+                                              "closeMenuOnSelect": true,
+                                              "components": Object {
+                                                "ClearIndicator": [Function],
+                                                "DropdownIndicator": [Function],
+                                                "Option": [Function],
+                                              },
+                                              "controlShouldRenderValue": true,
+                                              "escapeClearsValue": false,
+                                              "filterOption": [Function],
+                                              "formatGroupLabel": [Function],
+                                              "getOptionLabel": [Function],
+                                              "getOptionValue": [Function],
+                                              "hideSelectedOptions": false,
+                                              "inputValue": "",
+                                              "isClearable": false,
+                                              "isDisabled": false,
+                                              "isFetching": false,
+                                              "isLoading": false,
+                                              "isMulti": false,
+                                              "isOptionDisabled": [Function],
+                                              "isRtl": false,
+                                              "isSearchable": false,
+                                              "loadingMessage": [Function],
+                                              "maxMenuHeight": 300,
+                                              "menuIsOpen": false,
+                                              "menuPlacement": "bottom",
+                                              "menuPosition": "absolute",
+                                              "menuShouldBlockScroll": false,
+                                              "menuShouldScrollIntoView": true,
+                                              "minMenuHeight": 140,
+                                              "name": "type",
+                                              "noOptionsMessage": [Function],
+                                              "onBlur": [Function],
+                                              "onChange": [Function],
+                                              "onFocus": [Function],
+                                              "onInputChange": [Function],
+                                              "onMenuClose": [Function],
+                                              "onMenuOpen": [Function],
+                                              "openMenuOnClick": true,
+                                              "openMenuOnFocus": false,
+                                              "options": Array [
+                                                Object {
+                                                  "label": "STF",
+                                                  "pivot": "endpoints.stf.host",
+                                                  "value": "stf",
+                                                },
+                                                Object {
+                                                  "label": "AMQP",
+                                                  "pivot": "endponts.amqp.host",
+                                                  "value": "amqp",
+                                                },
+                                              ],
+                                              "pageSize": 5,
+                                              "placeholder": "<Choose>",
+                                              "screenReaderStatus": [Function],
+                                              "styles": Object {},
+                                              "tabIndex": "0",
+                                              "tabSelectsValue": true,
+                                              "value": Array [],
+                                            }
+                                          }
+                                          setValue={[Function]}
+                                          theme={
+                                            Object {
+                                              "borderRadius": 4,
+                                              "colors": Object {
+                                                "danger": "#DE350B",
+                                                "dangerLight": "#FFBDAD",
+                                                "neutral0": "hsl(0, 0%, 100%)",
+                                                "neutral10": "hsl(0, 0%, 90%)",
+                                                "neutral20": "hsl(0, 0%, 80%)",
+                                                "neutral30": "hsl(0, 0%, 70%)",
+                                                "neutral40": "hsl(0, 0%, 60%)",
+                                                "neutral5": "hsl(0, 0%, 95%)",
+                                                "neutral50": "hsl(0, 0%, 50%)",
+                                                "neutral60": "hsl(0, 0%, 40%)",
+                                                "neutral70": "hsl(0, 0%, 30%)",
+                                                "neutral80": "hsl(0, 0%, 20%)",
+                                                "neutral90": "hsl(0, 0%, 10%)",
+                                                "primary": "#2684FF",
+                                                "primary25": "#DEEBFF",
+                                                "primary50": "#B2D4FF",
+                                                "primary75": "#4C9AFF",
+                                              },
+                                              "spacing": Object {
+                                                "baseUnit": 4,
+                                                "controlHeight": 38,
+                                                "menuGutter": 8,
+                                              },
+                                            }
+                                          }
+                                        >
+                                          <ForwardRef(render)
+                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="span"
+                                            className="ddorg__pf3-component-mapper__select__indicator-separator"
+                                            css={
+                                              Object {
+                                                "alignSelf": "stretch",
+                                                "backgroundColor": "hsl(0, 0%, 80%)",
+                                                "boxSizing": "border-box",
+                                                "label": "indicatorSeparator",
+                                                "marginBottom": 8,
+                                                "marginTop": 8,
+                                                "width": 1,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="ddorg__pf3-component-mapper__select__indicator-separator css-1okebmr-indicatorSeparator"
+                                            />
+                                          </ForwardRef(render)>
+                                        </IndicatorSeparator>
+                                        <DropdownIndicator
+                                          clearValue={[Function]}
+                                          cx={[Function]}
+                                          getStyles={[Function]}
+                                          getValue={[Function]}
+                                          hasValue={false}
+                                          innerProps={
+                                            Object {
+                                              "aria-hidden": "true",
+                                              "onMouseDown": [Function],
+                                              "onTouchEnd": [Function],
+                                            }
+                                          }
+                                          isDisabled={false}
+                                          isFocused={false}
+                                          isMulti={false}
+                                          isRtl={false}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "label": "STF",
+                                                "pivot": "endpoints.stf.host",
+                                                "value": "stf",
+                                              },
+                                              Object {
+                                                "label": "AMQP",
+                                                "pivot": "endponts.amqp.host",
+                                                "value": "amqp",
+                                              },
+                                            ]
+                                          }
+                                          selectOption={[Function]}
+                                          selectProps={
+                                            Object {
+                                              "backspaceRemovesValue": true,
+                                              "blurInputOnSelect": true,
+                                              "captureMenuScroll": false,
+                                              "checked": undefined,
+                                              "className": "ddorg__pf3-component-mapper__select",
+                                              "classNamePrefix": "ddorg__pf3-component-mapper__select",
+                                              "closeMenuOnScroll": false,
+                                              "closeMenuOnSelect": true,
+                                              "components": Object {
+                                                "ClearIndicator": [Function],
+                                                "DropdownIndicator": [Function],
+                                                "Option": [Function],
+                                              },
+                                              "controlShouldRenderValue": true,
+                                              "escapeClearsValue": false,
+                                              "filterOption": [Function],
+                                              "formatGroupLabel": [Function],
+                                              "getOptionLabel": [Function],
+                                              "getOptionValue": [Function],
+                                              "hideSelectedOptions": false,
+                                              "inputValue": "",
+                                              "isClearable": false,
+                                              "isDisabled": false,
+                                              "isFetching": false,
+                                              "isLoading": false,
+                                              "isMulti": false,
+                                              "isOptionDisabled": [Function],
+                                              "isRtl": false,
+                                              "isSearchable": false,
+                                              "loadingMessage": [Function],
+                                              "maxMenuHeight": 300,
+                                              "menuIsOpen": false,
+                                              "menuPlacement": "bottom",
+                                              "menuPosition": "absolute",
+                                              "menuShouldBlockScroll": false,
+                                              "menuShouldScrollIntoView": true,
+                                              "minMenuHeight": 140,
+                                              "name": "type",
+                                              "noOptionsMessage": [Function],
+                                              "onBlur": [Function],
+                                              "onChange": [Function],
+                                              "onFocus": [Function],
+                                              "onInputChange": [Function],
+                                              "onMenuClose": [Function],
+                                              "onMenuOpen": [Function],
+                                              "openMenuOnClick": true,
+                                              "openMenuOnFocus": false,
+                                              "options": Array [
+                                                Object {
+                                                  "label": "STF",
+                                                  "pivot": "endpoints.stf.host",
+                                                  "value": "stf",
+                                                },
+                                                Object {
+                                                  "label": "AMQP",
+                                                  "pivot": "endponts.amqp.host",
+                                                  "value": "amqp",
+                                                },
+                                              ],
+                                              "pageSize": 5,
+                                              "placeholder": "<Choose>",
+                                              "screenReaderStatus": [Function],
+                                              "styles": Object {},
+                                              "tabIndex": "0",
+                                              "tabSelectsValue": true,
+                                              "value": Array [],
+                                            }
+                                          }
+                                          setValue={[Function]}
+                                          theme={
+                                            Object {
+                                              "borderRadius": 4,
+                                              "colors": Object {
+                                                "danger": "#DE350B",
+                                                "dangerLight": "#FFBDAD",
+                                                "neutral0": "hsl(0, 0%, 100%)",
+                                                "neutral10": "hsl(0, 0%, 90%)",
+                                                "neutral20": "hsl(0, 0%, 80%)",
+                                                "neutral30": "hsl(0, 0%, 70%)",
+                                                "neutral40": "hsl(0, 0%, 60%)",
+                                                "neutral5": "hsl(0, 0%, 95%)",
+                                                "neutral50": "hsl(0, 0%, 50%)",
+                                                "neutral60": "hsl(0, 0%, 40%)",
+                                                "neutral70": "hsl(0, 0%, 30%)",
+                                                "neutral80": "hsl(0, 0%, 20%)",
+                                                "neutral90": "hsl(0, 0%, 10%)",
+                                                "primary": "#2684FF",
+                                                "primary25": "#DEEBFF",
+                                                "primary50": "#B2D4FF",
+                                                "primary75": "#4C9AFF",
+                                              },
+                                              "spacing": Object {
+                                                "baseUnit": 4,
+                                                "controlHeight": 38,
+                                                "menuGutter": 8,
+                                              },
+                                            }
+                                          }
+                                        >
+                                          <i
+                                            className="ddorg__pf3-component-mapper__select__dropdown-indicator fa fa-angle-down placeholder"
+                                          />
+                                        </DropdownIndicator>
+                                      </div>
+                                    </ForwardRef(render)>
+                                  </IndicatorsContainer>
+                                </div>
+                              </ForwardRef(render)>
+                            </Control>
+                            <input
+                              name="type"
+                              type="hidden"
+                              value=""
+                            />
+                          </div>
+                        </ForwardRef(render)>
+                      </SelectContainer>
+                    </Select>
+                  </StateManager>
+                </Select>
+              </Select>
+            </div>
+          </div>
+        </FormGroup>
+      </Pf3FormGroup>
+    </Select>
+  </SelectWithOnChange>
+</ProtocolSelector>
+`;

--- a/app/javascript/spec/provider-form/__snapshots__/protocol-selector.spec.js.snap
+++ b/app/javascript/spec/provider-form/__snapshots__/protocol-selector.spec.js.snap
@@ -24,6 +24,7 @@ exports[`ProtocolSelector component should match the snapshot 1`] = `
     component="protocol-selector"
     label="Type"
     name="type"
+    onChange={[Function]}
     options={
       Array [
         Object {

--- a/app/javascript/spec/provider-form/protocol-selector.spec.js
+++ b/app/javascript/spec/provider-form/protocol-selector.spec.js
@@ -5,7 +5,7 @@ import toJson from 'enzyme-to-json';
 import FormRenderer, { useFormApi } from '@data-driven-forms/react-form-renderer';
 import { FormTemplate, componentMapper } from '@data-driven-forms/pf3-component-mapper';
 import ProtocolSelector from '../../components/provider-form/protocol-selector';
-import { EditingContext } from '../../components/provider-form';
+import EditingContext from '../../components/provider-form/editing-context';
 
 const DummyComponent = () => <div />;
 const FormApiComponent = () => {

--- a/app/javascript/spec/provider-form/protocol-selector.spec.js
+++ b/app/javascript/spec/provider-form/protocol-selector.spec.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import FormRenderer, { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { FormTemplate, componentMapper } from '@data-driven-forms/pf3-component-mapper';
+import ProtocolSelector from '../../components/provider-form/protocol-selector';
+import { EditingContext } from '../../components/provider-form';
+
+const DummyComponent = () => <div />;
+const FormApiComponent = () => {
+  const formOptions = useFormApi();
+  return <DummyComponent {...formOptions} />;
+};
+
+const RendererWrapper = props => (
+  <EditingContext.Provider value={{ providerId: true }}>
+    <FormRenderer
+      onSubmit={() => {}}
+      FormTemplate={FormTemplate}
+      componentMapper={{
+        ...componentMapper,
+        'protocol-selector': ProtocolSelector,
+        'form-api-component': FormApiComponent,
+      }}
+      schema={{
+        fields: [
+          {
+            component: 'form-api-component',
+            name: 'form-api',
+          },
+          {
+            component: 'protocol-selector',
+            name: 'type',
+            label: 'Type',
+            options: [
+              {
+                label: 'STF',
+                value: 'stf',
+                pivot: 'endpoints.stf.host',
+              },
+              {
+                label: 'AMQP',
+                value: 'amqp',
+                pivot: 'endponts.amqp.host',
+              },
+            ],
+          },
+          {
+            component: 'text-field',
+            name: 'endpoints.stf.host',
+            label: 'hostname',
+            condition: {
+              when: 'type',
+              is: 'stf',
+            },
+          },
+          {
+            component: 'text-field',
+            name: 'endpoints.amqp.host',
+            label: 'hostname',
+            condition: {
+              when: 'type',
+              is: 'amqp',
+            },
+          },
+          {
+            component: 'text-field',
+            name: 'authentications.stf.username',
+            label: 'username',
+            condition: {
+              when: 'type',
+              is: 'stf',
+            },
+          },
+          {
+            component: 'text-field',
+            name: 'authentications.amqp.username',
+            label: 'username',
+            condition: {
+              when: 'type',
+              is: 'amqp',
+            },
+          },
+        ],
+      }}
+      {...props}
+    />
+  </EditingContext.Provider>
+);
+
+describe('ProtocolSelector component', () => {
+  it('should match the snapshot', () => {
+    const wrapper = mount(<RendererWrapper />);
+    expect(toJson(wrapper.find(ProtocolSelector))).toMatchSnapshot();
+  });
+
+  const initialValues = {
+    endpoints: {
+      stf: {
+        host: 'localhost',
+      },
+    },
+    authentications: {
+      stf: {
+        username: 'Bob Smith',
+      },
+    },
+  };
+
+  it('should render correct form fields initially', async(done) => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<RendererWrapper initialValues={initialValues} />);
+      wrapper.update();
+    });
+
+    expect(wrapper.find('input[name="type"]').prop('value')).toEqual('stf');
+    expect(wrapper.find('input[name="endpoints.stf.host"]').prop('value')).toEqual('localhost');
+    expect(wrapper.find('input[name="authentications.stf.username"]').prop('value')).toEqual('Bob Smith');
+    expect(wrapper.contains('input[name="endpoints.amqp.host')).toBe(false);
+    expect(wrapper.contains('input[name="authentications.amqp.username')).toBe(false);
+    done();
+  });
+
+  it('should render correct form fields on change', async(done) => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<RendererWrapper initialValues={initialValues} />);
+    });
+
+    await act(async() => {
+      wrapper.find('DummyComponent').prop('change')('type', 'amqp');
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find('input[name="type"]').prop('value')).toEqual('amqp');
+    expect(wrapper.exists('input[name="endpoints.amqp.host"]')).toBe(true);
+    expect(wrapper.exists('input[name="authentications.amqp.username"]')).toBe(true);
+    expect(wrapper.exists('input[name="endpoints.stf.host"]')).toBe(false);
+    expect(wrapper.exists('input[name="authentications.stf.username"]')).toBe(false);
+    done();
+  });
+});


### PR DESCRIPTION
The `ProtocolSelector` component was not leveraging the `onChange` prop of the `SelectWithOnChange`.
This PR adds tests to the `ProtocolSelector` component and refactors it to use `SelectWithOnChange` by setting the `onChange` prop.

The tests use https://github.com/data-driven-forms/react-forms/issues/852#issuecomment-714385810.

@miq-bot add_label refactoring, react