### PR TITLE
Fix translation of storage manager select default text

### DIFF
--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -9,7 +9,6 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
       aws_encryption: false,
       incremental: false,
       force: false,
-      storage_manager_id: storageManagerId,
     };
 
     vm.formId = cloudVolumeFormId;
@@ -252,6 +251,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['miqService', 'API
   };
 
   var getCloudVolumeFormData = function(data) {
+    vm.cloudVolumeModel.storage_manager_id = storageManagerId;
     vm.cloudVolumeModel.emstype = data.ext_management_system.type;
     vm.cloudVolumeModel.name = data.name;
     // We have to display size in GB.


### PR DESCRIPTION

In this PR, fixed Storage manager dropdown default placeholder text translation.

Before:
<img width="1454" alt="Screen Shot 2020-12-04 at 1 43 30 PM" src="https://user-images.githubusercontent.com/37085529/101362831-a3c3ac80-386e-11eb-900b-2457c4668039.png">

After:
<img width="1121" alt="Screen Shot 2020-12-07 at 9 26 03 AM" src="https://user-images.githubusercontent.com/37085529/101362559-43346f80-386e-11eb-97e8-7a348770770e.png">

<img width="1063" alt="Screen Shot 2020-12-07 at 9 27 21 AM" src="https://user-images.githubusercontent.com/37085529/101362685-70811d80-386e-11eb-9226-b24400785726.png">

