### PR TITLE
Purpose tags should be editable from Service > Requests details page without breaking

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -293,7 +293,7 @@
           = react('TaggingWrapperConnected',
             :tags    => @tags,
             :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true, 
-                          :url => url_for_only_path(:action => 'prov_field_changed'), :isDisabled => @tags[:isDisabled]})
+                          :url => url, :isDisabled => @tags[:isDisabled]})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available
             = field_hash[:notes]


### PR DESCRIPTION
User should be able to edit Purpose Tags from Service > Requests details page. 

## Before

https://user-images.githubusercontent.com/29209973/136453342-4301faa7-8838-46cf-acb5-6404ec55d7a2.mov

## After

https://user-images.githubusercontent.com/29209973/136453020-e681db44-3db4-4104-a8a7-a483b0340508.mov


@miq-bot add-reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu