### PR TITLE
Add miq_global.js dependency for ManageIQ variable.

### DIFF
--- a/app/javascript/oldjs/i18n.js
+++ b/app/javascript/oldjs/i18n.js
@@ -1,6 +1,7 @@
 require('./locale/');
 require('gettext_i18n_rails_js/vendor/assets/javascripts/gettext/jed.js');
 require('gettext_i18n_rails_js/lib/assets/javascripts/gettext/all.js');
+require('./miq_global.js');
 
 $(function() {
   // set in layouts/i18n_js

--- a/app/javascript/oldjs/jquery_overrides.js
+++ b/app/javascript/oldjs/jquery_overrides.js
@@ -1,3 +1,5 @@
+require('./miq_global.js');
+
 window.logError = function(fn) {
   return function(text) {
     try {

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -3,6 +3,8 @@
 // MIQ specific JS functions
 
 // Things to be done on page loads
+require('./miq_global.js');
+
 window.miqOnLoad = function() {
   // controller to be used in url in miqDropComplete method
   ManageIQ.widget.dashboardUrl = 'dashboard/widget_dd_done';


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/8008

For WEBMKS, We are directly calling i18n.js without calling oldjs/application.js ( https://github.com/ManageIQ/manageiq-ui-classic/blob/83070ce0a3b7db143f9ea5ffa7ff9f37b5ce4f45/app/javascript/packs/remote_consoles_vnc.js#L3) 

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug