### PR TITLE
Updated Carbon Component Mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@carbon/charts-react": "~0.41.38",
     "@carbon/icons-react": "~10.26.0",
     "@carbon/themes": "~10.28.0",
-    "@data-driven-forms/carbon-component-mapper": "~2.24.0",
+    "@data-driven-forms/carbon-component-mapper": "~2.24.3",
     "@data-driven-forms/pf3-component-mapper": "~2.20.3",
     "@data-driven-forms/react-form-renderer": "~2.24.1",
     "@manageiq/ui-components": "1.4.4",


### PR DESCRIPTION
Updated the Carbon Component Mapper to version 2.24.3 to add this fix to ManageIQ: https://github.com/data-driven-forms/react-forms/pull/1042
Part of the Fix for: https://github.com/ManageIQ/manageiq-ui-classic/issues/7713

Before:
![image](https://user-images.githubusercontent.com/64800041/115448013-29754280-a1e7-11eb-90c9-7f73de075207.png)

After:
<img src="https://user-images.githubusercontent.com/64800041/115448094-4873d480-a1e7-11eb-8067-ab2bab1ea8ef.png" width="400">