### PR TITLE
[catalog_controller_spec.rb] Fix ems let... again

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -733,15 +733,18 @@ describe CatalogController do
       let(:auth) { FactoryBot.create(:authentication, :manager_ref => 6, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential") }
       let(:repository) { FactoryBot.create(:configuration_script_source, :manager => ems, :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource") }
       let(:inventory_root_group) { FactoryBot.create(:inventory_root_group) }
-      let(:ems) do
-        FactoryBot.create(:embedded_automation_manager_ansible, :inventory_root_groups => [inventory_root_group])
-      end
+      let(:provider) { FactoryBot.create(:provider_embedded_ansible) }
+      let(:ems) { provider.automation_manager }
       let(:dialog) { FactoryBot.create(:dialog) }
       let(:playbook) do
         FactoryBot.create(:embedded_playbook,
                            :configuration_script_source => repository,
                            :manager                     => ems,
                            :inventory_root_group        => inventory_root_group)
+      end
+
+      before do
+        ems.update_attributes(:inventory_root_groups => [inventory_root_group])
       end
 
       it "returns playbook service template details for provision & retirement tabs for summary screen" do


### PR DESCRIPTION
This is a follow up to 02e4b85 (aka: https://github.com/ManageIQ/manageiq-ui-classic/pull/7500 ) as the solution provided there, while works for this use case, ended up causing problems in `ManageIQ/manageiq-content`:

https://github.com/ManageIQ/manageiq/pull/20787#issuecomment-726357421

Instead, we use the `:provider_embedded_ansible` factory, and reference the `.automation_manager` from that.  In addition, since a update to the `:inventory_root_groups` was needed, we also modify the record in a `before` statement as well.

This ends up not being as clean as the previous implementation, but makes sure we are using the `EmbeddedAnsible` provider in the form that it would be called when used in the application.


Links
-----

* https://github.com/ManageIQ/manageiq-ui-classic/pull/7500
* Related to: https://github.com/ManageIQ/manageiq/issues/19977