### PR TITLE
Changed "Created New Network Router" Dialog

### DIFF
--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -78,7 +78,7 @@ class NetworkRouterController < ApplicationController
     router_name = session[:async][:params][:name]
     task = MiqTask.find(task_id)
     if MiqTask.status_ok?(task.status)
-      add_flash(_("Network Router \"%{name}\" created") % {:name => router_name})
+      add_flash(_("Queued Network Router \"%{name}\" for creation") % {:name => router_name})
     else
       add_flash(_("Unable to create Network Router \"%{name}\": %{details}") %
                 {:name => router_name, :details => task.message}, :error)


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/1602

Changes the creation dialog to emphasize the fact that Network Router creation must be queued and is not created instantly