### PR TITLE
Fixed generic objects form submit bug

### DIFF
--- a/app/javascript/components/generic-objects-form/helper.js
+++ b/app/javascript/components/generic-objects-form/helper.js
@@ -36,7 +36,7 @@ export const FileEditComponent = (props) => {
       <label className="bx--label" htmlFor={input.name}>{label}</label>
       <br />
       <div className="edit-div">
-        <img className="edit-image" alt={__("Uploaded Image")} id="imageDisplay" src={src} />
+        <img className="edit-image" alt={__('Uploaded Image')} id="imageDisplay" src={src} />
         <Button className="edit-button" renderIcon={TrashCan32} iconDescription={description} hasIconOnly onClick={deleteFile} {...input} />
       </div>
     </div>
@@ -48,20 +48,26 @@ export const uniqueNameValidator = (values) => {
   const errors = { attributes: [], associations: [], methods: [] };
   let result;
 
-  result = compare(values.attributes, 'attributes_name');
-  result.forEach((index) => {
-    errors.attributes[index] = { attributes_name: __('Name must be unique') };
-  });
+  if (values.attributes) {
+    result = compare(values.attributes, 'attributes_name');
+    result.forEach((index) => {
+      errors.attributes[index] = { attributes_name: __('Name must be unique') };
+    });
+  }
 
-  result = compare(values.associations, 'associations_name');
-  result.forEach((index) => {
-    errors.associations[index] = { associations_name: __('Name must be unique') };
-  });
+  if (values.associations) {
+    result = compare(values.associations, 'associations_name');
+    result.forEach((index) => {
+      errors.associations[index] = { associations_name: __('Name must be unique') };
+    });
+  }
 
-  result = compare(values.methods, 'methods_name');
-  result.forEach((index) => {
-    errors.methods[index] = { methods_name: __('Name must be unique') };
-  });
+  if (values.methods) {
+    result = compare(values.methods, 'methods_name');
+    result.forEach((index) => {
+      errors.methods[index] = { methods_name: __('Name must be unique') };
+    });
+  }
 
   return errors;
 };

--- a/app/javascript/components/generic-objects-form/index.jsx
+++ b/app/javascript/components/generic-objects-form/index.jsx
@@ -53,7 +53,7 @@ const GenericObjectForm = ({ recordId }) => {
   }, [recordId]);
 
   const onSubmit = (values, formApi) => {
-    promise.then(async ({ data: { allowed_association_types } }) => {
+    promise.then(async({ data: { allowed_association_types } }) => {
       // check to determine whether to delete or replace existing custom image
       if (values.file_upload) {
         const fileList = get(values, formApi.fileInputs[0]).inputFiles;
@@ -63,39 +63,44 @@ const GenericObjectForm = ({ recordId }) => {
 
       // modifies the attributes/methods data from the form to match what the API is expecting
       values.properties = { attributes: {}, associations: {}, methods: [] };
+      if (values.attributes) {
+        values.attributes.forEach((attr) => {
+          values.properties.attributes[attr.attributes_name] = attr.type;
+        });
+        delete values.attributes;
+      }
 
-      values.attributes.forEach((attr) => {
-        values.properties.attributes[attr.attributes_name] = attr.type;
-      });
+      if (values.methods) {
+        values.methods.forEach((method) => {
+          values.properties.methods.push(method.methods_name);
+        });
+        delete values.methods;
+      }
 
-      values.methods.forEach((method) => {
-        values.properties.methods.push(method.methods_name);
-      });
-
-      delete values.attributes;
-      delete values.methods;
       delete values.image_update;
       delete values.file_upload;
 
       // data in values.associations is handled differently when editing a generic object
       if (recordId) {
         API.get(`/api/generic_object_definitions/${recordId}?attributes=picture.image_href`).then((initialValues) => {
-          values.associations.forEach((association) => {
-            switch (typeof association.class) {
-              case 'object':
-                values.properties.associations[association.associations_name] = association.class.value;
-                break;
-              case 'undefined':
+          if (values.associations) {
+            values.associations.forEach((association) => {
+              switch (typeof association.class) {
+                case 'object':
+                  values.properties.associations[association.associations_name] = association.class.value;
+                  break;
+                case 'undefined':
                 // eslint-disable-next-line max-len
-                values.properties.associations[association.associations_name] = initialValues.properties.associations[association.associations_name];
-                break;
-              default:
-                values.properties.associations[association.associations_name] = Object.keys(allowed_association_types).find((key) =>
-                  allowed_association_types[key] === association.class.replace(/»/, '').replace(/«/, ''));
-            }
-          });
+                  values.properties.associations[association.associations_name] = initialValues.properties.associations[association.associations_name];
+                  break;
+                default:
+                  values.properties.associations[association.associations_name] = Object.keys(allowed_association_types).find((key) =>
+                    allowed_association_types[key] === association.class.replace(/»/, '').replace(/«/, ''));
+              }
+            });
+            delete values.associations;
+          }
 
-          delete values.associations;
           miqSparkleOn();
           const request = API.patch(`/api/generic_object_definitions/${recordId}`, values);
           request.then(() => {
@@ -104,11 +109,13 @@ const GenericObjectForm = ({ recordId }) => {
           }).catch(miqSparkleOff);
         });
       } else {
-        values.associations.forEach((association) => {
-          values.properties.associations[association.associations_name] = association.class.value;
-        });
+        if (values.associations) {
+          values.associations.forEach((association) => {
+            values.properties.associations[association.associations_name] = association.class.value;
+          });
 
-        delete values.associations;
+          delete values.associations;
+        }
 
         miqSparkleOn();
         const request = API.post('/api/generic_object_definitions', values);


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/7951

The generic objects form would not submit unless it had at least 1 of each attribute, association and method. This issue is fixed and the form can now be submitted with 0 attributes, associations or methods.

Before:
<img width="1261" alt="Screen Shot 2021-11-10 at 4 19 58 PM" src="https://user-images.githubusercontent.com/32444791/141195211-837e6d7d-f1ed-476c-8184-4a1d4834e861.png">
<img width="931" alt="Screen Shot 2021-11-10 at 4 19 45 PM" src="https://user-images.githubusercontent.com/32444791/141195214-44c29204-352b-4ae7-b2da-9a37b83c57f2.png">

After:
https://user-images.githubusercontent.com/32444791/141196145-0f94dc5f-b1a5-4db8-a251-57cef68b15f4.mov




@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug