### PR TITLE
[JANSA] Monitor > alerts > all alert bug fixed

### DIFF
--- a/app/assets/javascripts/services/alerts_center_service.js
+++ b/app/assets/javascripts/services/alerts_center_service.js
@@ -512,7 +512,12 @@ angular.module('ManageIQ').service('alertsCenterService', ['API', '$q', '$timeou
     } else {
       newAlert.severityInfo = _this.severities.info;
     }
-
+    
+    // when user click the Monitor > all alert menu, prevent to bug. - type error : name property is null
+    if (alertData.assignee === null) {
+      alertData.assignee = undefined;   
+    }
+    
     newAlert.age = moment.duration(retrievalTime - newAlert.evaluated_on).format('dd[d] hh[h] mm[m] ss[s]');
     newAlert.rowClass = 'alert ' + newAlert.severityInfo.severityClass;
     newAlert.lastUpdate = newAlert.evaluated_on;


### PR DESCRIPTION
Whenever the menu called monitor is pressed, a typeError occurs, so the alert list could not be checked.

so, when alertData.assignee property is null, i fixed the property null to undefined .

[ bug ]
![image](https://user-images.githubusercontent.com/52685322/115672877-f4075b00-a386-11eb-9ebd-d5567f32fe23.png)

![image](https://user-images.githubusercontent.com/52685322/115672709-ca4e3400-a386-11eb-8cb5-3789406b6709.png)

[ fixed ]
![image](https://user-images.githubusercontent.com/52685322/115672752-d508c900-a386-11eb-8a49-888256aefeb3.png)
