### PR TITLE
Cleanup after policy de-explorization

### DIFF
--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -1,9 +1,8 @@
 - url = url_for_only_path(:action => 'policy_sim_add')
 #main_div
-  - unless @explorer
-    %h1#explorer_title
-      %span#explorer_title_text
-        = safe_right_cell_text
+  %h1#explorer_title
+    %span#explorer_title_text
+      = safe_right_cell_text
   #flash_msg_div
     = render :partial => "layouts/flash_msg"
 
@@ -52,7 +51,7 @@
     = render :partial => "layouts/gtl",
              :locals  => {:view => @pol_view}
 
-- if params[:action] == 'policy_sim' && !@explorer
+- if params[:action] == 'policy_sim'
   %table{:width => "100%"}
     %tr
       %td{:align => 'right'}

--- a/app/views/vm_common/_policies.html.haml
+++ b/app/views/vm_common/_policies.html.haml
@@ -12,12 +12,11 @@
 
   = _('* Items in <font color="red"><i>red italics</i></font> do not change the outcome of the scope or expression.').html_safe
 
-- unless @explorer
-  #buttons{:align => 'right'}
-    -# Go back to policy simulation screen
-    = link_to(_('Back'),
-              {:action => 'policy_sim', :continue => true, :controller => 'vm'},
-               :class  => 'btn btn-default',
-               :alt    => t = _('Back'),
-               :title  => t,
-               :method => :post)
+#buttons{:align => 'right'}
+  -# Go back to policy simulation screen
+  = link_to(_('Back'),
+            {:action => 'policy_sim', :continue => true, :controller => 'vm'},
+             :class  => 'btn btn-default',
+             :alt    => t = _('Back'),
+             :title  => t,
+             :method => :post)

--- a/app/views/vm_common/_policy_options.html.haml
+++ b/app/views/vm_common/_policy_options.html.haml
@@ -1,10 +1,9 @@
 - url = {:url => url_for_only_path(:action => 'policy_options', :id => @record.id)}.to_json
 - url2 = {:url => url_for_only_path(:action => 'policy_show_options', :id => @record.id)}.to_json
 #policy_options_div
-  - unless @explorer
-    %h1#explorer_title
-      %span#explorer_title_text
-        = safe_right_cell_text
+  %h1#explorer_title
+    %span#explorer_title_text
+      = safe_right_cell_text
   %h3
     = _('Options')
   .form-horizontal


### PR DESCRIPTION
Assuming we should not be checking `@explorer` variable in policy views after https://github.com/ManageIQ/manageiq-ui-classic/pull/7401