### PR TITLE
Fix automation structured list

### DIFF
--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -280,15 +280,14 @@ module MiqAeClassHelper
   end
 
   def class_properties_data(name, record)
-    data = {:title => _("Properties"), :mode => "class_props"}
-    rows = [
-      {:label => _('Fully Qualified Name'), :value => h(name)},
-      {:label => _('Name'), :value => record.name},
-      {:label => _('Display Name'), :value => record.display_name},
-      {:label => _('Description'), :value => record.try(:description)},
-      {:label => _('Instances'), :value => h(record.ae_instances.length)},
+    data = {:title => _("Properties"), :mode => "class_props", :clickable => false}
+    data[:rows] = [
+      {:cells => {:label => _('Fully Qualified Name'), :value => h(name)}},
+      {:cells => {:label => _('Name'), :value => record.name}},
+      {:cells => {:label => _('Display Name'), :value => record.display_name}},
+      {:cells => {:label => _('Description'), :value => record.try(:description)}},
+      {:cells => {:label => _('Instances'), :value => h(record.ae_instances.length)}},
     ]
-    data[:rows] = rows
     miq_structured_list(data)
   end
 


### PR DESCRIPTION
Console error when we open the properties tab under Automation module

Before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/153584746-8ad80838-dba2-4492-be7c-e497c799c5e1.png">

After
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/153584537-372a13ef-95d8-4d25-b9e4-773fd4af8f4b.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu 
