### PR TITLE
Modified custom report layout to fit full string in Korean

### DIFF
--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -35,7 +35,7 @@
 
 .form-horizontal
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-lg-3.col-md-4
       = _('Available Custom Reports:')
     .col-md-8
       = select_tag('choices_chosen',


### PR DESCRIPTION
Issue: 'Available Custom Reports' string should be in single line in KOR

Steps for Testing/QA
-------------------------------
1. Click Overview -> Reports
2. Click Import / Export -> Custom Reports

Original Issue
------------------
'Available Custom Reports' string shows in 2 lines in KOR
![prob](https://user-images.githubusercontent.com/71033910/98389208-20722980-202a-11eb-8d2f-99b1872429cb.png)

Result
-----------------------
'Available Custom Reports' string displayes in single line in KOR
<img width="316" alt="Screen Shot 2020-11-06 at 12 16 25 PM" src="https://user-images.githubusercontent.com/71033910/98389045-e7d25000-2029-11eb-9b53-221c90490963.png">