### PR TITLE
Fill group_id when widget set is saved in dashboard.rb

### DIFF
--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -127,6 +127,7 @@ module ReportController::Dashboards
       if params[:button] == "add"
         g = MiqGroup.find(@sb[:nodes][2])
         @dashboard.owner = g
+        @dashboard.group_id = g.id
       end
       if @flash_array.nil? && @dashboard.save
         db_save_members


### PR DESCRIPTION
Overview -> Dashboards

`MiqWidgetSet#group_id` is same as `MiqWidgetSet#owner_id` (+ MiqWidgetSet#owner_type)

and we are adding model [validation](https://github.com/ManageIQ/manageiq/pull/20890)  that group has to be present in some cases.

In UI we populated send just `MiqWidgetSet#owner` and thanks to [callback](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_widget_set.rb#L109),
`MiqWidgetSet#group_id` iswas also stored but it was after validation (and it is late) - 
so I also populated  `MiqWidgetSet#group_id` in controller here in this PR so validation can work correctly.



this PR is required for [PR](https://github.com/ManageIQ/manageiq/pull/20890)

### Links
- [ ] https://github.com/ManageIQ/manageiq/pull/20890

