### PR TITLE
[WIP] [.gemspec] Move and upgrade `hamlit`

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "coffee-rails"
   s.add_dependency "font-fabulous", "~> 1.0.5"
+  s.add_dependency "hamlit", "~> 2.11.0"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "more_core_extensions", ">= 3.2", "< 5"
   s.add_dependency "novnc-rails", "~>0.2"


### PR DESCRIPTION
Requires Core PR: ManageIQ/manageiq#20735

This is mainly a dependency for the UI that has lived in core for some
time now, and probably has no reason still being there.

Moving to here, and bumping to 2.11.0 for Rails 6.0 compatibility.

(marked as `[WIP]` until the `kasporov` branch has been cut)

Reason for Upgrade
------------------

As mentioned in https://github.com/ManageIQ/manageiq/pull/20722 this addresses a deprecation warning:

```
DEPRECATION WARNING: Single arity template handlers are deprecated.
Template handlers must now accept two parameters, the view object and the
source for the view object.
Change:
  >> #<Hamlit::RailsTemplate:0x00007f8e7dbd7dc0>.call(template)
To:
  >> #<Hamlit::RailsTemplate:0x00007f8e7dbd7dc0>.call(template, source)
 (called from <top (required)> at ./manageiq/config/environment.rb:5)
```

Bumping to ~>2.11.0 to get some extra fixes that were included:

* https://github.com/k0kubun/hamlit/blob/master/CHANGELOG.md
* https://github.com/k0kubun/hamlit/compare/v2.8.5...v2.11.0


Links
-----

* Replaces https://github.com/ManageIQ/manageiq/pull/20722
* Core PR: https://github.com/ManageIQ/manageiq/pull/20735