### PR TITLE
Fix pdf print to display all records instead of 10

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1028,7 +1028,7 @@ module ApplicationHelper
   end
 
   def pdf_page_size_style
-    "#{@options[:page_size].sub(/^US-/i, '') || "legal"} #{@options[:page_layout]}"
+    "#{@options[:page_layout]}"
   end
 
   DOWNLOAD_VIEW_LAYOUTS = %w[action


### PR DESCRIPTION
**Before**

<img width="1310" alt="Screen Shot 2022-02-21 at 3 52 33 PM" src="https://user-images.githubusercontent.com/37085529/155024961-21dcb692-7012-4bda-9f6d-88582b458ddf.png">



**After**

<img width="1645" alt="Screen Shot 2022-02-21 at 3 49 54 PM" src="https://user-images.githubusercontent.com/37085529/155024977-f776b099-52b1-4a74-8eb5-26157df4171d.png">

@miq-bot assign @Fryguy 
@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 
