### PR TITLE
Sort MiqWidgetSets according to MiqGroup#dashboard_order in tree

### DIFF
--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -34,21 +34,6 @@ class TreeBuilderReportDashboards < TreeBuilder
   end
 
   def x_get_tree_g_kids(object, count_only)
-    objects = []
-    # dashboard nodes under each group
-    widgetsets = MiqWidgetSet.where(:owner_type => "MiqGroup", :owner_id => object.id)
-    # if dashboard sequence was saved, build tree using that, else sort by name and build the tree
-    if object.settings && object.settings[:dashboard_order]
-      object.settings[:dashboard_order].each do |ws_id|
-        widgetsets.each do |ws|
-          if ws_id == ws.id
-            objects.push(ws)
-          end
-        end
-      end
-    else
-      objects = copy_array(widgetsets.to_a)
-    end
-    count_only_or_objects(count_only, objects, :name)
+    count_only_or_objects(count_only, object.ordered_widget_sets)
   end
 end


### PR DESCRIPTION
Couple changes to fix ordering this list:

<img width="619" alt="Screenshot 2021-01-12 at 14 17 43" src="https://user-images.githubusercontent.com/14937244/104319374-0f89dc80-54e1-11eb-9762-52bd4d99e54b.png">


There are also other changes which lead to simplification of method `x_get_tree_g_kids`:

1. Use `MiqWidgetSet#ordered_widget_sets`.
2. Remove useless `copy_array`
3. **Fix: Sort MiqWidgetSets according to MiqGroup#dashboard_order**

@miq-bot add_label refactoring, bug



