### PR TITLE
Eliminating cyclic dependency for EditingContext

### DIFF
--- a/app/javascript/components/provider-form/editing-context.js
+++ b/app/javascript/components/provider-form/editing-context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext({});

--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -7,6 +7,7 @@ import { API } from '../../http_api';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import mapper from '../../forms/mappers/componentMapper';
+import EditingContext from './editing-context';
 import ProtocolSelector from './protocol-selector';
 import ProviderCredentials from './provider-credentials';
 import ValidateProviderCredentials from './validate-provider-credentials';
@@ -71,8 +72,6 @@ const typeSelectField = (edit, filter, setState) => ({
     fields: [firstField, ...fields],
   }))),
 });
-
-export const EditingContext = React.createContext({});
 
 const ProviderForm = ({ providerId, kind, title, redirect }) => {
   const edit = !!providerId;

--- a/app/javascript/components/provider-form/protocol-selector.jsx
+++ b/app/javascript/components/provider-form/protocol-selector.jsx
@@ -3,7 +3,7 @@ import { get } from 'lodash';
 
 import componentMapper from '../../forms/mappers/componentMapper';
 import { useFormApi, useFieldApi, componentTypes } from '@@ddf';
-import { EditingContext } from './index';
+import EditingContext from './editing-context';
 
 const Select = componentMapper[componentTypes.SELECT];
 

--- a/app/javascript/components/provider-form/provider-credentials.jsx
+++ b/app/javascript/components/provider-form/provider-credentials.jsx
@@ -2,7 +2,7 @@ import React, { Fragment, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { useFormApi } from '@@ddf';
-import { EditingContext } from './index';
+import EditingContext from './editing-context';
 
 const ProviderCredentials = ({ fields }) => {
   const { providerId } = useContext(EditingContext);

--- a/app/javascript/components/provider-form/validate-provider-credentials.jsx
+++ b/app/javascript/components/provider-form/validate-provider-credentials.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { pick } from 'lodash';
 
 import AsyncCredentials from '../async-credentials/async-credentials';
-import { EditingContext } from './index';
+import EditingContext from './editing-context';
 
 const ValidateProviderCredentials = ({ ...props }) => {
   const { providerId } = useContext(EditingContext);


### PR DESCRIPTION
Fixed the cyclic dependency of `EditingContext` in `ProviderForm` by extracting it into a separate file.

@miq-bot add_label cleanup, react
