### PR TITLE
[ops_controller/settings/zones.rb] Soft delete auth

### DIFF
--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -41,37 +41,6 @@
 
 %hr
 %h3
-  = _("Credentials - Windows Domain")
-.form-horizontal
-  .form-group
-    %label.control-label.col-md-2
-      = _("Username")
-    .col-md-8
-      = text_field_tag("userid",
-                        @edit[:new][:userid],
-                        :maxlength => 50,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  .form-group
-    %label.control-label.col-md-2
-      = _("Password")
-    .col-md-8
-      = password_field_tag("password",
-                        @edit[:new][:password],
-                        :maxlength => 50,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-  .form-group
-    %label.control-label.col-md-2
-      = _("Verify Password")
-    .col-md-8
-      = password_field_tag("verify",
-                        @edit[:new][:verify],
-                        :maxlength => 50,
-                        :class => "form-control",
-                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-%hr
-%h3
   = _("Settings")
 .form-horizontal
   .form-group

--- a/spec/controllers/ops_controller/settings/zones_spec.rb
+++ b/spec/controllers/ops_controller/settings/zones_spec.rb
@@ -12,8 +12,7 @@ describe OpsController do
     it 'sets flash array according to the missing name, description and verify password' do
       controller.send(:zone_edit)
       expect(controller.instance_variable_get(:@flash_array)).to eq([{:message => "Name can't be blank",                              :level => :error},
-                                                                     {:message => "Description can't be blank",                       :level => :error},
-                                                                     {:message => "Password and Verify Password fields do not match", :level => :error}])
+                                                                     {:message => "Description can't be blank",                       :level => :error}])
     end
   end
 


### PR DESCRIPTION
Removes Auth on Zones from both the form view and the controller in the UI.  Still allows them to be added via that `rails console`, but removes the feature from the UI, with the intent to possibly remove from the product all together in a future release.

~~Note:  Documentation should probably also be updated to remove mentioning this.~~ See **Links** below for docs PR.

Also, this "addresses" https://github.com/ManageIQ/manageiq-api/issues/898 by simply not making it a requirement to fix any more.  Also should simplify https://github.com/ManageIQ/manageiq-ui-classic/issues/6917


### Before

<img width="1904" alt="Screen Shot 2021-04-22 at 12 01 20 PM" src="https://user-images.githubusercontent.com/314014/115755044-834e4780-a362-11eb-961f-0e4347c5f814.png">


### Admin

<img width="1904" alt="Screen Shot 2021-04-22 at 11 59 24 AM" src="https://user-images.githubusercontent.com/314014/115755082-8d704600-a362-11eb-9973-56d3b5150dc4.png">


Links
-----

* Addresses https://github.com/ManageIQ/manageiq-api/issues/898
* Related:  https://github.com/ManageIQ/manageiq-ui-classic/issues/6917
* Docs PR:  https://github.com/ManageIQ/manageiq-documentation/pull/1535