### PR TITLE
Add vendor to configured systems and target platform to configuration profiles

### DIFF
--- a/product/views/ConfigurationProfile.yaml
+++ b/product/views/ConfigurationProfile.yaml
@@ -21,6 +21,7 @@ db: ConfigurationProfile
 cols:
 - name
 - description
+- target_platform
 - total_configured_systems
 - configuration_environment_name
 - my_zone
@@ -34,6 +35,7 @@ cols:
 col_order:
 - name
 - description
+- target_platform
 - total_configured_systems
 - configuration_environment_name
 - my_zone
@@ -43,6 +45,7 @@ col_order:
 headers:
 - Name
 - Description
+- Target Platform
 - Total Configured Systems
 - Environment
 - Zone

--- a/product/views/ConfiguredSystem.yaml
+++ b/product/views/ConfiguredSystem.yaml
@@ -25,6 +25,7 @@ cols:
 - build_state
 - my_zone
 - configuration_environment_name
+- vendor
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -37,6 +38,7 @@ col_order:
 - hostname
 - manager.name
 - type
+- vendor
 - last_checkin
 - build_state
 - my_zone
@@ -48,6 +50,7 @@ headers:
 - Hostname
 - Provider
 - Type
+- Vendor
 - Last Checkin
 - Build State
 - Zone


### PR DESCRIPTION
This is an enhancement to add the vendor to configured systems and target platform to the configuration profile list:

![Screen Shot 2021-03-22 at 4 38 25 PM](https://user-images.githubusercontent.com/22264185/112055876-c0d66f80-8b2d-11eb-8b17-0bd60606e241.png)

![Screen Shot 2021-03-22 at 4 38 07 PM](https://user-images.githubusercontent.com/22264185/112055881-c3d16000-8b2d-11eb-9622-6637f0ef9152.png)
