### PR TITLE
Fixed the missing information for volume info icon

### DIFF
--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -30,7 +30,7 @@
                                                       "data-trigger"      => "focus",
                                                       "data-placement"    => "top",
                                                       "data-toggle"       => "popover",
-                                                      "data-content"      => @record.try(:decorate).try(:provisioning_volume_size_tooltip)}
+                                                      "data-content"      => @record.try(:decorate).try(:provisioning_volume_size_tooltip) ? @record.try(:decorate).try(:provisioning_volume_size_tooltip) : _("Default value is 1") }
           .col-md-6
             - if workflow.get_field(key, dialog)[:data_type] == :string
               - if @edit && workflow.get_field(key, dialog)[:display] == :edit && !@edit[:stamp_typ]


### PR DESCRIPTION
Fixed the issue of no information being displayed for the provision instances volume info icon.

Before:
<img width="1514" alt="Screen Shot 2021-05-25 at 2 16 06 PM" src="https://user-images.githubusercontent.com/32444791/119548181-79669c80-bd85-11eb-896a-8fdcdec639a6.png">

After:
<img width="1517" alt="Screen Shot 2021-05-25 at 2 17 12 PM" src="https://user-images.githubusercontent.com/32444791/119548213-7ec3e700-bd85-11eb-929c-613e2dab756e.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug