### PR TITLE
[ApplicationController::Tags] Fix bulk_reassignment

### DIFF
--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -131,11 +131,11 @@ module ApplicationController::Tags
 
   # Add/remove tags in a single transaction
   def tagging_save_tags
-    @edit[:new][:assignments] = JSON.parse(params['data']).flat_map { |tag| tag['values'].map { |v| v['id'] } }
+    @edit[:new][:assignments] = JSON.parse(params['data']).flat_map { |tag| tag['values'].map { |v| v['id'].to_i } }
     Classification.bulk_reassignment(:model      => @edit[:tagging],
                                      :object_ids => @edit[:object_ids],
-                                     :add_ids    => @edit[:new][:assignments] - @edit[:current][:assignments],
-                                     :delete_ids => @edit[:current][:assignments] - @edit[:new][:assignments])
+                                     :add_ids    => @edit[:new][:assignments] - @edit[:current][:assignments].map { |c| c.id },
+                                     :delete_ids => @edit[:current][:assignments].map { |c| c.id } - @edit[:new][:assignments])
   rescue StandardError => bang
     add_flash(_("Error during 'Save Tags': %{error_message}") % {:error_message => bang.message}, :error)
   else


### PR DESCRIPTION
Fixes editing of tags, where instead of passing in the proper adds and deletes, all tags were passed in as deletes and adds, and only because adding comes after deleting did this work previously, but at the cost of performance.

By ensuring we are doing array subtraction with the same types, it fixes the `:add_ids` and `:delete_ids` from being incorrect and causing a surge of ActiveRecord queries when it isn't necessary.


Links
-----

* Addresses https://github.com/ManageIQ/manageiq/issues/21444


Steps for Testing/QA
--------------------

I have some scripts that I used to validate this change, but I need to update them to work against a fresh DB.  Will update this section with a link to a gist when I am able to put those together.