### PR TITLE
Fix BG color of  react form when opened from dashboard view.

### DIFF
--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -7,7 +7,7 @@
         .row.toolbar-pf#toolbar
           .col-sm-12
             = miq_toolbar toolbar_from_hash
-      .row#main-content.miq-layout-center_div_no_listnav{:class => @lastaction == "show_dashboard" || @layout == "monitor_alerts_overview" ? 'miq-body' : ''}
+      .row#main-content.miq-layout-center_div_no_listnav{:class => (@lastaction == "show_dashboard" || @layout == "monitor_alerts_overview") && !@in_a_form ? 'miq-body' : ''}
         .col-md-12
           .row
             .col-md-7


### PR DESCRIPTION
**Issue:** Right now , BG color of react forms (mostly edit forms) is not correct when opened from dashboard, all the filels and BG color are same , making it same as forms opened from table view.

**Before**

<img width="1529" alt="Screen Shot 2021-05-26 at 8 57 15 AM" src="https://user-images.githubusercontent.com/37085529/119665101-06e7d200-be02-11eb-90dd-1496dc471d8b.png">

**After**

<img width="1412" alt="Screen Shot 2021-05-26 at 9 02 35 AM" src="https://user-images.githubusercontent.com/37085529/119665119-0c451c80-be02-11eb-9765-06da78b537d3.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy, @DavidResende0 
@miq-bot add-label bug