### PR TITLE
Fixed infrastructure hosts breadcrumbs

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -139,7 +139,6 @@ class HostController < ApplicationController
       @in_a_form = true
       session[:changed] = false
       drop_breadcrumb(:name => _("Edit Host '%{name}'") % {:name => @host.name}, :url => "/host/edit/#{@host.id}")
-      @title = _("Info/Settings")
     else # if editing credentials for multi host
       drop_breadcrumb(:name => _('Edit Hosts'), :url => '/host/edit/')
       @title = _("Credentials/Settings")


### PR DESCRIPTION
Fixed the breadcrumb and title for the edit infrastructure hosts page.

Before:
<img width="1513" alt="Screen Shot 2022-01-31 at 11 26 50 AM" src="https://user-images.githubusercontent.com/32444791/151832697-30c37d13-e21c-4cd2-83c1-3c830822155d.png">

After:
<img width="1507" alt="Screen Shot 2022-01-31 at 11 28 40 AM" src="https://user-images.githubusercontent.com/32444791/151833019-a7a68036-c5d3-4d46-bdea-29f4618897e7.png">

