### PR TITLE
Allow filtering by multiple tags in chargeback report editor

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -956,7 +956,7 @@ module ReportController::Reports::Editor
         options[:tenant_id] = @edit[:new][:cb_tenant_id]
       elsif @edit[:new][:cb_show_typ] == "tag"
         if @edit[:new][:cb_tag_cat] && @edit[:new][:cb_tag_value]
-          options[:tag] = "/managed/#{@edit[:new][:cb_tag_cat]}/#{@edit[:new][:cb_tag_value]}"
+          options[:tag] = parse_tag_categories(@edit[:new][:cb_tag_cat], @edit[:new][:cb_tag_value])
         end
       elsif @edit[:new][:cb_show_typ] == "entity"
         options[:provider_id] = @edit[:new][:cb_provider_id]
@@ -1141,6 +1141,32 @@ module ReportController::Reports::Editor
     end
   end
 
+  def tag_category_from(tag_or_tags)
+    case tag_or_tags
+    when String
+      tag_or_tags
+    when Array
+      tag_or_tags.first
+    else
+      raise "Invalid tag category selected."
+    end.split("/")[-2]
+  end
+
+  def tag_values_from(tag_or_tags)
+    case tag_or_tags
+    when String
+      tag_or_tags.split("/")[-1]
+    when Array
+      tag_or_tags.map { |tag| tag.split("/")[-1] }
+    else
+      raise "Invalid tag value selected."
+    end
+  end
+
+  def parse_tag_categories(category, tag_values)
+    tag_values.split(",").map { |tag_value| "/managed/#{category}/#{tag_value}" }
+  end
+
   # Set form variables for edit
   def set_form_vars
     @edit = {}
@@ -1232,8 +1258,8 @@ module ReportController::Reports::Editor
         @edit[:new][:cb_tenant_id] = options[:tenant_id]
       elsif options.key?(:tag) # Get the tag options
         @edit[:new][:cb_show_typ] = "tag"
-        @edit[:new][:cb_tag_cat] = options[:tag].split("/")[-2]
-        @edit[:new][:cb_tag_value] = options[:tag].split("/")[-1]
+        @edit[:new][:cb_tag_cat] = tag_category_from(options[:tag])
+        @edit[:new][:cb_tag_value] = tag_values_from(options[:tag])
         @edit[:cb_tags] = entries_hash(@edit[:new][:cb_tag_cat])
       elsif options.key?(:entity_id)
         @edit[:new][:cb_show_typ] = "entity"

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -109,7 +109,9 @@
             - opts = [["<#{_('Choose a Value')}>", nil]] + Array(@edit[:cb_tags].invert).sort_by { |a| a.first.downcase }
             = select_tag("cb_tag_value",
               options_for_select(opts, @edit[:new][:cb_tag_value]),
-              :class                 => "selectpicker")
+              :class                 => "selectpicker",
+              "multiple"             => true,
+              "data-live-search"     => true)
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent('cb_tag_value', '#{url}', {beforeSend: true, complete: true});

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -62,20 +62,24 @@ describe ReportController do
         expect(chargeback_report.tz).to eq("Eastern Time (US & Canada)")
       end
 
-      it "should save the 'Tag Group' option" do
+      it "should save the 'Tag Group' and tag filter option" do
         ApplicationController.handle_exceptions = true
 
         report_edit_options[:new][:cb_groupby] = "tag"
         report_edit_options[:new][:cb_groupby_tag] = "department"
         report_edit_options[:cb_cats] = {'department' => 'Department'}
+        report_edit_options[:new][:cb_tag_cat] = "department"
+        report_edit_options[:new][:cb_tag_value] = "environment,accounting"
+        report_edit_options[:new][:cb_show_typ] = "tag"
 
         controller.instance_variable_set(:@edit, report_edit_options)
         session[:edit] = assigns(:edit)
 
         post :miq_report_edit, :params => { :id => chargeback_report.id, :button => 'save' }
-
         chargeback_report.reload
-        expect(chargeback_report.db_options[:options][:groupby_tag]).to eq('department')
+        expected_tag_categories = report_edit_options[:new][:cb_tag_value].split(",").map { |x| "/managed/#{report_edit_options[:new][:cb_tag_cat]}/#{x}" }
+        tag_categories = chargeback_report.reload.db_options[:options][:tag]
+        expect(tag_categories).to match_array(expected_tag_categories)
       end
 
       describe '#reportable_models' do


### PR DESCRIPTION
This is for Chargeback Vms and Chargeback Container Projects report.

Before
<img width="1042" alt="Screenshot 2021-02-02 at 15 32 30" src="https://user-images.githubusercontent.com/14937244/106614782-06ce7880-656c-11eb-8f30-9886c72422a1.png">

After
<img width="930" alt="Screenshot 2021-02-02 at 15 31 53" src="https://user-images.githubusercontent.com/14937244/106614778-059d4b80-656c-11eb-8b27-f768193544a7.png">

Backward compatibility is supported.

# Links 
- [ ] part of https://github.com/ManageIQ/manageiq/issues/20689
- [ ]  https://github.com/ManageIQ/manageiq/pull/20967 - required 

@miq-bot assign @h-kataria 
cc @gtanzillo 

@miq-bot add_label enhancement
