### PR TITLE
Fix right hand side title when search text present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -889,7 +889,7 @@ class ApplicationController < ActionController::Base
              end
 
     # add @search_text to title for gtl screens only
-    if @search_text.present? && @display.nil?
+    if @search_text.present? && @display.nil? && !@in_a_form
       @title += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text}
     end
   end

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -266,7 +266,7 @@ class InfraNetworkingController < ApplicationController
 
     options = {:model => "Switch", :named_scope => :shareable}
     process_show_list(options) if @show_list
-    @right_cell_text = if @search_text
+    @right_cell_text = if @search_text && !@in_a_form
                          _("All Switches (Names with \"%{search_text}\")") % {:search_text => @search_text}
                        else
                          _("All Switches")

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -502,7 +502,7 @@ class StorageController < ApplicationController
   end
 
   def set_right_cell_text
-    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && @nodetype != 'ds'
+    @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text} if @search_text.present? && @nodetype != 'ds' && !@in_a_form
     @right_cell_text += @edit[:adv_search_applied][:text] if x_tree && x_tree[:tree] == :storage_tree && @edit && @edit[:adv_search_applied]
   end
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -985,7 +985,7 @@ module VmCommon
       options = list_child_vms(model, node_id, title, show_list)
 
       # After adding to history, add name filter suffix if showing a list
-      if @search_text.present?
+      if @search_text.present? && !@in_a_form
         @right_cell_text += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text}
       end
     end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7711

In this issue, when search text is present, click on `Add New` gives title with search which is wrong. In this pr, added to show search title only when it is not in a form.

**Before**
<img width="1078" alt="Screen Shot 2021-05-17 at 9 26 27 AM" src="https://user-images.githubusercontent.com/37085529/118502341-9c46e000-b6f7-11eb-9e67-959532b1733e.png">
<img width="1245" alt="Screen Shot 2021-05-17 at 9 26 46 AM" src="https://user-images.githubusercontent.com/37085529/118502343-9c46e000-b6f7-11eb-9849-9b33fb9d86f6.png">
<img width="1414" alt="Screen Shot 2021-05-17 at 9 28 03 AM" src="https://user-images.githubusercontent.com/37085529/118502344-9c46e000-b6f7-11eb-8cae-792fd982b75e.png">
<img width="954" alt="Screen Shot 2021-05-17 at 9 28 13 AM" src="https://user-images.githubusercontent.com/37085529/118502345-9cdf7680-b6f7-11eb-9b43-fa0f07d52502.png">

**After**

<img width="1508" alt="Screen Shot 2021-05-17 at 9 28 54 AM" src="https://user-images.githubusercontent.com/37085529/118502389-a9fc6580-b6f7-11eb-8295-cac891da49cd.png">
<img width="1414" alt="Screen Shot 2021-05-17 at 9 29 25 AM" src="https://user-images.githubusercontent.com/37085529/118502391-a9fc6580-b6f7-11eb-80d2-ba5b89aa8498.png">

@miq-bot assign @Fryguy 
 @miq-bot add_reviewer @Fryguy , @DavidResende0 
