### PR TITLE
[custom_buttons_mixin.rb] Fix for MiqSet change

### DIFF
--- a/app/presenters/custom_buttons_mixin.rb
+++ b/app/presenters/custom_buttons_mixin.rb
@@ -11,8 +11,9 @@ module CustomButtonsMixin
   def get_custom_buttons(object)
     # FIXME: don't we have a method for the splits?
     # FIXME: cannot we ask for the null parent using Arel?
-    CustomButton.buttons_for(object.name.split('|').last.split('-').last).select do |uri|
-      uri.parent.nil?
+    button_name = object.name.split('|').last.split('-').last
+    CustomButton.buttons_for(button_name).includes(:custom_button_sets).select do |uri|
+      uri.custom_button_sets.blank?
     end
   end
 


### PR DESCRIPTION
Now that `acts_as_miq_set` doesn't use `RelationshipMixin`, `.parent` is no longer a valid method.

This fixes that by doing something similar that was done in `CustomActionsMixin` in core:

https://github.com/ManageIQ/manageiq/commit/01443d25


Links
-----

* FIXUP followup for https://github.com/ManageIQ/manageiq/issues/21246#issuecomment-881699321

Steps for Testing/QA
--------------------

* Login
* Go to `Automation -> Embedded Automate -> Custimization`
* With this patch, confirm the page loads

(will raise an error when it doesn't)

To apply the patch, you can do the following to your local `manageiq-ui-classic` repo:

```console
$ git apply <(curl -L https://github.com/ManageIQ/manageiq-ui-classic/pull/7791.patch)
```