### PR TITLE
Fix settings--> tasks table rows

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -782,9 +782,10 @@ class ApplicationController < ActionController::Base
       target = @targets_hash[row.id] unless row['id'].nil?
 
       new_row = {
-        :id      => list_row_id(row),
-        :long_id => row['id'].to_s,
-        :cells   => []
+        :id        => list_row_id(row),
+        :long_id   => row['id'].to_s,
+        :cells     => [],
+        :clickable => params.fetch_path(:additional_options, :clickable)
       }
 
       if defined?(row.data) && defined?(params) && params[:active_tree] != "reports_tree"

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -83,7 +83,7 @@ class MiqTaskController < ApplicationController
     when "tasks_2", "alltasks_2" then @layout = "all_tasks"
     end
 
-    @view, @pages = get_view(MiqTask, :named_scope => tasks_scopes(@tasks_options[@tabform]))
+    @view, @pages = get_view(MiqTask, :named_scope => tasks_scopes(@tasks_options[@tabform]), :clickable => false)
     @user_names = MiqTask.distinct.pluck("userid").delete_if(&:blank?) if @active_tab.to_i == 2
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -271,11 +271,6 @@ module ApplicationHelper
         action = 'show'
         return url_for_only_path(:action => action, :id => params[:id]) + "?display=generic_objects&generic_object_id="
       end
-      if %w[MiqTask].include?(view.db) && %w[miq_task].include?(params[:controller])
-
-        # This disables the click-through in GTL unless parent_path & parent_id are set on a row.
-        return true
-      end
       if @explorer
         # showing a list view of another CI inside vmx
         if %w[SecurityGroup

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -100,6 +100,12 @@ export const DataTable = ({
     ev.stopPropagation();
   };
 
+  const classNameRow = (row) => {
+    if (row.clickable === false) return 'simple-row';
+    if (row.clickable === null) return 'clickable-row';
+    return '';
+  };
+
   const localOnClickItem = row => ev => {
     if (ev.target.classList.contains('is-checkbox-cell') ||
        ev.target.parentElement.classList.contains('is-checkbox-cell')) {
@@ -115,11 +121,11 @@ export const DataTable = ({
     <tbody>
       {rows.map(row => (
         <tr
-          className={row.selected ? 'active' : ''}
+          className={row.selected ? `active ${classNameRow(row)}` : classNameRow(row)}
           key={`check_${row.id}`}
           onClick={localOnClickItem(row)}
           onKeyPress={localOnClickItem(row)}
-          tabIndex="0"
+          tabIndex={(row.clickable === false) ? '' : '0'}
         >
           {columns.map((column, columnKey) => (
             <td
@@ -225,4 +231,3 @@ DataTable.propTypes = {
 };
 
 export default DataTable;
-

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -7,6 +7,7 @@
 
 @import './carbon.scss';
 @import './charts.scss';
+@import './data-table.scss';
 @import './ddf_override.scss';
 @import './menu.scss';
 @import './navbar.scss';

--- a/app/stylesheet/data-table.scss
+++ b/app/stylesheet/data-table.scss
@@ -1,0 +1,5 @@
+.table-hover > tbody > .simple-row:hover > td, .table-hover > tbody > tr:hover > th {
+    background-color: transparent;
+    border-bottom-color: inherit;
+    cursor: auto;
+}


### PR DESCRIPTION
Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7683 and able to click on non clickable rows in table
 
As a part of this pr, fixed https://github.com/ManageIQ/manageiq-ui-classic/issues/7683 and removed pointer/blue color on hover in non clickable rows, this will reduce confusion to users.

**Before:**
<img width="1572" alt="Screen Shot 2021-04-02 at 12 03 46 PM" src="https://user-images.githubusercontent.com/37085529/113432675-ce9cb800-93ab-11eb-8ee6-e19b3557eeae.png">


**After:**

<img width="1587" alt="Screen Shot 2021-04-02 at 12 02 56 PM" src="https://user-images.githubusercontent.com/37085529/113432690-d5c3c600-93ab-11eb-8896-c86a98a0bea8.png">

@miq-bot  assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
