### PR TITLE
Revert carbon charts change for fonts issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@carbon/charts": "0.41.90",
-    "@carbon/charts-react": "0.41.90",
+    "@carbon/charts": "^0.41.90",
+    "@carbon/charts-react": "^0.41.90",
     "@carbon/icons-react": "~10.26.0",
     "@carbon/themes": "~10.28.0",
     "@data-driven-forms/carbon-component-mapper": "~3.11.2",


### PR DESCRIPTION
Fonts issue is fixed in below prs, so reverted the locking the carbon charts version.
https://github.com/carbon-design-system/carbon-charts/pull/1095
https://github.com/carbon-design-system/carbon-charts/pull/1096

**After:**

<img width="1680" alt="Screen Shot 2021-08-02 at 2 45 25 PM" src="https://user-images.githubusercontent.com/37085529/127909883-709c961b-c7c9-48aa-b9de-b158629d688d.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 


