### PR TITLE
[EmbeddedAnsible] verify_ssl field on repository

### DIFF
--- a/app/javascript/oldjs/controllers/ansible_repository/repository_form_controller.js
+++ b/app/javascript/oldjs/controllers/ansible_repository/repository_form_controller.js
@@ -14,7 +14,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['repositoryId', 'mi
       scm_branch: '',
     };
 
-    vm.attributes = ['name', 'description', 'scm_url', 'authentication_id', 'scm_branch'];
+    vm.attributes = ['name', 'description', 'scm_url', 'verify_ssl', 'authentication_id', 'scm_branch'];
     vm.model = 'repositoryModel';
 
     ManageIQ.angular.scope = $scope;
@@ -77,6 +77,7 @@ ManageIQ.angular.app.controller('repositoryFormController', ['repositoryId', 'mi
 
   var getRepositoryFormData = function(response) {
     var data = response;
+    data.verify_ssl = data.verify_ssl == 1;
     if ( data.hasOwnProperty( 'href' ) ) {
       delete data.href;
     }

--- a/app/views/ansible_repository/_repository_form.html.haml
+++ b/app/views/ansible_repository/_repository_form.html.haml
@@ -49,6 +49,14 @@
         %span.help-block{"ng-show" => "angularForm.scm_url.$error.urlValidation"}
           = _("URL must include a protocol (http://, https:// or file://) or be a valid SSH path (user@server:path or ssh://user@address:port/path)")
     .form-group
+      %label.control-label.col-md-2
+        = _("Verify SSL")
+      .col-md-8
+        %input{:type      => "checkbox",
+               :name      => "verify_ssl",
+               :id        => "verify_ssl",
+               'ng-model' => "vm.repositoryModel.verify_ssl"}
+    .form-group
       %label.col-md-2.control-label
         = _('SCM credentials')
       .col-md-8


### PR DESCRIPTION
Requires:  https://github.com/ManageIQ/manageiq/pull/21298

Adds `verify_ssl` checkbox for the `EmbeddedAnsible` repository form.  On the backend, this actually ends up saving the field on not the `ConfigurationScriptSource`, but the associated `GitRepository` object, but that is mostly a backend concern that is not visiable on the client side.


Screenshots
-----------

### Before

<img width="1792" alt="Screen Shot 2021-06-24 at 4 34 47 PM" src="https://user-images.githubusercontent.com/314014/123335489-2578e000-d50a-11eb-9353-e81ba96999aa.png">


### After

<img width="1792" alt="Screen Shot 2021-06-24 at 4 26 16 PM" src="https://user-images.githubusercontent.com/314014/123334601-f150ef80-d508-11eb-8bee-5b1659ab8172.png">



TODO
----

Merge the following:

- [x] https://github.com/ManageIQ/manageiq/pull/21298


Steps for Testing/QA
--------------------

* Go to:  Automation -> EmbeddedAnsible -> Repositories
* Add a new repo, and ensure that `Verify SSL` is checked
* Optional:  If running locally, ensure that you are using `simulate_queue_worker`
* Once saved, edit the new record, and ensure that `verify_ssl` is checked
* Uncheck the record, and save.
* Once saved, edit the record again to confirm the checkbox is unchecked

Much of what we want to confirm here is that the UI is properly setting and tracking the `virtual_attribute :verify_ssl` here.  Hence the multiple save steps and checking that the UI properly reflects the state in the checkbox