### PR TITLE
Rename automation managers file

### DIFF
--- a/app/controllers/ems_automation_controller.rb
+++ b/app/controllers/ems_automation_controller.rb
@@ -52,7 +52,7 @@ class EmsAutomationController < ApplicationController
   private
 
   def concrete_model
-    ManageIQ::Providers::AnsibleTower::AutomationManager
+    ManageIQ::Providers::ExternalAutomationManager
   end
 
   def self.model_to_name(_provmodel)
@@ -101,7 +101,6 @@ class EmsAutomationController < ApplicationController
     {
       :breadcrumbs => [
         {:title => _("Automation")},
-        {:title => _("Ansible Tower")},
         {:title => _("Providers"), :url => controller_url},
       ],
       :record_info => @ems,

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1028,7 +1028,7 @@ class MiqAeClassController < ApplicationController
 
     if %w[ansible_job_template ansible_workflow_template].include?(location)
       # ManageIQ::Providers::AnsibleTower::Provider.where('zone_id != ?', Zone.maintenance_zone.id)
-      list_of_managers = ManageIQ::Providers::AnsibleTower::AutomationManager
+      list_of_managers = ManageIQ::Providers::ExternalAutomationManager
                          .where(:enabled => true)
                          .pluck(:id, :name)
                          .map { |r| {:id => r[0], :name => r[1]} }

--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -8,9 +8,9 @@ class RestfulRedirectController < ApplicationController
       if record
         if record.kind_of?(EmsConfiguration)
           redirect_to(:controller => 'ems_configuration', :action => 'show', :id => params[:id])
-        elsif %w[ManageIQ::Providers::AnsibleTower::AutomationManager].include?(record.type)
+        elsif record.kind_of?(ManageIQ::Providers::ExternalAutomationManager)
           redirect_to(:controller => 'ems_automation', :action => 'show', :id => params[:id])
-        elsif %w[ManageIQ::Providers::EmbeddedAnsible::AutomationManager].include?(record.type)
+        elsif record.kind_of?(ManageIQ::Providers::EmbeddedAnsible::AutomationManager)
           redirect_to(:controller => 'ansible_playbook', :action => 'show_list')
         else
           begin

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -408,7 +408,7 @@ module ApplicationHelper
       controller = "ansible_credential"
     when "MiqWorker"
       controller = request.parameters[:controller]
-    when "ManageIQ::Providers::AnsibleTower::AutomationManager", "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource",
+    when "ManageIQ::Providers::ExternalAutomationManager", "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource",
         "ManageIQ::Providers::CloudManager::OrchestrationStack",
         "ManageIQ::Providers::CloudManager::CloudDatabase",
         "ManageIQ::Providers::ConfigurationManager",

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -427,7 +427,7 @@ class TreeBuilder
     "az"   => "AvailabilityZone",
     "azu"  => "ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate",
     "azs"  => "ManageIQ::Providers::AzureStack::CloudManager::OrchestrationTemplate",
-    "at"   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
+    "at"   => "ManageIQ::Providers::ExternalAutomationManager",
     "cl"   => "Classification",
     "cfp"  => "ConfigurationScriptPayload",
     "cw"   => "ConfigurationWorkflow",

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -31,7 +31,7 @@ module TreeNode
       else
         base_class = @object.class.base_model.name # i.e. Vm or MiqTemplate
         base_class = "Datacenter" if base_class == "EmsFolder" && @object.kind_of?(::Datacenter)
-        base_class = "ManageIQ::Providers::AnsibleTower::AutomationManager" if @object.kind_of?(ManageIQ::Providers::AnsibleTower::AutomationManager)
+        base_class = "ManageIQ::Providers::ExternalAutomationManager" if @object.kind_of?(ManageIQ::Providers::ExternalAutomationManager)
         prefix = TreeBuilder.get_prefix_for_model(base_class)
         cid = @object.id
         "#{@tree.try(:options).try(:[], :full_ids) && @parent_id.present? ? "#{@parent_id}_" : ''}#{prefix}-#{cid}"

--- a/product/views/ManageIQ_Providers_ExternalAutomationManager.yaml
+++ b/product/views/ManageIQ_Providers_ExternalAutomationManager.yaml
@@ -15,7 +15,7 @@ title: Ansible Tower Providers
 name: Ansible Tower Providers
 
 # Main DB table report is based on
-db: ManageIQ::Providers::AnsibleTower::AutomationManager
+db: ManageIQ::Providers::ExternalAutomationManager
 
 # Columns to fetch from the main table
 cols:


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/21743

Renamed automation managers yaml so that it shows all providers instead of ansible tower.

dependency pr- > https://github.com/ManageIQ/manageiq/pull/21740

**Before**
<img width="905" alt="Screen Shot 2022-03-23 at 4 42 14 PM" src="https://user-images.githubusercontent.com/37085529/159791980-4b6176de-43f6-4922-9cdb-d618aca1d3c9.png">


**After**

<img width="1375" alt="Screen Shot 2022-03-23 at 4 09 44 PM" src="https://user-images.githubusercontent.com/37085529/159791857-dea3a4b1-5ea3-449f-8dcc-758db1cb398c.png">


@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug