### PR TITLE
Fix provision screen multi tags assignment

### DIFF
--- a/app/javascript/components/taggingWrapper.jsx
+++ b/app/javascript/components/taggingWrapper.jsx
@@ -4,10 +4,15 @@ import PropTypes from 'prop-types';
 import { Loading } from 'carbon-components-react';
 import { TaggingWithButtonsConnected, TaggingConnected, taggingApp } from '../tagging';
 
+const selectedTags = (state, tag) => {
+  const selectedVal = Array.isArray(tag.tagValue) ? tag.tagValue.map((val) => val.id).flat() : [];
+  return [state.tagging.appState.assignedTags.map((t) => t.values.map((val) => val.id)).flat(), selectedVal].flat();
+};
+
 const params = (type = 'default', state, tag = {}) => ({
   provision: {
     id: 'new',
-    ids_checked: [state.tagging.appState.assignedTags.map((t) => t.values.map((val) => val.id)).flat(), tag.tagValue.id || tag.tagValue[0].id].flat(),
+    ids_checked: selectedTags(state, tag),
     tree_typ: 'tags',
   },
   default: {


### PR DESCRIPTION
**Issue:** In provision vm screen, for category that should allow multi tag assignments, it is allowing only one.

**Before**

<img width="1095" alt="Screen Shot 2021-10-01 at 3 04 50 PM" src="https://user-images.githubusercontent.com/37085529/135673742-435ba0df-498c-45e6-87d9-2e38e6c3b825.png">

**After**
<img width="1082" alt="Screen Shot 2021-10-01 at 2 59 18 PM" src="https://user-images.githubusercontent.com/37085529/135673761-fd41d8ed-3b71-4ccd-bb80-c31ef631f220.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 


