### PR TITLE
Support grouping by multiple tag categories in chargeback editor

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -967,7 +967,7 @@ module ReportController::Reports::Editor
       options[:include_metrics] = @edit[:new][:cb_include_metrics]
       options[:cumulative_rate_calculation] = @edit[:new][:cumulative_rate_calculation]
       options[:groupby] = @edit[:new][:cb_groupby]
-      options[:groupby_tag] = @edit[:new][:cb_groupby] == 'tag' ? @edit[:new][:cb_groupby_tag] : nil
+      options[:groupby_tag] = @edit[:new][:cb_groupby] == 'tag' ? @edit[:new][:cb_groupby_tag].split(",") : nil
       options[:groupby_label] = @edit[:new][:cb_groupby] == 'label' ? @edit[:new][:cb_groupby_label] : nil
 
       rpt.db_options[:options] = options

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -171,7 +171,9 @@
         - opts = [["<#{_('Choose a Category')}>", nil]] + Array(@edit[:cb_cats].invert).sort_by { |a| a.first.downcase }
         = select_tag("cb_groupby_tag",
           options_for_select(opts, @edit[:new][:cb_groupby_tag]),
-          :class                 => "selectpicker")
+          :class             => "selectpicker",
+          "multiple"         => true,
+          "data-live-search" => true)
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('cb_groupby_tag', '#{url}', {beforeSend: true, complete: true});

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -66,7 +66,7 @@ describe ReportController do
         ApplicationController.handle_exceptions = true
 
         report_edit_options[:new][:cb_groupby] = "tag"
-        report_edit_options[:new][:cb_groupby_tag] = "department"
+        report_edit_options[:new][:cb_groupby_tag] = "department,environment"
         report_edit_options[:cb_cats] = {'department' => 'Department'}
         report_edit_options[:new][:cb_tag_cat] = "department"
         report_edit_options[:new][:cb_tag_value] = "environment,accounting"
@@ -80,6 +80,7 @@ describe ReportController do
         expected_tag_categories = report_edit_options[:new][:cb_tag_value].split(",").map { |x| "/managed/#{report_edit_options[:new][:cb_tag_cat]}/#{x}" }
         tag_categories = chargeback_report.reload.db_options[:options][:tag]
         expect(tag_categories).to match_array(expected_tag_categories)
+        expect(chargeback_report.db_options[:options][:groupby_tag]).to match_array(%w[environment department])
       end
 
       describe '#reportable_models' do


### PR DESCRIPTION
This is for Chargeback Vms and Chargeback Container Projects report.

Before
<img width="788" alt="Screenshot 2021-02-10 at 18 46 27" src="https://user-images.githubusercontent.com/14937244/107549633-577b4c80-6bd0-11eb-894e-98030a32485c.png">


After
<img width="1268" alt="Screenshot 2021-02-10 at 18 44 57" src="https://user-images.githubusercontent.com/14937244/107549546-3c104180-6bd0-11eb-9a46-88ddb138d63f.png">

### Links
- [x] Backend https://github.com/ManageIQ/manageiq/pull/21025 (merged)
- part of ManageIQ/manageiq#20689
- similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/7614


@miq-bot assign @h-kataria
cc @gtanzillo

@miq-bot add_label enhancement