### PR TITLE
Fix style for full screen dashboard custom report

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -111,3 +111,14 @@
 .time-profile-reports {
   padding-bottom: 20px;
 }
+
+.report-data-table {
+  table tr td {
+    padding: 0 !important;
+
+    .cell {
+      min-height: 47px;
+      padding-left: 10px;
+    }
+  }
+}


### PR DESCRIPTION
Custom reports table widgets from dashboard when displayed in Full screen

Before
<img width="1788" alt="Screenshot 2022-02-07 at 8 40 43 PM" src="https://user-images.githubusercontent.com/87487049/152815527-345a7a08-69ea-460a-8b2f-7cd1a7824df6.png">

After
<img width="1768" alt="Screenshot 2022-02-07 at 8 41 40 PM" src="https://user-images.githubusercontent.com/87487049/152815557-edf8f56d-5ecf-4e9e-ba9d-c50b2d452f58.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label enhancement
@miq-bot assign @kavyanekkalapu

