### PR TITLE
Remove unused ApplicationHelper#type_has_quadicon method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -129,29 +129,6 @@ module ApplicationHelper
     record.class.base_model.name.underscore
   end
 
-  def type_has_quadicon(type)
-    !%w[
-      ConfigurationProfile
-      Account
-      GuestApplication
-      SystemService
-      Filesystem
-      ChargebackRate
-      ServiceTemplateProvisionRequest
-      MiqProvisionRequest
-      MiqProvisionRequestTemplate
-      MiqWebServiceWorker
-      CustomizationTemplateSysprep
-      CustomizationTemplateCloudInit
-      CustomizationTemplateKickstart
-      PxeImageType
-      IsoDatastore
-      MiqTask
-      MiqRequest
-      PxeServer
-    ].include?(type)
-  end
-
   CONTROLLER_TO_MODEL = {
     "ManageIQ::Providers::CloudManager::Template" => VmOrTemplate,
     "ManageIQ::Providers::CloudManager::Vm"       => VmOrTemplate,


### PR DESCRIPTION
This GitHub [search](https://github.com/ManageIQ/manageiq-ui-classic/search?q=type_has_quadicon&type=code) shows no callers