### PR TITLE
Fix delete modal for catalog item

### DIFF
--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -84,13 +84,14 @@ class RemoveCatalogItemModal extends React.Component {
       }));
 
     // Buttons setup
-    const { data } = this.state;
     dispatch({
       type: 'FormButtons.init',
       payload: {
         newRecord: true,
         pristine: true,
-        addClicked: () => removeCatalogItems(data),
+        // used this.state.data to get updated value from promise (whenever state updates)
+        // eslint-disable-next-line react/destructuring-assignment
+        addClicked: () => removeCatalogItems(this.state.data),
       },
     });
     dispatch({


### PR DESCRIPTION
**Before**

Nothing is happening when we click delete from delete modal

**After**

<img width="1424" alt="Screen Shot 2022-03-03 at 11 20 02 AM" src="https://user-images.githubusercontent.com/37085529/156606743-da1ea952-1611-485f-8a9e-94222c464ea9.png">

@miq-bot assign @Fryguy 
@miq-bot add-label bug,najdorf/yes?
@miq-bot add_reviewer @Fryguy 
