### PR TITLE
Remove patternfly-react references in button form and test files.

### DIFF
--- a/app/javascript/components/fonticon-picker/index.jsx
+++ b/app/javascript/components/fonticon-picker/index.jsx
@@ -1,9 +1,6 @@
 import React, { useState } from 'react';
-import {
-  Button,
-  ButtonGroup,
-  Icon,
-} from 'patternfly-react';
+import { Button } from 'carbon-components-react';
+import { ChevronDown32 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -33,14 +30,9 @@ const FontIconPicker = ({ iconTypes, selected, onChangeURL }) => {
 
   return (
     <div className="fonticon-picker">
-      <ButtonGroup>
-        <Button className="icon-picker-btn" onClick={show}>
-          { selectedIcon ? (<i id="selected-icon" className={classNames('fa-lg', selectedIcon)} />) : __('No icon') }
-        </Button>
-        <Button onClick={show}>
-          <Icon type="fa" name="angle-down" />
-        </Button>
-      </ButtonGroup>
+      <Button onClick={show} kind="tertiary" renderIcon={ChevronDown32} className="icon-button">
+        { selectedIcon ? (<i id="selected-icon" className={classNames('fa-lg', selectedIcon)} />) : __('No icon') }
+      </Button>
       <IconModal
         showModal={showModal}
         hide={hide}

--- a/app/javascript/spec/async-credentials/edit-password-field.spec.js
+++ b/app/javascript/spec/async-credentials/edit-password-field.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
-import { HelpBlock } from 'patternfly-react';
 import EditPasswordField from '../../components/async-credentials/edit-password-field';
+import HelperTextBlock from '../../forms/helper-text-block';
 
 jest.mock('@@ddf', () => ({
   useFieldApi: props => ({ meta: {}, input: {}, ...props }),
@@ -28,7 +28,7 @@ describe('Edit secret field form component', () => {
   it('should render correctly in error state', () => {
     initialProps.meta = { error: 'error message' };
     const wrapper = mount(<EditPasswordField {...initialProps} />);
-    expect(wrapper.find(HelpBlock)).toBeTruthy();
+    expect(wrapper.find(HelperTextBlock)).toBeTruthy();
   });
 
   it('should call setEditMode on input button click', () => {


### PR DESCRIPTION
**$ git grep patternfly-react**
```
app/javascript/components/fonticon-picker/index.jsx:6:} from 'patternfly-react';
app/javascript/spec/async-credentials/edit-password-field.spec.js:4:import { HelpBlock } from 'patternfly-react';
config/webpack/shared.js:33:  'patternfly-react',
package.json:85:    "patternfly-react": "2.39.14",
yarn.lock:13851:    patternfly-react: 2.39.14
yarn.lock:16170:"patternfly-react@npm:2.39.14":
yarn.lock:16172:  resolution: "patternfly-react@npm:2.39.14"
```

Below items are handled in PR https://github.com/ManageIQ/manageiq-ui-classic/pull/7967
```
app/javascript/components/data-tables/gtl/utils.js:9:} from 'patternfly-react';
app/javascript/components/report-data-table.jsx:17:} from 'patternfly-react';
app/javascript/spec/report-data-table.spec.js:5:import { EmptyState, Paginator, Table } from 'patternfly-react';
```

**Fonticon-picker in Button Form Page**
Before
<img width="1536" alt="Screenshot 2021-11-22 at 3 20 17 PM" src="https://user-images.githubusercontent.com/87487049/142966395-18f57b88-2a9b-4935-939f-8384b2d0c33f.png">
After
<img width="1539" alt="image" src="https://user-images.githubusercontent.com/87487049/142966748-d8074368-b8f3-4079-a3f3-73448a1ed2ba.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label enhancement
@miq-bot assign @kavyanekkalapu 
