### PR TITLE
Fix performance charts titles

### DIFF
--- a/app/javascript/components/performance-charts/areaChart.js
+++ b/app/javascript/components/performance-charts/areaChart.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AreaChart } from '@carbon/charts-react';
 
-const AreaChartGraph = ({ data, format, size }) => {
+const AreaChartGraph = ({
+  data, format, size, title,
+}) => {
   const getYAxisValue = (format, value) => {
     // eslint-disable-next-line no-useless-escape
     const tmp = /^([0-9\,\.]+)(.*)/.exec(ManageIQ.charts.formatters[format.function].c3(format.options)(value));
@@ -10,6 +12,7 @@ const AreaChartGraph = ({ data, format, size }) => {
   };
 
   const options = {
+    title,
     axes: {
       bottom: {
         mapsTo: 'key',
@@ -40,12 +43,14 @@ AreaChartGraph.propTypes = {
   data: PropTypes.instanceOf(Array),
   format: PropTypes.instanceOf(Object),
   size: PropTypes.string,
+  title: PropTypes.string,
 };
 
 AreaChartGraph.defaultProps = {
   data: null,
   format: null,
   size: '400px',
+  title: '',
 };
 
 export default AreaChartGraph;

--- a/app/javascript/components/performance-charts/index.jsx
+++ b/app/javascript/components/performance-charts/index.jsx
@@ -4,26 +4,30 @@ import LineChartGraph from './lineChart';
 import AreaChartGraph from './areaChart';
 import { getLineConvertedData } from '../carbon-charts/helpers';
 
-// eslint-disable-next-line no-unused-vars
-const PerformanceChartWidget = ({ data, id, size }) => {
+const PerformanceChartWidget = ({
+  // eslint-disable-next-line no-unused-vars
+  data, id, size, title,
+}) => {
   const convertedData = getLineConvertedData(data);
 
   if (data.miqChart === 'Area') {
-    return (<AreaChartGraph data={convertedData} format={data.miq.format} size={size} />);
+    return (<AreaChartGraph data={convertedData} format={data.miq.format} size={size} title={title} />);
   }
-  return (<LineChartGraph data={convertedData} format={data.miq.format} size={size} />);
+  return (<LineChartGraph data={convertedData} format={data.miq.format} size={size} title={title} />);
 };
 
 PerformanceChartWidget.propTypes = {
   data: PropTypes.instanceOf(Object),
   id: PropTypes.string,
   size: PropTypes.string,
+  title: PropTypes.string,
 };
 
 PerformanceChartWidget.defaultProps = {
   data: null,
   id: null,
   size: '400px',
+  title: '',
 };
 
 export default PerformanceChartWidget;

--- a/app/javascript/components/performance-charts/lineChart.js
+++ b/app/javascript/components/performance-charts/lineChart.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { LineChart } from '@carbon/charts-react';
 
-const LineChartGraph = ({ data, format, size }) => {
+const LineChartGraph = ({
+  data, format, size, title,
+}) => {
   const getYAxisValue = (format, value) => {
     // eslint-disable-next-line no-useless-escape
     const tmp = /^([0-9\,\.]+)(.*)/.exec(ManageIQ.charts.formatters[format.function].c3(format.options)(value));
@@ -10,6 +12,7 @@ const LineChartGraph = ({ data, format, size }) => {
   };
 
   const options = {
+    title,
     axes: {
       bottom: {
         mapsTo: 'key',
@@ -40,12 +43,14 @@ LineChartGraph.propTypes = {
   data: PropTypes.instanceOf(Array),
   format: PropTypes.instanceOf(Object),
   size: PropTypes.string,
+  title: PropTypes.string,
 };
 
 LineChartGraph.defaultProps = {
   data: null,
   format: null,
   size: '400px',
+  title: '',
 };
 
 export default LineChartGraph;

--- a/app/stylesheet/charts.scss
+++ b/app/stylesheet/charts.scss
@@ -31,6 +31,13 @@
       left: 5%;
       position: relative;
     }
+
+    .bx--cc--title {
+      .title {        
+        display: none,
+      }
+    }
+
     svg {
       overflow: visible !important;
     }

--- a/app/views/layouts/_perf_chart_js.html.haml
+++ b/app/views/layouts/_perf_chart_js.html.haml
@@ -8,7 +8,7 @@
               %h2.card-pf-title= _(charts[chart_index][:title])
             .overlay-container{"style" => "position: relative"}
               .card-pf-body
-                = react('PerformanceChartWidget',:data => chart_data[chart_index][:data], :id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'400px')
+                = react('PerformanceChartWidget',:data => chart_data[chart_index][:data], :id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'400px', :title => charts[chart_index][:title])
                 .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
           %ul.dropdown-menu{"role"            => "menu",
                           "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}",
@@ -23,7 +23,7 @@
           %div
             .overlay-container{"style" => "position: relative"}
               .card-pf-body
-                = react('PerformanceChartWidget',:data => chart_data[chart_index][:data2], :id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'150px')
+                = react('PerformanceChartWidget',:data => chart_data[chart_index][:data2], :id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'150px', :title => charts[chart_index][:title])
                 .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
                   %div
           %ul.dropdown-menu{"role"            => "menu",
@@ -43,7 +43,7 @@
           %h2.card-pf-title= _(charts[chart_index][:title])
         .card-pf-body
           .overlay-container{"style" => "position: relative"}
-            = react('PerformanceChartWidget',:data => chart_data[chart_index][:data],:id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'400px')
+            = react('PerformanceChartWidget',:data => chart_data[chart_index][:data],:id => "miq_chart_#{chart_set}_#{chart_index}", :size =>'400px', :title => charts[chart_index][:title])
             .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
             %div
       %ul.dropdown-menu{"role"            => "menu",


### PR DESCRIPTION
Fixed performance chart titles for utilization charts tabular representation.

Before:
<img width="1414" alt="Before1" src="https://user-images.githubusercontent.com/32444791/153947064-8cca424b-062f-4987-bef9-f7315f3633a0.png">
<img width="1437" alt="Before2" src="https://user-images.githubusercontent.com/32444791/153947068-4101739f-8245-4692-bfd8-36c1e205458c.png">

After:
<img width="1433" alt="After1" src="https://user-images.githubusercontent.com/32444791/153947343-05fc2347-b4f0-42c6-a08c-a63c242b0b40.png">
<img width="1434" alt="After2" src="https://user-images.githubusercontent.com/32444791/153947361-dda36785-f901-481d-ad80-e0c6c948798a.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label bug