### PR TITLE
Hide custom logos upload tab for podified env

### DIFF
--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -28,7 +28,7 @@
           = _("Authentication")
         = miq_tab_header("settings_workers", @sb[:active_tab]) do
           = _("Workers")
-        - if cur_svr_id == my_server.id
+        - if cur_svr_id == my_server.id && !MiqEnvironment::Command.is_podified?
           = miq_tab_header("settings_custom_logos", @sb[:active_tab]) do
             = _("Custom Logos")
         = miq_tab_header("settings_advanced", @sb[:active_tab]) do


### PR DESCRIPTION
In podified env, we are not allowing user to upload custom logos. So, hiding custom logos tab in this issue
**Before**

<img width="704" alt="Screen Shot 2022-02-17 at 3 13 13 PM" src="https://user-images.githubusercontent.com/37085529/154563189-0164d453-bc53-447f-afa0-4d8b9c2f43f0.png">

<img width="637" alt="Screen Shot 2022-02-17 at 3 10 50 PM" src="https://user-images.githubusercontent.com/37085529/154562851-1db4f048-b8d3-4307-906a-d049eadf9708.png">


**After**

<img width="1048" alt="Screen Shot 2022-02-17 at 3 10 29 PM" src="https://user-images.githubusercontent.com/37085529/154562869-d2acd3be-0d32-4b6f-bf04-db35d907ca65.png">
