### PR TITLE
Fix nav search-bar's close-button style

### DIFF
--- a/app/stylesheet/menu-colors.scss
+++ b/app/stylesheet/menu-colors.scss
@@ -14,6 +14,12 @@ $divider-fg: $disabled-02; // $carbon--gray-60;
 $find-bg: $carbon--gray-80;
 $find-placeholder-fg: $carbon--gray-50;
 
+$clear-btn-outline: $interactive-03;
+$clear-btn-fill: $ui-05;
+$clear-btn-background: $ui-01;
+$clear-btn-hover-background: $hover-ui;
+$clear-btn-active: $ui-02;
+
 // unused, theme default
 // $row-selected-border: $carbon--blue-60;
 
@@ -69,10 +75,38 @@ li.menu-group {
   .bx--search-input {
     background-color: $find-bg;
     color: $row-fg-text;
+    
+    &:focus~.bx--search-close:hover{
+      outline: 2px solid $clear-btn-outline;
+      outline-offset: -2px;
+    }
   }
 
-  .bx--search-close::before {
-    background-color: $find-bg;
+  button.bx--search-close {
+    fill: $clear-btn-fill;
+
+    &::before {
+      background-color: $clear-btn-background;
+    }
+  
+    &:hover {
+      background: $clear-btn-hover-background;
+    }
+
+    &:focus {
+      outline: 2px solid $clear-btn-outline;
+      outline-offset: -2px;
+      
+      &:before {
+        background-color: $clear-btn-outline;
+      }
+    }
+
+    &:active {
+      outline: 2px solid $clear-btn-outline;
+      outline-offset: -2px;
+      background-color: $clear-btn-active;
+    }
   }
 
   .bx--label {


### PR DESCRIPTION
Before
<img width="243" alt="image" src="https://user-images.githubusercontent.com/87487049/138401980-fdab9418-265c-46f5-aec0-73f9c7e2a0d3.png">

<img width="248" alt="image" src="https://user-images.githubusercontent.com/87487049/138401860-4f1c64d0-405b-4594-bb7f-9fbdff9f28fb.png">

After
<img width="241" alt="image" src="https://user-images.githubusercontent.com/87487049/138402151-b705a75a-7006-44f6-83aa-4d8f7f5fd4b3.png">

<img width="249" alt="image" src="https://user-images.githubusercontent.com/87487049/138401784-63adcd14-0f74-40d0-b6b1-1683f2d565c4.png">



@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label enhancement
@miq-bot assign @kavyanekkalapu 
