### PR TITLE
Converted the Advanced Settings form into DDF/React

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -498,11 +498,10 @@ class OpsController < ApplicationController
       elsif @sb[:active_tab] == "settings_tags" && @sb[:active_subtab] == "settings_label_tag_mapping" && @in_a_form
         action_url = "label_tag_mapping_edit"
         record_id = @lt_map.try(:id)
-      else
+      elsif @sb[:active_tab] != "settings_advanced"
         action_url = "settings_update"
         record_id = @sb[:active_tab].split("settings_").last
         locals[:no_cancel] = true
-        locals[:serialize] = true if @sb[:active_tab] == "settings_advanced"
       end
     elsif x_active_tree == :rbac_tree
       if %w[rbac_user_add rbac_user_copy rbac_user_edit].include?(@sb[:action])

--- a/app/javascript/components/advanced-settings-form/advanced-settings-form.schema.js
+++ b/app/javascript/components/advanced-settings-form/advanced-settings-form.schema.js
@@ -1,0 +1,28 @@
+import { validatorTypes } from '@@ddf';
+import YAML from 'yaml';
+
+const createSchema = () => ({
+  fields: [
+    {
+      component: 'code-editor',
+      id: 'settings',
+      name: 'settings',
+      mode: 'yaml',
+      label: '',
+      hideLabel: true,
+      validate: [
+        { type: validatorTypes.REQUIRED },
+        (value) => {
+          try {
+            YAML.parse(value);
+          } catch (err) {
+            return err.message;
+          }
+          return undefined;
+        },
+      ],
+    },
+  ],
+});
+
+export default createSchema;

--- a/app/javascript/components/advanced-settings-form/index.jsx
+++ b/app/javascript/components/advanced-settings-form/index.jsx
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import YAML from 'yaml';
+
+import MiqFormRenderer from '@@ddf';
+import createSchema from './advanced-settings-form.schema';
+
+const AdvancedSettingsForm = ({ url }) => {
+  const [{ isLoading, initialValues }, setState] = useState({ isLoading: true });
+
+  useEffect(() => {
+    API.get(url).then((settings) => setState({
+      initialValues: { // It is coming in as JSON but we need YAML
+        settings: YAML.stringify(settings),
+      },
+      isLoading: false,
+    }));
+  }, [url]);
+
+  const onSubmit = ({ settings }) => {
+    miqSparkleOn();
+    // The API expects us to send a JSON
+    API.patch(url, YAML.parse(settings)).then(() => {
+      add_flash(__('Configuration changes saved'), 'success');
+      // Scroll to the top of the page to see the flash message
+      document.querySelector('#flash_msg_div').scrollIntoView(false);
+      miqSparkleOff();
+    }).catch(miqSparkleOff);
+  };
+
+  return !isLoading && (
+    <>
+      <div />
+      <MiqFormRenderer
+        schema={createSchema()}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        canReset
+      />
+    </>
+  );
+};
+
+AdvancedSettingsForm.propTypes = {
+  url: PropTypes.string.isRequired,
+};
+
+export default AdvancedSettingsForm;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { TagGroup, TableListView, GenericGroup } from '@manageiq/react-ui-components/dist/textual_summary';
 import { Toolbar } from '@manageiq/react-ui-components/dist/toolbar';
 
+import AdvancedSettingsForm from '../components/advanced-settings-form';
 import AggregateStatusCard from '../components/aggregate_status_card';
 import AnsibleCredentialsForm from '../components/ansible-credentials-form';
 import { BreadcrumbsBar } from '../components/breadcrumbs';
@@ -52,6 +53,7 @@ import PhysicalStorageForm from '../components/physical-storage-form';
 * ManageIQ.component.addReact('ComponentName', props => <ComponentName {...props} />);
 */
 
+ManageIQ.component.addReact('AdvancedSettingsForm', AdvancedSettingsForm);
 ManageIQ.component.addReact('AggregateStatusCard', AggregateStatusCard);
 ManageIQ.component.addReact('AnsibleCredentialsForm', AnsibleCredentialsForm);
 ManageIQ.component.addReact('BreadcrumbsBar', BreadcrumbsBar);

--- a/app/javascript/spec/advanced-settings-form/__snapshots__/advanced-settings-form.spec.js.snap
+++ b/app/javascript/spec/advanced-settings-form/__snapshots__/advanced-settings-form.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdvancedSettingsForm component matches the snapshot 1`] = `""`;

--- a/app/javascript/spec/advanced-settings-form/advanced-settings-form.spec.js
+++ b/app/javascript/spec/advanced-settings-form/advanced-settings-form.spec.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+import AdvancedSettingsForm from '../../components/advanced-settings-form';
+import { mount } from '../helpers/mountForm';
+
+describe('AdvancedSettingsForm component', () => {
+  const url = '/api/foo';
+
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('matches the snapshot', async(done) => {
+    let wrapper;
+    await act(async() => {
+      wrapper = shallow(<AdvancedSettingsForm url={url} />);
+    });
+
+    wrapper.update();
+    expect(toJson(wrapper)).toMatchSnapshot();
+
+    done();
+  });
+
+  it('loads the data via the API', async(done) => {
+    fetchMock.get(url, { foo: 'bar' });
+
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<AdvancedSettingsForm url={url} />);
+    });
+
+    wrapper.update();
+    expect(fetchMock.called(url)).toBe(true);
+
+    done();
+  });
+});

--- a/app/views/ops/_settings_advanced_tab.html.haml
+++ b/app/views/ops/_settings_advanced_tab.html.haml
@@ -1,5 +1,4 @@
 - if @sb[:active_tab] == "settings_advanced"
-  - url = url_for_only_path(:action => 'settings_form_field_changed', :id => @sb[:active_tab].split('_').last)
   #form_div
     .alert.alert-warning
       %span.pficon.pficon-warning-triangle-o
@@ -9,12 +8,4 @@
       %span.pficon.pficon-info
       %strong
         = advanced_tab_info
-
-    = text_area_tag("file_data", @edit[:new][:file_data], :style => "display:none;")
-    = render :partial => "/layouts/my_code_mirror",
-             :locals  => {:text_area_id => "file_data",
-                          :mode         => "yaml",
-                          :line_numbers => true,
-                          :url          => url}
-    :javascript
-      ManageIQ.editor.refresh();
+  = react 'AdvancedSettingsForm', :url => api_resource_path(@record + '/settings')

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "table-resolver": "^4.1.1",
     "ui-select": "0.19.8",
     "whatwg-fetch": "~2.0.4",
-    "xml_display": "~0.1.1"
+    "xml_display": "~0.1.1",
+    "yaml": "^1.10.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -205,6 +205,9 @@ describe ApplicationHelper do
       VmCloud            => 'instances',
       Service            => 'services',
       OrchestrationStack => 'orchestration_stacks',
+      MiqServer          => 'servers',
+      Zone               => 'zones',
+      MiqRegion          => 'regions',
     }.each do |klass, path|
       context "collection is #{klass}" do
         it 'returns with a valid API endpoint' do
@@ -220,6 +223,9 @@ describe ApplicationHelper do
       :vm_cloud                  => 'instances',
       :service                   => 'services',
       :orchestration_stack_cloud => 'orchestration_stacks',
+      :miq_server                => 'servers',
+      :zone                      => 'zones',
+      :miq_region                => 'regions',
     }.each do |factory, path|
       context "resource is #{factory}" do
         it 'returns with a valida API endpoint' do


### PR DESCRIPTION
The form is available in the Application Settings on the `Advanced` tab under the Region, any Zone or Server. As the form is the same on each of these pages, but the API endpoint is different, I am utilizing the [`api_resource_path`](https://github.com/ManageIQ/manageiq-ui-classic/pull/7477) helper method to generate the API endpoint from the current `@record`.

The API is providing the data as JSON, so I had to pull in the YAML package to convert between these two formats. The conversion seems working, I tried to edit stuff on various places, but it would need a little bit more testing from others.

Visually there are a few changes:
* form buttons are completely on the bottom, you need to scroll down to see them (as in any other DDF form)
* the bottom bar for the fixed buttons is still visible with a 3px height (but barely visible)
* there is no redirect on the page, so the scrolling to the flash message is done explicitly

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6943
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7395