### PR TITLE
Make the vm server relationship form fully API driven

### DIFF
--- a/app/javascript/components/vm-server-relationship-form/vm-server-relationship-form.schema.js
+++ b/app/javascript/components/vm-server-relationship-form/vm-server-relationship-form.schema.js
@@ -1,13 +1,13 @@
 import { componentTypes } from '@@ddf';
 
-const createSchema = (options = []) => ({
+const createSchema = (promise) => ({
   fields: [{
     component: componentTypes.SELECT,
     name: 'serverId',
     id: 'serverId',
     label: __('Select Server:'),
     placeholder: `<${__('Not a Server')}>`,
-    options,
+    loadOptions: () => promise.then(({ resources }) => resources.map(({ id, name }) => ({ label: name, value: id }))),
   }],
 });
 

--- a/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
+++ b/app/javascript/spec/vm-server-relationship-form/vm-server-relationship-form.spec.js
@@ -1,114 +1,49 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
+import { act } from 'react-dom/test-utils';
 import VmServerRelationShipForm from '../../components/vm-server-relationship-form';
-import '../helpers/miqAjaxButton';
 import { mount } from '../helpers/mountForm';
 
 describe('Vm server relationship form component', () => {
-  const miqAjaxButtonSpy = jest.spyOn(window, 'miqAjaxButton');
   const servers = {
     resources: [
-      { href: '/api/servers/7', id: '7', name: 'miq-5.9.0.21-TE4' },
-      { href: '/api/servers/13', id: '13', name: 'miq-5.9.0.21-TE7' },
-      { href: '/api/servers/1', id: '1', name: 'miq-5.9.0.21-TE1' },
-      { href: '/api/servers/12', id: '12', name: 'miq-5.9.0.21-TE11' },
-      { href: '/api/servers/4', id: '4', name: 'miq-5.9.0.21-TE3' },
-      { href: '/api/servers/10', id: '10', name: 'miq-5.9.0.21-TE10' },
-      { href: '/api/servers/14', id: '14', name: 'miq-5.9.0.21-TE13' },
-      { href: '/api/servers/11', id: '11', name: 'miq-5.9.0.21-TE12' },
-      { href: '/api/servers/8', id: '8', name: 'miq-5.9.0.21-TE8' },
-      { href: '/api/servers/2', id: '2', name: 'miq-5.9.0.21-TE2' },
-      { href: '/api/servers/6', id: '6', name: 'miq-5.9.0.21-TE5' },
-      { href: '/api/servers/16', id: '16', name: 'EVM' },
+      { vm_id: '1', id: '1', name: 'foo' },
+      { id: '2', name: 'bar' },
+      { id: '3', name: 'baz' },
     ],
-  };
-
-  const props = {
-    vmId: '10',
   };
 
   afterEach(() => {
     fetchMock.reset();
-    miqAjaxButtonSpy.mockReset();
   });
 
-  it('should call cancel callback ', (done) => {
-    fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+  const url = '/api/servers?expand=resources&attributes=id,name,vm_id&sort_by=name&sort_order=desc';
 
-    setImmediate(() => {
-      wrapper.update();
-      wrapper.find('button').last().simulate('click');
-      expect(miqAjaxButtonSpy).toHaveBeenCalledWith('/vm_or_template/evm_relationship_update/10?button=cancel');
-      done();
+  it('should request data after mount and set to state', async(done) => {
+    fetchMock.getOnce(url, servers);
+    let wrapper;
+
+    await act(async() => {
+      wrapper = mount(<VmServerRelationShipForm recordId="2" redirect="" />);
     });
+    wrapper.update();
+
+    expect(fetchMock.called(url)).toBe(true);
+    expect(wrapper.find('input[name="serverId"]').prop('value')).toEqual('');
+    done();
   });
 
-  it('should request data after mount and set to state (no serverId)', (done) => {
-    fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    const wrapper = mount(<VmServerRelationShipForm {...props} />);
+  it('should request data after mount and set to state (with serverId)', async(done) => {
+    fetchMock.getOnce('/api/servers?expand=resources&attributes=id,name,vm_id&sort_by=name&sort_order=desc', servers);
+    let wrapper;
 
-    expect(fetchMock.called('/api/servers?expand=resources&sort_by=name&sort_order=desc')).toBe(true);
-
-    setImmediate(() => {
-      wrapper.update();
-      expect(wrapper.children().state().initialValues).toEqual({
-        serverId: undefined,
-      });
-      done();
+    await act(async() => {
+      wrapper = mount(<VmServerRelationShipForm recordId="1" redirect="" />);
     });
-  });
+    wrapper.update();
 
-  it('should request data after mount and set to state (with serverId)', (done) => {
-    fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    const wrapper = mount(<VmServerRelationShipForm {...props} serverId="13" />);
-
-    expect(fetchMock.called('/api/servers?expand=resources&sort_by=name&sort_order=desc')).toBe(true);
-
-    setImmediate(() => {
-      wrapper.update();
-      expect(wrapper.children().state().initialValues).toEqual({
-        serverId: '/api/servers/13',
-      });
-      done();
-    });
-  });
-
-  it('should not submit values when form is not valid', (done) => {
-    fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    const wrapper = mount(<VmServerRelationShipForm {...props} />);
-    const spy = jest.spyOn(wrapper.children().instance(), 'onSubmit');
-
-    setImmediate(() => {
-      wrapper.update();
-      const button = wrapper.find('button').first();
-      button.simulate('click');
-      expect(spy).toHaveBeenCalledTimes(0);
-      done();
-    });
-  });
-
-  it('onSubmit parses data and post to API', (done) => {
-    fetchMock.getOnce('/api/servers?expand=resources&sort_by=name&sort_order=desc', servers);
-    fetchMock.postOnce('/vm_or_template/evm_relationship_update/10?button=save', {});
-    fetchMock.postOnce('/api/vms/10', {});
-
-    const wrapper = mount(<VmServerRelationShipForm {...props} />);
-    const values = {
-      serverId: '/api/servers/16',
-    };
-    wrapper.children().instance().onSubmit(values).then(() => {
-      expect(miqAjaxButtonSpy).toHaveBeenCalledWith('/vm_or_template/evm_relationship_update/10?button=save');
-      expect(fetchMock.called('/api/vms/10',
-        {
-          action: 'set_miq_server',
-          resource: {
-            miq_server: {
-              href: values.serverId,
-            },
-          },
-        })).toBe(true);
-      done();
-    });
+    expect(fetchMock.called(url)).toBe(true);
+    expect(wrapper.find('input[name="serverId"]').prop('value')).toEqual('1');
+    done();
   });
 });

--- a/app/views/vm_common/_evm_relationship.html.haml
+++ b/app/views/vm_common/_evm_relationship.html.haml
@@ -3,4 +3,4 @@
   %h3
     = _('Servers')
   .col-md-12
-    = react('VmServerRelationshipForm', { :vmId => @edit[:vm_id].to_s, :serverId => @edit[:new][:server].to_s})
+    = react('VmServerRelationshipForm', :recordId => @edit[:vm_id].to_s, :redirect => url_for(:action => :show, :id => @record.id))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,10 +79,6 @@ Rails.application.routes.draw do
     exp_token_pressed
   )
 
-  evm_relationship_post = %w(
-    evm_relationship_update
-  )
-
   ownership_post = %w(
     ownership
     ownership_update
@@ -2944,7 +2940,6 @@ Rails.application.routes.draw do
                compare_post +
                dialog_runner_post +
                drift_post +
-               evm_relationship_post +
                exp_post +
                policy_post +
                pre_prov_post +
@@ -3032,7 +3027,6 @@ Rails.application.routes.draw do
                compare_post +
                dialog_runner_post +
                drift_post +
-               evm_relationship_post +
                exp_post +
                policy_post +
                pre_prov_post +
@@ -3128,7 +3122,6 @@ Rails.application.routes.draw do
                adv_search_post +
                compare_post +
                dialog_runner_post +
-               evm_relationship_post +
                exp_post +
                policy_post +
                pre_prov_post +

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -347,26 +347,6 @@ describe VmOrTemplateController do
     end
   end
 
-  describe '#evm_relationship_get_form_vars' do
-    before do
-      @vm = FactoryBot.create(:vm_vmware)
-      edit = {:vm_id => @vm.id, :new => {:server => nil}}
-      controller.instance_variable_set(:@edit, edit)
-    end
-
-    it 'does not set new server when params[:server_id] is not set' do
-      controller.params = {:server_id => ''}
-      controller.send(:evm_relationship_get_form_vars)
-      expect(assigns(:edit)[:new][:server]).to be(nil)
-    end
-
-    it 'sets new server when params[:server_id] is set' do
-      controller.params = {:server_id => '42'}
-      controller.send(:evm_relationship_get_form_vars)
-      expect(assigns(:edit)[:new][:server]).to eq(controller.params[:server_id])
-    end
-  end
-
   describe '#policy_show_options' do
     let(:vm) { FactoryBot.create(:vm_vmware) }
 

--- a/spec/routing/shared_examples/vm_common_examples.rb
+++ b/spec/routing/shared_examples/vm_common_examples.rb
@@ -77,14 +77,6 @@ shared_examples_for 'A controller that has vm_common routes' do
     end
   end
 
-  describe '#evm_relationship_update' do
-    it 'routes with POST' do
-      expect(
-        post("/#{controller_name}/evm_relationship_update")
-      ).to route_to("#{controller_name}#evm_relationship_update")
-    end
-  end
-
   describe '#explorer' do
     it 'routes with POST' do
       expect(post("/#{controller_name}/explorer")).to route_to("#{controller_name}#explorer")


### PR DESCRIPTION
The form was still using non-API endpoints to fetch data and its redirects after submit/cancel were pointing to dedicated routes. I converted the form into a function component and adjusted it to work with only API endpoints. You can access this form under a VM's summary screen:
![Screenshot from 2020-10-27 19-03-08](https://user-images.githubusercontent.com/649130/97342868-12ccdf00-1887-11eb-89a6-b9ede57d787d.png)
