### PR TITLE
Build the tabs after deleting a time profile

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -49,6 +49,7 @@ class ConfigurationController < ApplicationController
     if params[:pressed].ends_with?("_edit", "_copy")
       javascript_redirect(:action => @refresh_partial, :id => @redirect_id)
     else
+      build_tabs
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")


### PR DESCRIPTION
When rendering `ui_4.html.haml` which is accessible from `Settings -> My Settings -> Time Profiles`, the view expects the `@tabs` variable to be preseeded with data. When deleting a time profile, this variable is just `nil` which causes issues with the page to get rendered after the deletion.