### PR TITLE
Add stylelint-scss

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,9 +1,14 @@
 {
   "defaultSeverity": "warning",
   "extends": ["stylelint-config-standard"],
+  "plugins": [
+    "stylelint-scss"
+  ],
   "rules": {
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": true,
+
     "color-hex-length": null,
     "shorthand-property-no-redundant-values": null
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "style-loader": "~1.1.3",
     "stylelint": "~13.5.0",
     "stylelint-config-standard": "~20.0.0",
+    "stylelint-scss": "^4.0.0",
     "webpack": "~4.42.0",
     "webpack-cli": "~3.3.11",
     "webpack-dev-server": "~3.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13884,6 +13884,7 @@ fsevents@^1.2.7:
     style-loader: ~1.1.3
     stylelint: ~13.5.0
     stylelint-config-standard: ~20.0.0
+    stylelint-scss: ^4.0.0
     table-resolver: ^4.1.1
     ui-select: 0.19.8
     webpack: ~4.42.0
@@ -16865,7 +16866,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2":
+"postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.6":
   version: 6.0.6
   resolution: "postcss-selector-parser@npm:6.0.6"
   dependencies:
@@ -20261,6 +20262,21 @@ resolve@1.1.7:
   peerDependencies:
     stylelint: ">=10.1.0"
   checksum: 04d1a7d17cbe41ed550eb61294ee6f98044ee5722b6bafd16c378a38067ae44deb575b056ab8369e9936934caf42044282ffe907e9b935660daddedc57a2a561
+  languageName: node
+  linkType: hard
+
+"stylelint-scss@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "stylelint-scss@npm:4.0.0"
+  dependencies:
+    lodash: ^4.17.15
+    postcss-media-query-parser: ^0.2.3
+    postcss-resolve-nested-selector: ^0.1.1
+    postcss-selector-parser: ^6.0.6
+    postcss-value-parser: ^4.1.0
+  peerDependencies:
+    stylelint: ^14.0.0
+  checksum: 98f835547b7f60dcd1f3725d4d67dafaae89fd38e7fb62fb59afba5e8511b8552ca658908ced7421a83b2a6ef4174f575625e4e56113ec9a54aa42435ceae5cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes about 18 warnings that center around at-rules that are scss
specific.
@kavyanekkalapu Please review.