### PR TITLE
fix the physical rack spec

### DIFF
--- a/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_chassis_helper/textual_summary_spec.rb
@@ -258,7 +258,7 @@ describe PhysicalChassisHelper::TextualSummary do
 
     it 'show the chassis physical rack' do
       expect(subject).to eq(
-        :label => "Physical Rack",
+        :label => "Physical Racks",
         :value => "Rack XYZ",
         :icon  => "pficon pficon-enterprise",
         :image => nil

--- a/spec/helpers/physical_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/physical_storage_helper/textual_summary_spec.rb
@@ -203,7 +203,7 @@ describe PhysicalStorageHelper::TextualSummary do
 
     it 'show the storage physical rack' do
       expect(subject).to eq(
-        :label => "Physical Rack",
+        :label => "Physical Racks",
         :value => "Rack XYZ",
         :icon  => "pficon pficon-enterprise",
         :image => nil


### PR DESCRIPTION
it's failing because it's plural:

```
       @@ -1,5 +1,5 @@
        :icon => "pficon pficon-enterprise",
        :image => nil,
       -:label => "Physical Rack"
       +:label => "Physical Racks",
        :value => "Rack XYZ",

      
     # ./spec/helpers/physical_chassis_helper/textual_summary_spec.rb:260:in `block (3 levels) in <top (required)>'
```

