### PR TITLE
Add support for cpu/memory hot add in provisioning

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -408,7 +408,8 @@
             -# Display notes if available
             = field_hash[:notes]
       - elsif [:linked_clone, :migratable, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid, :seal_template,
-               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible, :public_network].include?(field)
+               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible, :public_network,
+               :cpu_hot_add, :cpu_hot_remove, :memory_hot_add].include?(field)
         -# ### Checkbox fields
         .col-md-8{:style => "vertical-align: top;"}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -144,7 +144,8 @@
   - when :hardware
     - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
-              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
+              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible,
+              :cpu_hot_add, :cpu_hot_remove, :memory_hot_add]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,


### PR DESCRIPTION
CPU and Memory hot-add/remove is a feature of the vmware provider which can be configured when a VM is created.  Add support for these checkboxes in the provision dialogs.

![Screenshot from 2021-06-09 14-29-35](https://user-images.githubusercontent.com/12851112/121409253-47ca0580-c92f-11eb-98b2-1c80dc655208.png)

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/725