### PR TITLE
Remove image Right-Size button from toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -66,16 +66,6 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
           :confirm      => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled      => false,
           :onwhen       => "1+"),
-        separator,
-        button(
-          :image_right_size,
-          'ff ff-database-squeezed fa-lg',
-          N_('CPU/Memory Recommendations of selected item'),
-          N_('Right-Size Recommendations'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1"),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -39,12 +39,6 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
                        N_('Remove Image from Inventory'),
                        :url_parms => "&refresh=y",
                        :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed!")),
-                     separator,
-                     button(
-                       :image_right_size,
-                       'ff ff-database-squeezed fa-lg',
-                       N_('CPU/Memory Recommendations of this Image'),
-                       N_('Right-Size Recommendations')),
                    ]
                  ),
                ])


### PR DESCRIPTION
We cannot do Right-Size for images. So, removing that button from toolbar.

core pr-> https://github.com/ManageIQ/manageiq/pull/21752

**Before**

<img width="1426" alt="Screen Shot 2022-03-01 at 4 05 12 PM" src="https://user-images.githubusercontent.com/37085529/156278197-0cc94655-3f4c-4c73-bfdf-3c0aeee9e1e6.png">

<img width="1298" alt="Screen Shot 2022-03-01 at 8 42 28 PM" src="https://user-images.githubusercontent.com/37085529/156278599-09975993-b5d0-4cd7-8e65-e37f0105ed80.png">



**After**

<img width="838" alt="Screen Shot 2022-03-01 at 8 40 25 PM" src="https://user-images.githubusercontent.com/37085529/156278406-88376c75-a008-45bf-b7dd-a0031c811126.png">


@miq-bot assign @agrare 
@miq-bot add-label bug, najdorf/yes?
@miq-bot add_reviewer @agrare 