### PR TITLE
Fixed About Modal loading bug

### DIFF
--- a/app/assets/stylesheets/about_modal_background.scss
+++ b/app/assets/stylesheets/about_modal_background.scss
@@ -1,5 +1,5 @@
 /* Bootstrap overrides */
-.bx--modal-container.whitelabel {
+.whitelabel {
   background-image: image-url($img-bg-login-whitelabel);
   background-size: 100% 100%;
 }

--- a/app/javascript/components/miq-about-modal/miq-about-modal.jsx
+++ b/app/javascript/components/miq-about-modal/miq-about-modal.jsx
@@ -65,10 +65,14 @@ class MiqAboutModal extends React.Component {
 
   render() {
     const {
-      data, hideModal,
+      data, dialogClassName, hideModal,
     } = this.props;
     const { show } = this.props;
     const { expand } = this.state;
+    let className = 'about-modal';
+    if (dialogClassName === 'whitelabel') {
+      className = dialogClassName;
+    }
     if (!data) {
       return null;
     }
@@ -88,7 +92,7 @@ class MiqAboutModal extends React.Component {
         open={show}
         onRequestClose={() => { hideModal(); }}
         passiveModal
-        className="about-modal"
+        className={className}
       >
         <ModalBody className="about-modal-body">
           <ModalItem
@@ -156,6 +160,7 @@ class MiqAboutModal extends React.Component {
 }
 
 MiqAboutModal.propTypes = {
+  dialogClassName: PropTypes.string,
   show: PropTypes.bool,
   data: PropTypes.shape({
     product_info: PropTypes.shape({
@@ -174,6 +179,7 @@ MiqAboutModal.propTypes = {
 };
 
 MiqAboutModal.defaultProps = {
+  dialogClassName: '',
   show: false,
   data: undefined,
 };

--- a/app/javascript/menu/item-type.js
+++ b/app/javascript/menu/item-type.js
@@ -29,7 +29,7 @@ export const linkProps = ({
   rel: (type === 'new_window' ? 'noreferrer noopener' : undefined),
 
   onClick: (event) => {
-    if (type === 'deleteModal') {
+    if (type === 'modal') {
       sendDataWithRx({ type: 'showAboutModal' });
       hideSecondary();
 


### PR DESCRIPTION
Fixed bug where About Modal will not load and added variable class name to support custom background image.

About modal loading bug is introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/7899

Before:
<img width="1419" alt="Screen Shot 2021-10-13 at 9 14 28 AM" src="https://user-images.githubusercontent.com/32444791/137139892-b470a679-ab23-484c-83a9-cb9bab775803.png">

After:
<img width="1421" alt="Screen Shot 2021-10-13 at 9 15 06 AM" src="https://user-images.githubusercontent.com/32444791/137139946-32a5d72b-98d4-4400-8515-2e84b7947c9f.png">

@miq-bot add-label bug
@miq-bot add_reviewer @kavyanekkalapu

