### PR TITLE
Volume mapping can now be done for Host Initiator Groups

### DIFF
--- a/app/javascript/components/volume-mapping-form/index.jsx
+++ b/app/javascript/components/volume-mapping-form/index.jsx
@@ -10,6 +10,7 @@ const VolumeMappingForm = ({ redirect }) => {
   const [storageId, setStorageId] = useState(undefined);
   const [volumeId, setVolumeId] = useState(undefined);
   const [hostInitiatorId, setHostInitiatorId] = useState(undefined);
+  const [hostInitiatorGroupId, setHostInitiatorGroupId] =  useState(undefined);
 
   const onSubmit = async(values) => {
     miqSparkleOn();
@@ -25,7 +26,7 @@ const VolumeMappingForm = ({ redirect }) => {
 
   return (
     <MiqFormRenderer
-      schema={createSchema(emsId, setEmsId, storageId, setStorageId, volumeId, setVolumeId, hostInitiatorId, setHostInitiatorId)}
+      schema={createSchema(emsId, setEmsId, storageId, setStorageId, volumeId, setVolumeId, hostInitiatorId, setHostInitiatorId, hostInitiatorGroupId, setHostInitiatorGroupId)}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq-providers-autosde/issues/116
Needs to be merged after https://github.com/ManageIQ/manageiq-providers-autosde/pull/117

When creating a volume mapping the user can now either map to a Host Initiator as before or to a group.
![image](https://user-images.githubusercontent.com/68283004/144847844-6305a2c8-0e57-41d0-80f0-801478fac326.png)