### PR TITLE
Fix advanced search modal css

### DIFF
--- a/app/stylesheet/legacy/patternfly_overrides.scss
+++ b/app/stylesheet/legacy/patternfly_overrides.scss
@@ -498,8 +498,13 @@ tr.rdetail > td {
   background-color: #f5f5f5 !important;
 }
 
-#advsearchModal .modal-dialog {
-  left: 50px;
+#advsearchModal {
+  z-index: 20000;
+  .modal-dialog {
+    left: 50px;
+    max-width: 800px;
+    overflow-x: scroll;
+  }
 }
 
 /// custom modal class for adv search


### PR DESCRIPTION
When zoom in , advanced search modal is hiding under left nav.

**Before**
<img width="1421" alt="Screen Shot 2022-02-19 at 11 31 48 AM" src="https://user-images.githubusercontent.com/37085529/154809709-ab2bd813-e11f-425e-b107-f17f0ceca03c.png">

**After**

<img width="1393" alt="Screen Shot 2022-02-19 at 11 29 45 AM" src="https://user-images.githubusercontent.com/37085529/154809716-ba7affc0-bf6c-406d-8bf3-292eaf6e1ffc.png">

 zoom in screenshot
<img width="1679" alt="Screen Shot 2022-02-19 at 11 30 10 AM" src="https://user-images.githubusercontent.com/37085529/154809717-094ad15b-fa36-41d4-913f-af602503bf6e.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug
