### PR TITLE
[rails6] Use ActiveSupport::ParameterFilter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -555,7 +555,7 @@ class ApplicationController < ActionController::Base
 
   def filter_config(data)
     @parameter_filter ||=
-      ActionDispatch::Http::ParameterFilter.new(
+      ActiveSupport::ParameterFilter.new(
         Rails.application.config.filter_parameters + PASSWORD_FIELDS
       )
     return data.map { |e| filter_config(e) } if data.kind_of?(Array)


### PR DESCRIPTION
Fixes the following deprecation warning (found in specs):

```
DEPRECATION WARNING: ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1.  Use ActiveSupport::ParameterFilter instead.
(called from filter_config at /Users/nicklamuro/code/redhat/manageiq-ui-classic/app/controllers/application_controller.rb:558)
```

Caused by upgrading to [Rails 6.0](https://github.com/ManageIQ/manageiq/issues/19977)


Links
-----

* https://github.com/ManageIQ/manageiq/issues/19977