### PR TITLE
[WIP] Select WWPN candidates from list when creating a new host-initiators

### DIFF
--- a/app/javascript/components/host-initiator-form/index.jsx
+++ b/app/javascript/components/host-initiator-form/index.jsx
@@ -6,7 +6,9 @@ import createSchema from './host-initiator-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 const HostInitiatorForm = ({ redirect }) => {
-  const state = useState(undefined);
+  // const state = useState(undefined);
+  const [emsId, setEmsId] = useState(undefined);
+  const [storageId, setStorageId] = useState(undefined);
 
   const onSubmit = async(values) => {
     miqSparkleOn();
@@ -20,9 +22,18 @@ const HostInitiatorForm = ({ redirect }) => {
     miqRedirectBack(message, 'success', redirect);
   };
 
+  const validate=(values) => {
+    const errors = {};
+    if ((!values.wwpn || !values.wwpn.length) && (!values.custom_wwpn || !values.custom_wwpn.length)){
+      errors.wwpn = "Please provide at least one WWPN."
+    }
+    return errors;
+  }
+
   return (
     <MiqFormRenderer
-      schema={createSchema(...state)}
+      validate={validate}
+      schema={createSchema(emsId, setEmsId, storageId, setStorageId)}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{


### PR DESCRIPTION
When creating an FC host-initiator, the user needs to provide at least one WWPN address. This feature will allow the user to pick a WWPN address from a list of candidates detected by the storage system. The previous functionality of inputting custom WWPNs is preserved.

Part of https://github.com/ManageIQ/manageiq-providers-autosde/issues/92

The video below demonstrates the changes to the form

https://user-images.githubusercontent.com/68283004/135974428-48781ed3-3e1c-4511-879f-2764cbed7586.mp4
