### PR TITLE
drop role_allows helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,8 +120,6 @@ module ApplicationHelper
 
   module_function :role_allows?
   public :role_allows?
-  alias_method :role_allows, :role_allows?
-  Vmdb::Deprecation.deprecate_methods(self, :role_allows => :role_allows?)
 
   # NB: This differs from controller_for_model; until they're unified,
   # make sure you have the right one.

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -66,9 +66,9 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_child_orchestration_stack
     num = @record.number_of(:children)
-    if num == 1 && role_allows(:feature => "orchestration_stack_show")
+    if num == 1 && role_allows?(:feature => "orchestration_stack_show")
       @record.children.first
-    elsif num > 1 && role_allows(:feature => "orchestration_stack_show_list")
+    elsif num > 1 && role_allows?(:feature => "orchestration_stack_show_list")
       h         = {:label => _("Child Orchestration Stacks"), :icon => "ff ff-stack", :value => num}
       h[:link]  = url_for_only_path(:action => 'show', :id => @record.id, :display => 'children')
       h[:title] = _("Show all Child Orchestration Stacks")


### PR DESCRIPTION
This was deprecated in 2016, removing the last call to the old format

pulled this out of https://github.com/ManageIQ/manageiq-ui-classic/pull/7949

@fryguy you already reviewed this [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/7949#discussion_r744937247). pulling out since it is not role related