### PR TITLE
Show Secondary Data for Run Ansible Playbook Action

### DIFF
--- a/app/controllers/miq_action_controller.rb
+++ b/app/controllers/miq_action_controller.rb
@@ -97,7 +97,7 @@ class MiqActionController < ApplicationController
       update_playbook_variables(params)
     end
     @edit[:new][:options][:service_template_id] = params[:service_template_id].to_i if params[:service_template_id]
-
+    @edit[:new][:options][:service_template_name] = ServiceTemplateAnsiblePlaybook.order(:name).where(:id => @edit[:new][:options][:service_template_id]).pluck(:name)
     # Note that the params[:tag] here is intentionally singular
     @edit[:new][:options][:tags] = params[:tag].present? ? [Classification.find(params[:tag]).tag.name] : nil if params[:tag]
 

--- a/app/views/miq_action/show.html.haml
+++ b/app/views/miq_action/show.html.haml
@@ -183,6 +183,29 @@
         .col-md-8
           = h(@record.options[:scan_item_set_name])
     %hr
+  - when "run_ansible_playbook"
+    %h3
+      = _("Run Ansible Playbook")
+    .form-horizontal
+      .form-group
+        %label.control-label.col-md-2
+          = _("Playbook Catalog Item")
+        .col-md-8
+          = h(@record.options[:service_template_name].join)
+      .form-group
+        %label.control-label.col-md-2
+          = _("Inventory")
+        - if @record.options[:use_localhost]
+          .col-md-8
+            = _("Localhost")
+        - elsif @record.options[:use_event_target]
+          .col-md-8
+            = _("Target Machine")
+        - else
+          .col-md-8
+            = _("Specific Hosts ")
+            = h(@record.options[:hosts])
+    %hr  
   - when "evaluate_alerts"
     %h3
       = _("Alerts to Evaluate")


### PR DESCRIPTION
Fixed issue which secondary data for Run Ansible Playbook Action does not show up in action summary page

**Before:**
Only shows Basic Information
![Screen Shot 2021-07-07 at 3 53 24 PM](https://user-images.githubusercontent.com/82469658/124820429-78578c00-df3b-11eb-81c4-39283995812d.png)

**After:** 
Show both Basic Information and Run Ansible Playbook Information
![Screen Shot 2021-07-07 at 3 52 37 PM](https://user-images.githubusercontent.com/82469658/124820337-5c53ea80-df3b-11eb-9e73-4954afd05117.png)

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug