### PR TITLE
Fix Providers column inconsistency issue in table header

### DIFF
--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -59,7 +59,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
-- Provider
+- Cloud Provider
 - Type
 - Compliant
 - Allocated Size

--- a/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
@@ -67,7 +67,7 @@ col_order:
 headers:
 - Name
 - Power State
-- Provider
+- Cloud Provider
 - Availability Zone
 - Flavor
 - IP Addresses

--- a/product/views/SecurityGroup.yaml
+++ b/product/views/SecurityGroup.yaml
@@ -49,7 +49,7 @@ headers:
 - Description
 - Instances
 - Cloud Tenant
-- Cloud Provider
+- Network Provider
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
Fix for Providers column inconsistency issue in table header

**1.Instances - Provider to Cloud Provider**
Before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/154198581-8fffa7d2-5a4b-4f86-b5e1-39d4b39fd083.png">
After
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/154198616-70242b69-b6c3-4992-bf4f-12a8a1c8a2cd.png">


**2.Images - Provider to Cloud Provider**
Before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/154196658-1ba02018-1cc5-4141-aeb6-445e6faa98f3.png">
After
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/154197381-216dad5b-d5e1-47b9-982b-9803afb391ec.png">


**3.Security Group - Cloud Provider to Network Provider**
Before
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/154408710-32b69da8-c247-430c-9c7c-f6cfa498a1e6.png">
After
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/154408801-243d850e-e4db-46df-aa15-3c47a5b63657.png">



@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label enhancement
@miq-bot assign @kavyanekkalapu
