### PR TITLE
[morphy] Fix edit ems storage

### DIFF
--- a/app/views/ems_storage/edit.html.haml
+++ b/app/views/ems_storage/edit.html.haml
@@ -1,0 +1,5 @@
+= react('ProviderForm', :providerId => @ems.id.to_s,
+  :redirect => edit_redirect_path(@lastaction, @ems),
+  :kind => 'storage',
+  :title => ui_lookup(:model => 'ManageIQ::Providers::StorageManager'))
+


### PR DESCRIPTION
In Morphy, trying to edit storage manager from the dashboard results with the following error:
EmsStorageController#edit is missing a template for request formats: text/html [ems_storage/edit]

Note! It works OK in master/latest, and also works ok in morphy for other providers (tested on vmware), except for an additional issue which describes in section 2 below.

![image](https://user-images.githubusercontent.com/53213107/150972188-392d0dc5-1a12-4b60-8e86-18c60ef6d436.png)

before
--
![image](https://user-images.githubusercontent.com/53213107/150972204-27f08ef0-ec42-434d-8bd7-0138360b3165.png)

after
--
![image](https://user-images.githubusercontent.com/53213107/150995700-dc42b9d9-ee91-44b6-a5e1-b4be45b632d1.png)


if we try to edit from the storage list page it works ok


links 
-----
https://github.com/ManageIQ/manageiq-ui-classic/issues/8020