### PR TITLE
[LASKER] Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 python: '2.7'
 rvm:
-- 2.5.8
 - 2.6.6
 cache:
   bundler: true
@@ -19,18 +18,6 @@ env:
   - TEST_SUITE=spec:compile
   - TEST_SUITE=spec:jest
   - TEST_SUITE=spec:debride
-matrix:
-  exclude:
-  - rvm: 2.5.8
-    env: TEST_SUITE=spec:routes
-  - rvm: 2.5.8
-    env: TEST_SUITE=spec:javascript
-  - rvm: 2.5.8
-    env: TEST_SUITE=spec:compile
-  - rvm: 2.5.8
-    env: TEST_SUITE=spec:jest
-  - rvm: 2.5.8
-    env: TEST_SUITE=spec:debride
 bundler_args: "--no-deployment"
 before_install: source bin/ci/before_install.sh
 install: bin/setup


### PR DESCRIPTION
Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678