### PR TITLE
Drop the MiqEventController#report_data from the pending route specs

### DIFF
--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -817,7 +817,6 @@ MiqAlertSetController:
 - x_show
 MiqEventController:
 - index
-- report_data
 - tree_autoload
 - tree_select
 - x_history


### PR DESCRIPTION
Someone probably introduced the right feature, so this can go away. Also fixes the broken master ...