### PR TITLE
Fix physical storage toolbar to work also from block storage dashboard

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -232,6 +232,7 @@ module Mixins
                                        "network_service_",
                                        "network_service_entry_",
                                        "orchestration_stack_",
+                                       "physical_storage_",
                                        "security_group_",
                                        "security_service_",
                                        "security_service_rule_",

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -24,7 +24,6 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             'pficon pficon-add-circle-o fa-lg',
             t = N_('Attach a new storage system'),
             t,
-            :url => "/new"
           ),
         ]
       ),

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -386,7 +386,7 @@ class ApplicationHelper::ToolbarChooser
     to_display = %w[availability_zones cloud_networks cloud_object_store_containers cloud_subnets configured_systems
                     cloud_tenants cloud_volumes ems_clusters flavors floating_ips host_aggregates hosts
                     network_ports network_routers network_services orchestration_stacks resource_pools
-                    security_groups security_policies security_policy_rules storages]
+                    security_groups security_policies security_policy_rules storages physical_storages]
     to_display_center = %w[stack_orchestration_template topology cloud_object_store_objects generic_objects physical_servers guest_devices]
     performance_layouts = %w[vm host ems_container]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1338,6 +1338,7 @@ Rails.application.routes.draw do
         new
       ],
       :post => %w[
+        button
         listnav_search_selected
         quick_search
         show_list


### PR DESCRIPTION
The toolbar is not visible if we enter physical storages page from within block storage dashboard.

before fix:
<img width="638" alt="5" src="https://user-images.githubusercontent.com/53213107/98459277-20953500-21a2-11eb-9888-897345a3b7eb.png">

after fix:
<img width="612" alt="6" src="https://user-images.githubusercontent.com/53213107/98459281-24c15280-21a2-11eb-8cc1-fbff8f95e0a7.png">

