### PR TITLE
Fix Refresh and powerstate of configuration provider

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -325,6 +325,13 @@ module ApplicationController::CiProcessing
                  "%{task} initiated for %{count} providers", manager_ids.length) %
                 {:task  => task_name(task),
                  :count => manager_ids.length})
+    if @lastaction == "show_list"
+      params[:miq_grid_checks] = []
+      show_list
+      @refresh_partial = "layouts/gtl"
+    else
+      params[:display] = @display
+    end
   end
 
   # Delete all selected or single displayed VM(s)

--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -181,8 +181,8 @@ const unSelectAll = (state) => {
 const gtlReducer = (state, action) => {
   switch (action.type) {
     case 'dataLoaded':
-      if (state && state.additionalOptions && state.additionalOptions.no_checkboxes_clicked
-        && state.additionalOptions.no_checkboxes_clicked.length === 0) {
+      if (state && state.additionalOptions && state.additionalOptions.checkboxes_clicked
+        && state.additionalOptions.checkboxes_clicked.length === 0) {
         // Making selected checkboxes array empty when those rows are  deleted or on compare/drift cancel
         ManageIQ.gridChecks = [];
       }


### PR DESCRIPTION
In Configuration Management--> Providers, Refresh Relationships and Providers functionality is broken, Once the Button is clicked, providers are disappearing.

**Before**

<img width="1677" alt="Screen Shot 2021-08-03 at 1 46 26 PM" src="https://user-images.githubusercontent.com/37085529/128062312-e7c82b71-cb5b-41ae-b750-900ae3bc6c65.png">
<img width="1671" alt="Screen Shot 2021-08-03 at 1 46 45 PM" src="https://user-images.githubusercontent.com/37085529/128062313-f2dfd37c-50c3-4b04-a51d-4cf58b4ad1c4.png">

**After**

<img width="1657" alt="Screen Shot 2021-08-03 at 1 48 08 PM" src="https://user-images.githubusercontent.com/37085529/128062334-13d31e7f-454d-49b6-8392-7b6c69f9c707.png">

@miq-bot assign @agrare 
@miq-bot add-label bug
@miq_bot add_reviewer @agrare 
