### PR TITLE
Added GUI cross-ref between host-initiator and cloud-volume.

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -12,7 +12,7 @@ class CloudVolumeController < ApplicationController
   include Mixins::BreadcrumbsMixin
 
   def self.display_methods
-    %w[cloud_volume_snapshots cloud_volume_backups instances custom_button_events]
+    %w[cloud_volume_snapshots cloud_volume_backups instances custom_button_events host_initiators]
   end
 
   def specific_buttons(pressed)

--- a/app/controllers/host_initiator_controller.rb
+++ b/app/controllers/host_initiator_controller.rb
@@ -11,6 +11,10 @@ class HostInitiatorController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def self.display_methods
+    %w[cloud_volumes]
+  end
+
   def new
     assert_privileges("host_initiator_new")
 

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module CloudVolumeHelper::TextualSummary
       _("Relationships"),
       %i[
         parent_ems_cloud ems availability_zone cloud_tenant base_snapshot cloud_volume_backups
-        cloud_volume_snapshots attachments custom_button_events
+        cloud_volume_snapshots attachments custom_button_events host_initiators
       ]
     )
   end
@@ -102,6 +102,16 @@ module CloudVolumeHelper::TextualSummary
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all attached Instances")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
+    end
+    h
+  end
+
+  def textual_host_initiators
+    num   = @record.number_of(:host_initiators)
+    h     = {:label => _('Host Initiators'), :value => num, :icon => "pficon pficon-volume"}
+    if num > 0 && role_allows?(:feature => "host_initiators_show_list")
+      h[:title] = _("Show host initiators mapped to this volume")
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'host_initiators')
     end
     h
   end

--- a/app/helpers/host_initiator_helper/textual_summary.rb
+++ b/app/helpers/host_initiator_helper/textual_summary.rb
@@ -12,6 +12,7 @@ module HostInitiatorHelper::TextualSummary
         name
         ems
         physical_storage
+        cloud_volumes
       ]
     )
   end
@@ -42,5 +43,15 @@ module HostInitiatorHelper::TextualSummary
 
   def textual_physical_storage
     textual_link(@record.physical_storage)
+  end
+
+  def textual_cloud_volumes
+    num   = @record.number_of(:cloud_volumes)
+    h     = {:label => _('Cloud Volumes'), :value => num, :icon => "pficon pficon-volume"}
+    if num > 0 && role_allows?(:feature => "cloud_volumes_show_list")
+      h[:title] = _("Show volumes mapped to this host initiator")
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_volumes')
+    end
+    h
   end
 end

--- a/app/views/cloud_volume/show.html.haml
+++ b/app/views/cloud_volume/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(cloud_volume_backups cloud_volume_snapshots instances custom_button_events).include?(@display)
+- if %w(cloud_volume_backups cloud_volume_snapshots instances custom_button_events host_initiators).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
   - if @showtype == "item"

--- a/app/views/host_initiator/show.html.haml
+++ b/app/views/host_initiator/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(host_initiator).include?(@display)
+- if %w(host_initiator cloud_volumes).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
   - if @showtype == "item"

--- a/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
@@ -9,6 +9,7 @@ describe CloudVolumeHelper::TextualSummary do
     cloud_volume_snapshots
     attachments
     custom_button_events
+    host_initiators
   )
   include_examples "textual_group", "Properties", %i(name size bootable description status)
 end


### PR DESCRIPTION
We have recently added HostVolumeMapping which binds instances of CloudVolume to Instance of HostInitiator. So each CloudVolume could have multiple HostInitiators, and each HostInitiator could have multiple CloudVolumes.

These 2 PRs add the mapped HostInitiators to the CloudVolume view and CloudVolumes to HostInitiators view.

I'd like to back-port these changes to Lasker.

Addition to host-initiator view
![image](https://user-images.githubusercontent.com/68283004/109510549-d1ee0c80-7aaa-11eb-8709-26e8350781ff.png)


Clicking the button from the host-initiator shows the mapped volumes
![image](https://user-images.githubusercontent.com/68283004/109420535-b405a680-79db-11eb-93dc-163aeeb02756.png)

Addition to the cloud-volume view
![image](https://user-images.githubusercontent.com/68283004/109510659-f5b15280-7aaa-11eb-8aec-3f7e134bb713.png)


Clicking the button on the cloud-volume view shows the mapped host-initiatords
![image](https://user-images.githubusercontent.com/68283004/109420561-d8fa1980-79db-11eb-8357-d05fd08924f5.png)



Relies on https://github.com/ManageIQ/manageiq/pull/21084