### PR TITLE
Use class_by_ems to access correct provider class

### DIFF
--- a/app/helpers/application_helper/button/host_initiator_group_new.rb
+++ b/app/helpers/application_helper/button/host_initiator_group_new.rb
@@ -11,10 +11,10 @@ class ApplicationHelper::Button::HostInitiatorGroupNew < ApplicationHelper::Butt
   def disabled?
     if @view_context.params["id"]
       current_ems = ExtManagementSystem.where(:id => @view_context.params["id"]).first
-      !"#{current_ems.type}::HostInitiatorGroup".safe_constantize.try(:supports_create?)
+      !current_ems.class_by_ems("HostInitiatorGroup").try(:supports_create?)
     else
       ExtManagementSystem.none? do |ems|
-        "#{ems.class}::HostInitiatorGroup".safe_constantize.try(:supports_create?)
+        ems.class_by_ems("HostInitiatorGroup").try(:supports_create?)
       end
     end
   end

--- a/app/helpers/application_helper/button/host_initiator_new.rb
+++ b/app/helpers/application_helper/button/host_initiator_new.rb
@@ -11,10 +11,10 @@ class ApplicationHelper::Button::HostInitiatorNew < ApplicationHelper::Button::B
   def disabled?
     if @view_context.params["id"]
       current_ems = ExtManagementSystem.where(:id => @view_context.params["id"]).first
-      !"#{current_ems.type}::HostInitiator".safe_constantize.try(:supports_create?)
+      !current_ems.class_by_ems("HostInitiator").try(:supports_create?)
     else
       ExtManagementSystem.none? do |ems|
-        "#{ems.class}::HostInitiator".safe_constantize.try(:supports_create?)
+        ems.class_by_ems("HostInitiator").try(:supports_create?)
       end
     end
   end


### PR DESCRIPTION
We can delegate the lookup of the correct provider `HostInitiator` and `HostInitiatorGroup` constants to `class_by_ems` and avoid some constantizing.