### PR TITLE
Filter/group by tag in chargeback for container images

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -56,7 +56,7 @@
         - elsif @edit[:new][:model] == "ChargebackVm" || @edit[:new][:model] == "MeteringVm"
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_('Tenant'), "tenant"]]
         - elsif @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
-          - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
+          - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"]]
         - elsif @edit[:new][:model] == "ChargebackConfiguredSystem"
           - opts += [["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"]]
         - else
@@ -158,7 +158,7 @@
     .col-md-8
       - opts = [[(_("Date and %{chargeback_model}")  % {:chargeback_model => @edit[:new][:cb_model]} ), "date"], ["#{_('Date Only')}", "date-only"]]
       - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
-      - opts += [["#{_('Project')}", "project"], [_('Label'), 'label']] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
+      - opts += [["#{_('Project')}", "project"], [_('Label'), 'label'], ["#{_('Tag')}", "tag"]] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Tenant')}", "tenant"]] if %w(ChargebackVm MeteringVm).include?(@edit[:new][:model])
       - selected_group_by_option = @edit[:new][:cb_groupby] == 'vm' ? 'date' : @edit[:new][:cb_groupby] # legacy reports can have 'vm', TODO: remove after migration
       = select_tag("cb_groupby", options_for_select(opts, selected_group_by_option), :class => "selectpicker")


### PR DESCRIPTION
Items in red circle were added:
<img width="857" alt="Screenshot 2021-03-04 at 15 32 52" src="https://user-images.githubusercontent.com/14937244/109979455-35707800-7cff-11eb-954b-23ed3c121c1b.png">
<img width="1010" alt="Screenshot 2021-03-04 at 15 33 00" src="https://user-images.githubusercontent.com/14937244/109979362-183ba980-7cff-11eb-9617-b9a3c0fbf7e7.png">

Filter/group by is added in both sections.

cc @gtanzillo 

## Links
- [x] https://github.com/ManageIQ/manageiq/pull/21096 (required - reason for WIP) 
- [ ] https://github.com/ManageIQ/manageiq/pull/21097