### PR TITLE
Edited Controller to Ensure Strings are Translated Correctly

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -358,10 +358,19 @@ class MiqAeCustomizationController < ApplicationController
 
   def right_cell_text_for_node(record, model_name)
     if record.try(:id)
-      _("Editing %{model} \"%{name}\"") % {:name  => record.kind_of?(CustomButtonSet) ? record.name.split("|").first : record.name,
-                                           :model => ui_lookup(:model => model_name)}
+      case model_name
+      when "CustomButton"
+        _("Editing Button \"%{name}\"") % {:name => record.name}
+      when "CustomButtonSet"
+        _("Editing Button Group \"%{name}\"") % {:name => record.name.split("|").first}
+      end
     else
-      _("Adding a new %{model}") % {:model => ui_lookup(:model => model_name)}
+      case model_name
+      when "CustomButton"
+        _("Adding a new Button")
+      when "CustomButtonSet"
+        _("Adding a new Button Group")
+      end
     end
   end
 


### PR DESCRIPTION
Found in Automation -> Automate -> Customization -> Buttons -> Add a new Button

Fixes: [#10506](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10506)

Re-writes `miq_ae_customization_controller.rb` so that title strings are translated as a single string as opposed to two strings concatenated together, fixing possible translation issues.

Preview:
<img src="https://user-images.githubusercontent.com/64800041/97714335-644bb880-1a97-11eb-9c38-afcae6aee5e4.png" width="700">
<img src="https://user-images.githubusercontent.com/64800041/97714394-7b8aa600-1a97-11eb-8ee7-d7394dd41f18.png" width="700">