### PR TITLE
Fixed bug of description appearing instead of name in category creation success message

### DIFF
--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -83,7 +83,7 @@ module OpsController::Settings::Tags
         else
           @category = Classification.find_by(:description => @edit[:new][:description])
           AuditEvent.success(build_created_audit(@category, @edit))
-          add_flash(_("Category \"%{name}\" was added") % {:name => @category.description})
+          add_flash(_("Category \"%{name}\" was added") % {:name => @category.name})
           get_node_info(x_node)
           @category = @edit = session[:edit] = nil # clean out the saved info
           replace_right_cell(:nodetype => "root")


### PR DESCRIPTION
Fixed a bug where the description instead of the name was being displayed in the category add success message.

Before:

<img width="1348" alt="Screen Shot 2021-05-19 at 2 38 48 PM" src="https://user-images.githubusercontent.com/32444791/118866460-01ddcc80-b8b0-11eb-8dc7-35e30cdfa9ed.png">


After:

<img width="1285" alt="Screen Shot 2021-05-19 at 2 37 24 PM" src="https://user-images.githubusercontent.com/32444791/118866508-0e622500-b8b0-11eb-85b3-6291f5706b6b.png">

@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug
