### PR TITLE
Updated carbon charts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@carbon/charts": "^0.41.100",
-    "@carbon/charts-react": "^0.41.100",
+    "@carbon/charts": "^0.54.12",
+    "@carbon/charts-react": "^0.54.12",
     "@carbon/icons-react": "~10.26.0",
     "@carbon/themes": "~10.28.0",
     "@data-driven-forms/carbon-component-mapper": "~3.15.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,36 +1301,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/charts-react@npm:^0.41.100":
-  version: 0.41.103
-  resolution: "@carbon/charts-react@npm:0.41.103"
+"@carbon/charts-react@npm:^0.54.12":
+  version: 0.54.12
+  resolution: "@carbon/charts-react@npm:0.54.12"
   dependencies:
-    "@carbon/charts": ^0.41.103
+    "@carbon/charts": ^0.54.12
     "@carbon/icons-react": ^10.32.0
     "@carbon/telemetry": 0.0.0-alpha.6
   peerDependencies:
     react: ^16.0.0 || ^17.0.0
     react-dom: ^16.0.0 || ^17.0.0
-  checksum: d1bad95f6b75c8362159d9396d72262c90530fd87ab185c3119ab511fe948695f982ceef6ecb4182a5a8574f199f56ab015930ba1c6ab90c5425472a7ce33aa4
+  checksum: 32a4b5c31b549f26f647d225f6668bd088ca81d69ed630863a4fd17d1f1da8d76f14336ffa6b614321b3a13349498a985bfd46089715e1cfd0fbf3b6f777752a
   languageName: node
   linkType: hard
 
-"@carbon/charts@npm:^0.41.100, @carbon/charts@npm:^0.41.103":
-  version: 0.41.103
-  resolution: "@carbon/charts@npm:0.41.103"
+"@carbon/charts@npm:^0.54.12":
+  version: 0.54.12
+  resolution: "@carbon/charts@npm:0.54.12"
   dependencies:
     "@carbon/colors": 10.29.0
     "@carbon/telemetry": 0.0.0-alpha.6
     "@carbon/utils-position": 1.1.1
     carbon-components: 10.40.0
     d3-cloud: 1.2.5
+    d3-sankey: 0.12.3
     date-fns: 2.8.1
     dom-to-image: 2.6.0
     lodash-es: 4.17.21
     resize-observer-polyfill: 1.5.0
   peerDependencies:
     d3: 7.x
-  checksum: e7b144068ba6d00d75c075d8f448890ae6684a57cc06a6af92a79fa042d309b0b457e9254c3364fbd75cc2ac0fc4b217308b075af813864b54c28d576cb2f73f
+  checksum: a4d83a105220f7d68542746981901d437277c137bf8ab6888868087b77905904dccb0ebb5698a6363e81b9e541e69c66bf9120e6d0fce9b6f7a7f93775b0e292
   languageName: node
   linkType: hard
 
@@ -6037,6 +6038,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:1 - 2":
+  version: 2.12.1
+  resolution: "d3-array@npm:2.12.1"
+  dependencies:
+    internmap: ^1.0.0
+  checksum: 97853b7b523aded17078f37c67742f45d81e88dda2107ae9994c31b9e36c5fa5556c4c4cf39650436f247813602dfe31bf7ad067ff80f127a16903827f10c6eb
+  languageName: node
+  linkType: hard
+
 "d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3":
   version: 3.1.1
   resolution: "d3-array@npm:3.1.1"
@@ -6213,6 +6223,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-path@npm:1":
+  version: 1.0.9
+  resolution: "d3-path@npm:1.0.9"
+  checksum: d4382573baf9509a143f40944baeff9fead136926aed6872f7ead5b3555d68925f8a37935841dd51f1d70b65a294fe35c065b0906fb6e42109295f6598fc16d0
+  languageName: node
+  linkType: hard
+
 "d3-path@npm:1 - 3, d3-path@npm:3":
   version: 3.0.1
   resolution: "d3-path@npm:3.0.1"
@@ -6238,6 +6255,16 @@ __metadata:
   version: 3.0.1
   resolution: "d3-random@npm:3.0.1"
   checksum: a70ad8d1cabe399ebeb2e482703121ac8946a3b336830b518da6848b9fdd48a111990fc041dc716f16885a72176ffa2898f2a250ca3d363ecdba5ef92b18e131
+  languageName: node
+  linkType: hard
+
+"d3-sankey@npm:0.12.3":
+  version: 0.12.3
+  resolution: "d3-sankey@npm:0.12.3"
+  dependencies:
+    d3-array: 1 - 2
+    d3-shape: ^1.2.0
+  checksum: df1cb9c9d02dd8fd14040e89f112f0da58c03bd7529fa001572a6925a51496d1d82ff25d9fedb6c429a91645fbd2476c19891e535ac90c8bc28337c33ee21c87
   languageName: node
   linkType: hard
 
@@ -6277,6 +6304,15 @@ __metadata:
   dependencies:
     d3-path: 1 - 3
   checksum: 958f15369d18ffba405a59efec08f2774e09ad80717a33f8f3f76bf83dbfc1eef8c5a474f2383168d468a98d6657eaef29fb127d8ec05c5e0126eb549af92581
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:^1.2.0":
+  version: 1.3.7
+  resolution: "d3-shape@npm:1.3.7"
+  dependencies:
+    d3-path: 1
+  checksum: 46566a3ab64a25023653bf59d64e81e9e6c987e95be985d81c5cedabae5838bd55f4a201a6b69069ca862eb63594cd263cac9034afc2b0e5664dfe286c866129
   languageName: node
   linkType: hard
 
@@ -9557,6 +9593,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"internmap@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "internmap@npm:1.0.1"
+  checksum: 9d00f8c0cf873a24a53a5a937120dab634c41f383105e066bb318a61864e6292d24eb9516e8e7dccfb4420ec42ca474a0f28ac9a6cc82536898fa09bbbe53813
+  languageName: node
+  linkType: hard
+
 "interpret@npm:^1.4.0":
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
@@ -11713,8 +11756,8 @@ fsevents@^1.2.7:
     "@babel/preset-react": ~7.9.1
     "@babel/register": ~7.9.0
     "@babel/runtime-corejs3": ~7.9.0
-    "@carbon/charts": ^0.41.100
-    "@carbon/charts-react": ^0.41.100
+    "@carbon/charts": ^0.54.12
+    "@carbon/charts-react": ^0.54.12
     "@carbon/icons-react": ~10.26.0
     "@carbon/themes": ~10.28.0
     "@data-driven-forms/carbon-component-mapper": ~3.15.5


### PR DESCRIPTION
Upgraded carbon charts and carbon-charts react versions in order to fix missing toolbar for the pie chart.

Before:
<img width="463" alt="Screen Shot 2022-03-02 at 4 11 34 PM" src="https://user-images.githubusercontent.com/32444791/156450410-a3a5074c-8efe-4077-9a2e-79f332b9a8ea.png">

After:
<img width="465" alt="Screen Shot 2022-03-02 at 4 03 01 PM" src="https://user-images.githubusercontent.com/32444791/156450584-c03d4c5c-667d-4e42-b098-1c57e6b4365f.png">


@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label enhancement