### PR TITLE
Add supports iso_datastore checks

### DIFF
--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -114,7 +114,7 @@ module PxeController::IsoDatastores
   # Set form variables for edit
   def iso_datastore_set_form_vars
     @edit = {}
-    @edit[:emses] = ManageIQ::Providers::Redhat::InfraManager.without_iso_datastores.order(:name)
+    @edit[:emses] = ExtManagementSystem.supporting(:create_iso_datastore).order(:name).select { |ems| ems.supports?(:create_iso_datastore) }
   end
 
   # Common Schedule button handler routines

--- a/app/helpers/application_helper/button/iso_datastore_new.rb
+++ b/app/helpers/application_helper/button/iso_datastore_new.rb
@@ -9,6 +9,6 @@ class ApplicationHelper::Button::IsoDatastoreNew < ApplicationHelper::Button::Bu
   private
 
   def no_ems_without_iso_datastores?
-    !ManageIQ::Providers::Redhat::InfraManager.any_without_iso_datastores?
+    ExtManagementSystem.supporting(:create_iso_datastore).select { |ems| ems.supports?(:create_iso_datastore) }.none?
   end
 end


### PR DESCRIPTION
- enable button check for iso_datastores now uses the supports feature
- part of the work to split oVirt provider

Depends on: 
- https://github.com/ManageIQ/manageiq/pull/21726
- https://github.com/ManageIQ/manageiq-providers-ovirt/pull/596