### PR TITLE
remove kwargs warning for menu item

### DIFF
--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -35,7 +35,7 @@ module Menu
     def visible?
       return true if rbac_feature.nil?
 
-      rbac_feature.nil? || ApplicationHelper.role_allows?(rbac_feature)
+      rbac_feature.nil? || ApplicationHelper.role_allows?(**rbac_feature)
     end
 
     def leaf?


### PR DESCRIPTION
ruby is complaining

```
app/presenters/menu/item.rb:38: warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
app/helpers/application_helper.rb:99: warning: The called method `role_allows?' is defined here
```