### PR TITLE
Fix placeholder prop console error

### DIFF
--- a/app/javascript/menu/search.jsx
+++ b/app/javascript/menu/search.jsx
@@ -79,7 +79,7 @@ const MenuSearch = ({
     <SideNavItem className="padded menu-search">
       <Search
         size="sm"
-        placeHolderText={__('Find')}
+        placeholder={__('Find')}
         labelText={__('Find') /* hidden in css */}
         onChange={event => searchResults(event.target.value)}
       />


### PR DESCRIPTION
Issue: PlaceHolderText prop is changed in carbon, so need to update it to placeholder.
<img width="1680" alt="Screen Shot 2021-03-17 at 11 27 36 AM" src="https://user-images.githubusercontent.com/37085529/111493522-03eea800-8714-11eb-85fe-fea17220f142.png">

@miq-bot assign @h-kataria
@miq-bot add_reviewer @h-kataria
