### PR TITLE
Remove unnecessary method

### DIFF
--- a/app/controllers/guest_device_controller.rb
+++ b/app/controllers/guest_device_controller.rb
@@ -11,10 +11,6 @@ class GuestDeviceController < ApplicationController
 
   feature_for_actions "#{controller_name}_show_list", *ADV_SEARCH_ACTIONS
 
-  def self.model
-    @model ||= "GuestDevice".safe_constantize
-  end
-
   def title
     _('Guest Devices')
   end

--- a/app/controllers/physical_network_port_controller.rb
+++ b/app/controllers/physical_network_port_controller.rb
@@ -8,10 +8,6 @@ class PhysicalNetworkPortController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  def self.model
-    @model ||= "PhysicalNetworkPort".safe_constantize
-  end
-
   def title
     _('Network Ports')
   end


### PR DESCRIPTION
The only reason to override this method is if your controller doesn't follow the convention.  Since these two controllers both follow the convention of `model + 'Controller'`, we can let the [superclass handle it](https://github.com/ManageIQ/manageiq-ui-classic/blob/96fc53321edaab4a5b3dc41b13966577bdffd90f/app/controllers/application_controller.rb#L145-L149)


For example (current master):

```
irb(main):001:0> PhysicalNetworkPortController.method(:model).source_location
=> ["/Users/joerafaniello/.gem/ruby/2.6.6/bundler/gems/manageiq-ui-classic-96fc53321eda/app/controllers/physical_network_port_controller.rb", 11]
irb(main):002:0> PhysicalNetworkPortController.method(:model).super_method.source_location
=> ["/Users/joerafaniello/.gem/ruby/2.6.6/bundler/gems/manageiq-ui-classic-96fc53321eda/app/controllers/application_controller.rb", 145]
irb(main):003:0> PhysicalNetworkPortController.method(:model).call == PhysicalNetworkPortController.method(:model).super_method.call
=> true
```

and 

```
irb(main):002:0> GuestDeviceController.method(:model).source_location
=> ["/Users/joerafaniello/.gem/ruby/2.6.6/bundler/gems/manageiq-ui-classic-96fc53321eda/app/controllers/guest_device_controller.rb", 14]
irb(main):003:0> GuestDeviceController.method(:model).super_method.source_location
=> ["/Users/joerafaniello/.gem/ruby/2.6.6/bundler/gems/manageiq-ui-classic-96fc53321eda/app/controllers/application_controller.rb", 145]
irb(main):005:0> GuestDeviceController.method(:model).call == GuestDeviceController.method(:model).super_method.call
=> true
```