### PR TITLE
Hiding search box in summary pages

### DIFF
--- a/app/views/layouts/_searchbar.html.haml
+++ b/app/views/layouts/_searchbar.html.haml
@@ -1,3 +1,4 @@
 - if @lastaction == 'show_list' && !session[:menu_click] && !@in_a_form
   = render :partial => 'layouts/quick_search' if display_adv_search?
-  = react('SearchBar', :searchText => @search_text, :action => 'show_list', :advancedSearch => display_adv_search?)
+  #searchbox
+    = react('SearchBar', :searchText => @search_text, :action => 'show_list', :advancedSearch => display_adv_search?)


### PR DESCRIPTION
Searchbox was visible in summary page 

Before
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/148066027-658da3d3-7b76-4006-9eea-192037453beb.png">

After
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/148066333-93b67ba6-1cb4-4bd3-8873-c9ec8dd9c7a4.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 