### PR TITLE
revert rename of all_vms_and_templates 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1312,7 +1312,7 @@ class ApplicationController < ActionController::Base
 
   def get_db_view(db, options = {})
     if %w[ManageIQ_Providers_InfraManager_Template ManageIQ_Providers_InfraManager_Vm]
-       .include?(db) && options[:association] == "vms_and_templates"
+       .include?(db) && options[:association] == "all_vms_and_templates"
       options[:association] = nil
     end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -930,7 +930,7 @@ module VmCommon
                          end
     else
       rec = TreeBuilder.get_model_for_prefix(@nodetype).constantize.find(node_id)
-      options[:association] = @nodetype == 'az' ? 'vms' : 'vms_and_templates'
+      options[:association] = @nodetype == 'az' ? 'vms' : 'all_vms_and_templates'
       options[:parent] = rec
       options[:named_scope] << :active
 


### PR DESCRIPTION
this change broke the list of vms loaded under folders
(broken in https://github.com/ManageIQ/manageiq-ui-classic/pull/7136 and https://github.com/ManageIQ/manageiq/pull/20149 originally)

thanks himdel

incoming core pr to address the needed core alias:
requires https://github.com/ManageIQ/manageiq/pull/20903

