### PR TITLE
Fix negative value in  vm retire form

### DIFF
--- a/app/javascript/components/retirement-form/retirement-form.schema.js
+++ b/app/javascript/components/retirement-form/retirement-form.schema.js
@@ -30,24 +30,28 @@ const createSchema = () => ({
         label: __('Months'),
         name: 'months',
         initialValue: 0,
+        min: 0,
       }, {
         component: 'text-field',
         type: 'number',
         label: __('Weeks'),
         name: 'weeks',
         initialValue: 0,
+        min: 0,
       }, {
         component: 'text-field',
         type: 'number',
         label: __('Days'),
         name: 'days',
         initialValue: 0,
+        min: 0,
       }, {
         component: 'text-field',
         type: 'number',
         label: __('Hours'),
         name: 'hours',
         initialValue: 0,
+        min: 0,
       },
       ],
     }, {

--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -50,6 +50,10 @@ export const linkProps = ({
     hideSecondary();
     miqSparkleOn();
 
+    if (type === 'new_window') {
+      miqSparkleOff();
+    }
+
     // react router support
     onNextRouteChange(() => miqSparkleOff());
   },

--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -50,10 +50,6 @@ export const linkProps = ({
     hideSecondary();
     miqSparkleOn();
 
-    if (type === 'new_window') {
-      miqSparkleOff();
-    }
-
     // react router support
     onNextRouteChange(() => miqSparkleOff());
   },


### PR DESCRIPTION
**Steps to Reproduce**

- Select a cloud vm and from Lifecycle down select "Set Retirement Dates"
- On the Retire VMs and Instances page, select "Time Delay from Now" on the "Enter Retire Date as" field.
- From the Time Delay section, you can change the all the field to a negative number
**Before**
<img width="394" alt="Screen Shot 2021-09-15 at 3 02 49 PM" src="https://user-images.githubusercontent.com/37085529/133494222-ad2db1b5-7f01-4ff0-af3e-b96a777e0bde.png">


**After**

<img width="996" alt="Screen Shot 2021-09-15 at 3 03 13 PM" src="https://user-images.githubusercontent.com/37085529/133494246-e6d871e8-1332-4675-b5c9-860cd64d2a13.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 