### PR TITLE
Fix doc link loading symbol.

### DIFF
--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -50,6 +50,10 @@ export const linkProps = ({
     hideSecondary();
     miqSparkleOn();
 
+    if (type === 'new_window') {
+      miqSparkleOff();
+    }
+
     // react router support
     onNextRouteChange(() => miqSparkleOff());
   },


### PR DESCRIPTION
This is originally fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/7864.

Somehow changes were overwritten in https://github.com/ManageIQ/manageiq-ui-classic/pull/7865( Note: it is not showing in files changed). so doing these changes again to fix bug.

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 

