### PR TITLE
fix failing test that renamed the cinder manager

### DIFF
--- a/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_storage_controller.rb
@@ -35,7 +35,7 @@ shared_examples :shared_examples_for_ems_storage_controller do |providers|
           get :show, :params => {:id => @ems.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "Test Cloud Manager Cinder Manager (Dashboard)",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Test Cloud Manager Swift Manager (Dashboard)",
                                                 :url  => "/ems_storage/show/#{@ems.id}"}])
           is_expected.to render_template(:partial => "ems_storage/_show_block_storage_dashboard")
         end


### PR DESCRIPTION
I think this got renamed recently and that's why it's failing. 
