### PR TITLE
Fix translation in Add condition page

### DIFF
--- a/app/views/condition/_form.html.haml
+++ b/app/views/condition/_form.html.haml
@@ -26,7 +26,7 @@
             = Condition::TOWHAT_APPLIES_TO_CLASSES[@edit[:new][:towhat]]
           - else
             = select_tag('towhat',
-                  options_for_select([[_("<Choose>"), nil]] + Array(Condition::TOWHAT_APPLIES_TO_CLASSES.invert), @edit[:new][:towhat]),
+                  options_for_select([[_("<Choose>"), nil]] + Condition::TOWHAT_APPLIES_TO_CLASSES.invert.map { |x| [_(x[0]), x[1]] }, @edit[:new][:towhat]),
                   :class => "selectpicker form-control")
             :javascript
               miqInitSelectPicker();


### PR DESCRIPTION
## Issue Summary
English string in Control -> Condditions page in non-English locale
String should be translated in every native locale
Please check the attachment for details

## Issue Details
### Steps to reproduce
1. Click Control -> Conditions
2. Click configuration-> add a new condition

### Expected behavior
Need to display translation string correct

Before:
<img width="664" alt="Screen Shot 2021-03-26 at 5 16 13 PM" src="https://user-images.githubusercontent.com/37085529/112693520-280a6180-8e57-11eb-941f-d8db56fb8612.png">

After:
<img width="1396" alt="Screen Shot 2021-03-26 at 5 15 20 PM" src="https://user-images.githubusercontent.com/37085529/112693554-322c6000-8e57-11eb-9969-5e1c6bbc3746.png">



