### PR TITLE
Notification should not display when last refresh data is unavailable

### DIFF
--- a/app/javascript/components/aggregate_status_card.jsx
+++ b/app/javascript/components/aggregate_status_card.jsx
@@ -49,7 +49,7 @@ const AggregateStatusCard = ({ providerId, providerType }) => {
 
   return (
     <div className="aggregate_status">
-      {(data.refreshStatus 
+      {(data.refreshStatus && data.refreshStatus.last_refresh.status !== 'never'
        && (data.refreshStatus.last_refresh.stale
          || data.refreshStatus.last_refresh.status !== 'success'))
             && (


### PR DESCRIPTION
Issue: Right now, broken notification is displaying when status is not defined.

**Before:**
<img width="1170" alt="Screen Shot 2021-05-21 at 4 24 46 PM" src="https://user-images.githubusercontent.com/37085529/119194581-4d7bac00-ba51-11eb-8ab3-3218915786d3.png">

**After:**
<img width="1177" alt="Screen Shot 2021-05-21 at 4 24 20 PM" src="https://user-images.githubusercontent.com/37085529/119194598-53718d00-ba51-11eb-9481-030aca1ce2a3.png">

@miq-bot add-label bug
@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
