### PR TITLE
Fix background color of navbar items on hover

### DIFF
--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -45,9 +45,14 @@
     height: 48px;
   }
 
+  .bx--side-nav__submenu:hover {
+    background-color: #666666
+  }
+
   .bx--side-nav__hr {
     margin: 16px 0 0 0;
   }
+
   .bx--side-nav--expanded {
     .bx--side-nav__hr {
       margin: 16px 16px 0 16px;


### PR DESCRIPTION
Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7731


Before:
<img width="1057" alt="beforepic" src="https://user-images.githubusercontent.com/32444791/117359979-3734f400-ae86-11eb-894c-9df3ff495ee5.png">

After:
<img width="1124" alt="Screen Shot 2021-05-06 at 4 15 51 PM" src="https://user-images.githubusercontent.com/32444791/117360093-5cc1fd80-ae86-11eb-98b5-b0a548251d1e.png">

@miq-bot assign @kavyanekkalapu 
@miq-bot add-reviewer @kavyanekkalapu 

