### PR TITLE
added new supported items to EMS

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -8,7 +8,7 @@ export const portTypes = [
 
 const loadProviders = () =>
   API.get(
-    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true',
+    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_add_host_initiator=true',
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
 

--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -2,7 +2,7 @@ import { componentTypes, validatorTypes } from '@@ddf';
 
 const loadProviders = () =>
   API.get(
-    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true',
+    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_add_storage=true',
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
 

--- a/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
+++ b/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
@@ -9,7 +9,7 @@ export const portTypes = [
 
 const loadProviders = () =>
   API.get(
-    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true',
+    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_add_volume_mapping=true',
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
 


### PR DESCRIPTION
This set of PRs is meant to limit some operations so that they can only be performed on EMSs that support them.
The operations in question all have to do with block-storage managers.
- Add a new storage-system to the EMS
- Add a new host-initiator to the EMS
- Add a new volume-mapping
Currently the only manger that supports these operations is the manageiq-providers-autosde. But there's nothing to stop users from trying to perform these operations on other block-storage managers, such as Cinder.

So we add features to represent these operations, and we filter by them in the UI-forms for the operations. 

Related PRs
https://github.com/ManageIQ/manageiq/pull/21387
https://github.com/ManageIQ/manageiq-ui-classic/pull/7837
https://github.com/ManageIQ/manageiq-providers-autosde/pull/77



The screenshot below shows one of the forms that would be affected.

![image](https://user-images.githubusercontent.com/68283004/130060008-724172f3-40a4-45c5-b2db-076c875760c7.png)


