### PR TITLE
show only relevant info in host-init-group field under volume-mapping

### DIFF
--- a/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
+++ b/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
@@ -33,11 +33,11 @@ const loadHostInitiators = (storage_id) =>
     })));
 
 const loadHostInitiatorGroups = (storage_id) =>
-  API.get(`/api/host_initiator_groups/?expand=resources&attributes=id,name&filter[]=physical_storage.id=${storage_id}`)
-    .then(({ resources }) => resources.map(({ name, id }) => ({
-      label: name,
-      value: id,
-    })));
+  API.get(`/api/host_initiators/?expand=resources&attributes=host_cluster_name,host_initiator_group_id&filter[]=host_initiator_group_id!=null&filter[]=physical_storage.id=${storage_id}`)
+    .then(({ resources }) => [...new Map(resources.map((item) => [item.host_initiator_group_id, ({
+      label: item.host_cluster_name,
+      value: item.host_initiator_group_id,
+    })])).values()]);
 
 const createSchema = (emsId, setEmsId, storageId, setStorageId, volumeId, setVolumeId,
   hostInitiatorId, setHostInitiatorId, hostInitiatorGroupId, setHostInitiatorGroupId) => ({
@@ -112,6 +112,7 @@ const createSchema = (emsId, setEmsId, storageId, setStorageId, volumeId, setVol
       id: 'host_initiator_group_id',
       label: __('Host Initiator Group:'),
       isRequired: true,
+      helperText: __("Note! Volume can't be mapped to an empty host-initiator-group (host-cluster). Empty host-initiator-groups are not listed."),
       includeEmpty: true,
       validate: [{ type: validatorTypes.REQUIRED }],
       loadOptions: () => (storageId ? loadHostInitiatorGroups(storageId) : Promise.resolve([])),


### PR DESCRIPTION
Volume can't be mapped to an empty host-initiator-group (host-cluster). In this PR I did the required changes so only optional host-initiator-groups are listed when mapping a new volume to an host-initiator-group. 
Empty host-initiator-groups are therefore not listed.

in the images below you can see that empty host-initiator-groups are not listed in the selection field:

![image](https://user-images.githubusercontent.com/53213107/147066349-e365fed6-7a1b-4057-906b-4b2eedc03193.png)

![image](https://user-images.githubusercontent.com/53213107/147066495-1a0f0d43-16a6-406c-984e-8bacac4fd434.png)
