### PR TITLE
Revert "Formatted Date and Time for Different Locales"

### DIFF
--- a/app/views/catalog/_ot_tree_show.html.haml
+++ b/app/views/catalog/_ot_tree_show.html.haml
@@ -24,12 +24,12 @@
     %label.col-md-2.control-label
       = _('Created On')
     .col-md-8
-      =  h(format_timezone(@record.created_at, Time.zone, "gtl"))
+      =  @record.created_at
   .form-group
     %label.col-md-2.control-label
       = _('Updated On')
     .col-md-8
-      =  h(format_timezone(@record.updated_at, Time.zone, "gtl"))
+      =  @record.updated_at
   .form-group
     .col-md-10
       #tag_group

--- a/product/views/OrchestrationTemplate.yaml
+++ b/product/views/OrchestrationTemplate.yaml
@@ -52,8 +52,8 @@ col_formats:
 - :model_name
 - :boolean_yes_no
 -
-- :datetime_local
-- :datetime_local
+-
+-
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
Reverts ManageIQ/manageiq-ui-classic#7507

@fryguy can you merge this, i was not aware that #7507 was dependent on core PR, the comment on the PR was not clear and pending core label was missing