### PR TITLE
Handle incoming numerics for id that are bigger than a bigint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1104,7 +1104,7 @@ class ApplicationController < ActionController::Base
       id = @search_text if /^\d+$/.match?(@search_text)
       condition = [[]]
       if id
-        add_to_search_condition(condition, "#{view.db_class.table_name}.id = ?", id)
+        add_to_search_condition(condition, "#{view.db_class.table_name}.id = ?", id.to_i)
       end
 
       if ::Settings.server.case_sensitive_name_search


### PR DESCRIPTION
This change takes advantage of ActiveRecord knowing that an incoming
integer cannot be larger than a bigint.  ActiveRecord will construct the
query in a way that prevents the query from returning any records, which
makes sense for oversized ids

Fixes #7692