### PR TITLE
Fix css for links in table summary page

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -719,3 +719,7 @@ table.c3-tooltip td {
 #popover {
   z-index: 9999;
 }
+
+.table-summary-screen > tbody > tr:hover > td, .table-summary-screen > tbody > tr:hover > th {
+  background-color: transparent;
+}


### PR DESCRIPTION
this is for https://github.com/ManageIQ/react-ui-components/pull/184, in this pr removing hover color for clickable rows.

Before:
<img width="1424" alt="Screen Shot 2020-11-09 at 8 51 00 AM" src="https://user-images.githubusercontent.com/37085529/98549407-bc897400-2268-11eb-9142-17738ac7926d.png">
 
After:
links are in different color and accessible with keyboard.
<img width="1417" alt="Screen Shot 2020-11-09 at 8 52 28 AM" src="https://user-images.githubusercontent.com/37085529/98549569-fa869800-2268-11eb-9eeb-38739b28fa3e.png">

<img width="1418" alt="Screen Shot 2020-11-09 at 8 52 42 AM" src="https://user-images.githubusercontent.com/37085529/98549589-01150f80-2269-11eb-8ca8-410175bebf48.png">
@miq-bot add_reviewer @skateman , @h-kataria 