### PR TITLE
[rails6] Use relative paths for layouts

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -45,8 +45,8 @@ module ApplicationController::ReportDownloads
   def render_pdf_internal_rr(report, result)
     @options = report_print_options(report, result) # used by the layouts/print
     render(
-      :template => '/layouts/print/report',
-      :layout   => '/layouts/print',
+      :template => 'layouts/print/report',
+      :layout   => 'layouts/print',
       :locals   => {
         :report => report,
         :data   => result.html_rows.join
@@ -122,8 +122,8 @@ module ApplicationController::ReportDownloads
 
     @options = report_print_options(result.report, result) # used by the layouts/print
     render(
-      :template => '/layouts/print/report',
-      :layout   => '/layouts/print',
+      :template => 'layouts/print/report',
+      :layout   => 'layouts/print',
       :locals   => {
         :report => result.report,
         :data   => result.html_rows.join
@@ -231,7 +231,7 @@ module ApplicationController::ReportDownloads
       end
 
       disable_client_cache
-      render :template => '/layouts/print/textual_summary', :layout => '/layouts/print'
+      render :template => 'layouts/print/textual_summary', :layout => 'layouts/print'
     end
   end
 end

--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -87,8 +87,8 @@ describe ApplicationController do
 
       expect(controller).to receive(:render).with(
         hash_including(
-          :template => '/layouts/print/report',
-          :layout   => '/layouts/print',
+          :template => 'layouts/print/report',
+          :layout   => 'layouts/print',
           :locals   => hash_including(
             :report # the report does not match due to a ".dup" call in the controller.
           )

--- a/spec/controllers/application_controller/report_downloads_spec.rb
+++ b/spec/controllers/application_controller/report_downloads_spec.rb
@@ -12,7 +12,7 @@ describe ApplicationController do
       end
 
       it "returns with print" do
-        expect(controller).to receive(:render).with(:layout => '/layouts/print', :template => '/layouts/print/textual_summary')
+        expect(controller).to receive(:render).with(:layout => 'layouts/print', :template => 'layouts/print/textual_summary')
         controller.send(:set_summary_pdf_data)
       end
     end


### PR DESCRIPTION
Fixes the following Deprecation warnings:

```
DEPRECATION WARNING: Rendering layouts from an absolute path is deprecated.
(called from render_pdf_internal_rr at /home/travis/build/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/report_downloads.rb:47)

DEPRECATION WARNING: Rendering layouts from an absolute path is deprecated.
(called from print_report at /Users/nicklamuro/code/redhat/manageiq-ui-classic/app/controllers/application_controller/report_downloads.rb:124)

DEPRECATION WARNING: Rendering layouts from an absolute path is deprecated.
(called from set_summary_pdf_data at /home/travis/build/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/report_downloads.rb:234)
```

Caused by the [Rails 6.0 Upgrade](https://github.com/ManageIQ/manageiq/issues/19977)


Note for reviewers
------------------

The specs that are fixed here are not the only specs that are exercising this code, just the specs that check for method arguments to be exact, and fail after the changes to the `app/controllers/**` code.  There are plenty of tests calling this code causing the original deprecation warnings:

https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/470572340#L2105-L2135

So my guess would be that this is probably a safe change, though it wouldn't hurt to have someone who knows better where this layout is used on a screen to confirm.


Links
-----

* https://github.com/ManageIQ/manageiq/issues/19977