### PR TITLE
[rails6][catalog_controller_spec.rb] Fix ems let

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -734,7 +734,7 @@ describe CatalogController do
       let(:repository) { FactoryBot.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
       let(:inventory_root_group) { FactoryBot.create(:inventory_root_group) }
       let(:ems) do
-        FactoryBot.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group], :provider => FactoryBot.create(:provider_embedded_ansible))
+        FactoryBot.create(:embedded_automation_manager_ansible, :inventory_root_groups => [inventory_root_group])
       end
       let(:dialog) { FactoryBot.create(:dialog) }
       let(:playbook) do


### PR DESCRIPTION
Similar to what was done in ManageIQ/manageiq@79c28269 which was that instead of trying to assign the provider prior to making the EMS in the factories, default a provider object type as part of the `ext_management_system` child definition, and reference it in the `let(:provider)`.

This is not a problem in Rails 5.2, but does lead to the following error in Rails 6.0

```
1) CatalogController tests that needs all rbac features access #fetch_playbook_details returns playbook service template details for provision & retirement tabs for summary screen
   Failure/Error: FactoryBot.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group], :provider => FactoryBot.create(:provider_embedded_ansible))

   ActiveRecord::HasManyThroughCantAssociateThroughHasOneOrManyReflection:
     Cannot modify association 'ManageIQ::Providers::EmbeddedAnsible::Provider#endpoints' because the source reflection class 'Endpoint' is associated to 'ExtManagementSystem' via :has_many.

   # ./spec/manageiq/spec/support/missing_factory_helper.rb:10:in `create'
   # ./spec/controllers/catalog_controller_spec.rb:737:in `block (4 levels) in <top (required)>'
   # ./spec/controllers/catalog_controller_spec.rb:734:in `block (4 levels) in <top (required)>'
   # ./spec/controllers/catalog_controller_spec.rb:757:in `block (4 levels) in <top (required)>'
   # /Users/nicklamuro/.gem/ruby/2.6.6/gems/webmock-3.9.5/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

Most likely do to a fix that I was unable to track down, but the
following `git log command` is most likely to contain some of the
commits with the fix:

```console
$ git log --oneline -E --grep "has.*many.*through" 5-2-stable..6-0-stable
```


Links
-----

* Part of the Rails 6 Upgrade: ManageIQ/manageiq#19977
* Similar fix done in `ManageIQ/manageiq` `master`: https://github.com/ManageIQ/manageiq/pull/20787