### PR TITLE
Hide search bar in summary page

### DIFF
--- a/app/views/layouts/_x_adv_searchbox.html.haml
+++ b/app/views/layouts/_x_adv_searchbox.html.haml
@@ -1,3 +1,4 @@
 -# If set, don't show advanced search and add nameonly class to name fields
 - nameonly ||= false
-= react('SearchBar', :searchText => @search_text, :action => 'x_search_by_name', :advancedSearch => !nameonly)
+#adv_searchbox_div{:style => "display: none;"}
+    = react('SearchBar', :searchText => @search_text, :action => 'x_search_by_name', :advancedSearch => !nameonly)


### PR DESCRIPTION
Search bar was visible in few summary pages.

**Before**
![image](https://user-images.githubusercontent.com/87487049/147946028-6406e436-4ca9-48e3-a197-6bac64fe3958.png)
![image](https://user-images.githubusercontent.com/87487049/147946041-88db26bf-bcca-4f9a-ad95-899217069af7.png)

**After**
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/147946148-fb930c70-c4d7-476a-9cbd-a31c7b7c2c8c.png">
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/147946190-ce77ac5e-6c45-4478-944e-f356356d5b7f.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 
