### PR TITLE
Use formApi to change dropdown value in SelectWithOnChange spec

### DIFF
--- a/app/javascript/spec/select/select.spec.js
+++ b/app/javascript/spec/select/select.spec.js
@@ -2,51 +2,62 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import FormRenderer from '@data-driven-forms/react-form-renderer';
+import FormRenderer, { useFormApi } from '@data-driven-forms/react-form-renderer';
 import { FormTemplate } from '@data-driven-forms/pf3-component-mapper';
 import Select from '../../components/select';
 
+const DummyComponent = () => <div />;
+const FormApiComponent = () => {
+  const formOptions = useFormApi();
+  return <DummyComponent {...formOptions} />;
+};
+
 const RendererWrapper = ({ onChange }) => (
   <FormRenderer
-    onSubmit={ () => {} }
-    FormTemplate={ FormTemplate }
+    onSubmit={() => {}}
+    FormTemplate={FormTemplate}
     componentMapper={{
-      'select': Select,
+      select: Select,
+      'form-api-component': FormApiComponent,
     }}
     schema={{
-      fields: [{
-        component: 'select',
-        name: 'selectField',
-        label: 'Choose',
-        options: [
-          {
-            "label": "Dogs",
-            "value": "1"
-          },
-          {
-            "label": "Cats",
-            "value": "2"
-          },
-        ],
-        onChange,
-      }],
+      fields: [
+        {
+          component: 'form-api-component',
+          name: 'form-api',
+        },
+        {
+          component: 'select',
+          name: 'selectField',
+          label: 'Choose',
+          options: [
+            {
+              label: 'Dogs',
+              value: '1',
+            },
+            {
+              label: 'Cats',
+              value: '2',
+            },
+          ],
+          onChange,
+        }],
     }}
   />
 );
 
 describe('Select component', () => {
   it('should match the snapshot', () => {
-    const wrapper = mount(<RendererWrapper/>);
+    const wrapper = mount(<RendererWrapper />);
     expect(toJson(wrapper.find(Select))).toMatchSnapshot();
   });
 
   it('should call onChange when changed', async(done) => {
     const onChange = jest.fn();
-    const wrapper = mount(<RendererWrapper onChange={ onChange }/>);
+    const wrapper = mount(<RendererWrapper onChange={onChange} />);
 
     await act(async() => {
-      const component = wrapper.find('SelectWithOnChange Select').at(2);
-      component.prop('onChange')("2");
+      wrapper.find('DummyComponent').prop('change')('selectField', '2');
     });
 
     expect(onChange).toHaveBeenCalled();


### PR DESCRIPTION
Instead of calling the internal `onChange` by tapping into the `Select` component, I am leveraging [the formApi exposed on a dummy component](https://github.com/data-driven-forms/react-forms/issues/852#issuecomment-714385810).

@miq-bot add_label test

