### PR TITLE
Fix autosde cloud volume editing

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -258,7 +258,12 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
     vm.cloudVolumeModel.size = data.size / 1073741824;
     vm.cloudVolumeModel.cloud_tenant_id = data.cloud_tenant_id;
     vm.cloudVolumeModel.volume_type = data.volume_type;
-    vm.cloudVolumeModel.availability_zone_id = data.availability_zone.ems_ref;
+    vm.cloudVolumeModel.storage_service_id = data.storage_service_id;
+    if (data.availability_zone) {
+      vm.cloudVolumeModel.availability_zone_id = data.availability_zone.ems_ref;
+    } else {
+      vm.cloudVolumeModel.availability_zone_id = data.availability_zone_id;
+    }
     // Currently, this is only relevant for AWS volumes so we are prefixing the
     // model attribute with AWS.
     vm.cloudVolumeModel.aws_encryption = data.encrypted;

--- a/app/views/cloud_volume/_common_new_edit.html.haml
+++ b/app/views/cloud_volume/_common_new_edit.html.haml
@@ -128,7 +128,7 @@
     %select{"name"        => "storage_service_id",
             "ng-model"    => "vm.cloudVolumeModel.storage_service_id",
             "ng-options"  => "service.id as service.name for service in vm.storageServices",
-
+            "ng-disabled" => "!vm.newRecord",
             "required"    => "",
             :checkchange  => true,
             "miq-select"  => true}


### PR DESCRIPTION
If we try to modify cloud volume managed by autosde storage manager we get an exception. 
This PR enables size and name modifications for volumes managed under autosde.

<img width="644" alt="1" src="https://user-images.githubusercontent.com/53213107/99183903-08945700-2748-11eb-87e4-faef01f27bbe.png">

<img width="642" alt="2" src="https://user-images.githubusercontent.com/53213107/99183902-07632a00-2748-11eb-8918-bee3d83f2dcd.png">

links
--------
https://github.com/ManageIQ/manageiq-providers-autosde/pull/47