### PR TITLE
Fix loading symbol for doc link click.

### DIFF
--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -50,6 +50,10 @@ export const linkProps = ({
     hideSecondary();
     miqSparkleOn();
 
+    if (type === 'new_window') {
+      miqSparkleOff();
+    }
+
     // react router support
     onNextRouteChange(() => miqSparkleOff());
   },


### PR DESCRIPTION
Go to Setting > ManageIQ.org will put the MIQ page in loading state forever.

**STR:**

- Lets start from the Overview page
- Click on Go to Settings > ManageIQ.org , this will open support link in new tab.
- Click on MIQ tab, now overview page is showing loading symbol.

**Before**
<img width="1677" alt="Screen Shot 2021-09-15 at 2 43 10 PM" src="https://user-images.githubusercontent.com/37085529/133491720-25ee04d0-2e15-4273-8b19-5f3e01583b86.png">


**After**
<img width="1520" alt="Screen Shot 2021-09-15 at 2 42 45 PM" src="https://user-images.githubusercontent.com/37085529/133491734-81c1e017-5522-49fc-92c5-064e6b64a6bc.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
