### PR TITLE
added columns and props for health state of cloud volume

### DIFF
--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -5,7 +5,7 @@ module CloudVolumeHelper::TextualSummary
   include TextualMixins::TextualCustomButtonEvents
 
   def textual_group_properties
-    TextualGroup.new(_("Properties"), %i[name size bootable description status])
+    TextualGroup.new(_("Properties"), %i[name size bootable description status health_state])
   end
 
   def textual_group_relationships
@@ -28,6 +28,10 @@ module CloudVolumeHelper::TextualSummary
 
   def textual_status
     {:label => _('Status'), :value => @record.status.to_s}
+  end
+
+  def textual_health_state
+    {:label => _('Health State'), :value => @record.health_state.to_s}
   end
 
   def textual_parent_ems_cloud

--- a/product/views/CloudVolume.yaml
+++ b/product/views/CloudVolume.yaml
@@ -21,6 +21,7 @@ db: CloudVolume
 cols:
 - name
 - size
+- health_state
 - status
 - volume_type
 - bootable
@@ -41,6 +42,7 @@ include:
 col_order:
 - name
 - size
+- health_state
 - status
 - volume_type
 - bootable
@@ -51,6 +53,7 @@ col_order:
 headers:
 - Name
 - Size
+- Health State
 - Status
 - Type
 - Bootable?

--- a/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
@@ -11,5 +11,5 @@ describe CloudVolumeHelper::TextualSummary do
     custom_button_events
     host_initiators
   )
-  include_examples "textual_group", "Properties", %i(name size bootable description status)
+  include_examples "textual_group", "Properties", %i(name size bootable description status health_state)
 end


### PR DESCRIPTION
added columns and props for the health state of cloud volume
this PR depends on https://github.com/ManageIQ/manageiq-schema/pull/598

![image](https://user-images.githubusercontent.com/58298268/128638232-3bc7c439-1cc1-4834-9e83-e7976548d45e.png)
![image](https://user-images.githubusercontent.com/58298268/128638245-27fae575-bbe6-4a7d-add2-f24fcc925ce8.png)
