### PR TITLE
Replace the edit icon with a delete on the CV snapshot delete button

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::CloudVolumeSnapshotCenter < ApplicationHelper:
                    :items => [
                      button(
                        :cloud_volume_snapshot_delete,
-                       'pficon pficon-edit fa-lg',
+                       'pficon pficon-delete fa-lg',
                        t = N_('Delete Cloud Volume Snapshot'),
                        t
                      ),


### PR DESCRIPTION
Wrong icon for the delete action, fixing :wrench: 

**Before:**
![Screenshot from 2020-12-07 11-31-37](https://user-images.githubusercontent.com/649130/101340290-cc07d700-387f-11eb-9c02-3e266c2c5ff0.png)

**After:**
![Screenshot from 2020-12-07 11-29-51](https://user-images.githubusercontent.com/649130/101340078-8e0ab300-387f-11eb-92b7-e77bd324a1eb.png)
