### PR TITLE
Add condition for error modal

### DIFF
--- a/app/javascript/oldjs/controllers/error_modal_controller.js
+++ b/app/javascript/oldjs/controllers/error_modal_controller.js
@@ -76,7 +76,7 @@ angular.module('miq.error', [])
     // inlining the template because it may be harder to GET when the server is down
     template: [
       '<div id="errorModal" ng-class="{ ' + "'modal-open'" + ': $ctrl.error }">',
-      '  <div class="modal" ng-class="{ show: $ctrl.error }">',
+      '  <div class="modal" ng-if="$ctrl.error" ng-class="{ show: $ctrl.error }">',
       '    <div class="modal-dialog">',
       '      <div class="modal-content error-modal-miq">',
       '        <div class="modal-header">',


### PR DESCRIPTION
Followup of https://github.com/ManageIQ/manageiq-ui-classic/pull/8125

This will only show up modal when error is present. We have ng-class to add class but it is not sufficient.

We are only seeing this error 1-2 seconds. After that it is redirecting dashboard page.

**Before**
<img width="515" alt="Screen Shot 2022-02-28 at 12 43 51 PM" src="https://user-images.githubusercontent.com/37085529/156032205-635bac41-15a2-4f6f-a4b4-4945485bbda8.png">

@miq-bot assign @Fryguy 
@miq-bot add_reviewer @Fryguy 
@miq-bot add-label bug
