### PR TITLE
Fix tenants tree in Edit catalog item

### DIFF
--- a/app/javascript/oldjs/controllers/buttons/button_group_controller.js
+++ b/app/javascript/oldjs/controllers/buttons/button_group_controller.js
@@ -1,6 +1,17 @@
 ManageIQ.angular.app.controller('buttonGroupController', ['$scope', 'miqService', function($scope, miqService) {
-  var init = function() {
+  const init = function() {
     $scope.saveable = miqService.saveable;
+    $scope.reactFormDirty = false;
   };
   init();
+
+  listenToRx((event) => {
+    if (event.name === 'dirty') {
+      $scope.reactFormDirty = true;
+      $scope.$apply();
+    } else {
+      $scope.reactFormDirty = false;
+      $scope.$apply();
+    }
+  });
 }]);

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -11,7 +11,7 @@
               :title     => t,
               :alt       => t,
               'ng-if'    => '!newRecord',
-              :enabled   => "saveable(angularForm)",
+              :enabled   => "saveable(angularForm) || reactFormDirty",
               'on-click' => "saveClicked({target: '.edit_buttons'}, true)",
               :primary   => 'true'}
   %miq-button{:name      => t = _("Reset"),


### PR DESCRIPTION
Issue: https://github.com/ManageIQ/manageiq/issues/21083

Here issue is, when we change something in the tenants tree, save button is not getting enabled (check before screenshot).

**rootcause:** There are two causes in this issue
-  Tree is a react componet where as rest of the form is angular, so angular form is not getting know when the tree is dirty.
- There is code in app/presenters/tree_builder_tenants.rb which has some conditions to execute, there is a delay in executing those functions and react component code is getting called before that code executes, To fix this, i am calling react reducer code when there is data change in the tree.


**Before:**
<img width="1227" alt="Screen Shot 2021-05-11 at 10 04 55 PM" src="https://user-images.githubusercontent.com/37085529/117907538-fdf4ed80-b2a4-11eb-85a8-f9a017ea82d6.png">

**After:**
<img width="1367" alt="Screen Shot 2021-05-11 at 10 04 14 PM" src="https://user-images.githubusercontent.com/37085529/117907561-05b49200-b2a5-11eb-9c7d-9da6210666fa.png">
