### PR TITLE
Fixed values_at bug

### DIFF
--- a/app/helpers/textual_listview.rb
+++ b/app/helpers/textual_listview.rb
@@ -11,6 +11,7 @@ TextualListview = Struct.new(:title, :headers, :col_order, :value) do
   end
 
   def self.new_from_hash(h)
+    h ||= {:title => "Variables", :headers => ["Name", "Value"], :col_order => ["name", "value"], :value => []}
     new(*h.values_at(*members))
   end
 

--- a/app/javascript/react/table_list_view_wrapper.js
+++ b/app/javascript/react/table_list_view_wrapper.js
@@ -1,8 +1,15 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import { TableListView } from '../components/textual_summary';
 import textualSummaryGenericClick from './textual_summary_click';
 
 export default (props) => {
+  // eslint-disable-next-line react/destructuring-assignment
   const onClick = props.onClick || textualSummaryGenericClick;
+  const { title, headers, values } = props;
+
+  if (title === null || headers === null || values === null) {
+    return null;
+  }
   return <TableListView onClick={onClick} {...props} />;
 };


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq/issues/21626

Added nil check to prevent error when the template summary page encounters a template with no variables.

Template page with variables:
<img width="1208" alt="Screen Shot 2021-12-22 at 2 09 45 PM" src="https://user-images.githubusercontent.com/32444791/147156231-9b122345-6975-419b-8147-2b602ed68e2f.png">

New template page for templates with no variables:
<img width="1101" alt="Screen Shot 2021-12-22 at 3 53 29 PM" src="https://user-images.githubusercontent.com/32444791/147156199-07693616-fed5-43a5-9969-99897ee8889d.png">


@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label bug