### PR TITLE
[widget_generate_content_spec.rb] Fix let(:record)

### DIFF
--- a/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
+++ b/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
@@ -3,8 +3,7 @@ describe ApplicationHelper::Button::WidgetGenerateContent do
   let(:record) do
     rec = FactoryBot.create(:miq_widget)
     set = FactoryBot.create(:miq_widget_set)
-    w_set_rel = FactoryBot.create(:relationship_miq_widget_set_with_membership, :resource_id => set.id)
-    FactoryBot.create(:relationship_miq_widget_with_membership, :resource_id => rec.id, :ancestry => w_set_rel.id)
+    set.add_member(rec)
     rec
   end
   let(:widget_running) { false }


### PR DESCRIPTION
**Requires** https://github.com/ManageIQ/manageiq/pull/21241

Updates the record generation code so it properly adds a member to the set after the `ActsAsMiqSet` changes.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/21241
* https://github.com/ManageIQ/manageiq/issues/21246