### PR TITLE
Fixed search modal hiding issue

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -487,6 +487,10 @@ tr.rdetail > td {
   background-color: #f5f5f5 !important;
 }
 
+#advsearchModal .modal-dialog {
+  left: 50px;
+}
+
 /// custom modal class for adv search
 @media (min-width: $screen-sm) {
   .modal-xl {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/87487049/136884271-a12b34ce-b934-41ec-a03e-e24fd9a04f67.png)

After
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/136884448-b0a67265-5158-4ba6-9ba0-4a004b904a45.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 

