### PR TITLE
UI changes to add 'OVF Templates' node in Orchestration templates tree

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,7 +58,8 @@ class CatalogController < ApplicationController
     'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate'      => "otazu",
     'ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate' => "otazs",
     'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate'           => "otvnf",
-    'ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate'     => "otvap"
+    'ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate'     => "otvap",
+    'ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate'     => "otovf"
   }.freeze
 
   # when methods are evaluated from this constant and return true that means: column is displayed
@@ -1711,7 +1712,7 @@ class CatalogController < ApplicationController
         get_node_info_handle_simple_leaf_node(id)
       elsif x_node == "root"
         get_node_info_handle_root_node
-      elsif %w[xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap].include?(x_node)
+      elsif %w[xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap xx-otovf].include?(x_node)
         get_node_info_handle_ot_folder_nodes
       elsif x_active_tree == :stcat_tree
         get_node_info_handle_leaf_node_stcat(id)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -198,7 +198,8 @@ class ApplicationHelper::ToolbarChooser
         "services_center_tb"
       end
     elsif x_active_tree == :ot_tree
-      if %w[root xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap].include?(x_node)
+      return nil if x_node == "xx-otovf" || @record.kind_of?(ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate)
+      if %w[root xx-otcfn xx-othot xx-otazu xx-otazs xx-otvnf xx-otvap xx-ovf].include?(x_node)
         "orchestration_templates_center_tb"
       else
         "orchestration_template_center_tb"

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -34,6 +34,11 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
        :text => _("AzureStack Templates"),
        :icon => "pficon pficon-template",
        :tip  => _("AzureStack Templates")},
+      {:id   => 'otovf',
+       :tree => "otovf_tree",
+       :text => _("OVF Templates"),
+       :icon => "pficon pficon-template",
+       :tip  => _("OVF Templates")},
       {:id   => 'otvnf',
        :tree => "otvnf_tree",
        :text => _("VNF Templates"),
@@ -55,7 +60,8 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "otazu" => ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate,
       "otazs" => ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate,
       "otvnf" => ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate,
-      "otvap" => ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate
+      "otvap" => ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate,
+      "otovf" => ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate
     }
     count_only_or_objects_filtered(count_only, classes[object[:id]].where(:orderable => true), "name")
   end

--- a/product/views/ManageIQ_Providers_Vmware_InfraManager_OrchestrationTemplate.yaml
+++ b/product/views/ManageIQ_Providers_Vmware_InfraManager_OrchestrationTemplate.yaml
@@ -1,0 +1,86 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: OVF Orchestration Templates
+
+# Menu name
+name: OVF Orchestration Template
+
+# Main DB table report is based on
+db: ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate
+
+# Columns to fetch from the main table
+cols:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Column titles, in order
+headers:
+- Name
+- Template Type
+- Draft
+- Description
+- Created On
+- Updated On
+
+col_formats:
+-
+- :model_name
+- :boolean_yes_no
+-
+-
+-
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/3450808/99001844-87e81780-2509-11eb-846c-0a5f1e939bb6.png)

after
![Screenshot from 2020-11-12 18-10-49](https://user-images.githubusercontent.com/3450808/99007563-75bea700-2512-11eb-9d7b-63da5fc35e5f.png)

![Screenshot from 2020-11-12 18-11-00](https://user-images.githubusercontent.com/3450808/99007566-78b99780-2512-11eb-95b1-1b8cb8feacb3.png)

This PR addresses issue mentioned in https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/15279

@lfu please test/verify
