### PR TITLE
Add support for creating multiple host initiators wwpn

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -116,10 +116,29 @@ const createSchema = (emsId, setEmsId) => ({
       }, {when: 'chap_authentication', is:true}]},
     },
     {
-      component: componentTypes.TEXT_FIELD,
+      component: componentTypes.FIELD_ARRAY,
       name: 'wwpn',
       id: 'wwpn',
       label: __('wwpn:'),
+      initialValue: [
+        null
+      ],
+      fieldKey: 'field_array',
+      buttonLabels: {
+        add: __('Add'),
+        remove: __('Remove'),
+      },
+      AddButtonProps: {
+        size: 'small',
+      },
+      RemoveButtonProps: {
+        size: 'small',
+      },
+      fields: [{
+        component: componentTypes.TEXT_FIELD,
+        isRequired: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+      }],
       isRequired: true,
       validate: [{ type: validatorTypes.REQUIRED }],
       condition: {


### PR DESCRIPTION
Adding host initiator ability: create new host-initiator with  multiple wwpn for FC port

before:
![image](https://user-images.githubusercontent.com/53213107/134794682-e5f1678e-317d-421d-aa25-64569070254e.png)


after:
![image](https://user-images.githubusercontent.com/53213107/134336098-57957699-af8f-46e9-9450-3390c3668611.png)

links
------
https://github.com/ManageIQ/manageiq-providers-autosde/pull/81