### PR TITLE
Replace 'sort_by' with 'order' to prevent error

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -255,7 +255,7 @@ module Mixins
 
           # if only one vm that supports disk reconfiguration is selected, get the disks information
           vmdisks = []
-          @reconfigureitems.first.hardware.disks.sort_by(&:filename).each do |disk|
+          @reconfigureitems.first.hardware.disks.order(:filename).each do |disk|
             next if disk.device_type != 'disk'
 
             dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))


### PR DESCRIPTION
An error occurred when trying to reconfigure a VM: 'comparison of String with nil failed'. This was caused by the 'sort_by(&:filename)' of the disks while one of the disks has no filename: a cdrom device without a cd mounted. This issue can be solved by replacing 'sort_by(&:filename)' with 'order(:filename)'.

![2020-12-08_15h19_39](https://user-images.githubusercontent.com/23237514/101615160-174ff000-3a0e-11eb-9e9c-caa2ed5631af.png)

Rails console output 
-------------------------------
> Vm.find_by(name: 'NCTVC-NLHAA1-002').hardware.disks.first
=> #<Disk id: 100183, device_name: "Hard disk 1", device_type: "disk", location: "0:0", filename: "[PV-SP-HA12] NCTVC-NLHAA1-002/NCTVC-...", hardware_id: 21389, mode: "persistent", controller_type: "scsi", size: 10842275840, free_space: nil, size_on_disk: nil, present: true, start_connected: true, auto_detect: nil, created_on: "2020-12-04 09:35:50", updated_on: "2020-12-04 09:35:50", disk_type: "thick", storage_id: 695, backing_id: nil, backing_type: nil, storage_profile_id: nil, bootable: nil>

> Vm.find_by(name: 'NCTVC-NLHAA1-002').hardware.disks.second
=> #<Disk id: 100182, device_name: "CD/DVD drive 1", device_type: "cdrom-raw", location: "1:0", filename: nil, hardware_id: 21389, mode: nil, controller_type: "ide", size: nil, free_space: nil, size_on_disk: nil, present: true,start_connected: false, auto_detect: nil, created_on: "2020-12-04 09:35:50", updated_on: "2020-12-04 09:35:50", disk_type: nil, storage_id: nil, backing_id: nil, backing_type: nil, storage_profile_id: nil, bootable: nil>

> Vm.find_by(name: 'NCTVC-NLHAA1-002').hardware.disks.count
=> 2

> Vm.find_by(name: 'NCTVC-NLHAA1-002').hardware.disks.sort_by(&:filename)
Traceback (most recent call last):
       13: from bin/rails:4:in `<main>'
       12: from bin/rails:4:in `require'
       11: from railties (5.1.7) lib/rails/commands.rb:16:in `<top (required)>'
       10: from railties (5.1.7) lib/rails/command.rb:44:in `invoke'
        9: from railties (5.1.7) lib/rails/command/base.rb:63:in `perform'
        8: from thor (1.0.1) lib/thor.rb:392:in `dispatch'
        7: from thor (1.0.1) lib/thor/invocation.rb:127:in `invoke_command'
        6: from thor (1.0.1) lib/thor/command.rb:27:in `run'
        5: from railties (5.1.7) lib/rails/commands/console/console_command.rb:97:in `perform'
        4: from railties (5.1.7) lib/rails/commands/console/console_command.rb:17:in `start'
        3: from railties (5.1.7) lib/rails/commands/console/console_command.rb:62:in `start'
        2: from (irb):7
        1: from (irb):7:in `sort_by'
ArgumentError (comparison of String with nil failed)

Steps for Testing
-------------------------------
* Provision a VM having one Hard disk and a CD/DVD drive without CD mounted.
* Click "Configuration" - "Reconfigure this VM" at the VM details page in ManageIQ.
* An error popup shows "comparison of String with nil failed".
