### PR TITLE
Resolving nil UI exception

### DIFF
--- a/app/helpers/configuration_script_helper.rb
+++ b/app/helpers/configuration_script_helper.rb
@@ -116,11 +116,10 @@ module ConfigurationScriptHelper
   end
 
   def textual_variables(vars)
-    return unless vars
     h = {:title     => _("Variables"),
          :headers   => [_('Name'), _('Value')],
          :col_order => %w[name value]}
-    h[:value] = vars.collect do |item|
+    h[:value] = Array(vars).collect do |item|
       {
         :name  => item[0].to_s,
         :value => item[1].to_s

--- a/app/views/configuration_script/show.html.haml
+++ b/app/views/configuration_script/show.html.haml
@@ -9,5 +9,5 @@
     :javascript
       ManageIQ.component.componentFactory('TagGroup', '#tag_group', #{textual_tags_render_data(@record).to_json});
   .col-md-12.col-lg-8
-    - if @record.survey_spec['spec']
+    - if @record.survey_spec&.dig("spec")
       = react 'TableListViewWrapper', TextualListview.data(textual_configuration_script_survey)


### PR DESCRIPTION
## Enhancement

When selecting a row from a data table, if the row is nil these changes will ensure that the exception is caught and the details will be shown (even if there are none because it is nil).

Fixes [#7745](https://github.com/ManageIQ/manageiq-ui-classic/issues/7745)

### Before:

<img width="1429" alt="Screen Shot 2021-07-15 at 1 58 21 PM" src="https://user-images.githubusercontent.com/29209973/125843743-97d070f0-5b29-48fe-86e6-ca4100226bc8.png">


### After:

<img width="1434" alt="Screen Shot 2021-07-15 at 3 09 02 PM" src="https://user-images.githubusercontent.com/29209973/125843835-f3e55930-19fe-4b3d-bf00-4d612cfd6ac4.png">

@miq-bot assign @kavyanekkalapu 
@miq-bot add_reviewer @kavyanekkalapu 
@miq-bot add_reviewer @agrare 