### PR TITLE
Prevented Text-Wrapping in Column Titles (CSS)

### DIFF
--- a/app/assets/stylesheets/list_view.scss
+++ b/app/assets/stylesheets/list_view.scss
@@ -14,4 +14,8 @@
   white-space: nowrap;
 }
 
+.miq-thead {
+  white-space: nowrap;
+}
+
 /* End list View Styling */

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -61,7 +61,7 @@ export const DataTable = ({
   };
 
   const renderTableHeader = () => (
-    <thead>
+    <thead className="miq-thead">
       <tr>
         {!inEditMode() && !noCheckboxes() &&
         <th className="narrow table-view-pf-select">


### PR DESCRIPTION
Adds a `white-space: nowrap;` property to table headers to ensure that the titles of columns remain on one line without affecting the tables body regardless of locale.

Preview (Overview -> Saved Reports ):
![image](https://user-images.githubusercontent.com/64800041/101374516-3f0f4e80-387c-11eb-83de-5e62d039032e.png)
![image](https://user-images.githubusercontent.com/64800041/101374552-4afb1080-387c-11eb-95a7-7c65d4018c3f.png)
