### PR TITLE
Add Different Titles for Alert Page New/Edit 

### DIFF
--- a/app/controllers/miq_alert_controller.rb
+++ b/app/controllers/miq_alert_controller.rb
@@ -693,7 +693,12 @@ class MiqAlertController < ApplicationController
   end
 
   def get_session_data
-    @title = _("Alerts")
+    @alert = MiqAlert.find_by(:id => params[:miq_grid_checks])
+    @title = if @alert.present?
+               _("Editing Alert \"%{name}\"") % {:name => @alert.description}
+             else
+               _("Adding a new Alert")
+             end
     @layout =  "miq_alert"
     @lastaction = session[:miq_alert_lastaction]
     @display = session[:miq_alert_display]


### PR DESCRIPTION
In Control--> Alerts, Add/Edit page have same title.

**Before:**
add a new alert:
![Screen Shot 2021-08-04 at 10 44 25 AM](https://user-images.githubusercontent.com/82469658/128201715-1ba7581b-949c-41d3-85ff-184e6a0532d7.png)
edit an alert:
![Screen Shot 2021-08-04 at 10 44 45 AM](https://user-images.githubusercontent.com/82469658/128201775-f889eca1-9610-416b-80dd-63f08d92bccb.png)

**After:**
add a new alert:
<img width="1502" alt="Screen Shot 2021-08-04 at 1 24 24 PM" src="https://user-images.githubusercontent.com/82469658/128226606-8305c19e-3e3a-4cd1-960a-60af2dceb818.png">

edit an alert:
<img width="1546" alt="Screen Shot 2021-08-04 at 1 25 28 PM" src="https://user-images.githubusercontent.com/82469658/128226595-1e6887a7-1631-4131-b8a9-b05d01018686.png">


@miq-bot add-label enhancement