### PR TITLE
Make the Settings/About focusable by setting its href to #

### DIFF
--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -21,7 +21,7 @@ export const linkProps = ({
   href: {
     big_iframe: `/dashboard/iframe?id=${id}`,
     default: href,
-    modal: undefined,
+    modal: '#',
     new_window: href,
   }[type || 'default'],
 


### PR DESCRIPTION
Links without a `href` attribute are not focusable. The only one in our menu is the `Settings -> About`, so fixing :wrench: 