### PR TITLE
 breadcrumbs changed from pattern-fly to carbon

### DIFF
--- a/app/javascript/components/breadcrumbs/breadcrumbs.jsx
+++ b/app/javascript/components/breadcrumbs/breadcrumbs.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Breadcrumb } from 'patternfly-react';
+import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';
 import { unescape } from 'lodash';
-
 import { onClickTree, onClick, onClickToExplorer } from './on-click-functions';
 
 // FIXME: don't parse html here
@@ -13,44 +14,43 @@ const renderItems = ({ items, controllerName }) => items
   .map((item, index) => {
     const text = parsedText(item.title);
     if (item.action || (!item.url && !item.key && !item.to_explorer)) {
-      // eslint-disable-next-line react/no-array-index-key
-      return <li key={index}>{text}</li>;
+      return <li key={index} className="inactive-item">{text}</li>;
     }
 
     if (item.key || item.to_explorer) {
       return (
-        <Breadcrumb.Item
-          // eslint-disable-next-line react/no-array-index-key
+        <BreadcrumbItem
           key={`${item.key}-${index}`}
+          href="#"
           onClick={(e) =>
             (item.to_explorer
               ? onClickToExplorer(e, controllerName, item.to_explorer)
               : onClickTree(e, controllerName, item))}
         >
           {text}
-        </Breadcrumb.Item>
+        </BreadcrumbItem>
       );
     }
 
     return (
-      <Breadcrumb.Item
+      <BreadcrumbItem
         key={item.url || index}
         href={item.url}
         onClick={(e) => onClick(e, item.url)}
       >
         {text}
-      </Breadcrumb.Item>
+      </BreadcrumbItem>
     );
   });
 
 export const Breadcrumbs = ({ items, title, controllerName }) => (
-  <Breadcrumb>
+  <Breadcrumb noTrailingSlash>
     {items && renderItems({ items, controllerName })}
-    <Breadcrumb.Item active>
+    <BreadcrumbItem isCurrentPage>
       <strong>
         {items && items.length > 0 ? parsedText(items[items.length - 1].title) : parsedText(title)}
       </strong>
-    </Breadcrumb.Item>
+    </BreadcrumbItem>
   </Breadcrumb>
 );
 

--- a/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
+++ b/app/javascript/spec/breadcrumbs/__snapshots__/breadcrumbs.spec.js.snap
@@ -61,84 +61,79 @@ exports[`Breadcrumbs component is correctly rendered 1`] = `
         title="Title"
       >
         <Breadcrumb
-          title={false}
+          noTrailingSlash={true}
         >
-          <Breadcrumb
-            bsClass="breadcrumb"
-            className=""
+          <nav
+            aria-label="Breadcrumb"
           >
             <ol
-              aria-label="breadcrumbs"
-              className="breadcrumb"
-              role="navigation"
+              className="bx--breadcrumb bx--breadcrumb--no-trailing-slash"
             >
               <BreadcrumbItem
-                active={false}
                 href="/providers"
                 key="/providers"
                 onClick={[Function]}
               >
                 <li
-                  className=""
+                  className="bx--breadcrumb-item"
+                  onClick={[Function]}
                 >
-                  <SafeAnchor
-                    componentClass="a"
+                  <Link
                     href="/providers"
-                    onClick={[Function]}
                   >
                     <a
+                      className="bx--link"
                       href="/providers"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
+                      rel={null}
                     >
                       Providers
                     </a>
-                  </SafeAnchor>
+                  </Link>
                 </li>
               </BreadcrumbItem>
               <BreadcrumbItem
-                active={false}
+                href="#"
                 key="in tree-1"
                 onClick={[Function]}
               >
                 <li
-                  className=""
+                  className="bx--breadcrumb-item"
+                  onClick={[Function]}
                 >
-                  <SafeAnchor
-                    componentClass="a"
-                    onClick={[Function]}
+                  <Link
+                    href="#"
                   >
                     <a
+                      className="bx--link"
                       href="#"
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      role="button"
+                      rel={null}
                     >
                       Google
                     </a>
-                  </SafeAnchor>
+                  </Link>
                 </li>
               </BreadcrumbItem>
               <li
+                className="inactive-item"
                 key="2"
               >
                 All
               </li>
               <BreadcrumbItem
-                active={true}
+                isCurrentPage={true}
               >
                 <li
-                  className="active"
+                  className="bx--breadcrumb-item bx--breadcrumb-item--current"
                 >
-                  <span>
-                    <strong>
-                      This
-                    </strong>
-                  </span>
+                  <strong
+                    className="bx--link"
+                  >
+                    This
+                  </strong>
                 </li>
               </BreadcrumbItem>
             </ol>
-          </Breadcrumb>
+          </nav>
         </Breadcrumb>
       </Breadcrumbs>
       <NotificationsToggle>

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -5,6 +5,7 @@
 @import '~@pf3/timeline/style.css';
 @import '~@manageiq/ui-components/dist/css/ui-components.css';
 
+@import './breadcrumbs.scss';
 @import './carbon.scss';
 @import './charts.scss';
 @import './data-table.scss';

--- a/app/stylesheet/breadcrumbs.scss
+++ b/app/stylesheet/breadcrumbs.scss
@@ -1,0 +1,22 @@
+#breadcrumbs{
+    div[id*='react']{
+        display: flex;
+        nav{
+            display: flex;
+            flex-grow: 1;
+            ol {
+                li.inactive-item{
+                    list-style: none;
+                    position: relative;
+                    display: flex;
+                    align-items: center;
+                    margin-right: 0.5rem;
+                    &::after{
+                        margin-left: 0.5rem;
+                        content: "/";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/stylesheet/notifications.scss
+++ b/app/stylesheet/notifications.scss
@@ -144,6 +144,7 @@
 
 .notification-module {
   display: inline;
+  margin: 5px 0;
 }
 
 .notification-title {


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7845

Before
<img width="422" alt="image" src="https://user-images.githubusercontent.com/87487049/131110633-325d39ff-4fdf-4d06-96a7-c60668b4c659.png">

After
<img width="717" alt="image" src="https://user-images.githubusercontent.com/87487049/131606381-ece6203f-0271-4ae4-9539-5bf0cdd35ff6.png">

