### PR TITLE
Select multiple rows across pages

### DIFF
--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -133,6 +133,14 @@ const setRowActive = (rows, item) => {
   return newRows;
 };
 
+
+const pushOneUnique = (array) => {
+  if (ManageIQ.gridChecks.indexOf(array) == -1) {
+    console.log("pushing0 " + array)
+    ManageIQ.gridChecks.push(array)
+  }
+};
+
 const broadcastSelectedItem = (item) => {
   sendDataWithRx({ rowSelect: item });
 
@@ -142,7 +150,7 @@ const broadcastSelectedItem = (item) => {
 
   const { ManageIQ } = window;
   if (item.checked) {
-    ManageIQ.gridChecks.push(item.id);
+    pushOneUnique(item.id);
   } else {
     const index = ManageIQ.gridChecks.indexOf(item.id);
     if (index !== -1) {
@@ -165,8 +173,14 @@ const reduceSelectedItem = (state, item, isSelected) => {
 };
 
 const unSelectAll = (state) => {
-  ManageIQ.gridChecks = [];
-  if (!state.rows) {
+  // ManageIQ.gridChecks = [];
+  // Investigate further: when does this get run?
+  // DANGER HERE this is unselecting ALL, full reset, that which are visible and not visible
+  // we're already runnning an unselect all in the data table
+  console.log("unSelectAll gtl-view")
+  console.log(state.rows)
+
+  if (! state.rows) {
     return state;
   }
 
@@ -181,7 +195,6 @@ const unSelectAll = (state) => {
 const gtlReducer = (state, action) => {
   switch (action.type) {
     case 'dataLoaded':
-      ManageIQ.gridChecks = [];
       return {
         ...state,
         isLoading: false,

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -12,6 +12,14 @@ const getNodeIconType = (row, columnKey) =>
 
 const isFilteredBy = (settings, column) => settings.sort_col === column.col_idx;
 
+const arrayRemove = (array) => {
+  console.log("unSelectAll arrayRemove dataTable")
+  for (var i=0; i<array.length; i++) {
+    var idx = ManageIQ.gridChecks.indexOf(array[i].id);
+    ManageIQ.gridChecks.splice(idx, 1);
+  }
+}
+
 export const DataTable = ({
   rows,
   columns,
@@ -39,6 +47,13 @@ export const DataTable = ({
         return;
       }
 
+      if (ev.target.checked) {
+        // arrayUnique(rows)
+      } else {
+        console.log("localOnSelectAll")
+        arrayRemove(rows)
+      }
+      
       onSelectAll(rows, ev.target);
       setCheckedItems({ ...checkedItems, [ev.target.name]: ev.target.checked });
       ev.stopPropagation();
@@ -61,7 +76,8 @@ export const DataTable = ({
     );
   };
 
-  const renderTableHeader = () => (
+  const renderTableHeader = () => {
+    return(
     <thead className="miq-thead">
       <tr>
         {!inEditMode() && !noCheckboxes()
@@ -100,9 +116,16 @@ export const DataTable = ({
             ))}
       </tr>
     </thead>
-  );
+  )};
 
   const localOnItemSelected = (row) => (ev) => {
+
+    if (ev.target.checked) { // true
+
+    } else { // false
+      arrayRemove([row])
+    }
+
     onItemSelect(row, ev.target.checked);
     ev.stopPropagation();
   };
@@ -124,7 +147,26 @@ export const DataTable = ({
     onItemClick(row);
   };
 
-  const renderTableBody = () => (
+  const renderTableBody = () => {
+    console.log("renderTableBody")
+    console.log("ManageIQ.gridChecks")
+    console.log(ManageIQ.gridChecks) // when u switch paged this gets reset
+    // i can access this
+
+    for (var m = 0 ; m < rows.length; m++) {
+      for(var n = 0 ; n < ManageIQ.gridChecks.length ; n++) {
+        if (rows[m].id == ManageIQ.gridChecks[n]) {
+          rows[m].selected = true  // verify this is neeeded
+          rows[m].checked = true
+        } else {
+          // we'll test this further later
+          // rows[m].selected = undefined
+          // rows[m].checked = undefined
+        }
+      }
+    }
+
+    return(
     <tbody>
       {rows.map((row) => (
         <tr
@@ -210,9 +252,10 @@ export const DataTable = ({
             </td>
           ))}
         </tr>
-      ))}
+      )
+      )}
     </tbody>
-  );
+  )};
 
   const renderTable = () => (
     <table className="table table-bordered table-striped table-hover miq-table-with-footer miq-table">

--- a/app/javascript/components/toolbar/ToolbarList.jsx
+++ b/app/javascript/components/toolbar/ToolbarList.jsx
@@ -8,7 +8,7 @@ import { ToolbarClick } from './ToolbarClick';
 import CountContext from './ToolbarContext';
 
 export const ToolbarList = (props) => {
-  const count = useContext(CountContext);
+  const count = ManageIQ.gridChecks.length;
   const { items, title, id } = props;
   // Set this true for overflowmenu keydown event
   const [overflowTab, setOverflowTab] = useState(false);


### PR DESCRIPTION
### Enhancement 

- User will be able to select multiple rows from a data table across the various pages of the data table. 
- Previously, the data table would deselect rows when the user switched pages. 

@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu