### PR TITLE
Fix missed icons in configuration systems table summary

### DIFF
--- a/app/helpers/configuration_profile_helper/textual_summary.rb
+++ b/app/helpers/configuration_profile_helper/textual_summary.rb
@@ -50,9 +50,14 @@ module ConfigurationProfileHelper::TextualSummary
        configured_systems]
   end
 
+  def textual_object_icon(klass)
+    decorated = klass.decorate
+    {:icon => decorated.try(:fonticon), :image => decorated.try(:fileicon)}
+  end
+
   def textual_configuration_manager
     configuration_manager = @record.configuration_manager
-    h = {:label => "Configuration Manager", :icon => "pficon pficon-configuration_manager", :value => (configuration_manager.nil? ? _("None") : configuration_manager.name)}
+    h = {:label => "Configuration Manager", :value => (configuration_manager.nil? ? _("None") : configuration_manager.name)}.merge(textual_object_icon(configuration_manager))
     if configuration_manager && role_allows?(:feature => "ems_configuration_show")
       h[:title] = _("Show this Configuration Profile's Configuration Manager")
       h[:link]  = url_for_only_path(:controller => 'ems_configuration', :action => 'show', :id => configuration_manager)
@@ -62,7 +67,7 @@ module ConfigurationProfileHelper::TextualSummary
 
   def textual_configured_systems
     num   = @record.number_of(:configured_systems)
-    h     = {:label => _('Configured Systems'), :icon => "pficon pficon-configured_system", :value => num}
+    h     = {:label => _('Configured Systems'), :value => num}.merge(textual_object_icon(ConfiguredSystem))
     if num.positive? && role_allows?(:feature => "configured_system_show_list")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'configured_systems')
       h[:title] = _("Show all Configured Systems")

--- a/app/helpers/configured_system_helper/textual_summary.rb
+++ b/app/helpers/configured_system_helper/textual_summary.rb
@@ -45,9 +45,14 @@ module ConfiguredSystemHelper::TextualSummary
     )
   end
 
+  def textual_object_icon(klass)
+    decorated = klass.decorate
+    {:icon => decorated.try(:fonticon), :image => decorated.try(:fileicon)}
+  end
+
   def textual_configuration_manager
     configuration_manager = @record.configuration_manager
-    h = {:label => "Configuration Manager", :icon => "pficon pficon-configuration_manager", :value => (configuration_manager.nil? ? _("None") : configuration_manager.name)}
+    h = {:label => "Configuration Manager", :value => (configuration_manager.nil? ? _("None") : configuration_manager.name)}.merge(textual_object_icon(configuration_manager))
     if configuration_manager && role_allows?(:feature => "ems_configuration_show")
       h[:title] = _("Show this Configured System's Configuration Manager")
       h[:link]  = url_for_only_path(:controller => 'ems_configuration', :action => 'show', :id => configuration_manager)
@@ -57,7 +62,7 @@ module ConfiguredSystemHelper::TextualSummary
 
   def textual_configuration_profile
     configuration_profile = @record.configuration_profile
-    h = {:label => "Configuration Profile", :icon => "pficon pficon-configuration_profile", :value => (configuration_profile.nil? ? _("None") : configuration_profile.name)}
+    h = {:label => "Configuration Profile", :value => (configuration_profile.nil? ? _("None") : configuration_profile.name)}.merge(textual_object_icon(configuration_profile))
     if configuration_profile && role_allows?(:feature => "configuration_profile_show")
       h[:title] = _("Show this Configured System's Configuration Profile")
       h[:link]  = url_for_only_path(:controller => 'configuration_profile', :action => 'show', :id => configuration_profile)

--- a/app/helpers/ems_configuration_helper/textual_summary.rb
+++ b/app/helpers/ems_configuration_helper/textual_summary.rb
@@ -45,9 +45,14 @@ module EmsConfigurationHelper::TextualSummary
     %i[configuration_profiles configured_systems]
   end
 
+  def textual_object_icon(klass)
+    decorated = klass.decorate
+    {:icon => decorated.try(:fonticon), :image => decorated.try(:fileicon)}
+  end
+
   def textual_configuration_profiles
     num   = @record.number_of(:configuration_profiles)
-    h     = {:label => _('Configuration Profiles'), :icon => "pficon pficon-configuration_profile", :value => num}
+    h     = {:label => _('Configuration Profiles'), :value => num}.merge(textual_object_icon(ConfigurationProfile))
     if num.positive? && role_allows?(:feature => "configuration_profile_show_list")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'configuration_profiles')
       h[:title] = _("Show all Configuration Profiles")
@@ -57,7 +62,7 @@ module EmsConfigurationHelper::TextualSummary
 
   def textual_configured_systems
     num   = @record.number_of(:configured_systems)
-    h     = {:label => _('Configured Systems'), :icon => "pficon pficon-configured_system", :value => num}
+    h     = {:label => _('Configured Systems'), :value => num}.merge(textual_object_icon(ConfiguredSystem))
     if num.positive? && role_allows?(:feature => "configured_system_show_list")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'configured_systems')
       h[:title] = _("Show all Configured Systems")


### PR DESCRIPTION
Icons are missing Configuration profiles, Configured systems, Configuration --> Provider table summaries, Missed icons causing text alignment left.

Before:
<img width="1027" alt="Screen Shot 2020-11-04 at 3 32 35 PM" src="https://user-images.githubusercontent.com/37085529/98165002-2265ac80-1eb3-11eb-8d03-f91c12d784c3.png">

After:
<img width="1078" alt="Screen Shot 2020-11-04 at 3 34 17 PM" src="https://user-images.githubusercontent.com/37085529/98165134-5a6cef80-1eb3-11eb-9bff-5fb94bea3867.png">

@miq-bot add_reviewer @h-kataria 

