### PR TITLE
Fix Chargeback assignments compute page translations.

### DIFF
--- a/app/views/chargeback_assignment/_compute_assignments.html.haml
+++ b/app/views/chargeback_assignment/_compute_assignments.html.haml
@@ -1,2 +1,2 @@
-%div{:id => @tabs[0][1], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[0][1]}_tab"}
+%div{:id => @tabs[0][0], 'role' => 'tabpanel', 'aria-labelledby' =>"#{@tabs[0][0]}_tab"}
   = render :partial => "form"


### PR DESCRIPTION
Issue: In chargeback page assignments page, In any language other than English, When user selected option in `Assign to `  dropdown, below contents are not refreshing.

<img width="1000" alt="Screen Shot 2021-08-16 at 9 55 26 AM" src="https://user-images.githubusercontent.com/37085529/129575431-32db745c-4a24-47ea-8db8-d21e6a392dcc.png">


**Before**
<img width="1350" alt="Screen Shot 2021-08-16 at 9 43 50 AM" src="https://user-images.githubusercontent.com/37085529/129575395-7c6f96bb-d0dc-48d4-ad6b-e9c391448e8d.png">

<img width="1435" alt="Screen Shot 2021-08-16 at 9 43 59 AM" src="https://user-images.githubusercontent.com/37085529/129575399-4a74b41d-6058-4392-be3e-3ecb73dac020.png">

**After**
<img width="1140" alt="Screen Shot 2021-08-16 at 9 37 35 AM" src="https://user-images.githubusercontent.com/37085529/129575416-dd71438b-8e4a-485d-99e9-486ea12d0913.png">

<img width="1294" alt="Screen Shot 2021-08-16 at 9 37 45 AM" src="https://user-images.githubusercontent.com/37085529/129575420-6f856c37-abfe-4e63-a9cb-0b41d6758094.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
