### PR TITLE
Moved Configured Systems out of Ansible Tower Explorer

### DIFF
--- a/app/controllers/automation_manager_configured_system_controller.rb
+++ b/app/controllers/automation_manager_configured_system_controller.rb
@@ -40,16 +40,16 @@ class AutomationManagerConfiguredSystemController < ApplicationController
   helper_method :textual_group_list
 
   def get_session_data
-    @title = _("Configured Systems")
-    @layout = "automation_manager_configured_system"
-    @lastaction = session[:automation_manager_configured_system_lastaction]
-    @display = session[:automation_manager_configured_system_display]
+    @title        = _("Configured Systems")
+    @layout       = "automation_manager_configured_system"
+    @lastaction   = session[:automation_manager_configured_system_lastaction]
+    @display      = session[:automation_manager_configured_system_display]
     @current_page = session[:automation_manager_configured_system_current_page]
   end
 
   def set_session_data
     super
-    session[:layout]                 = @layout
+    session[:layout]                                            = @layout
     session[:automation_manager_configured_system_current_page] = @current_page
   end
 

--- a/app/controllers/automation_manager_configured_system_controller.rb
+++ b/app/controllers/automation_manager_configured_system_controller.rb
@@ -1,0 +1,69 @@
+class AutomationManagerConfiguredSystemController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::BreadcrumbsMixin
+  include Mixins::GenericFormMixin
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::GenericShowMixin
+
+  def self.table_name
+    @table_name ||= "automation_manager_configured_system"
+  end
+
+  def button
+    case params[:pressed]
+    when "automation_manager_configured_system_tag"
+      tag(self.class.model)
+    end
+  end
+
+  def download_data
+    assert_privileges('automation_manager_configured_system_show_list')
+    super
+  end
+
+  def download_summary_pdf
+    assert_privileges('automation_manager_configured_system_show')
+    super
+  end
+
+  private
+
+  def textual_group_list
+    [%i[properties tags]]
+  end
+  helper_method :textual_group_list
+
+  def get_session_data
+    @title = _("Configured Systems")
+    @layout = "automation_manager_configured_system"
+    @lastaction = session[:automation_manager_configured_system_lastaction]
+    @display = session[:automation_manager_configured_system_display]
+    @current_page = session[:automation_manager_configured_system_current_page]
+  end
+
+  def set_session_data
+    super
+    session[:layout]                 = @layout
+    session[:automation_manager_configured_system_current_page] = @current_page
+  end
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _("Automation")},
+        {:title => _("Ansible Tower")},
+        {:title => _("Configured Systems"), :url => controller_url},
+      ],
+    }
+  end
+
+  menu_section :at
+  feature_for_actions controller_name, *ADV_SEARCH_ACTIONS
+  toolbar :automation_manager_configured_system, :automation_manager_configured_systems
+end

--- a/app/controllers/automation_manager_controller.rb
+++ b/app/controllers/automation_manager_controller.rb
@@ -204,12 +204,6 @@ class AutomationManagerController < ApplicationController
         :name     => :automation_manager_providers,
         :title    => _("Providers")
       },
-      {
-        :role     => "automation_manager_configured_system",
-        :role_any => true,
-        :name     => :automation_manager_cs_filter,
-        :title    => _("Configured Systems")
-      }
     ].map { |hsh| ApplicationController::Feature.new_with_hash(hsh) }
   end
 
@@ -306,7 +300,7 @@ class AutomationManagerController < ApplicationController
   end
 
   def rebuild_trees(replace_trees)
-    build_replaced_trees(replace_trees, %i[automation_manager_providers automation_manager_cs_filter])
+    build_replaced_trees(replace_trees, %i[automation_manager_providers])
   end
 
   def leaf_record

--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -113,7 +113,6 @@ module Sandbox
     cb_reports
     configuration_scripts
     condition
-    configuration_manager_cs_filter
     configuration_manager_providers
     customization_templates
     db

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -428,6 +428,7 @@ module ApplicationHelper
     when "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource",
         "ManageIQ::Providers::CloudManager::OrchestrationStack",
         "ManageIQ::Providers::ConfigurationManager",
+        "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem",
         "ManageIQ::Providers::AnsibleTower::AutomationManager::Job", "ConfigurationScript"
       controller = request.parameters[:controller]
     when "ContainerVolume"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -750,6 +750,7 @@ module ApplicationHelper
        storage_resource
        host_initiator
        physical_storage
+       automation_manager_configured_system
        availability_zone
        automation_manager
        cloud_network
@@ -1055,6 +1056,7 @@ module ApplicationHelper
 
   DOWNLOAD_VIEW_LAYOUTS = %w[action
                              auth_key_pair_cloud
+                             automation_manager_configured_system
                              availability_zone
                              alerts_overview
                              alerts_list

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -4,6 +4,7 @@ module ApplicationHelper
       common_layouts = %w[
         physical_storage
         auth_key_pair_cloud
+        automation_manager_configured_system
         availability_zone
         cloud_network
         cloud_object_store_container

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -188,6 +188,7 @@ module ApplicationHelper::PageLayouts
       auth_key_pair_cloud
       availability_zone
       automation_manager
+      automation_manager_configured_system
       cloud_network
       cloud_object_store_container
       cloud_object_store_object

--- a/app/helpers/application_helper/toolbar/automation_manager_configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_configured_system_center.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Toolbar::AutomationManagerConfiguredSystemCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configured_system_policy', [
+    select(
+      :automation_manager_configured_system_policy_choice,
+      nil,
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :automation_manager_configured_system_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Configured System'),
+          N_('Edit Tags')),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/automation_manager_configured_systems_center.rb
+++ b/app/helpers/application_helper/toolbar/automation_manager_configured_systems_center.rb
@@ -1,0 +1,20 @@
+class ApplicationHelper::Toolbar::AutomationManagerConfiguredSystemsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('automation_manager_configuration_manager_policy', [
+    select(
+      :automation_manager_configuration_manager_policy_choice,
+      nil,
+      N_('Policy'),
+      :items => [
+        button(
+          :automation_manager_configured_system_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Configured System'),
+          N_('Edit Tags'),
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1+"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/automation_manager_configured_system_helper.rb
+++ b/app/helpers/automation_manager_configured_system_helper.rb
@@ -1,0 +1,44 @@
+module AutomationManagerConfiguredSystemHelper
+  include TextualMixins::TextualGroupTags
+
+  def textual_group_properties
+    TextualGroup.new(
+      _("Properties"),
+      %i[hostname ipmi_present ipaddress mac_address provider_name zone]
+    )
+  end
+
+  def textual_hostname
+    {:label => _("Hostname"),
+     :icon  => "ff ff-configured-system",
+     :value => @record.hostname}
+  end
+
+  def textual_ipmi_present
+    {:label => _("IPMI Present"), :value => @record.ipmi_present}
+  end
+
+  def textual_ipaddress
+    {:label => _("IP Address"), :value => @record.ipaddress}
+  end
+
+  def textual_mac_address
+    {:label => _("Mac address"), :value => @record.mac_address}
+  end
+
+  def textual_provider_name
+    {:label    => _("Provider"),
+     :image    => @record.configuration_manager.decorate.fileicon,
+     :value    => @record.configuration_manager.try(:name),
+     :explorer => true}
+  end
+
+  def textual_zone
+    {:label => _("Zone"), :value => @record.configuration_manager.my_zone}
+  end
+
+  def textual_group_smart_management
+    TextualTags.new(_("Smart Management"), %i[tags])
+  end
+end
+#

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -256,7 +256,7 @@ module Menu
       def automation_manager_menu_section
         Menu::Section.new(:at, N_("Ansible Tower"), nil, [
           Menu::Item.new('automation_manager_provider', N_('Explorer'), 'automation_manager', {:feature => 'automation_manager', :any => true}, '/automation_manager/explorer'),
-          Menu::Item.new('configuration_script', N_('Templates'), 'configuration_script', {:feature => 'configuration_script_show_list'}, '/configuration_script/show_list'),
+          Menu::Item.new('automation_manager_configured_system', N_('Configured Systems'), 'automation_manager_configured_system', {:feature => 'automation_manager_configured_system_show_list'}, '/automation_manager_configured_system/show_list'),
           Menu::Item.new('configuration_job',  N_('Jobs'),     'configuration_job',  {:feature => 'configuration_job_show_list'},      '/configuration_job/show_list')
         ])
       end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -257,6 +257,7 @@ module Menu
         Menu::Section.new(:at, N_("Ansible Tower"), nil, [
           Menu::Item.new('automation_manager_provider', N_('Explorer'), 'automation_manager', {:feature => 'automation_manager', :any => true}, '/automation_manager/explorer'),
           Menu::Item.new('automation_manager_configured_system', N_('Configured Systems'), 'automation_manager_configured_system', {:feature => 'automation_manager_configured_system_show_list'}, '/automation_manager_configured_system/show_list'),
+          Menu::Item.new('configuration_script', N_('Templates'), 'configuration_script', {:feature => 'configuration_script_show_list'}, '/configuration_script/show_list'),
           Menu::Item.new('configuration_job',  N_('Jobs'),     'configuration_job',  {:feature => 'configuration_job_show_list'},      '/configuration_job/show_list')
         ])
       end

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -380,8 +380,6 @@ class TreeBuilder
     ## Management
     ### Providers
     :configuration_manager_providers => "TreeBuilderConfigurationManager",
-    ### Configured Systems
-    :configuration_manager_cs_filter => "TreeBuilderConfigurationManagerConfiguredSystems",
 
     # Control
     ## Explorer
@@ -397,8 +395,6 @@ class TreeBuilder
     ## Ansible Tower
     ### Providers
     :automation_manager_providers    => "TreeBuilderAutomationManagerProviders",
-    ### Configured Systems
-    :automation_manager_cs_filter    => "TreeBuilderAutomationManagerConfiguredSystems",
 
     ## Automate
     ### Explorer

--- a/app/views/automation_manager_configured_system/show.html.haml
+++ b/app/views/automation_manager_configured_system/show.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "layouts/textual_groups_generic"

--- a/app/views/automation_manager_configured_system/show_list.html.haml
+++ b/app/views/automation_manager_configured_system/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -542,7 +542,6 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
-        delete_volumes
         index
         new
         show
@@ -561,6 +560,7 @@ Rails.application.routes.draw do
         dynamic_checkbox_refresh
         listnav_search_selected
         quick_search
+        reload
         sections_field_changed
         show
         show_list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,27 @@ Rails.application.routes.draw do
         x_post
     },
 
+    :automation_manager_configured_system => {
+      :get => %w(
+        download_summary_pdf
+        show
+        show_list
+        tagging_edit
+      ),
+      :post => %w(
+        button
+        listnav_search_selected
+        quick_search
+        reload
+        show
+        show_list
+        tagging_edit
+      )  +
+        adv_search_post +
+        exp_post +
+        x_post
+    },
+
     :configuration_script => {
       :get  => %w(
         configuration_script_service_dialog
@@ -522,6 +543,7 @@ Rails.application.routes.draw do
         backup_select
         snapshot_new
         edit
+        delete_volumes
         index
         new
         show
@@ -537,7 +559,6 @@ Rails.application.routes.draw do
         snapshot_create
         button
         create
-        reload
         dynamic_checkbox_refresh
         listnav_search_selected
         quick_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,8 +208,7 @@ Rails.application.routes.draw do
         tagging_edit
       )  +
         adv_search_post +
-        exp_post +
-        x_post
+        exp_post
     },
 
     :configuration_script => {

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -55,6 +55,9 @@ AutomationManagerController:
 - wait_for_task
 - x_history
 - x_search_by_name
+AutomationManagerConfiguredSystemController:
+- index
+- reload
 AvailabilityZoneController:
 - compare_cancel
 - compare_choose_base

--- a/spec/controllers/automation_manager_controller_spec.rb
+++ b/spec/controllers/automation_manager_controller_spec.rb
@@ -45,7 +45,7 @@ describe AutomationManagerController do
 
     get :explorer
     accords = controller.instance_variable_get(:@accords)
-    expect(accords.size).to eq(2)
+    expect(accords.size).to eq(1)
     breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
     expect(breadcrumbs[0]).to include(:url => '/automation_manager/show_list')
     expect(response.status).to eq(200)
@@ -66,13 +66,13 @@ describe AutomationManagerController do
   end
 
   context "renders the explorer based on RBAC" do
-    it "renders explorer based on RBAC access to feature 'automation_manager_configured_system_tag'" do
-      login_as user_with_feature %w(automation_manager_configured_system_tag)
+    it "renders explorer based on RBAC access to feature 'automation_manager_refresh_provider'" do
+      login_as user_with_feature %w(automation_manager_refresh_provider)
 
       get :explorer
       accords = controller.instance_variable_get(:@accords)
       expect(accords.size).to eq(1)
-      expect(accords[0][:name]).to eq("automation_manager_cs_filter")
+      expect(accords[0][:name]).to eq("automation_manager_providers")
       expect(response.status).to eq(200)
       expect(response.body).to_not be_empty
     end
@@ -364,12 +364,6 @@ describe AutomationManagerController do
     it "fetches list for Providers accordion" do
       key = ems_key_for_provider(automation_provider1)
       allow(controller).to receive(:x_active_tree).and_return(:automation_manager_providers_tree)
-      controller.send(:get_node_info, key)
-    end
-
-    it "fetches list for Configured Systems accordion" do
-      key = ems_key_for_provider(automation_provider1)
-      allow(controller).to receive(:x_active_tree).and_return(:automation_manager_cs_filter_tree)
       controller.send(:get_node_info, key)
     end
   end


### PR DESCRIPTION
De-explorized Configured Systems, Added new second level "Configured Systems" under Automation/Ansible Tower

Dependent core [PR](https://github.com/ManageIQ/manageiq/pull/21076)
Cross repo [PR](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/333)

before
<img width="1533" alt="Screen Shot 2021-02-22 at 1 44 42 PM" src="https://user-images.githubusercontent.com/3450808/108887603-79b19900-75d8-11eb-8c92-bfd7a07b49e8.png">
<img width="1531" alt="Screen Shot 2021-02-22 at 1 44 27 PM" src="https://user-images.githubusercontent.com/3450808/108887625-7dddb680-75d8-11eb-9731-ddcca5358ddd.png">
<img width="1146" alt="Screen Shot 2021-02-22 at 1 44 01 PM" src="https://user-images.githubusercontent.com/3450808/108887637-80401080-75d8-11eb-9319-4b5cbf397e70.png">

after
<img width="1527" alt="Screen Shot 2021-02-23 at 1 15 05 PM" src="https://user-images.githubusercontent.com/3450808/108888239-30ae1480-75d9-11eb-9de5-2775289ba05b.png">

<img width="902" alt="Screen Shot 2021-02-23 at 1 09 38 PM" src="https://user-images.githubusercontent.com/3450808/108887579-73232180-75d8-11eb-9052-237f9f23bffd.png">