### PR TITLE
Fix detailed dialog page bug

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -174,7 +174,7 @@ class MiqAeCustomizationController < ApplicationController
       feature = "old_dialogs_accord"
     else
       klass = Dialog
-      feature = "dialogs_accord"
+      feature = "dialog_accord"
     end
     assert_privileges(feature)
 


### PR DESCRIPTION
Fixed a bug that was blocking the detailed service dialog page from displaying.

Before:
<img width="1293" alt="Screen Shot 2021-10-15 at 3 59 16 PM" src="https://user-images.githubusercontent.com/32444791/137546836-80df356a-ebcb-46ca-807b-aab2e231abac.png">

After:
<img width="1269" alt="Screen Shot 2021-10-15 at 3 57 26 PM" src="https://user-images.githubusercontent.com/32444791/137546896-1f21afde-df9b-407e-ac5e-b476eb7f3365.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug