### PR TITLE
Only send arguments to the receiver if the block accepts them

### DIFF
--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -77,8 +77,8 @@ module TreeNode
 
           if result.nil?
             if block_given?
-              args = [@object, @parent_id].take(block.arity.abs)
-              result = instance_exec(*args, &block)
+              # All blocks here are either to_procs that only take the receiver or a block with no arguments.
+              result = instance_exec(@object, &block)
             else
               result = value
             end


### PR DESCRIPTION
Always send the object if a block is given to set_attribute

set_attribute used to send more arguments (object, parent_id, options, etc) to
the instance_exec.  It has been simplified to only pass object and parent_id but
we only ever use the object.

Because of 2.7/3.0 differences described below, we can further simplify this and
just send the object if a block is given.  For blocks that take no arguments, it is
simply unused.

In ruby 3.0, Symbol#to_proc returns a lambda with different arity than ruby 2.7.

Note, an arity of -1 means that all parameters are optional.
An arity of -2 means that 1 parameter is required and any other parameters are
optional.

See: https://ruby-doc.org/core-3.0.0/Proc.html#method-i-arity

Since ruby 2.7's arity on Symbol#to_proc looks wrong, it's better to not even
check it if we don't have to.

```
irb(main):001:0> RUBY_VERSION
=> "2.7.5"
irb(main):002:0> :name.to_proc.arity
=> -1
irb(main):003:0> :name.to_proc.lambda?
=> false
irb(main):004:0> :name.to_proc.parameters
=> [[:rest]]
```

Ruby 3.0 fixed the arity as it's now a lambda.
https://bugs.ruby-lang.org/issues/16260

```
irb(main):001:0> RUBY_VERSION
=> "3.0.3"
irb(main):002:0> :name.to_proc.arity
=> -2
irb(main):003:0> :name.to_proc.lambda?
=> true
irb(main):004:0> :name.to_proc.parameters
=> [[:req], [:rest]]
```

Note, this is tested in lots of the tree node tests and was failing on ruby 3 with errors like the following:

```
  36) TreeNode::MiqDialog#text returns with the object description
      Failure/Error: result = instance_exec(*args, &block)
      
      ArgumentError:
        wrong number of arguments (given 1, expected 0)
      Shared Example Group: "TreeNode::Node#text description" called from ./spec/presenters/tree_node/miq_dialog_spec.rb:7
      # ./app/presenters/tree_node/node.rb:81:in `instance_exec'
      # ./app/presenters/tree_node/node.rb:81:in `block in set_attribute'
      # ./spec/shared/presenters/tree_node/common.rb:44:in `block (3 levels) in <top (required)>'
  37) TreeNode::GuestDevice ethernet #tooltip returns the prefixed text
      Failure/Error: result = instance_exec(*args, &block)
      
      ArgumentError:
        wrong number of arguments (given 1, expected 0)
      Shared Example Group: "TreeNode::Node#tooltip prefix" called from ./spec/presenters/tree_node/guest_device_spec.rb:14
      # ./app/presenters/tree_node/node.rb:81:in `instance_exec'
      # ./app/presenters/tree_node/node.rb:81:in `block in set_attribute'
      # ./spec/shared/presenters/tree_node/common.rb:36:in `block (3 levels) in <top (required)>'
```

Here is an example where we use a symbol to proc Proc or a block: https://github.com/ManageIQ/manageiq-ui-classic/blob/f763b48f2d82dd95e0a99767fa3195496aa45896/app/presenters/tree_node/guest_device.rb#L3-L12