### PR TITLE
Formatted Date and Time for Different Locales

### DIFF
--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -24,12 +24,12 @@
     %label.col-md-2.control-label
       = _('Created On')
     .col-md-8
-      =  @record.created_at
+      =  h(format_timezone(@record.created_at, Time.zone, "gtl"))
   .form-group
     %label.col-md-2.control-label
       = _('Updated On')
     .col-md-8
-      =  @record.updated_at
+      =  h(format_timezone(@record.updated_at, Time.zone, "gtl"))
   .form-group
     .col-md-10
       #tag_group

--- a/product/views/OrchestrationTemplate.yaml
+++ b/product/views/OrchestrationTemplate.yaml
@@ -52,8 +52,8 @@ col_formats:
 - :model_name
 - :boolean_yes_no
 -
--
--
+- :datetime_local
+- :datetime_local
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
Found in Services->Catalogs->Orchestration Templates

Related to: https://github.com/ManageIQ/manageiq/pull/20817

Preview:
- English
<img src="https://user-images.githubusercontent.com/64800041/99104345-ef0bd780-25ae-11eb-8397-1e17ce86f339.png" width="500">
<img src="https://user-images.githubusercontent.com/64800041/99104466-04810180-25af-11eb-9ada-0c0797f6a445.png" width="500">

- French
<img src="https://user-images.githubusercontent.com/64800041/99104743-63467b00-25af-11eb-99d0-6a0c5986293f.png" width="300">
<img src="https://user-images.githubusercontent.com/64800041/99104752-680b2f00-25af-11eb-989a-0dbc7553ae45.png" width="500">