### PR TITLE
No more coffee (gem) for rails

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -11,7 +11,6 @@ require 'sprockets/railtie'
 # For this to work properly, it is dependent on patternfly/patternfly-sass#150
 if ENV["RAILS_ENV"] != "production" || defined?(Rake)
   require 'sass-rails'
-  require 'coffee-rails'
   require 'font-fabulous'
   require 'patternfly-sass'
 else

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 6.0.0"
 
-  s.add_dependency "coffee-rails"
   s.add_dependency "execjs", "2.7.0" # HACK: 2.8.1 is causing node to exit 1 when compiling uglify's sourcecode in some environments. See https://github.com/rails/execjs/issues #105
   s.add_dependency "font-fabulous", "~> 1.0.5"
   s.add_dependency "high_voltage", "~> 3.0.0"


### PR DESCRIPTION
We have removed all coffee script files
see  eb4bfaadbbf244a5c6a4d49a7f5bc95a1d9f1aa7

This is removing the dependency

@kavyanekkalapu thanks for the help with tracking down some of these dependencies

uglifier and ruby sass are the next on the docket but those look like they are still hanging on

/cc @Fryguy 