### PR TITLE
[CI] Force bundler 2.2.9 (avoid 2.2.10)

### DIFF
--- a/bin/ci/before_install.sh
+++ b/bin/ci/before_install.sh
@@ -1,3 +1,5 @@
+gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+gem install bundler -v '2.2.9'
 if [ "$TEST_SUITE" = "spec:javascript" -o "$TEST_SUITE" = "spec:jest" -o "$TEST_SUITE" = "spec:compile" ]; then
   # Check if `nvm` is available as a command or bash function
   type nvm >/dev/null 2>&1


### PR DESCRIPTION
For now, our bundler relies on dependent gems from rubygems.org for gems
that are in rubygems.manageiq.org.  This is because we use
rubygems.manageiq.org to host gems we have overwritten.

However, bundler 2.2.10 prevents this for security reasons, but doesn't
offer a way to handle our use case.  For now, sticking to bundler 2.2.9
should allow CI to continue to run.


Links
-----

* Beginning of conversation on `gitter`: https://gitter.im/ManageIQ/manageiq?at=602a96a84c79215749ea61cd
* https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html

Steps for Testing/QA
--------------------

This is just fixing CI, so hopefully that passing should be sufficient.