### PR TITLE
Change url_parms to accepts Procs instead of eval of Strings

### DIFF
--- a/app/helpers/application_helper/toolbar/drift_center.rb
+++ b/app/helpers/application_helper/toolbar/drift_center.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_all",
-      :url_parms => "?compare_task=all&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => Proc.new { "?compare_task=all&db=#{@compare_db}&id=#{@drift_obj.id}" }),
     twostate(
       :drift_diff,
       'ff ff-compare-different fa-lg',
@@ -15,7 +15,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_differences",
-      :url_parms => "?compare_task=different&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => Proc.new { "?compare_task=different&db=#{@compare_db}&id=#{@drift_obj.id}" }),
     twostate(
       :drift_same,
       'ff ff-compare-same fa-lg',
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       nil,
       :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_same",
-      :url_parms => "?compare_task=same&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
+      :url_parms => Proc.new { "?compare_task=same&db=#{@compare_db}&id=#{@drift_obj.id}" }),
   ])
   button_group('compare_mode', [
     twostate(

--- a/app/helpers/application_helper/toolbar/summary_center.rb
+++ b/app/helpers/application_helper/toolbar/summary_center.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::SummaryCenter < ApplicationHelper::Toolbar::Ba
       end,
       nil,
       :url       => "/show",
-      :url_parms => "?id=\#{@record.id}",
+      :url_parms => Proc.new { "?id=#{@record.id}" },
       :klass     => ApplicationHelper::Button::ShowSummary),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_center_restful.rb
+++ b/app/helpers/application_helper/toolbar/summary_center_restful.rb
@@ -8,7 +8,7 @@ class ApplicationHelper::Toolbar::SummaryCenterRestful < ApplicationHelper::Tool
       end,
       nil,
       :url       => "/",
-      :url_parms => "?id=\#{@record.id}",
+      :url_parms => Proc.new { "?id=#{@record.id}" },
       :klass     => ApplicationHelper::Button::ShowSummary),
   ])
 end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -505,6 +505,7 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :text  => "Configuration"
         )
       end
+
       it "includes the correct button items in the show screen" do
         items = _toolbar_builder.build_toolbar(toolbar_to_build).first[:items]
 
@@ -531,6 +532,28 @@ describe ApplicationHelper, "::ToolbarBuilder" do
           :text    => "Remove selected Generic Object Definitions from Inventory",
           :onwhen  => "1+",
           :enabled => false,
+        )
+      end
+    end
+
+    context "when the toolbar has dynamic url_parms" do
+      let(:toolbar_to_build) { 'drift_center_tb' }
+      let(:request) { double("ActionDispatch::Request", :query_string => "") }
+
+      let(:compare_db) { "VmOrTemplate" }
+      let(:drift_obj)  { FactoryBot.create(:vm_vmware) }
+
+      before do
+        # instance variables are set since the toolbar will build using the current
+        #   example as the @view_context
+        @compare_db = compare_db
+        @drift_obj  = drift_obj
+      end
+
+      it "evaluates the url_parms in the view context" do
+        expect(_toolbar_builder.build_toolbar(toolbar_to_build).first).to include(
+          :id        => "drift_all",
+          :url_parms => "?compare_task=all&db=#{@compare_db}&id=#{@drift_obj.id}"
         )
       end
     end


### PR DESCRIPTION
This PR removes the eval code from the Toolbar Builder by using procs instead of the eval of Strings.  Additionally, once the eval went away, there was no longer a need for the view_binding, so that was removed too.

Fixes #2049