### PR TITLE
fix date format in provider dashboard charts

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/helpers.js
+++ b/app/javascript/components/provider-dashboard-charts/helpers.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export const getConvertedData = (data, units) => {
   if (data && data.xData && data.yData) {
     const columnsData = data.xData;
@@ -7,7 +9,7 @@ export const getConvertedData = (data, units) => {
       columnsData.forEach((item, i) => {
         const obj = {};
         obj.group = units;
-        obj.date = item;
+        obj.date = moment(item).tz(ManageIQ.timezone || 'UTC').format('MM/DD/YYYY HH:mm:ss z')
         obj.value = rowsData[i];
         arr.push(obj);
       });


### PR DESCRIPTION
**Before**

**Bug:** Provider dashboard is showing previous than created date.

**Before**

<img width="1680" alt="Screen Shot 2022-03-02 at 2 12 40 PM" src="https://user-images.githubusercontent.com/37085529/156432497-dbf83461-b866-4bdd-998e-c25caedbe8ac.png">

**After**

<img width="1365" alt="Screen Shot 2022-03-02 at 2 11 45 PM" src="https://user-images.githubusercontent.com/37085529/156432525-762a3bfe-acf3-4cfe-89d3-bd41f8fbd243.png">

@miq-bot assign @Fryguy 
@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 
