### PR TITLE
[spec] Fix create_user_with_group errors

### DIFF
--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -78,7 +78,7 @@ describe ApplicationController do
 
     # http://lucifer.usersys.redhat.com:3000/container_build/download_data?download_type=pdf#/
     it 'builds a report from the GTL data' do
-      user = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      user = create_user_with_group('User-2', "Group-1", MiqUserRole.find_by(:name => "EvmRole-operator"))
       report = create_and_generate_report_for_user("Vendor and Guest OS", user)
 
       session[:view] = report

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -498,7 +498,7 @@ describe DashboardController do
     end
 
     it "renders the print layout" do
-      user = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      user = create_user_with_group('User-2', "Group-1", MiqUserRole.find_by(:name => "EvmRole-operator"))
       report = create_and_generate_report_for_user("Vendor and Guest OS", user)
       report_result_id = report.miq_report_results.first.id
 

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1194,7 +1194,7 @@ describe ReportController do
       allow(User).to receive(:server_timezone).and_return("UTC")
       sb[:rep_tree_build_time] = Time.now.utc
       MiqWidgetSet.seed
-      user2 = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      user2 = create_user_with_group('User-2', "Group-1", MiqUserRole.find_by(:name => "EvmRole-operator"))
       @rpt = create_and_generate_report_for_user("Vendor and Guest OS", user2)
 
       expect(controller).to receive(:reload_trees_by_presenter).with(
@@ -1276,10 +1276,10 @@ describe ReportController do
         role = MiqUserRole.find_by(:name => "EvmRole-operator")
 
         # User1 with 2 groups(Group1,Group2), current group for User2 is Group2
-        @user2 = create_user_with_group('User2', "Group1", role)
+        @user2 = create_user_with_group('User-2', "Group-1", role)
 
-        @user1 = create_user_with_group('User1', "Group2", role)
-        @user1.miq_groups << MiqGroup.where(:description => "Group1")
+        @user1 = create_user_with_group('User-1', "Group-2", role)
+        @user1.miq_groups << MiqGroup.where(:description => "Group-1")
         login_as @user1
       end
 
@@ -1516,7 +1516,7 @@ describe ReportController do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       allow(controller).to receive(:server_timezone).and_return('UTC')
-      @user2 = create_user_with_group('User2', "Group1", MiqUserRole.find_by(:name => "EvmRole-operator"))
+      @user2 = create_user_with_group('User-2', "Group-1", MiqUserRole.find_by(:name => "EvmRole-operator"))
     end
 
     describe "#print_report" do

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -10,11 +10,11 @@ describe TreeBuilderReportSavedReports do
         role = MiqUserRole.find_by(:name => "EvmRole-operator")
 
         # User1 with current group Group2
-        @user1 = create_user_with_group('User1', "Group1", role)
+        @user1 = create_user_with_group('User-1', "Group-1", role)
 
         # User2 with 2 groups(Group1,Group2), current group: Group2
-        @user2 = create_user_with_group('User2', "Group2", role)
-        @user2.miq_groups << MiqGroup.where(:description => "Group1")
+        @user2 = create_user_with_group('User-2', "Group-2", role)
+        @user2.miq_groups << MiqGroup.where(:description => "Group-1")
 
         login_as @user2
         @rpt = create_and_generate_report_for_user("Vendor and Guest OS", @user1)


### PR DESCRIPTION
So this was a bit of a doosey, and not at all made longer by the fact that `userid` definitely thought we had a race condition with the _**`id`**_ column... and not the **"user name"** column...

_... he says sarcastically..._

Detailed Explaination
---------------------

When used in conjunction with the :user factory, if this is the first spec to be run that creates a user, or the sequence for FactoryBot is somehow reset (unlikely), this can cause a error with the `userid` field since they are case sensitive[[2](https://github.com/NickLaMuro/manageiq/blob/769dd2d0c96b8b46bed73a22abf1241eefc2f726/app/models/user.rb#L45)].  Meaning the following:

- "User1"
- "user1"

Are considered the same id.  The format for `FactoryBot.create(:user)` (defined in ManageIQ/manageiq) is `"user#{s}"`[[1](https://github.com/NickLaMuro/manageiq/blob/769dd2d0c96b8b46bed73a22abf1241eefc2f726/spec/factories/user.rb#L11)], where `s` is the current sequence number, so this has a non-deterministic failure rate when using a Random seed.

However, when checking out the commit prior to this one and running the following:

```console
$ bundle exec rspec --seed 25104 spec/controllers/report_controller_spec.rb
```

The error is reproduced every single time.

Links
-----

* Found after Rails 6 merge (though not related to the merge):  https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/builds/212718463
* Cleanup PRs for deprecation warnings:
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/7573
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/7574

Steps for Testing/QA
--------------------

If you want to reproduce this on `master`, just run:

```console
$ bundle exec rspec --seed 25104 spec/controllers/report_controller_spec.rb
```