### PR TITLE
Fix provision show/hide deprecate column mismatch

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -164,7 +164,7 @@ module ApplicationController::MiqRequestMethods
   end
 
   def provisioning_is_cloud?
-    params[:template_klass] == 'cloud' || %w[auth_key_pair_cloud availability_zone cloud_tenant ems_cloud host_aggregate orchestration_stack vm_cloud].include?(params[:controller])
+    params[:template_klass] == 'cloud' || %w[auth_key_pair_cloud availability_zone cloud_tenant ems_cloud host_aggregate orchestration_stack vm_cloud miq_request].include?(params[:controller])
   end
 
   def provisioning_is_infra?

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -85,7 +85,7 @@ describe MiqRequestController do
       let(:kls) { 'infra' }
 
       it 'returns proper template klass' do
-        expect(subject).to eq(ManageIQ::Providers::InfraManager::Template)
+        expect(subject).to eq(ManageIQ::Providers::CloudManager::Template)
       end
     end
 
@@ -104,6 +104,15 @@ describe MiqRequestController do
 
       it 'returns proper template klass' do
         expect(subject).to eq(ManageIQ::Providers::CloudManager::Template)
+      end
+    end
+
+    context 'provisioning instances displayed through details page of infra provider' do
+      let(:ctrl) { 'vm_infra' }
+      let(:kls) { 'infra' }
+
+      it 'returns proper template klass' do
+        expect(subject).to eq(ManageIQ::Providers::InfraManager::Template)
       end
     end
 


### PR DESCRIPTION
When check/uncheck 'Hide deprecated' checkbox, the column headers were changed

Before
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/154299647-a34be236-eb02-40d0-b078-ad5a662e99fb.png">

After
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/154299259-9b999c8c-2c18-499f-b207-ccb6af58fba5.png">

@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu
