### PR TITLE
Fixed missing request page buttons

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -95,6 +95,8 @@ class MiqRequestController < ApplicationController
     @display = params[:display] || "main" unless pagination_or_gtl_request?
     @gtl_url = "/show"
 
+    @request_tab = params[:typ] || 'service'
+
     if @display == "main"
       prov_set_show_vars
     elsif @display == "miq_provisions"


### PR DESCRIPTION
Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7718

Fixed issue of request page buttons missing when opening a request link directly and then signing in.

Before:
<img width="1462" alt="Screen Shot 2021-05-26 at 3 38 52 PM" src="https://user-images.githubusercontent.com/32444791/119722242-1551e000-be3a-11eb-9562-d8493a888596.png">

After:
<img width="1310" alt="Screen Shot 2021-05-26 at 3 30 50 PM" src="https://user-images.githubusercontent.com/32444791/119722235-13881c80-be3a-11eb-8a7a-1d5db23647e7.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug