### PR TITLE
Added validation to forms with emptySchema

### DIFF
--- a/app/javascript/components/cloud-network-form/cloud-network-form.jsx
+++ b/app/javascript/components/cloud-network-form/cloud-network-form.jsx
@@ -60,16 +60,14 @@ class CloudNetworkForm extends Component {
   };
 
   saveClicked = (values) => {
-    if (values.ems_id !== '-1') {
-      const { cloudNetworkId } = this.props;
-      if (cloudNetworkId) {
-        const { cloudTenantName } = this.state;
-        const url = `/cloud_network/update/${cloudNetworkId}?button=save`;
-        miqAjaxButton(url, { ...values, cloud_tenant: { id: values.cloud_tenant, name: cloudTenantName } }, { complete: false });
-      } else {
-        const url = 'create/new?button=add';
-        miqAjaxButton(url, { ...values, vlan_transparent: false, cloud_tenant: { id: values.cloud_tenant } }, { complete: false });
-      }
+    const { cloudNetworkId } = this.props;
+    if (cloudNetworkId) {
+      const { cloudTenantName } = this.state;
+      const url = `/cloud_network/update/${cloudNetworkId}?button=save`;
+      miqAjaxButton(url, { ...values, cloud_tenant: { id: values.cloud_tenant, name: cloudTenantName } }, { complete: false });
+    } else {
+      const url = 'create/new?button=add';
+      miqAjaxButton(url, { ...values, vlan_transparent: false, cloud_tenant: { id: values.cloud_tenant } }, { complete: false });
     }
   };
 
@@ -82,6 +80,14 @@ class CloudNetworkForm extends Component {
   }
 
   render() {
+    const validation = (values) => {
+      const errors = {};
+      if (values.ems_id === '-1') {
+        errors.ems_id = __('Required');
+      }
+      return errors;
+    };
+
     const {
       initialValues, ems, isLoading,
     } = this.state;
@@ -99,6 +105,7 @@ class CloudNetworkForm extends Component {
           initialValues={initialValues}
           schema={createSchema(ems, cloudNetworkId, this.loadSchema, this.emptySchema, fields)}
           onSubmit={this.saveClicked}
+          validate={validation}
           onCancel={this.cancelClicked}
           canReset={!!cloudNetworkId}
           buttonsLabels={{

--- a/app/javascript/components/cloud-network-form/cloud-network-form.schema.js
+++ b/app/javascript/components/cloud-network-form/cloud-network-form.schema.js
@@ -1,15 +1,11 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { API } from '../../http_api';
 
-let showError = false;
-
 function changeValue(value, loadSchema, emptySchema) {
   if (value === '-1') {
     emptySchema();
-    showError = true;
   } else {
     API.options(`/api/cloud_networks?ems_id=${value}`).then(loadSchema());
-    showError = false;
   }
 }
 
@@ -37,14 +33,6 @@ function createSchema(ems, cloudNetworkId, loadSchema, emptySchema, providerFiel
       options: providers.map(({ id, name }) => ({ label: name, value: id })),
     }],
   },
-  ...(showError ? [
-    {
-      id: 'networkWarning',
-      component: componentTypes.PLAIN_TEXT,
-      name: 'networkWarning',
-      label: __('Please select a network manager.'),
-    },
-  ] : []),
   ...providerFields,
   ];
   return { fields };

--- a/app/javascript/components/cloud-volume-form/index.jsx
+++ b/app/javascript/components/cloud-volume-form/index.jsx
@@ -68,7 +68,7 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
   const validation = (values) => {
     const errors = {};
     if (values.ems_id === '-1') {
-      errors.ems_id = __('Please select a storage manager.');
+      errors.ems_id = __('Required');
     }
     return errors;
   };

--- a/app/javascript/components/network-floatingIPs-form/index.jsx
+++ b/app/javascript/components/network-floatingIPs-form/index.jsx
@@ -92,11 +92,20 @@ const NetworkFloatingIPsForm = ({
     miqRedirectBack(message, 'warning', url);
   };
 
+  const validation = (values) => {
+    const errors = {};
+    if (values.ems_id === '-1') {
+      errors.ems_id = __('Required');
+    }
+    return errors;
+  };
+
   return !isLoading && (
     <MiqFormRenderer
       schema={createSchema(ems, !!recordId, loadSchema, emptySchema, fields)}
       initialValues={initialValues}
       canReset={!!recordId}
+      validate={validation}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{ submitLabel }}

--- a/app/javascript/components/network-floatingIPs-form/network-floatingIPs-form.schema.js
+++ b/app/javascript/components/network-floatingIPs-form/network-floatingIPs-form.schema.js
@@ -1,20 +1,18 @@
 /* eslint-disable no-restricted-syntax */
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 
-let showError = false;
-
 function changeValue(value, loadSchema, emptySchema) {
   if (value === '-1') {
     emptySchema();
-    showError = true;
   } else {
     API.options(`/api/floating_ips?ems_id=${value}`).then(loadSchema(), value);
-    showError = false;
   }
 }
 
 function createSchema(ems, recordId, loadSchema, emptySchema, providerFields = []) {
   const providers = ems.filter((tenant) => tenant.type !== 'ManageIQ::Providers::Nuage::NetworkManager');
+  const providerOptions = providers.map(({ id, name }) => ({ label: name, value: id }));
+  providerOptions.unshift({ label: `<${__('Choose')}>`, value: '-1' });
 
   const fields = [
     {
@@ -29,25 +27,16 @@ function createSchema(ems, recordId, loadSchema, emptySchema, providerFields = [
           name: 'ems_id',
           label: __('Network Manager'),
           isDisabled: !!recordId,
-          includeEmpty: true,
           validateOnMount: true,
           onChange: (value) => changeValue(value, loadSchema, emptySchema),
           validate: [{
             type: validatorTypes.REQUIRED,
             message: __('Required'),
           }],
-          options: providers.map(({ id, name }) => ({ label: name, value: id })),
+          options: providerOptions,
         },
       ],
     },
-    ...(showError ? [
-      {
-        id: 'networkWarning',
-        component: componentTypes.PLAIN_TEXT,
-        name: 'networkWarning',
-        label: __('Please select a network manager.'),
-      },
-    ] : []),
     ...providerFields,
   ];
   return { fields };

--- a/app/javascript/components/network-security-groups-form/index.jsx
+++ b/app/javascript/components/network-security-groups-form/index.jsx
@@ -93,12 +93,21 @@ const NetworkSecurityGroupsForm = ({ securityGroupId }) => {
     miqRedirectBack(message, 'warning', url);
   };
 
+  const validation = (values) => {
+    const errors = {};
+    if (values.ems_id === '-1') {
+      errors.ems_id = __('Required');
+    }
+    return errors;
+  };
+
   if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
   return !isLoading && (
     <MiqFormRenderer
       schema={createSchema(securityGroupId, fields, subnets, loadSchema, emptySchema)}
       initialValues={initialValues}
       canReset={!!securityGroupId}
+      validate={validation}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{ submitLabel }}

--- a/app/javascript/components/network-security-groups-form/network-security-groups-form.schema.js
+++ b/app/javascript/components/network-security-groups-form/network-security-groups-form.schema.js
@@ -1,14 +1,11 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { API } from '../../http_api';
 
-let showError = false;
-
 const emsUrl = '/api/providers?&expand=resources&filter[]=supports_create_security_group=true';
 
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
     emptySchema();
-    showError = true;
   } else {
     API.options(`/api/security_groups?ems_id=${value}`).then(loadSchema({}, value));
   }
@@ -44,14 +41,6 @@ function createSchema(securityGroupId, providerFields = [], subnets, loadSchema,
       loadOptions: networkManagers,
     }],
   },
-  ...(showError ? [
-    {
-      id: 'networkWarning',
-      component: componentTypes.PLAIN_TEXT,
-      name: 'networkWarning',
-      label: __('Please select a network manager.'),
-    },
-  ] : []),
   ...providerFields,
   ];
   return { fields };

--- a/app/javascript/components/routers-form/RoutersForm.schema.js
+++ b/app/javascript/components/routers-form/RoutersForm.schema.js
@@ -1,7 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { API } from '../../http_api';
 
-let showError = false;
 let showSubnets = false;
 
 const emsUrl = '/api/providers?expand=resources&attributes=id,name,supports_create_network_router,type&filter[]=supports_create_network_router=true';
@@ -9,7 +8,6 @@ const emsUrl = '/api/providers?expand=resources&attributes=id,name,supports_crea
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
     emptySchema();
-    showError = true;
   } else {
     API.options(`/api/network_routers?ems_id=${value}`).then(loadSchema({}, value));
 
@@ -21,7 +19,6 @@ const changeValue = (value, loadSchema, emptySchema) => {
         }
       });
     });
-    showError = false;
   }
 };
 
@@ -56,14 +53,6 @@ function createSchema(routerId, providerFields = [], subnets, loadSchema, emptyS
       loadOptions: networkManagers,
     }],
   },
-  ...(showError ? [
-    {
-      id: 'networkWarning',
-      component: componentTypes.PLAIN_TEXT,
-      name: 'networkWarning',
-      label: __('Please select a network manager.'),
-    },
-  ] : []),
   ...providerFields,
   ...(showSubnets ? [
     {

--- a/app/javascript/components/routers-form/index.jsx
+++ b/app/javascript/components/routers-form/index.jsx
@@ -123,18 +123,16 @@ const RoutersForm = ({ routerId }) => {
   const onSubmit = (values) => {
     const resources = getSubmitData(values);
 
-    if (values.ems_id !== '-1') {
-      miqSparkleOn();
-      const request = routerId ? API.patch(`/api/network_routers/${routerId}`, resources) : API.post('/api/network_routers', resources);
-      const url = routerId ? `/network_router/show/${routerId}` : '/network_router';
-      request.then(() => {
-        const message = sprintf(routerId
-          ? __('Editing of Network Router %s has been successfully queued')
-          : __('Adding of Network Router %s has been successfully queued.'),
-        resources.name);
-        miqRedirectBack(message, 'success', url);
-      }).catch(miqSparkleOff);
-    }
+    miqSparkleOn();
+    const request = routerId ? API.patch(`/api/network_routers/${routerId}`, resources) : API.post('/api/network_routers', resources);
+    const url = routerId ? `/network_router/show/${routerId}` : '/network_router';
+    request.then(() => {
+      const message = sprintf(routerId
+        ? __('Editing of Network Router %s has been successfully queued')
+        : __('Adding of Network Router %s has been successfully queued.'),
+      resources.name);
+      miqRedirectBack(message, 'success', url);
+    }).catch(miqSparkleOff);
   };
 
   const onCancel = () => {
@@ -150,12 +148,21 @@ const RoutersForm = ({ routerId }) => {
     miqRedirectBack(message, 'warning', url);
   };
 
+  const validation = (values) => {
+    const errors = {};
+    if (values.ems_id === '-1') {
+      errors.ems_id = __('Required');
+    }
+    return errors;
+  };
+
   if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
   return !isLoading && (
     <MiqFormRenderer
       schema={createSchema(!!routerId, fields, subnets, loadSchema, emptySchema)}
       initialValues={initialValues}
       canReset={!!routerId}
+      validate={validation}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{ submitLabel }}

--- a/app/javascript/components/subnet-form/index.jsx
+++ b/app/javascript/components/subnet-form/index.jsx
@@ -48,30 +48,28 @@ const SubnetForm = ({ recordId }) => {
   }, [recordId]);
 
   const onSubmit = (values) => {
-    if (values.ems_id !== '-1') {
-      API.get(`/api/providers/${values.ems_id}`).then(({ type }) => {
-        if (type === 'ManageIQ::Providers::Openstack::NetworkManager') {
-          if (values.ip_version === undefined) {
-            values.ip_version = '4';
-          }
-          if (values.dhcp_enabled === undefined) {
-            values.dhcp_enabled = false;
-          }
-          values.enable_dhcp = values.dhcp_enabled;
-          delete values.dhcp_enabled;
-          delete Object.assign(values, values.extra_attributes).extra_attributes;
+    API.get(`/api/providers/${values.ems_id}`).then(({ type }) => {
+      if (type === 'ManageIQ::Providers::Openstack::NetworkManager') {
+        if (values.ip_version === undefined) {
+          values.ip_version = '4';
         }
-        miqSparkleOn();
-        const request = recordId ? API.patch(`/api/cloud_subnets/${recordId}`, values) : API.post('/api/cloud_subnets', values);
-        request.then(() => {
-          const message = sprintf(recordId
-            ? __('Modification of Cloud Subnet %s has been successfully queued')
-            : __('Add of Cloud Subnet "%s" has been successfully queued.'),
-          values.name);
-          miqRedirectBack(message, 'success', '/cloud_subnet/show_list');
-        }).catch(miqSparkleOff);
-      });
-    }
+        if (values.dhcp_enabled === undefined) {
+          values.dhcp_enabled = false;
+        }
+        values.enable_dhcp = values.dhcp_enabled;
+        delete values.dhcp_enabled;
+        delete Object.assign(values, values.extra_attributes).extra_attributes;
+      }
+      miqSparkleOn();
+      const request = recordId ? API.patch(`/api/cloud_subnets/${recordId}`, values) : API.post('/api/cloud_subnets', values);
+      request.then(() => {
+        const message = sprintf(recordId
+          ? __('Modification of Cloud Subnet %s has been successfully queued')
+          : __('Add of Cloud Subnet "%s" has been successfully queued.'),
+        values.name);
+        miqRedirectBack(message, 'success', '/cloud_subnet/show_list');
+      }).catch(miqSparkleOff);
+    });
   };
 
   const onCancel = () => {
@@ -84,12 +82,21 @@ const SubnetForm = ({ recordId }) => {
     miqRedirectBack(message, 'warning', '/cloud_subnet/show_list');
   };
 
+  const validation = (values) => {
+    const errors = {};
+    if (values.ems_id === '-1') {
+      errors.ems_id = __('Required');
+    }
+    return errors;
+  };
+
   if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
   return !isLoading && (
     <MiqFormRenderer
       schema={createSchema(!!recordId, fields, loadSchema, emptySchema)}
       initialValues={initialValues}
       canReset={!!recordId}
+      validate={validation}
       onSubmit={onSubmit}
       onCancel={onCancel}
       buttonsLabels={{ submitLabel }}

--- a/app/javascript/components/subnet-form/subnet-form.schema.js
+++ b/app/javascript/components/subnet-form/subnet-form.schema.js
@@ -10,7 +10,6 @@ const networkManagers = () => API.get(emsUrl).then(({ resources }) => {
 });
 
 let empty = true;
-let showError = false;
 
 const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
   fields: [
@@ -23,11 +22,9 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
         if (value !== '-1') {
           API.options(`/api/cloud_subnets?ems_id=${value}`).then(loadSchema());
           empty = false;
-          showError = false;
         } else {
           emptySchema();
           empty = true;
-          showError = true;
         }
       },
       loadOptions: networkManagers,
@@ -84,14 +81,6 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
           when: 'ems_id',
           isNotEmpty: true,
         },
-      },
-    ] : []),
-    ...(showError ? [
-      {
-        id: 'networkWarning',
-        component: componentTypes.PLAIN_TEXT,
-        name: 'networkWarning',
-        label: __('Please select a network manager.'),
       },
     ] : []),
     ...fields,

--- a/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
+++ b/app/javascript/spec/cloud-network-form/__snapshots__/cloud-network-form.spec.js.snap
@@ -78,6 +78,7 @@ exports[`Cloud Network form component should render edit variant 1`] = `
         ],
       }
     }
+    validate={[Function]}
   />
 </Grid>
 `;
@@ -161,6 +162,7 @@ exports[`Cloud Network form component should render form 1`] = `
         ],
       }
     }
+    validate={[Function]}
   />
 </Grid>
 `;

--- a/app/javascript/spec/network-floating-ip-form/__snapshots__/network-floating-ip-form.spec.js.snap
+++ b/app/javascript/spec/network-floating-ip-form/__snapshots__/network-floating-ip-form.spec.js.snap
@@ -19,12 +19,16 @@ exports[`Floating Ips Profile Form Component should render correctly 1`] = `
             Object {
               "component": "select",
               "id": "ems_id",
-              "includeEmpty": true,
               "isDisabled": false,
               "label": "Network Manager",
               "name": "ems_id",
               "onChange": [Function],
-              "options": Array [],
+              "options": Array [
+                Object {
+                  "label": "<Choose>",
+                  "value": "-1",
+                },
+              ],
               "validate": Array [
                 Object {
                   "message": "Required",
@@ -41,5 +45,6 @@ exports[`Floating Ips Profile Form Component should render correctly 1`] = `
       ],
     }
   }
+  validate={[Function]}
 />
 `;

--- a/app/javascript/spec/network-router-form/__snapshots__/network-router-form.spec.js.snap
+++ b/app/javascript/spec/network-router-form/__snapshots__/network-router-form.spec.js.snap
@@ -66,6 +66,7 @@ exports[`Network Router form component should render add form 1`] = `
       ],
     }
   }
+  validate={[Function]}
 />
 `;
 

--- a/app/javascript/spec/network-security-groups-form/__snapshots__/network-security-groups-form.spec.js.snap
+++ b/app/javascript/spec/network-security-groups-form/__snapshots__/network-security-groups-form.spec.js.snap
@@ -43,6 +43,7 @@ exports[`Network Router Interfaces Form Component should add security group 1`] 
       ],
     }
   }
+  validate={[Function]}
 />
 `;
 
@@ -109,6 +110,7 @@ exports[`Network Router Interfaces Form Component should render add security gro
       ],
     }
   }
+  validate={[Function]}
 />
 `;
 

--- a/app/javascript/spec/subnet-form/__snapshots__/subnet-form.spec.js.snap
+++ b/app/javascript/spec/subnet-form/__snapshots__/subnet-form.spec.js.snap
@@ -32,6 +32,7 @@ exports[`Subnet form component renders the adding form variant 1`] = `
       ],
     }
   }
+  validate={[Function]}
 />
 `;
 

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -61,12 +61,6 @@
   margin-bottom: 25px;
 }
 
-#networkWarning {
-  margin-top: -30px;
-  color: #da1e28;
-  font-size: 14px;
-}
-
 .bx--fieldset {
   legend.bx--label {
     font-size: 16px;


### PR DESCRIPTION
Used validation to check for an empty network manager field in forms that use emptySchema. Previously used a plain text component to warn the user but could not visually disable the save button. This is changed to instead use validation which warns the user and disables the button as well. Also, fixes the emptySchema on the floating IPs form.

Before:
<img width="1506" alt="floatingIPsBefore" src="https://user-images.githubusercontent.com/32444791/153675006-add4a39f-87c0-4c2e-86db-9d70785ffda1.png">
<img width="1495" alt="subnetBefore" src="https://user-images.githubusercontent.com/32444791/153675016-377dec66-184f-4de4-9088-fa0c00f699a8.png">
<img width="1491" alt="networkRouterBefore" src="https://user-images.githubusercontent.com/32444791/153675033-824572eb-d30a-4180-92d9-327b5b710ce6.png">
<img width="1503" alt="securityGroupsBefore" src="https://user-images.githubusercontent.com/32444791/153675035-631e6e20-bf6c-4187-a89f-9f9e5ee073d1.png">
<img width="1505" alt="cloudNetworkBefore" src="https://user-images.githubusercontent.com/32444791/153675040-280a4c91-8b20-458f-a771-cd25dbff1c91.png">

After:
<img width="1333" alt="FloatingIPsAfter" src="https://user-images.githubusercontent.com/32444791/154127792-fe62896e-cdce-47f1-bb91-4c1c24eb8c5a.png">
<img width="1338" alt="SubnetsAfter" src="https://user-images.githubusercontent.com/32444791/154127825-04466498-b1f2-4bbc-8362-d780f5b9d3fc.png">
<img width="1332" alt="RoutersAfter" src="https://user-images.githubusercontent.com/32444791/154127832-3a61036f-65b8-4ce5-820a-a8a3b57d768a.png">
<img width="1331" alt="SecurityGroupAfter" src="https://user-images.githubusercontent.com/32444791/154127845-cb559fd4-2b05-4ccd-8ae0-9bb90f4a8132.png">
<img width="1344" alt="CloudNetworkAfter" src="https://user-images.githubusercontent.com/32444791/154127857-341991b6-79af-4ec9-8926-c349809ecca8.png">
<img width="1353" alt="CloudVolumeAfter" src="https://user-images.githubusercontent.com/32444791/154127878-a6033001-d3c4-4b0d-bfae-a19985970af9.png">




@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label enhancement