### PR TITLE
Fix row highlight in provision instance

### DIFF
--- a/app/javascript/components/miq-data-table/index.jsx
+++ b/app/javascript/components/miq-data-table/index.jsx
@@ -106,9 +106,13 @@ const MiqDataTable = ({
   /** Function to identify if the row is clickable or not and the returns a class name */
   const classNameRow = (item) => {
     if (item) {
-      const { clickable } = item;
+      const { clickable, id } = item;
       if (clickable === false) return 'simple-row';
-      if (clickable === true || clickable === null) return 'clickable-row';
+      if (clickable === true || clickable === null) {
+        return (gridChecks.includes(id)
+          ? 'clickable-row bx--data-table--selected'
+          : 'clickable-row');
+      }
     }
     return '';
   };


### PR DESCRIPTION
When we select a row in Provision instance, the row background will now be highlighted.

Before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/149455931-4a5536bd-e6e9-445b-806b-7b4b9e2637c2.png">

After
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/149513601-902a158b-87d1-4817-a3cf-02d91b64619f.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 