### PR TITLE
miq_debug: rewrite angular parts to react

### DIFF
--- a/app/javascript/components/miq_debug/index.jsx
+++ b/app/javascript/components/miq_debug/index.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { ToastWrapper } from './toast-wrapper.jsx';
+
+const state = {
+  items: [],
+  keyCounter: 0,
+
+  add: (item) => {
+    state.items = [...state.items, item];
+    state.render();
+  },
+  clear: () => {
+    state.items = [];
+    state.render();
+  },
+  disable: () => {
+    sessionStorage.setItem('disableDebugToasts', true);
+    state.clear();
+  },
+  remove: (item) => {
+    state.items = state.items.filter((i) => i !== item);
+    state.render();
+  },
+
+  render: () => null,
+};
+
+// render once, and set state.render
+export const renderToastWrapper = (element) => {
+  const render = ({ items, clear, remove, disable }) => {
+    ReactDOM.render(<ToastWrapper items={items} clear={clear} remove={remove} disable={disable} />, element);
+  };
+  state.render = () => render(state);
+
+  state.render();
+};
+
+const debug_toast = function(type, data) {
+  // Don't display debug toasts if the user doesn't want it
+  if (sessionStorage.getItem('disableDebugToasts')) {
+    return false;
+  }
+
+  if (type === 'warn') {
+    type = 'warning';
+  }
+
+  // to make sure user can see the whole error even if we show incomplete toast
+  console.debug('debug_toast', type, data);
+
+  state.add({
+    data,
+    type,
+    key: state.keyCounter++,
+  });
+};
+
+export const setupErrorHandlers = () => {
+  const orig = {
+    error: window.console.error,
+    warn: window.console.warn,
+  };
+
+  Object.keys(orig).forEach(function(key) {
+    window.console[key] = function() {
+      orig[key].apply(window.console, arguments);
+      debug_toast(key, Array.from(arguments));
+    };
+  });
+
+  window.onerror = function(msg, url, lineNo, columnNo, error) {
+    debug_toast('error', {
+      message: msg,
+      url: url,
+      lineNo: lineNo,
+      columnNo: columnNo,
+      error: error,
+    });
+  };
+
+  window.addEventListener('error', function(ev) {
+    debug_toast('error', ev);
+  }, true);
+};

--- a/app/javascript/components/miq_debug/toast-item.jsx
+++ b/app/javascript/components/miq_debug/toast-item.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { isPlainObject, isArray } from 'lodash';
+
+const level2class = {
+  error: 'alert-danger',
+  info: 'alert-info',
+  success: 'alert-success',
+  warning: 'alert-warning',
+};
+
+const level2icon = {
+  error: 'pficon pficon-error-circle-o',
+  info: 'pficon pficon-info',
+  success: 'pficon pficon-ok',
+  warning: 'pficon pficon-warning-triangle-o',
+};
+
+const sanitize = function(data) {
+  if (isPlainObject(data) && (data.error || data.message)) {
+    return (data.error || '').toString() + ' ' + (data.message || '').toString();
+  }
+
+  if (isPlainObject(data)) {
+    return JSON.stringify(data);
+  }
+
+  if (isArray(data) && data.length === 1) {
+    return sanitize(data[0]);
+  }
+
+  if (data.toString().substr(0, 8) === '[object ') {
+    return 'Unknown error, please see the console for details';
+  } // no i18n, devel mode only
+
+  return data.toString();
+};
+
+export const ToastItem = ({ type, data, close }) => {
+  const icon = level2icon[type];
+  const alert = level2class[type];
+  const message = sanitize(data);
+
+  return (
+    <div className="row">
+      <div className={`toast-pf alert alert-dismissable col-xs-12 ${alert}`}>
+        <button type="button" className="close" data-dismiss="alert" aria-hidden="true" onClick={close}>
+          <span className="pficon pficon-close"></span>
+        </button>
+        <span className={icon}></span>
+        {message}
+      </div>
+    </div>
+  );
+};

--- a/app/javascript/components/miq_debug/toast-wrapper.jsx
+++ b/app/javascript/components/miq_debug/toast-wrapper.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { ToastItem } from './toast-item.jsx';
+
+export const ToastWrapper = ({ items, clear, remove, disable }) => {
+  if (! items.length) {
+    return (<></>);
+  }
+
+  const handler = (fn) => (ev) => {
+    fn();
+    ev.preventDefault();
+    return false;
+  };
+
+  return (
+    <div className="container miq-toast-wrapper">
+      <div className="row">
+        <div className="toast-pf alert col-xs-12" onClick={handler(clear)}>
+          <span className="pficon pficon-close"></span>
+          <a href="" onClick={handler(clear)}>
+            Clear all
+          </a>
+          &nbsp;|&nbsp;
+          <a href="" onClick={handler(disable)}>
+            Disable notifications
+          </a>
+        </div>
+      </div>
+
+      {items.map((item) => (
+        <ToastItem type={item.type} data={item.data} close={handler(() => remove(item))} key={item.key} />
+      ))}
+    </div>
+  );
+};

--- a/app/javascript/oldjs/application.js
+++ b/app/javascript/oldjs/application.js
@@ -31,3 +31,8 @@ require('./miq_toolbar.js');
 require('./miq_c3.js');
 require('./miq_explorer.js');
 require('./miq_timeline.js');
+
+if (process.env.NODE_ENV === 'development') {
+  require('./miq_debug.js');
+  require('./miq_debug.css');
+}

--- a/app/javascript/oldjs/miq_debug.js
+++ b/app/javascript/oldjs/miq_debug.js
@@ -1,187 +1,29 @@
-/* global miqSparkleOff */
+import { renderToastWrapper, setupErrorHandlers } from '../components/miq_debug/';
 
-if (process.env.NODE_ENV === 'development') {
-  require('./miq_debug.css');
+const { miqSparkleOff, $ } = window;
 
-  // CTRL+SHIFT+X stops the spinner
-  $(document).bind('keyup', 'ctrl+shift+x', miqSparkleOff);
+// NOTE: this file is only included in development mode
 
-  // / Warn for duplicate DOM IDs
-  (function() {
-    var duplicate = function() {
-      $('[id]').each(function() {
-        var ids = $('[id="' + this.id + '"]');
-        if (ids.length > 1 && $.inArray(this, ids) !== -1) {
-          console.warn('Duplicate DOM ID #' + this.id, this);
-        }
-      });
-    };
+// CTRL+SHIFT+X stops the spinner
+$(document).bind('keyup', 'ctrl+shift+x', miqSparkleOff);
 
-    $(duplicate);
-    $(document).ajaxComplete(duplicate);
-  })();
-
-  // toast on error
-  $(function() {
-    var orig = {
-      error: window.console.error,
-      warn: window.console.warn,
-    };
-
-    Object.keys(orig).forEach(function(key) {
-      window.console[key] = function() {
-        orig[key].apply(window.console, arguments);
-        window.debug_toast(key, Array.from(arguments));
-      };
-    });
-
-    window.onerror = function(msg, url, lineNo, columnNo, error) {
-      window.debug_toast('error', {
-        message: msg,
-        url: url,
-        lineNo: lineNo,
-        columnNo: columnNo,
-        error: error,
-      });
-    };
-
-    window.addEventListener('error', function(ev) {
-      window.debug_toast('error', ev);
-    }, true);
-
-    window.debug_toast = function(type, data) {
-      // Don't display debug toasts if the user doesn't want it
-      if (sessionStorage.getItem('disableDebugToasts')) {
-        return false;
-      }
-
-      if (type === 'warn') {
-        type = 'warning';
-      }
-
-      // to make sure user can see the whole error even if we show incomplete toast
-      console.debug('debug_toast', type, data);
-
-      sendDataWithRx({
-        error: {
-          type: type,
-          data: data,
-        },
-      });
-    };
-
-    var el = $('<toast-wrapper></toast-wrapper>');
-    el.appendTo(document.body);
-    miq_bootstrap(el, 'miq.debug');
+// Warn for duplicate DOM IDs
+const duplicate = () => {
+  $('[id]').each(function() {
+    var ids = $('[id="' + this.id + '"]');
+    if (ids.length > 1 && $.inArray(this, ids) !== -1) {
+      console.warn('Duplicate DOM ID #' + this.id, this);
+    }
   });
+};
+$(duplicate);
+$(document).bind('ajaxComplete', duplicate);
 
-  angular.module('miq.debug', [])
-    .component('toastWrapper', {
-      template: [
-        '<div class="container miq-toast-wrapper" ng-if="$ctrl.items.length">',
-        '  <div class="row">',
-        '    <div class="toast-pf alert col-xs-12" ng-click="$ctrl.clear()">',
-        '      <span class="pficon pficon-close"></span>',
-        '      <a href="">Clear all</a>',
-        '      &nbsp;|&nbsp;',
-        '      <a href="" ng-click="$ctrl.disable()">Disable notifications</a>',
-        '    </div>',
-        '  </div>',
-        '',
-        '  <toast-item ng-repeat="item in $ctrl.items" data="item" close="$ctrl.close"></toast-item>',
-        '</div>',
-      ].join('\n'),
-      controller: ['$timeout', function($timeout) {
-        var $ctrl = this;
-        this.items = [];
+// toast on error
+$(() => {
+  var el = $('<div class="toast-wrapper"></div>');
+  el.appendTo(document.body);
 
-        listenToRx(function(event) {
-          if (!event.error || !event.error.data) {
-            return;
-          }
-
-          $timeout(function() {
-            $ctrl.items.push(event.error);
-          });
-        });
-
-        this.close = function(item) {
-          _.remove(this.items, item);
-        };
-
-        this.clear = function() {
-          _.remove(this.items, _.identity);
-        };
-
-        this.disable = function() {
-          sessionStorage.setItem('disableDebugToasts', true);
-        };
-      }],
-    })
-    .component('toastItem', {
-      bindings: {
-        data: '<',
-        _close: '< close',
-      },
-      template: [
-        '<div class="row">',
-        '  <div class="toast-pf alert alert-dismissable col-xs-12" ng-class="$ctrl.alert">',
-        '    <button type="button" class="close" data-dismiss="alert" aria-hidden="true" ng-click="$ctrl.close()">',
-        '      <span class="pficon pficon-close"></span>',
-        '    </button>',
-        '    <span ng-class="$ctrl.icon"></span>',
-        '    {{$ctrl.message}}',
-        '  </div>',
-        '</div>',
-      ].join('\n'),
-      controller: [function() {
-        var $ctrl = this;
-
-        var level2class = {
-          error: 'alert-danger',
-          warning: 'alert-warning',
-          info: 'alert-info',
-          success: 'alert-success',
-        };
-
-        var level2icon = {
-          error: 'pficon pficon-error-circle-o',
-          warning: 'pficon pficon-warning-triangle-o',
-          info: 'pficon pficon-info',
-          success: 'pficon pficon-ok',
-        };
-
-        var sanitize = function(data) {
-          if (_.isPlainObject(data) && (data.error || data.message)) {
-            return (data.error || '').toString() + ' ' + (data.message || '').toString();
-          }
-
-          if (_.isPlainObject(data)) {
-            return JSON.stringify(data);
-          }
-
-          if (_.isArray(data) && data.length === 1) {
-            return sanitize(data[0]);
-          }
-
-          if (data.toString().substr(0, 8) === '[object ') {
-            return 'Unknown error, please see the console for details';
-          } // no i18n, devel mode only
-
-          return data.toString();
-        };
-
-        this.$onInit = function() {
-          $ctrl.icon = level2icon[$ctrl.data.type];
-          $ctrl.alert = level2class[$ctrl.data.type];
-
-          $ctrl.message = sanitize($ctrl.data.data);
-        };
-
-        this.close = function() {
-          $ctrl._close($ctrl.data);
-        };
-      }],
-    });
-
-}
+  renderToastWrapper(el[0]);
+  setupErrorHandlers();
+});


### PR DESCRIPTION
Require miq_debug from application.js when in development (forgotten in https://github.com/ManageIQ/manageiq-ui-classic/pull/7576),
drop all the angular code and replace with a `ToastItem` and `ToastWrapper` react components, using just patternfly base css.

Also dropped the Rx way of sending errors and listening for them elsewhere, as we can just add the item to the list more directly.

