### PR TITLE
[WIP] add end2end test for create ph_storage

### DIFF
--- a/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
+++ b/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
@@ -55,6 +55,8 @@ describe('Physical storage form component', () => {
       {"id":"2","name":"xiv","version":"1.1","ems_id":"2","ems_ref":"b91e94ab-8056-4c61-bec6-00430e9c1e4c","created_at":"2021-08-29T10:40:21Z","updated_at":"2021-08-29T10:40:21Z"}
     ]};
 
+  const create_ph_storage_hash = require('../../../../spec/javascripts/fixtures/json/physical_storage.json');
+
   beforeEach(() => {
 
   });
@@ -64,8 +66,20 @@ describe('Physical storage form component', () => {
     fetchMock.restore();
   });
 
+  // this will check the create physical storage form fields against the end2end json file containing the required values
   it('should render adding form variant', (done) => {
     const wrapper = shallow(<PhysicalStorageForm />);
+
+    let ph_storage_fields_arr = toJson(wrapper)["props"]["schema"]["fields"]
+    let parsed_ph_storage_fields_arr = []
+    for (var i = 0; i < ph_storage_fields_arr.length; i++) {
+      parsed_ph_storage_fields_arr.push(ph_storage_fields_arr[i]["name"])
+    }
+
+    let required_create_ph_storage_fields = Object.keys(create_ph_storage_hash)
+    for (var i = 0; i < required_create_ph_storage_fields.length; i++) {
+      expect(parsed_ph_storage_fields_arr.includes(required_create_ph_storage_fields[i])).toBe(true);
+    }
 
     setImmediate(() => {
       wrapper.update();

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 describe PhysicalStorageController do
   render_views
 
@@ -12,6 +14,18 @@ describe PhysicalStorageController do
     EvmSpecHelper.local_miq_server
     EvmSpecHelper.create_guid_miq_server_zone
     login_as FactoryBot.create(:user)
+  end
+
+  it "compare end2end create physical storage hash" do
+    end2end_json_path = Rails.root.join("spec", "fixtures", "end2end", "physical_storage.json").to_s
+    end2end_json_file = File.read(end2end_json_path)
+    end2end_create_ph_storage_hash = JSON.parse(end2end_json_file)
+
+    ui_classic_json_path = File.join(File.dirname(__FILE__), '../javascripts/fixtures/json/physical_storage.json')
+    ui_classic_json_file = File.read(ui_classic_json_path)
+    ui_classic_create_ph_storage_hash = JSON.parse(ui_classic_json_file)
+
+    expect(end2end_create_ph_storage_hash).to eq(ui_classic_create_ph_storage_hash)
   end
 
   describe "#show_list" do

--- a/spec/controllers/physical_storage_controller_spec.rb
+++ b/spec/controllers/physical_storage_controller_spec.rb
@@ -17,15 +17,15 @@ describe PhysicalStorageController do
   end
 
   it "compare end2end create physical storage hash" do
-    end2end_json_path = Rails.root.join("spec", "fixtures", "end2end", "physical_storage.json").to_s
-    end2end_json_file = File.read(end2end_json_path)
-    end2end_create_ph_storage_hash = JSON.parse(end2end_json_file)
+    autosde_provider_json_path = File.join(ManageIQ::Providers::Autosde::Engine.root, 'spec', 'fixtures', 'json', 'physical_storage.json')
+    autosde_provider_json_file = File.read(autosde_provider_json_path)
+    autosde_provider_create_ph_storage_hash = JSON.parse(autosde_provider_json_file)
 
-    ui_classic_json_path = File.join(File.dirname(__FILE__), '../javascripts/fixtures/json/physical_storage.json')
+    ui_classic_json_path = File.join(ManageIQ::UI::Classic::Engine.root, 'spec', 'javascripts', 'fixtures', 'json', 'physical_storage.json')
     ui_classic_json_file = File.read(ui_classic_json_path)
     ui_classic_create_ph_storage_hash = JSON.parse(ui_classic_json_file)
 
-    expect(end2end_create_ph_storage_hash).to eq(ui_classic_create_ph_storage_hash)
+    expect(autosde_provider_create_ph_storage_hash).to eq(ui_classic_create_ph_storage_hash)
   end
 
   describe "#show_list" do

--- a/spec/javascripts/fixtures/json/physical_storage.json
+++ b/spec/javascripts/fixtures/json/physical_storage.json
@@ -1,0 +1,7 @@
+{
+  "name"                       : "svc-178",
+  "password"                   : "<password>",
+  "user"                       : "<user>",
+  "physical_storage_family_id" : 123,
+  "management_ip"              : "9.151.159.178"
+}


### PR DESCRIPTION
Since MIQ has no system-tests, we have been toying with an idea of simulating system tests by stitching unit tests back-to-back.

below are a set of PR with a very basic POC demonstrating the idea.
https://github.com/ManageIQ/manageiq/pull/21622
https://github.com/ManageIQ/manageiq-providers-autosde/pull/122
https://github.com/ManageIQ/manageiq-ui-classic/pull/7993


general outline of the approach
------------
Usually when someone submits a PR, they only run unit-tests in the repo that they changed. However, the change might affect flows in other repositories. 
In the POC we have a scenario where we create a new Physical Storage. It involves filling a JS form. The data from the form is submitted through the API to the appropriate create method in the backend, and the backend sends a request to the EMS. 
To cover this scenario we would write two tests. 
One in the UI would check that the form’s state matches what we need to send to the API. 
In the backend, we’d check that calling the create method of the controller with the correct parameters results in the correct API calls to the EMS. 
This would cover the end-to-end scenario but have a problem. 
If anyone were to change the backend, they’d adjust the tests for the backend but would not know to adjust the complementary tests for the UI. The two tests covering the scenario would drift apart over time and no longer cover a coherent flow. 
To overcome this, we couple the backend test to the UI form test through a separate set of tests. It these meta-tests make sure that the UI test’s state matches the input to the backend test. 
This way if anyone changes either the backend or the UI they will need to make sure the entire scenario still works. 

