### PR TITLE
Fixed error for cancel button in template editor

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -34,7 +34,7 @@ module ApplicationController::AdvancedSearch
       @edit[:adv_search_open] = false
       @edit[@expkey][:exp_model] = model.to_s
     end
-    @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Build the table to display the exp
+    @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) if @edit[@expkey] # Build the table to display the exp
     @edit[:in_explorer] = @explorer # Remember if we're in an explorer
 
     if @hist && @hist[:qs_exp] # Override qs exp if qs history button was pressed


### PR DESCRIPTION
Error occurs when clicking cancel on the template editor form.

<img width="1264" alt="Screen Shot 2021-06-28 at 4 48 41 PM" src="https://user-images.githubusercontent.com/32444791/123702086-b3b5d480-d830-11eb-9b91-6954144c50d0.png">

@miq-bot assign @kavyanekkalapu
@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug