### PR TITLE
rename parent to module_parent

### DIFF
--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -136,7 +136,7 @@ class CloudObjectStoreContainerController < ApplicationController
   def retrieve_provider_regions
     managers = ManageIQ::Providers::CloudManager.supported_subclasses.select(&:supports_regions?)
     managers.each_with_object({}) do |manager, provider_regions|
-      regions = manager.parent::Regions.all.sort_by { |r| r[:description] }
+      regions = manager.module_parent::Regions.all.sort_by { |r| r[:description] }
       provider_regions[manager.name] = regions.map { |region| [region[:description], region[:name]] }
     end
   end


### PR DESCRIPTION
`Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1