### PR TITLE
Fixed delete subnet queued method name

### DIFF
--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -156,7 +156,7 @@ describe CloudSubnetController do
     let(:queue_options) do
       {
         :class_name  => cloud_subnet.class.name,
-        :method_name => 'raw_delete_cloud_subnet',
+        :method_name => 'delete_cloud_subnet',
         :instance_id => cloud_subnet.id,
         :args        => []
       }


### PR DESCRIPTION
- This is to account for a recent change in core to change the queued method name for deleting subnets

See:
https://github.com/ManageIQ/manageiq/pull/21307
