### PR TITLE
Make the RBAC spec's error and false positive messages meaningful

### DIFF
--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -14,6 +14,32 @@ pending_routes = YAML.safe_load(ManageIQ::UI::Classic.root.join('spec', 'config'
 describe 'Application routes' do
   before(:all) { MiqProductFeature.seed_features }
 
+  def error_message
+    <<~ERROR
+      This route probably does not have an RBAC check enforced on itself. This is could be because of:
+      * a missing feature that should be defined in the "\#{controller}_\#{action}" format
+      * a missing `feature_for_actions` mapping in the controller between the action and a feature
+      * missing explicit call(s) to assert_privileges in the action's method in the controller
+      * the route is not available without a session variable that is being set in an enforced route (FP)
+      * the route is a redirect to another route that has RBAC enforcement (FP)
+      * the route is checked properly, but the test is somehow not detecting it (FP)
+      * the route should be exposed to any logged in user without a role check (FP)
+
+      The routes marked with (FP) should be treated as false positives and can be added into the
+      `spec/config/routes.pending.yml` file. Please note that if the action is not available under any
+      other controller, there is a high chance that it is not a false positive and it should not be
+      added into this file without an explanation.
+    ERROR
+  end
+
+  def fp_message
+    <<~ERROR
+      This route has been marked as a false positive. It might produce a red result, which means that it
+      has RBAC enforcement and it should no longer be on the list of false positives. If this happens
+      please remove it from the `spec/config/routes.pending.yml` file.
+    ERROR
+  end
+
   routes.each do |controller, actions|
     describe controller do
       actions.uniq.each do |action|
@@ -22,7 +48,7 @@ describe 'Application routes' do
             expect(subject.respond_to?(action)).to be_truthy
           end
 
-          describe 'RBAC' do
+          describe 'RBAC check' do
             before do
               allow(PrivilegeCheckerService).to receive(:new).and_return(check_service)
               allow(check_service).to receive(:valid_session?).and_return(true)
@@ -38,7 +64,9 @@ describe 'Application routes' do
             let(:request) { double }
 
             it 'is enforced' do
-              pending('ignored') if pending_routes[controller.to_s]&.include?(action)
+              # Check if the test is not marked as a false positive
+              fp = pending_routes[controller.to_s]&.include?(action)
+              pending(fp_message) if fp
 
               # Mock the controller's action name as it's not available implicitly
               allow(subject).to receive(:action_name).and_return(action)
@@ -53,7 +81,7 @@ describe 'Application routes' do
                 raise
               rescue => ex
                 # NOP: we don't care if any other exception happens
-              end.to raise_error(MiqException::RbacPrivilegeException)
+              end.to raise_error(MiqException::RbacPrivilegeException), !fp && error_message
             end
           end
         end


### PR DESCRIPTION
As @Fryguy requested, I'm making the error messages a little bit more descriptive...