### PR TITLE
fix broken breadcrumb url for physical_storage

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3233,7 +3233,6 @@ Rails.application.routes.draw do
     ems_storage
     miq_ae_customization
     network_service
-    physical_storage
     pxe
     security_policy
     security_policy_rule

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -965,7 +965,8 @@ PhysicalServerController:
 - perf_top_chart
 - tl_chooser
 - wait_for_task
-PhysicalStorageController: []
+PhysicalStorageController:
+- index
 PhysicalSwitchController:
 - index
 PictureController:


### PR DESCRIPTION
Click on Storage -> Storages -> <Select on any existing Physical Storage">, The breadcrumb link shows the following Navigation LInk as shown below:

Compute–> Physical Infrastructure–> +*Storages*+ --> GTSFS9150A (Summary)

But clicking on the storage link throws a page not found error..

![image](https://user-images.githubusercontent.com/53213107/124101267-daaa1b80-da67-11eb-9f56-4810f4b7d366.png)
