### PR TITLE
Implemented autofocus/blur to access/exit the second level menu

### DIFF
--- a/app/javascript/menu/first-level.jsx
+++ b/app/javascript/menu/first-level.jsx
@@ -1,33 +1,46 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { SideNavItems, SideNavLink } from 'carbon-components-react/es/components/UIShell';
 import SideNavMenuLink from './side-nav-menu-link';
 import { carbonizeIcon } from './icon';
 import { itemId, linkProps } from './item-type';
 
-const mapItems = (items, expanded, { activeSection, setSection }) => items.map(item => (
-  item.items.length ? (
-    <MenuSection
-      key={item.id}
-      {...item}
-      hover={item.id === activeSection}
-      setSection={setSection}
-      expanded={expanded}
-    />
-  ) : (
-    <MenuItem key={item.id} {...item} />
-  )
-));
+const mapItems = (items, expanded, { activeSection, onSelect, ref: { prevRef, nextRef } }) => items.map((item, idx) => {
+  const prev = items[idx - 1]; // Retrieve the previous item in the menu
 
+  // Set the reference to the previous/next item relatively to the selected one
+  const ref = (item.id === activeSection && prevRef)
+           || (prev && prev.id === activeSection && nextRef)
+           || undefined;
+
+  const props = {
+    key: item.id,
+    ref,
+    ...item,
+  };
+
+  return (
+    item.items.length ? (
+      <MenuSection
+        {...props}
+        hover={item.id === activeSection}
+        onSelect={onSelect}
+        expanded={expanded}
+      />
+    ) : (
+      <MenuItem {...props} />
+    )
+  );
+});
 
 // SideNavMenuItem can't render an icon, SideNavLink can
-const MenuItem = ({
+const MenuItem = forwardRef(({
   active, href, icon, id, title, type,
-}) => (
-  <SideNavLink id={itemId(id)} isActive={active} renderIcon={carbonizeIcon(icon)} {...linkProps({ type, href, id })}>
+}, ref) => (
+  <SideNavLink id={itemId(id)} isActive={active} ref={ref} renderIcon={carbonizeIcon(icon)} {...linkProps({ type, href, id })}>
     {__(title)}
   </SideNavLink>
-);
+));
 
 MenuItem.propTypes = {
   active: PropTypes.bool,
@@ -44,23 +57,23 @@ MenuItem.defaultProps = {
   type: 'default',
 };
 
-const MenuSection = ({
-  active, expanded, hover, icon, id, items, title, setSection,
-}) => (
+const MenuSection = forwardRef(({
+  active, expanded, hover, icon, id, items, title, onSelect,
+}, ref) => (
   <SideNavMenuLink
     expanded={expanded}
     id={itemId(id, true)}
     isActive={active}
     forceHover={hover}
     onClick={(e) => {
-      setSection({ id, items });
+      onSelect({ id, items });
       e.stopPropagation();
     }}
+    ref={ref}
     renderIcon={carbonizeIcon(icon)}
     title={__(title)}
   />
-);
-
+));
 
 MenuSection.propTypes = {
   active: PropTypes.bool,
@@ -69,7 +82,7 @@ MenuSection.propTypes = {
   icon: PropTypes.string,
   id: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.any).isRequired,
-  setSection: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
 };
 
@@ -79,20 +92,19 @@ MenuSection.defaultProps = {
   icon: undefined,
 };
 
-
-const FirstLevel = ({
-  activeSection, expanded, menu, setSection,
-}) => (
+const FirstLevel = forwardRef(({
+  activeSection, expanded, menu, onSelect,
+}, ref) => (
   <SideNavItems className="menu-items">
-    {mapItems(menu, expanded, { setSection, activeSection })}
+    {mapItems(menu, expanded, { onSelect, activeSection, ref })}
   </SideNavItems>
-);
+));
 
 FirstLevel.propTypes = {
   activeSection: PropTypes.string,
   expanded: PropTypes.bool.isRequired,
   menu: PropTypes.any.isRequired,
-  setSection: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
 };
 
 FirstLevel.defaultProps = {

--- a/app/javascript/menu/second-level.jsx
+++ b/app/javascript/menu/second-level.jsx
@@ -1,28 +1,35 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { SideNavItems, SideNavMenu, SideNavMenuItem } from 'carbon-components-react/es/components/UIShell';
 import { itemId, linkProps } from './item-type';
 
-const mapItems = (items, hideSecondary) => items.map((item) => {
+const mapItems = (items, hideSecondary, ref) => items.map((item, key) => {
   const Component = item.items.length ? MenuSection : MenuItem;
 
-  return <Component hideSecondary={hideSecondary} key={item.id} {...item} />;
+  return (
+    <Component
+      hideSecondary={hideSecondary}
+      key={item.id}
+      {...item}
+      {...(ref && key === 0 && { ref })}
+    />
+  );
 });
 
-
-const MenuItem = ({
+const MenuItem = forwardRef(({
   active, href, id, title, type, hideSecondary,
-}) => (
+}, ref) => (
   <SideNavMenuItem
     id={itemId(id)}
     isActive={active}
+    ref={ref}
     {...linkProps({
       type, href, id, hideSecondary,
     })}
   >
     {__(title)}
   </SideNavMenuItem>
-);
+));
 
 MenuItem.propTypes = {
   active: PropTypes.bool,
@@ -39,19 +46,19 @@ MenuItem.defaultProps = {
   type: 'default',
 };
 
-
-const MenuSection = ({
+const MenuSection = forwardRef(({
   active, id, items, title, hideSecondary,
-}) => (
+}, ref) => (
   <SideNavMenu
     id={itemId(id, true)}
     isActive={active}
     defaultExpanded={active} // autoexpand active section
+    ref={ref}
     title={__(title)}
   >
     {mapItems(items, hideSecondary)}
   </SideNavMenu>
-);
+));
 
 MenuSection.propTypes = {
   active: PropTypes.bool,
@@ -65,11 +72,11 @@ MenuSection.defaultProps = {
   active: false,
 };
 
-const SecondLevel = ({ menu, hideSecondary }) => (
+const SecondLevel = forwardRef(({ menu, hideSecondary }, ref) => (
   <SideNavItems>
-    {mapItems(menu, hideSecondary)}
+    {mapItems(menu, hideSecondary, ref)}
   </SideNavItems>
-);
+));
 
 SecondLevel.propTypes = {
   menu: PropTypes.any.isRequired,

--- a/app/javascript/menu/side-nav-menu-link.jsx
+++ b/app/javascript/menu/side-nav-menu-link.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { SideNavIcon, SideNavItem } from 'carbon-components-react/es/components/UIShell';
 import Link from 'carbon-components-react/es/components/UIShell/Link';
@@ -9,7 +9,7 @@ import TooltipIcon from 'carbon-components-react/es/components/TooltipIcon';
 // SideNavLink with a chevron from SideNavMenu instead of SideNavLinkText
 // has an onClick, not items like SideNavMenu
 
-const SideNavMenuLink = ({
+const SideNavMenuLink = forwardRef(({
   expanded,
   forceHover,
   id,
@@ -17,7 +17,7 @@ const SideNavMenuLink = ({
   onClick,
   renderIcon: IconElement,
   title,
-}) => {
+}, ref) => {
   const className = cx({
     'bx--side-nav__link': true,
     'bx--side-nav__link--current': isActive,
@@ -26,7 +26,7 @@ const SideNavMenuLink = ({
 
   return (
     <SideNavItem id={id}>
-      <Link className={className} onClick={onClick} onKeyPress={onClick} tabIndex="0">
+      <Link className={className} onClick={onClick} onKeyPress={onClick} ref={ref} tabIndex="0">
         {IconElement && (
           <SideNavIcon small>
             {expanded && (<IconElement />)}
@@ -51,7 +51,7 @@ const SideNavMenuLink = ({
       </Link>
     </SideNavItem>
   );
-};
+});
 
 SideNavMenuLink.propTypes = {
   expanded: PropTypes.bool.isRequired,


### PR DESCRIPTION
I am forwarding/passing a `ref` to the first element in the secondary menu and calling its focus after something in the first level has been activated. It was necessary to add some `forwardRef` magic around our components, while the ones provided by carbon already had it implemented. 

I wanted to implement the unfocusing symmetrically on the last element in the second level, but there's no `onBlur` prop exposed on the `SideNavMenu` and `SideNavMenuItem` components. So I had to create a focusable `span` element after the second level menu that hides the second level when focused. I know that this is an ugly hack, but I had no better idea :confused:  

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7358