### PR TITLE
Don't apply gettext to title instance variable

### DIFF
--- a/app/views/layouts/_tabs.html.haml
+++ b/app/views/layouts/_tabs.html.haml
@@ -62,4 +62,4 @@
             = safe_right_cell_text
       - else
         %h1
-          = _(@title)
+          = @title


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq-ui-classic/pull/7035 we applied gettext to `@title`, though this is not correct, becase the content of the variable should already be translated. If it is not, the problem lies elsewhere, most likely `locale/en.yml` needs a proper entry for given table or model.