### PR TITLE
Fix rows selection across multiple pages in table view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -372,6 +372,7 @@ class ApplicationController < ActionController::Base
     end
 
     render :json => {
+      :checkboxes_clicked => params.fetch_path(:additional_options, :checkboxes_clicked),
       :settings => settings,
       :data     => view_to_hash(@view, true),
       :messages => @flash_array
@@ -491,6 +492,7 @@ class ApplicationController < ActionController::Base
   # Clear the Search and display original list of items
   def search_clear
     @search_text = @sb[:search_text] = nil
+    params[:miq_grid_checks] = []
     if params[:in_explorer] == "true"
       reload
     else # non-explorer screens

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -289,6 +289,7 @@ module ApplicationController::CiProcessing
         :models  => ui_lookup(:models => klass.to_s)
       }
     )
+    params[:miq_grid_checks] = [] if task == 'destroy' # Making selected checkboxes array empty when those rows are  deleted in table
   end
 
   def manager_button_operation(method, display_name)
@@ -837,6 +838,7 @@ module ApplicationController::CiProcessing
     elements = find_records_with_rbac(model_class, checked_or_params)
     send(destroy_method, elements.ids, 'destroy')
     if params[:miq_grid_checks].present? || @lastaction == "show_list" || (@lastaction == "show" && @layout != model_name.singularize) # showing a list
+      params[:miq_grid_checks] = []
       unless flash_errors?
         add_flash(n_("Delete initiated for %{count} %{model} from the %{product} Database",
                      "Delete initiated for %{count} %{models} from the %{product} Database", elements.length) %

--- a/app/controllers/application_controller/report_data_additional_options.rb
+++ b/app/controllers/application_controller/report_data_additional_options.rb
@@ -24,6 +24,7 @@ class ApplicationController
     :supported_features_filter,
     :clickable,
     :no_checkboxes,
+    :checkboxes_clicked,
     :show_pagination,
     :report_name,
     :custom_action
@@ -74,6 +75,10 @@ class ApplicationController
 
     def with_no_checkboxes(no_checkboxes)
       self.no_checkboxes = no_checkboxes
+    end
+
+    def with_checkboxes_clicked(checkboxes_clicked)
+      self.checkboxes_clicked = checkboxes_clicked
     end
 
     def in_a_form(in_a_form)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -996,6 +996,11 @@ module VmCommon
 
   # Replace the right cell of the explorer
   def replace_right_cell(options = {})
+    if params[:action] == 'x_history'
+      # Making selected checkboxes array empty when compare cancel is clicked
+      params[:miq_grid_checks] = []
+    end
+
     action, presenter, refresh_breadcrumbs = options.values_at(:action, :presenter, :refresh_breadcrumbs)
     refresh_breadcrumbs = true unless options.key?(:refresh_breadcrumbs)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1223,6 +1223,7 @@ module ApplicationHelper
     @report_data_additional_options.with_sb_controller(params[:sb_controller]) if params[:sb_controller]
     @report_data_additional_options.with_model(curr_model) if curr_model
     @report_data_additional_options.with_no_checkboxes(@no_checkboxes || options[:no_checkboxes])
+    @report_data_additional_options.with_checkboxes_clicked(params[:miq_grid_checks]) if params[:miq_grid_checks]
     @report_data_additional_options.freeze
   end
 

--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -181,7 +181,11 @@ const unSelectAll = (state) => {
 const gtlReducer = (state, action) => {
   switch (action.type) {
     case 'dataLoaded':
-      ManageIQ.gridChecks = [];
+      if (state && state.additionalOptions && state.additionalOptions.no_checkboxes_clicked
+        && state.additionalOptions.no_checkboxes_clicked.length === 0) {
+        // Making selected checkboxes array empty when those rows are  deleted or on compare/drift cancel
+        ManageIQ.gridChecks = [];
+      }
       return {
         ...state,
         isLoading: false,
@@ -287,6 +291,7 @@ const GtlView = ({
   // const { settings, data } = props;
   const initState = {
     ...initialState,
+    additionalOptions,
     // namedScope is taken from props to state and then used from state
     namedScope: additionalOptions.named_scope,
   };
@@ -307,8 +312,8 @@ const GtlView = ({
       isExplorer,
       {}, // settings, // FIXME
       records,
+      additionalOptions,
       {
-        ...additionalOptions,
         named_scope: state.namedScope,
       },
     );

--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -113,6 +113,12 @@ export const DataTable = ({
     return '';
   };
 
+  const getRowsSelected = (rows, checks) => {
+    rows.forEach((row) => {
+      if (checks.indexOf(row.id) !== -1) { row.selected = true; row.checked = true; }
+    });
+  };
+
   const localOnClickItem = (row) => (ev) => {
     if (ev.target.classList.contains('is-checkbox-cell')
        || ev.target.parentElement.classList.contains('is-checkbox-cell')) {
@@ -124,18 +130,21 @@ export const DataTable = ({
     onItemClick(row);
   };
 
-  const renderTableBody = () => (
-    <tbody>
-      {rows.map((row) => (
-        <tr
-          className={row.selected ? `active ${classNameRow(row)}` : classNameRow(row)}
-          key={`check_${row.id}`}
-          onClick={localOnClickItem(row)}
-          onKeyPress={localOnClickItem(row)}
-          tabIndex={(row.clickable === false) ? '' : '0'}
-        >
-          {columns.map((column, columnKey) => (
-            <td
+  const renderTableBody = () => {
+    getRowsSelected(rows, ManageIQ.gridChecks);
+
+    return (
+      <tbody>
+        {rows.map((row) => (
+          <tr
+            className={row.selected ? `active ${classNameRow(row)}` : classNameRow(row)}
+            key={`check_${row.id}`}
+            onClick={localOnClickItem(row)}
+            onKeyPress={localOnClickItem(row)}
+            tabIndex={(row.clickable === false) ? '' : '0'}
+          >
+            {columns.map((column, columnKey) => (
+              <td
               // eslint-disable-next-line react/no-array-index-key
               key={`td_${columnKey}`}
               className={classNames({
@@ -207,12 +216,13 @@ export const DataTable = ({
                     {row.cells[columnKey].text}
                   </button>
                 )}
-            </td>
-          ))}
-        </tr>
-      ))}
-    </tbody>
-  );
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    );
+  };
 
   const renderTable = () => (
     <table className="table table-bordered table-striped table-hover miq-table-with-footer miq-table">

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -1352,6 +1352,7 @@ window.miqHideSearchClearButton = function(explorer) {
     $(this).hide();
     // Clear Search text values as well
     var url = '/' + ManageIQ.controller + '/search_clear' + '?in_explorer=' + explorer;
+    ManageIQ.gridChecks=[];
     miqJqueryRequest(url);
   });
 }


### PR DESCRIPTION
# Enhancement

User will be able to select multiple rows from a data table across the various pages of the data table.
Previously, the data table would deselect rows when the user switched pages.

## Original Behavior

Note: User selected rows do not persist across pages. 

https://user-images.githubusercontent.com/29209973/123815814-caa60680-d8c4-11eb-9c17-11588fc7a18f.mov

Note: After comparing rows, when returning to the main table all rows have been deselected. 

https://user-images.githubusercontent.com/29209973/123815885-da254f80-d8c4-11eb-8dc2-6e5a6d1bdf16.mov

## New Behavior 

Note: User selected rows DO persist across pages and across changing pagination size. 

https://user-images.githubusercontent.com/29209973/123816123-0d67de80-d8c5-11eb-95a7-a48d0384b48b.mov


Note: This behavior is still a work in progress. 
After comparing rows, when returning to the main table all rows are NOT deselected. Currently working on deselecting after comparing. 

https://user-images.githubusercontent.com/29209973/123816024-f7f2b480-d8c4-11eb-9d63-f20901f72706.mov




@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 