### PR TITLE
Fix message persists after automate export screen

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -122,7 +122,10 @@ class MiqAeCustomizationController < ApplicationController
 
   def explorer
     @trees = []
-    @flash_array = @sb[:flash_msg] if @sb[:flash_msg].present?
+    if @sb[:flash_msg].present?
+      @flash_array = @sb[:flash_msg]
+      @sb[:flash_msg] = []
+    end
     @explorer = true
 
     build_resolve_screen


### PR DESCRIPTION
### Before
<img width="905" alt="image" src="https://user-images.githubusercontent.com/87487049/126868031-0a14bc9a-6f1a-414f-818f-9ed33fb4d730.png">


### After
Now the export error message is not displayed in other pages. Only the expected messages are displayed.
 
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/87487049/126867771-ec61e8ac-b418-4010-9cb2-35fe27b9e964.png">

