### PR TITLE
Drop the DB garbage collection button/handler from the UI

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -366,17 +366,6 @@ module OpsController::Diagnostics
     render :json => log_depot_json
   end
 
-  def db_gc_collection
-    begin
-      MiqSchedule.run_adhoc_db_gc(:userid => session[:userid])
-    rescue => bang
-      add_flash(_("Error during 'Database Garbage Collection': %{message}") % {:message => bang.message}, :error)
-    else
-      add_flash(_("Database Garbage Collection successfully initiated"))
-    end
-    javascript_flash(:spinner_off => true)
-  end
-
   # to delete orphaned records for user that was delete from db
   def orphaned_records_delete
     MiqReportResult.delete_by_userid(params[:userid])

--- a/app/views/ops/_diagnostics_database_tab.html.haml
+++ b/app/views/ops/_diagnostics_database_tab.html.haml
@@ -198,26 +198,5 @@
                     'on-click'       => "vm.submitButtonClicked('#{_("Are you sure you want to Run a Database Backup Now?")}')",
                     :primary         => 'true'}
 
-
-  %hr
-  %h3
-    = _("Run Database Garbage Collection Now")
-  .form-group
-    .col-md-8
-      = _("Press submit to start the Database Vacuum process")
-  %table{:width => "100%"}
-    %tr
-      %td{:align => "right"}
-        #gc_submit_on
-          - caption = _("Run Database Garbage Collection Now")
-          - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
-
-          = link_to(submit, {:action => 'db_gc_collection'},
-            "data-miq_sparkle_on" => true,
-            :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"),
-            :remote               => true,
-            'data-method'         => :post,
-            :title                => caption)
-
 :javascript
   miq_bootstrap('#form_div');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2438,7 +2438,6 @@ Rails.application.routes.draw do
         cu_repair_field_changed
         db_backup
         db_backup_form_field_changed
-        db_gc_collection
         diagnostics_server_list
         diagnostics_tree_select
         explorer

--- a/spec/routing/ops_routing_spec.rb
+++ b/spec/routing/ops_routing_spec.rb
@@ -42,7 +42,6 @@ describe "routing for OpsController" do
     cu_repair_field_changed
     db_backup
     db_backup_form_field_changed
-    db_gc_collection
     diagnostics_server_list
     diagnostics_tree_select
     explorer


### PR DESCRIPTION
There's an option for running the PG vacuum by pressing a button under OPS/Diagnostics/Region/Database which I'm deleting according to https://github.com/ManageIQ/manageiq-ui-classic/issues/6878#issuecomment-739965221

**Before:**
![Screenshot from 2020-12-08 12-17-23](https://user-images.githubusercontent.com/649130/101477386-700c8380-394f-11eb-9e94-5f67b52c1e2c.png)

**After:**
![Screenshot from 2020-12-08 12-18-01](https://user-images.githubusercontent.com/649130/101477413-77339180-394f-11eb-97f4-6b9e4ef27578.png)
