### PR TITLE
menu - ensure secondary menu has a 100% viewport heigh, so that the scrollbar appears when needed

### DIFF
--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -25,6 +25,11 @@
     .bx--side-nav__link-text {
       font-weight: 400;
     }
+
+    // ensure secondary overflow auto has the right height to work with
+    .bx--side-nav__items {
+      height: 100vh;
+    }
   }
 
   .bx--side-nav__header.padded,


### PR DESCRIPTION
Secondary menu does not display the scrollbar when there are too many items.
This fixes it by ensuring the height is 100% viewport height.

Before:

![bad](https://user-images.githubusercontent.com/289743/98832907-5140cd00-2435-11eb-8383-4ff6fe9e4f49.png)

After:

![good](https://user-images.githubusercontent.com/289743/98832930-57cf4480-2435-11eb-8ef4-083e9dabad6d.png)


(https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/15073)