### PR TITLE
Fixed download buttons for automation-configured systems

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
 
     :automation_manager_configured_system => {
       :get => %w(
+        download_data
         download_summary_pdf
         show
         show_list


### PR DESCRIPTION
Git Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7742

Fixed the download buttons for the automation configured systems.

Before:

<img width="843" alt="Screen Shot 2021-05-20 at 1 29 49 PM" src="https://user-images.githubusercontent.com/32444791/119043035-9b77ad80-b986-11eb-9152-118fca88f3a7.png">

@miq-bot assign @kavyanekkalapu 
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug