### PR TITLE
Made retire form error string more informative

### DIFF
--- a/app/javascript/components/retirement-form/retirement-form.schema.js
+++ b/app/javascript/components/retirement-form/retirement-form.schema.js
@@ -144,7 +144,7 @@ const createSchema = (showTimeField, setShowTimeField, showDateError) => ({
         id: 'dateWarning',
         component: componentTypes.PLAIN_TEXT,
         name: 'dateWarning',
-        label: __('Invalid date selected.'),
+        label: __('Invalid date selected. Please select a future date.'),
       },
     ] : []),
     ],


### PR DESCRIPTION
Before:
<img width="886" alt="Screen Shot 2021-11-03 at 9 29 23 AM" src="https://user-images.githubusercontent.com/32444791/140069028-05bd22b1-18a4-4eb7-b2c3-8ed3a31e63c8.png">

After:
<img width="874" alt="Screen Shot 2021-11-03 at 9 32 36 AM" src="https://user-images.githubusercontent.com/32444791/140069441-9de1c51a-9bec-4d98-863c-32031ab849b9.png">

@miq-bot add_reviewer @kavyanekkalapu