### PR TITLE
Fixed bug with removing retirement date for multiple instances

### DIFF
--- a/app/javascript/components/retirement-form/index.jsx
+++ b/app/javascript/components/retirement-form/index.jsx
@@ -24,8 +24,10 @@ const RetirementForm = ({
     formMode, retirementDate, retirementTime, retirementWarning, days, weeks, months, hours,
   }) => {
     let NotEmpty = true;
-    if (retirementDate === []) {
-      NotEmpty = false;
+    if (Array.isArray(retirementDate)) {
+      if (retirementDate.length === 0) {
+        NotEmpty = false;
+      }
     }
 
     if ((retirementDate || formMode === 'delay') && NotEmpty) {


### PR DESCRIPTION
Fixed a bug with removing the retirement date of multiple vms at once.

**Before:**
<img width="880" alt="Screen Shot 2021-11-03 at 10 02 04 AM" src="https://user-images.githubusercontent.com/32444791/140081377-a2846f4d-e938-45f5-ace2-825789d333f2.png">
<img width="875" alt="Screen Shot 2021-11-03 at 10 02 44 AM" src="https://user-images.githubusercontent.com/32444791/140081371-4c650088-c559-4881-ab0f-e5de8dfc40ea.png">

**After:**
<img width="882" alt="Screen Shot 2021-11-03 at 9 59 28 AM" src="https://user-images.githubusercontent.com/32444791/140081489-8086a83c-7db0-416e-84d3-6bf8b159533b.png">
<img width="888" alt="Screen Shot 2021-11-03 at 10 01 11 AM" src="https://user-images.githubusercontent.com/32444791/140081444-a04bd863-b3a8-41c2-8f19-8f5318185c72.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug

