### PR TITLE
Ensured Related Dialog Fields are Synchronized when Adding a New OVF Service Template

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -261,6 +261,28 @@ class CatalogController < ApplicationController
 
     changed = (@edit[:new] != @edit[:current])
 
+    if changed && @edit[:new][:ovf_template_id]
+      ovf_template = ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate.find_by(:id => @edit[:new][:ovf_template_id])
+      @edit[:new][:src_vm_id] = @edit[:new][:ovf_template_id]
+      ovf_template.refresh_field_values(@edit[:new])
+
+      @edit[:available_folders] = ovf_template.allowed_folders
+                                              .collect { |m| [m.last, m.first] }
+                                              .sort
+      @edit[:available_resource_pools] = ovf_template.allowed_resource_pools
+                                                     .collect { |m| [m.last, m.first] }
+                                                     .sort
+      @edit[:available_datacenters] = ovf_template.allowed_datacenters
+                                                  .collect { |m| [m.last, m.first] }
+                                                  .sort
+      @edit[:available_hosts] = ovf_template.allowed_hosts
+                                            .collect { |h| [h.name, h.id] }
+                                            .sort
+      @edit[:available_storages] = ovf_template.allowed_storages
+                                               .collect { |s| [s.name, s.id] }
+                                               .sort
+    end
+
     render :update do |page|
       page << javascript_prologue
       if @edit[:new][:st_prov_type] == "generic_ansible_playbook"
@@ -270,7 +292,7 @@ class CatalogController < ApplicationController
         # for generic/orchestration type tabs do not show up on screen
         # as there is only a single tab when form is initialized
         # when display in catalog is checked, replace div so tabs can be redrawn
-        if params[:st_prov_type] || (params[:display] && @edit[:new][:st_prov_type].starts_with?("generic"))
+        if (params[:st_prov_type] || (params[:display] && @edit[:new][:st_prov_type].starts_with?("generic"))) || params[:ovf_template_id]
           page.replace("form_div", :partial => "st_form")
         end
         if automate_tree_needed?
@@ -1848,6 +1870,9 @@ class CatalogController < ApplicationController
     rp = ResourcePool.find_by(:id => provision[:resource_pool_id])
     ovf_template_details[:provisioning][:resource_pool_name] = rp.try(:name)
 
+    dc = Datacenter.find_by(:id => provision[:datacenter_id])
+    ovf_template_details[:provisioning][:datacenter_name] = dc.try(:name)
+
     host = Host.find_by(:id => provision[:host_id])
     ovf_template_details[:provisioning][:host_name] = host.try(:name)
 
@@ -1859,8 +1884,13 @@ class CatalogController < ApplicationController
 
     ovf_template_details[:provisioning][:disk_format] = provision[:disk_format]
 
-    folder = EmsFolder.find_by(:id => provision[:ems_folder_id])
-    ovf_template_details[:provisioning][:ems_folder_name] = folder.try(:name)
+    folder =
+      if dc
+        dc.folders.find { |f| f.name == 'vm' }.try(:ems_ref)
+      else
+        EmsFolder.find_by(:id => provision[:ems_folder_id]).try(:name)
+      end
+    ovf_template_details[:provisioning][:ems_folder_name] = folder if folder
 
     ovf_template = ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate.find_by(:id => provision[:ovf_template_id])
     ovf_template_details[:provisioning][:ovf_template_name] = ovf_template.try(:name)
@@ -1870,7 +1900,7 @@ class CatalogController < ApplicationController
 
   def fetch_form_vars_ovf_template
     @edit[:new][:accept_all_eula] = params[:accept_all_eula] == "1" if params[:accept_all_eula]
-    copy_params_if_present(@edit[:new], params, %i[disk_format ems_folder_id host_id network_id ovf_template_id resource_pool_id storage_id vm_name])
+    copy_params_if_present(@edit[:new], params, %i[datacenter_id disk_format ems_folder_id host_id network_id ovf_template_id resource_pool_id storage_id vm_name])
     form_available_vars_ovf_template if params[:st_prov_type] || params[:ovf_template_id]
   end
 
@@ -1888,6 +1918,7 @@ class CatalogController < ApplicationController
     if @record.try(:id) && params[:button] != "save"
       options = @record.config_info[:provision]
       @edit[:new][:ovf_template_id] ||= options[:ovf_template_id]
+      @edit[:new][:datacenter_id] ||= options[:datacenter_id]
       @edit[:new][:vm_name] ||= options[:vm_name]
       @edit[:new][:resource_pool_id] ||= options[:resource_pool_id]
       @edit[:new][:ems_folder_id] ||= options[:ems_folder_id]
@@ -1901,6 +1932,9 @@ class CatalogController < ApplicationController
 
     if @edit[:new][:ovf_template_id]
       ovf_template = ManageIQ::Providers::Vmware::InfraManager::OrchestrationTemplate.find_by(:id => @edit[:new][:ovf_template_id])
+      @edit[:available_datacenters] = ovf_template.allowed_datacenters
+                                                  .collect { |m| [m.last, m.first] }
+                                                  .sort
       @edit[:available_resource_pools] = ovf_template.allowed_resource_pools
                                                      .collect { |m| [m.last, m.first] }
                                                      .sort
@@ -1918,11 +1952,13 @@ class CatalogController < ApplicationController
                                             .sort
     else
       @edit[:available_resource_pools] = []
+      @edit[:available_datacenters]    = []
       @edit[:available_folders]        = []
       @edit[:available_hosts]          = []
       @edit[:available_storages]       = []
       @edit[:available_vlans]          = []
       @edit[:new][:resource_pool_id]   = nil
+      @edit[:new][:datacenter_id]      = nil
       @edit[:new][:host_id]            = nil
       @edit[:new][:storage_id]         = nil
       @edit[:new][:disk_format]        = nil
@@ -1943,6 +1979,7 @@ class CatalogController < ApplicationController
     options[:service_template_catalog_id] = @edit[:new][:catalog_id].nil? ? nil : @edit[:new][:catalog_id]
     provision = {}
     provision[:ovf_template_id] = @edit[:new][:ovf_template_id] if @edit[:new][:ovf_template_id]
+    provision[:datacenter_id] = @edit[:new][:datacenter_id] if @edit[:new][:datacenter_id]
     provision[:vm_name] = @edit[:new][:vm_name] if @edit[:new][:vm_name]
     provision[:resource_pool_id] = @edit[:new][:resource_pool_id] if @edit[:new][:resource_pool_id]
     provision[:ems_folder_id] = @edit[:new][:ems_folder_id] if @edit[:new][:ems_folder_id]
@@ -1968,7 +2005,8 @@ class CatalogController < ApplicationController
   end
 
   def automate_tree_needed?
-    params[:display] || params[:template_id] || params[:manager_id] || params[:ovf_template_id]
+    options = %i[display template_id manager_id ovf_template_id datacenter_id resource_pool_id ems_folder_id host_id storage_id]
+    options.any? { |x| params[x] }
   end
   helper_method :automate_tree_needed?
 

--- a/app/views/catalog/_form_ovf_template_options.html.haml
+++ b/app/views/catalog/_form_ovf_template_options.html.haml
@@ -32,6 +32,18 @@
           = check_box_tag("accept_all_eula", "1", @edit[:new][:accept_all_eula],
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
 
+    - opts = [["<#{_('Choose')}>", nil]] + @edit[:available_datacenters]
+    .form-group
+      %label.col-md-2.control-label
+        = _('Datacenter')
+      .col-md-8
+        = select_tag('datacenter_id',
+                          options_for_select(opts, @edit[:new][:datacenter_id]),
+                          "data-miq_sparkle_on" => true,
+                          :class                => "selectpicker")
+        :javascript
+              miqSelectPickerEvent('datacenter_id', '#{url}')
+
     - opts = [["<#{_('Choose')}>", nil]] + @edit[:available_resource_pools]
     .form-group
       %label.col-md-2.control-label

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -153,6 +153,12 @@
           .form-horizontal
             .form-group
               %label.col-md-3.control-label
+                = _('Datacenter')
+              .col-md-9
+                = provisioning[:datacenter_name]
+          .form-horizontal
+            .form-group
+              %label.col-md-3.control-label
                 = _('Resource Pool')
               .col-md-9
                 = provisioning[:resource_pool_name]


### PR DESCRIPTION
Introduces the Datacenter field and calls the `refresh_field_values` method anytime a dialog field is selected which synchronizes the fields, filtering out unrelated dialogs.

Related to: https://github.com/ManageIQ/manageiq/pull/20895 and https://github.com/ManageIQ/manageiq-providers-vmware/pull/680

Before: 
![image](https://user-images.githubusercontent.com/64800041/122573306-a4f34480-d01c-11eb-8378-b949f75ea508.png)

After:
![image](https://user-images.githubusercontent.com/64800041/122573264-9573fb80-d01c-11eb-8976-82a1657caf09.png)