### PR TITLE
Fix issue allowing users to select previous dates on retire form

### DIFF
--- a/app/javascript/components/retirement-form/helper.js
+++ b/app/javascript/components/retirement-form/helper.js
@@ -8,6 +8,16 @@ export const convertDate = (date, timezone) => {
   return moment(date).add({ minutes: browserOffset - miqOffset })._d;
 };
 
+export const datePassed = (retirementDate) => {
+  const retireDate = new Date(retirementDate);
+  const today = new Date();
+
+  if (retireDate <= today) {
+    return true;
+  }
+  return false;
+};
+
 // Convert date from UTC time to user's manageiq timezone
 export const getDateFromUTC = (retirementDate, timezone) => {
   const utcOffset = -1 * moment(retirementDate).utcOffset();

--- a/app/javascript/components/retirement-form/retirement-form.schema.js
+++ b/app/javascript/components/retirement-form/retirement-form.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 
-const createSchema = (showTimeField, setShowTimeField) => ({
+const createSchema = (showTimeField, setShowTimeField, showDateError) => ({
   fields: [{
     component: componentTypes.SUB_FORM,
     name: 'retirement-date-subform',
@@ -139,6 +139,14 @@ const createSchema = (showTimeField, setShowTimeField) => ({
         or: [{ when: 'formMode', is: 'delay' }, { when: 'retirementDate', isNotEmpty: true }],
       },
     },
+    ...(showDateError ? [
+      {
+        id: 'dateWarning',
+        component: componentTypes.PLAIN_TEXT,
+        name: 'dateWarning',
+        label: __('Invalid date selected.'),
+      },
+    ] : []),
     ],
   },
   ],

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -48,6 +48,11 @@
   font-size: 14px;
 }
 
+#dateWarning {
+  color: #da1e28;
+  font-size: 14px;
+}
+
 #dateInfo {
   margin-top: -25px;
   margin-bottom: 25px;


### PR DESCRIPTION
Fixes the issue of users being able to submit the retire form with a date in the past selected.


<img width="1361" alt="Screen Shot 2021-11-01 at 11 06 24 AM" src="https://user-images.githubusercontent.com/32444791/139693926-1db3b311-1c15-484e-b567-26612babc694.png">
<img width="1373" alt="Screen Shot 2021-11-01 at 11 06 46 AM" src="https://user-images.githubusercontent.com/32444791/139693968-79bf908f-cbb3-4bcf-aea7-e52cc7801f95.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug

