### PR TITLE
Add status and host_cluster_name to host_initiators table

### DIFF
--- a/product/views/HostInitiator.yaml
+++ b/product/views/HostInitiator.yaml
@@ -28,6 +28,8 @@ include:
 cols:
 - name
 - v_total_addresses
+- status
+- host_cluster_name
 
 
 # Included tables and columns for query performance
@@ -40,6 +42,8 @@ col_order:
 - ext_management_system.name
 - physical_storage.name
 - v_total_addresses
+- status
+- host_cluster_name
 
 
 # Column titles, in order
@@ -48,6 +52,8 @@ headers:
 - EMS Name
 - Storage System Name
 - Total addresses
+- Status
+- Host Cluster Name
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
two fields were added to host initiators listing page:
- status
- host_cluster_name

![Screenshot 2021-07-28 150036](https://user-images.githubusercontent.com/53213107/127433149-73563b89-76a4-44a7-a69f-00967c7eb647.jpg)

links
--------
https://github.com/ManageIQ/manageiq-providers-autosde/pull/73 - need to be merged before this PR
https://github.com/ManageIQ/manageiq-schema/pull/594 - need to be merged before this PR