### PR TITLE
Temporarily fix CI by setting total_space for the mocked storage

### DIFF
--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -1,5 +1,5 @@
 describe StorageController do
-  let(:storage) { FactoryBot.create(:storage, :name => 'test_storage1') }
+  let(:storage) { FactoryBot.create(:storage, :name => 'test_storage1', :total_space => 4) }
   let(:storage_cluster) { FactoryBot.create(:storage_cluster, :name => 'test_storage_cluster1') }
   let(:storage_with_miq_templates) do
     st = FactoryBot.create(:storage)


### PR DESCRIPTION
This is a temporary fix for making the CI happy, since https://github.com/ManageIQ/manageiq/pull/20871 was merged into core. The `Storage#total_space` can return `nil` which causes the `zero?` method to fail which is a problem when testing the `report_data` of storages. As this problem might affect other callsites as well so IMO it should be fixed in the model. If I'm wrong, then we might want to add a dummy value into the storage factory for the tests to stay happy.

FYI @djberg96 @Fryguy 
