### PR TITLE
Add Provider column for Configured Systems

### DIFF
--- a/product/views/ConfiguredSystem.yaml
+++ b/product/views/ConfiguredSystem.yaml
@@ -28,10 +28,14 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  manager:
+    columns:
+    - name
 
 # Order of columns (from all tables)
 col_order:
 - hostname
+- manager.name
 - type
 - last_checkin
 - build_state
@@ -42,6 +46,7 @@ col_order:
 # Column titles, in order
 headers:
 - Hostname
+- Provider
 - Type
 - Last Checkin
 - Build State


### PR DESCRIPTION
This enhancement adds a Provider column to the Configured Systems page.

<img width="1877" alt="Configured_Systems_Add_Provider_Columns" src="https://user-images.githubusercontent.com/41962815/97920107-f5848e80-1d26-11eb-9d9d-d557517ff58a.png">
