### PR TITLE
populate itemIds with gridchecks values if such values exists

### DIFF
--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -98,7 +98,7 @@ class RemoveGenericItemModal extends React.Component {
     const {
       recordId, gridChecks, modalData, dispatch,
     } = this.props;
-    const itemsIds = recordId ? [recordId] : _.uniq(gridChecks);
+    const itemsIds = gridChecks && Array.isArray(gridChecks) && gridChecks.length > 0 ? _.uniq(gridChecks) : [recordId];
     const {
       ajax_reload,
       api_url,


### PR DESCRIPTION
Deleting a volume works only from the volume listing page. If going from storage manager dashboard we get error:

```
URL https://9.151.190.43/api/cloud_volumes/3/?attributes=supports_safe_delete

Status 404 Not Found

Content-Type application/json; charset=utf-8

Data {"error":{"kind":"not_found","message":"Couldn't find CloudVolume with 'id'=3","klass":"ActiveRecord::RecordNotFound"}}
```

going to the volume listing page from the storage dashboard pass the storage provider recordId (see the url in the images below) and therefore it cause error since the code expected that if a recordId pass its the volume recordId.
The correct way is to check the gridChecks first and use its value if exists. only if the gridCheck is empty use the recordId which must be supllied in that case and must be the volume recordId

before
----
![image](https://user-images.githubusercontent.com/53213107/152746397-5aa0805c-b974-436c-b573-54ea455f13a6.png)


after
----
![image](https://user-images.githubusercontent.com/53213107/152745444-43256568-6924-406f-9962-8d7e2900ac52.png)
