### PR TITLE
Fix provision instance table and deprecated checkbox

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -189,6 +189,7 @@ module ApplicationController::MiqRequestMethods
       @report_data_additional_options = ApplicationController::ReportDataAdditionalOptions.from_options(options)
       @report_data_additional_options.with_no_checkboxes(true)
       @report_data_additional_options.in_a_form(true)
+      @report_data_additional_options.show_pagination(true)
 
       @edit[:template_kls] = get_template_kls
     end

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -24,6 +24,7 @@ class ApplicationController
     :supported_features_filter,
     :clickable,
     :no_checkboxes,
+    :show_pagination,
     :report_name,
     :custom_action
   ) do
@@ -77,6 +78,10 @@ class ApplicationController
 
     def in_a_form(in_a_form)
       self.in_a_form = in_a_form
+    end
+
+    def show_pagination(show_pagination)
+      self.show_pagination = show_pagination
     end
   end
 end

--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -390,6 +390,7 @@ const GtlView = ({
 
   const inEditMode = () => additionalOptions.in_a_form;
   const noCheckboxes = () => additionalOptions.no_checkboxes;
+  const showPagination = () => additionalOptions.show_pagination;
 
   const onItemButtonClick = (item) => (ev) => {
     ev.stopPropagation();
@@ -399,13 +400,6 @@ const GtlView = ({
   };
 
   const onItemClick = (item, event) => {
-    // no need to set targetUrl if custom_action is set i.e. for pre prov screen
-    let targetUrl = (additionalOptions && additionalOptions.custom_action) ? undefined : showUrl;
-    // Empty showUrl disables onRowClick action. Nothing to do.
-    if (!showUrl) {
-      return false;
-    }
-
     // If custom_action is specified, send and RxJS message with actionType set
     // to custom_action value.
     if (additionalOptions && additionalOptions.custom_action) {
@@ -417,6 +411,12 @@ const GtlView = ({
           action: additionalOptions.custom_action,
         },
       });
+    }
+    // no need to set targetUrl if custom_action is set i.e. for pre prov screen
+    let targetUrl = (additionalOptions && additionalOptions.custom_action) ? undefined : showUrl;
+    // Empty showUrl disables onRowClick action. Nothing to do.
+    if (!showUrl) {
+      return false;
     }
 
     // Handling of click-through on request/tasks/jobs (navigate to VM/Host/etc...)
@@ -481,6 +481,7 @@ const GtlView = ({
           onItemClick={onItemClick}
           onSort={onSort}
           onSelectAll={onSelectAll}
+          showPagination={showPagination}
         />
       )}
     </div>

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -29,6 +29,7 @@ export const DataTable = ({
   onItemButtonClick,
   onPerPageSelect,
   onPageSet,
+  showPagination,
 }) => {
 
   const selectAll = () => {
@@ -202,8 +203,8 @@ export const DataTable = ({
     <div className="miq-data-table">
       { isLoading && <div className="spinner spinner-lg" /> }
       { renderDataTableToolbar() }
-      { !inEditMode() && isVisible &&
-      renderPagination({
+      { (!inEditMode() || showPagination()) && isVisible
+      && renderPagination({
         pagination, total, onPerPageSelect, onPageSet,
       })
       }

--- a/app/javascript/components/gtl/StaticGTLView.jsx
+++ b/app/javascript/components/gtl/StaticGTLView.jsx
@@ -20,6 +20,7 @@ export const StaticGTLView = ({
   onSelectAll,
   onPerPageSelect,
   onPageSet,
+  showPagination,
 }) => {
   const miqDataTable = () => (
     <DataTable
@@ -38,6 +39,7 @@ export const StaticGTLView = ({
       onItemButtonClick={onItemButtonClick}
       onPageSet={onPageSet}
       onPerPageSelect={onPerPageSelect}
+      showPagination={showPagination}
     />
   );
   return miqDataTable();


### PR DESCRIPTION
**Issue:**
1)  In Compute-->Instances-->Instances by provider-->Lifecycle-->Provision Instances, when loading the page initially, pagination is missing on table.
2) In same page, once select/deselect check box happens, click on any image, continue button is still disabled.

**Before:**
<img width="1442" alt="Screen Shot 2021-04-12 at 9 20 56 AM" src="https://user-images.githubusercontent.com/37085529/114402655-0bb63680-9b72-11eb-9333-d5d2f3b414e0.png">
<img width="1490" alt="Screen Shot 2021-04-12 at 9 21 07 AM" src="https://user-images.githubusercontent.com/37085529/114402657-0c4ecd00-9b72-11eb-9890-0327eec8ec7d.png">

**After**
<img width="1482" alt="Screen Shot 2021-04-12 at 9 19 20 AM" src="https://user-images.githubusercontent.com/37085529/114402707-1b357f80-9b72-11eb-98b2-d3dc518e7e88.png">
<img width="1515" alt="Screen Shot 2021-04-12 at 9 19 35 AM" src="https://user-images.githubusercontent.com/37085529/114402710-1b357f80-9b72-11eb-8a6f-f73057fb18a1.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy @DavidResende
