### PR TITLE
 Safe delete for cloud-volume

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_center.rb
@@ -68,9 +68,18 @@ class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar
                        'pficon pficon-delete fa-lg',
                        t = N_('Delete this Cloud Volume'),
                        t,
-                       :url_parms    => 'main_div',
-                       :send_checked => true,
-                       :confirm      => N_('Warning: This Cloud Volume and ALL of its components will be removed!')
+                       :url_parms => 'main_div',
+                       :klass     => ApplicationHelper::Button::CatalogItemButton,
+                       :data      => {'function'      => 'sendDataWithRx',
+                                      'function-data' => {:controller      => 'provider_dialogs',
+                                                          :modal_title     => N_('Delete Volume'),
+                                                          :modal_text      => N_('Are you sure you want to delete this volume?'),
+                                                          :api_url         => 'cloud_volumes',
+                                                          :async_delete    => false,
+                                                          :ajax_reload     => true,
+                                                          :redirect_url    => '/cloud_volume/show_list',
+                                                          :try_safe_delete => true,
+                                                          :component_name  => 'RemoveGenericItemModal'}}
                      ),
                    ]
                  )

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -88,11 +88,18 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        'pficon pficon-delete fa-lg',
                        t = N_('Delete selected Cloud Volumes'),
                        t,
-                       :url_parms    => 'main_div',
-                       :send_checked => true,
-                       :confirm      => N_('Warning: The selected Cloud Volume and ALL of their components will be removed!'),
-                       :enabled      => false,
-                       :onwhen       => '1+'
+                       :url_parms => 'main_div',
+                       :klass     => ApplicationHelper::Button::CatalogItemButton,
+                       :data      => {'function'      => 'sendDataWithRx',
+                                      'function-data' => {:controller      => 'provider_dialogs',
+                                                          :modal_title     => N_('Delete Volumes'),
+                                                          :modal_text      => N_('Are you sure you want to delete these volumes?'),
+                                                          :api_url         => 'cloud_volumes',
+                                                          :async_delete    => false,
+                                                          :ajax_reload     => false,
+                                                          :redirect_url    => '/cloud_volume/show_list',
+                                                          :try_safe_delete => true,
+                                                          :component_name  => 'RemoveGenericItemModal'}}
                      ),
                    ]
                  )

--- a/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
+++ b/app/javascript/spec/remove-generic-item-modal/remove-generic-item-modal.spec.js
@@ -15,8 +15,8 @@ describe('RemoveGenericItemModal', () => {
   const item2 = 456;
   const url1 = `/api/authentications/${item1}`;
   const url2 = `/api/authentications/${item2}`;
-  const apiResponse1 = {id: item1, name: 'name123'};
-  const apiResponse2 = {id: item2, name: 'name456'};
+  const apiResponse1 = {id: item1, name: 'name123', supports_safe_delete: false};
+  const apiResponse2 = {id: item2, name: 'name456', supports_safe_delete: false};
   const store = configureStore()({});
   const dispatchMock = jest.spyOn(store, 'dispatch');
   const modalData = {api_url: 'authentications', async_delete: true, redirect_url: '/go/home', modal_text: 'TEXT'};
@@ -42,7 +42,7 @@ describe('RemoveGenericItemModal', () => {
 
     setImmediate(() => {
       component.update();
-      expect(component.childAt(0).state()).toEqual({data: [apiResponse1], loaded: true});
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1], loaded: true, force: true});
       done();
     });
   });
@@ -55,7 +55,7 @@ describe('RemoveGenericItemModal', () => {
 
     setImmediate(() => {
       component.update();
-      expect(component.childAt(0).state()).toEqual({data: [apiResponse1, apiResponse2], loaded: true});
+      expect(component.childAt(0).state()).toEqual({data: [apiResponse1, apiResponse2], loaded: true, force: true});
       done();
     });
   });
@@ -102,7 +102,7 @@ describe('RemoveGenericItemModal', () => {
     const component = mount(<RemoveGenericItemModal store={store} recordId={item1} modalData={modalData} />);
 
     setImmediate(() => {
-      removeItems(component.childAt(0).state().data, {
+      removeItems(component.childAt(0).state().data, false,{
         apiUrl: modalData.api_url,
         asyncDelete: modalData.async_delete,
         redirectUrl: modalData.redirect_url,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -500,7 +500,6 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
-        delete_volumes
         index
         new
         show
@@ -516,6 +515,7 @@ Rails.application.routes.draw do
         snapshot_create
         button
         create
+        reload
         dynamic_checkbox_refresh
         listnav_search_selected
         quick_search


### PR DESCRIPTION
This PR changes the regular delete button of cloud-volume to a modal which allows picking between forced and non-forced option.

![image](https://user-images.githubusercontent.com/68283004/108099369-2f3a9480-708d-11eb-9fec-93aed41c8f31.png)

Part of https://github.com/ManageIQ/manageiq/issues/21055

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1010