### PR TITLE
Rename Flavors cpus -> total_cpu_cores and add cpu_sockets

### DIFF
--- a/app/helpers/flavor_helper/textual_summary.rb
+++ b/app/helpers/flavor_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module FlavorHelper::TextualSummary
     TextualGroup.new(
       _("Properties"),
       %i[
-        cpus cpu_cores memory enabled publicly_available supports_32_bit supports_64_bit supports_hvm supports_paravirtual
+        cpus cpu_sockets memory enabled publicly_available supports_32_bit supports_64_bit supports_hvm supports_paravirtual
         block_storage_based_only cloud_subnet_required
       ]
     )
@@ -28,11 +28,11 @@ module FlavorHelper::TextualSummary
   end
 
   def textual_cpus
-    {:label => _("CPUs"), :value => @record.cpus}
+    {:label => _("CPUs"), :value => @record.cpu_total_cores}
   end
 
-  def textual_cpu_cores
-    {:label => _("CPU Cores"), :value => @record.cpu_cores}
+  def textual_cpu_sockets
+    {:label => _("CPU Sockets"), :value => @record.cpu_sockets}
   end
 
   def textual_enabled

--- a/spec/helpers/flavor_helper/textual_summary_spec.rb
+++ b/spec/helpers/flavor_helper/textual_summary_spec.rb
@@ -1,7 +1,7 @@
 describe FlavorHelper::TextualSummary do
   include_examples "textual_group", "Properties", %i(
     cpus
-    cpu_cores
+    cpu_sockets
     memory
     enabled
     publicly_available


### PR DESCRIPTION
The flavor model's cpu attributes had vague meanings leading to
confusion, and also were different from the hardware model's cpu
attributes used by VMs and Hosts.

The `#cpus` property was used as the "total vcpus/cores" where
`#cpu_cores` was typically used as "sockets" despite the name.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/582

https://github.com/ManageIQ/manageiq/issues/21192