### PR TITLE
[WIP] Update ui-components to 1.5

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -302,6 +302,103 @@ miq-quadicon > .single-wrapper {
   }
 }
 
+.pagination {
+  .disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    background-color: #fafafa !important;
+    background-image: none !important;
+    border-color: #d1d1d1 !important;
+    color: #8b8d8f !important;
+    opacity: 1;
+  }
+}
+
+
+.span-right-border{
+  border-right: 1px solid #d1d1d1;
+  padding-right: 10px;
+  margin-right: 10px !important;
+}
+
+.content-view-pf-pagination .form-group {
+  align-items: center;
+}
+.content-view-pf-pagination .form-group .per-page-label {
+  padding-left: 10px;
+}
+
+.pagination {
+  .page-selector {
+    span {
+      &, &:hover, &:active, &:focus, &:active:focus, &:hover:active {
+        box-shadow: initial;
+        border: 0;
+        background: initial;
+        padding-top: 0;
+      }
+    }
+
+    input[type="number"]::-webkit-outer-spin-button,
+    input[type="number"]::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+    input[type="number"] {
+      text-align: right;
+      width: 35px;
+      -moz-appearance: textfield;
+    }
+  }
+}
+
+/* new Patternfly pagination code */
+
+.content-view-pf-pagination {
+  background-color: #f5f5f5;
+  border: 1px solid #d1d1d1;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -ms-flex-pack: justify;
+      justify-content: space-between;
+}
+
+.content-view-pf-pagination .form-group {
+  -ms-flex-align: baseline;
+      align-items: baseline;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-positive: 1;
+      flex-grow: 1;
+  float: left;
+  margin: 5px;
+}
+@supports (display: flex) {
+  .content-view-pf-pagination .form-group {
+    float: none;
+  }
+}
+.content-view-pf-pagination .form-group:last-child {
+  -ms-flex-pack: end;
+      justify-content: flex-end;
+  float: right;
+}
+.content-view-pf-pagination .pagination {
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0 0 0 10px;
+}
+.content-view-pf-pagination .pagination a {
+  float: none;
+}
+@supports (display: flex) {
+  .content-view-pf-pagination .pagination a {
+    display: block;
+  }
+}
+
 /// end paginator styling
 
 /// begin table view styling
@@ -722,4 +819,14 @@ table.c3-tooltip td {
 
 .table-summary-screen > tbody > tr:hover > td, .table-summary-screen > tbody > tr:hover > th {
   background-color: transparent;
+}
+
+// gtl css from ui-components
+table.miq-table-with-footer {
+  margin-bottom: 0px;
+}
+
+.miq-table thead th {
+  color: #0099d3;
+  cursor: pointer;
 }

--- a/app/javascript/oldjs/miq_angular_application.js
+++ b/app/javascript/oldjs/miq_angular_application.js
@@ -8,10 +8,9 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'miq.compat',
   'miq.util',
   'miqStaticAssets',
-  'miqStaticAssets.common',
-  'miqStaticAssets.dialogEditor',
+  'miqStaticAssets.dialogEditor', // TODO
   'miqStaticAssets.dialogUser',
-  'miqStaticAssets.fonticonPicker',
+  'miqStaticAssets.fonticonPicker', // TODO
   'miqStaticAssets.miqSelect',
   'miqStaticAssets.treeSelector',
   'miqStaticAssets.treeView',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@data-driven-forms/pf3-component-mapper": "~2.18.3",
     "@data-driven-forms/react-form-renderer": "~2.18.3",
     "@manageiq/react-ui-components": "~0.11.70",
-    "@manageiq/ui-components": "1.4.4",
+    "@manageiq/ui-components": "~1.5.0",
     "@novnc/novnc": "~1.2.0",
     "@pf3/select": "~1.12.6",
     "@pf3/timeline": "~1.0.8",


### PR DESCRIPTION
Part of ManageIQ/manageiq-ui-classic#6716

Once ManageIQ/ui-components#455 is released as 1.5.0,
this should make ui-classic use that version and work.

---

TODO
eat https://github.com/ManageIQ/manageiq-ui-classic/pull/6954
move fonticon-picker
eat https://github.com/ManageIQ/manageiq-ui-classic/pull/6449
update https://github.com/ManageIQ/manageiq-ui-classic/issues/7603
verify the added css
and peerDependencies