### PR TITLE
Remove the disablement of the Metrics/LineLength cop from the menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/LineLength
 module Menu
   class DefaultMenu
     class << self


### PR DESCRIPTION
This seems like introduces rubocop errors, but it really just fixes rubocop for the whole project. Without this it would crash and won't even check other files:

```
app/presenters/menu/default_menu.rb: Metrics/LineLength has the wrong namespace - should be Layout
/tmp/d20210111-6-1qai503/config/routes.rb: Warning: no department given for MultilineOperationIndentation. Run `rubocop -a --only Migration/DepartmentName` to fix.
```