### PR TITLE
Fix keyboard accessibility for compare and drift screens

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -530,6 +530,10 @@ tr.rdetail > td {
 .sidebar-pf-left {
   .panel-group {
     margin-bottom: 0;
+    .panel-title > a:focus {
+      outline: -webkit-focus-ring-color auto 5px;
+      outline-offset: -2px;
+    }
   }
 }
 
@@ -722,4 +726,18 @@ table.c3-tooltip td {
 
 .table-summary-screen > tbody > tr:hover > td, .table-summary-screen > tbody > tr:hover > th {
   background-color: transparent;
+}
+
+.content-focus-order {
+  @media (min-width: 992px) {
+    .col-md-push-3 {
+      left: 0%;
+    }
+  }
+  
+  @media (min-width: 992px) {
+    .col-md-pull-9 {
+      right: 0%;
+    }
+  }
 }

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -837,14 +837,17 @@ module ApplicationController::Compare
                records.length
              end
     cell_text += " (#{length})"
+    section_class = section[:name].to_s.gsub(/[\.]/, '_')
     row = {
-      :col0       => cell_text,
-      :id         => "id_#{@rows.length}",
-      :indent     => 0,
-      :parent     => nil,
-      :section    => true,
-      :exp_id     => section[:name].to_s,
-      :_collapsed => collapsed_state(section[:name].to_s)
+      :col0           => length > 0 ? "<div> <a  class=\"exp-link #{section_class}\"  tabindex=\"0\" ><i class=\"fa fa-fw fa-angle-right exp-icon \"></i></a>#{cell_text}</div>" : cell_text,
+      :id             => "id_#{@rows.length}",
+      :indent         => 0,
+      :node_parent    => nil,
+      :parent         => nil,
+      :parent_section => nil,
+      :section        => true,
+      :exp_id         => section[:name].to_s,
+      :_collapsed     => collapsed_state(section[:name].to_s)
     }
     row.merge!(drift_section_data_cols(view, section))
     @section_parent_id = @rows.length
@@ -879,14 +882,17 @@ module ApplicationController::Compare
   # Build a record row for the compare grid xml
   def drift_add_record(view, section, record, ridx)
     @same = true
+    section_class = "#{section[:name]}_#{ridx}".to_s.gsub(/[\.]/, '_')
     row = {
-      :col0       => record,
-      :id         => "id_#{@rows.length}",
-      :indent     => 1,
-      :parent     => @section_parent_id,
-      :record     => true,
-      :exp_id     => "#{section[:name]}_#{ridx}",
-      :_collapsed => collapsed_state("#{section[:name]}_#{ridx}")
+      :col0           => @rows.blank? ? record : "<div> <a  class=\"exp-link #{section_class}\"  tabindex=\"0\" ><i class=\"fa fa-fw fa-angle-right exp-icon \"></i></a>#{record}</div>",
+      :id             => "id_#{@rows.length}",
+      :indent         => 1,
+      :node_parent    => nil,
+      :parent         => @section_parent_id,
+      :parent_section => section[:name].to_s.gsub(/[\.]/, '_'),
+      :record         => true,
+      :exp_id         => "#{section[:name]}_#{ridx}",
+      :_collapsed     => collapsed_state("#{section[:name]}_#{ridx}")
     }
     row.merge!(drift_record_data_cols(view, section, record))
 
@@ -970,16 +976,19 @@ module ApplicationController::Compare
   end
 
   # Build a field row under a record row
-  def drift_add_record_field(view, section, record, field)
+  def drift_add_record_field(view, section, record, field, ridx)
     row = if @compressed # Compressed
             drift_record_field_compressed(view, section, record, field)
           else # Expanded
             drift_record_field_expanded(view, section, record, field)
           end
-    row.merge!(:id           => "id_#{@rows.length}",
-               :indent       => 2,
-               :parent       => @record_parent_id,
-               :record_field => true)
+    row.merge!(:col0           => _(field[:header]),
+               :id             => "id_#{@rows.length}",
+               :indent         => 2,
+               :node_parent    => section[:name].to_s.gsub(/[\.]/, '_'),
+               :parent_section => "#{section[:name]}_#{ridx}".to_s.gsub(/[\.]/, '_'),
+               :parent         => @record_parent_id,
+               :record_field   => true)
     @rows << row
   end
 
@@ -1063,11 +1072,13 @@ module ApplicationController::Compare
   def drift_add_section_field(view, section, field)
     @same = true
     row = {
-      :col0          => field[:header].to_s,
-      :id            => "id_#{@rows.length}",
-      :indent        => 1,
-      :parent        => @section_parent_id,
-      :section_field => true
+      :col0           => field[:header].to_s,
+      :id             => "id_#{@rows.length}",
+      :indent         => 1,
+      :node_parent    => nil,
+      :parent         => @section_parent_id,
+      :parent_section => section[:name].to_s.gsub(/[\.]/, '_'),
+      :section_field  => true
     }
 
     if @compressed  # Compressed
@@ -1190,7 +1201,7 @@ module ApplicationController::Compare
       next if fields.nil? # Build field rows under records
 
       fields.each_with_index do |field, _fidx| # If we have fields, build field rows per record
-        comp_add_record_field(view, section, record, field)
+        comp_add_record_field(view, section, record, field, ridx)
       end
     end
   end
@@ -1360,14 +1371,17 @@ module ApplicationController::Compare
                records.length
              end
     cell_text += " (#{length})"
+    section_class = section[:name].to_s.gsub(/[\.]/, '_')
     row = {
-      :col0       => cell_text,
-      :id         => "id_#{@rows.length}",
-      :indent     => 0,
-      :parent     => nil,
-      :section    => true,
-      :exp_id     => section[:name].to_s,
-      :_collapsed => collapsed_state(section[:name].to_s)
+      :col0           => length > 0 ? "<div> <a  class=\"exp-link #{section_class}\"  tabindex=\"0\" ><i class=\"fa fa-fw fa-angle-right exp-icon \"></i></a>#{cell_text}</div>" : cell_text,
+      :id             => "id_#{@rows.length}",
+      :indent         => 0,
+      :node_parent    => nil,
+      :parent         => nil,
+      :parent_section => nil,
+      :section        => true,
+      :exp_id         => section[:name].to_s,
+      :_collapsed     => collapsed_state(section[:name].to_s)
     }
     row.merge!(compare_section_data_cols(view, section, records))
 
@@ -1403,14 +1417,17 @@ module ApplicationController::Compare
   # Build a record row for the compare grid xml
   def comp_add_record(view, section, record, ridx)
     @same = true
+    section_class = "#{section[:name]}_#{ridx}".to_s.gsub(/[\.]/, '_')
     row = {
-      :col0       => _(record),
-      :id         => "id_#{@rows.length}",
-      :indent     => 1,
-      :parent     => @section_parent_id,
-      :record     => true,
-      :exp_id     => "#{section[:name]}_#{ridx}",
-      :_collapsed => collapsed_state("#{section[:name]}_#{ridx}")
+      :col0           => @rows.blank? ? record : "<div> <a  class=\"exp-link #{section_class}\"  tabindex=\"0\" ><i class=\"fa fa-fw fa-angle-right exp-icon\"></i></a>#{record}</div>",
+      :id             => "id_#{@rows.length}",
+      :indent         => 1,
+      :node_parent    => nil,
+      :parent         => @section_parent_id,
+      :parent_section => section[:name].to_s.gsub(/[\.]/, '_'),
+      :record         => true,
+      :exp_id         => "#{section[:name]}_#{ridx}",
+      :_collapsed     => collapsed_state("#{section[:name]}_#{ridx}")
     }
     row.merge!(comp_record_data_cols(view, section, record))
 
@@ -1529,13 +1546,15 @@ module ApplicationController::Compare
   end
 
   # Build a field row under a record row
-  def comp_add_record_field(view, section, record, field)
+  def comp_add_record_field(view, section, record, field, ridx)
     row = {
-      :col0         => _(field[:header]),
-      :id           => "id_#{@rows.length}",
-      :indent       => 2,
-      :parent       => @record_parent_id,
-      :record_field => true
+      :col0           => _(field[:header]),
+      :id             => "id_#{@rows.length}",
+      :indent         => 2,
+      :parent         => @record_parent_id,
+      :node_parent    => section[:name].to_s.gsub(/[\.]/, '_'),
+      :parent_section => "#{section[:name]}_#{ridx}".to_s.gsub(/[\.]/, '_'),
+      :record_field   => true
     }
 
     if @compressed # Compressed
@@ -1662,11 +1681,13 @@ module ApplicationController::Compare
     @same = true
 
     row = {
-      :col0          => _(field[:header]),
-      :id            => "id_#{@rows.length}",
-      :indent        => 1,
-      :parent        => @section_parent_id,
-      :section_field => true
+      :col0           => _(field[:header]),
+      :id             => "id_#{@rows.length}",
+      :indent         => 1,
+      :node_parent    => nil,
+      :parent         => @section_parent_id,
+      :parent_section => section[:name].to_s.gsub(/[\.]/, '_'),
+      :section_field  => true
     }
 
     if @compressed  # Compressed
@@ -1758,8 +1779,9 @@ module ApplicationController::Compare
         end
       end
     end
-
+    
     @lastaction = "drift"
+    @explorer = true if request.xml_http_request? && explorer_controller?
   end
 
   def drift_build_record_rows(view, section, records, fields)
@@ -1772,7 +1794,7 @@ module ApplicationController::Compare
       next if fields.nil? || @exists_mode # Build field rows under records
 
       fields.each_with_index do |field, _fidx| # If we have fields, build field rows per record
-        drift_add_record_field(view, section, record, field)
+        drift_add_record_field(view, section, record, field, ridx)
       end
     end
   end

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -215,16 +215,19 @@ module ApplicationHelper
     # Create a collapsed panel based on a condition
     def miq_accordion_panel(title, condition, id, &block)
       id = valid_html_id(id)
+      control_id = "control_#{id}"
       content_tag(:div, :class => "panel panel-default") do
-        out = content_tag(:div, :class => "panel-heading") do
+        out = content_tag(:div, :class => "panel-heading", 'role' => 'tab', :id => control_id) do
           content_tag(:h4, :class => "panel-title") do
             link_to(title, "##{id}",
-                    'data-parent' => '#accordion',
-                    'data-toggle' => 'collapse',
-                    :class        => condition ? '' : 'collapsed')
+                    'aria-controls' => id,
+                    'data-parent'   => '#accordion',
+                    'data-toggle'   => 'collapse',
+                    :class          => condition ? '' : 'collapsed',
+                    'tabindex'      => 0)
           end
         end
-        out << content_tag(:div, :id => id, :class => "panel-collapse collapse #{condition ? 'in' : ''}") do
+        out << content_tag(:div, :id => id, 'aria-labelledby' => control_id, 'role' => 'tabpanel', :class => "panel-collapse collapse #{condition ? 'in' : ''}") do
           content_tag(:div, :class => "panel-body", &block)
         end
       end

--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -7,7 +7,11 @@
         - if @layout == "dashboard"
           = render :partial => "/layouts/tabs"
         = miq_toolbar toolbar_from_hash
-  .row.max-height
+  .row.max-height.content-focus-order
+    .col-sm-4.col-md-3.col-sm-pull-8.col-md-pull-9.sidebar-pf.sidebar-pf-left.max-height
+      -# listnav_div
+      = render :partial => "layouts/listnav"
+
     .col-sm-8.col-md-9.col-sm-push-4.col-md-push-3.max-height
       #main-content.row.miq-layout-center_div_with_listnav
         .col-md-12
@@ -22,7 +26,3 @@
             .col-md-12
               = yield
       .row#paging_div{:style => @in_a_form ? '' : 'display: none'}
-
-    .col-sm-4.col-md-3.col-sm-pull-8.col-md-pull-9.sidebar-pf.sidebar-pf-left.max-height
-      -# listnav_div
-      = render :partial => "layouts/listnav"

--- a/app/views/layouts/_compare.html.haml
+++ b/app/views/layouts/_compare.html.haml
@@ -3,7 +3,7 @@
   = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}
 - else
   #compare-grid
-    %table.table.table-bordered.table-treegrid{:class => @compressed ? 'table-compressed' : 'table-expanded'}
+    %table.table.table-bordered.table-treegrid.table-expanded
       %thead
         %tr
           - @cols.each do |col|
@@ -12,19 +12,25 @@
                 = col[:name].html_safe
       %tbody
         - @rows.each do |row|
-          %tr{'data-parent' => row[:parent], :class => row[:_collapsed] ? 'collapsed' : nil, 'data-exp-id' => row[:exp_id]}
+          %tr{'data-parent' => row[:parent], 'data-parent-section' => row[:parent_section], :class => row[:_collapsed] ? 'collapsed' : 'nil',:class => row[:parent] ? 'hidden' : 'nil', 'data-exp-id' => row[:exp_id], 'data-node-parent' => row[:node_parent]}
             %th.treegrid-node
               = row[:col0].html_safe
             - (@cols.length - 1).times do |i|
               %td
                 = row["col#{i + 1}".to_sym].to_s.html_safe
     :javascript
-      $('.table-treegrid').treegrid({
-        callback: function (e) {
-          var item = $(e.target).parent().parent();
-          var exp_id = item.data('exp-id');
-          var state = item.hasClass('collapsed') ? '1' : '-1';
-          miqJqueryRequest('/' + ManageIQ.controller + '/compare_set_state?rowId=' + exp_id + '&state=' + state);
+      $('.exp-link').on('click keydown', function (e) {
+        if (e.which === 13 || e.type === 'click') {
+          e.preventDefault();
+          var parentSection=e.currentTarget.classList[1];
+          $(e.currentTarget.firstChild).toggleClass('fa-angle-right fa-angle-down');
+          $(`tr[data-parent-section=${parentSection}]`).toggleClass("hidden");
+          if ($(`tr[data-node-parent=${parentSection}]`).length > 0) {
+            $(`tr[data-node-parent=${parentSection}]`).each(function(index,item){
+              if($(item).hasClass("hidden")===false) 
+                $(item).addClass("hidden");
+            });
+          }
         }
       });
 

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -9,7 +9,18 @@
     .row.toolbar-pf#toolbar.miq-toolbar-menu
       .col-sm-12
         = miq_toolbar toolbar_from_hash
-    .row.max-height
+    .row.max-height.content-focus-order
+      - if simulate?
+        #left_div.sidebar-pf.sidebar-pf-left.scrollable.max-height.col-sm-5.col-md-4.col-sm-pull-7.col-md-pull-8
+          #default_left_cell
+            = yield :left
+      - else
+        #left_div.sidebar-pf.sidebar-pf-left.scrollable.max-height.col-sm-4.col-md-3.col-sm-pull-8.col-md-pull-9
+          #default_left_cell
+            - if @accords && @trees
+              = render :partial => "layouts/listnav"
+            = yield :left
+          #custom_left_cell
       .max-height{:class => simulate? ? 'col-sm-7 col-md-8 col-sm-push-5 col-md-push-4' : 'col-sm-8 col-md-9 col-sm-push-4 col-md-push-3'}
         #main-content.row.miq-layout-center_div_with_listnav
           .col-md-12
@@ -42,18 +53,6 @@
             - if saved_report_paging?
               = render(:partial => 'layouts/saved_report_paging_bar',
                        :locals  => {:pages => @sb[:pages]})
-
-      - if simulate?
-        #left_div.sidebar-pf.sidebar-pf-left.scrollable.max-height.col-sm-5.col-md-4.col-sm-pull-7.col-md-pull-8
-          #default_left_cell
-            = yield :left
-      - else
-        #left_div.sidebar-pf.sidebar-pf-left.scrollable.max-height.col-sm-4.col-md-3.col-sm-pull-8.col-md-pull-9
-          #default_left_cell
-            - if @accords && @trees
-              = render :partial => "layouts/listnav"
-            = yield :left
-          #custom_left_cell
 
 - elsif layout_full_center
   = render :partial => layout_full_center

--- a/app/views/layouts/listnav/_compare_sections.html.haml
+++ b/app/views/layouts/listnav/_compare_sections.html.haml
@@ -1,26 +1,6 @@
 - if @explorer
   - style = "width:auto"
 .panel-group{:style => style}
-  - if @lastaction == "drift"
-    = miq_accordion_panel(h(@drift_obj.name), true, "icon") do
-      - if @sb[:compare_db] != "EmsCluster"
-        - if @drift_obj.product_name != "" && @drift_obj.service_pack != ""
-          - height = "100px"
-        - elsif @drift_obj.product_name != "" || @drift_obj.service_pack != ""
-          - height = "105px"
-        - else
-          - height = "110px"
-      - else
-        - height = "100px"
-      %div{:style => "position: relative; width: 152px; height: #{height}; z-index: 0; margin: 0px auto;"}
-        = render :partial => 'shared/quadicon', :locals => {:record => @drift_obj}
-      - if @sb[:compare_db] != "EmsCluster"
-        %div{:style => "margin-top: -25px;"}
-          %center{:style => "color:#000;"}
-            = @drift_obj.product_name
-            %br
-            = @drift_obj.service_pack
-
   = miq_accordion_panel(@lastaction == "drift" ? _("Drift Sections") : _("Comparison Sections"), true, "sections") do
     :javascript
       miqTreeResetState('#{j_str @sections_tree.name}');

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1018,7 +1018,7 @@ describe ApplicationHelper do
       let(:active) { true }
 
       it 'renders an active accordion' do
-        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\"><h4 class=\"panel-title\"><a data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" class=\"panel-collapse collapse in\"><div class=\"panel-body\">content</div></div></div>")
+        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse in\"><div class=\"panel-body\">content</div></div></div>")
       end
     end
 
@@ -1026,7 +1026,7 @@ describe ApplicationHelper do
       let(:active) { false }
 
       it 'renders an active accordion' do
-        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\"><h4 class=\"panel-title\"><a data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"collapsed\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" class=\"panel-collapse collapse \"><div class=\"panel-body\">content</div></div></div>")
+        expect(subject).to eq("<div class=\"panel panel-default\"><div class=\"panel-heading\" role=\"tab\" id=\"control_identifier\"><h4 class=\"panel-title\"><a aria-controls=\"identifier\" data-parent=\"#accordion\" data-toggle=\"collapse\" class=\"collapsed\" tabindex=\"0\" href=\"#identifier\">title</a></h4></div><div id=\"identifier\" aria-labelledby=\"control_identifier\" role=\"tabpanel\" class=\"panel-collapse collapse \"><div class=\"panel-body\">content</div></div></div>")
       end
     end
   end


### PR DESCRIPTION
Issue : https://github.com/ManageIQ/manageiq-ui-classic/issues/7364

Before:

Clickable links in compare and drift screens are not accessible by keyboard (TAB and ENTER)

After:

<img width="1333" alt="Screen Shot 2021-03-01 at 10 18 35 PM" src="https://user-images.githubusercontent.com/37085529/109592219-e6e39380-7adc-11eb-875d-bd89483045f2.png">
<img width="1413" alt="Screen Shot 2021-03-01 at 10 18 55 PM" src="https://user-images.githubusercontent.com/37085529/109592222-e6e39380-7adc-11eb-9d45-8006847ecc3e.png">
<img width="1448" alt="Screen Shot 2021-03-01 at 10 19 25 PM" src="https://user-images.githubusercontent.com/37085529/109592223-e77c2a00-7adc-11eb-97bf-1b179a432ed3.png">
<img width="1435" alt="Screen Shot 2021-03-01 at 10 19 35 PM" src="https://user-images.githubusercontent.com/37085529/109592225-e77c2a00-7adc-11eb-97fb-28b202c6a9c1.png">
<img width="1016" alt="Screen Shot 2021-03-01 at 10 19 52 PM" src="https://user-images.githubusercontent.com/37085529/109592226-e77c2a00-7adc-11eb-822e-761d22cfb3dc.png">

@miq-bot assign @h-kataria 
@miq-bot add_reviewer @h-kataria 
