### PR TITLE
Fix dashboard charts footer css

### DIFF
--- a/app/stylesheet/legacy/patternfly_overrides.scss
+++ b/app/stylesheet/legacy/patternfly_overrides.scss
@@ -119,6 +119,7 @@ body#dashboard .blank-slate-pf {
 }
 
 .card-pf-footer {
+  margin-top: 30px !important;
   a > {
     .ff {
       margin-right: 5px;


### PR DESCRIPTION
the alignment of the divider line in chart panel is off

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug

**Before**

<img width="515" alt="Screen Shot 2022-02-21 at 10 20 23 AM" src="https://user-images.githubusercontent.com/37085529/154983613-5e7ed484-3959-4596-994c-2b1ea2420c6d.png">

<img width="537" alt="Screen Shot 2022-02-21 at 10 20 29 AM" src="https://user-images.githubusercontent.com/37085529/154983615-e700ed8e-5d9e-4d8d-a7ec-fdded0d29fb1.png">


**After**

<img width="625" alt="Screen Shot 2022-02-21 at 10 18 14 AM" src="https://user-images.githubusercontent.com/37085529/154983655-d16389ad-c0b5-4f0c-b12d-9c5836d0bf27.png">

<img width="527" alt="Screen Shot 2022-02-21 at 10 18 20 AM" src="https://user-images.githubusercontent.com/37085529/154983656-894e1514-19fe-4511-a2f8-045aeb120065.png">
