### PR TITLE
Adjusted ansible credential textual summary generation

### DIFF
--- a/app/helpers/ansible_credential_helper/textual_summary.rb
+++ b/app/helpers/ansible_credential_helper/textual_summary.rb
@@ -12,16 +12,16 @@ module AnsibleCredentialHelper::TextualSummary
   def textual_group_options
     options = []
 
-    @record.class::API_ATTRIBUTES.each do |key, value|
-      next if value[:type] == :password
+    DDF.traverse(:fields => @record.class::API_ATTRIBUTES) do |field|
+      next if field[:type].to_s == 'password' || field[:name].nil?
 
-      options << key
+      options << field[:name].to_sym
 
-      define_singleton_method "textual_#{key}" do
+      define_singleton_method "textual_#{field[:name]}" do
         {
-          :label => _(value[:label]),
-          :title => _(value[:help_text]),
-          :value => attribute_value(key, @record)
+          :label => _(field[:label]),
+          :title => _(field[:helperText]),
+          :value => attribute_value(field[:name], @record)
         }
       end
     end
@@ -30,7 +30,7 @@ module AnsibleCredentialHelper::TextualSummary
   end
 
   def attribute_value(key, rec)
-    (rec.try(key) || rec.options.try(:[], key)).presence
+    key.split('.').reduce(rec) { |obj, chunk| obj.send(:try, :[], chunk) }
   end
   private :attribute_value
 

--- a/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
+++ b/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
@@ -504,6 +504,7 @@ exports[`Ansible Credential Form Component should render adding a new credential
                   ButtonGroup={[Function]}
                   Description={[Function]}
                   FormWrapper={[Function]}
+                  Header={Symbol(react.fragment)}
                   Title={[Function]}
                   canReset={false}
                   cancelLabel="Cancel"
@@ -629,7 +630,15 @@ exports[`Ansible Credential Form Component should render adding a new credential
                           name="manager_resource"
                           type="hidden"
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "name": "manager_resource",
+                                "type": "hidden",
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -723,7 +732,23 @@ exports[`Ansible Credential Form Component should render adding a new credential
                             ]
                           }
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "name",
+                                "isRequired": true,
+                                "label": "Name",
+                                "maxLength": 128,
+                                "name": "name",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -848,7 +873,26 @@ exports[`Ansible Credential Form Component should render adding a new credential
                             ]
                           }
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "select",
+                                "id": "type",
+                                "isDisabled": false,
+                                "isRequired": true,
+                                "label": "Credential type",
+                                "loadOptions": [Function],
+                                "name": "type",
+                                "onChange": [Function],
+                                "placeholder": "<Choose>",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -2203,7 +2247,15 @@ exports[`Ansible Credential Form Component should render adding a new credential
                           key="spy-field"
                           name="spy-field"
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "spy-field",
+                                "initialize": undefined,
+                                "name": "spy-field",
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -3056,6 +3108,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                   ButtonGroup={[Function]}
                   Description={[Function]}
                   FormWrapper={[Function]}
+                  Header={Symbol(react.fragment)}
                   Title={[Function]}
                   canReset={true}
                   cancelLabel="Cancel"
@@ -3197,7 +3250,15 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                           name="manager_resource"
                           type="hidden"
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "name": "manager_resource",
+                                "type": "hidden",
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -3281,7 +3342,23 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                             ]
                           }
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "name",
+                                "isRequired": true,
+                                "label": "Name",
+                                "maxLength": 128,
+                                "name": "name",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -3406,7 +3483,26 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                             ]
                           }
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "select",
+                                "id": "type",
+                                "isDisabled": true,
+                                "isRequired": true,
+                                "label": "Credential type",
+                                "loadOptions": [Function],
+                                "name": "type",
+                                "onChange": [Function],
+                                "placeholder": "<Choose>",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -4530,7 +4626,18 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                           label="Access Key"
                           name="userid"
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "helperText": "AWS Access Key for this credential",
+                                "id": "userid",
+                                "isRequired": true,
+                                "label": "Access Key",
+                                "name": "userid",
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >
@@ -4691,7 +4798,15 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                           key="spy-field"
                           name="spy-field"
                         >
-                          <FormConditionWrapper>
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "spy-field",
+                                "initialize": undefined,
+                                "name": "spy-field",
+                              }
+                            }
+                          >
                             <FormFieldHideWrapper
                               hideField={false}
                             >

--- a/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
+++ b/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
@@ -4,35 +4,81 @@ describe AnsibleCredentialHelper::TextualSummary do
   include_examples "textual_group", "Relationships", %i(repositories)
 
   class TestClass
-    API_ATTRIBUTES = {
-      :userid          => {
-        :label     => N_('Username'),
-        :help_text => N_('Username for this credential')
+    API_ATTRIBUTES = [
+      {
+        :component  => 'text-field',
+        :label      => N_('Username'),
+        :helperText => N_('Username for this credential'),
+        :name       => 'userid',
+        :id         => 'userid',
       },
-      :password        => {
-        :type      => :password,
-        :label     => N_('Password'),
-        :help_text => N_('Password for this credential')
+      {
+        :component  => 'password-field',
+        :label      => N_('Password'),
+        :helperText => N_('Password for this credential'),
+        :name       => 'password',
+        :id         => 'password',
+        :type       => 'password',
       },
-      :ssh_key_data    => {
-        :type      => :password,
-        :multiline => true,
-        :label     => N_('Private key'),
-        :help_text => N_('RSA or DSA private key to be used instead of password')
+      {
+        :component      => 'password-field',
+        :label          => N_('Private key'),
+        :helperText     => N_('RSA or DSA private key to be used instead of password'),
+        :componentClass => 'textarea',
+        :name           => 'ssh_key_data',
+        :id             => 'ssh_key_data',
+        :type           => 'password',
       },
-      :become_method   => {
-        :type      => :choice,
-        :label     => N_('Privilege Escalation'),
-        :help_text => N_('Privilege escalation method'),
-        :choices   => ['', 'sudo', 'su', 'pbrun', 'pfexec']
+      {
+        :component  => 'password-field',
+        :label      => N_('Private key passphrase'),
+        :helperText => N_('Passphrase to unlock SSH private key if encrypted'),
+        :name       => 'ssh_key_unlock',
+        :id         => 'ssh_key_unlock',
+        :maxLength  => 1024,
+        :type       => 'password',
       },
-      :become_username => {
-        :type       => :string,
+      {
+        :component        => 'select',
+        :label            => N_('Privilege Escalation'),
+        :helperText       => N_('Privilege escalation method'),
+        :name             => 'become_method',
+        :id               => 'become_method',
+        :type             => 'choice',
+        :isClearable      => true,
+        :options          => %w[
+          sudo
+          su
+          pbrum
+          pfexec
+          doas
+          dzdo
+          pmrun
+          runas
+          enable
+          ksu
+          sesu
+          machinectl
+        ].map { |item| {:label => item, :value => item} },
+      },
+      {
+        :component  => 'text-field',
         :label      => N_('Privilege Escalation Username'),
-        :help_text  => N_('Privilege escalation username'),
-        :max_length => 1024
-      }
-    }.freeze
+        :helperText => N_('Privilege escalation username'),
+        :name       => 'become_username',
+        :id         => 'become_username',
+        :maxLength  => 1024,
+      },
+      {
+        :component  => 'password-field',
+        :label      => N_('Privilege Escalation Password'),
+        :helperText => N_('Password for privilege escalation method'),
+        :name       => 'become_password',
+        :id         => 'become_password',
+        :maxLength  => 1024,
+        :type       => 'password',
+      },
+    ].freeze
   end
 
   describe "#textual_group_options" do
@@ -50,19 +96,19 @@ describe AnsibleCredentialHelper::TextualSummary do
   end
 
   describe "#attribute_value (private)" do
-    it "returns an attributes value" do
-      rec = double(:thing => "stuff", :options => nil)
-      expect(send(:attribute_value, :thing, rec)).to eq("stuff")
+    it "returns a sinmple value" do
+      rec = { 'thing' => "stuff" }
+      expect(send(:attribute_value, 'thing', rec)).to eq("stuff")
     end
 
-    it "returns an options value" do
-      rec = double(:options => {:thing => "stuff"})
-      expect(send(:attribute_value, :thing, rec)).to eq("stuff")
+    it "returns deeply stored value" do
+      rec = { 'foo' => { 'bar' => 'baz' } }
+      expect(send(:attribute_value, 'foo.bar', rec)).to eq("baz")
     end
 
     it "returns nil if a key isn't present" do
-      rec = double(:secret => "password", :options => nil)
-      expect(send(:attribute_value, :thing, rec)).to be_nil
+      rec = {}
+      expect(send(:attribute_value, 'foo.bar', rec)).to be_nil
     end
   end
 end

--- a/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
+++ b/spec/helpers/ansible_credential_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe AnsibleCredentialHelper::TextualSummary do
   include_examples "textual_group_smart_management"
-  include_examples "textual_group", "Properties", %i(name type created updated)
-  include_examples "textual_group", "Relationships", %i(repositories)
+  include_examples "textual_group", "Properties", %i[name type created updated]
+  include_examples "textual_group", "Relationships", %i[repositories]
 
   class TestClass
     API_ATTRIBUTES = [
@@ -39,14 +39,14 @@ describe AnsibleCredentialHelper::TextualSummary do
         :type       => 'password',
       },
       {
-        :component        => 'select',
-        :label            => N_('Privilege Escalation'),
-        :helperText       => N_('Privilege escalation method'),
-        :name             => 'become_method',
-        :id               => 'become_method',
-        :type             => 'choice',
-        :isClearable      => true,
-        :options          => %w[
+        :component   => 'select',
+        :label       => N_('Privilege Escalation'),
+        :helperText  => N_('Privilege escalation method'),
+        :name        => 'become_method',
+        :id          => 'become_method',
+        :type        => 'choice',
+        :isClearable => true,
+        :options     => %w[
           sudo
           su
           pbrum
@@ -85,7 +85,7 @@ describe AnsibleCredentialHelper::TextualSummary do
     before { @record = TestClass.new }
 
     it "doesn't return options for password types" do
-      expect(textual_group_options.items).to match_array(%i[userid become_method become_username])
+      expect(textual_group_options.items).to(match_array(%i[userid become_method become_username]))
     end
 
     context "defines the textual methods" do
@@ -97,18 +97,18 @@ describe AnsibleCredentialHelper::TextualSummary do
 
   describe "#attribute_value (private)" do
     it "returns a sinmple value" do
-      rec = { 'thing' => "stuff" }
-      expect(send(:attribute_value, 'thing', rec)).to eq("stuff")
+      rec = {'thing' => "stuff"}
+      expect(send(:attribute_value, 'thing', rec)).to(eq("stuff"))
     end
 
     it "returns deeply stored value" do
-      rec = { 'foo' => { 'bar' => 'baz' } }
-      expect(send(:attribute_value, 'foo.bar', rec)).to eq("baz")
+      rec = {'foo' => {'bar' => 'baz'}}
+      expect(send(:attribute_value, 'foo.bar', rec)).to(eq("baz"))
     end
 
     it "returns nil if a key isn't present" do
       rec = {}
-      expect(send(:attribute_value, 'foo.bar', rec)).to be_nil
+      expect(send(:attribute_value, 'foo.bar', rec)).to(be_nil)
     end
   end
 end


### PR DESCRIPTION
The textual summary generation for embedded ansible credential summary screen depends on the `API_FIELDS` constant declared in core. The fields in the constant have been converted to a [DDF schema](https://github.com/ManageIQ/manageiq/pull/20568) as we're [consuming](https://github.com/ManageIQ/manageiq-ui-classic/pull/7324) them using DDF. However, the textual summary generation has not been adjusted, which makes the summary screen generation fail.

I also noticed that the snapshots introduced in the [UI part](https://github.com/ManageIQ/manageiq-ui-classic/pull/7324) were not adjusted to the latest version of DDF, so I am adjusting them too to make travis happy.