### PR TITLE
Revert "Fixed i18n `n__` call syntax."

### DIFF
--- a/app/javascript/components/breadcrumbs/notifications-toggle.jsx
+++ b/app/javascript/components/breadcrumbs/notifications-toggle.jsx
@@ -17,7 +17,7 @@ export const NotificationsToggle = () => {
   };
 
   const unreadCountText = function(count) {
-    return sprintf(n__('%d unread notification', '%d unread notifications'), count);
+    return sprintf(n__('%d unread notification', '%d unread notifications', count), count);
   };
 
   return (

--- a/app/javascript/components/notification-drawer/helpers.js
+++ b/app/javascript/components/notification-drawer/helpers.js
@@ -1,5 +1,5 @@
 export const newCountText = function(count) {
-  return sprintf(n__('%d New', '%d New'), count);
+  return sprintf(n__('%d New', '%d New', count), count);
 };
 
 export const getNotficationStatusIconName = notification => (


### PR DESCRIPTION
Reverts ManageIQ/manageiq-ui-classic#7677

Reverting this PR as this is not the correct fix, issue is actually introduced by https://github.com/ManageIQ/manageiq/pull/21115 https://github.com/ManageIQ/manageiq-ui-classic/pull/7668 will create a new PR with a fix to those files