### PR TITLE
Convert cloud tenant charts to carbon

### DIFF
--- a/app/views/cloud_tenant/_show_dashboard.html.haml
+++ b/app/views/cloud_tenant/_show_dashboard.html.haml
@@ -4,9 +4,11 @@
     = react 'AggregateStatusCard', {:providerId => @record.id.to_s, :providerType => 'cloud_tenant'}
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-6
-      = render :partial => "recent-instances-line-chart"
+      = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent Instances'),
+       :config => 'recentInstancesConfig', :apiUrl => 'cloud_tenant_dashboard/recent_instances_data', :dataPoint => 'recentResources')
     .col-xs-12.col-sm-12.col-md-6
-      = render :partial => "recent-images-line-chart"
+      = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent Images'),
+       :config => 'recentImagesConfig', :apiUrl => 'cloud_tenant_dashboard/recent_images_data', :dataPoint => 'recentResources')
   :javascript
     ManageIQ.angular.app.value('#{@record.id}');
     miq_bootstrap('.cloud-tenant-dashboard');


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/7625
Part of https://github.com/ManageIQ/manageiq-ui-classic/pull/7658/files 
I missed converting cloud tenant dashboards charts to carbon in above pr.

**Before:**
<img width="1537" alt="Screen Shot 2021-04-26 at 10 05 36 AM" src="https://user-images.githubusercontent.com/37085529/116097729-670b1d00-a678-11eb-866c-7c2333cf00f9.png">

**After:**
<img width="1462" alt="Screen Shot 2021-04-26 at 10 16 10 AM" src="https://user-images.githubusercontent.com/37085529/116097801-79855680-a678-11eb-98a8-66b3627da09d.png">

