### PR TITLE
KWArgs Role

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -19,7 +19,7 @@ module OpsController::OpsRbac
       options[:feature] = MiqProductFeature.tenant_identifier(options[:feature], id)
     end
 
-    super(options)
+    super(**options)
   end
 
   # Edit user or group tags

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,7 +115,7 @@ module ApplicationHelper
       end
     end
 
-    Rbac.role_allows?(options.merge(:user => User.current_user)) rescue false
+    Rbac.role_allows?(:user => User.current_user, **options) rescue false
   end
 
   module_function :role_allows?

--- a/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
@@ -2,22 +2,31 @@ require 'spec_helper'
 
 describe ApplicationHelper::Button::CatalogItemButton do
   let(:session) { {} }
+  let(:user) { FactoryBot.create(:user) }
+  let(:view_context) { setup_view_context_with_sandbox({}).tap { |ctx| allow(ctx).to receive(:current_user).and_return(user) } }
+  let(:button) { described_class.new(view_context, {}, {}, {:child_id => "ab_button_new"}) }
+  let(:features) { %w[catalogitem_new catalogitem_edit atomic_catalogitem_new atomic_catalogitem_edit] }
+
   before do
-    @view_context = setup_view_context_with_sandbox({})
-    allow(@view_context).to receive(:current_user).and_return(FactoryBot.create(:user))
-    @button = described_class.new(@view_context, {}, {}, {:child_id => "ab_button_new"})
+    # all the button features need to be seeded
+    # otherwise our tests detect a potential issue
+    EvmSpecHelper.seed_specific_product_features(features)
+    login_as user
+    # current_user is actually passed in via button -> view_context -> current_user
+    # and not via User.current_user
   end
 
-  context "#role_allows_feature?" do
-    it "will be skipped" do
-      expect(@button.role_allows_feature?).to be false
+  describe "#role_allows_feature?" do
+    it "will deny access" do
+      expect(button.role_allows_feature?).to be false
     end
 
-    it "won't be skipped" do
-      EvmSpecHelper.seed_specific_product_features("catalogitem_new")
-      feature = MiqProductFeature.find_all_by_identifier(["everything"])
-      allow(@view_context).to receive(:current_user).and_return(FactoryBot.create(:user, :features => feature))
-      expect(@button.role_allows_feature?).to be true
+    context "with privileged user" do
+      let(:user) { FactoryBot.create(:user, :features => "catalogitem_new") }
+
+      it "will grant access" do
+        expect(button.role_allows_feature?).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
Depends upon:

- [x] https://github.com/ManageIQ/manageiq/pull/21548

For ruby 3.0, we need to be more explicit around keyword args.

Also following through on comment from [authorizer.rb](https://github.com/ManageIQ/manageiq/blob/a0625967a209c2abce9870af72f58700c5c8abfd/lib/rbac/authorizer.rb#L18-L21)

> The 'identifiers' option comes from the former User#role_allows_any? API
> It should be noted that there may be only ONE caller using 'identifiers'
> in Menu::Section, so this option may be changed shortly.

The code passed in multiple features via `identifiers: []`. If `identifiers` goes away,
then `Rbac.role_allows?` needs to accept `features: []`. The required PR in core makes this change
so we can avoid the `:identifiers` parameter.

What was done:

- convert hash syntax to kwargs (ruby 3.0)
- remove call to `User#role_allows_any?` and go through `Rbac#role_allows?`
- remove `identifiers:` and go with the `any: true, feature: []` syntax