### PR TITLE
Fix i18n message

### DIFF
--- a/app/helpers/application_helper/button/delete_server.rb
+++ b/app/helpers/application_helper/button/delete_server.rb
@@ -3,8 +3,7 @@ class ApplicationHelper::Button::DeleteServer < ApplicationHelper::Button::ZoneD
 
   def disabled?
     @error_message = unless @record.is_deleteable?
-                       _("Server %{server_name} [%{server_id}] can only be deleted if it is stopped or \
-has not responded for a while") % {:server_name => @record.name, :server_id => @record.id}
+                       _("Server %{server_name} [%{server_id}] can only be deleted if it is stopped or has not responded for a while") % {:server_name => @record.name, :server_id => @record.id}
                      end
     @error_message.present?
   end

--- a/app/helpers/application_helper/button/role_suspend.rb
+++ b/app/helpers/application_helper/button/role_suspend.rb
@@ -5,8 +5,7 @@ class ApplicationHelper::Button::RoleSuspend < ApplicationHelper::Button::RolePo
     @error_message = if @view_context.x_node != 'root' && @record.server_role.regional_role?
                        _('This role can only be managed at the Region level')
                      elsif @record.active
-                       _("Activate the %{server_role_description} Role on another Server to \
-suspend it on %{server_name} [%{server_id}]") %
+                       _("Activate the %{server_role_description} Role on another Server to suspend it on %{server_name} [%{server_id}]") %
                          {:server_role_description => @record.server_role.description,
                           :server_name             => @record.miq_server.name,
                           :server_id               => @record.miq_server.id} if @record.server_role.max_concurrent == 1


### PR DESCRIPTION
Because lines were split in the code, they were getting put in the message catalog as:

"Activate the %{server_role_description} Role on another Server to \\\nsuspend it on %{server_name} [%{server_id}]"
"Server %{server_name} [%{server_id}] can only be deleted if it is stopped or \\\nhas not responded for a while"