### PR TITLE
Fix instance edit page from availability zone summary

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -582,9 +582,11 @@ module VmCommon
     @edit ||= {}
     @edit[:explorer] = true if params[:action] == "x_button" || session.fetch_path(:edit, :explorer)
     @explorer = true if @edit[:explorer]
-
-    drop_breadcrumb(:name => _("Edit VM '%{name}'") % {:name => @record.name}, :url => "/vm/edit") unless @explorer
-
+    @in_a_form = true
+    @title = _("Editing %{vm_or_template} \"%{name}\"") % {:name => @record.name, :vm_or_template => model_for_vm(@record).display_name}
+    @right_cell_text = @title
+    drop_breadcrumb(:name => @title, :url => "/vm/edit") unless @explorer
+    @lastaction = "show_list"
     @refresh_partial = "vm_common/form"
   end
 

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -108,8 +108,6 @@ module ApplicationHelper::PageLayouts
                !%w[new create edit copy update explorer].include?(controller.action_name)
              when 'timeline'
                @in_a_form
-             when 'vm'
-               controller.action_name != 'edit'
              else
                true
              end
@@ -120,7 +118,6 @@ module ApplicationHelper::PageLayouts
                else
                  true
                end
-
     layout && showtype
   end
 

--- a/app/views/vm/edit.html.haml
+++ b/app/views/vm/edit.html.haml
@@ -1,0 +1,7 @@
+#main_div
+  = render :partial => "layouts/flash_msg"
+  = react('VmEditForm', {:recordId    => @record.id&.to_s,
+                         :emsId       => @record.ems_id&.to_s,
+                         :showTitle   => !@edit[:explorer],
+                         :isTemplate  => @record.kind_of?(::MiqTemplate),
+                         :displayName => model_for_vm(@record).display_name})


### PR DESCRIPTION
Bug-> if we try edit instance from zones summary page, it is giving error.

**Steps to reproduce the behavior:**

- Select Availability Zones from compute-->clouds
- click a zone with instances
- Select Instances
- Click the box of the Instance
- Configuration -> Edit Selected Item

**Before**

<img width="1336" alt="Screen Shot 2022-02-24 at 3 35 19 PM" src="https://user-images.githubusercontent.com/37085529/155603356-fa1cb714-6586-41b1-8b54-52fddece130d.png">


**After**

<img width="1429" alt="Screen Shot 2022-02-24 at 3 23 36 PM" src="https://user-images.githubusercontent.com/37085529/155602388-64533231-c812-4bdd-8b3b-55d997a50f4c.png">

