### PR TITLE
Fix validation error message display in providers screen

### DIFF
--- a/app/javascript/forms/helper-text-block.jsx
+++ b/app/javascript/forms/helper-text-block.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 const HelperTextBlock = ({ helperText, errorText, warnText }) => {
   if (errorText) {
-    return <div className="bx--form-requirement ddorg__carbon-error-helper-text">{errorText}</div>;
+    return <div className="ddorg__carbon-error-helper-text">{errorText}</div>;
   }
 
   if (warnText) {
-    return <div className="bx--form-requirement ddorg__carbon-warning-helper-text">{warnText}</div>;
+    return <div className="ddorg__carbon-warning-helper-text">{warnText}</div>;
   }
 
   if (helperText) {

--- a/app/javascript/spec/async-credentials/async-credentials.spec.js
+++ b/app/javascript/spec/async-credentials/async-credentials.spec.js
@@ -77,7 +77,7 @@ describe('Async credentials component', () => {
 
     wrapper.update();
 
-    expect(wrapper.find('div.bx--form-requirement.ddorg__carbon-error-helper-text').text()).toEqual('Validation failed');
+    expect(wrapper.find('div.ddorg__carbon-error-helper-text').text()).toEqual('Validation failed');
 
     done();
   });
@@ -96,7 +96,7 @@ describe('Async credentials component', () => {
     expect(wrapper.find('div.bx--form__helper-text').text()).toEqual('Validation successful');
     wrapper.find('input[name="foo"]').simulate('change', { target: { value: 'test' } });
     wrapper.update();
-    expect(wrapper.find('div.bx--form-requirement.ddorg__carbon-error-helper-text').text()).toEqual('Validation Required');
+    expect(wrapper.find('div.ddorg__carbon-error-helper-text').text()).toEqual('Validation Required');
 
     done();
   });
@@ -115,7 +115,7 @@ describe('Async credentials component', () => {
     expect(wrapper.find('div.bx--form__helper-text').text()).toEqual('Validation successful');
     wrapper.find('input[name="foo"]').simulate('change', { target: { value: 'test' } });
     wrapper.update();
-    expect(wrapper.find('div.bx--form-requirement.ddorg__carbon-error-helper-text').text()).toEqual('Validation Required');
+    expect(wrapper.find('div.ddorg__carbon-error-helper-text').text()).toEqual('Validation Required');
     wrapper.find('input[name="foo"]').simulate('change', { target: { value: 'baz' } });
     wrapper.update();
     expect(wrapper.find('div.bx--form__helper-text').text()).toEqual('Validation successful');


### PR DESCRIPTION
In providers screen, when validate is clicked, if api call is giving error, it is not displaying. It is supposed to display, but css is stopping from showing, fixed it in this pr.

**Before**

<img width="1016" alt="Screen Shot 2021-07-13 at 1 57 29 PM" src="https://user-images.githubusercontent.com/37085529/125501970-33d259ca-54bc-42f8-94fe-11ccbe97154b.png">


**After**
<img width="1002" alt="Screen Shot 2021-07-13 at 1 43 29 PM" src="https://user-images.githubusercontent.com/37085529/125501758-ba0289b4-d5df-47ba-8331-703bc22c11a4.png">
<img width="772" alt="Screen Shot 2021-07-13 at 1 43 11 PM" src="https://user-images.githubusercontent.com/37085529/125501781-f9e6d596-5728-4c86-80f6-763bb396ec31.png">

@miq-bot add-label bug
@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
