### PR TITLE
Disable template cloning for IBM Power HMC infrastructure provider

### DIFF
--- a/app/helpers/application_helper/button/button_template_clone.rb
+++ b/app/helpers/application_helper/button/button_template_clone.rb
@@ -2,11 +2,7 @@ class ApplicationHelper::Button::ButtonTemplateClone < ApplicationHelper::Button
   needs :@record
 
   def disabled?
-    if @record.type.eql?("ManageIQ::Providers::IbmPowerHmc::InfraManager") then
-      true
-    else
-      false
-    end
+    @error_message = _('Template cannot be cloned') if @record.type.eql?("ManageIQ::Providers::IbmPowerHmc::InfraManager")
+    @error_message.present?
   end
 end
-

--- a/app/helpers/application_helper/button/button_template_clone.rb
+++ b/app/helpers/application_helper/button/button_template_clone.rb
@@ -1,0 +1,12 @@
+class ApplicationHelper::Button::ButtonTemplateClone < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    if @record.type.eql?("ManageIQ::Providers::IbmPowerHmc::InfraManager") then
+      true
+    else
+      false
+    end
+  end
+end
+

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -143,7 +143,8 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,
-          :onwhen       => "1"),
+          :onwhen       => "1",
+          :klass        => ApplicationHelper::Button::ButtonTemplateClone),
       ]
     ),
  ])


### PR DESCRIPTION
Template cloning is not yet implemented in IBM Power HMC infrastructure provider, so disabling it.

Before:
![image](https://user-images.githubusercontent.com/82665100/153250202-7c86cead-acd2-4fd6-81e2-a1fd85954c65.png)

After:
![image](https://user-images.githubusercontent.com/82665100/153250834-1e3ad5c6-9582-4c27-923f-9eb8a63a7d50.png)
