### PR TITLE
Clean up session variable from the orchestration stack retirement

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -63,7 +63,6 @@ module Mixins
           build_targets_hash(@retireitems)
           @view = get_db_view(kls) # Instantiate the MIQ Report view object
           @in_a_form = true
-          @edit[:object_ids] = @retireitems
           @refresh_partial = "shared/views/retire" if @explorer || @layout == "orchestration_stack"
         end
       end


### PR DESCRIPTION
Missed from https://github.com/ManageIQ/manageiq-ui-classic/pull/7518 the `@edit` is no longer available, so setting its value causes errors :scissors: :fire: 