### PR TITLE
Replace last usage of ems#supports_port?

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -64,8 +64,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @record.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
+    @record.ipaddress.present? ? {:label => _("Discovered IP Address"), :value => @record.ipaddress} : nil
   end
 
   def textual_type
@@ -73,7 +72,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid

--- a/app/helpers/ems_configuration_helper/textual_summary.rb
+++ b/app/helpers/ems_configuration_helper/textual_summary.rb
@@ -24,9 +24,7 @@ module EmsConfigurationHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @record.ipaddress.blank?
-
-    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
+    @record.ipaddress.present? ? {:label => _("Discovered IP Address"), :value => @record.ipaddress} : nil
   end
 
   def textual_type
@@ -34,7 +32,7 @@ module EmsConfigurationHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module EmsContainerHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? @record.port : nil
+    @record.port.presence
   end
 
   def textual_topology

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -42,9 +42,7 @@ module EmsInfraHelper::TextualSummary
   #
 
   def textual_region
-    return nil if @record.region_id.blank?
-
-    {:label => _('Region'), :value => @record.region_id}
+    @record.region_id.present? ? {:label => _('Region'), :value => @record.region_id} : nil
   end
 
   def textual_hostname
@@ -60,7 +58,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_cpu_resources

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -39,8 +39,7 @@ module EmsNetworkHelper::TextualSummary
   # Items
   #
   def textual_provider_region
-    return nil if @record.provider_region.nil?
-    {:label => _("Region"), :value => @record.description}
+    @record.provider_region.present? ? {:label => _("Region"), :value => @record.description} : nil
   end
 
   def textual_hostname
@@ -48,8 +47,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @record.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
+    @record.ipaddress.present? ? {:label => _("Discovered IP Address"), :value => @record.ipaddress} : nil
   end
 
   def textual_type
@@ -57,7 +55,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid

--- a/app/helpers/ems_physical_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_physical_infra_helper/textual_summary.rb
@@ -52,7 +52,7 @@ module EmsPhysicalInfraHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_physical_racks

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -43,8 +43,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_ipaddress
-    return nil if @record.ipaddress.blank?
-    {:label => _("Discovered IP Address"), :value => @record.ipaddress}
+    @record.ipaddress.present? ? {:label => _("Discovered IP Address"), :value => @record.ipaddress} : nil
   end
 
   def textual_type
@@ -52,7 +51,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_port
-    @record.supports_port? ? {:label => _("API Port"), :value => @record.port} : nil
+    @record.port.present? ? {:label => _("API Port"), :value => @record.port} : nil
   end
 
   def textual_guid


### PR DESCRIPTION
`ExtManagementSystem#supports_port?` used to be used when creating providers but has since been replaced with DDF.  These are the last callers of `supports_port?` and can be replaced with a simple `.present?` check.

Follow-up to https://github.com/ManageIQ/manageiq/pull/21495