### PR TITLE
Added form-control class to fix truncation

### DIFF
--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -43,7 +43,7 @@
             = select_tag('chosen_queue_timeout',
               options_for_select(opts, @edit[:new][:queue_timeout]),
               :multiple              => false,
-              :class                 => "selectpicker",
+              :class                 => "selectpicker form-control",
               "data-miq_sparkle_on"  => true,
               "data-miq_sparkle_off" => true)
             :javascript


### PR DESCRIPTION
Issue: Truncation occurs in Overview -> Reports -> Reports -> Configuration -> Add a new report

Steps for Testing/QA
-------------------------------
1. Click Overview -> Reports
2. Click Reports
3. Click Configuration Management -> Virtual Machines -> Account Groups - Linux
4. Click Configuration
5. Click Add a new report

Original Issue
------------------
Truncation occurs
![truncate](https://user-images.githubusercontent.com/71033910/98568499-88717b80-2287-11eb-9b88-4dbffc8da1c9.png)


Result
-----------------------
No truncation occurs
<img width="507" alt="Screen Shot 2020-11-09 at 12 20 50 PM" src="https://user-images.githubusercontent.com/71033910/98568342-5d872780-2287-11eb-98cf-8a45d7b936a4.png">
