### PR TITLE
Use the group_levels method since the constant was removed

### DIFF
--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -81,7 +81,7 @@ module ApplicationController::Timelines
     end
 
     def group_levels
-      EmsEvent::GROUP_LEVELS
+      EmsEvent.group_levels
     end
   end
 


### PR DESCRIPTION
Broken by https://github.com/ManageIQ/manageiq/pull/21569

The constant was defined in the base class, but was actually an EmsEvent concern
so this was moved to a method for subclasses to override.