### PR TITLE
Eliminate some of the async warnings from our jest tests

### DIFF
--- a/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
+++ b/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
@@ -2564,7 +2564,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
   }
 >
   <AnsibleCredentialsForm
-    recordId={1}
+    recordId="1"
   >
     <Connect(MiqFormRenderer)
       buttonsLabels={

--- a/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
+++ b/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
@@ -68,7 +68,7 @@ describe('Ansible Credential Form Component', () => {
     let wrapper;
 
     await act(async() => {
-      wrapper = mount(<AnsibleCredentialsForm recordId={1} />);
+      wrapper = mount(<AnsibleCredentialsForm recordId="1" />);
     });
     wrapper.update();
     expect(fetchMock.calls()).toHaveLength(3);

--- a/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
+++ b/app/javascript/spec/automate-import-export-form/import-datastore-via-git.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
 import fetchMock from 'fetch-mock';
+import { act } from 'react-dom/test-utils';
 import { shallow } from 'enzyme';
 
 import ImportDatastoreViaGit from '../../components/automate-import-export-form/import-datastore-via-git';
@@ -26,13 +27,20 @@ describe('Import datastore via git component', () => {
     expect(button.props().disabled).toBe(true);
   });
 
-  it('should call api correct endpoint after submit', (done) => {
+  it('should call api correct endpoint after submit', async(done) => {
     const flashSpy = jest.spyOn(window, 'add_flash');
     fetchMock.postOnce('/miq_ae_tools/retrieve_git_datastore', [{ message: 'Foo', level: 'Bar' }]);
 
-    const wrapper = mount(<ImportDatastoreViaGit />);
-    wrapper.find('input[name="git_url"]').simulate('change', { target: { value: 'http://' } });
-    wrapper.find('form').simulate('submit');
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<ImportDatastoreViaGit />);
+    });
+    wrapper.update();
+
+    await act(async() => {
+      wrapper.find('input[name="git_url"]').simulate('change', { target: { value: 'http://' } });
+      wrapper.find('form').simulate('submit');
+    });
 
     const expectedCall = expect.arrayContaining([
       '/miq_ae_tools/retrieve_git_datastore',
@@ -40,10 +48,9 @@ describe('Import datastore via git component', () => {
         body: '{"git_url":"http://","git_verify_ssl":true}',
       }),
     ]);
-    setImmediate(() => {
-      expect(fetchMock.lastCall()).toEqual(expectedCall);
-      expect(flashSpy).toHaveBeenCalledWith('Foo', 'Bar');
-      done();
-    });
+
+    expect(fetchMock.lastCall()).toEqual(expectedCall);
+    expect(flashSpy).toHaveBeenCalledWith('Foo', 'Bar');
+    done();
   });
 });

--- a/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
+++ b/app/javascript/spec/orchestration-template/orchestration-template-form.spec.js
@@ -39,15 +39,18 @@ describe('OrcherstrationTemplate form', () => {
       wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
     });
     wrapper.update();
-    wrapper.find('input[name="name"]').simulate('change', { target: { value: 'foo' } });
-    /**
-       * manually change content value
-       * Code component is not standard input element
-       * Two first parameters are codemirror element and data
-       */
-    wrapper.find(CodeEditor).props().onChange(null, null, 'Some random content');
-    wrapper.update();
-    wrapper.find('form').simulate('submit');
+
+    await act(async() => {
+      wrapper.find('input[name="name"]').simulate('change', { target: { value: 'foo' } });
+      /**
+         * manually change content value
+         * Code component is not standard input element
+         * Two first parameters are codemirror element and data
+         */
+      wrapper.find(CodeEditor).props().onChange(null, null, 'Some random content');
+      wrapper.find('form').simulate('submit');
+    });
+
     expect(fetchMock.lastCall()).toBeTruthy();
     expect(JSON.parse(fetchMock.lastCall()[1].body)).toEqual(expect.objectContaining({
       name: 'foo',
@@ -57,15 +60,23 @@ describe('OrcherstrationTemplate form', () => {
     done();
   });
 
-  it('should call miqFlashLater on cancel action', () => {
-    const wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
+  it('should call miqFlashLater on cancel action', async(done) => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<OrcherstrationTemplateForm {...initialProps} />);
+    });
     wrapper.update();
-    wrapper.find('button').last().simulate('click');
+
+    await act(async() => {
+      wrapper.find('button').last().simulate('click');
+    });
+
     expect(miqRedirectBack).toHaveBeenCalledWith(
       'Creation of a new Orchestration Template was cancelled by the user',
       'success',
       '/catalog/explorer',
     );
+    done();
   });
 
   it('should render edit variant', async(done) => {
@@ -102,20 +113,21 @@ describe('OrcherstrationTemplate form', () => {
       name: 'foo',
       content: 'content',
     });
+
     let wrapper;
     await act(async() => {
       wrapper = mount(<OrcherstrationTemplateForm {...initialProps} otId={123} copy />);
     });
     wrapper.update();
-    wrapper.find('input[name="name"]').simulate('change', { target: { value: 'bar' } });
-    /**
-         * manually change content value
-         * Code component is not standard input element
-         * Two first parameters are codemirror element and data
-         */
-    wrapper.find(CodeEditor).props().onChange(null, null, 'updated content');
-    wrapper.update();
+
     await act(async() => {
+      wrapper.find('input[name="name"]').simulate('change', { target: { value: 'bar' } });
+      /**
+           * manually change content value
+           * Code component is not standard input element
+           * Two first parameters are codemirror element and data
+           */
+      wrapper.find(CodeEditor).props().onChange(null, null, 'updated content');
       wrapper.find('form').simulate('submit');
     });
 


### PR DESCRIPTION
Some of our tests are producing warning because of how we (don't) use the asynchronous handling for components. I am trying to figure out all of them, with more or less success. Here are a few changes that reduce the number of warnings printed into the test output...