### PR TITLE
Move the common onReset attribute from all DDF forms to the parent

### DIFF
--- a/app/javascript/components/ansible-credentials-form/index.jsx
+++ b/app/javascript/components/ansible-credentials-form/index.jsx
@@ -77,7 +77,6 @@ const AnsibleCredentialsForm = ({ recordId }) => {
       initialValues={initialValues}
       canReset={!!recordId}
       onSubmit={onSubmit}
-      onReset={() => add_flash(__('All changes have been reset'), 'warn')}
       onCancel={onCancel}
       buttonsLabels={{ submitLabel }}
     />

--- a/app/javascript/components/catalog-form/catalog-form.jsx
+++ b/app/javascript/components/catalog-form/catalog-form.jsx
@@ -121,7 +121,6 @@ class CatalogForm extends Component {
           schema={schema}
           onSubmit={this.submitValues}
           onCancel={() => miqAjaxButton(cancelUrl)}
-          onReset={() => add_flash(__('All changes have been reset'), 'warn')}
           canReset={!!catalogId}
           buttonsLabels={{
             submitLabel: catalogId ? __('Save') : __('Add'),

--- a/app/javascript/components/cloud-network-form/cloud-network-form.jsx
+++ b/app/javascript/components/cloud-network-form/cloud-network-form.jsx
@@ -80,7 +80,6 @@ class CloudNetworkForm extends Component {
           schema={createSchema(ems, cloudNetworkId)}
           onSubmit={this.saveClicked}
           onCancel={this.cancelClicked}
-          onReset={() => add_flash(__('All changes have been reset'), 'warn')}
           canReset={!!cloudNetworkId}
           buttonsLabels={{
             submitLabel: cloudNetworkId ? __('Save') : __('Add'),

--- a/app/javascript/components/cloud-tenant-form/cloud-tenant-form.jsx
+++ b/app/javascript/components/cloud-tenant-form/cloud-tenant-form.jsx
@@ -35,7 +35,6 @@ class CloudTenantForm extends Component {
           schema={this.state.schema}
           onSubmit={values => miqAjaxButton(submitUrl, values, { complete: false })}
           onCancel={() => miqAjaxButton(cancelUrl)}
-          onReset={() => add_flash(__('All changes have been reset'), 'warn')}
           canReset={!!cloudTenantFormId}
           buttonsLabels={{
             submitLabel: cloudTenantFormId ? __('Save') : __('Add'),

--- a/app/javascript/components/copy-dashboard-form/copy-dashboard-form.jsx
+++ b/app/javascript/components/copy-dashboard-form/copy-dashboard-form.jsx
@@ -62,7 +62,6 @@ const CopyDashboardForm = ({ dashboardId }) => {
         schema={schema}
         onSubmit={submitValues}
         onCancel={cancelClicked}
-        onReset={() => add_flash(__('All changes have been reset'), 'warn')}
         canReset
         buttonsLabels={{
           submitLabel: __('Save'),

--- a/app/javascript/components/edit-service-form/index.jsx
+++ b/app/javascript/components/edit-service-form/index.jsx
@@ -27,7 +27,6 @@ const EditServiceForm = ({ maxNameLen, maxDescLen, recordId }) => {
         schema={createSchema(maxNameLen, maxDescLen)}
         onSubmit={onSubmit}
         onCancel={() => miqAjaxButton(`/service/service_edit/${recordId}?button=cancel`)}
-        onReset={() => add_flash(__('All changes have been reset'), 'warn')}
         canReset
         buttonsLabels={{
           submitLabel: __('Save'),

--- a/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
+++ b/app/javascript/components/ops-tenant-form/ops-tenant-form.jsx
@@ -83,7 +83,6 @@ const OpsTenantForm = ({
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         canReset={!!recordId}
-        onReset={() => add_flash(__('All changes have been reset'), 'warning')}
         buttonsLabels={{
           submitLabel: !!recordId ? __('Save') : __('Add'),
         }}

--- a/app/javascript/components/orchestration-template/orcherstration-template-form.js
+++ b/app/javascript/components/orchestration-template/orcherstration-template-form.js
@@ -70,7 +70,6 @@ const OrcherstrationTemplateForm = ({ otId, copy }) => {
         initialValues={initialValues}
         onCancel={() => miqRedirectBack(cancelMessage, 'success', '/catalog/explorer')}
         canReset={!!otId && !copy}
-        onReset={() => add_flash(__('All changes have been reset'), 'warning')}
         buttonsLabels={{
           submitLabel: otId && !copy ? __('Save') : __('Add'),
         }}

--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -173,7 +173,6 @@ const ProviderForm = ({ providerId, kind, title, redirect }) => {
             schema={{ fields }}
             onSubmit={onSubmit}
             onCancel={onCancel}
-            onReset={() => add_flash(__('All changes have been reset'), 'warn')}
             initialValues={initialValues}
             clearedValue={null}
             buttonsLabels={{ submitLabel }}

--- a/app/javascript/components/region-form/index.jsx
+++ b/app/javascript/components/region-form/index.jsx
@@ -48,7 +48,6 @@ const RegionForm = ({ id, maxDescLen }) => {
         schema={createSchema(maxDescLen)}
         onSubmit={onSubmit}
         onCancel={onCancel}
-        onReset={() => add_flash(__('All changes have been reset'), 'warn')}
         canReset
         buttonsLabels={{
           submitLabel: __('Save'),

--- a/app/javascript/components/set-ownership-form/index.jsx
+++ b/app/javascript/components/set-ownership-form/index.jsx
@@ -114,7 +114,6 @@ function SetOwnershipForm(props) {
         initialValues={initialValues}
         schema={createSchema(userOptions, groupOptions)}
         onSubmit={values => handleSubmit(values, submitUrl)}
-        onReset={() => add_flash(__('All changes have been reset'), 'warn')}
         onCancel={() => miqAjaxButton(cancelUrl)}
         canReset
       />

--- a/app/javascript/components/vm-server-relationship-form/index.jsx
+++ b/app/javascript/components/vm-server-relationship-form/index.jsx
@@ -42,7 +42,6 @@ const VmServerRelationShipForm = ({ recordId, redirect }) => {
         initialValues={initialValues}
         schema={createSchema(promise)}
         onSubmit={onSubmit}
-        onReset={() => add_flash(__('All changes have been reset'), 'warn')}
         onCancel={onCancel}
         canReset
         buttonsLabels={{

--- a/app/javascript/forms/data-driven-form.jsx
+++ b/app/javascript/forms/data-driven-form.jsx
@@ -76,6 +76,7 @@ const MiqFormRenderer = ({
       FormTemplate={MiqFormTemplate}
       schema={{ fields: [...fields, { component: 'spy-field', name: 'spy-field', initialize }], ...schema }}
       onSubmit={submitWrapper(onSubmit)}
+      onReset={() => add_flash(__('All changes have been reset'), 'warn')}
       {...props}
     />
   );

--- a/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
+++ b/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
@@ -33,7 +33,6 @@ exports[`Ansible Credential Form Component should render adding a new credential
         }
       }
       onCancel={[Function]}
-      onReset={[Function]}
       onSubmit={[Function]}
       schema={
         Object {
@@ -128,7 +127,6 @@ exports[`Ansible Credential Form Component should render adding a new credential
           }
         }
         onCancel={[Function]}
-        onReset={[Function]}
         onSubmit={[Function]}
         schema={
           Object {
@@ -2584,7 +2582,6 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
         }
       }
       onCancel={[Function]}
-      onReset={[Function]}
       onSubmit={[Function]}
       schema={
         Object {
@@ -2686,7 +2683,6 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
           }
         }
         onCancel={[Function]}
-        onReset={[Function]}
         onSubmit={[Function]}
         schema={
           Object {

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -12,7 +12,6 @@ exports[`Catalog form component should render add variant form 1`] = `
     }
     canReset={false}
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {
@@ -104,7 +103,6 @@ exports[`Catalog form component should render edit variant form 1`] = `
       }
     }
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {

--- a/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
+++ b/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
@@ -44,7 +44,6 @@ exports[`Cloud Network form component should render edit variant 1`] = `
       }
     }
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {
@@ -349,7 +348,6 @@ exports[`Cloud Network form component should render form 1`] = `
       }
     }
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {

--- a/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
+++ b/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
@@ -17,7 +17,6 @@ exports[`Cloud tenant form component should render adding form variant 1`] = `
     }
     canReset={false}
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {
@@ -91,7 +90,6 @@ exports[`Cloud tenant form component should render editing form variant 1`] = `
     }
     canReset={true}
     onCancel={[Function]}
-    onReset={[Function]}
     onSubmit={[Function]}
     schema={
       Object {

--- a/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
+++ b/app/javascript/spec/ops-tenant-form/ops-tenant-form.spec.js
@@ -153,7 +153,7 @@ describe('OpstTenantForm', () => {
     wrapper.find('input').first().simulate('change', { target: { value: 'bar' } });
     wrapper.update();
     wrapper.find('button').at(1).simulate('click');
-    expect(flashSpy).toHaveBeenCalledWith('All changes have been reset', 'warning');
+    expect(flashSpy).toHaveBeenCalledWith('All changes have been reset', 'warn');
     done();
   });
 


### PR DESCRIPTION
The same exact `onReset` is being specified for each DDF instance and they're not doing anything without the `canReset` prop being set to `true`. So it is safe to move all of them to a common location...

![duplicate](https://user-images.githubusercontent.com/649130/98778476-b45d4000-23f2-11eb-8177-8d71e2a97933.gif)


