### PR TITLE
Add operating system and background icon for powerstate in vms table

### DIFF
--- a/app/javascript/components/gtl/DataTable.jsx
+++ b/app/javascript/components/gtl/DataTable.jsx
@@ -113,6 +113,29 @@ export const DataTable = ({
     return '';
   };
 
+  const renderIcon = (row, columnKey) => (
+    <i
+      className={row.cells[columnKey].icon}
+      title={row.cells[columnKey].title}
+    >
+      <i ng-if="row.cells[columnKey].icon2" className={row.cells[columnKey].icon2} />
+    </i>
+  );
+
+  const renderBackgroundIcon = (row, columnKey) => {
+    if (row.cells[columnKey].background) {
+      const { background } = row.cells[columnKey];
+      return (
+        <div style={{ background }} className="backgrounded-icon">
+          {renderIcon(row, columnKey)}
+        </div>
+      );
+    }
+    return (
+      renderIcon(row, columnKey)
+    );
+  };
+
   const localOnClickItem = (row) => (ev) => {
     if (ev.target.classList.contains('is-checkbox-cell')
        || ev.target.parentElement.classList.contains('is-checkbox-cell')) {
@@ -171,12 +194,7 @@ export const DataTable = ({
               )}
               { getNodeIconType(row, columnKey) === 'icon'
                 && (
-                  <i
-                    className={row.cells[columnKey].icon}
-                    title={row.cells[columnKey].title}
-                  >
-                    <i ng-if="row.cells[columnKey].icon2" className={row.cells[columnKey].icon2} />
-                  </i>
+                  renderBackgroundIcon(row, columnKey)
                 )}
               { getNodeIconType(row, columnKey) === 'image'
                 && (

--- a/product/views/ManageIQ_Providers_InfraManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Template.yaml
@@ -26,6 +26,8 @@ cols:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- product_name
+- os_image_name
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -50,6 +52,7 @@ include_for_find:
 col_order:
 - name
 - ext_management_system.name
+- product_name
 - ems_cluster_name
 - host.name
 - storage.name
@@ -58,11 +61,13 @@ col_order:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- os_image_name
 
 # Column titles, in order
 headers:
 - Name
 - Provider
+- Operating System
 - Cluster
 - Host
 - Datastore

--- a/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
@@ -27,6 +27,8 @@ cols:
 - last_scan_on
 - region_description
 - normalized_state
+- product_name
+- os_image_name
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -51,6 +53,7 @@ include_for_find:
 col_order:
 - name
 - normalized_state
+- product_name
 - ext_management_system.name
 - ems_cluster_name
 - host.name
@@ -60,11 +63,13 @@ col_order:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- os_image_name
 
 # Column titles, in order
 headers:
 - Name
 - Power State
+- Operating System
 - Provider
 - Cluster
 - Host

--- a/product/views/VmOrTemplate.yaml
+++ b/product/views/VmOrTemplate.yaml
@@ -28,6 +28,8 @@ cols:
 - last_scan_on
 - region_description
 - normalized_state
+- os_image_name
+- product_name
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -52,6 +54,7 @@ include_for_find:
 col_order:
 - name
 - normalized_state
+- product_name
 - ext_management_system.name
 - ems_cluster_name
 - host.name
@@ -62,11 +65,13 @@ col_order:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- os_image_name
 
 # Column titles, in order
 headers:
 - Name
 - Power State
+- Operating System
 - Provider
 - Cluster
 - Host

--- a/spec/controllers/application_controller/report_data_spec.rb
+++ b/spec/controllers/application_controller/report_data_spec.rb
@@ -27,8 +27,8 @@ describe ApplicationController do
       expect(headder[0]).to eql("is_narrow" => true)
       expect(headder[1]).to eql("text" => "Name", "sort" => "str", "col_idx" => 0, "align" => "left")
       expect(headder[2]).to eql("text" => "Power State", "sort" => "str", "col_idx" => 1, "align" => "left")
-      expect(headder[3]).to eql("text" => "Provider", "sort" => "str", "col_idx" => 2, "align" => "left")
-      expect(headder[4]).to eql("text" => "Cluster", "sort" => "str", "col_idx" => 3, "align" => "left")
+      expect(headder[3]).to eql("text" => "Operating System", "sort" => "str", "col_idx" => 2, "align" => "left")
+      expect(headder[4]).to eql("text" => "Provider", "sort" => "str", "col_idx" => 3, "align" => "left")
     end
 
     it "should call specific functions" do


### PR DESCRIPTION
Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7772

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label enhancement

**Before**

<img width="1074" alt="Screen Shot 2021-07-06 at 11 32 45 AM" src="https://user-images.githubusercontent.com/37085529/124627883-eb82d480-de4d-11eb-8439-a95c0d2a1d46.png">


**After**

<img width="1425" alt="Screen Shot 2021-07-08 at 9 45 31 PM" src="https://user-images.githubusercontent.com/37085529/125011148-e3858900-e035-11eb-84f4-6270bc9d15c6.png">
<img width="1435" alt="Screen Shot 2021-07-08 at 9 45 41 PM" src="https://user-images.githubusercontent.com/37085529/125011151-e4b6b600-e035-11eb-8a3b-f87f6f79b220.png">

