### PR TITLE
Fixed error message persists across customization  explorer modules

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -122,7 +122,10 @@ class MiqAeCustomizationController < ApplicationController
 
   def explorer
     @trees = []
-    @flash_array = @sb[:flash_msg] if @sb[:flash_msg].present?
+    if @sb[:flash_msg].present?
+      @flash_array = @sb[:flash_msg]
+      @sb[:flash_msg] = []
+    end
     @explorer = true
 
     build_resolve_screen


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7021

### Before

<img width="905" alt="126868031-0a14bc9a-6f1a-414f-818f-9ed33fb4d730" src="https://user-images.githubusercontent.com/87487049/127017644-a0efcee1-ad6e-4bd5-80d7-42528bf5df9f.png">

### After
<img width="1289" alt="126867771-ec61e8ac-b418-4010-9cb2-35fe27b9e964" src="https://user-images.githubusercontent.com/87487049/127017689-64376154-0041-4eba-be5c-575add5f30d7.png">

