### PR TITLE
Use `.providers_supporting` from SupportsFeatureMixin

### DIFF
--- a/app/controllers/host_aggregate_controller.rb
+++ b/app/controllers/host_aggregate_controller.rb
@@ -28,9 +28,8 @@ class HostAggregateController < ApplicationController
     @host_aggregate = HostAggregate.new
     @in_a_form = true
 
-    supported_types = HostAggregate.descendants.select { |klass| klass.supports?(:create) }.map(&:module_parent).map(&:name)
     @ems_choices = Rbac::Filterer.filtered(
-      ManageIQ::Providers::CloudManager.where(:type => supported_types)
+      ManageIQ::Providers::CloudManager.where(:type => HostAggregate.providers_supporting(:create))
     ).pluck(:name, :id).to_h
 
     drop_breadcrumb(

--- a/app/helpers/application_helper/button/auth_key_pair_cloud_create.rb
+++ b/app/helpers/application_helper/button/auth_key_pair_cloud_create.rb
@@ -2,8 +2,7 @@ class ApplicationHelper::Button::AuthKeyPairCloudCreate < ApplicationHelper::But
   def disabled?
     # check that at least one EMS the user has access to supports
     # creation or import of key pairs.
-    supported_types = ManageIQ::Providers::CloudManager::AuthKeyPair.descendants.select { |klass| klass.supports?(:create) }.map(&:module_parent).map(&:name)
-    return false if Rbac.filtered(ManageIQ::Providers::CloudManager.where(:type => supported_types)).any?
+    return false if Rbac.filtered(ManageIQ::Providers::CloudManager::AuthKeyPair.providers_supporting(:create)).any?
 
     @error_message = _('No cloud providers support key pair import or creation.')
     @error_message.present?

--- a/app/helpers/application_helper/button/new_host_aggregate.rb
+++ b/app/helpers/application_helper/button/new_host_aggregate.rb
@@ -1,7 +1,6 @@
 class ApplicationHelper::Button::NewHostAggregate < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    supported_types = HostAggregate.descendants.select { |klass| klass.supports?(:create) }.map(&:module_parent).map(&:name)
-    Rbac::Filterer.filtered(ManageIQ::Providers::CloudManager.where(:type => supported_types)).any?
+    Rbac::Filterer.filtered(HostAggregate.providers_supporting(:create)).any?
   end
 
   def disabled?


### PR DESCRIPTION
Cleanup the `.descendants.select { |klass| klass.supports?(:create) }` calls to use the new  `providers_supporting` call added to SupportsFeatureMixin.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21553