### PR TITLE
Modified CSS So That Text Wrapping Does Not Occur

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -310,7 +310,7 @@ table.non-breakable td:not(.table-view-pf-select) {
   word-break: unset !important;
 }
 
-table.table td:not(.table-view-pf-select) {
+table.table td:not(.table-view-pf-select):not(.generic-row-label) {
   //Force word break but prevent bs-switch from wrapping
   word-break: break-all;
 }


### PR DESCRIPTION
Found in Services -> Workloads -> VMs and Instances

Fixes: [#10465](https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/10465) (2nd issue)

Preview:
<img src="https://user-images.githubusercontent.com/64800041/97896406-03c0b380-1d03-11eb-985e-945a43fef809.png" width="400">
<img src="https://user-images.githubusercontent.com/64800041/97896452-15a25680-1d03-11eb-96cf-1645f7d4d259.png" width="800">