### PR TITLE
Button group form cancel event changes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2211,7 +2211,7 @@ class CatalogController < ApplicationController
           locals[:action_url] = 'servicetemplate_edit'
           locals[:serialize] = true
         end
-        presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals])
+        presenter.update(:form_buttons_div, r[:partial => "layouts/x_edit_buttons", :locals => locals]) if allow_presenter_update(action)
       elsif action == "dialog_provision"
         presenter.hide(:toolbar)
         # incase it was hidden for summary screen, and incase there were no records on show_list
@@ -2240,6 +2240,12 @@ class CatalogController < ApplicationController
     presenter.update(:breadcrumbs, r[:partial => 'layouts/breadcrumbs'])
 
     render :json => presenter.for_render
+  end
+
+  # This method disables the action buttons of the old button-group form page.
+  def allow_presenter_update(action)
+    restricted_actions = ['group_edit']
+    action ? restricted_actions.exclude?(action.to_s) : false
   end
 
   def need_ansible_locals?

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -448,12 +448,6 @@ class MiqAeCustomizationController < ApplicationController
   end
 
   def group_button_add_save(typ)
-    # override for AE Customization Buttons - the label doesn't say Description
-    if @edit[:new][:description].blank?
-      render_flash(_("Button Group Hover Text is required"), :error)
-      return
-    end
-
     super(typ)
   end
 

--- a/app/javascript/components/button-group/helper.js
+++ b/app/javascript/components/button-group/helper.js
@@ -1,0 +1,27 @@
+/** Function to change the format of the props available_fields & fields from the format
+   * [[string,number]] to [{label:string, value:number}] to use as options in dual-list-select
+   * available_fields or an empty array is passed as props. */
+export const formatButton = (buttons) => {
+  if (buttons.length <= 0) {
+    return [];
+  }
+  const options = [];
+  buttons.forEach((btn) => options.push({ label: btn[0], value: btn[1] }));
+  return options;
+};
+
+/** Function to extract the ButtonGroupName from api result like 'ButtonGroupName | xyz'. */
+export const formatName = (buttonGroupName) => {
+  if (!buttonGroupName) {
+    return undefined;
+  }
+  return buttonGroupName.split('|')[0].trim('');
+};
+
+/** Function to update the field set_data's values during form submit */
+export const formatSetData = (setData, buttonIcon, appliesToClass) => ({
+  ...setData,
+  button_color: (setData && setData.button_color) ? setData.button_color : '#000',
+  button_icon: buttonIcon,
+  applies_to_class: appliesToClass,
+});

--- a/app/views/shared/buttons/_group_form.html.haml
+++ b/app/views/shared/buttons/_group_form.html.haml
@@ -1,7 +1,8 @@
-- url = url_for_only_path(:action => 'group_form_field_changed', :id => (@custom_button_set.id || 'new'))
+#group_form_div
+  = render :partial => "layouts/flash_msg"
 = react 'GroupForm', :recId => @edit[:rec_id],
                     :availableFields => (@edit[:new][:available_fields] || []), 
                     :fields => (@edit[:new][:fields] || []),
-                    :url => url, 
-                    :appliesToClass => @sb[:applies_to_class]
-
+                    :url => (url_for_only_path(:action => 'group_form_field_changed', :id => (@custom_button_set.id || 'new'))), 
+                    :appliesToClass => @sb[:applies_to_class],
+                    :appliesToId => @sb[:applies_to_id]


### PR DESCRIPTION
<img width="505" alt="image" src="https://user-images.githubusercontent.com/87487049/131848868-273bd546-9860-497a-a7cc-de8215b2537d.png">

When the button group form page is accessed from **Services / Catelogs / Catelogs Items > Configuration > Add New Button Group**, and when the **Cancel** button in the form is clicked -

**Before**
Back event does not work as expected.
<img width="256" alt="image" src="https://user-images.githubusercontent.com/87487049/131849127-d56d6a4a-5213-4780-9ae0-c7c597286461.png">

**After**
URL dosen't change and goes back to previous page.
<img width="344" alt="image" src="https://user-images.githubusercontent.com/87487049/131849786-f13bc77e-c2e3-4be0-87a9-33cc6e8977e8.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 

