### PR TITLE
Fixed i18n `n__` call syntax.

### DIFF
--- a/app/javascript/components/breadcrumbs/notifications-toggle.jsx
+++ b/app/javascript/components/breadcrumbs/notifications-toggle.jsx
@@ -17,7 +17,7 @@ export const NotificationsToggle = () => {
   };
 
   const unreadCountText = function(count) {
-    return sprintf(n__('%d unread notification', '%d unread notifications', count), count);
+    return sprintf(n__('%d unread notification', '%d unread notifications'), count);
   };
 
   return (

--- a/app/javascript/components/notification-drawer/helpers.js
+++ b/app/javascript/components/notification-drawer/helpers.js
@@ -1,5 +1,5 @@
 export const newCountText = function(count) {
-  return sprintf(n__('%d New', '%d New', count), count);
+  return sprintf(n__('%d New', '%d New'), count);
 };
 
 export const getNotficationStatusIconName = notification => (


### PR DESCRIPTION
Fixed syntax, this was not causing any issue with previous version of ruby, but started throwing a JS error after upgrading to ruby 2.6.6

Error in web console, breadcrumbs bar and notification drawer were not getting loaded in UI
![image](https://user-images.githubusercontent.com/3450808/112056583-90430580-8b2e-11eb-96a0-1550c383951a.png)

Following occurrences were using correct syntax
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/components/remove-catalog-item-modal.jsx#L107-L108
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/javascript/components/remove-catalog-item-modal.jsx#L125-L126