### PR TITLE
Converted spinner and grid from patternfly to carbon react

### DIFF
--- a/app/javascript/components/catalog-form/catalog-form.jsx
+++ b/app/javascript/components/catalog-form/catalog-form.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './catalog-form.schema';
 import { API } from '../../http_api';
@@ -122,7 +122,7 @@ class CatalogForm extends Component {
     if (!isLoaded) return null;
 
     return (
-      <Grid fluid>
+      <Grid>
         <MiqFormRenderer
           initialValues={initialValues}
           schema={schema}

--- a/app/javascript/components/cloud-network-form/cloud-network-form.jsx
+++ b/app/javascript/components/cloud-network-form/cloud-network-form.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './cloud-network-form.schema';
 import { networkProviders } from '../../helpers/network-providers';
@@ -94,7 +94,7 @@ class CloudNetworkForm extends Component {
     const { fields } = this.state;
 
     return (
-      <Grid fluid>
+      <Grid>
         <MiqFormRenderer
           initialValues={initialValues}
           schema={createSchema(ems, cloudNetworkId, this.loadSchema, this.emptySchema, fields)}

--- a/app/javascript/components/cloud-tenant-form/index.jsx
+++ b/app/javascript/components/cloud-tenant-form/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
-
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '@@ddf';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import createSchema from './cloud-tenant-form.schema';
@@ -42,7 +41,7 @@ const CloudTenantForm = ({ recordId }) => {
   };
 
   return !isLoading && (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         initialValues={initialValues}
         schema={createSchema(recordId, emsId, setState)}

--- a/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
+++ b/app/javascript/components/copy-catalog-form/copy-catalog-form.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './copy-catalog-form.schema';
 import { http } from '../../http_api';
@@ -45,7 +45,7 @@ class CopyCatalogForm extends Component {
     const cancelUrl = `/catalog/servicetemplate_copy_cancel/${catalogId}`;
 
     return (
-      <Grid fluid>
+      <Grid>
         <MiqFormRenderer
           initialValues={initialValues}
           schema={schema}

--- a/app/javascript/components/copy-dashboard-form/copy-dashboard-form.jsx
+++ b/app/javascript/components/copy-dashboard-form/copy-dashboard-form.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './copy-dashboard-form.schema';
 import { http, API } from '../../http_api';
@@ -57,7 +57,7 @@ const CopyDashboardForm = ({ dashboardId }) => {
 
   if (isLoading) return null;
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         initialValues={initialValues}
         schema={schema}

--- a/app/javascript/components/edit-service-form/index.jsx
+++ b/app/javascript/components/edit-service-form/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import createSchema from './edit-service-form.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 
@@ -21,7 +21,7 @@ const EditServiceForm = ({ maxNameLen, maxDescLen, recordId }) => {
   };
 
   return !isLoading && (
-    <Grid fluid style={{ paddingTop: 20 }}>
+    <Grid style={{ paddingTop: 20 }}>
       <MiqFormRenderer
         initialValues={initialValues}
         schema={createSchema(maxNameLen, maxDescLen)}

--- a/app/javascript/components/firmware-registry/firmware-registry-form.jsx
+++ b/app/javascript/components/firmware-registry/firmware-registry-form.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import schema from './firmware-registry-form.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 
@@ -35,7 +35,7 @@ const FirmwareRegistryForm = () => {
   });
 
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         initialValues={{ type: TYPES.rest_api_depot.value }}
         schema={schema(TYPES)}

--- a/app/javascript/components/flavor-form/index.jsx
+++ b/app/javascript/components/flavor-form/index.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
-
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '@@ddf';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import createSchema from './flavor-form.schema';
@@ -21,7 +20,7 @@ const FlavorForm = ({ redirect }) => {
   };
 
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         schema={createSchema(emsId, setState)}
         onSubmit={onSubmit}

--- a/app/javascript/components/orchestration-template/orcherstration-template-form.js
+++ b/app/javascript/components/orchestration-template/orcherstration-template-form.js
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-
-import { Grid } from 'patternfly-react';
-
+import { Grid } from 'carbon-components-react';
 import { API } from '../../http_api';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
@@ -66,7 +64,7 @@ const OrcherstrationTemplateForm = ({ otId, copy }) => {
     : __('Creation of a new Orchestration Template was cancelled by the user');
 
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         schema={schema}
         onSubmit={onSubmit}

--- a/app/javascript/components/pxe-servers-form/pxe-server-form.jsx
+++ b/app/javascript/components/pxe-servers-form/pxe-server-form.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import createSchema from './pxe-server-form.schema';
 import { API } from '../../http_api';
@@ -76,7 +76,7 @@ const PxeServersForm = ({ id }) => {
   }
 
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer initialValues={initialValues} canReset={!!id} onSubmit={onSubmit} onCancel={onCancel} schema={createSchema(!!id)} />
     </Grid>
   );

--- a/app/javascript/components/region-form/index.jsx
+++ b/app/javascript/components/region-form/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import createSchema from './region-form.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { API } from '../../http_api';
@@ -42,7 +42,7 @@ const RegionForm = ({ id, maxDescLen }) => {
   }
 
   return (
-    <Grid fluid style={{ paddingTop: 20 }}>
+    <Grid style={{ paddingTop: 20 }}>
       <MiqFormRenderer
         initialValues={{ description }}
         schema={createSchema(maxDescLen)}

--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Modal, Spinner } from 'patternfly-react';
+import { Modal } from 'patternfly-react';
+import { Loading } from 'carbon-components-react';
 import { API } from '../http_api';
 
 const parseApiError = (error) => {
@@ -39,6 +40,7 @@ export const removeCatalogItems = (catalogItems) => {
             miqFlashLater({ message: sprintf(__('Error deleting catalog item "%s": %s'), item.name, parseApiError(item.data)), level: 'error' });
           }
         });
+        miqSparkleOff();
       }
       return apiData;
     })
@@ -139,7 +141,11 @@ class RemoveCatalogItemModal extends React.Component {
 
     const renderSpinner = (spinnerOn) => {
       if (spinnerOn) {
-        return <Spinner loading size="lg" />;
+        return (
+          <div className="loadingSpinner">
+            <Loading active small withOverlay={false} className="loading" />
+          </div>
+        );
       }
     };
 

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Modal, Spinner } from 'patternfly-react';
+import { Modal } from 'patternfly-react';
+import { Loading } from 'carbon-components-react';
 import { API } from '../http_api';
 
 const apiTransformFunctions = {
@@ -162,7 +163,11 @@ class RemoveGenericItemModal extends React.Component {
     // eslint-disable-next-line consistent-return
     const renderSpinner = (spinnerOn) => {
       if (spinnerOn) {
-        return <Spinner loading size="lg" />;
+        return (
+          <div className="loadingSpinner">
+            <Loading active small withOverlay={false} className="loading" />
+          </div>
+        );
       }
     };
     const { modalData } = this.props;

--- a/app/javascript/components/service-dialog-from-form/service-dialog-from.jsx
+++ b/app/javascript/components/service-dialog-from-form/service-dialog-from.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 
 import MiqFormRenderer from '../../forms/data-driven-form';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
@@ -24,7 +24,7 @@ const ServiceDialogFromOt = ({
   ));
 
   return (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         schema={serviceDialogFromOtSchema}
         onSubmit={onSubmit}

--- a/app/javascript/components/set-ownership-form/index.jsx
+++ b/app/javascript/components/set-ownership-form/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { groupBy } from 'lodash';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { API } from '../../http_api';
 import createSchema from './ownership-form.schema';
@@ -108,7 +108,7 @@ function SetOwnershipForm(props) {
   };
 
   return (
-    <Grid fluid id="set-ownership-form">
+    <Grid id="set-ownership-form">
       <MiqFormRenderer
         initialValues={initialValues}
         schema={createSchema(userOptions, groupOptions)}

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Spinner } from 'patternfly-react';
+import { Loading } from 'carbon-components-react';
 import { TaggingWithButtonsConnected, TaggingConnected, taggingApp } from '../tagging';
 
 const params = (type = 'default', state, tag = {}) => ({
@@ -59,7 +59,14 @@ class TaggingWrapper extends React.Component {
 
   render() {
     const { isLoaded } = this.props;
-    if (!isLoaded) return <Spinner loading size="lg" />;
+
+    if (!isLoaded) {
+      return (
+        <div className="loadingSpinner">
+          <Loading active small withOverlay={false} className="loading" />
+        </div>
+      );
+    }
     const { urls, options, tagging } = this.props;
     // eslint-disable-next-line no-mixed-operators
     return (options && options.hideButtons && <TaggingConnected options={{ ...options, params, onDelete }} /> || (
@@ -76,8 +83,8 @@ class TaggingWrapper extends React.Component {
           description: __('Save'),
         }}
         cancelButton={{
-        // FIXME: jQuery is necessary here as it communicates with the old world
-        // don't replace $.post with http.post
+          // FIXME: jQuery is necessary here as it communicates with the old world
+          // don't replace $.post with http.post
           onClick: () => { this.reset(); $.post(urls.cancel_url); },
           href: '',
           type: 'button',

--- a/app/javascript/components/vm-server-relationship-form/index.jsx
+++ b/app/javascript/components/vm-server-relationship-form/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import MiqFormRenderer from '../../forms/data-driven-form';
 import { API } from '../../http_api';
 import createSchema from './vm-server-relationship-form.schema';
@@ -37,7 +37,7 @@ const VmServerRelationShipForm = ({ recordId, redirect }) => {
   const onCancel = () => miqRedirectBack(__('Edit Management Engine Relationship was cancelled by the user'), 'warning', redirect);
 
   return !isLoading && (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         initialValues={initialValues}
         schema={createSchema(promise)}

--- a/app/javascript/components/vm-snapshot-form/vm-snapshot-form.jsx
+++ b/app/javascript/components/vm-snapshot-form/vm-snapshot-form.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 import MiqFormRenderer from '../../forms/data-driven-form';
@@ -20,7 +20,7 @@ const VmSnapshotForm = ({ url, redirect }) => {
   };
 
   return !isLoading && (
-    <Grid fluid>
+    <Grid>
       <MiqFormRenderer
         schema={schema}
         onSubmit={onSubmit}

--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import { get } from 'lodash';
 import addSchema from './workers.schema';
 import MiqFormRenderer from '../../forms/data-driven-form';
@@ -174,7 +174,7 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
   }
 
   return (
-    <Grid fluid style={{ marginBottom: 16 }}>
+    <Grid style={{ marginBottom: 16 }}>
       <MiqFormRenderer
         initialValues={initialValues}
         schema={schema}

--- a/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
+++ b/app/javascript/spec/catalog-form/__snapshots__/catalog-form.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Catalog form component should render add variant form 1`] = `
 <div
-  className="container-fluid"
+  className="bx--grid"
 >
   <Connect(MiqFormRenderer)
     buttonsLabels={
@@ -74,7 +74,7 @@ exports[`Catalog form component should render add variant form 1`] = `
 
 exports[`Catalog form component should render edit variant form 1`] = `
 <div
-  className="container-fluid"
+  className="bx--grid"
 >
   <Connect(MiqFormRenderer)
     buttonsLabels={

--- a/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
+++ b/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cloud Network form component should render edit variant 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {
@@ -87,11 +83,7 @@ exports[`Cloud Network form component should render edit variant 1`] = `
 `;
 
 exports[`Cloud Network form component should render form 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {

--- a/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
+++ b/app/javascript/spec/cloud-tenant-form/__snapshots__/cloud-tenant-form.spec.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cloud tenant form component should render adding form variant 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {

--- a/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
+++ b/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flavor form component matches the snapshot 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Connect(MiqFormRenderer)
     buttonsLabels={
       Object {

--- a/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
+++ b/app/javascript/spec/pxe-servers-form/__snapshots__/pxe-server-form.spec.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PxeServersForm should render correctly 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Connect(MiqFormRenderer)
     canReset={false}
     initialValues={Object {}}

--- a/app/javascript/tagging/components/Tagging/Tagging.js
+++ b/app/javascript/tagging/components/Tagging/Tagging.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Row, Col } from 'patternfly-react';
+import { Row, Col } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import TagModifier from '../InnerComponents/TagModifier';
 import TagView from '../InnerComponents/TagView';
 import CategoryModifier from '../InnerComponents/CategoryModifier';
@@ -52,7 +53,7 @@ class Tagging extends React.Component {
 
   render() {
     return (
-      <Grid fluid>
+      <Grid>
         <Row>
           <Col xs={12} md={8} lg={6}>
             <TagModifier hideHeader={this.props.options && this.props.options.hideHeaders}>

--- a/app/javascript/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
+++ b/app/javascript/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Row, ButtonGroup, Button } from 'patternfly-react';
+import { Row, ButtonGroup, Button } from 'patternfly-react';
+import { Grid } from 'carbon-components-react';
 import Tagging from '../Tagging/Tagging';
 import TaggingPropTypes from '../TaggingPropTypes';
 
@@ -11,7 +12,7 @@ class TaggingWithButtons extends React.Component {
 
   render() {
     return (
-      <Grid fluid>
+      <Grid>
         <Tagging
           selectedTagCategory={this.props.selectedTagCategory}
           tags={this.props.tags}

--- a/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tagging component without redux mapping match snapshot 1`] = `
-<Grid
-  bsClass="container"
-  componentClass="div"
-  fluid={true}
->
+<Grid>
   <Row
     bsClass="row"
     componentClass="div"

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -241,3 +241,7 @@
     padding-bottom: 12px;
   }
 }
+
+.loadingSpinner {
+  margin-left: 15rem;
+}


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/7847

Converted the patternfly-react Spinner and Grid components to carbon-components-react.

Before:
<img width="933" alt="Screen Shot 2021-09-21 at 10 42 33 AM" src="https://user-images.githubusercontent.com/32444791/134192573-72ec54be-6b2a-47c2-854a-0d3257686923.png">


After:
<img width="853" alt="Screen Shot 2021-09-21 at 11 18 23 AM" src="https://user-images.githubusercontent.com/32444791/134198767-1ac06fbc-6939-45a3-bdc3-6af541a84580.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label enhancement
