### PR TITLE
fixing edit hidden field initial value

### DIFF
--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -63,6 +63,7 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         id: 'edit',
         label: 'edit',
         hideField: true,
+        initialValue: '',
       },
       {
         component: componentTypes.CHECKBOX,

--- a/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
+++ b/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
@@ -67,6 +67,7 @@ exports[`Physical storage form component should render adding form variant 1`] =
           "component": "text-field",
           "hideField": true,
           "id": "edit",
+          "initialValue": "",
           "label": "edit",
           "name": "edit",
         },
@@ -246,6 +247,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
               "component": "text-field",
               "hideField": true,
               "id": "edit",
+              "initialValue": "",
               "label": "edit",
               "name": "edit",
             },
@@ -440,6 +442,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                 "component": "text-field",
                 "hideField": true,
                 "id": "edit",
+                "initialValue": "",
                 "label": "edit",
                 "name": "edit",
               },
@@ -626,6 +629,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                   "component": "text-field",
                   "hideField": true,
                   "id": "edit",
+                  "initialValue": "",
                   "label": "edit",
                   "name": "edit",
                 },
@@ -817,6 +821,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                     component="text-field"
                     hideField={true}
                     id="edit"
+                    initialValue=""
                     label="edit"
                     name="edit"
                   />,
@@ -980,6 +985,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                       "component": "text-field",
                       "hideField": true,
                       "id": "edit",
+                      "initialValue": "",
                       "label": "edit",
                       "name": "edit",
                     },
@@ -1146,6 +1152,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                       component="text-field"
                       hideField={true}
                       id="edit"
+                      initialValue=""
                       label="edit"
                       name="edit"
                     />,
@@ -1315,6 +1322,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                         "component": "text-field",
                         "hideField": true,
                         "id": "edit",
+                        "initialValue": "",
                         "label": "edit",
                         "name": "edit",
                       },
@@ -1496,6 +1504,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                         component="text-field"
                         hideField={true}
                         id="edit"
+                        initialValue=""
                         label="edit"
                         name="edit"
                       />,
@@ -1665,6 +1674,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                           "component": "text-field",
                           "hideField": true,
                           "id": "edit",
+                          "initialValue": "",
                           "label": "edit",
                           "name": "edit",
                         },
@@ -2306,6 +2316,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                           component="text-field"
                           hideField={true}
                           id="edit"
+                          initialValue=""
                           key="edit"
                           label="edit"
                           name="edit"
@@ -2315,6 +2326,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                               Object {
                                 "component": "text-field",
                                 "id": "edit",
+                                "initialValue": "",
                                 "label": "edit",
                                 "name": "edit",
                               }
@@ -2329,6 +2341,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 <TextField
                                   component="text-field"
                                   id="edit"
+                                  initialValue=""
                                   label="edit"
                                   name="edit"
                                 >
@@ -3699,6 +3712,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                   component="text-field"
                                   hideField={true}
                                   id="edit"
+                                  initialValue=""
                                   label="edit"
                                   name="edit"
                                 />,
@@ -3851,7 +3865,9 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 },
                                 "hasSubmitErrors": false,
                                 "hasValidationErrors": false,
-                                "initialValues": Object {},
+                                "initialValues": Object {
+                                  "edit": "",
+                                },
                                 "invalid": false,
                                 "modified": Object {},
                                 "modifiedSinceLastSubmit": false,
@@ -3864,7 +3880,9 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 "touched": Object {},
                                 "valid": true,
                                 "validating": false,
-                                "values": Object {},
+                                "values": Object {
+                                  "edit": "",
+                                },
                                 "visited": Object {},
                               }
                             }
@@ -3927,6 +3945,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                     "component": "text-field",
                                     "hideField": true,
                                     "id": "edit",
+                                    "initialValue": "",
                                     "label": "edit",
                                     "name": "edit",
                                   },


### PR DESCRIPTION
some fields are missing **only in Morphy version (Not in master)** when trying to create new physical storage.

in M release
-------------
![image](https://user-images.githubusercontent.com/53213107/149139003-4fc447e9-0642-4985-b0e5-4584b5e83257.png)


expected / in master
------------------------
![image](https://user-images.githubusercontent.com/53213107/149141030-5298f7da-69bb-4e3f-83ca-4c4b103acb32.png)

the problem with the new physical storage form is because one of the variables used is not initialized correctly.
we have an hidden text field in the form that use to determine if we are in edit mode or new mode. the default value of the field is empty string, and in edit mode it set to 'yes'. for some reasone in the M release the default value (empty string) is not set correctly, and the fix for that is adding to that field the following attribute: initialValue: ''

I dont know why the default value is not working like we expect in the M release. in the master branch it works like expected (empty text fields have value of empty string by defualt).

in this PR I'm adding the initialValue attribute to the hidden field to make sure it set up correctly.
This PR should be backported to Morphy


