### PR TITLE
Fix the SwiftManager subclass type check in shared_storage_manager_context

### DIFF
--- a/spec/shared/controllers/shared_storage_manager_context.rb
+++ b/spec/shared/controllers/shared_storage_manager_context.rb
@@ -6,7 +6,7 @@ shared_context :shared_storage_manager_context do |t|
       @swift_manager    = @cinder_manager = nil
       @storage_managers = @ems_cloud.storage_managers
       @storage_managers.each do |sm|
-        if sm.type == "ManageIQ::Providers::StorageManager::SwiftManager"
+        if sm.type == "ManageIQ::Providers::Openstack::StorageManager::SwiftManager"
           @swift_manager = sm
         else
           @cinder_manager = sm


### PR DESCRIPTION
The SwiftManager is now subclassed under the ManageIQ::Providers::Openstack::StorageManager class, this exact class name check was causing swift managers to be assigned to the `@cinder_manager` ivar

Fixes https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/471734344#L2753-L2766