### PR TITLE
Fix vms table os  column image

### DIFF
--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -125,13 +125,15 @@ class GtlFormatter
                 :text  => text}.compact
       elsif COLUMN_WITH_TIME.include?(col)
         celltext = format_time_for_display(row, col)
-      elsif COLUMN_WITH_OS_ICON.key?(col)
-        @osicon = send(COLUMN_WITH_OS_ICON[col], record)
-        @ostext = format_col_for_display(view, row, col).presence || _("Unknown")
       elsif COLUMN_WITH_OS_TEXT.include?(col)
+        osicon_col = view.col_order.detect { |c| COLUMN_WITH_OS_ICON.key?(c) }
+        if osicon_col
+          osicon = send(COLUMN_WITH_OS_ICON[osicon_col], record)
+          ostext = format_col_for_display(view, row, osicon_col).presence || _("Unknown")
+        end
         name = format_col_for_display(view, row, col)
-        text = name.presence || @ostext
-        image = @osicon || ''
+        text = name.presence || ostext
+        image = osicon || ''
         item = {:title => text,
                 :image => ActionController::Base.helpers.image_path(image.to_s),
                 :text  => text}.compact


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7962

**Before**

<img width="1258" alt="Screen Shot 2021-11-17 at 12 11 59 PM" src="https://user-images.githubusercontent.com/37085529/142248655-1c596f13-0f55-45d5-8667-ccf465e3d485.png">

**After**
<img width="1340" alt="Screen Shot 2021-11-17 at 12 09 23 PM" src="https://user-images.githubusercontent.com/37085529/142248256-7c7dde11-78e4-407b-a714-884ea41ecd88.png">

@miq-bot assign @Fryguy 
@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 
