### PR TITLE
Fix textual summary for cloud-volumes and host-initiators

### DIFF
--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -113,7 +113,7 @@ module CloudVolumeHelper::TextualSummary
   def textual_host_initiators
     num   = @record.number_of(:host_initiators)
     h     = {:label => _('Host Initiators'), :value => num, :icon => "pficon pficon-volume"}
-    if num > 0 && role_allows?(:feature => "host_initiators_show_list")
+    if num > 0 && role_allows?(:feature => "host_initiator_show_list")
       h[:title] = _("Show host initiators mapped to this volume")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'host_initiators')
     end

--- a/app/helpers/host_initiator_helper/textual_summary.rb
+++ b/app/helpers/host_initiator_helper/textual_summary.rb
@@ -48,7 +48,7 @@ module HostInitiatorHelper::TextualSummary
   def textual_cloud_volumes
     num   = @record.number_of(:cloud_volumes)
     h     = {:label => _('Cloud Volumes'), :value => num, :icon => "pficon pficon-volume"}
-    if num > 0 && role_allows?(:feature => "cloud_volumes_show_list")
+    if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:title] = _("Show volumes mapped to this host initiator")
       h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'cloud_volumes')
     end


### PR DESCRIPTION
Trying to get into cloud-volume summary results with the following error:
`role_allows? no feature was found with identifier: ["host_initiators_show_list"]. Correct the identifier or add it to miq_product_features.yml. [cloud_volume/show]`

![image](https://user-images.githubusercontent.com/53213107/131820184-9ec23108-af22-4e8e-98c4-793e961a4d14.png)
 

we get similar error for host-initiators summary:
`role_allows? no feature was found with identifier: ["cloud_volumes_show_list"]. Correct the identifier or add it to miq_product_features.yml. [host_initiator/show]`