### PR TITLE
Fix render :file to :template

### DIFF
--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -7,6 +7,6 @@
 - elsif @showtype == "main"
   = render :partial => "layouts/textual_groups_generic"
 - elsif @showtype == "dashboard"
-  = render :file => 'container_project/show_dashboard'
+  = render :template => 'container_project/show_dashboard'
 - elsif @showtype == "topology"
-  = render :file => 'container_topology/show'
+  = render :template => 'container_topology/show'

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -33,6 +33,6 @@
   - elsif @showtype == 'ad_hoc_metrics'
     = render :partial => 'show_ad_hoc_metrics'
   - elsif @showtype == 'topology'
-    = render :file => 'container_topology/show'
+    = render :template => 'container_topology/show'
   - elsif @showtype == "compliance_history"
     = render :partial => "shared/views/compliance_history"


### PR DESCRIPTION
According to https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-raw-file, this ~would never work~ is deprecated.  Spotted while reviewing Travis runs.

An example: `DEPRECATION WARNING: render file: should be given the absolute path to a file (called from ___sers_oleg__rojects__anage___manageiq_ui_classic_app_views_shared_views_ems_common__show_html_haml__2976362415708902536_70183127350080 at /Users/oleg/Projects/ManageIQ/manageiq-ui-classic/app/views/shared/views/ems_common/_show.html.haml:36)`