### PR TITLE
Support Chargeback for configured systems

### DIFF
--- a/app/helpers/configured_system_helper/textual_summary.rb
+++ b/app/helpers/configured_system_helper/textual_summary.rb
@@ -4,7 +4,7 @@ module ConfiguredSystemHelper::TextualSummary
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
-      %i[hostname ipmi_present ipaddress mac_address vendor zone]
+      %i[hostname ipmi_present ipaddress mac_address container zone]
     )
   end
 
@@ -28,10 +28,17 @@ module ConfiguredSystemHelper::TextualSummary
     {:label => _("Mac address"), :value => @record.mac_address}
   end
 
-  def textual_vendor
-    return nil if @record.vendor.blank?
-
-    {:label => _("Vendor"), :image => @record.decorate.fileicon, :value => @record.vendor}
+  def textual_container
+    h = {:label => _("Container")}
+    vendor = @record.vendor
+    if vendor.blank?
+      h[:value] = _("None")
+    else
+      h[:image] = @record.decorate.fileicon
+      cpus = n_("%{cpu} CPU", "%{cpu} CPUs", @record.cpu_total_cores) % {:cpu => @record.cpu_total_cores}
+      h[:value] = "#{vendor}: #{cpus}, #{@record.ram_size} MB"
+    end
+    h
   end
 
   def textual_zone

--- a/app/helpers/term_of_service_helper.rb
+++ b/app/helpers/term_of_service_helper.rb
@@ -41,6 +41,7 @@ module TermOfServiceHelper
       "ext_management_system"  => N_("Selected Providers"),
       "ems_cluster"            => N_("Selected Clusters"),
       "vm-tags"                => N_("Tagged VMs and Instances"),
+      "configured_system-tags" => N_("Tagged Configured Systems"),
       "container_image-tags"   => N_("Tagged Container Images"),
       "container_image-labels" => N_("Labeled Container Images"),
       "tenant"                 => N_("Tenants")

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -57,6 +57,8 @@
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_('Tenant'), "tenant"]]
         - elsif @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
           - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
+        - elsif @edit[:new][:model] == "ChargebackConfiguredSystem"
+          - opts += [["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"]]
         - else
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
         = select_tag("cb_show_typ",


### PR DESCRIPTION
Ui enhancements - implements https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/55
- Expose cpu/memory information for Configured Systems (related backend change - https://github.com/ManageIQ/manageiq/pull/21045)
- updated **Show Costs by** options for Chargeback for Configured Systems
- added option to assign tags for Configured Systems

<img width="1074" alt="Configured_System_Hardware_Details" src="https://user-images.githubusercontent.com/41962815/107693635-63bce380-6c7c-11eb-8fab-6f80edf3622c.png">

<img width="1439" alt="Chargeback_report_Group_By" src="https://user-images.githubusercontent.com/41962815/107693657-6ae3f180-6c7c-11eb-909a-7dcd2ff01919.png">

<img width="1437" alt="ChargeBack_Tagged_CS_Assignments" src="https://user-images.githubusercontent.com/41962815/107693673-6f100f00-6c7c-11eb-92ab-3acbc0c18203.png">
