### PR TITLE
Scroll to top on flash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1411,6 +1411,7 @@ class ApplicationController < ActionController::Base
     render :update do |page|
       page << javascript_prologue
       page.replace(:flash_msg_div, :partial => "layouts/flash_msg") # Replace the flash message
+      page << "miqScrollTop();" if @flash_array.present?
       page << "miqSetButtons(0, 'center_tb');" # Reset the center toolbar
       if layout_uses_listnav?
         page.replace(:listnav_div, :partial => "layouts/listnav") # Replace accordion, if list_nav_div is there

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1888,7 +1888,7 @@ class ApplicationController < ActionController::Base
       add_flash(_("%{task} does not apply to at least one of the selected items") %
                   {:task => type.split.map(&:capitalize).join(' ')}, :error)
     end
-    javascript_flash(:scroll_top => true) if @explorer
+    javascript_flash if @explorer
   end
 
   def set_gettext_locale

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -25,6 +25,7 @@ module ApplicationController::Automate
       page << javascript_prologue
       page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace_html("main_div", :partial => "results_tabs")
       page << javascript_reload_toolbars
       page << "miqSparkle(false);"

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -75,6 +75,7 @@ module ApplicationController::Buttons
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg") unless @refresh_div && @refresh_div != "column_lists"
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace(@refresh_div, :partial => "shared/buttons/#{@refresh_partial}") if @refresh_div
         page << "miqSparkle(false);"
         page << javascript_for_miq_button_visibility_changed(@changed)
@@ -196,6 +197,7 @@ module ApplicationController::Buttons
       page.replace(@refresh_div, :partial => "shared/buttons/#{@refresh_partial}") if @refresh_div
       if @flash_array
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
       else
         page << javascript_for_miq_button_visibility(@changed && valid)
       end
@@ -479,6 +481,7 @@ module ApplicationController::Buttons
         render :update do |page|
           page << javascript_prologue
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqScrollTop();" if @flash_array.present?
           page << "document.querySelector(\"#ab_advanced_tab_tab > a\").click();"
         end
       else
@@ -556,6 +559,7 @@ module ApplicationController::Buttons
         render :update do |page|
           page << javascript_prologue
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqScrollTop();" if @flash_array.present?
           page << "document.querySelector(\"#ab_advanced_tab_tab > a\").click();"
         end
       else

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -392,8 +392,8 @@ module ApplicationController::CiProcessing
     # Check each record if there is any compliance policy assigned to it
     if records.any? { |record| !record.has_compliance_policies? }
       javascript_flash(
-        :text       => _('No Compliance Policies assigned to one or more of the selected items'),
-        :severity   => :error
+        :text     => _('No Compliance Policies assigned to one or more of the selected items'),
+        :severity => :error
       )
       return
     end
@@ -600,8 +600,8 @@ module ApplicationController::CiProcessing
     records = find_records_with_rbac(record_class, checked_or_params)
     if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
-        :text       => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},
-        :severity   => :error
+        :text     => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},
+        :severity => :error
       )
       return
     end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -393,8 +393,7 @@ module ApplicationController::CiProcessing
     if records.any? { |record| !record.has_compliance_policies? }
       javascript_flash(
         :text       => _('No Compliance Policies assigned to one or more of the selected items'),
-        :severity   => :error,
-        :scroll_top => true
+        :severity   => :error
       )
       return
     end
@@ -602,8 +601,7 @@ module ApplicationController::CiProcessing
     if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
         :text       => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},
-        :severity   => :error,
-        :scroll_top => true
+        :severity   => :error
       )
       return
     end

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -52,6 +52,8 @@ module ApplicationController::Filter
         page << javascript_prologue
         # Don't need to replace flash div as it's included throught
         # exp_editor. That is rendered either throught adv_search_body or directly.
+        page << "miqScrollTop();" if @flash_array.present?
+
         if !@edit[:adv_search_open].nil?
           page.replace("adv_search_body", :partial => "layouts/adv_search_body", :locals => {:force => true})
           page.replace("adv_search_footer", :partial => "layouts/adv_search_footer", :locals => {:force => true})
@@ -100,6 +102,7 @@ module ApplicationController::Filter
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("exp_editor_div", :partial => "layouts/exp_editor")
         page << "$('#exp_#{token}').css({'text-decoration': 'underline'})"
         page << javascript_hide("exp_buttons_off")
@@ -139,6 +142,7 @@ module ApplicationController::Filter
       render :update do |page|
         page << javascript_prologue
         page.replace("exp_editor_flash", :partial => "layouts/flash_msg", :locals => {:flash_div_id => 'exp_editor_flash'})
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("exp_atom_editor_div", :partial => "layouts/exp_atom/editor")
 
         page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
@@ -315,6 +319,7 @@ module ApplicationController::Filter
         page << javascript_prologue
         page.replace(:listnav_div, :partial => "layouts/listnav")
         page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page << "miqSparkleOff();"
       end
     else

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -66,6 +66,7 @@ module ApplicationController::MiqRequestMethods
           page << javascript_for_miq_button_visibility(changed)
         end
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page << "miqSparkle(false);"
       end
     end
@@ -688,6 +689,7 @@ module ApplicationController::MiqRequestMethods
         page << javascript_prologue
         page.replace("prov_wf_div", :partial => "/miq_request/prov_wf") if @error_div
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
       end
     end
   end

--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -61,6 +61,7 @@ module ApplicationController::Performance
       page << "ManageIQ.toolbars.applyChanges(#{button_changes.to_json})" if button_changes.present?
 
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("perf_options_div", :partial => "layouts/perf_options")
       page.replace("candu_charts_div", :partial => "layouts/perf_charts",
                                        :locals  => {:chart_data => @chart_data, :chart_set => "candu"})

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -25,6 +25,7 @@ module ApplicationController::Timelines
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("tl_div", :partial => "layouts/tl_detail")
       page << "ManageIQ.calendar.calDateFrom = new Date(#{@tl_options.date.start});" unless @tl_options.date.start.nil?
       page << "ManageIQ.calendar.calDateTo = new Date(#{@tl_options.date.end});" unless @tl_options.date.end.nil?

--- a/app/controllers/application_controller/wait_for_task.rb
+++ b/app/controllers/application_controller/wait_for_task.rb
@@ -31,6 +31,7 @@ module ApplicationController::WaitForTask
       ajax_call = remote_function(:url => {:action => 'wait_for_task', :task_id => task_id})
       page << "setTimeout(\"#{ajax_call}\", #{session[:async][:interval]});"
       page.replace("flash_msg_div", :partial => "layouts/flash_msg") if should_flash
+      page << "miqScrollTop();" if @flash_array.present?
     end
   end
   private :browser_refresh_task

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -52,6 +52,7 @@ class ConfigurationController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("main_div", :partial => "ui_4") # Replace the main div area contents
         page << javascript_reload_toolbars
       end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -550,6 +550,7 @@ class DashboardController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page << javascript_show("flash_div")
         page << "miqAjaxAuthFail();"
         page << "miqSparkle(false);"

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -448,6 +448,7 @@ class InfraNetworkingController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("main_div", :partial => "show") # Replace main div area contents
         page << javascript_reload_toolbars
       end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -28,6 +28,7 @@ class MiqAeClassController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page << javascript_reload_toolbars
       page << "miqSparkle(false);"
     end
@@ -324,6 +325,7 @@ class MiqAeClassController < ApplicationController
     end
 
     presenter.replace('flash_msg_div', r[:partial => "layouts/flash_msg"]) if @flash_array
+    presenter.scroll_top if @flash_array.present?
 
     if @in_a_form && !@angular_form
       action_url = create_action_url(nodes.first)
@@ -826,6 +828,7 @@ class MiqAeClassController < ApplicationController
       page << "var ta = document.getElementById('method_data');"
       page << "}"
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page << "var lineHeight = ta.clientHeight / ta.rows;"
       page << "ta.scrollTop = (#{line.to_i}-1) * lineHeight;"
       if line.positive?
@@ -1706,6 +1709,7 @@ class MiqAeClassController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("form_div", :partial => "copy_objects_form") if params[:domain] || params[:override_source]
       page << "$('#namespace_remove').attr('disabled', #{@edit[:new][:namespace].blank?});"
       page << javascript_for_miq_button_visibility(@changed)
@@ -1751,6 +1755,7 @@ class MiqAeClassController < ApplicationController
       page << javascript_show("flash_msg_div")
       page << javascript_for_miq_button_visibility(@changed)
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("embedded_methods_div", :partial => "embedded_methods")
     end
   end

--- a/app/controllers/miq_policy_set_controller.rb
+++ b/app/controllers/miq_policy_set_controller.rb
@@ -43,6 +43,7 @@ class MiqPolicySetController < ApplicationController
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("form_div", :partial => "form") unless @flash_errors
       end
     else

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -225,6 +225,7 @@ class MiqRequestController < ApplicationController
         page << javascript_prologue
         if @error_div
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqScrollTop();" if @flash_array.present?
         else
           page.replace("prov_wf_div", :partial => "prov_wf")
         end
@@ -275,6 +276,7 @@ class MiqRequestController < ApplicationController
         page.replace_html(:requester, :partial => "shared/views/prov_dialog",
                                       :locals  => {:wf => @edit[:wf], :dialog => :requester})
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
       end
     end
   end

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -214,6 +214,7 @@ class MiqTaskController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page << "miqSetButtons(0, 'center_tb');" # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
       page << "miqSparkle(false);"

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -60,18 +60,18 @@ module Mixins
           if recs.empty?
             add_flash(_("One or more %{model} must be selected to Reconfigure") %
               {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize, :plural => true)}, :error)
-            javascript_flash(:scroll_top => true)
+            javascript_flash
             return
           else
 
             if VmOrTemplate.includes_template?(recs)
               add_flash(_("Reconfigure does not apply because you selected at least one VM Template"), :error)
-              javascript_flash(:scroll_top => true)
+              javascript_flash
               return
             end
             unless VmOrTemplate.reconfigurable?(recs)
               add_flash(_("Reconfigure does not apply because you selected at least one un-reconfigurable VM"), :error)
-              javascript_flash(:scroll_top => true)
+              javascript_flash
               return
             end
             reconfigure_ids = recs.collect(&:to_i)

--- a/app/controllers/mixins/actions/vm_actions/retire.rb
+++ b/app/controllers/mixins/actions/vm_actions/retire.rb
@@ -23,7 +23,7 @@ module Mixins
           if !%w[orchestration_stack service].include?(request.parameters["controller"]) && !%w[orchestration_stacks].include?(params[:display]) &&
              VmOrTemplate.find(selected_items).any? { |vm| !vm.supports_retire? }
             add_flash(_("Set Retirement Date does not apply to selected VM Template"), :error)
-            javascript_flash(:scroll_top => true)
+            javascript_flash
             return
           end
           session[:retire_items] = selected_items # Set the array of retire items

--- a/app/controllers/mixins/actions/vm_actions/right_size.rb
+++ b/app/controllers/mixins/actions/vm_actions/right_size.rb
@@ -15,7 +15,7 @@ module Mixins
             return
           elsif record.template?
             add_flash(_("Right-Size Recommendations does not apply to selected VM Template"), :error)
-            javascript_flash(:scroll_top => true)
+            javascript_flash
             return
           end
           if @explorer

--- a/app/controllers/mixins/explorer_show.rb
+++ b/app/controllers/mixins/explorer_show.rb
@@ -170,6 +170,7 @@ module Mixins
         render :update do |page|
           page << javascript_prologue
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqScrollTop();" if @flash_array.present?
           page.replace_html("main_div", :partial => "shared/views/ems_common/show") # Replace the main div area contents
           page << javascript_reload_toolbars
         end
@@ -202,6 +203,7 @@ module Mixins
         render :update do |page|
           page << javascript_prologue
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqScrollTop();" if @flash_array.present?
           page.replace_html("main_div", :partial => "shared/views/ems_common/show") # Replace main div area contents
           page << javascript_reload_toolbars
           page.replace_html("paging_div",

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -602,6 +602,7 @@ class OpsController < ApplicationController
     extra_js_commands(presenter)
 
     presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
+    presenter.scroll_top if @flash_array.present?
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs']) unless %w[change_tab].include?(action_name)
 
     render :json => presenter.for_render

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -217,6 +217,7 @@ module OpsController::Diagnostics
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace_html("diagnostics_cu_repair", :partial => "diagnostics_cu_repair_tab")
       page << "ManageIQ.calendar.calDateFrom = null;"
       page << "ManageIQ.calendar.calDateTo = new Date();"
@@ -256,6 +257,7 @@ module OpsController::Diagnostics
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace_html("diagnostics_cu_repair", :partial => "diagnostics_cu_repair_tab")
       page << "ManageIQ.calendar.calDateFrom = null;"
       page << "ManageIQ.calendar.calDateTo = new Date();"
@@ -322,6 +324,7 @@ module OpsController::Diagnostics
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("diagnostics_database", :partial => "diagnostics_database_tab")
         page << "miqSparkle(false);"
       end
@@ -656,6 +659,7 @@ module OpsController::Diagnostics
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("selected_#{@sb[:active_tab].split('_').last}_div", :partial => "selected")
       #   Replace tree
       if params[:pressed] == "delete_server"

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -521,6 +521,7 @@ module OpsController::OpsRbac
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("ldap_user_div", :partial => "ldap_auth_users")
       end
     else
@@ -786,6 +787,7 @@ module OpsController::OpsRbac
       if %w[up down].include?(params[:button])
         if @refresh_div
           page.replace("flash_msg_div", :partial => "layouts/flash_msg") if @refresh_div == "column_lists"
+          page << "miqScrollTop();" if @flash_array.present?
           page.replace(@refresh_div, :partial => @refresh_partial)
         end
       else

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -68,6 +68,7 @@ module OpsController::Settings
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("forest_entries_div", :partial => "ldap_forest_entries", :locals => {:entry => "new", :edit => true})
       end
       session[:entry] = "new"
@@ -79,6 +80,7 @@ module OpsController::Settings
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("forest_entries_div", :partial => "ldap_forest_entries", :locals => {:entry => entry, :edit => true})
       end
       session[:entry] = entry
@@ -99,6 +101,7 @@ module OpsController::Settings
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page << javascript_for_miq_button_visibility(@changed)
       page.replace("forest_entries_div", :partial => "ldap_forest_entries", :locals => {:entry => nil, :edit => false})
     end
@@ -139,6 +142,7 @@ module OpsController::Settings
       page << javascript_prologue
       page << javascript_for_miq_button_visibility(@changed)
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("forest_entries_div", :partial => "ldap_forest_entries", :locals => {:entry => nil, :edit => false}) if no_changes
     end
   end

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -69,6 +69,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:edit_filename], :edit => true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
         page << "$('#entry_#{j_str(params[:field])}').select();"
@@ -80,6 +81,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:reg_data], :edit => true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
         page << "$('#entry_#{j_str(params[:field])}').select();"
@@ -100,6 +102,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => session[:nteventlog_data], :edit => true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
         page << "$('#entry_#{j_str(params[:field])}').select();"
@@ -111,6 +114,7 @@ module OpsController::Settings::AnalysisProfiles
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => "new", :edit => true})
         page << javascript_focus('entry_name')
         page << "$('#entry_name').select();"
@@ -166,6 +170,7 @@ module OpsController::Settings::AnalysisProfiles
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("ap_form_div", :partial => "ap_form", :locals => {:entry => "new", :edit => false})
       page << javascript_for_miq_button_visibility(changed)
     end

--- a/app/controllers/ops_controller/settings/help_menu.rb
+++ b/app/controllers/ops_controller/settings/help_menu.rb
@@ -31,6 +31,7 @@ module OpsController::Settings::HelpMenu
       page << javascript_prologue
       page << javascript_for_miq_button_visibility(!success)
       page.replace(:flash_msg_div, :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
     end
   end
 

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -335,6 +335,7 @@ module OpsController::Settings::LabelTagMapping
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html('settings_label_tag_mapping', :partial => 'settings_label_tag_mapping_tab')
       end
     else

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -28,6 +28,7 @@ module OpsController::Settings::Tags
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace_html('settings_co_categories', :partial => 'settings_co_categories_tab')
       end
     else
@@ -168,6 +169,7 @@ module OpsController::Settings::Tags
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("classification_entries_div", :partial => "classification_entries", :locals => {:entry => "new", :edit => true})
         page << javascript_focus('entry_name')
         page << "$('#entry_name').select();"
@@ -178,6 +180,7 @@ module OpsController::Settings::Tags
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace("classification_entries_div", :partial => "classification_entries", :locals => {:entry => entry, :edit => true})
         page << javascript_focus("entry_#{j_str(params[:field])}")
         page << "$('#entry_#{j_str(params[:field])}').select();"

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -800,12 +800,14 @@ class ReportController < ApplicationController
       session[:changed] = @sb[:menu_default] ? true : (@edit[:new] != @edit[:current])
     elsif nodetype == "menu_edit_reports"
       presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
+      presenter.scroll_top if @flash_array.present?
       presenter.show(:menu_div1)
       presenter[:element_updates][:menu_roles_treebox] = {:class => 'disabled', :add => true}
       presenter.replace(:menu_div2, r[:partial => "menu_form2"])
       presenter.hide(:menu_div1, :menu_div3).show(:menu_div2)
     elsif nodetype == "menu_commit_reports"
       presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
+      presenter.scroll_top if @flash_array.present?
       if @refresh_div
         presenter.hide(:flash_msg_div)
         presenter.replace(@refresh_div.to_s, r[:partial => @refresh_partial, :locals => {:action_url => "menu_update"}])
@@ -828,6 +830,7 @@ class ReportController < ApplicationController
       # Hide flash_msg if it's being shown from New folder add event
       if flash_errors?
         presenter.replace(:flash_msg_div, r[:partial => 'layouts/flash_msg'])
+        presenter.scroll_top if @flash_array.present?
       else
         presenter.hide(:flash_msg_div)
       end
@@ -842,6 +845,7 @@ class ReportController < ApplicationController
       @sb[:tree_err] = false
     elsif %w[menu_discard_folders menu_discard_reports].include?(nodetype)
       presenter.replace(:flash_msg_div, r[:partial => 'layouts/flash_msg'])
+      presenter.scroll_top if @flash_array.present?
       presenter.replace(:menu_div1, r[:partial => 'menu_form1', :locals => {:folders => @grid_folders}])
       presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
       presenter[:element_updates][:menu_roles_treebox] = {:class => 'disabled', :remove => true}

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -198,6 +198,7 @@ module ReportController::Dashboards
       end
       if %w[up down].include?(params[:button])
         page.replace("flash_msg_div", :partial => "layouts/flash_msg") unless @refresh_div && @refresh_div != "column_lists"
+        page << "miqScrollTop();" if @flash_array.present?
         page.replace(@refresh_div, :partial => @refresh_partial, :locals => {:action => "db_seq_edit"}) if @refresh_div
       end
       page << javascript_for_miq_button_visibility(changed)

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -155,6 +155,7 @@ module ReportController::Reports::Editor
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg") unless @refresh_div && @refresh_div != "column_lists"
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace(@refresh_div, :partial => @refresh_partial) if @refresh_div
       page.replace("chart_sample_div", :partial => "form_chart_sample") if @refresh_div == "chart_div"
       page.replace_html("calc_#{@calc_div}_div", :text => @calc_val) if @calc_div

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -288,6 +288,7 @@ module VmCommon
       page << javascript_reload_toolbars
 
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+      page << "miqScrollTop();" if @flash_array.present?
       page.replace("desc_content", :partial => "/vm_common/snapshots_desc",
                                    :locals  => {:selected => params[:id]})
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1024,6 +1024,7 @@ module ApplicationHelper
     ex = ExplorerPresenter.main_div.update('main_div', render_to_string(args))
 
     ex.replace("flash_msg_div", render_to_string(:partial => "layouts/flash_msg")) if options[:flash]
+    ex.scroll_top if @flash_array.present?
     ex.spinner_off if options[:spinner_off]
 
     render :json => ex.for_render

--- a/app/helpers/application_helper/flash.rb
+++ b/app/helpers/application_helper/flash.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
       ex = ExplorerPresenter.flash.replace(flash_div_id,
                                            render_to_string(:partial => "layouts/flash_msg",
                                                             :locals  => {:flash_div_id => flash_div_id}))
-      ex.scroll_top if args[:scroll_top]
+      ex.scroll_top if @flash_array.present?
       ex.spinner_off if args[:spinner_off]
       ex.focus(args[:focus]) if args[:focus]
       ex.activate_tree_node(args[:activate_node]) if args[:activate_node]

--- a/app/javascript/oldjs/miq_explorer.js
+++ b/app/javascript/oldjs/miq_explorer.js
@@ -142,7 +142,7 @@ ManageIQ.explorer.rx = function(data) {
 
 ManageIQ.explorer.scrollTop = function(data) {
   if (data.scrollTop) {
-    $('#main_div').scrollTop(0);
+    miqScrollTop();
   }
 };
 

--- a/app/javascript/oldjs/miq_flash.js
+++ b/app/javascript/oldjs/miq_flash.js
@@ -71,6 +71,10 @@ window.add_flash = function(msg, level, options) {
   miqScrollTop();
 }
 
+window.miqScrollTop = function() {
+  $('#main_div, #main-content').scrollTop(0);
+};
+
 window.clearFlash = function() {
   $('#flash_msg_div').empty();
 }

--- a/app/javascript/oldjs/miq_flash.js
+++ b/app/javascript/oldjs/miq_flash.js
@@ -66,6 +66,9 @@ window.add_flash = function(msg, level, options) {
   if ( options.long_alert && !checkElipsis(alertDiv) ) {
     detailsLink.hide();
   }
+
+  // any new flash message scrolls to top
+  miqScrollTop();
 }
 
 window.clearFlash = function() {

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -191,7 +191,7 @@ class ExplorerPresenter
     data = {:explorer => 'flash'}
     data[:replacePartials] = @options[:replace_partials]
     data[:spinnerOff] = true if @options[:spinner_off]
-    data[:scrollTop] = true if @options[:scroll_top]
+    data[:scrollTop] = true if @options[:scroll_top] || @flash_array.present?
     data[:focus] = @options[:focus] if @options[:focus]
     data[:activateNode] = @options[:activate_node] if @options[:activate_node]
     data

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -28,8 +28,9 @@ describe ApplicationController do
           :miq_grid_checks => "#{vm1.id}, #{vm3.id}, #{vm2.id}")
         # calling 'vm_button_action' creates a proc calling 'process_objects'
         expect(controller).to receive(:javascript_flash).with(
-          :text => "Smartstate Analysis action does not apply to selected items",
-          :severity => :error)
+          :text     => "Smartstate Analysis action does not apply to selected items",
+          :severity => :error
+        )
         process_proc = controller.send(:vm_button_action)
         controller.send(
           :generic_button_operation,

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -29,8 +29,7 @@ describe ApplicationController do
         # calling 'vm_button_action' creates a proc calling 'process_objects'
         expect(controller).to receive(:javascript_flash).with(
           :text => "Smartstate Analysis action does not apply to selected items",
-          :severity => :error,
-          :scroll_top => true)
+          :severity => :error)
         process_proc = controller.send(:vm_button_action)
         controller.send(
           :generic_button_operation,


### PR DESCRIPTION
Fixes #7606, cc @Fryguy , @h-kataria 

This ensures that `miqScrollTop()`  happens when there are flash messages on:

 * `page.replace('flash_msg_div` during `render :update`
 *  `presenter.replace('flash_msg_div` using `ExplorerPresenter`
 * `ExplorerPresenter.flash`
 * `javascript_flash`
 * javascript `add_flash`

This should mean *most* ajax-updated and all js-updated flash messages should scroll the viewpoint to the top, to see them.
(Full page updates scroll to top naturally.)

Any cases where flash_msg_div is updated while updaing some other div that includes it are not covered, but will eventually get there the rewrite route.

(I don't think we have any custom JS flash implementations in angular or react code anymore, but if there are any, those should just use js `add_flash` (or `miqFlashLater`, etc.).)

