### PR TITLE
Created a helper method to build API URLs from AR classes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,23 @@ module ApplicationHelper
     url_for(:only_path => true, **args)
   end
 
+  def api_collection_path(klass)
+    identifier = api_identifier_by_class(klass)
+    send("api_#{identifier}_path")
+  end
+
+  def api_resource_path(record)
+    identifier = api_identifier_by_class(record.class).to_s.singularize
+    send("api_#{identifier}_path", nil, record.id)
+  end
+
+  def api_identifier_by_class(klass)
+    raise "API plugin not loaded" unless defined?(Api::ApiConfig)
+
+    @api_cc ||= Api::CollectionConfig.new
+    @api_cc.name_for_klass(klass) || @api_cc.name_for_subclass(klass)
+  end
+
   def settings(*path)
     @settings ||= {}
     @settings.fetch_path(*path)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -198,6 +198,38 @@ describe ApplicationHelper do
     end
   end
 
+  describe '#api_collection_path' do
+    {
+      Vm                 => 'vms',
+      VmInfra            => 'vms',
+      VmCloud            => 'instances',
+      Service            => 'services',
+      OrchestrationStack => 'orchestration_stacks',
+    }.each do |klass, path|
+      context "collection is #{klass}" do
+        it 'returns with a valid API endpoint' do
+          expect(helper.api_collection_path(klass)).to eq("/api/#{path}")
+        end
+      end
+    end
+  end
+
+  describe '#api_resource_path' do
+    {
+      :vm_infra                  => 'vms',
+      :vm_cloud                  => 'instances',
+      :service                   => 'services',
+      :orchestration_stack_cloud => 'orchestration_stacks',
+    }.each do |factory, path|
+      context "resource is #{factory}" do
+        it 'returns with a valida API endpoint' do
+          record = FactoryBot.create(factory)
+          expect(helper.api_resource_path(record)).to eq("/api/#{path}/#{record.id}")
+        end
+      end
+    end
+  end
+
   describe "#url_for_db" do
     before do
       @action = 'show'


### PR DESCRIPTION
This new method can build the URL of an API endpoint based on an ActiveRecord model class. It will be useful when determining the target URL for the retirement form submission.