### PR TITLE
Handle queue workers inheriting values from worker_base: fix incorrect count and memory threshold values on workers tab

### DIFF
--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -20,57 +20,55 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
       .then(({ workers: { worker_base } }) => {
         const wb = worker_base;
 
-        const countDefault = wb.defaults.count;
-        const memDefault = toBytes(wb.defaults.memory_threshold);
-        const baseMemDefault = toBytes(wb.queue_worker_base.defaults.memory_threshold);
-        const monitorDefault = toBytes(wb.event_catcher.defaults.memory_threshold);
-
-        const selectCount = value => (typeof value === 'number' ? value : countDefault);
+        const baseCount = wb.defaults.count;
+        const queueCount = wb.queue_worker_base.defaults.count || baseCount;
+        const baseMem = toBytes(wb.defaults.memory_threshold);
+        const queueMem = toBytes(wb.queue_worker_base.defaults.memory_threshold) || baseMem;
 
         const parsedValues = {
           generic_worker: {
-            memory_threshold: parseWorker(wb.queue_worker_base.generic_worker).bytes || baseMemDefault,
-            count: selectCount(wb.queue_worker_base.generic_worker.count),
+            memory_threshold: parseWorker(wb.queue_worker_base.generic_worker).bytes || queueMem,
+            count: wb.queue_worker_base.generic_worker.count || queueCount,
           },
           priority_worker: {
-            memory_threshold: parseWorker(wb.queue_worker_base.priority_worker).bytes || baseMemDefault,
-            count: selectCount(wb.queue_worker_base.priority_worker.count),
+            memory_threshold: parseWorker(wb.queue_worker_base.priority_worker).bytes || queueMem,
+            count: wb.queue_worker_base.priority_worker.count || queueCount,
           },
           ems_metrics_collector_worker: {
             defaults: {
-              memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_collector_worker.defaults).bytes || baseMemDefault,
-              count: selectCount(wb.queue_worker_base.ems_metrics_collector_worker.defaults.count),
+              memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_collector_worker.defaults).bytes || queueMem,
+              count: wb.queue_worker_base.ems_metrics_collector_worker.defaults.count || queueCount,
             },
           },
           ems_metrics_processor_worker: {
-            memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_processor_worker).bytes || baseMemDefault,
-            count: selectCount(wb.queue_worker_base.ems_metrics_processor_worker.count),
+            memory_threshold: parseWorker(wb.queue_worker_base.ems_metrics_processor_worker).bytes || queueMem,
+            count: wb.queue_worker_base.ems_metrics_processor_worker.count || queueCount,
           },
           event_catcher: {
-            memory_threshold: parseWorker(wb.event_catcher).bytes || monitorDefault,
+            memory_threshold: parseWorker(wb.event_catcher.defaults).bytes || baseMem,
           },
           ems_refresh_worker: {
             defaults: {
-              memory_threshold: parseWorker(wb.queue_worker_base.ems_refresh_worker.defaults).bytes || baseMemDefault,
+              memory_threshold: parseWorker(wb.queue_worker_base.ems_refresh_worker.defaults).bytes || queueMem,
             },
           },
           smart_proxy_worker: {
-            memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || baseMemDefault,
-            count: selectCount(wb.queue_worker_base.smart_proxy_worker.count),
+            memory_threshold: parseWorker(wb.queue_worker_base.smart_proxy_worker).bytes || queueMem,
+            count: wb.queue_worker_base.smart_proxy_worker.count || queueCount,
           },
           ui_worker: {
-            count: selectCount(wb.ui_worker.count),
+            count: wb.ui_worker.count || baseCount,
           },
           reporting_worker: {
-            memory_threshold: parseWorker(wb.queue_worker_base.reporting_worker).bytes || baseMemDefault,
-            count: selectCount(wb.queue_worker_base.reporting_worker.count),
+            memory_threshold: parseWorker(wb.queue_worker_base.reporting_worker).bytes || queueMem,
+            count: wb.queue_worker_base.reporting_worker.count || queueCount,
           },
           web_service_worker: {
-            memory_threshold: parseWorker(wb.web_service_worker).bytes || memDefault,
-            count: selectCount(wb.web_service_worker.count),
+            memory_threshold: parseWorker(wb.web_service_worker).bytes || baseMem,
+            count: wb.web_service_worker.count || baseCount,
           },
           remote_console_worker: {
-            count: selectCount(wb.remote_console_worker.count),
+            count: wb.remote_console_worker.count || baseCount,
           },
         };
 

--- a/app/javascript/spec/workers-form/workers-form.spec.js
+++ b/app/javascript/spec/workers-form/workers-form.spec.js
@@ -48,9 +48,7 @@ describe('Workers form', () => {
                 memory_threshold: 2147483648,
               },
             },
-            defaults: {
-              memory_threshold: '500.megabytes',
-            },
+            defaults: {},
             ems_metrics_processor_worker: {
               count: 2, memory_threshold: 629145600,
             },
@@ -58,7 +56,7 @@ describe('Workers form', () => {
             priority_worker: {
               memory_threshold: 419430400, count: 2,
             },
-            reporting_worker: { count: 2, memory_threshold: 524288000 },
+            reporting_worker: { count: 2 },
             smart_proxy_worker: {
               count: 2, memory_threshold: 576716800,
             },
@@ -92,7 +90,7 @@ describe('Workers form', () => {
       'priority_worker.memory_threshold': 419430400,
       'remote_console_worker.count': 1,
       'reporting_worker.count': 2,
-      'reporting_worker.memory_threshold': 524288000,
+      'reporting_worker.memory_threshold': 419430400,
       'smart_proxy_worker.count': 2,
       'smart_proxy_worker.memory_threshold': 576716800,
       'ui_worker.count': 1,


### PR DESCRIPTION
The existing code was checking only the worker's value and falling back to
queue_worker_base but not falling back to the worker_base if the other two
locations had no value.

This causes the select's value to be the first item in the select, which is 200 MB.
If you as a user try to change some other unrelated value and then save, all
of these "incorrect" 200 MB values get saved instead of the correct value
inherited from worker_base.

For example, smart_proxy_worker was correct because that worker class specified a
memory_threshold.  Reporting, C & U processor and collector, Generic, and
Priority workers were all showing 200 MB in the select because that's the first
entry in the select and because the default of 1.gigabyte was coming from
worker_base and no value was coming from queue_worker_base or the worker class
itself.

For more information, review https://github.com/ManageIQ/manageiq/blob/19b57d3c88679b12718e301f4a19d4b1fee11705/config/settings.yml#L1063-L1113 and see that the reporting worker specifies no memory_threshold and the queue_worker_base also specifies no memory_threshold but should inherit the worker_base value of 1.gigabytes.  This is the same problem for the other workers mentioned above.

## Before
![workers_tab_1](https://user-images.githubusercontent.com/19339/116446340-d9b8fb80-a824-11eb-9080-54645294a504.png)
![workers_tab_2](https://user-images.githubusercontent.com/19339/116446349-dc1b5580-a824-11eb-9b9e-a60065995302.png)

## After
![workers_tab_after](https://user-images.githubusercontent.com/19339/116446355-de7daf80-a824-11eb-95fe-90b5eb38bb09.png)

