### PR TITLE
Rework to not use SupportsFeatureMixin::UnknownFeatureError

### DIFF
--- a/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
+++ b/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
@@ -2,12 +2,14 @@ class ApplicationHelper::Button::GenericFeatureButtonWithDisable < ApplicationHe
   needs :@record
 
   def disabled?
-    @error_message = begin
-                      @record.unsupported_reason(@feature) unless @record.supports?(@feature)
-                    rescue SupportsFeatureMixin::UnknownFeatureError
-                      # TODO: remove with deleting AvailabilityMixin module
-                      @record.is_available_now_error_message(@feature) unless @record.is_available?(@feature)
-                    end
+    @error_message =
+      # Feature supported via SupportsFeatureMixin
+      if @record.respond_to?("supports_#{@feature}?")
+        @record.unsupported_reason(@feature) unless @record.supports?(@feature)
+      else # Feature supported via AvailabilityMixin
+        @record.is_available_now_error_message(@feature) unless @record.is_available?(@feature)
+      end
+
     @error_message.present?
   end
 

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -39,12 +39,13 @@ shared_examples_for 'GenericFeatureButtonWithDisabled#calculate_properties' do
     before do
       allow(record).to receive(:is_available?).with(feature).and_return(available)
       allow(record).to receive(:is_available_now_error_message).and_return('unavailable')
-      allow(record).to receive(:supports?).with(feature).and_return(support) if defined? support
+      allow(record).to receive("supports_#{feature}?").and_return(support) if defined? support
+      allow(record).to receive(:unsupported_reason).with(feature).and_return("Feature not available/supported") if defined? support && !support
       button.calculate_properties
     end
 
     context 'when feature exists' do
-      let(:feature) { :evacuate }
+      let(:feature) { :existent_feature }
       context 'and feature is supported' do
         let(:support) { true }
         it_behaves_like 'an enabled button'


### PR DESCRIPTION
`SupportsFeatureMixin::UnknownFeatureError` removed in https://github.com/ManageIQ/manageiq/pull/21046