### PR TITLE
Fixed error for  adding policies

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -145,10 +145,11 @@ module MiqPolicyController::Policies
       @edit[:new][:notes] = params[:notes].presence if params[:notes]
       @edit[:new][:active] = (params[:active] == "1") if params.key?(:active)
       @edit[:new][:mode] = params[:mode] if params[:mode]
+      params[:towhat] ||= 'Vm'
       if params[:towhat]
         @edit[:new][:towhat] = params[:towhat]
-        policy = @edit[:rec_id] ? MiqPolicy.find_by(:id => @edit[:rec_id]) : MiqPolicy.new
-        build_expression(policy, params[:towhat])
+        @policy = @edit[:rec_id] ? MiqPolicy.find_by(:id => @edit[:rec_id]) : MiqPolicy.new
+        build_expression(@policy, params[:towhat])
       end
     end
     send_button_changes


### PR DESCRIPTION
Fixed error that would occur when the add policy form was edited.

Before: 
<img width="1270" alt="Screen Shot 2021-06-28 at 1 56 35 PM" src="https://user-images.githubusercontent.com/32444791/123682174-aa207280-d818-11eb-9f8b-3af638ddbe3b.png">

After:
<img width="1397" alt="Screen Shot 2021-06-28 at 1 57 47 PM" src="https://user-images.githubusercontent.com/32444791/123682292-d3410300-d818-11eb-8e22-c1f34c20c801.png">

@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug
