### PR TITLE
Change dashboard toolbar to carbon and fix A11y

### DIFF
--- a/app/javascript/components/dashboard_toolbar.jsx
+++ b/app/javascript/components/dashboard_toolbar.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, MenuItem } from 'patternfly-react';
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
+import { ChevronDown20 } from '@carbon/icons-react';
 
-const addClick = item =>
+const addClick = (item) =>
   window.miqJqueryRequest(`widget_add?widget=${item.id}`, { beforeSend: true, complete: true });
 
 const resetClick = () => {
@@ -15,7 +16,7 @@ const resetClick = () => {
 const resetButton = () => (
   <button
     type="button"
-    className="btn btn-default"
+    className="btn btn-default refresh_button"
     title={__('Reset Dashboard Widgets to the defaults')}
     onClick={resetClick}
   >
@@ -23,30 +24,65 @@ const resetButton = () => (
   </button>
 );
 
+const closeFunc = () => {
+  document.getElementById('dropdown-custom-2').focus();
+};
+
+const MenuIcon = (props) => (
+  <div>
+    { props.image && <i className={props.image} /> }
+    &nbsp;
+    <span>{ props.text }</span>
+  </div>
+);
+
+MenuIcon.propTypes = {
+  image: PropTypes.string,
+  text: PropTypes.string,
+};
+
+MenuIcon.defaultProps = {
+  image: undefined,
+  text: undefined,
+};
+
 const addMenu = (items, locked) => {
   const title = locked
     ? __('Cannot add a Widget, this Dashboard has been locked by the Administrator')
     : __('Add a widget');
+  const buttonName = __('Add widget');
 
   return (
-    <Dropdown id="dropdown-custom-2" disabled={locked}>
-      <Dropdown.Toggle title={title}>
-        <span className="fa fa-plus fa-lg" />
-      </Dropdown.Toggle>
-      <Dropdown.Menu className="scrollable-menu">
-        { items.map(item => (
-          item.type === 'separator'
-            ? <MenuItem key={item.id} eventKey={item.id} divider />
-            : (
-              <MenuItem key={item.id} onClick={() => addClick(item)}>
-                <i className={item.image} />
-                &nbsp;
-                {item.text}
-              </MenuItem>
-            )
-        ))}
-      </Dropdown.Menu>
-    </Dropdown>
+    <OverflowMenu
+      ariaLabel={title}
+      id="dropdown-custom-2"
+      floatingmenu="true"
+      disabled={locked}
+      title={title}
+      onClose={closeFunc}
+      menuOptionsClass="scrollable-options"
+      renderIcon={() => (
+        <div className="toolbar-dashboard">
+          <span>{buttonName}</span>
+          <ChevronDown20 />
+        </div>
+      )}
+    >
+      { items.map((item) => (
+        <OverflowMenuItem
+          className="scrollable-menu"
+          key={item.id}
+          aria-label={item.title}
+          hasDivider={(item.type === 'separator')}
+          disabled={(item.type === 'separator')}
+          itemText={<MenuIcon image={item.image} text={item.text} />}
+          title={item.title ? item.title : null}
+          requireTitle
+          onClick={(item.type !== 'separator') ? (() => addClick(item)) : null}
+        />
+
+      )) }
+    </OverflowMenu>
   );
 };
 
@@ -69,10 +105,10 @@ const DashboardToolbar = (props) => {
   } = props;
 
   const renderContent = () => (
-    <React.Fragment>
+    <>
       { allowAdd && addMenu(items, locked) }
       { allowReset && resetButton() }
-    </React.Fragment>
+    </>
   );
 
   return (

--- a/app/javascript/components/topology_toolbar.jsx
+++ b/app/javascript/components/topology_toolbar.jsx
@@ -14,7 +14,7 @@ const resetSearchClick = () => {
 };
 
 const TopologyToolbar = () => (
-  <div className="toolbar-pf-actions miq-toolbar-actions">
+  <div className="toolbar-pf-actions miq-toolbar-actions topology_toolbar">
     <div className="miq-toolbar-group form-group">
       <div className="form-group text">
         <label htmlFor="box_display_names" className="topology-checkbox checkbox-inline">
@@ -23,14 +23,16 @@ const TopologyToolbar = () => (
         </label>
       </div>
       <div className="form-group">
-        <button type="button" className="btn btn-default" title={__('Refresh this page')} onClick={refreshClick}>
+        <button type="button" className="btn btn-default topology_refresh" title={__('Refresh this page')} onClick={refreshClick}>
           <i className="fa fa-refresh fa-lg" />
+&nbsp;
+          {__('Refresh')}
         </button>
       </div>
       <form
         style={{ display: 'inline' }}
         className="topology-tb topology-search"
-        onSubmit={e => searchClick(e)}
+        onSubmit={(e) => searchClick(e)}
       >
         <div className="form-group has-clear">
           <div className="search-pf-input-group" style={{ position: 'relative' }}>

--- a/app/javascript/spec/toolbar/__snapshots__/dashboard_toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/dashboard_toolbar.spec.jsx.snap
@@ -23,148 +23,101 @@ exports[`<DashboardToolbar /> renders ok 1`] = `
     <div
       className="miq-toolbar-group form-group"
     >
-      <ForwardRef
+      <ForwardRef(OverflowMenu)
+        ariaLabel="Add a widget"
         disabled={false}
+        floatingmenu="true"
         id="dropdown-custom-2"
+        menuOptionsClass="scrollable-options"
+        onClose={[Function]}
+        renderIcon={[Function]}
+        title="Add a widget"
       >
-        <Uncontrolled(Dropdown)
+        <OverflowMenu
+          ariaLabel="Add a widget"
+          direction="bottom"
           disabled={false}
+          flipped={false}
+          floatingmenu="true"
+          iconDescription="open and close list of options"
           id="dropdown-custom-2"
           innerRef={null}
+          light={false}
+          menuOffset={[Function]}
+          menuOffsetFlip={[Function]}
+          menuOptionsClass="scrollable-options"
+          onClick={[Function]}
+          onClose={[Function]}
+          onKeyDown={[Function]}
+          onOpen={[Function]}
+          open={false}
+          renderIcon={[Function]}
+          selectorPrimaryFocus="[data-overflow-menu-primary-focus]"
+          title="Add a widget"
         >
-          <Dropdown
-            bsClass="dropdown"
-            componentClass={[Function]}
-            disabled={false}
-            id="dropdown-custom-2"
-            onToggle={[Function]}
+          <ClickListener
+            onClickOutside={[Function]}
           >
-            <ButtonGroup
-              block={false}
-              bsClass="btn-group"
-              className="dropdown"
-              justified={false}
-              vertical={false}
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Add a widget"
+              className="bx--overflow-menu"
+              disabled={false}
+              floatingmenu="true"
+              id="dropdown-custom-2"
+              onClick={[Function]}
+              onClose={[Function]}
+              onKeyDown={[Function]}
+              open={false}
+              title="Add a widget"
+              type="button"
             >
-              <div
-                className="dropdown btn-group"
+              <renderIcon
+                aria-label="open and close list of options"
+                className="bx--overflow-menu__icon"
+                onClick={[Function]}
+                onKeyDown={[Function]}
               >
-                <DropdownToggle
-                  bsClass="dropdown-toggle"
-                  bsRole="toggle"
-                  disabled={false}
-                  id="dropdown-custom-2"
-                  key=".0"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  open={false}
-                  title="Add a widget"
-                  useAnchor={false}
+                <div
+                  className="toolbar-dashboard"
                 >
-                  <Button
-                    active={false}
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="dropdown-toggle"
-                    disabled={false}
-                    id="dropdown-custom-2"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="button"
-                    title="Add a widget"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="dropdown-toggle btn btn-default"
-                      disabled={false}
-                      id="dropdown-custom-2"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      role="button"
-                      title="Add a widget"
-                      type="button"
+                  <span>
+                    Add widget
+                  </span>
+                  <ForwardRef(ChevronDown20)>
+                    <Icon
+                      fill="currentColor"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        className="fa fa-plus fa-lg"
-                      />
-                       
-                      <span
-                        className="caret"
-                      />
-                    </button>
-                  </Button>
-                </DropdownToggle>
-                <DropdownMenu
-                  bsClass="dropdown-menu"
-                  bsRole="menu"
-                  className="scrollable-menu"
-                  key=".1"
-                  labelledBy="dropdown-custom-2"
-                  onClose={[Function]}
-                  onSelect={[Function]}
-                  pullRight={false}
-                >
-                  <RootCloseWrapper
-                    disabled={true}
-                    event="click"
-                    onRootClose={[Function]}
-                  >
-                    <ul
-                      aria-labelledby="dropdown-custom-2"
-                      className="scrollable-menu dropdown-menu"
-                      role="menu"
-                    >
-                      <MenuItem
-                        bsClass="dropdown"
-                        disabled={false}
-                        divider={false}
-                        header={false}
-                        key=".$31"
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        onSelect={[Function]}
+                      <svg
+                        aria-hidden={true}
+                        fill="currentColor"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <li
-                          className=""
-                          role="presentation"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="menuitem"
-                              tabIndex="-1"
-                            >
-                              <i
-                                className="fa fa-pie-chart fa-lg"
-                              />
-                               
-                              add
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </MenuItem>
-                    </ul>
-                  </RootCloseWrapper>
-                </DropdownMenu>
-              </div>
-            </ButtonGroup>
-          </Dropdown>
-        </Uncontrolled(Dropdown)>
-      </ForwardRef>
+                        <path
+                          d="M16 22L6 12 7.4 10.6 16 19.2 24.6 10.6 26 12z"
+                        />
+                      </svg>
+                    </Icon>
+                  </ForwardRef(ChevronDown20)>
+                </div>
+              </renderIcon>
+            </button>
+          </ClickListener>
+        </OverflowMenu>
+      </ForwardRef(OverflowMenu)>
       <button
-        className="btn btn-default"
+        className="btn btn-default refresh_button"
         onClick={[Function]}
         title="Reset Dashboard Widgets to the defaults"
         type="button"

--- a/app/javascript/spec/toolbar/__snapshots__/topology_toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/topology_toolbar.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<TopologyToolbar /> renders ok 1`] = `
 <TopologyToolbar>
   <div
-    className="toolbar-pf-actions miq-toolbar-actions"
+    className="toolbar-pf-actions miq-toolbar-actions topology_toolbar"
   >
     <div
       className="miq-toolbar-group form-group"
@@ -26,7 +26,7 @@ exports[`<TopologyToolbar /> renders ok 1`] = `
         className="form-group"
       >
         <button
-          className="btn btn-default"
+          className="btn btn-default topology_refresh"
           onClick={[Function]}
           title="Refresh this page"
           type="button"
@@ -34,6 +34,8 @@ exports[`<TopologyToolbar /> renders ok 1`] = `
           <i
             className="fa fa-refresh fa-lg"
           />
+           
+          Refresh
         </button>
       </div>
       <form

--- a/app/stylesheet/toolbar.scss
+++ b/app/stylesheet/toolbar.scss
@@ -154,3 +154,54 @@
 
 }
 
+#dropdown-custom-2 {
+  svg {
+    position:absolute;
+    top:10px;
+    margin-left: 15px;
+  }
+}
+
+.refresh_button {
+  margin-left:20px;
+  background-color: inherit;
+  border: none;
+  background-image: none;
+  box-shadow: none;
+  &:hover {
+    background-color: #e5e5e5;
+  }
+}
+
+.scrollable-options {
+  overflow-y: scroll !important;
+  max-height: 610px !important;
+}
+
+.topology_refresh,.search-topology-button {
+  background-color: inherit;
+  border: none;
+  background-image: none;
+  box-shadow: none;
+  bottom: 1px;
+  position: relative;
+}
+
+.topology_toolbar {
+  margin-bottom: 20px;
+  .text {
+    padding-left: 0px !important;
+  }
+  .topology-checkbox {
+    padding-top: 8px;
+  }
+  .search-pf-input-group {
+    margin-top: 5px;
+  }
+}
+
+.bx--overflow-menu--divider { 
+  .scrollable-menu {
+    display: none;
+  }
+}


### PR DESCRIPTION
This PR fixes dashboard toolbar A11y, moving PF component to carbon, fixing scroll issue for long list of items in dropdown.
Before:
component is using patternfly components, A11y is not working, when we scroll with keyboard, screen is broken like second picture.
<img width="1422" alt="Screen Shot 2020-12-10 at 10 47 57 AM" src="https://user-images.githubusercontent.com/37085529/101796217-b50ef200-3ad6-11eb-8544-1421a9adb5ca.png">

<img width="1665" alt="Screen Shot 2020-12-10 at 10 48 14 AM" src="https://user-images.githubusercontent.com/37085529/101796246-bb04d300-3ad6-11eb-95d8-f57f7fe1f5b8.png">

After:
<img width="1020" alt="Screen Shot 2020-12-10 at 10 36 19 AM" src="https://user-images.githubusercontent.com/37085529/101796578-09b26d00-3ad7-11eb-9fda-337c433a19ed.png">

<img width="1645" alt="Screen Shot 2020-12-10 at 10 36 35 AM" src="https://user-images.githubusercontent.com/37085529/101796592-0dde8a80-3ad7-11eb-93fd-81974417d067.png">

@miq-bot add_reviewer @himdel , @skateman 

