### PR TITLE
Switch Redhat references to oVirt

### DIFF
--- a/app/helpers/provision_customize_helper.rb
+++ b/app/helpers/provision_customize_helper.rb
@@ -4,12 +4,12 @@ module ProvisionCustomizeHelper
       @edit[:new][:sysprep_enabled][0] && @edit[:new][:sysprep_enabled][0] != "disabled") ||
       (!@edit && @options && @options[:sysprep_enabled] &&
         @options[:sysprep_enabled][0] && @options[:sysprep_enabled][0] != "disabled")) &&
-      !workflow.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow)
+      !workflow.kind_of?(ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow)
   end
 
   def select_check?(workflow)
     (workflow.kind_of?(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow) ||
-      workflow.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow)) &&
+      workflow.kind_of?(ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow)) &&
       !workflow.supports_pxe? && !workflow.supports_iso?
   end
 end

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -31,8 +31,8 @@
         :prefix                     => "/miq_request/",
         :keys                       => keys})
   - when :service
-    - keys = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? [:src_vm_id, :provision_type, :linked_clone, :seal_template] : [:vm_filter, :src_vm_id, :provision_type, :linked_clone, :snapshot]
-    - label = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? _("Selected VM") : _("Select")
+    - keys = wf.kind_of?(ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow) ? [:src_vm_id, :provision_type, :linked_clone, :seal_template] : [:vm_filter, :src_vm_id, :provision_type, :linked_clone, :snapshot]
+    - label = wf.kind_of?(ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow) ? _("Selected VM") : _("Select")
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
@@ -196,7 +196,7 @@
           :prefix                     => "/miq_request/",
           :keys                       => keys})
       - if edit_or_options[0] == "fields"
-        - if wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow)
+        - if wf.kind_of?(ManageIQ::Providers::Ovirt::InfraManager::ProvisionWorkflow)
           - if edit_or_options[1] == "Sysprep Specification"
             - keys = [:sysprep_computer_name, :sysprep_organization, :sysprep_admin_password, :sysprep_product_key]
             = render(:partial => "/miq_request/prov_dialog_fieldset",


### PR DESCRIPTION
- part of the work to split oVirt provider

Related to:
- https://github.com/ManageIQ/manageiq-providers-ovirt/pull/595

@miq-bot add_label enhancement
@miq-bot assign @agrare 