### PR TITLE
Fixed tree selection issues with screens in Reports explorer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -783,7 +783,7 @@ class ApplicationController < ActionController::Base
       }
 
       if defined?(row.data) && defined?(params) && params[:active_tree] != "reports_tree"
-        new_row[:parent_id] = "xx-#{row.data['miq_report_id']}" if row.data['miq_report_id']
+        new_row[:parent_id] = "rep-#{row.data['miq_report_id']}" if row.data['miq_report_id']
       end
       new_row[:parent_id] = "xx-#{CONTENT_TYPE_ID[target[:content_type]]}" if target && target[:content_type]
       new_row[:tree_id] = TreeBuilder.build_node_id(target) if target

--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -110,9 +110,9 @@ const isCurrentControllerOrPolicies = (url) => {
   return splitUrl && (splitUrl[1] === ManageIQ.controller || splitUrl[2] === 'policies');
 };
 
-const EXPAND_TREES = ['treeview-policy_tree', 'treeview-savedreports_tree', 'treeview-widgets_tree'];
+const EXPAND_TREES = ['policy_tree', 'reports_tree'];
 const activateNodeSilently = (itemId) => {
-  const treeId = angular.element('.collapse.in .treeview').attr('id');
+  const treeId = angular.element('.collapse.in miq-tree-view').attr('name');
   if (!EXPAND_TREES.includes(treeId)) {
     miqTreeExpandRecursive(treeId, itemId);
   }


### PR DESCRIPTION
These issues were introduced with react conversion of list views, 3 issues were fixed
- Infinite spinner when clicking on a saved reports item from the right side in Reports accordion on Saved Reports tab. Call to expand tree was not being called.
- Incorrect tree node id is fixed when clicking on an item on the right side of Saved Reports accordion, this was loading the correct contents but not selecting an item in the tree.
- Tree on the left was not getting expanded to show/select node as selected in tree when selecting a Widget from the list on the right side in Dashboard Widgets accordion.

before

![Screenshot from 2020-12-08 15-44-08](https://user-images.githubusercontent.com/3450808/101540465-0d76b000-396e-11eb-8709-c590ea9e5638.png)

![Screenshot from 2020-12-08 15-43-42](https://user-images.githubusercontent.com/3450808/101540573-37c86d80-396e-11eb-86ea-4c927eb94a71.png)


![Screenshot from 2020-12-08 15-57-04](https://user-images.githubusercontent.com/3450808/101540511-1f585300-396e-11eb-84f4-683b6eb7d6b2.png)

![Screenshot from 2020-12-08 15-56-02](https://user-images.githubusercontent.com/3450808/101540498-19627200-396e-11eb-87d4-655f0c9b4447.png)

after
![Screenshot from 2020-12-08 15-28-14](https://user-images.githubusercontent.com/3450808/101537770-0baaed80-396a-11eb-918e-4db442422c18.png)

![Screenshot from 2020-12-08 15-27-59](https://user-images.githubusercontent.com/3450808/101537785-11a0ce80-396a-11eb-9fa9-4489fcadad45.png)

![Screenshot from 2020-12-08 15-27-39](https://user-images.githubusercontent.com/3450808/101537797-16658280-396a-11eb-9204-db7739aa3284.png)

@gtanzillo this should fix the issue you reported with Saved report selection from Reports accordion. Please test.
