### PR TITLE
Fixed policy profile delete button to redirect to show_list.

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_policy_set_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_set_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::MiqPolicySetCenter < ApplicationHelper::Toolba
                                          :display_field  => 'description',
                                          :modal_text     => N_("Are you sure you want to delete this Policy Profile?"),
                                          :modal_title    => N_("Delete Policy Profile"),
-                                         :ajax_reload    => true}}),
+                                         :redirect_url   => '/miq_policy_set/show_list'}}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_policy_sets_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_sets_center.rb
@@ -36,7 +36,8 @@ class ApplicationHelper::Toolbar::MiqPolicySetsCenter < ApplicationHelper::Toolb
                                                 :controller     => 'provider_dialogs',
                                                 :display_field  => 'description',
                                                 :modal_text     => N_("Are you sure you want to delete this Policy Profiles?"),
-                                                :modal_title    => N_("Delete Policy Profiles")}}
+                                                :modal_title    => N_("Delete Policy Profiles"),
+                                                :redirect_url   => '/miq_policy_set/show_list'}}
         ),
       ]
     ),


### PR DESCRIPTION
## Issue Summary
Failed to delete the policy profile.

## Issue Details
### Steps to reproduce

1.  Click Control->policy profiles
2. Create one new profile
3. Check on new profile you created
4. Click Configuration -> Delete policy profiles
5. Verify profile can be deleted successfully

### Expected behavior
profile can be deleted successfully and page is redirected to profile list page.
### What really happened
After delete page was redirected to system error page.
