### PR TITLE
New feature - Editing physical storage

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -268,6 +268,7 @@ module Mixins
         when "storage_scan"                     then scanstorage
         when "storage_tag"                      then tag(Storage)
         when "physical_storage_new"             then javascript_redirect(:action => 'new', :controller => 'physical_storage', :storage_manager_id => block_storage_manager_id(params[:id]))
+        when "physical_storage_edit"            then javascript_redirect(:action => "edit", :controller => "physical_storage", :id => checked_or_params)
         when "host_initiator_new"               then javascript_redirect(:action => 'new', :controller => 'host_initiator', :storage_manager_id => block_storage_manager_id(params[:id]))
         when "volume_mapping_new"               then javascript_redirect(:action => 'new', :controller => 'volume_mapping', :storage_manager_id => block_storage_manager_id(params[:id]))
 

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -17,8 +17,22 @@ class PhysicalStorageController < ApplicationController
 
   def new
     @in_a_form = true
+    if params[:storage_manager_id]
+      @storage_manager = find_record_with_rbac(ExtManagementSystem, params[:storage_manager_id])
+    end
     drop_breadcrumb(:name => _("Add New %{table}") % {:table => ui_lookup(:table => table_name)},
                     :url  => "/#{controller_name}/new")
+  end
+
+  def edit
+    params[:id] = checked_item_id if params[:id].blank?
+    assert_privileges("physical_storage_edit")
+    @storage = find_record_with_rbac(PhysicalStorage, params[:id])
+    @in_a_form = true
+    drop_breadcrumb(
+      :name => _("Edit Physical Storage \"%{name}\"") % {:name => @storage.name},
+      :url  => "/physical_storage/edit/#{@storage.id}"
+    )
   end
 
   def self.table_name
@@ -73,6 +87,8 @@ class PhysicalStorageController < ApplicationController
     case pressed
     when 'physical_storage_new'
       javascript_redirect(:action => 'new')
+    when 'physical_storage_edit'
+      javascript_redirect(:action => 'edit', :id => checked_item_id)
     else
       return false
     end

--- a/app/helpers/application_helper/toolbar/physical_storage_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storage_center.rb
@@ -19,6 +19,14 @@ class ApplicationHelper::Toolbar::PhysicalStorageCenter < ApplicationHelper::Too
             :confirm => N_("Refresh relationships and power states for all items related to this Physical Storage?"),
             :options => {:feature => :refresh}
           ),
+          button(
+            :physical_storage_edit,
+            'pficon pficon-edit fa-lg',
+            t = N_('Edit this Physical Storage'),
+            t,
+            :url_parms    => 'main_div',
+            :send_checked => true
+          ),
           api_button(
             :physical_storage_delete,
             nil,

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -25,6 +25,16 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             t = N_('Attach a new storage system'),
             t,
           ),
+          button(
+            :physical_storage_edit,
+            'pficon pficon-edit fa-lg',
+            t = N_('Edit selected Physical Storage'),
+            t,
+            :url_parms    => 'main_div',
+            :send_checked => true,
+            :enabled      => false,
+            :onwhen       => '1'
+          ),
           api_button(
             :physical_storage_delete,
             nil,

--- a/app/javascript/components/physical-storage-form/index.jsx
+++ b/app/javascript/components/physical-storage-form/index.jsx
@@ -1,40 +1,83 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import MiqFormRenderer from '@@ddf';
+import { Loading } from 'carbon-components-react';
 import createSchema from './physical-storage-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 
-const PhysicalStorageForm = ({ redirect }) => {
-  const state = useState(undefined);
+const PhysicalStorageForm = ({ recordId, storageManagerId }) => {
+  const [state, setState] = useState({});
+  const {isLoading, initialValues} = state;
+  const submitLabel = !!recordId ? __('Save') : __('Add');
 
-  const onSubmit = async(values) => {
+  const loadSchema = (appendState = {}) => () => {
+    setState((state) => ({
+      ...state,
+      ...appendState,
+    }));
+  };
+
+  useEffect(() => {
+    if (recordId) {
+      API.get(`/api/physical_storages/${recordId}`).then((initialValues) => {
+        API.options(`/api/physical_storages?ems_id=${initialValues.ems_id}`)
+          .then(loadSchema({ initialValues: { ...initialValues, edit: 'yes' }, isLoading: false }));
+      });
+    }
+    if (storageManagerId) {
+      API.options(`/api/physical_storages?ems_id=${storageManagerId}`)
+        .then(loadSchema({ initialValues: { ems_id: storageManagerId }, isLoading: false }));
+    }
+  }, [recordId, storageManagerId]);
+
+  const onSubmit = ({ edit: _edit, ...values }) => {
     miqSparkleOn();
-    const message = __('Physical storage added');
-    API.post('/api/physical_storages', { action: 'create', resource: values })
-      .then(() => miqRedirectBack(message, 'success', redirect)).catch(miqSparkleOff);
+
+    const request = recordId ? API.patch(`/api/physical_storages/${recordId}`, values) : API.post('/api/physical_storages', values);
+    request.then(() => {
+      const message = sprintf(
+        recordId
+          ? __('Modification of Physical Storage "%s" has been successfully queued.')
+          : __('Add of Physical Storage "%s" has been successfully queued.'),
+        values.name,
+      );
+      miqRedirectBack(message, undefined, '/physical_storage/show_list');
+    }).catch(miqSparkleOff);
   };
 
   const onCancel = () => {
-    const message = __('Adding of physical storage was cancelled by the user');
-    miqRedirectBack(message, 'success', redirect);
+    const message = sprintf(
+      recordId
+        ? __('Edit of Physical Storage "%s" was canceled by the user.')
+        : __('Add of new Physical Storage was cancelled by the user.'),
+      initialValues && initialValues.name,
+    );
+    miqRedirectBack(message, 'warning', '/physical_storage/show_list');
   };
 
-  return (
+  if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
+
+  return !isLoading && (
     <MiqFormRenderer
-      schema={createSchema(...state)}
+      schema={createSchema(!!recordId, !!storageManagerId, initialValues, state, setState)}
+      initialValues={initialValues}
+      canReset={!!recordId}
       onSubmit={onSubmit}
+      onReset={() => add_flash(__('All changes have been reset'), 'warn')}
       onCancel={onCancel}
-      buttonsLabels={{
-        submitLabel: __('Add'),
-        cancelLabel: __('Cancel'),
-      }}
+      buttonsLabels={{ submitLabel }}
     />
   );
 };
 
 PhysicalStorageForm.propTypes = {
-  redirect: PropTypes.string.isRequired,
+  recordId: PropTypes.string,
+  storageManagerId: PropTypes.string,
+};
+PhysicalStorageForm.defaultProps = {
+  recordId: undefined,
+  storageManagerId: undefined,
 };
 
 export default PhysicalStorageForm;

--- a/app/javascript/components/physical-storage-form/index.jsx
+++ b/app/javascript/components/physical-storage-form/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-
 import MiqFormRenderer from '@@ddf';
 import { Loading } from 'carbon-components-react';
 import createSchema from './physical-storage-form.schema';
@@ -8,7 +7,7 @@ import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 const PhysicalStorageForm = ({ recordId, storageManagerId }) => {
   const [state, setState] = useState({});
-  const {isLoading, initialValues} = state;
+  const { isLoading, initialValues } = state;
   const submitLabel = !!recordId ? __('Save') : __('Add');
 
   const loadSchema = (appendState = {}) => () => {
@@ -33,7 +32,6 @@ const PhysicalStorageForm = ({ recordId, storageManagerId }) => {
 
   const onSubmit = ({ edit: _edit, ...values }) => {
     miqSparkleOn();
-
     const request = recordId ? API.patch(`/api/physical_storages/${recordId}`, values) : API.post('/api/physical_storages', values);
     request.then(() => {
       const message = sprintf(

--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -27,7 +27,7 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         id: 'ems_id',
         label: __('Provider:'),
         isRequired: true,
-        isDisabled: edit || ems ,
+        isDisabled: edit || ems,
         loadOptions: loadProviders,
         includeEmpty: true,
         onChange: (value) => setState({ ...state, ems_id: value }),

--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -13,69 +13,104 @@ const loadFamilies = (id) => API.get(`/api/providers/${id}?attributes=type,physi
     value: id,
   })));
 
-const createSchema = (emsId, setEmsId) => ({
-  fields: [
-    {
-      component: componentTypes.SELECT,
-      name: 'ems_id',
-      key: `${emsId}`,
-      id: 'ems_id',
-      label: __('Provider:'),
-      isRequired: true,
-      loadOptions: loadProviders,
-      includeEmpty: true,
-      onChange: (value) => setEmsId(value),
-      validate: [{ type: validatorTypes.REQUIRED }],
-    },
-    {
-      component: componentTypes.TEXT_FIELD,
-      name: 'name',
-      id: 'name',
-      label: __('Name:'),
-      isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
-    },
-    {
-      component: componentTypes.SELECT,
-      name: 'physical_storage_family_id',
-      id: 'physical_storage_family_id',
-      label: __('System Type:'),
-      isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
-      loadOptions: () => (emsId ? loadFamilies(emsId) : Promise.resolve([])),
-      includeEmpty: true,
-      key: `physical_storage_family_id-${emsId}`,
-      condition: {
-        when: 'ems_id',
-        isNotEmpty: true,
+const createSchema = (edit, ems, initialValues, state, setState) => {
+  let emsId = state.ems_id;
+  if (initialValues && initialValues.ems_id) {
+    emsId = initialValues.ems_id;
+  }
+  return ({
+    fields: [
+      {
+        component: componentTypes.SELECT,
+        name: 'ems_id',
+        key: `${emsId}`,
+        id: 'ems_id',
+        label: __('Provider:'),
+        isRequired: true,
+        isDisabled: edit || ems ,
+        loadOptions: loadProviders,
+        includeEmpty: true,
+        onChange: (value) => setState({ ...state, ems_id: value }),
+        validate: [{ type: validatorTypes.REQUIRED }],
       },
-    },
-    {
-      component: componentTypes.TEXT_FIELD,
-      name: 'management_ip',
-      id: 'management_ip',
-      label: __('Management IP:'),
-      isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
-    },
-    {
-      component: componentTypes.TEXT_FIELD,
-      name: 'user',
-      id: 'user',
-      label: __('User:'),
-      isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
-    },
-    {
-      component: componentTypes.TEXT_FIELD,
-      name: 'password',
-      type: 'password',
-      id: 'physical_storage_password',
-      label: __('Password:'),
-      isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
-    },
-  ],
-});
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'name',
+        id: 'name',
+        label: __('Name:'),
+        isRequired: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+      },
+      {
+        component: componentTypes.SELECT,
+        name: 'physical_storage_family_id',
+        id: 'physical_storage_family_id',
+        label: __('System Type:'),
+        isRequired: true,
+        isDisabled: edit,
+        validate: [{ type: validatorTypes.REQUIRED }],
+        loadOptions: () => (emsId ? loadFamilies(emsId) : Promise.resolve([])),
+        includeEmpty: true,
+        key: `physical_storage_family_id-${emsId}`,
+        condition: {
+          when: 'ems_id',
+          isNotEmpty: true,
+        },
+      },
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'edit',
+        id: 'edit',
+        label: 'edit',
+        hideField: true,
+      },
+      {
+        component: componentTypes.CHECKBOX,
+        id: 'edit_authentication',
+        name: 'edit_authentication',
+        label: __('Edit Authentication'),
+        initialValue: false,
+        condition: {
+          when: 'edit',
+          is: 'yes',
+        },
+      },
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'management_ip',
+        id: 'management_ip',
+        label: __('Management IP:'),
+        isRequired: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+        condition: {
+          or: [{ when: 'edit_authentication', is: true }, { when: 'edit', is: '' }],
+        },
+      },
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'user',
+        id: 'user',
+        label: __('User:'),
+        isRequired: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+        condition: {
+          or: [{ when: 'edit_authentication', is: true }, { when: 'edit', is: '' }],
+        },
+      },
+      {
+        component: componentTypes.TEXT_FIELD,
+        name: 'password',
+        type: 'password',
+        id: 'physical_storage_password',
+        label: __('Password:'),
+        isRequired: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+        condition: {
+          or: [{ when: 'edit_authentication', is: true }, { when: 'edit', is: '' }],
+        },
+      },
+    ],
+  });
+};
 
 export default createSchema;

--- a/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
+++ b/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
@@ -1,0 +1,4138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Physical storage form component should render adding form variant 1`] = `
+<Connect(MiqFormRenderer)
+  buttonsLabels={
+    Object {
+      "submitLabel": "Add",
+    }
+  }
+  canReset={false}
+  onCancel={[Function]}
+  onReset={[Function]}
+  onSubmit={[Function]}
+  schema={
+    Object {
+      "fields": Array [
+        Object {
+          "component": "select",
+          "id": "ems_id",
+          "includeEmpty": true,
+          "isDisabled": false,
+          "isRequired": true,
+          "key": "undefined",
+          "label": "Provider:",
+          "loadOptions": [Function],
+          "name": "ems_id",
+          "onChange": [Function],
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+        Object {
+          "component": "text-field",
+          "id": "name",
+          "isRequired": true,
+          "label": "Name:",
+          "name": "name",
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+        Object {
+          "component": "select",
+          "condition": Object {
+            "isNotEmpty": true,
+            "when": "ems_id",
+          },
+          "id": "physical_storage_family_id",
+          "includeEmpty": true,
+          "isDisabled": false,
+          "isRequired": true,
+          "key": "physical_storage_family_id-undefined",
+          "label": "System Type:",
+          "loadOptions": [Function],
+          "name": "physical_storage_family_id",
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+        Object {
+          "component": "text-field",
+          "hideField": true,
+          "id": "edit",
+          "label": "edit",
+          "name": "edit",
+        },
+        Object {
+          "component": "checkbox",
+          "condition": Object {
+            "is": "yes",
+            "when": "edit",
+          },
+          "id": "edit_authentication",
+          "initialValue": false,
+          "label": "Edit Authentication",
+          "name": "edit_authentication",
+        },
+        Object {
+          "component": "text-field",
+          "condition": Object {
+            "or": Array [
+              Object {
+                "is": true,
+                "when": "edit_authentication",
+              },
+              Object {
+                "is": "",
+                "when": "edit",
+              },
+            ],
+          },
+          "id": "management_ip",
+          "isRequired": true,
+          "label": "Management IP:",
+          "name": "management_ip",
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+        Object {
+          "component": "text-field",
+          "condition": Object {
+            "or": Array [
+              Object {
+                "is": true,
+                "when": "edit_authentication",
+              },
+              Object {
+                "is": "",
+                "when": "edit",
+              },
+            ],
+          },
+          "id": "user",
+          "isRequired": true,
+          "label": "User:",
+          "name": "user",
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+        Object {
+          "component": "text-field",
+          "condition": Object {
+            "or": Array [
+              Object {
+                "is": true,
+                "when": "edit_authentication",
+              },
+              Object {
+                "is": "",
+                "when": "edit",
+              },
+            ],
+          },
+          "id": "physical_storage_password",
+          "isRequired": true,
+          "label": "Password:",
+          "name": "password",
+          "type": "password",
+          "validate": Array [
+            Object {
+              "type": "required",
+            },
+          ],
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`Physical storage form component should render editing form variant 1`] = `
+<Provider
+  store={
+    Object {
+      "asyncReducers": Object {
+        "FormButtons": [Function],
+        "notificationReducer": [Function],
+      },
+      "dispatch": [Function],
+      "getState": [Function],
+      "injectReducers": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <PhysicalStorageForm
+    recordId="1"
+  >
+    <Connect(MiqFormRenderer)
+      buttonsLabels={
+        Object {
+          "submitLabel": "Save",
+        }
+      }
+      canReset={true}
+      onCancel={[Function]}
+      onReset={[Function]}
+      onSubmit={[Function]}
+      schema={
+        Object {
+          "fields": Array [
+            Object {
+              "component": "select",
+              "id": "ems_id",
+              "includeEmpty": true,
+              "isDisabled": true,
+              "isRequired": true,
+              "key": "undefined",
+              "label": "Provider:",
+              "loadOptions": [Function],
+              "name": "ems_id",
+              "onChange": [Function],
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+            Object {
+              "component": "text-field",
+              "id": "name",
+              "isRequired": true,
+              "label": "Name:",
+              "name": "name",
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+            Object {
+              "component": "select",
+              "condition": Object {
+                "isNotEmpty": true,
+                "when": "ems_id",
+              },
+              "id": "physical_storage_family_id",
+              "includeEmpty": true,
+              "isDisabled": true,
+              "isRequired": true,
+              "key": "physical_storage_family_id-undefined",
+              "label": "System Type:",
+              "loadOptions": [Function],
+              "name": "physical_storage_family_id",
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+            Object {
+              "component": "text-field",
+              "hideField": true,
+              "id": "edit",
+              "label": "edit",
+              "name": "edit",
+            },
+            Object {
+              "component": "checkbox",
+              "condition": Object {
+                "is": "yes",
+                "when": "edit",
+              },
+              "id": "edit_authentication",
+              "initialValue": false,
+              "label": "Edit Authentication",
+              "name": "edit_authentication",
+            },
+            Object {
+              "component": "text-field",
+              "condition": Object {
+                "or": Array [
+                  Object {
+                    "is": true,
+                    "when": "edit_authentication",
+                  },
+                  Object {
+                    "is": "",
+                    "when": "edit",
+                  },
+                ],
+              },
+              "id": "management_ip",
+              "isRequired": true,
+              "label": "Management IP:",
+              "name": "management_ip",
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+            Object {
+              "component": "text-field",
+              "condition": Object {
+                "or": Array [
+                  Object {
+                    "is": true,
+                    "when": "edit_authentication",
+                  },
+                  Object {
+                    "is": "",
+                    "when": "edit",
+                  },
+                ],
+              },
+              "id": "user",
+              "isRequired": true,
+              "label": "User:",
+              "name": "user",
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+            Object {
+              "component": "text-field",
+              "condition": Object {
+                "or": Array [
+                  Object {
+                    "is": true,
+                    "when": "edit_authentication",
+                  },
+                  Object {
+                    "is": "",
+                    "when": "edit",
+                  },
+                ],
+              },
+              "id": "physical_storage_password",
+              "isRequired": true,
+              "label": "Password:",
+              "name": "password",
+              "type": "password",
+              "validate": Array [
+                Object {
+                  "type": "required",
+                },
+              ],
+            },
+          ],
+        }
+      }
+    >
+      <MiqFormRenderer
+        buttonsLabels={
+          Object {
+            "submitLabel": "Save",
+          }
+        }
+        canReset={true}
+        className="form-react"
+        componentMapper={
+          Object {
+            "checkbox": [Function],
+            "code-editor": [Function],
+            "date-picker": [Function],
+            "dual-list-select": [Function],
+            "edit-password-field": [Function],
+            "field-array": [Function],
+            "file-upload": [Function],
+            "font-icon-picker": [Function],
+            "font-icon-picker-ddf": [Function],
+            "multi-select": [Function],
+            "password-field": [Function],
+            "plain-text": [Function],
+            "radio": [Function],
+            "select": [Function],
+            "slider": [Function],
+            "sub-form": [Function],
+            "switch": [Function],
+            "tabs": [Function],
+            "text-field": [Function],
+            "textarea": [Function],
+            "time-picker": [Function],
+            "tree-selector": [Function],
+            "tree-view": [Function],
+            "validate-credentials": [Function],
+            "wizard": [Function],
+          }
+        }
+        disableSubmit={
+          Array [
+            "pristine",
+            "invalid",
+          ]
+        }
+        dispatch={[Function]}
+        onCancel={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
+        schema={
+          Object {
+            "fields": Array [
+              Object {
+                "component": "select",
+                "id": "ems_id",
+                "includeEmpty": true,
+                "isDisabled": true,
+                "isRequired": true,
+                "key": "undefined",
+                "label": "Provider:",
+                "loadOptions": [Function],
+                "name": "ems_id",
+                "onChange": [Function],
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+              Object {
+                "component": "text-field",
+                "id": "name",
+                "isRequired": true,
+                "label": "Name:",
+                "name": "name",
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+              Object {
+                "component": "select",
+                "condition": Object {
+                  "isNotEmpty": true,
+                  "when": "ems_id",
+                },
+                "id": "physical_storage_family_id",
+                "includeEmpty": true,
+                "isDisabled": true,
+                "isRequired": true,
+                "key": "physical_storage_family_id-undefined",
+                "label": "System Type:",
+                "loadOptions": [Function],
+                "name": "physical_storage_family_id",
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+              Object {
+                "component": "text-field",
+                "hideField": true,
+                "id": "edit",
+                "label": "edit",
+                "name": "edit",
+              },
+              Object {
+                "component": "checkbox",
+                "condition": Object {
+                  "is": "yes",
+                  "when": "edit",
+                },
+                "id": "edit_authentication",
+                "initialValue": false,
+                "label": "Edit Authentication",
+                "name": "edit_authentication",
+              },
+              Object {
+                "component": "text-field",
+                "condition": Object {
+                  "or": Array [
+                    Object {
+                      "is": true,
+                      "when": "edit_authentication",
+                    },
+                    Object {
+                      "is": "",
+                      "when": "edit",
+                    },
+                  ],
+                },
+                "id": "management_ip",
+                "isRequired": true,
+                "label": "Management IP:",
+                "name": "management_ip",
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+              Object {
+                "component": "text-field",
+                "condition": Object {
+                  "or": Array [
+                    Object {
+                      "is": true,
+                      "when": "edit_authentication",
+                    },
+                    Object {
+                      "is": "",
+                      "when": "edit",
+                    },
+                  ],
+                },
+                "id": "user",
+                "isRequired": true,
+                "label": "User:",
+                "name": "user",
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+              Object {
+                "component": "text-field",
+                "condition": Object {
+                  "or": Array [
+                    Object {
+                      "is": true,
+                      "when": "edit_authentication",
+                    },
+                    Object {
+                      "is": "",
+                      "when": "edit",
+                    },
+                  ],
+                },
+                "id": "physical_storage_password",
+                "isRequired": true,
+                "label": "Password:",
+                "name": "password",
+                "type": "password",
+                "validate": Array [
+                  Object {
+                    "type": "required",
+                  },
+                ],
+              },
+            ],
+          }
+        }
+        showFormControls={true}
+      >
+        <FormRenderer
+          FormTemplate={[Function]}
+          clearOnUnmount={false}
+          componentMapper={
+            Object {
+              "checkbox": [Function],
+              "code-editor": [Function],
+              "date-picker": [Function],
+              "dual-list-select": [Function],
+              "edit-password-field": [Function],
+              "field-array": [Function],
+              "file-upload": [Function],
+              "font-icon-picker": [Function],
+              "font-icon-picker-ddf": [Function],
+              "multi-select": [Function],
+              "password-field": [Function],
+              "plain-text": [Function],
+              "radio": [Function],
+              "select": [Function],
+              "slider": [Function],
+              "spy-field": [Function],
+              "sub-form": [Function],
+              "switch": [Function],
+              "tabs": [Function],
+              "text-field": [Function],
+              "textarea": [Function],
+              "time-picker": [Function],
+              "tree-selector": [Function],
+              "tree-view": [Function],
+              "validate-credentials": [Function],
+              "wizard": [Function],
+            }
+          }
+          dispatch={[Function]}
+          initialValues={Object {}}
+          onCancel={[Function]}
+          onReset={[Function]}
+          onSubmit={[Function]}
+          schema={
+            Object {
+              "fields": Array [
+                Object {
+                  "component": "select",
+                  "id": "ems_id",
+                  "includeEmpty": true,
+                  "isDisabled": true,
+                  "isRequired": true,
+                  "key": "undefined",
+                  "label": "Provider:",
+                  "loadOptions": [Function],
+                  "name": "ems_id",
+                  "onChange": [Function],
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "text-field",
+                  "id": "name",
+                  "isRequired": true,
+                  "label": "Name:",
+                  "name": "name",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "select",
+                  "condition": Object {
+                    "isNotEmpty": true,
+                    "when": "ems_id",
+                  },
+                  "id": "physical_storage_family_id",
+                  "includeEmpty": true,
+                  "isDisabled": true,
+                  "isRequired": true,
+                  "key": "physical_storage_family_id-undefined",
+                  "label": "System Type:",
+                  "loadOptions": [Function],
+                  "name": "physical_storage_family_id",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "text-field",
+                  "hideField": true,
+                  "id": "edit",
+                  "label": "edit",
+                  "name": "edit",
+                },
+                Object {
+                  "component": "checkbox",
+                  "condition": Object {
+                    "is": "yes",
+                    "when": "edit",
+                  },
+                  "id": "edit_authentication",
+                  "initialValue": false,
+                  "label": "Edit Authentication",
+                  "name": "edit_authentication",
+                },
+                Object {
+                  "component": "text-field",
+                  "condition": Object {
+                    "or": Array [
+                      Object {
+                        "is": true,
+                        "when": "edit_authentication",
+                      },
+                      Object {
+                        "is": "",
+                        "when": "edit",
+                      },
+                    ],
+                  },
+                  "id": "management_ip",
+                  "isRequired": true,
+                  "label": "Management IP:",
+                  "name": "management_ip",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "text-field",
+                  "condition": Object {
+                    "or": Array [
+                      Object {
+                        "is": true,
+                        "when": "edit_authentication",
+                      },
+                      Object {
+                        "is": "",
+                        "when": "edit",
+                      },
+                    ],
+                  },
+                  "id": "user",
+                  "isRequired": true,
+                  "label": "User:",
+                  "name": "user",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "text-field",
+                  "condition": Object {
+                    "or": Array [
+                      Object {
+                        "is": true,
+                        "when": "edit_authentication",
+                      },
+                      Object {
+                        "is": "",
+                        "when": "edit",
+                      },
+                    ],
+                  },
+                  "id": "physical_storage_password",
+                  "isRequired": true,
+                  "label": "Password:",
+                  "name": "password",
+                  "type": "password",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "spy-field",
+                  "initialize": undefined,
+                  "name": "spy-field",
+                },
+              ],
+            }
+          }
+        >
+          <ReactFinalForm
+            decorators={
+              Array [
+                [Function],
+              ]
+            }
+            dispatch={[Function]}
+            initialValues={Object {}}
+            mutators={
+              Object {
+                "concat": [Function],
+                "insert": [Function],
+                "move": [Function],
+                "pop": [Function],
+                "push": [Function],
+                "remove": [Function],
+                "removeBatch": [Function],
+                "shift": [Function],
+                "swap": [Function],
+                "unshift": [Function],
+                "update": [Function],
+              }
+            }
+            onSubmit={[Function]}
+            render={[Function]}
+            subscription={
+              Object {
+                "pristine": true,
+                "submitting": true,
+                "valid": true,
+              }
+            }
+          >
+            <Component
+              formFields={
+                Array [
+                  <SingleField
+                    component="select"
+                    id="ems_id"
+                    includeEmpty={true}
+                    isDisabled={true}
+                    isRequired={true}
+                    label="Provider:"
+                    loadOptions={[Function]}
+                    name="ems_id"
+                    onChange={[Function]}
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="text-field"
+                    id="name"
+                    isRequired={true}
+                    label="Name:"
+                    name="name"
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="select"
+                    condition={
+                      Object {
+                        "isNotEmpty": true,
+                        "when": "ems_id",
+                      }
+                    }
+                    id="physical_storage_family_id"
+                    includeEmpty={true}
+                    isDisabled={true}
+                    isRequired={true}
+                    label="System Type:"
+                    loadOptions={[Function]}
+                    name="physical_storage_family_id"
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="text-field"
+                    hideField={true}
+                    id="edit"
+                    label="edit"
+                    name="edit"
+                  />,
+                  <SingleField
+                    component="checkbox"
+                    condition={
+                      Object {
+                        "is": "yes",
+                        "when": "edit",
+                      }
+                    }
+                    id="edit_authentication"
+                    initialValue={false}
+                    label="Edit Authentication"
+                    name="edit_authentication"
+                  />,
+                  <SingleField
+                    component="text-field"
+                    condition={
+                      Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      }
+                    }
+                    id="management_ip"
+                    isRequired={true}
+                    label="Management IP:"
+                    name="management_ip"
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="text-field"
+                    condition={
+                      Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      }
+                    }
+                    id="user"
+                    isRequired={true}
+                    label="User:"
+                    name="user"
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="text-field"
+                    condition={
+                      Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      }
+                    }
+                    id="physical_storage_password"
+                    isRequired={true}
+                    label="Password:"
+                    name="password"
+                    type="password"
+                    validate={
+                      Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ]
+                    }
+                  />,
+                  <SingleField
+                    component="spy-field"
+                    name="spy-field"
+                  />,
+                ]
+              }
+              schema={
+                Object {
+                  "fields": Array [
+                    Object {
+                      "component": "select",
+                      "id": "ems_id",
+                      "includeEmpty": true,
+                      "isDisabled": true,
+                      "isRequired": true,
+                      "key": "undefined",
+                      "label": "Provider:",
+                      "loadOptions": [Function],
+                      "name": "ems_id",
+                      "onChange": [Function],
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "text-field",
+                      "id": "name",
+                      "isRequired": true,
+                      "label": "Name:",
+                      "name": "name",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "select",
+                      "condition": Object {
+                        "isNotEmpty": true,
+                        "when": "ems_id",
+                      },
+                      "id": "physical_storage_family_id",
+                      "includeEmpty": true,
+                      "isDisabled": true,
+                      "isRequired": true,
+                      "key": "physical_storage_family_id-undefined",
+                      "label": "System Type:",
+                      "loadOptions": [Function],
+                      "name": "physical_storage_family_id",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "text-field",
+                      "hideField": true,
+                      "id": "edit",
+                      "label": "edit",
+                      "name": "edit",
+                    },
+                    Object {
+                      "component": "checkbox",
+                      "condition": Object {
+                        "is": "yes",
+                        "when": "edit",
+                      },
+                      "id": "edit_authentication",
+                      "initialValue": false,
+                      "label": "Edit Authentication",
+                      "name": "edit_authentication",
+                    },
+                    Object {
+                      "component": "text-field",
+                      "condition": Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      },
+                      "id": "management_ip",
+                      "isRequired": true,
+                      "label": "Management IP:",
+                      "name": "management_ip",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "text-field",
+                      "condition": Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      },
+                      "id": "user",
+                      "isRequired": true,
+                      "label": "User:",
+                      "name": "user",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "text-field",
+                      "condition": Object {
+                        "or": Array [
+                          Object {
+                            "is": true,
+                            "when": "edit_authentication",
+                          },
+                          Object {
+                            "is": "",
+                            "when": "edit",
+                          },
+                        ],
+                      },
+                      "id": "physical_storage_password",
+                      "isRequired": true,
+                      "label": "Password:",
+                      "name": "password",
+                      "type": "password",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "spy-field",
+                      "initialize": undefined,
+                      "name": "spy-field",
+                    },
+                  ],
+                }
+              }
+            >
+              <WrappedFormTemplate
+                canReset={true}
+                cancelLabel="Cancel"
+                disableSubmit={
+                  Array [
+                    "pristine",
+                    "invalid",
+                  ]
+                }
+                formFields={
+                  Array [
+                    <SingleField
+                      component="select"
+                      id="ems_id"
+                      includeEmpty={true}
+                      isDisabled={true}
+                      isRequired={true}
+                      label="Provider:"
+                      loadOptions={[Function]}
+                      name="ems_id"
+                      onChange={[Function]}
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="text-field"
+                      id="name"
+                      isRequired={true}
+                      label="Name:"
+                      name="name"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="select"
+                      condition={
+                        Object {
+                          "isNotEmpty": true,
+                          "when": "ems_id",
+                        }
+                      }
+                      id="physical_storage_family_id"
+                      includeEmpty={true}
+                      isDisabled={true}
+                      isRequired={true}
+                      label="System Type:"
+                      loadOptions={[Function]}
+                      name="physical_storage_family_id"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="text-field"
+                      hideField={true}
+                      id="edit"
+                      label="edit"
+                      name="edit"
+                    />,
+                    <SingleField
+                      component="checkbox"
+                      condition={
+                        Object {
+                          "is": "yes",
+                          "when": "edit",
+                        }
+                      }
+                      id="edit_authentication"
+                      initialValue={false}
+                      label="Edit Authentication"
+                      name="edit_authentication"
+                    />,
+                    <SingleField
+                      component="text-field"
+                      condition={
+                        Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        }
+                      }
+                      id="management_ip"
+                      isRequired={true}
+                      label="Management IP:"
+                      name="management_ip"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="text-field"
+                      condition={
+                        Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        }
+                      }
+                      id="user"
+                      isRequired={true}
+                      label="User:"
+                      name="user"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="text-field"
+                      condition={
+                        Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        }
+                      }
+                      id="physical_storage_password"
+                      isRequired={true}
+                      label="Password:"
+                      name="password"
+                      type="password"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
+                    />,
+                    <SingleField
+                      component="spy-field"
+                      name="spy-field"
+                    />,
+                  ]
+                }
+                formWrapperProps={
+                  Object {
+                    "className": "form-react",
+                  }
+                }
+                resetLabel="Reset"
+                schema={
+                  Object {
+                    "fields": Array [
+                      Object {
+                        "component": "select",
+                        "id": "ems_id",
+                        "includeEmpty": true,
+                        "isDisabled": true,
+                        "isRequired": true,
+                        "key": "undefined",
+                        "label": "Provider:",
+                        "loadOptions": [Function],
+                        "name": "ems_id",
+                        "onChange": [Function],
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "text-field",
+                        "id": "name",
+                        "isRequired": true,
+                        "label": "Name:",
+                        "name": "name",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "select",
+                        "condition": Object {
+                          "isNotEmpty": true,
+                          "when": "ems_id",
+                        },
+                        "id": "physical_storage_family_id",
+                        "includeEmpty": true,
+                        "isDisabled": true,
+                        "isRequired": true,
+                        "key": "physical_storage_family_id-undefined",
+                        "label": "System Type:",
+                        "loadOptions": [Function],
+                        "name": "physical_storage_family_id",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "text-field",
+                        "hideField": true,
+                        "id": "edit",
+                        "label": "edit",
+                        "name": "edit",
+                      },
+                      Object {
+                        "component": "checkbox",
+                        "condition": Object {
+                          "is": "yes",
+                          "when": "edit",
+                        },
+                        "id": "edit_authentication",
+                        "initialValue": false,
+                        "label": "Edit Authentication",
+                        "name": "edit_authentication",
+                      },
+                      Object {
+                        "component": "text-field",
+                        "condition": Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        },
+                        "id": "management_ip",
+                        "isRequired": true,
+                        "label": "Management IP:",
+                        "name": "management_ip",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "text-field",
+                        "condition": Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        },
+                        "id": "user",
+                        "isRequired": true,
+                        "label": "User:",
+                        "name": "user",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "text-field",
+                        "condition": Object {
+                          "or": Array [
+                            Object {
+                              "is": true,
+                              "when": "edit_authentication",
+                            },
+                            Object {
+                              "is": "",
+                              "when": "edit",
+                            },
+                          ],
+                        },
+                        "id": "physical_storage_password",
+                        "isRequired": true,
+                        "label": "Password:",
+                        "name": "password",
+                        "type": "password",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "spy-field",
+                        "initialize": undefined,
+                        "name": "spy-field",
+                      },
+                    ],
+                  }
+                }
+                showFormControls={true}
+                submitLabel="Save"
+              >
+                <FormTemplate
+                  Button={[Function]}
+                  ButtonGroup={[Function]}
+                  Description={[Function]}
+                  FormWrapper={[Function]}
+                  Header={[Function]}
+                  Title={[Function]}
+                  buttonOrder={
+                    Array [
+                      "submit",
+                      "reset",
+                      "cancel",
+                    ]
+                  }
+                  canReset={true}
+                  cancelLabel="Cancel"
+                  disableSubmit={
+                    Array [
+                      "pristine",
+                      "invalid",
+                    ]
+                  }
+                  formFields={
+                    Array [
+                      <SingleField
+                        component="select"
+                        id="ems_id"
+                        includeEmpty={true}
+                        isDisabled={true}
+                        isRequired={true}
+                        label="Provider:"
+                        loadOptions={[Function]}
+                        name="ems_id"
+                        onChange={[Function]}
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="text-field"
+                        id="name"
+                        isRequired={true}
+                        label="Name:"
+                        name="name"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="select"
+                        condition={
+                          Object {
+                            "isNotEmpty": true,
+                            "when": "ems_id",
+                          }
+                        }
+                        id="physical_storage_family_id"
+                        includeEmpty={true}
+                        isDisabled={true}
+                        isRequired={true}
+                        label="System Type:"
+                        loadOptions={[Function]}
+                        name="physical_storage_family_id"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="text-field"
+                        hideField={true}
+                        id="edit"
+                        label="edit"
+                        name="edit"
+                      />,
+                      <SingleField
+                        component="checkbox"
+                        condition={
+                          Object {
+                            "is": "yes",
+                            "when": "edit",
+                          }
+                        }
+                        id="edit_authentication"
+                        initialValue={false}
+                        label="Edit Authentication"
+                        name="edit_authentication"
+                      />,
+                      <SingleField
+                        component="text-field"
+                        condition={
+                          Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          }
+                        }
+                        id="management_ip"
+                        isRequired={true}
+                        label="Management IP:"
+                        name="management_ip"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="text-field"
+                        condition={
+                          Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          }
+                        }
+                        id="user"
+                        isRequired={true}
+                        label="User:"
+                        name="user"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="text-field"
+                        condition={
+                          Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          }
+                        }
+                        id="physical_storage_password"
+                        isRequired={true}
+                        label="Password:"
+                        name="password"
+                        type="password"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                      <SingleField
+                        component="spy-field"
+                        name="spy-field"
+                      />,
+                    ]
+                  }
+                  formWrapperProps={
+                    Object {
+                      "className": "form-react",
+                    }
+                  }
+                  resetLabel="Reset"
+                  schema={
+                    Object {
+                      "fields": Array [
+                        Object {
+                          "component": "select",
+                          "id": "ems_id",
+                          "includeEmpty": true,
+                          "isDisabled": true,
+                          "isRequired": true,
+                          "key": "undefined",
+                          "label": "Provider:",
+                          "loadOptions": [Function],
+                          "name": "ems_id",
+                          "onChange": [Function],
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "text-field",
+                          "id": "name",
+                          "isRequired": true,
+                          "label": "Name:",
+                          "name": "name",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "select",
+                          "condition": Object {
+                            "isNotEmpty": true,
+                            "when": "ems_id",
+                          },
+                          "id": "physical_storage_family_id",
+                          "includeEmpty": true,
+                          "isDisabled": true,
+                          "isRequired": true,
+                          "key": "physical_storage_family_id-undefined",
+                          "label": "System Type:",
+                          "loadOptions": [Function],
+                          "name": "physical_storage_family_id",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "text-field",
+                          "hideField": true,
+                          "id": "edit",
+                          "label": "edit",
+                          "name": "edit",
+                        },
+                        Object {
+                          "component": "checkbox",
+                          "condition": Object {
+                            "is": "yes",
+                            "when": "edit",
+                          },
+                          "id": "edit_authentication",
+                          "initialValue": false,
+                          "label": "Edit Authentication",
+                          "name": "edit_authentication",
+                        },
+                        Object {
+                          "component": "text-field",
+                          "condition": Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          },
+                          "id": "management_ip",
+                          "isRequired": true,
+                          "label": "Management IP:",
+                          "name": "management_ip",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "text-field",
+                          "condition": Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          },
+                          "id": "user",
+                          "isRequired": true,
+                          "label": "User:",
+                          "name": "user",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "text-field",
+                          "condition": Object {
+                            "or": Array [
+                              Object {
+                                "is": true,
+                                "when": "edit_authentication",
+                              },
+                              Object {
+                                "is": "",
+                                "when": "edit",
+                              },
+                            ],
+                          },
+                          "id": "physical_storage_password",
+                          "isRequired": true,
+                          "label": "Password:",
+                          "name": "password",
+                          "type": "password",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                        Object {
+                          "component": "spy-field",
+                          "initialize": undefined,
+                          "name": "spy-field",
+                        },
+                      ],
+                    }
+                  }
+                  showFormControls={true}
+                  submitLabel="Save"
+                >
+                  <Form
+                    className="form-react"
+                    onSubmit={[Function]}
+                  >
+                    <Form
+                      className="form-0-2-3 form-react"
+                      noValidate={true}
+                      onSubmit={[Function]}
+                    >
+                      <form
+                        className="bx--form form-0-2-3 form-react"
+                        noValidate={true}
+                        onSubmit={[Function]}
+                      >
+                         
+                        <SingleField
+                          component="select"
+                          id="ems_id"
+                          includeEmpty={true}
+                          isDisabled={true}
+                          isRequired={true}
+                          key="undefined"
+                          label="Provider:"
+                          loadOptions={[Function]}
+                          name="ems_id"
+                          onChange={[Function]}
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "select",
+                                "id": "ems_id",
+                                "includeEmpty": true,
+                                "isDisabled": true,
+                                "isRequired": true,
+                                "label": "Provider:",
+                                "loadOptions": [Function],
+                                "name": "ems_id",
+                                "onChange": [Function],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <FormFieldHideWrapper
+                              hideField={false}
+                            >
+                              <SelectWithOnChange
+                                component="select"
+                                id="ems_id"
+                                includeEmpty={true}
+                                isDisabled={true}
+                                isRequired={true}
+                                label="Provider:"
+                                loadOptions={[Function]}
+                                name="ems_id"
+                                onChange={[Function]}
+                                placeholder="<Choose>"
+                                validate={
+                                  Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ]
+                                }
+                              >
+                                <Select
+                                  component="select"
+                                  id="ems_id"
+                                  isDisabled={true}
+                                  isRequired={true}
+                                  label="Provider:"
+                                  loadOptions={[Function]}
+                                  loadingMessage="Loading..."
+                                  name="ems_id"
+                                  placeholder="<Choose>"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Select
+                                    SelectComponent={[Function]}
+                                    disabled={true}
+                                    id="ems_id"
+                                    invalid={false}
+                                    invalidText=""
+                                    isClearable={false}
+                                    isSearchable={false}
+                                    labelText={
+                                      <IsRequired>
+                                        Provider:
+                                      </IsRequired>
+                                    }
+                                    loadOptions={[Function]}
+                                    loadOptionsChangeCounter={0}
+                                    loadingMessage="Loading..."
+                                    name="ems_id"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    options={Array []}
+                                    placeholder="<Choose>"
+                                    pluckSingleValue={true}
+                                    simpleValue={false}
+                                    value=""
+                                  >
+                                    <ClearedSelect
+                                      className=""
+                                      closeMenuOnSelect={true}
+                                      disabled={true}
+                                      hideSelectedOptions={false}
+                                      id="ems_id"
+                                      invalidText=""
+                                      isClearable={false}
+                                      isFetching={false}
+                                      isSearchable={false}
+                                      labelText={
+                                        <IsRequired>
+                                          Provider:
+                                        </IsRequired>
+                                      }
+                                      name="ems_id"
+                                      noOptionsMessage={[Function]}
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      onInputChange={[Function]}
+                                      options={Array []}
+                                      placeholder="<Choose>"
+                                      value=""
+                                    >
+                                      <Select
+                                        className=""
+                                        disabled={true}
+                                        helperText=""
+                                        id="ems_id"
+                                        inline={false}
+                                        invalid={false}
+                                        invalidText=""
+                                        labelText={
+                                          <IsRequired>
+                                            Provider:
+                                          </IsRequired>
+                                        }
+                                        light={false}
+                                        name="ems_id"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        value=""
+                                      >
+                                        <div
+                                          className="bx--form-item"
+                                        >
+                                          <div
+                                            className="bx--select bx--select--disabled"
+                                          >
+                                            <label
+                                              className="bx--label bx--label--disabled"
+                                              htmlFor="ems_id"
+                                            >
+                                              <IsRequired>
+                                                <span
+                                                  aria-hidden="true"
+                                                  className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+                                                >
+                                                  *
+                                                </span>
+                                                Provider:
+                                              </IsRequired>
+                                            </label>
+                                            <div
+                                              className="bx--select-input__wrapper"
+                                              data-invalid={null}
+                                            >
+                                              <select
+                                                className="bx--select-input"
+                                                disabled={true}
+                                                id="ems_id"
+                                                name="ems_id"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                value=""
+                                              />
+                                              <ForwardRef(ChevronDown16)
+                                                className="bx--select__arrow"
+                                              >
+                                                <Icon
+                                                  className="bx--select__arrow"
+                                                  fill="currentColor"
+                                                  height={16}
+                                                  preserveAspectRatio="xMidYMid meet"
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="bx--select__arrow"
+                                                    fill="currentColor"
+                                                    focusable="false"
+                                                    height={16}
+                                                    preserveAspectRatio="xMidYMid meet"
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                                                    />
+                                                  </svg>
+                                                </Icon>
+                                              </ForwardRef(ChevronDown16)>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </Select>
+                                    </ClearedSelect>
+                                  </Select>
+                                </Select>
+                              </SelectWithOnChange>
+                            </FormFieldHideWrapper>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="text-field"
+                          id="name"
+                          isRequired={true}
+                          key="name"
+                          label="Name:"
+                          name="name"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "name",
+                                "isRequired": true,
+                                "label": "Name:",
+                                "name": "name",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <FormFieldHideWrapper
+                              hideField={false}
+                            >
+                              <TextField
+                                component="text-field"
+                                id="name"
+                                isRequired={true}
+                                label="Name:"
+                                name="name"
+                                validate={
+                                  Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ]
+                                }
+                              >
+                                <ForwardRef(TextInput)
+                                  disabled={false}
+                                  helperText=""
+                                  id="name"
+                                  inline={false}
+                                  invalid={false}
+                                  invalidText=""
+                                  key="name"
+                                  labelText={
+                                    <IsRequired>
+                                      Name:
+                                    </IsRequired>
+                                  }
+                                  light={false}
+                                  name="name"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  type="text"
+                                  value=""
+                                  warn={false}
+                                  warnText=""
+                                >
+                                  <div
+                                    className="bx--form-item bx--text-input-wrapper"
+                                  >
+                                    <label
+                                      className="bx--label"
+                                      htmlFor="name"
+                                    >
+                                      <IsRequired>
+                                        <span
+                                          aria-hidden="true"
+                                          className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+                                        >
+                                          *
+                                        </span>
+                                        Name:
+                                      </IsRequired>
+                                    </label>
+                                    <div
+                                      className="bx--text-input__field-outer-wrapper"
+                                    >
+                                      <div
+                                        className="bx--text-input__field-wrapper"
+                                        data-invalid={null}
+                                      >
+                                        <input
+                                          className="bx--text-input bx--text__input"
+                                          disabled={false}
+                                          id="name"
+                                          name="name"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="text"
+                                          value=""
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                </ForwardRef(TextInput)>
+                              </TextField>
+                            </FormFieldHideWrapper>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="select"
+                          condition={
+                            Object {
+                              "isNotEmpty": true,
+                              "when": "ems_id",
+                            }
+                          }
+                          id="physical_storage_family_id"
+                          includeEmpty={true}
+                          isDisabled={true}
+                          isRequired={true}
+                          key="physical_storage_family_id-undefined"
+                          label="System Type:"
+                          loadOptions={[Function]}
+                          name="physical_storage_family_id"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            condition={
+                              Object {
+                                "isNotEmpty": true,
+                                "when": "ems_id",
+                              }
+                            }
+                            field={
+                              Object {
+                                "component": "select",
+                                "id": "physical_storage_family_id",
+                                "includeEmpty": true,
+                                "isDisabled": true,
+                                "isRequired": true,
+                                "label": "System Type:",
+                                "loadOptions": [Function],
+                                "name": "physical_storage_family_id",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <ConditionTriggerDetector
+                              condition={
+                                Object {
+                                  "isNotEmpty": true,
+                                  "when": "ems_id",
+                                }
+                              }
+                              field={
+                                Object {
+                                  "component": "select",
+                                  "id": "physical_storage_family_id",
+                                  "includeEmpty": true,
+                                  "isDisabled": true,
+                                  "isRequired": true,
+                                  "label": "System Type:",
+                                  "loadOptions": [Function],
+                                  "name": "physical_storage_family_id",
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                }
+                              }
+                              triggers={
+                                Array [
+                                  "ems_id",
+                                ]
+                              }
+                            >
+                              <ForwardRef(Field)
+                                name="ems_id"
+                                subscription={
+                                  Object {
+                                    "value": true,
+                                  }
+                                }
+                              >
+                                <ConditionTriggerDetector
+                                  condition={
+                                    Object {
+                                      "isNotEmpty": true,
+                                      "when": "ems_id",
+                                    }
+                                  }
+                                  field={
+                                    Object {
+                                      "component": "select",
+                                      "id": "physical_storage_family_id",
+                                      "includeEmpty": true,
+                                      "isDisabled": true,
+                                      "isRequired": true,
+                                      "label": "System Type:",
+                                      "loadOptions": [Function],
+                                      "name": "physical_storage_family_id",
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  triggers={Array []}
+                                  values={
+                                    Object {
+                                      "ems_id": "",
+                                    }
+                                  }
+                                >
+                                  <ConditionTriggerWrapper
+                                    condition={
+                                      Object {
+                                        "isNotEmpty": true,
+                                        "when": "ems_id",
+                                      }
+                                    }
+                                    field={
+                                      Object {
+                                        "component": "select",
+                                        "id": "physical_storage_family_id",
+                                        "includeEmpty": true,
+                                        "isDisabled": true,
+                                        "isRequired": true,
+                                        "label": "System Type:",
+                                        "loadOptions": [Function],
+                                        "name": "physical_storage_family_id",
+                                        "validate": Array [
+                                          Object {
+                                            "type": "required",
+                                          },
+                                        ],
+                                      }
+                                    }
+                                    values={
+                                      Object {
+                                        "ems_id": "",
+                                      }
+                                    }
+                                  >
+                                    <Component
+                                      condition={
+                                        Object {
+                                          "isNotEmpty": true,
+                                          "when": "ems_id",
+                                        }
+                                      }
+                                      field={
+                                        Object {
+                                          "component": "select",
+                                          "id": "physical_storage_family_id",
+                                          "includeEmpty": true,
+                                          "isDisabled": true,
+                                          "isRequired": true,
+                                          "label": "System Type:",
+                                          "loadOptions": [Function],
+                                          "name": "physical_storage_family_id",
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      values={
+                                        Object {
+                                          "ems_id": "",
+                                        }
+                                      }
+                                    />
+                                  </ConditionTriggerWrapper>
+                                </ConditionTriggerDetector>
+                              </ForwardRef(Field)>
+                            </ConditionTriggerDetector>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="text-field"
+                          hideField={true}
+                          id="edit"
+                          key="edit"
+                          label="edit"
+                          name="edit"
+                        >
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "edit",
+                                "label": "edit",
+                                "name": "edit",
+                              }
+                            }
+                          >
+                            <FormFieldHideWrapper
+                              hideField={true}
+                            >
+                              <div
+                                hidden={true}
+                              >
+                                <TextField
+                                  component="text-field"
+                                  id="edit"
+                                  label="edit"
+                                  name="edit"
+                                >
+                                  <ForwardRef(TextInput)
+                                    disabled={false}
+                                    helperText=""
+                                    id="edit"
+                                    inline={false}
+                                    invalid={false}
+                                    invalidText=""
+                                    key="edit"
+                                    labelText="edit"
+                                    light={false}
+                                    name="edit"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    type="text"
+                                    value=""
+                                    warn={false}
+                                    warnText=""
+                                  >
+                                    <div
+                                      className="bx--form-item bx--text-input-wrapper"
+                                    >
+                                      <label
+                                        className="bx--label"
+                                        htmlFor="edit"
+                                      >
+                                        edit
+                                      </label>
+                                      <div
+                                        className="bx--text-input__field-outer-wrapper"
+                                      >
+                                        <div
+                                          className="bx--text-input__field-wrapper"
+                                          data-invalid={null}
+                                        >
+                                          <input
+                                            className="bx--text-input bx--text__input"
+                                            disabled={false}
+                                            id="edit"
+                                            name="edit"
+                                            onBlur={[Function]}
+                                            onChange={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            type="text"
+                                            value=""
+                                          />
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </ForwardRef(TextInput)>
+                                </TextField>
+                              </div>
+                            </FormFieldHideWrapper>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="checkbox"
+                          condition={
+                            Object {
+                              "is": "yes",
+                              "when": "edit",
+                            }
+                          }
+                          id="edit_authentication"
+                          initialValue={false}
+                          key="edit_authentication"
+                          label="Edit Authentication"
+                          name="edit_authentication"
+                        >
+                          <FormConditionWrapper
+                            condition={
+                              Object {
+                                "is": "yes",
+                                "when": "edit",
+                              }
+                            }
+                            field={
+                              Object {
+                                "component": "checkbox",
+                                "id": "edit_authentication",
+                                "initialValue": false,
+                                "label": "Edit Authentication",
+                                "name": "edit_authentication",
+                              }
+                            }
+                          >
+                            <ConditionTriggerDetector
+                              condition={
+                                Object {
+                                  "is": "yes",
+                                  "when": "edit",
+                                }
+                              }
+                              field={
+                                Object {
+                                  "component": "checkbox",
+                                  "id": "edit_authentication",
+                                  "initialValue": false,
+                                  "label": "Edit Authentication",
+                                  "name": "edit_authentication",
+                                }
+                              }
+                              triggers={
+                                Array [
+                                  "edit",
+                                ]
+                              }
+                            >
+                              <ForwardRef(Field)
+                                name="edit"
+                                subscription={
+                                  Object {
+                                    "value": true,
+                                  }
+                                }
+                              >
+                                <ConditionTriggerDetector
+                                  condition={
+                                    Object {
+                                      "is": "yes",
+                                      "when": "edit",
+                                    }
+                                  }
+                                  field={
+                                    Object {
+                                      "component": "checkbox",
+                                      "id": "edit_authentication",
+                                      "initialValue": false,
+                                      "label": "Edit Authentication",
+                                      "name": "edit_authentication",
+                                    }
+                                  }
+                                  triggers={Array []}
+                                  values={
+                                    Object {
+                                      "edit": "",
+                                    }
+                                  }
+                                >
+                                  <ConditionTriggerWrapper
+                                    condition={
+                                      Object {
+                                        "is": "yes",
+                                        "when": "edit",
+                                      }
+                                    }
+                                    field={
+                                      Object {
+                                        "component": "checkbox",
+                                        "id": "edit_authentication",
+                                        "initialValue": false,
+                                        "label": "Edit Authentication",
+                                        "name": "edit_authentication",
+                                      }
+                                    }
+                                    values={
+                                      Object {
+                                        "edit": "",
+                                      }
+                                    }
+                                  >
+                                    <Component
+                                      condition={
+                                        Object {
+                                          "is": "yes",
+                                          "when": "edit",
+                                        }
+                                      }
+                                      field={
+                                        Object {
+                                          "component": "checkbox",
+                                          "id": "edit_authentication",
+                                          "initialValue": false,
+                                          "label": "Edit Authentication",
+                                          "name": "edit_authentication",
+                                        }
+                                      }
+                                      values={
+                                        Object {
+                                          "edit": "",
+                                        }
+                                      }
+                                    />
+                                  </ConditionTriggerWrapper>
+                                </ConditionTriggerDetector>
+                              </ForwardRef(Field)>
+                            </ConditionTriggerDetector>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="text-field"
+                          condition={
+                            Object {
+                              "or": Array [
+                                Object {
+                                  "is": true,
+                                  "when": "edit_authentication",
+                                },
+                                Object {
+                                  "is": "",
+                                  "when": "edit",
+                                },
+                              ],
+                            }
+                          }
+                          id="management_ip"
+                          isRequired={true}
+                          key="management_ip"
+                          label="Management IP:"
+                          name="management_ip"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            condition={
+                              Object {
+                                "or": Array [
+                                  Object {
+                                    "is": true,
+                                    "when": "edit_authentication",
+                                  },
+                                  Object {
+                                    "is": "",
+                                    "when": "edit",
+                                  },
+                                ],
+                              }
+                            }
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "management_ip",
+                                "isRequired": true,
+                                "label": "Management IP:",
+                                "name": "management_ip",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <ConditionTriggerDetector
+                              condition={
+                                Object {
+                                  "or": Array [
+                                    Object {
+                                      "is": true,
+                                      "when": "edit_authentication",
+                                    },
+                                    Object {
+                                      "is": "",
+                                      "when": "edit",
+                                    },
+                                  ],
+                                }
+                              }
+                              field={
+                                Object {
+                                  "component": "text-field",
+                                  "id": "management_ip",
+                                  "isRequired": true,
+                                  "label": "Management IP:",
+                                  "name": "management_ip",
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                }
+                              }
+                              triggers={
+                                Array [
+                                  "edit_authentication",
+                                  "edit",
+                                ]
+                              }
+                            >
+                              <ForwardRef(Field)
+                                name="edit_authentication"
+                                subscription={
+                                  Object {
+                                    "value": true,
+                                  }
+                                }
+                              >
+                                <ConditionTriggerDetector
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  field={
+                                    Object {
+                                      "component": "text-field",
+                                      "id": "management_ip",
+                                      "isRequired": true,
+                                      "label": "Management IP:",
+                                      "name": "management_ip",
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  triggers={
+                                    Array [
+                                      "edit",
+                                    ]
+                                  }
+                                  values={
+                                    Object {
+                                      "edit_authentication": "",
+                                    }
+                                  }
+                                >
+                                  <ForwardRef(Field)
+                                    name="edit"
+                                    subscription={
+                                      Object {
+                                        "value": true,
+                                      }
+                                    }
+                                  >
+                                    <ConditionTriggerDetector
+                                      condition={
+                                        Object {
+                                          "or": Array [
+                                            Object {
+                                              "is": true,
+                                              "when": "edit_authentication",
+                                            },
+                                            Object {
+                                              "is": "",
+                                              "when": "edit",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      field={
+                                        Object {
+                                          "component": "text-field",
+                                          "id": "management_ip",
+                                          "isRequired": true,
+                                          "label": "Management IP:",
+                                          "name": "management_ip",
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      triggers={Array []}
+                                      values={
+                                        Object {
+                                          "edit": "",
+                                          "edit_authentication": "",
+                                        }
+                                      }
+                                    >
+                                      <ConditionTriggerWrapper
+                                        condition={
+                                          Object {
+                                            "or": Array [
+                                              Object {
+                                                "is": true,
+                                                "when": "edit_authentication",
+                                              },
+                                              Object {
+                                                "is": "",
+                                                "when": "edit",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        field={
+                                          Object {
+                                            "component": "text-field",
+                                            "id": "management_ip",
+                                            "isRequired": true,
+                                            "label": "Management IP:",
+                                            "name": "management_ip",
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        values={
+                                          Object {
+                                            "edit": "",
+                                            "edit_authentication": "",
+                                          }
+                                        }
+                                      >
+                                        <Component
+                                          condition={
+                                            Object {
+                                              "or": Array [
+                                                Object {
+                                                  "is": true,
+                                                  "when": "edit_authentication",
+                                                },
+                                                Object {
+                                                  "is": "",
+                                                  "when": "edit",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          field={
+                                            Object {
+                                              "component": "text-field",
+                                              "id": "management_ip",
+                                              "isRequired": true,
+                                              "label": "Management IP:",
+                                              "name": "management_ip",
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          values={
+                                            Object {
+                                              "edit": "",
+                                              "edit_authentication": "",
+                                            }
+                                          }
+                                        >
+                                          <FormFieldHideWrapper
+                                            hideField={false}
+                                          >
+                                            <TextField
+                                              component="text-field"
+                                              id="management_ip"
+                                              isRequired={true}
+                                              label="Management IP:"
+                                              name="management_ip"
+                                              validate={
+                                                Array [
+                                                  Object {
+                                                    "type": "required",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <ForwardRef(TextInput)
+                                                disabled={false}
+                                                helperText=""
+                                                id="management_ip"
+                                                inline={false}
+                                                invalid={false}
+                                                invalidText=""
+                                                key="management_ip"
+                                                labelText={
+                                                  <IsRequired>
+                                                    Management IP:
+                                                  </IsRequired>
+                                                }
+                                                light={false}
+                                                name="management_ip"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                type="text"
+                                                value=""
+                                                warn={false}
+                                                warnText=""
+                                              >
+                                                <div
+                                                  className="bx--form-item bx--text-input-wrapper"
+                                                >
+                                                  <label
+                                                    className="bx--label"
+                                                    htmlFor="management_ip"
+                                                  >
+                                                    <IsRequired>
+                                                      <span
+                                                        aria-hidden="true"
+                                                        className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+                                                      >
+                                                        *
+                                                      </span>
+                                                      Management IP:
+                                                    </IsRequired>
+                                                  </label>
+                                                  <div
+                                                    className="bx--text-input__field-outer-wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--text-input__field-wrapper"
+                                                      data-invalid={null}
+                                                    >
+                                                      <input
+                                                        className="bx--text-input bx--text__input"
+                                                        disabled={false}
+                                                        id="management_ip"
+                                                        name="management_ip"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </ForwardRef(TextInput)>
+                                            </TextField>
+                                          </FormFieldHideWrapper>
+                                        </Component>
+                                      </ConditionTriggerWrapper>
+                                    </ConditionTriggerDetector>
+                                  </ForwardRef(Field)>
+                                </ConditionTriggerDetector>
+                              </ForwardRef(Field)>
+                            </ConditionTriggerDetector>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="text-field"
+                          condition={
+                            Object {
+                              "or": Array [
+                                Object {
+                                  "is": true,
+                                  "when": "edit_authentication",
+                                },
+                                Object {
+                                  "is": "",
+                                  "when": "edit",
+                                },
+                              ],
+                            }
+                          }
+                          id="user"
+                          isRequired={true}
+                          key="user"
+                          label="User:"
+                          name="user"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            condition={
+                              Object {
+                                "or": Array [
+                                  Object {
+                                    "is": true,
+                                    "when": "edit_authentication",
+                                  },
+                                  Object {
+                                    "is": "",
+                                    "when": "edit",
+                                  },
+                                ],
+                              }
+                            }
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "user",
+                                "isRequired": true,
+                                "label": "User:",
+                                "name": "user",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <ConditionTriggerDetector
+                              condition={
+                                Object {
+                                  "or": Array [
+                                    Object {
+                                      "is": true,
+                                      "when": "edit_authentication",
+                                    },
+                                    Object {
+                                      "is": "",
+                                      "when": "edit",
+                                    },
+                                  ],
+                                }
+                              }
+                              field={
+                                Object {
+                                  "component": "text-field",
+                                  "id": "user",
+                                  "isRequired": true,
+                                  "label": "User:",
+                                  "name": "user",
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                }
+                              }
+                              triggers={
+                                Array [
+                                  "edit_authentication",
+                                  "edit",
+                                ]
+                              }
+                            >
+                              <ForwardRef(Field)
+                                name="edit_authentication"
+                                subscription={
+                                  Object {
+                                    "value": true,
+                                  }
+                                }
+                              >
+                                <ConditionTriggerDetector
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  field={
+                                    Object {
+                                      "component": "text-field",
+                                      "id": "user",
+                                      "isRequired": true,
+                                      "label": "User:",
+                                      "name": "user",
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  triggers={
+                                    Array [
+                                      "edit",
+                                    ]
+                                  }
+                                  values={
+                                    Object {
+                                      "edit_authentication": "",
+                                    }
+                                  }
+                                >
+                                  <ForwardRef(Field)
+                                    name="edit"
+                                    subscription={
+                                      Object {
+                                        "value": true,
+                                      }
+                                    }
+                                  >
+                                    <ConditionTriggerDetector
+                                      condition={
+                                        Object {
+                                          "or": Array [
+                                            Object {
+                                              "is": true,
+                                              "when": "edit_authentication",
+                                            },
+                                            Object {
+                                              "is": "",
+                                              "when": "edit",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      field={
+                                        Object {
+                                          "component": "text-field",
+                                          "id": "user",
+                                          "isRequired": true,
+                                          "label": "User:",
+                                          "name": "user",
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      triggers={Array []}
+                                      values={
+                                        Object {
+                                          "edit": "",
+                                          "edit_authentication": "",
+                                        }
+                                      }
+                                    >
+                                      <ConditionTriggerWrapper
+                                        condition={
+                                          Object {
+                                            "or": Array [
+                                              Object {
+                                                "is": true,
+                                                "when": "edit_authentication",
+                                              },
+                                              Object {
+                                                "is": "",
+                                                "when": "edit",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        field={
+                                          Object {
+                                            "component": "text-field",
+                                            "id": "user",
+                                            "isRequired": true,
+                                            "label": "User:",
+                                            "name": "user",
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        values={
+                                          Object {
+                                            "edit": "",
+                                            "edit_authentication": "",
+                                          }
+                                        }
+                                      >
+                                        <Component
+                                          condition={
+                                            Object {
+                                              "or": Array [
+                                                Object {
+                                                  "is": true,
+                                                  "when": "edit_authentication",
+                                                },
+                                                Object {
+                                                  "is": "",
+                                                  "when": "edit",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          field={
+                                            Object {
+                                              "component": "text-field",
+                                              "id": "user",
+                                              "isRequired": true,
+                                              "label": "User:",
+                                              "name": "user",
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          values={
+                                            Object {
+                                              "edit": "",
+                                              "edit_authentication": "",
+                                            }
+                                          }
+                                        >
+                                          <FormFieldHideWrapper
+                                            hideField={false}
+                                          >
+                                            <TextField
+                                              component="text-field"
+                                              id="user"
+                                              isRequired={true}
+                                              label="User:"
+                                              name="user"
+                                              validate={
+                                                Array [
+                                                  Object {
+                                                    "type": "required",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <ForwardRef(TextInput)
+                                                disabled={false}
+                                                helperText=""
+                                                id="user"
+                                                inline={false}
+                                                invalid={false}
+                                                invalidText=""
+                                                key="user"
+                                                labelText={
+                                                  <IsRequired>
+                                                    User:
+                                                  </IsRequired>
+                                                }
+                                                light={false}
+                                                name="user"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                type="text"
+                                                value=""
+                                                warn={false}
+                                                warnText=""
+                                              >
+                                                <div
+                                                  className="bx--form-item bx--text-input-wrapper"
+                                                >
+                                                  <label
+                                                    className="bx--label"
+                                                    htmlFor="user"
+                                                  >
+                                                    <IsRequired>
+                                                      <span
+                                                        aria-hidden="true"
+                                                        className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+                                                      >
+                                                        *
+                                                      </span>
+                                                      User:
+                                                    </IsRequired>
+                                                  </label>
+                                                  <div
+                                                    className="bx--text-input__field-outer-wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--text-input__field-wrapper"
+                                                      data-invalid={null}
+                                                    >
+                                                      <input
+                                                        className="bx--text-input bx--text__input"
+                                                        disabled={false}
+                                                        id="user"
+                                                        name="user"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </ForwardRef(TextInput)>
+                                            </TextField>
+                                          </FormFieldHideWrapper>
+                                        </Component>
+                                      </ConditionTriggerWrapper>
+                                    </ConditionTriggerDetector>
+                                  </ForwardRef(Field)>
+                                </ConditionTriggerDetector>
+                              </ForwardRef(Field)>
+                            </ConditionTriggerDetector>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="text-field"
+                          condition={
+                            Object {
+                              "or": Array [
+                                Object {
+                                  "is": true,
+                                  "when": "edit_authentication",
+                                },
+                                Object {
+                                  "is": "",
+                                  "when": "edit",
+                                },
+                              ],
+                            }
+                          }
+                          id="physical_storage_password"
+                          isRequired={true}
+                          key="password"
+                          label="Password:"
+                          name="password"
+                          type="password"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        >
+                          <FormConditionWrapper
+                            condition={
+                              Object {
+                                "or": Array [
+                                  Object {
+                                    "is": true,
+                                    "when": "edit_authentication",
+                                  },
+                                  Object {
+                                    "is": "",
+                                    "when": "edit",
+                                  },
+                                ],
+                              }
+                            }
+                            field={
+                              Object {
+                                "component": "text-field",
+                                "id": "physical_storage_password",
+                                "isRequired": true,
+                                "label": "Password:",
+                                "name": "password",
+                                "type": "password",
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              }
+                            }
+                          >
+                            <ConditionTriggerDetector
+                              condition={
+                                Object {
+                                  "or": Array [
+                                    Object {
+                                      "is": true,
+                                      "when": "edit_authentication",
+                                    },
+                                    Object {
+                                      "is": "",
+                                      "when": "edit",
+                                    },
+                                  ],
+                                }
+                              }
+                              field={
+                                Object {
+                                  "component": "text-field",
+                                  "id": "physical_storage_password",
+                                  "isRequired": true,
+                                  "label": "Password:",
+                                  "name": "password",
+                                  "type": "password",
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                }
+                              }
+                              triggers={
+                                Array [
+                                  "edit_authentication",
+                                  "edit",
+                                ]
+                              }
+                            >
+                              <ForwardRef(Field)
+                                name="edit_authentication"
+                                subscription={
+                                  Object {
+                                    "value": true,
+                                  }
+                                }
+                              >
+                                <ConditionTriggerDetector
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  field={
+                                    Object {
+                                      "component": "text-field",
+                                      "id": "physical_storage_password",
+                                      "isRequired": true,
+                                      "label": "Password:",
+                                      "name": "password",
+                                      "type": "password",
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  triggers={
+                                    Array [
+                                      "edit",
+                                    ]
+                                  }
+                                  values={
+                                    Object {
+                                      "edit_authentication": "",
+                                    }
+                                  }
+                                >
+                                  <ForwardRef(Field)
+                                    name="edit"
+                                    subscription={
+                                      Object {
+                                        "value": true,
+                                      }
+                                    }
+                                  >
+                                    <ConditionTriggerDetector
+                                      condition={
+                                        Object {
+                                          "or": Array [
+                                            Object {
+                                              "is": true,
+                                              "when": "edit_authentication",
+                                            },
+                                            Object {
+                                              "is": "",
+                                              "when": "edit",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      field={
+                                        Object {
+                                          "component": "text-field",
+                                          "id": "physical_storage_password",
+                                          "isRequired": true,
+                                          "label": "Password:",
+                                          "name": "password",
+                                          "type": "password",
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        }
+                                      }
+                                      triggers={Array []}
+                                      values={
+                                        Object {
+                                          "edit": "",
+                                          "edit_authentication": "",
+                                        }
+                                      }
+                                    >
+                                      <ConditionTriggerWrapper
+                                        condition={
+                                          Object {
+                                            "or": Array [
+                                              Object {
+                                                "is": true,
+                                                "when": "edit_authentication",
+                                              },
+                                              Object {
+                                                "is": "",
+                                                "when": "edit",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        field={
+                                          Object {
+                                            "component": "text-field",
+                                            "id": "physical_storage_password",
+                                            "isRequired": true,
+                                            "label": "Password:",
+                                            "name": "password",
+                                            "type": "password",
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                        values={
+                                          Object {
+                                            "edit": "",
+                                            "edit_authentication": "",
+                                          }
+                                        }
+                                      >
+                                        <Component
+                                          condition={
+                                            Object {
+                                              "or": Array [
+                                                Object {
+                                                  "is": true,
+                                                  "when": "edit_authentication",
+                                                },
+                                                Object {
+                                                  "is": "",
+                                                  "when": "edit",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          field={
+                                            Object {
+                                              "component": "text-field",
+                                              "id": "physical_storage_password",
+                                              "isRequired": true,
+                                              "label": "Password:",
+                                              "name": "password",
+                                              "type": "password",
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          values={
+                                            Object {
+                                              "edit": "",
+                                              "edit_authentication": "",
+                                            }
+                                          }
+                                        >
+                                          <FormFieldHideWrapper
+                                            hideField={false}
+                                          >
+                                            <TextField
+                                              component="text-field"
+                                              id="physical_storage_password"
+                                              isRequired={true}
+                                              label="Password:"
+                                              name="password"
+                                              type="password"
+                                              validate={
+                                                Array [
+                                                  Object {
+                                                    "type": "required",
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <ForwardRef(TextInput)
+                                                disabled={false}
+                                                helperText=""
+                                                id="physical_storage_password"
+                                                inline={false}
+                                                invalid={false}
+                                                invalidText=""
+                                                key="password"
+                                                labelText={
+                                                  <IsRequired>
+                                                    Password:
+                                                  </IsRequired>
+                                                }
+                                                light={false}
+                                                name="password"
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                type="password"
+                                                value=""
+                                                warn={false}
+                                                warnText=""
+                                              >
+                                                <div
+                                                  className="bx--form-item bx--text-input-wrapper"
+                                                >
+                                                  <label
+                                                    className="bx--label"
+                                                    htmlFor="physical_storage_password"
+                                                  >
+                                                    <IsRequired>
+                                                      <span
+                                                        aria-hidden="true"
+                                                        className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
+                                                      >
+                                                        *
+                                                      </span>
+                                                      Password:
+                                                    </IsRequired>
+                                                  </label>
+                                                  <div
+                                                    className="bx--text-input__field-outer-wrapper"
+                                                  >
+                                                    <div
+                                                      className="bx--text-input__field-wrapper"
+                                                      data-invalid={null}
+                                                    >
+                                                      <input
+                                                        className="bx--text-input bx--text__input"
+                                                        disabled={false}
+                                                        id="physical_storage_password"
+                                                        name="password"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="password"
+                                                        value=""
+                                                      />
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </ForwardRef(TextInput)>
+                                            </TextField>
+                                          </FormFieldHideWrapper>
+                                        </Component>
+                                      </ConditionTriggerWrapper>
+                                    </ConditionTriggerDetector>
+                                  </ForwardRef(Field)>
+                                </ConditionTriggerDetector>
+                              </ForwardRef(Field)>
+                            </ConditionTriggerDetector>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <SingleField
+                          component="spy-field"
+                          key="spy-field"
+                          name="spy-field"
+                        >
+                          <FormConditionWrapper
+                            field={
+                              Object {
+                                "component": "spy-field",
+                                "initialize": undefined,
+                                "name": "spy-field",
+                              }
+                            }
+                          >
+                            <FormFieldHideWrapper
+                              hideField={false}
+                            >
+                              <SpyField
+                                component="spy-field"
+                                name="spy-field"
+                              >
+                                <FormSpy
+                                  onChange={[Function]}
+                                  subscription={
+                                    Object {
+                                      "pristine": true,
+                                      "valid": true,
+                                    }
+                                  }
+                                />
+                              </SpyField>
+                            </FormFieldHideWrapper>
+                          </FormConditionWrapper>
+                        </SingleField>
+                        <FormSpy>
+                          <FormControls
+                            Button={[Function]}
+                            ButtonGroup={[Function]}
+                            FormSpy={[Function]}
+                            buttonOrder={
+                              Array [
+                                "submit",
+                                "reset",
+                                "cancel",
+                              ]
+                            }
+                            buttonsProps={Object {}}
+                            canReset={true}
+                            canSubmit={false}
+                            cancelLabel="Cancel"
+                            disableSubmit={true}
+                            formFields={
+                              Array [
+                                <SingleField
+                                  component="select"
+                                  id="ems_id"
+                                  includeEmpty={true}
+                                  isDisabled={true}
+                                  isRequired={true}
+                                  label="Provider:"
+                                  loadOptions={[Function]}
+                                  name="ems_id"
+                                  onChange={[Function]}
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="text-field"
+                                  id="name"
+                                  isRequired={true}
+                                  label="Name:"
+                                  name="name"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="select"
+                                  condition={
+                                    Object {
+                                      "isNotEmpty": true,
+                                      "when": "ems_id",
+                                    }
+                                  }
+                                  id="physical_storage_family_id"
+                                  includeEmpty={true}
+                                  isDisabled={true}
+                                  isRequired={true}
+                                  label="System Type:"
+                                  loadOptions={[Function]}
+                                  name="physical_storage_family_id"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="text-field"
+                                  hideField={true}
+                                  id="edit"
+                                  label="edit"
+                                  name="edit"
+                                />,
+                                <SingleField
+                                  component="checkbox"
+                                  condition={
+                                    Object {
+                                      "is": "yes",
+                                      "when": "edit",
+                                    }
+                                  }
+                                  id="edit_authentication"
+                                  initialValue={false}
+                                  label="Edit Authentication"
+                                  name="edit_authentication"
+                                />,
+                                <SingleField
+                                  component="text-field"
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  id="management_ip"
+                                  isRequired={true}
+                                  label="Management IP:"
+                                  name="management_ip"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="text-field"
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  id="user"
+                                  isRequired={true}
+                                  label="User:"
+                                  name="user"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="text-field"
+                                  condition={
+                                    Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  id="physical_storage_password"
+                                  isRequired={true}
+                                  label="Password:"
+                                  name="password"
+                                  type="password"
+                                  validate={
+                                    Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ]
+                                  }
+                                />,
+                                <SingleField
+                                  component="spy-field"
+                                  name="spy-field"
+                                />,
+                              ]
+                            }
+                            formSpyProps={
+                              Object {
+                                "active": undefined,
+                                "dirty": false,
+                                "dirtyFields": Object {},
+                                "dirtyFieldsSinceLastSubmit": Object {},
+                                "dirtySinceLastSubmit": false,
+                                "error": undefined,
+                                "errors": Object {},
+                                "form": Object {
+                                  "batch": [Function],
+                                  "blur": [Function],
+                                  "change": [Function],
+                                  "destroyOnUnregister": false,
+                                  "focus": [Function],
+                                  "getFieldState": [Function],
+                                  "getRegisteredFields": [Function],
+                                  "getState": [Function],
+                                  "initialize": [Function],
+                                  "isValidationPaused": [Function],
+                                  "mutators": Object {
+                                    "concat": [Function],
+                                    "insert": [Function],
+                                    "move": [Function],
+                                    "pop": [Function],
+                                    "push": [Function],
+                                    "remove": [Function],
+                                    "removeBatch": [Function],
+                                    "shift": [Function],
+                                    "swap": [Function],
+                                    "unshift": [Function],
+                                    "update": [Function],
+                                  },
+                                  "pauseValidation": [Function],
+                                  "registerField": [Function],
+                                  "reset": [Function],
+                                  "resetFieldState": [Function],
+                                  "restart": [Function],
+                                  "resumeValidation": [Function],
+                                  "setConfig": [Function],
+                                  "submit": [Function],
+                                  "subscribe": [Function],
+                                },
+                                "hasSubmitErrors": false,
+                                "hasValidationErrors": false,
+                                "initialValues": Object {},
+                                "invalid": false,
+                                "modified": Object {},
+                                "modifiedSinceLastSubmit": false,
+                                "pristine": true,
+                                "submitError": undefined,
+                                "submitErrors": undefined,
+                                "submitFailed": false,
+                                "submitSucceeded": false,
+                                "submitting": false,
+                                "touched": Object {},
+                                "valid": true,
+                                "validating": false,
+                                "values": Object {},
+                                "visited": Object {},
+                              }
+                            }
+                            onCancel={[Function]}
+                            onReset={[Function]}
+                            resetLabel="Reset"
+                            schema={
+                              Object {
+                                "fields": Array [
+                                  Object {
+                                    "component": "select",
+                                    "id": "ems_id",
+                                    "includeEmpty": true,
+                                    "isDisabled": true,
+                                    "isRequired": true,
+                                    "key": "undefined",
+                                    "label": "Provider:",
+                                    "loadOptions": [Function],
+                                    "name": "ems_id",
+                                    "onChange": [Function],
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "text-field",
+                                    "id": "name",
+                                    "isRequired": true,
+                                    "label": "Name:",
+                                    "name": "name",
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "select",
+                                    "condition": Object {
+                                      "isNotEmpty": true,
+                                      "when": "ems_id",
+                                    },
+                                    "id": "physical_storage_family_id",
+                                    "includeEmpty": true,
+                                    "isDisabled": true,
+                                    "isRequired": true,
+                                    "key": "physical_storage_family_id-undefined",
+                                    "label": "System Type:",
+                                    "loadOptions": [Function],
+                                    "name": "physical_storage_family_id",
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "text-field",
+                                    "hideField": true,
+                                    "id": "edit",
+                                    "label": "edit",
+                                    "name": "edit",
+                                  },
+                                  Object {
+                                    "component": "checkbox",
+                                    "condition": Object {
+                                      "is": "yes",
+                                      "when": "edit",
+                                    },
+                                    "id": "edit_authentication",
+                                    "initialValue": false,
+                                    "label": "Edit Authentication",
+                                    "name": "edit_authentication",
+                                  },
+                                  Object {
+                                    "component": "text-field",
+                                    "condition": Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    },
+                                    "id": "management_ip",
+                                    "isRequired": true,
+                                    "label": "Management IP:",
+                                    "name": "management_ip",
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "text-field",
+                                    "condition": Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    },
+                                    "id": "user",
+                                    "isRequired": true,
+                                    "label": "User:",
+                                    "name": "user",
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "text-field",
+                                    "condition": Object {
+                                      "or": Array [
+                                        Object {
+                                          "is": true,
+                                          "when": "edit_authentication",
+                                        },
+                                        Object {
+                                          "is": "",
+                                          "when": "edit",
+                                        },
+                                      ],
+                                    },
+                                    "id": "physical_storage_password",
+                                    "isRequired": true,
+                                    "label": "Password:",
+                                    "name": "password",
+                                    "type": "password",
+                                    "validate": Array [
+                                      Object {
+                                        "type": "required",
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "component": "spy-field",
+                                    "initialize": undefined,
+                                    "name": "spy-field",
+                                  },
+                                ],
+                              }
+                            }
+                            submitLabel="Save"
+                          >
+                            <ButtonGroup>
+                              <ButtonSet
+                                className=""
+                              >
+                                <div
+                                  className="bx--btn-set"
+                                >
+                                  <Button
+                                    buttonType="submit"
+                                    disabled={true}
+                                    key="form-submit"
+                                    label="Save"
+                                    type="submit"
+                                    variant="primary"
+                                  >
+                                    <Button
+                                      disabled={true}
+                                      kind="primary"
+                                      size="default"
+                                      tabIndex={0}
+                                      tooltipAlignment="center"
+                                      tooltipPosition="top"
+                                      type="submit"
+                                      variant="primary"
+                                    >
+                                      <button
+                                        className="bx--btn bx--btn--primary bx--btn--disabled"
+                                        disabled={true}
+                                        tabIndex={0}
+                                        type="submit"
+                                        variant="primary"
+                                      >
+                                        Save
+                                      </button>
+                                    </Button>
+                                  </Button>
+                                  <Button
+                                    buttonType="reset"
+                                    disabled={true}
+                                    key="form-reset"
+                                    label="Reset"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <Button
+                                      disabled={true}
+                                      kind="secondary"
+                                      onClick={[Function]}
+                                      size="default"
+                                      tabIndex={0}
+                                      tooltipAlignment="center"
+                                      tooltipPosition="top"
+                                      type="button"
+                                    >
+                                      <button
+                                        className="bx--btn bx--btn--secondary bx--btn--disabled"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        tabIndex={0}
+                                        type="button"
+                                      >
+                                        Reset
+                                      </button>
+                                    </Button>
+                                  </Button>
+                                  <Button
+                                    buttonType="cancel"
+                                    key="form-cancel"
+                                    label="Cancel"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <Button
+                                      disabled={false}
+                                      kind="secondary"
+                                      onClick={[Function]}
+                                      size="default"
+                                      tabIndex={0}
+                                      tooltipAlignment="center"
+                                      tooltipPosition="top"
+                                      type="button"
+                                    >
+                                      <button
+                                        className="bx--btn bx--btn--secondary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        tabIndex={0}
+                                        type="button"
+                                      >
+                                        Cancel
+                                      </button>
+                                    </Button>
+                                  </Button>
+                                </div>
+                              </ButtonSet>
+                            </ButtonGroup>
+                          </FormControls>
+                        </FormSpy>
+                         
+                      </form>
+                    </Form>
+                  </Form>
+                </FormTemplate>
+              </WrappedFormTemplate>
+            </Component>
+          </ReactFinalForm>
+        </FormRenderer>
+      </MiqFormRenderer>
+    </Connect(MiqFormRenderer)>
+  </PhysicalStorageForm>
+</Provider>
+`;

--- a/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
+++ b/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import fetchMock from 'fetch-mock';
+import { shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import PhysicalStorageForm from '../../components/physical-storage-form';
+import { mount } from '../helpers/mountForm';
+import miqRedirectBack from "../../helpers/miq-redirect-back";
+
+require('../helpers/miqSparkle.js');
+require('../helpers/miqAjaxButton.js');
+
+describe('Physical storage form component', () => {
+  const emsList = {
+    resources: [
+      { name: 'name1', id: 1 },
+      { name: 'name2', id: 2 },
+    ],
+  };
+
+  const physicalStorageMock = {
+    href:"https://9.151.190.197/api/physical_storages/1",
+    id:"1",
+    ems_ref:"d5ed1342-10a6-4604-9de5-f3cbaae5d467",
+    uid_ems:null,
+    name:"svc-178",
+    type:"ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage",
+    access_state:null,
+    health_state:null,
+    overall_health_state:null,
+    ems_id:"2",
+    physical_rack_id:null,
+    drive_bays:null,
+    enclosures:null,
+    canister_slots:null,
+    created_at:"2021-08-19T08:54:41Z",
+    updated_at:"2021-08-19T08:56:22Z",
+    physical_chassis_id:null,
+    total_space:null,
+    physical_storage_family_id:"1",
+    actions:[
+      {"name":"edit","method":"patch","href":"https://9.151.190.197/api/physical_storages/1"},
+      {"name":"edit","method":"put","href":"https://9.151.190.197/api/physical_storages/1"},
+      {"name":"refresh","method":"post","href":"https://9.151.190.197/api/physical_storages/1"},
+      {"name":"delete","method":"post","href":"https://9.151.190.197/api/physical_storages/1"}
+    ]
+  };
+
+  const physicalStorageFamilyMock = {
+    href:"https://9.151.190.130/api/providers/2",
+    type:"ManageIQ::Providers::Autosde::StorageManager",
+    id:"2",
+    physical_storage_families:[
+      {"id":"1","name":"svc","version":"1.1","ems_id":"2","ems_ref":"4689c707-3064-4b1c-b001-7688bd9b5655","created_at":"2021-08-29T10:40:21Z","updated_at":"2021-08-29T10:40:21Z"},
+      {"id":"2","name":"xiv","version":"1.1","ems_id":"2","ems_ref":"b91e94ab-8056-4c61-bec6-00430e9c1e4c","created_at":"2021-08-29T10:40:21Z","updated_at":"2021-08-29T10:40:21Z"}
+    ]};
+
+  beforeEach(() => {
+
+  });
+
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+
+  it('should render adding form variant', (done) => {
+    const wrapper = shallow(<PhysicalStorageForm />);
+
+    setImmediate(() => {
+      wrapper.update();
+      expect(toJson(wrapper)).toMatchSnapshot();
+      done();
+    });
+  });
+
+  it('should render editing form variant', async(done) => {
+    fetchMock.getOnce('/api/physical_storages/1', physicalStorageMock);
+    fetchMock.mock('/api/physical_storages?ems_id=2', { data: { form_schema: { fields: [] } } }, { method: 'OPTIONS' });
+    fetchMock.mock('/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_add_storage=true', emsList);
+    fetchMock.mock('/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true', emsList);
+    fetchMock.mock('/api/providers/2?attributes=type,physical_storage_families', physicalStorageFamilyMock);
+
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<PhysicalStorageForm recordId="1" />);
+    });
+    expect(fetchMock.called('/api/physical_storages/1')).toBe(true);
+    expect(toJson(wrapper)).toMatchSnapshot();
+    done();
+  });
+
+  it('should call miqRedirectBack when canceling create form', async(done) => {
+    let wrapper;
+    await act(async() => {
+      wrapper = mount(<PhysicalStorageForm />);
+    });
+    wrapper.find('button').last().simulate('click');
+    expect(miqRedirectBack).toHaveBeenCalledWith('Add of new Physical Storage was cancelled by the user.', 'warning', '/physical_storage/show_list');
+    done();
+  });
+});

--- a/app/views/physical_storage/edit.html.haml
+++ b/app/views/physical_storage/edit.html.haml
@@ -1,0 +1,3 @@
+= render :partial => "layouts/flash_msg"
+= react 'PhysicalStorageForm', :recordId => @storage.id.to_s
+

--- a/app/views/physical_storage/new.html.haml
+++ b/app/views/physical_storage/new.html.haml
@@ -1,3 +1,7 @@
-= react('PhysicalStorageForm',
-         :redirect => previous_breadcrumb_url)
+= render :partial => "layouts/flash_msg"
+
+- if @storage_manager
+  = react 'PhysicalStorageForm', :storageManagerId => @storage_manager.id.to_s
+- else
+  = react 'PhysicalStorageForm', :redirect => previous_breadcrumb_url
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1316,6 +1316,7 @@ Rails.application.routes.draw do
       :get  => %w[
         download_data
         download_summary_pdf
+        edit
         show
         show_list
         new


### PR DESCRIPTION
This PR add new feature for physical-storages, the ability to edit an existing physical-storage. We can change the storage name and/or the storage credentials (management-ip, user and password)

![image](https://user-images.githubusercontent.com/53213107/130013313-306aeba4-75cf-4c5b-8fff-24ac8444f62a.png)

![image](https://user-images.githubusercontent.com/53213107/130013379-5d4a7254-80b0-4921-bf0c-4a598847d3e9.png)

![image](https://user-images.githubusercontent.com/53213107/130013441-f79260a6-30b5-4bbe-affb-c70b81e8c76d.png)


links
-----
https://github.com/ManageIQ/manageiq-providers-autosde/pull/76
https://github.com/ManageIQ/manageiq-api/pull/1066