### PR TITLE
Ability to add custom close function to modal

### DIFF
--- a/app/javascript/packs/provider-dialogs-common.js
+++ b/app/javascript/packs/provider-dialogs-common.js
@@ -5,13 +5,15 @@ function reactModal(buttonData) {
   const props = {
     recordId: ManageIQ.record.recordId,
     gridChecks: ManageIQ.gridChecks,
-    modalData: buttonData
+    modalData: buttonData,
   };
 
   const Component = ManageIQ.component.getReact(buttonData.component_name);
   const inner = () => <Component {...props} />;
-
-  renderModal(__(buttonData.modal_title), inner);
+  const noop = () => {};
+  const closefunc = (Component.WrappedComponent && Component.WrappedComponent.defaultProps && Component.WrappedComponent.defaultProps.closefunc)
+    ? Component.WrappedComponent.defaultProps.closefunc : noop;
+  renderModal(__(buttonData.modal_title), inner, closefunc);
 }
 
 function apiCall(buttonData, dialogData) {

--- a/app/javascript/provider-dialogs/modal.js
+++ b/app/javascript/provider-dialogs/modal.js
@@ -18,12 +18,16 @@ function closeModal(id) {
   divs[divs.length - 1].remove(); // the div closest to body
 }
 
-export default function renderModal(title = __('Modal'), Inner = () => <div>Empty?</div>) {
+export default function renderModal(title = __('Modal'), Inner = () => <div>Empty?</div>, closefunc) {
   const div = document.createElement('div');
   document.body.appendChild(div);
   const removeId = 'provider-dialogs';
 
-  const close = () => closeModal(removeId);
+  // combine  default close function with the one coming from component
+  const close = () => {
+    closefunc();
+    closeModal(removeId);
+  };
 
   const output = modal(title, Inner, close, removeId);
 
@@ -32,12 +36,11 @@ export default function renderModal(title = __('Modal'), Inner = () => <div>Empt
 
 function modal(title, Inner, closed, removeId) {
   const overrides = {
-    addClicked: orig => Promise.resolve(orig()).then(closed),
-    saveClicked: orig => Promise.resolve(orig()).then(closed),
-    cancelClicked: orig => Promise.resolve(orig()).then(closed),
+    addClicked: (orig) => Promise.resolve(orig()).then(closed),
+    saveClicked: (orig) => Promise.resolve(orig()).then(closed),
+    cancelClicked: (orig) => Promise.resolve(orig()).then(closed),
     // don't close on reset
   };
-
   return (
     <Provider store={ManageIQ.redux.store}>
       <Modal


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7784

This will provide ability add a custom function on close in provider dialogs. Default close function will execute after custonm function. 

@miq-bot Add-label enhancement
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 

