### PR TITLE
Set the global Carbon theme to g10 and set g90 for the menu only

### DIFF
--- a/app/stylesheet/carbon.scss
+++ b/app/stylesheet/carbon.scss
@@ -14,7 +14,7 @@ $css--default-type: false;
 
 // Use the gray 90 theme
 @import '~@carbon/themes/scss/themes';
-$carbon--theme: $carbon--theme--g90;
+$carbon--theme: $carbon--theme--g10;
 @include carbon--theme();
 
 @import '~carbon-components/scss/globals/scss/styles.scss';

--- a/app/stylesheet/menu-colors.scss
+++ b/app/stylesheet/menu-colors.scss
@@ -11,9 +11,10 @@ $user-fg: $text-05; // $carbon--gray-50
 
 $divider-fg: $disabled-02; // $carbon--gray-60;
 
+$find-bg: $carbon--gray-80;
+$find-placeholder-fg: $carbon--gray-50;
+
 // unused, theme default
-// $find-placeholder-fg: $carbon--gray-50;
-// $find-bg: $carbon--gray-80;
 // $row-selected-border: $carbon--blue-60;
 
 
@@ -62,4 +63,19 @@ li.menu-group {
 
 .menu-user {
   color: $user-fg;
+}
+
+.menu-search {
+  .bx--search-input {
+    background-color: $find-bg;
+    color: $row-fg-text;
+  }
+
+  .bx--search-close::before {
+    background-color: $find-bg;
+  }
+
+  .bx--label {
+    color: $find-placeholder-fg;
+  }
 }

--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -1,5 +1,13 @@
 #main-menu {
+  @import '~@carbon/themes/scss/themes';
+  $carbon--theme: $carbon--theme--g90;
+  @include carbon--theme();
+
   @import './menu-colors.scss';
+
+  *:focus {
+    outline-color: $focus;
+  }
 
   list-style: none;
 


### PR DESCRIPTION
We need the `g10` theme to have our forms look as they should, but for the menu we need to keep the g90 theme. The searchbar in the menu now became brighter and the focus color became blue, not sure if these can or should be fixed though.

**EDIT: fixed, it should be identical now**

**Before:**
![Screenshot from 2020-11-04 12-07-59](https://user-images.githubusercontent.com/649130/98104286-8332bc00-1e96-11eb-8b57-2c930e50ac6d.png)

**After:**
![Screenshot from 2020-11-04 12-07-44](https://user-images.githubusercontent.com/649130/98104292-86c64300-1e96-11eb-8733-a7136b383bf9.png)