### PR TITLE
Fix page layout for Automate-->Simulation page

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -730,13 +730,13 @@ table.c3-tooltip td {
 
 .content-focus-order {
   @media (min-width: 992px) {
-    .col-md-push-3 {
+    .col-md-push-3, .col-md-push-4 {
       left: 0%;
     }
   }
 
   @media (min-width: 992px) {
-    .col-md-pull-9 {
+    .col-md-pull-9, .col-md-pull-8 {
       right: 0%;
     }
   }


### PR DESCRIPTION
**Before:**

<img width="1643" alt="Screen Shot 2021-06-07 at 1 24 32 PM" src="https://user-images.githubusercontent.com/37085529/121063041-d570ee00-c793-11eb-94a0-290bf386950a.png">


**After**

<img width="1524" alt="Screen Shot 2021-06-07 at 1 24 10 PM" src="https://user-images.githubusercontent.com/37085529/121063072-de61bf80-c793-11eb-94d6-958afda50625.png">

@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 
@miq-bot assign @Fryguy 

