### PR TITLE
Lockdown execjs to 2.7.0

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 6.0.0"
 
   s.add_dependency "coffee-rails"
+  s.add_dependency "execjs", "2.7.0" # HACK: 2.8.1 is causing node to exit 1 when compiling uglify's sourcecode in some environments. See https://github.com/rails/execjs/issues #105
   s.add_dependency "font-fabulous", "~> 1.0.5"
   s.add_dependency "high_voltage", "~> 3.0.0"
   s.add_dependency "more_core_extensions", ">= 3.2", "< 5"


### PR DESCRIPTION
Lockdown execjs to 2.7.0

It's unclear why but the change to make node wait for STDOUT to flush before
exiting seems to be causing ExecJS.compile to exit 1 with "ok" in some
environments for some files.

https://github.com/rails/execjs/commit/a6abf130c721ca6ec05cfc7ed79cf2e87a7dcc35

See https://github.com/rails/execjs/issues 105

Note, 2.8.0 seems to be ok but since 2.7.0 is the version we were using for a while, we're going back to that for now.