### PR TITLE
Enable "Delete cloud object store container"

### DIFF
--- a/app/controllers/cloud_object_store_container_controller.rb
+++ b/app/controllers/cloud_object_store_container_controller.rb
@@ -183,7 +183,7 @@ class CloudObjectStoreContainerController < ApplicationController
           :userid       => session[:userid]
         }
         AuditEvent.success(audit)
-        CloudObjectStoreContainer.cloud_object_store_container_delete_queue(session[:userid], container)
+        container.cloud_object_store_container_delete_queue(session[:userid])
       end
       add_flash(n_("Delete initiated for %{number} Cloud Object Store Container.",
                    "Delete initiated for %{number} Cloud Object Store Containers.",


### PR DESCRIPTION
I tried to enable the button "Delete Cloud Object Store Container".