### PR TITLE
Adding host_initiators for block-storage-dashboard

### DIFF
--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsStorageHelper::TextualSummary
   def textual_group_relationships
     relationships = %i[
                        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
-                       cloud_object_store_containers custom_button_events physical_storages storage_resources
+                       cloud_object_store_containers custom_button_events host_initiators physical_storages storage_resources
       ]
     relationships.push(:cloud_volume_types) if @record.kind_of?(ManageIQ::Providers::StorageManager::CinderManager)
     TextualGroup.new(_("Relationships"), relationships)
@@ -85,6 +85,10 @@ module EmsStorageHelper::TextualSummary
 
   def textual_storage_resources
     textual_link(@record.try(:storage_resources), :label => _('Resources (Pools)'))
+  end
+
+  def textual_host_initiators
+    textual_link(@record.try(:host_initiators), :label => _('Host Initiators'))
   end
 
   def textual_physical_storages

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -21,7 +21,7 @@ class EmsStorageDashboardService < EmsDashboardService
 
   def attributes_data
     attributes = if @ems.supports?(:block_storage)
-                   %i[physical_storages storage_resources cloud_volumes]
+                   %i[physical_storages storage_resources cloud_volumes host_initiators]
                  else
                    %i[cloud_object_store_containers cloud_object_store_objects]
                  end
@@ -30,6 +30,7 @@ class EmsStorageDashboardService < EmsDashboardService
       :physical_storages             => 'pficon pficon-container-node',
       :storage_resources             => 'pficon pficon-resource-pool',
       :cloud_volumes                 => 'pficon pficon-volume',
+      :host_initiators               => 'pficon pficon-virtual-machine',
       :cloud_object_store_containers => 'ff ff-cloud-object-store',
       :cloud_object_store_objects    => 'fa fa-star',
     }
@@ -38,6 +39,7 @@ class EmsStorageDashboardService < EmsDashboardService
       :storage_resources             => 'storage_resources',
       :cloud_volumes                 => 'cloud_volumes',
       :physical_storages             => 'physical_storages',
+      :host_initiators               => 'host_initiators',
       :cloud_object_store_containers => 'cloud_object_store_containers',
       :cloud_object_store_objects    => 'cloud_object_store_objects',
     }
@@ -46,6 +48,7 @@ class EmsStorageDashboardService < EmsDashboardService
       :storage_resources             => _('Resources (Pools)'),
       :cloud_volumes                 => _('Volumes'),
       :physical_storages             => _('Physical Storages'),
+      :host_initiators               => _('Host Initiators'),
       :cloud_object_store_containers => _('Containers'),
       :cloud_object_store_objects    => _('Objects'),
     }

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -14,6 +14,7 @@ describe EmsStorageHelper::TextualSummary do
       cloud_volume_backups
       cloud_object_store_containers
       custom_button_events
+      host_initiators
       physical_storages
       storage_resources
     ]
@@ -36,6 +37,7 @@ describe EmsStorageHelper::TextualSummary do
       cloud_volume_backups
       cloud_object_store_containers
       custom_button_events
+      host_initiators
       physical_storages
       storage_resources
       cloud_volume_types


### PR DESCRIPTION
Host Initiators (AKA physical storage hosts) are virtual entities that only exists as a set of definitions within the `PhysicalStorage' and hold the information about consumers/hosts that use (defined) the physical storage.

This PR includes the work for adding host initiators to block storage dashboard and summary page

![Screenshot 2021-01-17 060105](https://user-images.githubusercontent.com/53213107/104830663-6f89d580-5889-11eb-9ba9-749544904683.jpg)
![Screenshot 2021-01-17 060009](https://user-images.githubusercontent.com/53213107/104830664-70bb0280-5889-11eb-87d1-9ec731ce4eff.jpg)

Host-initiators example data
---------
Below are diagrams that shows how we'd represent rather standard scenario. 

<img width="941" alt="111" src="https://user-images.githubusercontent.com/53213107/102864880-91846980-443d-11eb-8211-351df62ecab2.png">

All items in white are already part of miq:
We have a single IRL storage-system Called SVC Storage 1.
It has 2 storage pools: Pool1 and Pool2.
Pool1 has two volumes: Volume1 and Volume2.

All items in blue are changes done in this PR:
The Physical Storage has a single host-initiator defined in it. It has been defined with two addresses: iqn-addr-1, and wwpn-addr-1. For the sake of brevity I won't use real IQN and WWPN addresses as they are too long. 

All items in peach are future drafts pending changes (not part of this PR):
The host-initiator in the storage-system has been mapped to Volume1.
A DB server consumes Volume1.
One of the FC addresses of the DB server is wwpn-addr-2. Remeber that this address was defined on the host-initiator above. This, together with the fact that the host-initiator was mapped to Volume1 allows the DB server to consume it.

In this diagram, the addresses are implemented as an STI.
There's a general SAN (Storage Area Network) Address table that holds all possible info for all address. It's expected to be a sparse table as concrete addresses will only populate their specific fields. 
So FcAddresses will have nil for their iscsi values such as IQN and CHAP. And the reverse holds true for IscsiAddresses.

links
-----
https://github.com/ManageIQ/manageiq-decorators/pull/43