### PR TITLE
Add kebab menu for custom toolbars count

### DIFF
--- a/app/javascript/components/toolbar/ToolbarKebab.jsx
+++ b/app/javascript/components/toolbar/ToolbarKebab.jsx
@@ -1,0 +1,95 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  OverflowMenu,
+  SideNavMenu,
+  SideNavMenuItem,
+  SideNavDivider,
+  SideNavLink,
+  SideNavItems,
+} from 'carbon-components-react';
+import { ToolbarClick } from './ToolbarClick';
+
+const KebabListItem = (item, props) => {
+  if (item.type === 'separator') {
+    return <SideNavDivider key={item.id} />;
+  }
+
+  const ButtonIcon = () => (
+    <i className={item.icon || ''} style={{ color: item.color || '' }} />
+  );
+
+  if (item.type === 'buttonSelect') {
+    return (
+      <SideNavMenu
+        key={item.id}
+        renderIcon={ButtonIcon}
+        title={item.text || item.title}
+      >
+        { item.items.filter((i) => !i.hidden).map((i) => (
+          <SideNavMenuItem
+            key={i.id}
+            onClick={props.onClick && i.enabled ? (() => props.onClick(i)) : null}
+          >
+            <ToolbarClick {...i} />
+          </SideNavMenuItem>
+        )) }
+
+      </SideNavMenu>
+    );
+  }
+
+  return (
+    <SideNavLink onClick={item.onClick && item.enabled ? (() => item.onClick(item)) : null}><ToolbarClick key={item.id} {...item} /></SideNavLink>
+  );
+};
+
+KebabListItem.propTypes = {
+  item: PropTypes.arrayOf(PropTypes.any),
+  onClick: PropTypes.func.isRequired,
+};
+
+KebabListItem.defaultProps = {
+  item: null,
+};
+
+// eslint-disable-next-line no-unused-vars
+export const DropDownMenu = forwardRef((props, ref) => (
+  <SideNavItems className="button_groups">
+    {props.items.map((item) => KebabListItem(item, props))}
+  </SideNavItems>
+));
+
+DropDownMenu.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.any),
+};
+
+DropDownMenu.defaultProps = {
+  items: null,
+};
+
+export const ToolbarKebab = forwardRef((props, ref) => (
+  <div className="btn-group kebab">
+    <OverflowMenu ref={ref}>
+      <DropDownMenu {...props} ref={ref} />
+    </OverflowMenu>
+  </div>
+));
+
+ToolbarKebab.propTypes = {
+  id: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.any),
+  onClick: PropTypes.func.isRequired,
+  icon: PropTypes.string,
+  color: PropTypes.string,
+  text: PropTypes.string,
+  title: PropTypes.string,
+};
+
+ToolbarKebab.defaultProps = {
+  color: null,
+  text: null,
+  icon: null,
+  title: null,
+  items: null,
+};

--- a/app/javascript/spec/toolbar/toolbar.test.js
+++ b/app/javascript/spec/toolbar/toolbar.test.js
@@ -6,6 +6,7 @@ import { ToolbarButton } from '../../components/toolbar/ToolbarButton';
 import { ToolbarGroup } from '../../components/toolbar/Toolbar';
 import { ToolbarList } from '../../components/toolbar/ToolbarList';
 import { ToolbarView } from '../../components/toolbar/ToolbarView';
+import { ToolbarKebab } from '../../components/toolbar/ToolbarKebab';
 
 import toolbarData from './data/toolbar-big.json';
 import viewData from './data/toolbar-view.json';
@@ -93,5 +94,16 @@ describe('Toolbar', () => {
       count={0}
     />);
     expect(t.find(ToolbarList)).toHaveLength(10);
+  });
+
+  it('renders kebab buttons', () => {
+    const t = mount(<Toolbar
+      onClick={() => {}}
+      onViewClick={() => {}}
+      groups={toolbarData}
+      views={viewData}
+      count={0}
+    />);
+    expect(t.find(ToolbarKebab)).toHaveLength(1);
   });
 });

--- a/app/stylesheet/toolbar.scss
+++ b/app/stylesheet/toolbar.scss
@@ -129,7 +129,15 @@
       color: #c6c6c6;
       pointer-events: inherit;
     }
-    
+    .bx--side-nav__menu-item {
+      list-style: none;
+    }
+    .bx--side-nav__menu {
+      padding-left: 0px;
+    }
+    .bx--side-nav__item.bx--side-nav__item--icon a.bx--side-nav__link {
+      padding-left: 2rem;
+    }
 }
 
 .bx--overflow-menu-options[data-floating-menu-direction=bottom]::after {


### PR DESCRIPTION
Based on custom_button_count in advanced ui settings https://github.com/ManageIQ/manageiq-ui-classic/blob/c1fa26b793e35c9e641ebff98504ca10d746016f/app/helpers/application_helper.rb#L1353 we have to display custom button groups. 
For example , if custom_button_count =1, we can display one button group in main toolbar and others in kebab menu.

**Before**

<img width="1358" alt="Screen Shot 2021-10-27 at 1 27 01 PM" src="https://user-images.githubusercontent.com/37085529/139116165-436682ff-58a0-4107-8ff1-c2684fa4bf57.png">

**After**

<img width="1209" alt="Screen Shot 2021-10-27 at 11 29 21 AM" src="https://user-images.githubusercontent.com/37085529/139116144-f97cc5cf-9d17-423e-a353-0a8c07737ad2.png">
<img width="1179" alt="Screen Shot 2021-10-27 at 11 29 31 AM" src="https://user-images.githubusercontent.com/37085529/139116146-5d8d8bd7-78e4-4088-85eb-6bf39f553bfc.png">

@miq-bot add-label bug
@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 