### PR TITLE
Modified CSS to Prevent Text Wrapping in Certain Locales

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -734,10 +734,15 @@ table.c3-tooltip td {
       left: 0%;
     }
   }
-  
+
   @media (min-width: 992px) {
     .col-md-pull-9 {
       right: 0%;
     }
   }
+}
+
+/* overrides col-md-2 from patternfly (width: 16.6666666667%) */
+.report-col {
+  width: 17.6666666667%;
 }

--- a/app/views/report/_form.html.haml
+++ b/app/views/report/_form.html.haml
@@ -8,7 +8,7 @@
     %h3
       = _('Basic Report Info')
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('Menu Name')
       .col-md-8
         #name_div
@@ -18,7 +18,7 @@
             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     = javascript_tag(javascript_focus('name'))
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('Title')
       .col-md-8
         #title_div

--- a/app/views/report/_form_chart.html.haml
+++ b/app/views/report/_form_chart.html.haml
@@ -4,7 +4,7 @@
     = _('Chart Settings')
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-2.control-label.report-col
         = _('Choose a chart type')
       .col-md-8
         = select_tag('chosen_graph',
@@ -16,7 +16,7 @@
           miqSelectPickerEvent('chosen_graph', '#{url}', {beforeSend: true, complete: true});
     - unless @edit[:new][:graph_type].blank?
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label.report-col
           = _('Chart mode')
         .col-md-8
           - if chart_mode_values_allowed?
@@ -32,7 +32,7 @@
             = hidden_field_tag('chart_mode', 'counts')
       .form-group
         - if @edit[:new][:chart_mode] == 'values'
-          %label.col-md-2.control-label
+          %label.col-md-2.control-label.report-col
             = _('Data column')
           .col-md-8
             = select_tag('chart_column',
@@ -43,7 +43,7 @@
               miqInitSelectPicker();
               miqSelectPickerEvent('chart_column', '#{url}', {beforeSend: true, complete: true});
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label.report-col
           = _('Top values to show')
         .col-md-8
           = select_tag('chosen_count',
@@ -54,7 +54,7 @@
             miqInitSelectPicker();
             miqSelectPickerEvent('chosen_count', '#{url}', {beforeSend: true, complete: true});
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-2.control-label.report-col
           = _("Sum 'Other' values")
         .col-md-8
           = check_box_tag("chosen_other", "1", @edit[:new][:graph_other],

--- a/app/views/report/_form_columns.html.haml
+++ b/app/views/report/_form_columns.html.haml
@@ -6,14 +6,14 @@
     %h3
       = _('Configure Report Columns')
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('* Base the report on')
       .col-md-8
         = select_tag('chosen_model',
           options_for_select(@edit[:models].sort, @edit[:new][:model]),
           :multiple              => false,
           "data-live-search"     => "true",
-          :class                 => "selectpicker")
+          :class                 => "selectpicker form-control")
         :javascript
           miqInitSelectPicker();
           miqSelectPickerEvent('chosen_model', '#{url}', {beforeSend: true, complete: true});
@@ -36,7 +36,7 @@
         = _('Report Creation Timeout')
       .form-horizontal
         .form-group
-          %label.control-label.col-md-2
+          %label.control-label.col-md-2.report-col
             = _('Cancel after')
           .col-md-8
             - opts = [["<#{_('System Default')} (#{distance_of_time_in_words(MiqReport.default_queue_timeout)})>", nil]] + (1..6).map { |i| [n_('%{number} Hour', '%{number} Hours', i) % {:number => i}, i.hours] }

--- a/app/views/report/_form_consolidate.html.haml
+++ b/app/views/report/_form_consolidate.html.haml
@@ -4,7 +4,7 @@
     = _('Group Records by up to 3 Columns')
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('Column 1')
       .col-md-8
         = select_tag('chosen_pivot1',
@@ -16,7 +16,7 @@
           miqSelectPickerEvent('chosen_pivot1', '#{url}', {beforeSend: true, complete: true});
     - if @pivot.by1 != ReportHelper::NOTHING_STRING
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
           = _('Column 2')
         .col-md-8
           = select_tag('chosen_pivot2',
@@ -28,7 +28,7 @@
             miqSelectPickerEvent('chosen_pivot2', '#{url}', {beforeSend: true});
       - if @pivot.by2 != ReportHelper::NOTHING_STRING
         .form-group
-          %label.control-label.col-md-2
+          %label.control-label.col-md-2.report-col
             = _('Column 3')
           .col-md-8
             = select_tag('chosen_pivot3',

--- a/app/views/report/_form_filter.html.haml
+++ b/app/views/report/_form_filter.html.haml
@@ -12,7 +12,7 @@
     %h3= _("Primary (Record) Filter - Filters the %{model} table records") % {:model => @edit[:new][:model]}
     .form-horizontal
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
         .col-md-8
           - if @expkey == :record_filter
             = render :partial => 'layouts/exp_editor'
@@ -27,7 +27,7 @@
       -# Expression editor for the display filter
       %h3= _('Secondary (Display) Filter - Filters the rows based on child table fields')
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
         .col-md-8
           - if @expkey == :display_filter
             = render :partial => 'layouts/exp_editor'

--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -4,7 +4,7 @@
     = _('PDF Output')
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('Page Size')
       .col-md-8
         = select_tag('pdf_page_size',

--- a/app/views/report/_form_sort.html.haml
+++ b/app/views/report/_form_sort.html.haml
@@ -4,7 +4,7 @@
     = _('Sort Criteria')
   .form-horizontal
     .form-group
-      %label.control-label.col-md-2
+      %label.control-label.col-md-2.report-col
         = _('Sort the Report By')
       .col-md-8
         - if @sortby1.include?("__") && MiqReport.is_break_suffix?(@sortby1.split("__")[1])
@@ -29,7 +29,7 @@
             miqSelectPickerEvent('sort1_suffix', '#{url}', {beforeSend: true, complete: true});
     - if @sortby1 != ReportHelper::NOTHING_STRING
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
           = _('Sort Order')
         .col-md-8
           - opts = [[_("Ascending"), "Ascending"], [_("Descending"), "Descending"]]
@@ -41,7 +41,7 @@
             miqInitSelectPicker();
             miqSelectPickerEvent('sort_order', '#{url}', {beforeSend: true, complete: true});
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
           = _('Show Sort Breaks')
         .col-md-8
           - opts = [[_("No"), "No"], [_("Yes"), "Yes"], [_("Counts"), "Counts"]]
@@ -54,7 +54,7 @@
             miqSelectPickerEvent('sort_group', '#{url}', {beforeSend: true, complete: true});
       - unless @edit[:new][:group] == "No"
         .form-group
-          %label.control-label.col-md-2
+          %label.control-label.col-md-2.report-col
             = _('Hide Detail Rows')
           .col-md-8
             = check_box_tag("hide_details", "1", @edit[:new][:hide_details],
@@ -64,7 +64,7 @@
         - ci = MiqReport.get_col_info(@sortby1)
         - unless ci[:available_formats].empty?
           .form-group
-            %label.control-label.col-md-2
+            %label.control-label.col-md-2.report-col
               = _('Format on Summary Row')
             .col-md-8
               - opts = [["<#{_('None')}>", "_none_"], ["<#{_('Reset to Default')}>", nil]] + Array(ci[:available_formats].invert).sort_by(&:first)
@@ -79,7 +79,7 @@
     %br
     .form-horizontal
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
           = _('Within Above Field, Sort By')
         .col-md-8
           - if @sortby2.include?("__") && MiqReport.is_break_suffix?(@sortby2.split("__")[1])
@@ -103,7 +103,7 @@
               miqInitSelectPicker();
               miqSelectPickerEvent('sort2_suffix', '#{url}', {beforeSend: true, complete: true});
       .form-group
-        %label.control-label.col-md-2
+        %label.control-label.col-md-2.report-col
           = _('Number of Rows to Show')
         .col-md-8
           - if @edit[:new][:group] == "No"


### PR DESCRIPTION
Found in: Overview->Reports->Add a new Report->Columns

Fixes: https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/18234

Before:
<img src="https://user-images.githubusercontent.com/64800041/114076348-8fbba600-9874-11eb-881c-140f549b5b33.png" width="400">

After:
<img src="https://user-images.githubusercontent.com/64800041/114076384-9a763b00-9874-11eb-8a23-be208504e417.png" width="600">