### PR TITLE
Fix broken privilege assertions - raise errors in non-production on future broken feature assertions

### DIFF
--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -118,12 +118,14 @@ class CloudObjectStoreContainerController < ApplicationController
   end
 
   def download_data
-    assert_privileges('cloud_object_store_container_view')
+    # TODO: rename to match others: cloud_object_store_container_view, write migration to update existing
+    assert_privileges('cloudobject_store_container_view')
     super
   end
 
   def download_summary_pdf
-    assert_privileges('cloud_object_store_container_view')
+    # TODO: rename to match others: cloud_object_store_container_view, write migration to update existing
+    assert_privileges('cloudobject_store_container_view')
     super
   end
 

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -2,7 +2,7 @@ module MiqPolicyController::Events
   extend ActiveSupport::Concern
 
   def miq_event_edit
-    assert_privileges("miq_event_edit")
+    assert_privileges("miq_policy_event_edit")
     case params[:button]
     when "cancel"
       @edit = nil
@@ -67,7 +67,7 @@ module MiqPolicyController::Events
   end
 
   def event_build_action_values
-    assert_privileges("miq_event_edit")
+    assert_privileges("miq_policy_event_edit")
     # Reload @edit/vars for other buttons
     id = params[:id] || "new"
     return unless load_edit("event_edit__#{id}")

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -13,9 +13,9 @@ module MiqPolicyController::Policies
   end
 
   def policy_edit_reset
-    assert_privileges('miq_policy_edit') if params[:button] == "reset"
-    @in_a_form = true
     @policy = params[:id] ? MiqPolicy.find(params[:id]) : MiqPolicy.new # Get existing or new record
+    assert_privileges("miq_policy_#{@policy.id ? "edit" : "new"}")
+    @in_a_form = true
 
     if @policy.read_only
       add_flash(_("This Policy is read only and cannot be modified"), :error)
@@ -31,7 +31,7 @@ module MiqPolicyController::Policies
   end
 
   def policy_edit_save
-    assert_privileges("policy_#{@policy.id ? "edit" : "new"}")
+    assert_privileges("miq_policy_#{@policy.id ? "edit" : "new"}")
     policy = @policy.id.blank? ? MiqPolicy.new : MiqPolicy.find(@policy.id) # Get new or existing record
     policy.mode = @edit[:new][:mode]
     policy.updated_by = session[:userid]
@@ -103,7 +103,7 @@ module MiqPolicyController::Policies
 
   # Copy a policy
   def copy
-    assert_privileges("policy_copy")
+    assert_privileges("miq_policy_copy")
     @_params[:id] ||= find_checked_items[0]
     policy = MiqPolicy.find(params[:id])
     new_desc = truncate("Copy of #{policy.description}", :length => 255, :omission => "")
@@ -155,11 +155,11 @@ module MiqPolicyController::Policies
   end
 
   def miq_policy_edit_events
-    assert_privileges('miq_policy_edit_events')
+    assert_privileges('miq_policy_events_assignment')
     case params[:button]
     when "cancel"
       @sb[:action] = @edit = nil
-      flash_msg = _("Edit of Policy's Event Assginment cancelled by user")
+      flash_msg = _("Edit of Policy's Event Assignment cancelled by user")
       session[:changed] = false
       javascript_redirect(:action => @lastaction, :id => params[:id], :flash_msg => flash_msg)
     when "reset", nil # Reset or first time in
@@ -182,7 +182,7 @@ module MiqPolicyController::Policies
   end
 
   def miq_policy_edit_conditions
-    assert_privileges('miq_policy_edit_conditions')
+    assert_privileges('miq_policy_conditions_assignment')
     case params[:button]
     when "cancel"
       @sb[:action] = @edit = nil

--- a/app/controllers/miq_policy_set_controller.rb
+++ b/app/controllers/miq_policy_set_controller.rb
@@ -83,7 +83,7 @@ class MiqPolicySetController < ApplicationController
   end
 
   def profile_save_add
-    assert_privileges("miq_policy_set#{params[:id] ? "edit" : "new"}")
+    assert_privileges("miq_policy_set_#{params[:id] ? "edit" : "new"}")
     return unless load_edit("profile_edit__#{params[:id] ? "#{params[:id]}" : "new"}")
     add_flash(_("Policy Profile must contain at least one Policy"), :error) if @edit[:new][:policies].length.zero? # At least one member is required
 

--- a/app/controllers/miq_policy_set_controller.rb
+++ b/app/controllers/miq_policy_set_controller.rb
@@ -83,7 +83,7 @@ class MiqPolicySetController < ApplicationController
   end
 
   def profile_save_add
-    assert_privileges("profile_#{params[:id] ? "edit" : "new"}")
+    assert_privileges("miq_policy_set#{params[:id] ? "edit" : "new"}")
     return unless load_edit("profile_edit__#{params[:id] ? "#{params[:id]}" : "new"}")
     add_flash(_("Policy Profile must contain at least one Policy"), :error) if @edit[:new][:policies].length.zero? # At least one member is required
 

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -23,7 +23,7 @@ module PxeController::IsoDatastores
   end
 
   def iso_datastore_create
-    assert_privileges('iso_datastore_create')
+    assert_privileges('iso_datastore_new')
     id = params[:id] || "new"
     return unless load_edit("isd_edit__#{id}")
     iso_datastore_get_form_vars

--- a/app/controllers/security_policy_rule_controller.rb
+++ b/app/controllers/security_policy_rule_controller.rb
@@ -31,12 +31,12 @@ class SecurityPolicyRuleController < ApplicationController
   end
 
   def download_summary_pdf
-    assert_privileges('security_policy_rules_view')
+    assert_privileges('security_policy_rule_view')
     super
   end
 
   def download_data
-    assert_privileges('security_policy_rules_view')
+    assert_privileges('security_policy_rule_view')
     super
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,9 +97,15 @@ module ApplicationHelper
 
   # Check role based authorization for a UI task
   def role_allows?(**options)
-    if options[:feature].nil?
-      $log.debug("Auth failed - no feature was specified (required)")
-      return false
+    features = Array(options[:feature])
+
+    if features.blank?
+       $log.debug("Auth failed - no feature was specified (required)")
+       return false
+     end
+
+    if !Rails.env.production? && MiqProductFeature.where(:identifier => features).count != features.length
+      raise("#{__method__} with non-existing product feature identifier: #{features.inspect} is not supported.  Create it or use an existing one.")
     end
 
     Rbac.role_allows?(options.merge(:user => User.current_user)) rescue false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,22 +100,18 @@ module ApplicationHelper
     features = Array(options[:feature])
 
     if features.blank?
-       $log.debug("Auth failed - no feature was specified (required)")
-       return false
-     end
+      $log.debug("Auth failed - no feature was specified (required)")
+      return false
+    end
 
-    if !Rails.env.production?
-      # Detect if queried features are missing from the database and possibly invalid
-      if MiqProductFeature.where(:identifier => features).count != features.length
-        message = "#{__method__} no feature was found with identifier: #{features.inspect}.  Correct the identifier or add it to miq_product_features.yml."
-        identifiers = MiqProductFeature.all.pluck(:identifier)
-        features.each do |feature|
-          if Rails.env.development?
-            raise message
-          elsif Rails.env.test? && identifiers.length >= 5
-            raise("#{message} Note: detected features: #{identifiers.inspect}")
-          end
-        end
+    # Detect if queried features are missing from the database and possibly invalid
+    if !Rails.env.production? && MiqProductFeature.where(:identifier => features).count != features.length
+      message = "#{__method__} no feature was found with identifier: #{features.inspect}.  Correct the identifier or add it to miq_product_features.yml."
+      identifiers = MiqProductFeature.all.pluck(:identifier)
+      if Rails.env.development?
+        raise message
+      elsif Rails.env.test? && identifiers.length >= 5
+        raise("#{message} Note: detected features: #{identifiers.inspect}")
       end
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,13 +107,14 @@ module ApplicationHelper
     if !Rails.env.production?
       # Detect if queried features are missing from the database and possibly invalid
       if MiqProductFeature.where(:identifier => features).count != features.length
-        message = "#{__method__} with non-existing product feature identifier: #{features.inspect} is not supported.  Create it or use an existing one."
-        feature_identifiers = MiqProductFeature.all.pluck(:identifier)
-        if feature_identifiers.length <= 5
-          # TODO: Handle these in a followup. Allow tests that seed "everything" or a few features to get by.
-          # warn "#{message} Note: some features were seeded: #{feature_identifiers.inspect}.  Seed the missing feature(s)."
-        else
-          raise("#{message} Note: detected features: #{feature_identifiers.inspect}")
+        message = "#{__method__} no feature was found with identifier: #{features.inspect}.  Correct the identifier or add it to miq_product_features.yml."
+        identifiers = MiqProductFeature.all.pluck(:identifier)
+        features.each do |feature|
+          if Rails.env.development?
+            raise message
+          elsif Rails.env.test? && identifiers.length >= 5
+            raise("#{message} Note: detected features: #{identifiers.inspect}")
+          end
         end
       end
     end

--- a/app/helpers/application_helper/button/miq_action_modify.rb
+++ b/app/helpers/application_helper/button/miq_action_modify.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::MiqActionModify < ApplicationHelper::Button::Basic
   needs :@record
   def role_allows_feature?
-    super && role_allows?(:feature => 'miq_event_edit')
+    super && role_allows?(:feature => 'miq_policy_event_edit')
   end
 
   def visible?

--- a/app/helpers/application_helper/toolbar/miq_policy_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policy_center.rb
@@ -67,7 +67,7 @@ class ApplicationHelper::Toolbar::MiqPolicyCenter < ApplicationHelper::Toolbar::
           :options   => {:feature => 'miq_policy_edit_events'}
         ),
         button(
-          :miq_event_edit,
+          :miq_policy_event_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit Actions for this Policy\'s Event'),
           t,

--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolbar::Basic
   button_group('saved_report_reloading', [
     button(
-      :reload,
+      :miq_report_saved_reports_reload,
       'fa fa-refresh fa-lg',
       N_('Refresh selected Reports'),
       nil,

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -255,7 +255,7 @@ module Menu
 
       def automation_manager_menu_section
         Menu::Section.new(:at, N_("Automation"), nil, [
-          Menu::Item.new('ems_automation', N_('Providers'), 'ems_automation', {:feature => 'ems_automation_show_list', :any => true}, '/ems_automation/show_list'),
+          Menu::Item.new('ems_automation', N_('Providers'), 'ems_automation', {:feature => 'ems_automation_manager_show_list', :any => true}, '/ems_automation/show_list'),
           Menu::Item.new('automation_manager_configured_system', N_('Configured Systems'), 'automation_manager_configured_system', {:feature => 'automation_manager_configured_system_show_list'}, '/automation_manager_configured_system/show_list'),
           Menu::Item.new('configuration_script', N_('Templates'), 'configuration_script', {:feature => 'configuration_script_show_list'}, '/configuration_script/show_list'),
           Menu::Item.new('configuration_job',  N_('Jobs'),     'configuration_job',  {:feature => 'configuration_job_show_list'},      '/configuration_job/show_list')

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -808,7 +808,6 @@ MiqPolicyController:
 - exp_token_pressed
 - index
 - miq_event_field_changed
-- miq_policy_edit
 - policy_field_changed
 - quick_search
 - reload

--- a/spec/controllers/ems_storage_controller_spec.rb
+++ b/spec/controllers/ems_storage_controller_spec.rb
@@ -13,7 +13,7 @@ describe EmsStorageController do
 
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      EvmSpecHelper.seed_specific_product_features(%w(ems_block_storage_show ems_block_storage_show_list))
+      EvmSpecHelper.seed_specific_product_features(%w(ems_block_storage_show ems_block_storage_show_list ems_object_storage_show))
       login_as user
     end
 

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -139,6 +139,9 @@ describe MiqAeCustomizationController do
       controller.instance_variable_set(:@settings, :display => {:locale => 'default'})
       controller.instance_variable_set(:@sb, :flash_msg => sandbox_flash_messages)
       bypass_rescue
+      EvmSpecHelper.seed_specific_product_features(
+        %w(dialog_accord old_dialogs_accord ab_buttons_accord miq_ae_class_import_export)
+      )
     end
 
     it "assigns the sandbox active tree" do

--- a/spec/controllers/miq_alert_controller_spec.rb
+++ b/spec/controllers/miq_alert_controller_spec.rb
@@ -91,7 +91,7 @@ describe MiqAlertController do
   context 'test click on toolbar button' do
     before do
       EvmSpecHelper.local_miq_server
-      login_as FactoryBot.create(:user, :features => %w[alert alert_edit alert_profile_assign alert_delete alert_copy alert_profile_new])
+      login_as FactoryBot.create(:user, :features => %w[miq_alert miq_alert_edit alert_profile_assign alert_delete alert_copy alert_profile_new])
       # login_as FactoryBot.create(:user, :features => "alert_admin")
       @miq_alert = FactoryBot.create(:miq_alert)
     end

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -5,7 +5,9 @@ describe ReportController do
     let(:user)           { FactoryBot.create(:user, :features => "db_edit") }
 
     before do
-      stub_user(:features => :all)
+      EvmSpecHelper.seed_specific_product_features(%w(db_edit db_copy))
+      EvmSpecHelper.local_miq_server
+      login_as user
     end
 
     describe "#db_copy" do

--- a/spec/controllers/miq_report_controller/dashboards_spec.rb
+++ b/spec/controllers/miq_report_controller/dashboards_spec.rb
@@ -2,10 +2,9 @@ describe ReportController do
   context "::Dashboards" do
     let(:miq_widget)     { FactoryBot.create(:miq_widget) }
     let(:miq_widget_set) { FactoryBot.create(:miq_widget_set, :owner => user.current_group, :set_data => {:col1 => [miq_widget.id], :col2 => [], :col3 => []}) }
-    let(:user)           { FactoryBot.create(:user, :features => "db_edit") }
+    let(:user)           { user_with_feature(%w(db_copy db_edit)) }
 
     before do
-      EvmSpecHelper.seed_specific_product_features(%w(db_edit db_copy))
       EvmSpecHelper.local_miq_server
       login_as user
     end

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -24,14 +24,17 @@ describe PxeController do
 
   describe 'x_button' do
     let!(:server) { EvmSpecHelper.local_miq_server }
+    let(:pending_actions) { %w(pxe_image_tag windows_image_tag) }
+    let(:allowed_actions) { PxeController::PXE_X_BUTTON_ALLOWED_ACTIONS.keys - pending_actions }
 
     before do
       ApplicationController.handle_exceptions = true
-      login_as user_with_feature(%w(pxe_server_accord pxe_server_refresh))
+      login_as user_with_feature(%w(pxe_server_accord pxe_server_refresh) + allowed_actions)
     end
     describe 'corresponding methods are called for allowed actions' do
       PxeController::PXE_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do
+          pending("Action hasn't been fully implemented with toolbar entries or features yet") if pending_actions.include?(action_name)
           expect(controller).to receive(method)
           get :x_button, :params => { :pressed => action_name }
         end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -68,7 +68,7 @@ describe VmOrTemplateController do
       allow(User).to receive(:server_timezone).and_return("UTC")
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
       allow(controller).to receive(:check_privileges).and_return(true)
-      EvmSpecHelper.seed_specific_product_features("vandt_accord", "vms_instances_filter_accord")
+      EvmSpecHelper.seed_specific_product_features("vandt_accord", "vms_instances_filter_accord", "vms_filter_accord")
       @vm = FactoryBot.create(:vm_vmware)
     end
 

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -85,10 +85,11 @@ describe 'Application routes' do
                 rescue MiqException::RbacPrivilegeException
                   raise
                 end.to raise_error(MiqException::RbacPrivilegeException)
-              rescue RSpec::Expectations::ExpectationNotMetError
-                # Append a custom error message
-                $!.message << "\n\n" + error_message unless fp
-                raise
+              rescue RSpec::Expectations::ExpectationNotMetError => err
+                raise if fp
+
+                # Reraise but with a custom error message
+                raise err.class, "#{err.message} \n\n#{error_message}"
               end
             end
           end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -17,6 +17,7 @@ pending_routes = YAML.safe_load(ManageIQ::UI::Classic.root.join('spec', 'config'
 
 describe 'Application routes' do
   before(:all) { MiqProductFeature.seed_features }
+  after(:all)  { MiqProductFeature.destroy_all }
 
   def error_message
     <<~ERROR

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -74,14 +74,18 @@ describe 'Application routes' do
               allow(subject).to receive(:redirect_to).with(:controller => 'dashboard', :action => 'auth_error').and_raise(MiqException::RbacPrivilegeException)
               allow(subject).to receive(:add_flash).with("The user is not authorized for this task or item.", :error).and_raise(MiqException::RbacPrivilegeException)
 
-              expect do
-                subject.send(:check_privileges)
-                subject.send(action)
-              rescue MiqException::RbacPrivilegeException
+              begin
+                expect do
+                  subject.send(:check_privileges)
+                  subject.send(action)
+                rescue MiqException::RbacPrivilegeException
+                  raise
+                end.to raise_error(MiqException::RbacPrivilegeException)
+              rescue RSpec::Expectations::ExpectationNotMetError
+                # Append a custom error message
+                $!.message << "\n\n" + error_message unless fp
                 raise
-              rescue => ex
-                # NOP: we don't care if any other exception happens
-              end.to raise_error(MiqException::RbacPrivilegeException), -> { !fp && error_message }
+              end
             end
           end
         end

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -82,8 +82,6 @@ describe 'Application routes' do
                 expect do
                   subject.send(:check_privileges)
                   subject.send(action)
-                rescue MiqException::RbacPrivilegeException
-                  raise
                 end.to raise_error(MiqException::RbacPrivilegeException)
               rescue RSpec::Expectations::ExpectationNotMetError => err
                 raise if fp

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -1,9 +1,13 @@
+test_specific_controller = ENV['TEST_CONTROLLER']
+warn "Running with routes test for #{test_specific_controller.inspect}" if test_specific_controller.present?
+
 routes = Rails.application.routes.routes.each_with_object({}) do |route, obj|
   controller, action = route.defaults.values_at(:controller, :action)
 
   next if controller.nil? || controller.starts_with?('api/') || controller.starts_with?('rails/')
 
   klass = "#{controller}_controller".camelize.constantize
+  next if test_specific_controller.present? && !controller.starts_with?(test_specific_controller)
 
   obj[klass] ||= []
   obj[klass] << action


### PR DESCRIPTION
* Change UI frontend method `role_allows?` to verify the product feature being checked exists so we can find typo'd/renamed feature identifiers.  
* Fix assert_privileges calls to use the correct identifier
* Change the routes_spec to show us the failures in the event of an unexpected exception
* Raises an error in non-production when the database is seemingly seeded with features but still missing the requested feature.  This very gracefully allows tests that assume super admin feature list ("everything") to bypass the above check.  We will need to change existing specs to properly seed the features they need to they can test as non-admin users with only the features they need.
* Fix tests that partially seed features to see all of the needed ones

- [x] Depends on https://github.com/ManageIQ/manageiq/pull/21222 to pass the last few tests.
- [x] One more, depends on https://github.com/ManageIQ/manageiq/pull/21230 for high level `pxe_tag` feature