### PR TITLE
routes_spec - silence WARNING about false message

### DIFF
--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -81,7 +81,7 @@ describe 'Application routes' do
                 raise
               rescue => ex
                 # NOP: we don't care if any other exception happens
-              end.to raise_error(MiqException::RbacPrivilegeException), !fp && error_message
+              end.to raise_error(MiqException::RbacPrivilegeException), -> { !fp && error_message }
             end
           end
         end


### PR DESCRIPTION
running `rake spec:routes` emits a Kernel.warn for every false positive (about 1300 messages) ([example](https://travis-ci.com/github/ManageIQ/manageiq-ui-classic/jobs/480758459#L2103))

    WARNING: ignoring the provided expectation message argument (false) since it is not a string or a proc.

that's because `!fp && error_message` returns false or the string, and false is warned about.

Since Proc is also an option, wrapping in a proc, which prevents the warning.

Cc @skateman