### PR TITLE
Fix cloud volume form

### DIFF
--- a/app/javascript/components/cloud-volume-form/index.jsx
+++ b/app/javascript/components/cloud-volume-form/index.jsx
@@ -17,6 +17,15 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
     }));
   };
 
+  const emptySchema = (appendState = {}) => {
+    const fields = [];
+    setState((state) => ({
+      ...state,
+      ...appendState,
+      fields,
+    }));
+  };
+
   useEffect(() => {
     if (recordId) {
       API.get(`/api/cloud_volumes/${recordId}`).then((initialValues) => {
@@ -30,18 +39,20 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
   }, [recordId, storageManagerId]);
 
   const onSubmit = ({ edit: _edit, ...values }) => {
-    miqSparkleOn();
+    if (values.ems_id !== '-1') {
+      miqSparkleOn();
 
-    const request = recordId ? API.patch(`/api/cloud_volumes/${recordId}`, values) : API.post('/api/cloud_volumes', values);
-    request.then(() => {
-      const message = sprintf(
-        recordId
-          ? __('Modification of Cloud Volume "%s" has been successfully queued.')
-          : __('Add of Cloud Volume "%s" has been successfully queued.'),
-        values.name,
-      );
-      miqRedirectBack(message, undefined, '/cloud_volume/show_list');
-    }).catch(miqSparkleOff);
+      const request = recordId ? API.patch(`/api/cloud_volumes/${recordId}`, values) : API.post('/api/cloud_volumes', values);
+      request.then(() => {
+        const message = sprintf(
+          recordId
+            ? __('Modification of Cloud Volume "%s" has been successfully queued.')
+            : __('Add of Cloud Volume "%s" has been successfully queued.'),
+          values.name,
+        );
+        miqRedirectBack(message, undefined, '/cloud_volume/show_list');
+      }).catch(miqSparkleOff);
+    }
   };
 
   const onCancel = () => {
@@ -54,11 +65,20 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
     miqRedirectBack(message, 'warning', '/cloud_volume/show_list');
   };
 
+  const validation = (values) => {
+    const errors = {};
+    if (values.ems_id === '-1') {
+      errors.ems_id = __('Please select a storage manager.');
+    }
+    return errors;
+  };
+
   return !isLoading && (
     <MiqFormRenderer
-      schema={createSchema(fields, !!recordId, !!storageManagerId, loadSchema)}
+      schema={createSchema(fields, !!recordId, !!storageManagerId, loadSchema, emptySchema)}
       initialValues={initialValues}
       canReset={!!recordId}
+      validate={validation}
       onSubmit={onSubmit}
       onReset={() => add_flash(__('All changes have been reset'), 'warn')}
       onCancel={onCancel}


### PR DESCRIPTION
Removed unnecessary code from the files for the cloud volume form. Also updated the form so that it will clear the page from all provider fields when the user selects no storage manager. Also, added a load symbol while the form is loading in provider fields.

Before:
<img width="1502" alt="ClearFormBefore" src="https://user-images.githubusercontent.com/32444791/152609813-2ef2c52e-6a15-40d9-b3ba-55539e29bba2.png">

After:
<img width="1505" alt="ClearFormAfter" src="https://user-images.githubusercontent.com/32444791/152609817-d1dc42f7-bf04-4f81-afc5-43f1ccf8046d.png">

<img width="1506" alt="Screen Shot 2022-02-04 at 5 08 58 PM" src="https://user-images.githubusercontent.com/32444791/152609905-fe520b6d-0413-40ee-938f-b20540b569ed.png">


@miq-bot add_reviewer @kavyanekkalapu
@miq-bot add-label enhancement