### PR TITLE
Fix Conditions description clear issue when dropdown value changes

### DIFF
--- a/app/views/condition/_form.html.haml
+++ b/app/views/condition/_form.html.haml
@@ -15,7 +15,6 @@
               :maxlength         => ViewHelper::MAX_DESC_LEN,
               "data-miq_observe" => observe_with_interval,
               :class             => "form-control")
-            = javascript_tag(javascript_focus('description'))
       %hr
     .form-horizontal
       .form-group


### PR DESCRIPTION
**Before**
In the condition's new form page, after entering the value in the **Description** field and then changing the **Applies to** drop down field, the description field will be cleared.
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/155065333-30186c75-c5aa-4f54-9ec2-479dbe8ee0ae.png">
<img width="1782" alt="image" src="https://user-images.githubusercontent.com/87487049/155065515-9c947e47-7278-4b75-b7fb-7f1ec3de8698.png">

**After**
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/87487049/155065585-22484575-f441-4201-8003-bdb378325f52.png">

@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu

