### PR TITLE
Add Text Area Functionality to edit-password-field

### DIFF
--- a/app/javascript/components/async-credentials/edit-password-field.jsx
+++ b/app/javascript/components/async-credentials/edit-password-field.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, TextInput, Button } from 'carbon-components-react';
+import { FormGroup, TextInput, TextArea, Button } from 'carbon-components-react';
 import { prepareProps } from '@data-driven-forms/carbon-component-mapper';
 import { EditOff16 } from '@carbon/icons-react';
 
-import { useFieldApi } from '@@ddf';
+import { useFieldApi, componentTypes } from '@@ddf';
 
-const EditPasswordField = ({ ...props }) => {
+const EditPasswordField = ({ componentClass, ...props }) => {
   const {
     labelText, validateOnMount, isDisabled, editMode, setEditMode, buttonLabel, input, meta, ...rest
   } = useFieldApi(prepareProps(props));
@@ -14,27 +14,46 @@ const EditPasswordField = ({ ...props }) => {
   const invalid = (meta.touched || validateOnMount) && meta.error;
   const warn = (meta.touched || validateOnMount) && meta.warning;
 
+  const field = componentClass === componentTypes.TEXT_FIELD ? (
+    <TextInput
+      {...input}
+      key={input.name}
+      labelText=""
+      invalid={Boolean(invalid)}
+      invalidText={invalid || ''}
+      warn={Boolean(warn)}
+      warnText={warn || ''}
+      style={{ zIndex: 'initial' }}
+      id={`${input.name}-input`}
+      autoFocus
+      disabled={editMode || isDisabled}
+      type="password"
+      autoComplete="new-password"
+      {...rest}
+    />
+  ) : (
+    <TextArea
+      {...input}
+      key={input.name}
+      labelText=""
+      invalid={Boolean(invalid)}
+      invalidText={invalid || ''}
+      style={{ zIndex: 'initial' }}
+      id={`${input.name}-input`}
+      autoFocus
+      disabled={editMode || isDisabled}
+      type="password"
+      autoComplete="new-password"
+      {...rest}
+    />
+  );
+
   return (
     <FormGroup legendText={labelText}>
       <div className="bx--grid" style={{ paddingLeft: 0, marginLeft: 0 }}>
         <div className="bx--row">
           <div className="bx--col-lg-15 bx--col-md-7 bx--col-sm-3">
-            <TextInput
-              {...input}
-              key={input.name}
-              labelText=""
-              invalid={Boolean(invalid)}
-              invalidText={invalid || ''}
-              warn={Boolean(warn)}
-              warnText={warn || ''}
-              style={{ zIndex: 'initial' }}
-              id={`${input.name}-input`}
-              autoFocus
-              disabled={editMode || isDisabled}
-              type="password"
-              autoComplete="new-password"
-              {...rest}
-            />
+            { field }
           </div>
           <div className="bx--col-sm-1 bx--col-md-1 bx--col-lg-1">
             <Button hasIconOnly kind="secondary" size="field" onClick={setEditMode} iconDescription={buttonLabel} renderIcon={EditOff16} />
@@ -50,11 +69,13 @@ EditPasswordField.propTypes = {
   isDisabled: PropTypes.bool,
   setEditMode: PropTypes.func.isRequired,
   helperText: PropTypes.string,
+  componentClass: PropTypes.string,
 };
 
 EditPasswordField.defaultProps = {
   isDisabled: false,
   helperText: undefined,
+  componentClass: componentTypes.TEXT_FIELD,
 };
 
 export default EditPasswordField;

--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -12,6 +12,7 @@ const PasswordField = ({
   helperText,
   edit,
   parent,
+  componentClass,
   ...rest
 }) => {
   const formOptions = useFormApi();
@@ -22,7 +23,8 @@ const PasswordField = ({
     validateOnMount: rest.validateOnMount,
     helperText,
     ...rest,
-    component: edit ? 'edit-password-field' : componentTypes.TEXT_FIELD,
+    component: edit ? 'edit-password-field' : componentClass, 
+    componentClass: componentClass,
   };
 
   return (
@@ -80,6 +82,7 @@ PasswordField.propTypes = {
   helperText: PropTypes.string,
   edit: PropTypes.bool,
   parent: PropTypes.string,
+  componentClass: PropTypes.string,
 };
 
 PasswordField.defaultProps = {
@@ -88,6 +91,7 @@ PasswordField.defaultProps = {
   helperText: undefined,
   edit: false,
   parent: undefined,
+  componentClass: componentTypes.TEXT_FIELD,
 };
 
 export default PasswordField;

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
+  componentClass="text-field"
   edit={true}
   name="foo"
 >
@@ -158,18 +159,21 @@ exports[`Secret switch field component should render correctly in non edit mode 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
+  componentClass="text-field"
   edit={false}
   name="foo"
 >
   <MockDummyComponent
     autoComplete="new-password"
     component="text-field"
+    componentClass="text-field"
     name="foo"
     type="password"
   >
     <button
       autoComplete="new-password"
       component="text-field"
+      componentClass="text-field"
       name="foo"
       type="button"
     >

--- a/app/javascript/spec/async-credentials/edit-password-field.spec.js
+++ b/app/javascript/spec/async-credentials/edit-password-field.spec.js
@@ -6,6 +6,9 @@ import EditPasswordField from '../../components/async-credentials/edit-password-
 
 jest.mock('@@ddf', () => ({
   useFieldApi: props => ({ meta: {}, input: {}, ...props }),
+  componentTypes: {
+    TEXT_FIELD: 'text-field',
+  },
 }));
 
 describe('Edit secret field form component', () => {


### PR DESCRIPTION
Modifies `edit-password-field.jsx` to support Text Areas

Fixes: #7647