### PR TITLE
Added space under time profile reports

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -107,3 +107,7 @@
 .chargeback-rate table tbody tr td {
   vertical-align: top !important;
 }
+
+.time-profile-reports {
+  padding-bottom: 20px;
+}


### PR DESCRIPTION
Added some padding to bottom of the time profile reports table.

Before:
<img width="1510" alt="Screen Shot 2022-01-17 at 11 44 15 AM" src="https://user-images.githubusercontent.com/32444791/149810378-1b859d58-8c10-4e91-a871-df7b48d70b45.png">

After:
<img width="1508" alt="Screen Shot 2022-01-17 at 11 47 31 AM" src="https://user-images.githubusercontent.com/32444791/149810443-9be520ee-600f-4f02-b4e1-b762876f77ff.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label enhancement
