### PR TITLE
Remove dom-to-image package and fix charts css

### DIFF
--- a/app/stylesheet/charts.scss
+++ b/app/stylesheet/charts.scss
@@ -24,3 +24,22 @@
 .bx--cc--pie {
   overflow: visible !important;
 }
+
+.bx--cc--toolbar {
+  .bx--overflow-menu-options {
+    top : 10%;
+  }
+}
+.spacer {
+  margin-top: 10px;
+  height: 0px;
+}
+
+
+.bx--cc--legend {
+  .legend-item {
+    height: 30px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@carbon/charts": "~0.41.38",
-    "@carbon/charts-react": "~0.41.38",
-    "dom-to-image": "2.6.0",
+    "@carbon/charts": "~0.41.84",
+    "@carbon/charts-react": "~0.41.84",
     "@carbon/icons-react": "~10.26.0",
     "@carbon/themes": "~10.28.0",
     "@data-driven-forms/carbon-component-mapper": "~3.11.2",


### PR DESCRIPTION
Remove dom-to-image package as it is added as dependency from carbon charts 0.41.84 version, also fixed charts css after recent updated to charts package.

**Before:**

<img width="1380" alt="Screen Shot 2021-07-20 at 3 01 43 PM" src="https://user-images.githubusercontent.com/37085529/126381424-f3a82403-4476-4774-aac6-fa6f76d1434f.png">


**After:**
<img width="1365" alt="Screen Shot 2021-07-20 at 2 32 39 PM" src="https://user-images.githubusercontent.com/37085529/126381447-6a7f95ff-905c-45a6-9528-011cf19ae4e0.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq_bot add_reviewer @Fryguy 
