### PR TITLE
Fix provider dashboard charts title and sort order

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/pod-trend-charts/podsAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/pod-trend-charts/podsAreaChart.js
@@ -7,6 +7,7 @@ import EmptyChart from '../emptyChart';
 const PodsAreaChart = ({ data, config, dataPoint }) => {
   const usageData = data[dataPoint];
   const areaOptions = {
+    title: config.headTitle,
     grid: {
       x: {
         enabled: false,

--- a/app/javascript/components/provider-dashboard-charts/recent-host-chart/hostLineChart.js
+++ b/app/javascript/components/provider-dashboard-charts/recent-host-chart/hostLineChart.js
@@ -6,6 +6,7 @@ import EmptyChart from '../emptyChart';
 
 const HostLineChart = ({ data, config }) => {
   const areaOptions = {
+    title: data.config.title,
     grid: {
       x: {
         enabled: false,

--- a/app/javascript/components/provider-dashboard-charts/recent-vm-chart/index.js
+++ b/app/javascript/components/provider-dashboard-charts/recent-vm-chart/index.js
@@ -27,7 +27,7 @@ const RecentVmGraph = ({
         <h2 className="card-pf-title">{title}</h2>
       </div>
       <div className="card-pf-body">
-        <VmAreaChart data={data.vms} config={chartConfig[config]} dataPoint={dataPoint} />
+        <VmAreaChart data={data.vms} config={chartConfig[config]} dataPoint={dataPoint} title={title} />
       </div>
     </div>
   );

--- a/app/javascript/components/provider-dashboard-charts/recent-vm-chart/vmAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/recent-vm-chart/vmAreaChart.js
@@ -4,9 +4,12 @@ import { AreaChart } from '@carbon/charts-react';
 import { getConvertedData } from '../helpers';
 import EmptyChart from '../emptyChart';
 
-const VmAreaChart = ({ data, config, dataPoint }) => {
+const VmAreaChart = ({
+  data, config, dataPoint, title,
+}) => {
   const usageData = data[dataPoint];
   const areaOptions = {
+    title,
     grid: {
       x: {
         enabled: false,
@@ -50,6 +53,7 @@ const VmAreaChart = ({ data, config, dataPoint }) => {
 VmAreaChart.propTypes = {
   data: PropTypes.objectOf(PropTypes.any).isRequired,
   dataPoint: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
   config: PropTypes.shape({
     legendLeftText: PropTypes.string.isRequired,
     units: PropTypes.string.isRequired,

--- a/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/index.js
+++ b/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/index.js
@@ -32,7 +32,7 @@ const UsageTrendChart = ({
         <h2 className="card-pf-title">{title}</h2>
       </div>
       <div className="card-pf-body">
-        {resultData[dataPoint].dataAvailable ? <UsageAreaChart data={data.vms} config={chartConfig[configName]} dataPoint={dataPoint} />
+        {resultData[dataPoint].dataAvailable ? <UsageAreaChart data={data.vms} config={chartConfig[configName]} dataPoint={dataPoint} title={title} />
           : <EmptyChart /> }
       </div>
     </div>

--- a/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/usageAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/usageAreaChart.js
@@ -4,9 +4,12 @@ import { AreaChart } from '@carbon/charts-react';
 import { getConvertedData, getLatestValue } from '../helpers';
 import EmptyChart from '../emptyChart';
 
-const UsageAreaChart = ({ data, config, dataPoint }) => {
+const UsageAreaChart = ({
+  data, config, dataPoint, title,
+}) => {
   const usageData = data[dataPoint];
   const areaOptions = {
+    title,
     grid: {
       x: {
         enabled: false,
@@ -70,6 +73,7 @@ const UsageAreaChart = ({ data, config, dataPoint }) => {
 UsageAreaChart.propTypes = {
   data: PropTypes.objectOf(PropTypes.any).isRequired,
   dataPoint: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
   config: PropTypes.shape({
     units: PropTypes.string.isRequired,
     timeFrame: PropTypes.string.isRequired,

--- a/app/services/ems_dashboard_service.rb
+++ b/app/services/ems_dashboard_service.rb
@@ -11,7 +11,7 @@ class EmsDashboardService < DashboardService
   end
 
   def recent_resources(model, title, label)
-    all_resources = recent_records(model)
+    all_resources = recent_records(model).sort.to_h
     config = {
       :title => title,
       :label => label


### PR DESCRIPTION

**Before**

title is undefined and data is not in order

<img width="1267" alt="Screen Shot 2022-02-15 at 3 40 24 PM" src="https://user-images.githubusercontent.com/37085529/154146601-7a830ef0-1425-472a-b353-bc1f93cf28d2.png">


**After**

<img width="1361" alt="Screen Shot 2022-02-15 at 3 30 04 PM" src="https://user-images.githubusercontent.com/37085529/154146656-51196552-4eda-4933-8bbc-673d888af9e0.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug 

