### PR TITLE
Add Different Title Name for Action Form When Add/Edit

### DIFF
--- a/app/controllers/miq_action_controller.rb
+++ b/app/controllers/miq_action_controller.rb
@@ -424,7 +424,12 @@ class MiqActionController < ApplicationController
   end
 
   def get_session_data
-    @title = _("Actions")
+    @action = MiqAction.find_by(:id => params[:miq_grid_checks])
+    @title = if @action.present?
+               _("Editing Action \"%{name}\"") % {:name => @action.description}
+             else
+               _("Adding a new Action")
+             end
     @layout = "miq_action"
     @lastaction = session[:miq_action_lastaction]
     @display = session[:miq_action_display]


### PR DESCRIPTION
In Control--> Actions, Add/Edit page have same title

**Before:**
add a new action:
![Screen Shot 2021-08-03 at 3 38 41 PM](https://user-images.githubusercontent.com/82469658/128075792-26767237-fd8e-459a-9fc6-d0f0e43d9018.png)
edit an action:
![Screen Shot 2021-08-03 at 3 39 01 PM](https://user-images.githubusercontent.com/82469658/128075840-fb41f291-dd9d-47ab-9a65-3c6719fc7815.png)

**After:**
add a new action:
![Screen Shot 2021-08-03 at 3 43 27 PM](https://user-images.githubusercontent.com/82469658/128076463-f4efa2c9-f8af-438e-bbd4-b68601ab0b93.png)

edit an action:
![Screen Shot 2021-08-03 at 3 42 09 PM](https://user-images.githubusercontent.com/82469658/128076314-f7ac66a4-f66f-4247-87bd-32782bf0bd48.png)

@miq-bot add-label enhancement
@miq-bot add_reviewer @kavyanekkalapu 
