### PR TITLE
Prevent drag drop widgets with dashboard_view role

### DIFF
--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -8,6 +8,7 @@ ManageIQ.angular.app.component('widgetWrapper', {
     widgetTitle: '@',
     widgetLastRun: '@',
     widgetNextRun: '@',
+    widgetDragDrop: '<',
   },
   controllerAs: 'vm',
   controller: ['$http', 'miqService', '$sce', 'API', function($http, miqService, $sce, API) {
@@ -87,8 +88,8 @@ ManageIQ.angular.app.component('widgetWrapper', {
           <div class="card-pf-heading-kebab">
             <dropdown-menu widget-id="{{vm.widgetId}}"
                            buttons-data="vm.parsedButtons"></dropdown-menu>
-            <h2 class="card-pf-title sortable-handle ui-sortable-handle"
-                style="cursor:move">
+            <h2 ng-class="{'sortable-handle ui-sortable-handle': vm.widgetDragDrop}" class="card-pf-title"
+                ng-style="vm.widgetDragDrop && {'cursor':'move'}">
               {{vm.widgetTitle}}
             </h2>
           </div>

--- a/app/views/dashboard/_widget.html.haml
+++ b/app/views/dashboard/_widget.html.haml
@@ -1,11 +1,12 @@
 %div{:id => "ww_#{presenter.widget.id}"}
   - last_run, next_run = last_next_run(presenter.widget)
-  %widget-wrapper{"widget-id"       => presenter.widget.id,
-                  "widget-type"     => presenter.widget.content_type,
-                  "widget-buttons"  => presenter.widget_buttons,
-                  "widget-last-run" => last_run,
-                  "widget-next-run" => next_run,
-                  "widget-title"    => _(presenter.widget.title)}
+  %widget-wrapper{"widget-id"        => presenter.widget.id,
+                  "widget-type"      => presenter.widget.content_type,
+                  "widget-buttons"   => presenter.widget_buttons,
+                  "widget-last-run"  => last_run,
+                  "widget-next-run"  => next_run,
+                  "widget-title"     => _(presenter.widget.title),
+                  "widget-drag-drop" => presenter.role_allows?(:feature => "dashboard_add")}
 
 :javascript
   miq_bootstrap("#ww_#{presenter.widget.id}");


### PR DESCRIPTION
Users where able to drag and drop widgets in the dashboard regardless if they had the dashboard view or add role.
When users with only view permissions tried to do this, an error would appear on screen which told them they didn't have
the correct permissions. With this change users with only the view rights will not be able to move widgets.
