### PR TITLE
Correctly switch locale in My Setting

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -138,9 +138,6 @@ class ConfigurationController < ApplicationController
       get_form_vars if @tabform != "ui_3"
       case @tabform
       when "ui_1" # Visual tab
-        if @settings[:display][:locale] != @edit[:new][:display][:locale]
-          FastGettext.locale = @edit[:new][:display][:locale]
-        end
         @settings.merge!(@edit[:new]) # Apply the new saved settings
 
         if current_user
@@ -148,6 +145,7 @@ class ConfigurationController < ApplicationController
           current_user.update(:settings => user_settings)
 
           set_user_time_zone
+          set_gettext_locale
           add_flash(_("User Interface settings saved for User %{name}") % {:name => current_user.name})
         else
           add_flash(_("User Interface settings saved for this session"))


### PR DESCRIPTION
1. Go to My Settings, switch the locale to some particular language, for example French
2. Save new settings, the page will re-render in French
3. Again in the My Settings screen (now rendered in French), set the locale to global default
4. Save new settings.

Now the page should re-render in whatever locale corresponds to global default, but it always sets to German. It's because we're actually doing:
```ruby
FastGettext.locale = 'default'
```
which is nonsensical and `FastGettext` falls back to first registered locale here (in this case German). We need to use `set_gettext_locale()` routine from `ApplicationController`, which is able to correctly resolve locale to use even in corner-case situations.