### PR TITLE
Fix Infrastructure UI spacing on vm page

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -110,10 +110,7 @@
 
   .wrap_text {
     width: 100%;
-    display: inline-block;
-    text-overflow: ellipsis;
-    white-space: pre-wrap;
-    overflow: hidden;
+    word-break: break-all;
   }
 
   &.bordered-list {
@@ -130,6 +127,11 @@
 }
 
 .miq-structured-list-accordion {
+  li .bx--accordion__content {
+    padding: 0.5rem 0 0 0 !important;
+    margin: 0 !important;
+  }
+
   li:last-child {
     border-bottom: 0;
   }


### PR DESCRIPTION
Fixing the padding and word wrap issues

Before
<img width="1792" alt="Screenshot 2022-02-18 at 10 05 10 AM" src="https://user-images.githubusercontent.com/87487049/154619427-cc39592b-61ab-4e92-81dd-86f74fb3b019.png">

After
<img width="1792" alt="Screenshot 2022-02-18 at 10 05 46 AM" src="https://user-images.githubusercontent.com/87487049/154619440-fb9e0abd-282c-47a7-90c7-17f3bbbab68e.png">

@miq-bot add-reviewer @kavyanekkalapu 
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu