### PR TITLE
setting host-initiator-groups breadcrumb to Host Initiator Groups

### DIFF
--- a/app/controllers/host_initiator_group_controller.rb
+++ b/app/controllers/host_initiator_group_controller.rb
@@ -37,7 +37,7 @@ class HostInitiatorGroupController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Storage")},
-        {:title => _("Hosts Cluster Initiators"), :url => controller_url},
+        {:title => _("Host Initiator Groups"), :url => controller_url},
       ],
     }
   end


### PR DESCRIPTION
MIQ team have found an incorrect text in one of our breadcrumbs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/7881#issuecomment-965272731

The section is Host Initiator Groups. The bread crumb incorrectly says Hosts Cluster Initiators.

