### PR TITLE
Fix search alignment in topology toolbar

### DIFF
--- a/app/javascript/components/topology_toolbar.jsx
+++ b/app/javascript/components/topology_toolbar.jsx
@@ -43,12 +43,10 @@ const TopologyToolbar = () => (
             <button type="button" className="clear" aria-hidden="true" onClick={resetSearchClick}>
               <span className="pficon pficon-close" />
             </button>
+            <button type="button" className="btn btn-default search-topology-button" onClick={searchClick}>
+              <span className="fa fa-search" />
+            </button>
           </div>
-        </div>
-        <div className="form-group search-button">
-          <button type="button" className="btn btn-default search-topology-button" onClick={searchClick}>
-            <span className="fa fa-search" />
-          </button>
         </div>
       </form>
     </div>

--- a/app/javascript/spec/toolbar/__snapshots__/topology_toolbar.spec.jsx.snap
+++ b/app/javascript/spec/toolbar/__snapshots__/topology_toolbar.spec.jsx.snap
@@ -80,20 +80,16 @@ exports[`<TopologyToolbar /> renders ok 1`] = `
                 className="pficon pficon-close"
               />
             </button>
+            <button
+              className="btn btn-default search-topology-button"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="fa fa-search"
+              />
+            </button>
           </div>
-        </div>
-        <div
-          className="form-group search-button"
-        >
-          <button
-            className="btn btn-default search-topology-button"
-            onClick={[Function]}
-            type="button"
-          >
-            <span
-              className="fa fa-search"
-            />
-          </button>
         </div>
       </form>
     </div>

--- a/app/stylesheet/toolbar.scss
+++ b/app/stylesheet/toolbar.scss
@@ -178,13 +178,22 @@
   max-height: 610px !important;
 }
 
-.topology_refresh,.search-topology-button {
+.topology_refresh {
   background-color: inherit;
   border: none;
   background-image: none;
   box-shadow: none;
   bottom: 1px;
   position: relative;
+}
+
+.search-topology-button {
+    background-color: #f1f1f1;
+    position: absolute;
+    right: -29px;
+    top: 0px;
+    width: 25px;
+    height: 26px;
 }
 
 .topology_toolbar {


### PR DESCRIPTION
This is to fix search alignment in topology toolbar, i tried to match search field with other searches in MIQ. 

Before:
<img width="1447" alt="Screen Shot 2021-01-06 at 11 08 31 AM" src="https://user-images.githubusercontent.com/37085529/103794647-f8e01300-5012-11eb-8c33-25208b2c01df.png">

@miq-bot assign @himdel 
@miq-bot add_reviewer @himdel 

After:
<img width="1031" alt="Screen Shot 2021-01-06 at 11 26 50 AM" src="https://user-images.githubusercontent.com/37085529/103794702-085f5c00-5013-11eb-8309-d707da37972b.png">


