### PR TITLE
Fix generic objects view filter

### DIFF
--- a/app/views/layouts/_center_div_with_listnav.html.haml
+++ b/app/views/layouts/_center_div_with_listnav.html.haml
@@ -9,22 +9,41 @@
           = render :partial => "/layouts/tabs"
         = miq_toolbar toolbar_from_hash
   %div{:class => "row max-height content-focus-order #{left_div_classname}"}
-    .col-sm-12.col-md-12.col-sm-push-12.col-md-push-3.max-height
-      #main-content.row.miq-layout-center_div_with_listnav
-        .col-md-12
-          .row
-            .col-md-5
-              - if layout_uses_tabs?
-                = render :partial => 'layouts/tabs'
-            .col-md-4
-              - if filters_present?
+    - if !controller.respond_to?(:display_tree)
+      .col-sm-12.col-md-12.col-sm-push-12.col-md-push-3.max-height
+        #main-content.row.miq-layout-center_div_with_listnav
+          .col-md-12
+            .row
+              .col-md-5
+                - if layout_uses_tabs?
+                  = render :partial => 'layouts/tabs'
+              .col-md-4
+                - if filters_present?
+                  %br
+                  = react('FilterDropdown', :defSearches => @def_searches, :mySearches => @my_searches,
+                   :filterSelected => 'listnav_search_selected', :defaultSelected => 'save_default_search', :selectedFilter => @selected_filter)
+              .col-md-3
                 %br
-                = react('FilterDropdown', :defSearches => @def_searches, :mySearches => @my_searches,
-                 :filterSelected => 'listnav_search_selected', :defaultSelected => 'save_default_search', :selectedFilter => @selected_filter)
-            .col-md-3
-              %br
-              = render :partial => 'layouts/searchbar'
-          .row
-            .col-md-12
-              = yield
-      .row#paging_div{:style => @in_a_form ? '' : 'display: none'}
+                = render :partial => 'layouts/searchbar'
+            .row
+              .col-md-12
+                = yield
+        .row#paging_div{:style => @in_a_form ? '' : 'display: none'}
+    - else
+      .col-sm-4.col-md-3.col-sm-pull-8.col-md-pull-9.sidebar-pf.sidebar-pf-left.max-height
+        -# listnav_div
+        = render :partial => "layouts/listnav"
+      .col-sm-8.col-md-9.col-sm-push-4.col-md-push-3.max-height
+        #main-content.row.miq-layout-center_div_with_listnav
+          .col-md-12
+            .row
+              .col-md-7
+                - if layout_uses_tabs?
+                  = render :partial => 'layouts/tabs'
+              .col-md-5
+                %br
+                = render :partial => 'layouts/searchbar'
+            .row
+              .col-md-12
+                = yield
+        .row#paging_div{:style => @in_a_form ? '' : 'display: none'}


### PR DESCRIPTION
Issue caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/7953

**Before** 
Filter is not working.

<img width="1394" alt="Screen Shot 2021-11-22 at 9 08 09 AM" src="https://user-images.githubusercontent.com/37085529/142875831-3c471be1-7b24-44f0-b1b7-3f36fc14437a.png">

**After**

<img width="1628" alt="Screen Shot 2021-11-19 at 9 21 32 PM" src="https://user-images.githubusercontent.com/37085529/142875521-b963d412-ca25-4849-b2e8-294055590cc3.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug