### PR TITLE
Fix date select in retirement form.

### DIFF
--- a/app/javascript/components/retirement-form/index.jsx
+++ b/app/javascript/components/retirement-form/index.jsx
@@ -16,7 +16,7 @@ const RetirementForm = ({ retirementID, redirect, url }) => {
   }) => {
     miqSparkleOn();
 
-    const date = formMode !== 'delay' ? retirementDate : moment().add({
+    const date = formMode !== 'delay' ? retirementDate[0] : moment().add({
       hours: Number(hours),
       days: Number(days),
       weeks: Number(weeks),


### PR DESCRIPTION
Fixed an issue with the date select on the Set Retire Date form sending the date to the api in an array when the backend expects a string.

<img width="1427" alt="Screen Shot 2021-09-14 at 3 58 30 PM" src="https://user-images.githubusercontent.com/32444791/133325330-2f510c9b-366e-406c-9022-0d283e646ed3.png">
