### PR TITLE
Extract params from build_search_filter_from_params in schedules

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -545,9 +545,15 @@ module OpsController::Settings::Schedules
     { MiqAeEngine.create_automation_attribute_key(object).to_s => MiqAeEngine.create_automation_attribute_value(object) }
   end
 
-  def build_filter_expression_from(schedule, filter_typ, filter_value)
+  def parse_filter_value(filter_value)
     value       = filter_value.split("__").first
     other_value = filter_value.split("__").size == 1 ? "" : filter_value.split("__").last
+
+    [value, other_value]
+  end
+
+  def build_filter_expression_from(schedule, filter_typ, filter_value)
+    value, other_value = parse_filter_value(filter_value)
 
     MiqExpression.new(build_search_filter_from_params(schedule, filter_typ, value, other_value))
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -547,8 +547,9 @@ module OpsController::Settings::Schedules
   end
 
   def parse_filter_value(filter_value)
-    value       = filter_value.split("__").first
-    other_value = filter_value.split("__").size == 1 ? "" : filter_value.split("__").last
+    values      = filter_value&.split("__")
+    value       = values&.first
+    other_value = values&.size == 1 ? "" : values&.last
 
     [value, other_value]
   end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -532,7 +532,7 @@ module OpsController::Settings::Schedules
       schedule.filter     = nil # Clear out existing filter expression
       schedule.miq_search = params[:filter_value] ? MiqSearch.find(params[:filter_value]) : nil # Set up the search relationship
     else # Build the filter expression
-      schedule.filter     = MiqExpression.new(build_search_filter_from_params)
+      schedule.filter     = build_filter_expression
       schedule.miq_search = nil if schedule.miq_search # Clear out any search relationship
     end
   end
@@ -543,6 +543,10 @@ module OpsController::Settings::Schedules
     klass = params[:target_class].constantize
     object = klass.find(params[:target_id])
     { MiqAeEngine.create_automation_attribute_key(object).to_s => MiqAeEngine.create_automation_attribute_value(object) }
+  end
+
+  def build_filter_expression
+    MiqExpression.new(build_search_filter_from_params)
   end
 
   def build_search_filter_from_params

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -639,7 +639,7 @@ module OpsController::Settings::Schedules
             {"=" => {"field" => "#{resource_type}-v_owning_datacenter", "value" => other_value}}
           ]}
         end
-      when "ExtManagementSystem"  then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
+      when "ExtManagementSystem" then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
       when "Host" then {"=" => {"field" => "Host-name", "value" => value}}
       when "Vm"   then {"=" => {"field" => "Vm-name", "value" => value}}
       else             {"IS NOT NULL" => {"field" => "#{resource_type}-name"}}
@@ -653,7 +653,7 @@ module OpsController::Settings::Schedules
             {"=" => {"field" => "#{resource_type}-v_owning_datacenter", "value" => other_value}}
           ]}
         end
-      when "ExtManagementSystem"          then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
+      when "ExtManagementSystem" then {"=" => {"field" => "#{resource_type}.ext_management_system-name", "value" => value}}
       when "Host"         then {"=" => {"field" => "#{resource_type}.host-name", "value" => value}}
       when "MiqTemplate", "Vm", "ContainerImage" then {"=" => {"field" => "#{resource_type}-name", "value" => value}}
       else {"IS NOT NULL" => {"field" => "#{resource_type}-name"}}

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -533,7 +533,7 @@ module OpsController::Settings::Schedules
       schedule.miq_search = params[:filter_value] ? MiqSearch.find(params[:filter_value]) : nil # Set up the search relationship
     else # Build the filter expression
       filter_type         = convert_filter_type_to_klass(params[:filter_typ])
-      schedule.filter     = build_filter_expression_from(schedule, filter_type, *parse_filter_value(params[:filter_value]))
+      schedule.filter     = build_filter_expression(schedule, filter_type, *parse_filter_value(params[:filter_value]))
       schedule.miq_search = nil if schedule.miq_search # Clear out any search relationship
     end
   end
@@ -573,7 +573,7 @@ module OpsController::Settings::Schedules
     end
   end
 
-  def build_filter_expression_from(schedule, filter_type, value, other_value)
+  def build_filter_expression(schedule, filter_type, value, other_value)
     expression = build_search_filter_from_params(schedule, filter_type, value, other_value)
     MiqExpression.new(expression)
   end


### PR DESCRIPTION
**This is first part of issue** https://github.com/ManageIQ/manageiq/issues/20768
------
PR updates method `build_search_filter_from_params` to be more transferable to core repo.

This supports effort in order to implement [API Endpoint for Schedules](https://github.com/ManageIQ/manageiq-api/issues/893)

@miq-bot refactoring




### Links
https://github.com/ManageIQ/manageiq-api/issues/893