### PR TITLE
Fix translation issue in "Reports - Reports - Configuration - Add a new report - Styling"

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -2,20 +2,20 @@ module ReportHelper
   include_concern 'Editor'
 
   STYLE_CLASSES = {
-    :miq_rpt_red_text    => _("Red Text"),
-    :miq_rpt_red_bg      => _("Red Background"),
-    :miq_rpt_yellow_text => _("Yellow Text"),
-    :miq_rpt_yellow_bg   => _("Yellow Background"),
-    :miq_rpt_green_text  => _("Green Text"),
-    :miq_rpt_green_bg    => _("Green Background"),
-    :miq_rpt_blue_text   => _("Blue Text"),
-    :miq_rpt_blue_bg     => _("Blue Background"),
-    :miq_rpt_maroon_text => _("Light Blue Text"),
-    :miq_rpt_maroon_bg   => _("Light Blue Background"),
-    :miq_rpt_purple_text => _("Purple Text"),
-    :miq_rpt_purple_bg   => _("Purple Background"),
-    :miq_rpt_gray_text   => _("Gray Text"),
-    :miq_rpt_gray_bg     => _("Gray Background")
+    :miq_rpt_red_text    => N_("Red Text"),
+    :miq_rpt_red_bg      => N_("Red Background"),
+    :miq_rpt_yellow_text => N_("Yellow Text"),
+    :miq_rpt_yellow_bg   => N_("Yellow Background"),
+    :miq_rpt_green_text  => N_("Green Text"),
+    :miq_rpt_green_bg    => N_("Green Background"),
+    :miq_rpt_blue_text   => N_("Blue Text"),
+    :miq_rpt_blue_bg     => N_("Blue Background"),
+    :miq_rpt_maroon_text => N_("Light Blue Text"),
+    :miq_rpt_maroon_bg   => N_("Light Blue Background"),
+    :miq_rpt_purple_text => N_("Purple Text"),
+    :miq_rpt_purple_bg   => N_("Purple Background"),
+    :miq_rpt_gray_text   => N_("Gray Text"),
+    :miq_rpt_gray_bg     => N_("Gray Background")
   }.freeze
 
   NOTHING_STRING = N_("<<<Nothing>>>").freeze

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -36,7 +36,7 @@
               - break if s_idx > 0 && (styles[s_idx - 1].blank? || styles[s_idx - 1][:operator] == "DEFAULT")
               - if s_idx > 0
                 %br
-              - opts = [[styles[s_idx] ? "<#{_('Remove')}>" : "<#{_('Normal')}>", nil]] + ReportHelper::STYLE_CLASSES.invert.to_a.sort_by { |a| a.first.downcase }
+              - opts = [[styles[s_idx] ? "<#{_('Remove')}>" : "<#{_('Normal')}>", nil]] + Array(ReportHelper::STYLE_CLASSES.invert).map{|x| [_(x[0]), x[1]]}.to_a.sort_by { |a| a.first.downcase }
               = select_tag("style_#{f_idx}_#{s_idx}",
                 options_for_select(opts, styles[s_idx] ? styles[s_idx][:class] : nil),
                 "data-miq_sparkle_on" => true,


### PR DESCRIPTION
Steps to reproduce:
- Open https://cloudform511-42.rtp.raleigh.ibm.com/dashboard/show and login with admin/smartvm
- Click Overview -> Reports
- Click Reports
- Click Configuration Management -> Virtual Machines -> Account Groups - Linux
- Click Configuration
- Click Add a new report
- Click Availiable Fields and select at one item
- Click icon
- Click Formatting
- Click Styling

Expected behavior
translated string will occur

What really happened:
English string occurs
![manageiq](https://user-images.githubusercontent.com/12009928/106758730-ddf7c300-65ff-11eb-9944-c7af4b9defae.png)


