### PR TITLE
Fix Breadcrumbs for Security Policy and Network Services Page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3238,7 +3238,6 @@ Rails.application.routes.draw do
     ems_storage
     miq_ae_customization
     pxe
-    security_policy_rule
     storage_resource
   ].freeze
 

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1071,6 +1071,7 @@ SecurityPolicyRuleController:
 - dynamic_date_refresh
 - dynamic_radio_button_refresh
 - dynamic_text_box_refresh
+- index
 - open_url_after_dialog
 - wait_for_task
 ServiceController:


### PR DESCRIPTION
Fixes: #7894 

Breadcrumbs are not working when click back on `Network Services` and `Security Policies`:
```
(1) Network/Network Services/aaa (Summary)
(2) Network/Security Policies/aaaa (Summary)
```
**Before:** 
![Screen Shot 2021-10-13 at 11 02 49 AM](https://user-images.githubusercontent.com/82469658/137160179-fb84571a-0d28-43a1-b0be-09792f099dad.png)

**After:**
<img width="1688" alt="Screen Shot 2021-10-13 at 10 41 08 AM" src="https://user-images.githubusercontent.com/82469658/137155905-a5d7a199-d788-4e0d-acfb-5de18682113f.png">

@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu
@miq-bot add-reviewer @kavyanekkalapu

