### PR TITLE
Fix formatting for Provider name

### DIFF
--- a/product/views/ConfiguredSystem.yaml
+++ b/product/views/ConfiguredSystem.yaml
@@ -55,6 +55,7 @@ headers:
 
 col_formats:
 -
+-
 - :model_name
 -
 -


### PR DESCRIPTION
This PR addresses an issue with the Provider name formatting. When the Provider name contains '.', it was only displaying the last part of the string.

Provider Name: 'Andy.Bob.Cat Configuration Manager' shows up as 'Cat Configuration Manager'