### PR TITLE
Fix dashboard empty chart

### DIFF
--- a/app/javascript/components/dashboard-charts/emptyChart.js
+++ b/app/javascript/components/dashboard-charts/emptyChart.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const EmptyChart = () =>
+  (
+    <div className="empty-chart-content">
+      <span className="pficon pficon-info" />
+      <span>{__('No data available')}</span>
+    </div>
+  );
+export default EmptyChart;

--- a/app/javascript/components/dashboard-charts/index.jsx
+++ b/app/javascript/components/dashboard-charts/index.jsx
@@ -5,36 +5,39 @@ import {
   StackAreaChart, StackBarChartGraph, StackHorizontalChart,
 } from '../carbon-charts';
 import { getConvertedData } from '../carbon-charts/helpers';
+import EmptyChart from './emptyChart';
 
 // eslint-disable-next-line no-unused-vars
 const DashboardWidget = ({ data, id }) => {
   const convertedData = getConvertedData(data);
-
-  if (data.miqChart === 'Area') {
-    return (<AreaChartGraph data={convertedData} />);
-  }
-  if (data.miqChart === 'Donut') {
-    return (<DonutChartGraph data={convertedData} />);
-  }
-  if (data.miqChart === 'Line') {
-    return (<LineChartGraph data={convertedData} />);
-  }
-  if (data.miqChart === 'Pie') {
-    return (<PieChartGraph data={convertedData} />);
-  }
-  if (data.miqChart === 'StackedArea') {
-    return (<StackAreaChart data={convertedData} />);
-  }
-  if (data.miqChart === 'StackedBar' && data.data.groups) {
-    return (<StackHorizontalChart data={convertedData} />);
-  }
-  if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && data.data.groups) {
+  if (convertedData.length > 0) {
+    if (data.miqChart === 'Area') {
+      return (<AreaChartGraph data={convertedData} />);
+    }
+    if (data.miqChart === 'Donut') {
+      return (<DonutChartGraph data={convertedData} />);
+    }
+    if (data.miqChart === 'Line') {
+      return (<LineChartGraph data={convertedData} />);
+    }
+    if (data.miqChart === 'Pie') {
+      return (<PieChartGraph data={convertedData} />);
+    }
+    if (data.miqChart === 'StackedArea') {
+      return (<StackAreaChart data={convertedData} />);
+    }
+    if (data.miqChart === 'StackedBar' && data.data.groups) {
+      return (<StackHorizontalChart data={convertedData} />);
+    }
+    if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && data.data.groups) {
+      return (<StackBarChartGraph data={convertedData} />);
+    }
+    if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && !data.data.groups) {
+      return (<GroupBarChart data={convertedData} />);
+    }
     return (<StackBarChartGraph data={convertedData} />);
   }
-  if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && !data.data.groups) {
-    return (<GroupBarChart data={convertedData} />);
-  }
-  return (<StackBarChartGraph data={convertedData} />);
+  return <EmptyChart />;
 };
 
 DashboardWidget.propTypes = {


### PR DESCRIPTION
Carbon empty chart is confusing. It seems data is not loaded properly in chart.
**Before**

<img width="456" alt="Screen Shot 2022-01-24 at 9 24 26 AM" src="https://user-images.githubusercontent.com/37085529/150800838-c5fec93f-25bf-4cf2-a053-b76c190bdce9.png">


**After**

<img width="1036" alt="Screen Shot 2022-01-24 at 9 20 54 AM" src="https://user-images.githubusercontent.com/37085529/150800870-abd1a3c5-f6de-4d69-9fb3-54854a784c8d.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug
