### PR TITLE
Fix physical storage typo in storage manager summary page

### DIFF
--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -90,8 +90,4 @@ module EmsStorageHelper::TextualSummary
   def textual_physical_storages
     textual_link(@record.try(:physical_storages), :label => _('Physical Storages'))
   end
-
-  def textual_physical_storages
-    textual_link(@record.try(:physical_storages), :label => _('Storage Systems'))
-  end
 end


### PR DESCRIPTION
In block storage manager summary page storage systems need to be replaced with physical storages. The reason for the wrong label is duplicate function (textual_physical_storages) inside ems_storage textual_summary page.  

before fix:
<img width="442" alt="3" src="https://user-images.githubusercontent.com/53213107/98459011-060d8c80-219f-11eb-82ec-5eeaa52cdd8c.png">

after fix:
<img width="493" alt="4" src="https://user-images.githubusercontent.com/53213107/98459018-0c036d80-219f-11eb-842c-906b1694f24c.png">
