### PR TITLE
Remove col3 reference from dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -196,9 +196,7 @@ class DashboardController < ApplicationController
     @sb[:dashboards][@sb[:active_db]][:minimized] ||= [] # Init minimized widgets array
 
     # Build the available widgets for the pulldown
-    dashboard = @sb[:dashboards][@sb[:active_db]]
-    dashboard[:col1], dashboard[:col2], dashboard[:col3] = override_columns(dashboard)
-    col_widgets = [:col1, :col2, :col3].map { |column| dashboard[column] }.flatten.uniq.compact
+    col_widgets = column_widgets(@sb[:dashboards][@sb[:active_db]]).flatten.uniq.compact
 
     # Build widget_list to load the widget dropdown list toolbar
     widget_list = []
@@ -320,15 +318,13 @@ class DashboardController < ApplicationController
   # A widget has been dropped
   def widget_dd_done
     assert_privileges("dashboard_add")
-    if params[:col1] || params[:col2] || params[:col3]
+    if params[:col1] || params[:col2]
       if params[:col1] && params[:col1] != [""]
         @sb[:dashboards][@sb[:active_db]][:col1] = param_widgets(params[:col1])
         @sb[:dashboards][@sb[:active_db]][:col2].delete_if { |w| @sb[:dashboards][@sb[:active_db]][:col1].include?(w) }
-        @sb[:dashboards][@sb[:active_db]][:col3].delete_if { |w| @sb[:dashboards][@sb[:active_db]][:col1].include?(w) }
       elsif params[:col2] && params[:col2] != [""]
         @sb[:dashboards][@sb[:active_db]][:col2] = param_widgets(params[:col2])
         @sb[:dashboards][@sb[:active_db]][:col1].delete_if { |w| @sb[:dashboards][@sb[:active_db]][:col2].include?(w) }
-        @sb[:dashboards][@sb[:active_db]][:col3].delete_if { |w| @sb[:dashboards][@sb[:active_db]][:col2].include?(w) }
       end
       save_user_dashboards
     end
@@ -340,8 +336,9 @@ class DashboardController < ApplicationController
     assert_privileges("dashboard_view")
     if params[:widget] # Make sure we got a widget in
       w = params[:widget].to_i
-      dashboard = @sb[:dashboards][@sb[:active_db]]
-      [:col1, :col2, :col3, :minimized].each { |column| dashboard[column].delete(w) }
+      @sb[:dashboards][@sb[:active_db]][:col1].delete(w)
+      @sb[:dashboards][@sb[:active_db]][:col2].delete(w)
+      @sb[:dashboards][@sb[:active_db]][:minimized].delete(w)
       ws = MiqWidgetSet.where_unique_on(@sb[:active_db], current_user).first
       w = MiqWidget.find_by(:id => w)
       ws.remove_member(w) if w

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -13,26 +13,7 @@ module DashboardHelper
     [last_run, next_run]
   end
 
-  def column_data(dashboard, column)
-    dashboard.key?(column) ? dashboard[column].uniq : []
-  end
-
-  # Method to convert 3 columns to 2 columns design for dashboard and sample dashboard page.
-  def override_columns(dashboard)
-    col1, col2, col3 = [:col1, :col2, :col3].map { |column| column_data(dashboard, column) }
-    col2 = ((col2 + col3).uniq - col1)
-    col3 = []
-    col1, col2 = split_widgets(col1) if col2.empty? && col1.length >= 2
-    col1, col2 = split_widgets(col2) if col1.empty? && col2.length >= 2
-    return col1, col2, col3
-  end
-
-  private
-  
-  def split_widgets(widgets)
-    length = widgets.length
-    col1 = widgets.slice(0, length / 2)
-    col2 = widgets.slice(length / 2, length)
-    return col1, col2
+  def column_widgets(dashboard)
+    [:col1, :col2].map { |column| dashboard.key?(column) ? dashboard[column].uniq : [] }
   end
 end

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -767,7 +767,7 @@ window.miqClearLoginFields = function() {
 window.miqInitDashboardCols = function() {
   if (miqDomElementExists('col1')) {
     $('#col1').sortable({
-      connectWith: '#col2, #col3',
+      connectWith: '#col2',
       handle: '.sortable-handle',
       helper: 'clone',
       placeholder: 'sortable-placeholder',
@@ -778,7 +778,7 @@ window.miqInitDashboardCols = function() {
   }
   if (miqDomElementExists('col2')) {
     $('#col2').sortable({
-      connectWith: '#col1, #col3',
+      connectWith: '#col1',
       handle: '.sortable-handle',
       helper: 'clone',
       placeholder: 'sortable-placeholder',
@@ -786,17 +786,6 @@ window.miqInitDashboardCols = function() {
     });
     $('#col2').off('sortupdate');
     $('#col2').on('sortupdate', miqDropComplete);
-  }
-  if (miqDomElementExists('col3')) {
-    $('#col3').sortable({
-      connectWith: '#col1, #col2',
-      handle: '.sortable-handle',
-      helper: 'clone',
-      placeholder: 'sortable-placeholder',
-      forcePlaceholderSize: true,
-    });
-    $('#col3').off('sortupdate');
-    $('#col3').on('sortupdate', miqDropComplete);
   }
 }
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -253,7 +253,7 @@ describe DashboardController do
       wi = FactoryBot.create(:miq_widget)
       @ws.update(:userid => @user.userid)
       session[:sandboxes] = {"dashboard" => {:active_db  => @ws.name,
-                                             :dashboards => {@ws.name => {:col1 => [], :col2 => [], :col3 => []}}}}
+                                             :dashboards => {@ws.name => {:col1 => [], :col2 => []}}}}
       login_as @user
       allow(User).to receive(:server_timezone).and_return("UTC")
       allow(MiqServer).to receive(:my_zone).and_return('default')
@@ -280,12 +280,11 @@ describe DashboardController do
 
       # get user's copy of dashboard and add widgets
       user_dashboard = MiqWidgetSet.find_by(:name => @ws.name, :userid => @user.userid)
-      user_dashboard.update(:set_data => {:last_group_db_updated => Time.now.utc - 1, :col1 => [1, 2, 3], :col2 => [4], :col3 => [5, 7]})
+      user_dashboard.update(:set_data => {:last_group_db_updated => Time.now.utc - 1, :col1 => [1, 2, 3], :col2 => [4]})
 
       # verify groupd dashboard and user's dashboard has different widgets
       expect(user_dashboard.set_data[:col1]).not_to eq(@ws.set_data[:col1])
       expect(user_dashboard.set_data[:col2]).not_to eq(@ws.set_data[:col2])
-      expect(user_dashboard.set_data[:col3]).not_to eq(@ws.set_data[:col3])
 
       # login again to verify that the user's copy of dashboard gets reset to group dashboard settings
       login_as @user
@@ -294,7 +293,6 @@ describe DashboardController do
       user_dashboard.reload
       expect(user_dashboard.set_data[:col1]).to eq(@ws.set_data[:col1])
       expect(user_dashboard.set_data[:col2]).to eq(@ws.set_data[:col2])
-      expect(user_dashboard.set_data[:col3]).to eq(@ws.set_data[:col3])
     end
   end
 
@@ -367,7 +365,7 @@ describe DashboardController do
       controller.instance_variable_set(
         :@sb,
         :active_db  => wset.name, :active_db_id => wset.id,
-        :dashboards => {wset.name => {:col1 => [widget.id], :col2 => [], :col3 => []}}
+        :dashboards => {wset.name => {:col1 => [widget.id], :col2 => []}}
       )
 
       controller.show


### PR DESCRIPTION
Removing col3 reference from dashboard since it is not used anymore

Related PR- https://github.com/ManageIQ/manageiq-schema/pull/641

@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label enhancement
@miq-bot assign @kavyanekkalapu