### PR TITLE
User should not be able to edit Purpose Tags from Service / Request page

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -254,7 +254,7 @@ class MiqRequestController < ApplicationController
       page.replace_html(
         @options[:current_tab_key],
         :partial => dialog_partial_for_workflow,
-        :locals  => {:wf => @options[:wf], :dialog => @options[:current_tab_key]}
+        :locals  => {:wf => @options[:wf], :dialog => @options[:current_tab_key], :isDisabled => true}
       )
       # page << javascript_show("hider_#{@options[:current_tab_key].to_s}_div")
       page << "miqSparkle(false);"

--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -72,6 +72,7 @@ class TaggingWrapper extends React.Component {
         </div>
       );
     }
+    const isDisabled = this.props.isDisabled;
     const { urls, options, tagging } = this.props;
     // eslint-disable-next-line no-mixed-operators
     return (options && options.hideButtons && <TaggingConnected options={{ ...options, params, onDelete }} /> || (
@@ -103,7 +104,7 @@ class TaggingWrapper extends React.Component {
           disabled: _.isEqual({ ...tagging.initialState, selected: undefined }, { ...tagging.appState, selected: undefined }),
           description: __('Reset'),
         }}
-        options={{ ...options, params, onDelete }}
+        options={{ ...options, params, onDelete, isDisabled }}
       />
     ));
   }

--- a/app/javascript/pf-select/pf-select.jsx
+++ b/app/javascript/pf-select/pf-select.jsx
@@ -35,6 +35,7 @@ export const PfSelect = ({
   input,
   meta,
   simpleValue,
+  isDisabled,
   ...rest
 }) => (
   <ReactSelect
@@ -56,6 +57,7 @@ export const PfSelect = ({
     onChange={option => input.onChange(rest.multi
           ? selectValue(option, simpleValue)
           : option && (simpleValue ? option.value : option))}
+    isDisabled={isDisabled}
   />
 );
 
@@ -63,10 +65,12 @@ PfSelect.propTypes = {
   meta: PropTypes.object.isRequired,
   input: PropTypes.object.isRequired,
   simpleValue: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 PfSelect.defaultProps = {
   simpleValue: true,
+  isDisabled: false,
 };
 
 export default PfSelect;

--- a/app/javascript/tagging/components/InnerComponents/CategoryModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/CategoryModifier.js
@@ -9,6 +9,7 @@ const CategoryModifier = ({
   onTagCategoryChange,
   selectedTagCategory,
   categoryLabel,
+  isDisabled,
 }) => (
   <FormGroup>
     <Col xs={12} md={4} lg={4}>
@@ -19,6 +20,7 @@ const CategoryModifier = ({
         tagCategories={tagCategories}
         onTagCategoryChange={onTagCategoryChange}
         selectedOption={selectedTagCategory}
+        isDisabled={isDisabled}
       />
     </Col>
   </FormGroup>
@@ -29,11 +31,13 @@ CategoryModifier.propTypes = {
   selectedTagCategory: TaggingPropTypes.category,
   onTagCategoryChange: PropTypes.func.isRequired,
   categoryLabel: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 CategoryModifier.defaultProps = {
   categoryLabel: __('Category'),
   selectedTagCategory: {},
+  isDisabled: false,
 };
 
 export default CategoryModifier;

--- a/app/javascript/tagging/components/InnerComponents/Tag.js
+++ b/app/javascript/tagging/components/InnerComponents/Tag.js
@@ -4,27 +4,44 @@ import { Label } from 'patternfly-react';
 import TaggingPropTypes from '../TaggingPropTypes';
 
 const Tag = ({
-  onTagDeleteClick, tagCategory, tagValue, truncate,
-}) => (
-  <li key={tagValue.id} className="tag">
-    <Label
-      key={tagValue.id}
-      id={`tag_value_${tagValue.id}`}
-      bsStyle="primary"
-      onRemoveClick={onTagDeleteClick ? () => onTagDeleteClick(tagCategory, tagValue) : undefined}
-      className="tagColor"
-      title={tagValue.description}
-    >
-      {truncate(tagValue.description)}
-    </Label>
-  </li>
-);
+  onTagDeleteClick, tagCategory, tagValue, truncate, showCloseButton,
+}) => {
+  if (showCloseButton) {
+    return (
+      <li key={tagValue.id} className="tag">
+        <Label
+          key={tagValue.id}
+          id={`tag_value_${tagValue.id}`}
+          bsStyle="primary"
+          onRemoveClick={onTagDeleteClick ? () => onTagDeleteClick(tagCategory, tagValue) : undefined}
+          className="tagColor"
+          title={tagValue.description}
+        >
+          {truncate(tagValue.description)}
+        </Label>
+      </li>
+    );
+  }
+  return (
+    <li key={tagValue.id} className="tag">
+      <Label
+        key={tagValue.id}
+        id={`tag_value_${tagValue.id}`}
+        className="tagColor"
+        title={tagValue.description}
+      >
+        {truncate(tagValue.description)}
+      </Label>
+    </li>
+  );
+};
 
 Tag.propTypes = {
   onTagDeleteClick: PropTypes.func,
   tagCategory: TaggingPropTypes.category,
   tagValue: TaggingPropTypes.value,
   truncate: PropTypes.func.isRequired,
+  showCloseButton: PropTypes.bool,
 };
 
 export default Tag;

--- a/app/javascript/tagging/components/InnerComponents/TagCategory.js
+++ b/app/javascript/tagging/components/InnerComponents/TagCategory.js
@@ -11,6 +11,7 @@ class TagCategory extends React.Component {
       tagValue={tagValue}
       onTagDeleteClick={this.props.onTagDeleteClick}
       truncate={this.props.valueTruncate}
+      showCloseButton={this.props.showCloseButton}
     />
   );
 
@@ -37,12 +38,14 @@ TagCategory.propTypes = {
   values: PropTypes.arrayOf(TaggingPropTypes.category).isRequired,
   categoryTruncate: PropTypes.func,
   valueTruncate: PropTypes.func,
+  showCloseButton: PropTypes.bool,
 };
 
 TagCategory.defaultProps = {
   categoryTruncate: str =>
     (str.length > 18 ? `${str.substring(0, 18)}...` : str),
   valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
+  showCloseButton: true,
 };
 
 export default TagCategory;

--- a/app/javascript/tagging/components/InnerComponents/TagSelector.js
+++ b/app/javascript/tagging/components/InnerComponents/TagSelector.js
@@ -55,6 +55,7 @@ class TagSelector extends React.Component {
         // clearable={false}
         simpleValue={false}
         searchable
+        isDisabled={this.props.isDisabled}
       />
     );
   }
@@ -64,11 +65,13 @@ TagSelector.propTypes = {
   selectedOption: TaggingPropTypes.value,
   onTagCategoryChange: PropTypes.func.isRequired,
   infoText: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 TagSelector.defaultProps = {
   infoText: __('Only a single value can be assigned from these categories'),
   selectedOption: {},
+  isDisabled: false,
 };
 
 export default TagSelector;

--- a/app/javascript/tagging/components/InnerComponents/TagView.js
+++ b/app/javascript/tagging/components/InnerComponents/TagView.js
@@ -12,6 +12,7 @@ class TagView extends React.Component {
         tagCategory={{ id: tag.id, description: tag.description }}
         values={tag.values}
         onTagDeleteClick={this.props.onTagDeleteClick}
+        showCloseButton={this.props.showCloseButton}
       />
     </li>
   );
@@ -44,11 +45,13 @@ TagView.propTypes = {
   onTagDeleteClick: PropTypes.func,
   header: PropTypes.string,
   hideHeader: PropTypes.bool,
+  showCloseButton: PropTypes.bool,
 };
 
 TagView.defaultProps = {
   header: __('Assigned tags'),
   hideHeader: false,
+  showCloseButton: true,
 };
 
 export default TagView;

--- a/app/javascript/tagging/components/InnerComponents/ValueModifier.js
+++ b/app/javascript/tagging/components/InnerComponents/ValueModifier.js
@@ -10,6 +10,7 @@ const ValueModifier = ({
   selectedTagValues,
   multiValue,
   valueLabel,
+  isDisabled,
 }) => (
   <FormGroup>
     <Col xs={12} md={4} lg={4}>
@@ -21,6 +22,7 @@ const ValueModifier = ({
         onTagValueChange={onTagValueChange}
         selectedOption={selectedTagValues}
         multiValue={multiValue}
+        isDisabled={isDisabled}
       />
     </Col>
   </FormGroup>
@@ -32,11 +34,13 @@ ValueModifier.propTypes = {
   valueLabel: PropTypes.string,
   multiValue: PropTypes.bool,
   values: PropTypes.arrayOf(TaggingPropTypes.value).isRequired,
+  isDisabled: PropTypes.bool,
 };
 
 ValueModifier.defaultProps = {
   valueLabel: __('Value'),
   multiValue: true,
+  isDisabled: false,
 };
 
 export default ValueModifier;

--- a/app/javascript/tagging/components/InnerComponents/ValueSelector.js
+++ b/app/javascript/tagging/components/InnerComponents/ValueSelector.js
@@ -49,6 +49,7 @@ class ValueSelector extends React.Component {
       clearable
       searchable={values.length > 0}
       placeholder={__('Select tag value')}
+      isDisabled={this.props.isDisabled}
     />
   );
 
@@ -65,11 +66,13 @@ ValueSelector.propTypes = {
   values: PropTypes.arrayOf(TaggingPropTypes.value).isRequired,
   onTagValueChange: PropTypes.func.isRequired,
   multiValue: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 ValueSelector.defaultProps = {
   multiValue: false,
   selectedOption: [],
+  isDisabled: false,
 };
 
 export default ValueSelector;

--- a/app/javascript/tagging/components/Tagging/Tagging.js
+++ b/app/javascript/tagging/components/Tagging/Tagging.js
@@ -56,6 +56,7 @@ class Tagging extends React.Component {
   })) || [];
 
   render() {
+    const isDisabled = this.props.options && this.props.options.isDisabled;
     return (
       <Grid>
         <Row>
@@ -65,12 +66,14 @@ class Tagging extends React.Component {
                 selectedTagCategory={this.props.selectedTagCategory}
                 onTagCategoryChange={this.props.onTagCategoryChange}
                 tagCategories={this.tagCategories}
+                isDisabled={isDisabled}
               />
               <ValueModifier
                 onTagValueChange={this.onTagValueChange}
                 selectedTagValues={this.getSelectedCategoryValues().values}
                 multiValue={this.isMulti(this.props.selectedTagCategory)}
                 values={this.getCategoryValues()}
+                isDisabled={isDisabled}
               />
             </TagModifier>
           </Col>
@@ -78,7 +81,8 @@ class Tagging extends React.Component {
             <TagView
               hideHeader={this.props.options && this.props.options.hideHeaders}
               assignedTags={this.props.assignedTags}
-              onTagDeleteClick={this.onTagDeleteClick}
+              onTagDeleteClick={isDisabled ? () => {} : this.onTagDeleteClick}
+              showCloseButton={!isDisabled}
             />
           </Col>
         </Row>
@@ -98,6 +102,7 @@ Tagging.propTypes = {
   options: PropTypes.shape({
     onlySingleTag: PropTypes.bool,
     hideHeaders: PropTypes.bool,
+    isDisabled: PropTypes.bool,
   }),
 };
 
@@ -105,6 +110,7 @@ Tagging.defaultProps = {
   options: {
     onlySingleTag: false,
     hideHeaders: false,
+    isDisabled: false,
   },
 };
 

--- a/app/javascript/tagging/tests/__snapshots__/category.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/category.modifier.test.js.snap
@@ -27,6 +27,7 @@ exports[`TagCategory Component match snapshot 1`] = `
   >
     <TagSelector
       infoText="Only a single value can be assigned from these categories"
+      isDisabled={false}
       onTagCategoryChange={[MockFunction]}
       selectedOption={
         Object {

--- a/app/javascript/tagging/tests/__snapshots__/tag.category.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.category.test.js.snap
@@ -18,6 +18,7 @@ exports[`TagCategory Component match snapshot 1`] = `
   <Tag
     key="1"
     onTagDeleteClick={[Function]}
+    showCloseButton={true}
     tagCategory={
       Object {
         "description": "animal",
@@ -35,6 +36,7 @@ exports[`TagCategory Component match snapshot 1`] = `
   <Tag
     key="2"
     onTagDeleteClick={[Function]}
+    showCloseButton={true}
     tagCategory={
       Object {
         "description": "animal",

--- a/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.modifier.test.js.snap
@@ -24,6 +24,7 @@ exports[`Tagging modifier match snapshot 1`] = `
   >
     <CategoryModifier
       categoryLabel="Category"
+      isDisabled={false}
       onTagCategoryChange={[Function]}
       selectedTagCategory={
         Object {
@@ -53,6 +54,7 @@ exports[`Tagging modifier match snapshot 1`] = `
       }
     />
     <ValueModifier
+      isDisabled={false}
       multiValue={false}
       onTagValueChange={[Function]}
       selectedTagValue={

--- a/app/javascript/tagging/tests/__snapshots__/tag.selector.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.selector.test.js.snap
@@ -14,6 +14,7 @@ exports[`Tagging modifier match snapshot 1`] = `
       },
     }
   }
+  isDisabled={false}
   meta={Object {}}
   options={
     Array [

--- a/app/javascript/tagging/tests/__snapshots__/tag.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.test.js.snap
@@ -6,11 +6,9 @@ exports[`Tag Component match snapshot 1`] = `
   key="1"
 >
   <Label
-    bsStyle="primary"
     className="tagColor"
     id="tag_value_1"
     key="1"
-    onRemoveClick={[Function]}
     title="duck"
     type="default"
   />

--- a/app/javascript/tagging/tests/__snapshots__/tag.view.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tag.view.test.js.snap
@@ -37,6 +37,7 @@ exports[`Tag view match snapshot 1`] = `
             categoryTruncate={[Function]}
             key="1"
             onTagDeleteClick={[MockFunction]}
+            showCloseButton={true}
             tagCategory={
               Object {
                 "description": "Name",

--- a/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/tagging.test.js.snap
@@ -19,6 +19,7 @@ exports[`Tagging component without redux mapping match snapshot 1`] = `
       >
         <CategoryModifier
           categoryLabel="Category"
+          isDisabled={false}
           onTagCategoryChange={[MockFunction]}
           selectedTagCategory={
             Object {
@@ -57,6 +58,7 @@ exports[`Tagging component without redux mapping match snapshot 1`] = `
           }
         />
         <ValueModifier
+          isDisabled={false}
           multiValue={true}
           onTagValueChange={[Function]}
           selectedTagValues={
@@ -108,6 +110,7 @@ exports[`Tagging component without redux mapping match snapshot 1`] = `
         header="Assigned tags"
         hideHeader={false}
         onTagDeleteClick={[Function]}
+        showCloseButton={true}
       />
     </Col>
   </Row>
@@ -133,6 +136,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
       >
         <CategoryModifier
           categoryLabel="Category"
+          isDisabled={false}
           onTagCategoryChange={[MockFunction]}
           selectedTagCategory={
             Object {
@@ -171,6 +175,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
           }
         />
         <ValueModifier
+          isDisabled={false}
           multiValue={true}
           onTagValueChange={[Function]}
           selectedTagValues={Array []}
@@ -219,6 +224,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
         header="Assigned tags"
         hideHeader={false}
         onTagDeleteClick={[Function]}
+        showCloseButton={true}
       />
     </Col>
   </Row>
@@ -244,6 +250,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
       >
         <CategoryModifier
           categoryLabel="Category"
+          isDisabled={false}
           onTagCategoryChange={[MockFunction]}
           selectedTagCategory={
             Object {
@@ -282,6 +289,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
           }
         />
         <ValueModifier
+          isDisabled={false}
           multiValue={false}
           onTagValueChange={[Function]}
           selectedTagValues={Array []}
@@ -326,6 +334,7 @@ exports[`Tagging component without redux mapping should call methods - singleVal
         header="Assigned tags"
         hideHeader={false}
         onTagDeleteClick={[Function]}
+        showCloseButton={true}
       />
     </Col>
   </Row>

--- a/app/javascript/tagging/tests/__snapshots__/value.modifier.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/value.modifier.test.js.snap
@@ -26,6 +26,7 @@ exports[`TagCategory Component match snapshot 1`] = `
     xs={12}
   >
     <ValueSelector
+      isDisabled={false}
       multiValue={false}
       onTagValueChange={[MockFunction]}
       selectedOption={

--- a/app/javascript/tagging/tests/__snapshots__/value.selector.test.js.snap
+++ b/app/javascript/tagging/tests/__snapshots__/value.selector.test.js.snap
@@ -10,6 +10,7 @@ exports[`match snapshot 1`] = `
       "value": 2,
     }
   }
+  isDisabled={false}
   meta={Object {}}
   multi={false}
   options={
@@ -40,6 +41,7 @@ exports[`match snapshot without multiple values 1`] = `
       "value": 2,
     }
   }
+  isDisabled={false}
   meta={Object {}}
   multi={false}
   options={

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -292,7 +292,8 @@
         .col-md-10
           = react('TaggingWrapperConnected',
             :tags    => @tags,
-            :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true, :url => url_for_only_path(:action => 'prov_field_changed')})
+            :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true, 
+                          :url => url_for_only_path(:action => 'prov_field_changed'), :isDisabled => @tags[:isDisabled]})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -22,6 +22,7 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :purpose
+    - (defined? isDisabled) ? @tags[:isDisabled] = isDisabled : @tags[:isDisabled] = false
     - keys = [:vm_tags]
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,


### PR DESCRIPTION
The `Purpose Tag` in the Service Request page should not be editable by users. 

## Before

If a user changes the values in the dropdown to try and add more tags the edit will be aborted with error. Additionally users shouldn't be able to edit it in the first place. 

![Screen Shot 2021-09-28 at 4 08 44 PM](https://user-images.githubusercontent.com/29209973/135158377-c8714c30-8f95-4115-9408-03612f606146.png)

![Screen Shot 2021-09-28 at 4 10 50 PM](https://user-images.githubusercontent.com/29209973/135158605-4f3062d0-15d5-4144-a5a1-92f8206c2dde.png)

## After 

Drop down is disabled and so is the `x` to remove tags. 

With Tags
![Screen Shot 2021-09-29 at 3 24 24 PM](https://user-images.githubusercontent.com/29209973/135336858-a34a5aab-9fa8-4c6b-badc-30569afe17c0.png)

No Tags
![Screen Shot 2021-09-29 at 3 37 19 PM](https://user-images.githubusercontent.com/29209973/135336925-162ecfa7-e1ce-4478-96b3-bc6091875cd7.png)

