### PR TITLE
Fix toolbar reset for chargeback reports

### DIFF
--- a/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
+++ b/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
@@ -285,7 +285,7 @@ const ReportDataTable = (props) => {
   return (
     <>
       {
-        state.total > 0 && hasSearch && renderToolBar()
+        hasSearch && renderToolBar()
       }
       {state.total > 0 && (
         <MiqDataTable

--- a/app/javascript/spec/report-data-table.spec.js
+++ b/app/javascript/spec/report-data-table.spec.js
@@ -62,7 +62,7 @@ limit=${limit}&offset=${offset}`;
     wrapper.update();
 
     expect(fetchMock.calls()).toHaveLength(1);
-    expect(wrapper.find('div.report-table-toolbar')).toHaveLength(0);
+    expect(wrapper.find('div.report-table-toolbar')).toHaveLength(1);
     expect(wrapper.find('div.report-data-table')).toHaveLength(0);
     expect(wrapper.find('div.miq-pagination')).toHaveLength(0);
     expect(wrapper.find('div.no-records-found')).toHaveLength(1);


### PR DESCRIPTION
When you Run the Queue to have a Chargeback report and the report comes when you go inside the report you Search for a word that is not under that report a No records found will show up. But to continue searching there was no back button to perform a new search.

Before
![image](https://user-images.githubusercontent.com/87487049/153171650-0f2f2a6e-72f5-4c20-86f5-84357c11a71f.png)

After
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/153171769-8f0453cc-ca6d-4324-8d9a-e48cb9a3910d.png">


@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 