### PR TITLE
Trim ApplicationController::CiProcessing#testable_action method

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -633,7 +633,7 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_untestable_actions = %w[destroy vm_miq_request_new]
+    vm_infra_untestable_actions = %w[vm_miq_request_new]
     ems_cluster_untestable_actions = %w[scan]
 
     return false if @display == 'ems_clusters' && action == 'scan'

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -632,17 +632,7 @@ module ApplicationController::CiProcessing
   #             support for the action
   #           - false otherwise
   def testable_action(action)
-    controller = params[:controller]
-    ems_cluster_untestable_actions = %w[scan]
-
-    return false if @display == 'ems_clusters' && action == 'scan'
-
-    case controller
-    when 'ems_cluster'
-      ems_cluster_untestable_actions.exclude?(action)
-    else
-      true
-    end
+    true
   end
 
   # Maps UI actions to queryable feature in case it is not possible

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -633,17 +633,14 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_untestable_actions = %w[check_compliance_queue destroy refresh_ems vm_miq_request_new]
-    ems_cluster_untestable_actions = %w[check_compliance_queue scan]
-    other_untestable_actions = %w[check_compliance_queue]
+    vm_infra_untestable_actions = %w[destroy refresh_ems vm_miq_request_new]
+    ems_cluster_untestable_actions = %w[scan]
 
     return false if @display == 'ems_clusters' && action == 'scan'
 
     case controller
     when 'ems_cluster'
       ems_cluster_untestable_actions.exclude?(action)
-    when 'auth_key_pair_cloud', 'availability_zone', 'cloud_network', 'cloud_subnet', 'cloud_tenant', 'ems_cloud', 'ems_infra', 'flavor', 'host', 'host_aggregate', 'network_router', 'resource_pool', 'security_group', 'storage', 'vm_cloud'
-      other_untestable_actions.exclude?(action)
     when 'vm_infra'
       vm_infra_untestable_actions.exclude?(action)
     else
@@ -659,12 +656,12 @@ module ApplicationController::CiProcessing
   # Returns:
   #   symbol      - a feature implemented by using AvailabilityMixin or
   #                 SupportsFeatureMixin
-  #               - SupportsFeatureMixin::QUERYABLE_FEATURES
   def action_to_feature(action)
     feature_aliases = {
-      "scan"       => :smartstate_analysis,
-      "retire_now" => :retire,
-      "vm_destroy" => :terminate
+      "scan"                   => :smartstate_analysis,
+      "retire_now"             => :retire,
+      "vm_destroy"             => :terminate,
+      "check_compliance_queue" => :check_compliance
     }
     feature_aliases[action] || action.to_sym
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -633,7 +633,6 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_untestable_actions = %w[vm_miq_request_new]
     ems_cluster_untestable_actions = %w[scan]
 
     return false if @display == 'ems_clusters' && action == 'scan'
@@ -641,8 +640,6 @@ module ApplicationController::CiProcessing
     case controller
     when 'ems_cluster'
       ems_cluster_untestable_actions.exclude?(action)
-    when 'vm_infra'
-      vm_infra_untestable_actions.exclude?(action)
     else
       true
     end
@@ -661,6 +658,7 @@ module ApplicationController::CiProcessing
       "scan"                   => :smartstate_analysis,
       "retire_now"             => :retire,
       "vm_destroy"             => :terminate,
+      "vm_miq_request_new"     => :provisioning,
       "check_compliance_queue" => :check_compliance
     }
     feature_aliases[action] || action.to_sym

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -633,7 +633,7 @@ module ApplicationController::CiProcessing
   #           - false otherwise
   def testable_action(action)
     controller = params[:controller]
-    vm_infra_untestable_actions = %w[destroy refresh_ems vm_miq_request_new]
+    vm_infra_untestable_actions = %w[destroy vm_miq_request_new]
     ems_cluster_untestable_actions = %w[scan]
 
     return false if @display == 'ems_clusters' && action == 'scan'

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -606,7 +606,7 @@ module ApplicationController::CiProcessing
   #   options     - other optional parameters
   def generic_button_operation(action, action_name, operation, options = {})
     records = find_records_with_rbac(record_class, checked_or_params)
-    if testable_action(action) && !records_support_feature?(records, action_to_feature(action))
+    if !records_support_feature?(records, action_to_feature(action))
       javascript_flash(
         :text       => _("%{action_name} action does not apply to selected items") % {:action_name => action_name},
         :severity   => :error,
@@ -617,22 +617,6 @@ module ApplicationController::CiProcessing
     operation.call(records.map(&:id), action, action_name)
     @single_delete = action == 'destroy' && !flash_errors?
     screen_redirection(options)
-  end
-
-  # Some of the tasks are not testable by SupportsFeatureMixin
-  # nor AvailabilityMixin.
-  #
-  # In case a record does not support the feature, the test won't be ran for
-  # any of selected records.
-  #
-  # Params:
-  #   action  - a string indicating the operation user wants to execute
-  # Returns:
-  #   boolean - true, if the action should not skip the test for records
-  #             support for the action
-  #           - false otherwise
-  def testable_action(action)
-    true
   end
 
   # Maps UI actions to queryable feature in case it is not possible

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -760,27 +760,6 @@ describe ApplicationController do
     end
   end
 
-  describe '#testable_action' do
-    before { controller.params = {:controller => 'vm_infra'} }
-
-    %w[reboot_guest reset shutdown_guest start stop suspend].each do |op|
-      it "returns true for #{op} operation on a VM" do
-        expect(controller.send(:testable_action, op)).to be(true)
-      end
-    end
-
-    context 'Clusters displayed from dashboard of a Provider' do
-      before do
-        controller.params = {:controller => 'ems_infra'}
-        controller.instance_variable_set(:@display, 'ems_clusters')
-      end
-
-      it 'returns false for SmartState Analysis and Clusters' do
-        expect(controller.send(:testable_action, 'scan')).to be(false)
-      end
-    end
-  end
-
   describe '#edit_record' do
     before do
       allow(controller).to receive(:assert_privileges)


### PR DESCRIPTION
Ultimate goal is to delete the entire method, but maybe it makes sense to trim it down first until all the lists are empty (thus making this method meaningless).

The untestable items are:
- [x] With https://github.com/ManageIQ/manageiq/pull/21374 merged, can now verify `check_compliance_queue` in standard approach via SupportsFeatureMixin.  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/ac35283b04c4921eca12db2b1ce2a95ff79c8435
- [x] trimmed `refresh_ems` because standard setup is [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1669).  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/c8c7f8f658d6dd47fa3174169207eb40acd0194f
- [x] trimmed `destroy` because standard setup is [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1668).  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/45305400870cb7f24a428367b778f76b28078ddb
- [x] trimmed  EmsCluster `scan` to use standard `supports?(:smartstate_analysis)` introduced [here](https://github.com/ManageIQ/manageiq/pull/21375).  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/0bf012084108e1ae66bdce57d04a8ad6ad8d542c
- [x] trimmed `vm_miq_request_new` to use standard `supports?(:provisioning)` instead.  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/c4642e0b629fa46bd7b9718b468ddc265b937777
- [x] Delete the now empty testable_action method.  See commit https://github.com/ManageIQ/manageiq-ui-classic/pull/7828/commits/360bcbe5ac49f58b9d5eb7bdf4248f31d99ca14c