### PR TITLE
Fixed dashboard widget remove

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -341,7 +341,7 @@ class DashboardController < ApplicationController
     if params[:widget] # Make sure we got a widget in
       w = params[:widget].to_i
       dashboard = @sb[:dashboards][@sb[:active_db]]
-      [:col1, :col2, :col3, :minimized].each { |column| column_data(dashboard, column).delete(w) }
+      [:col1, :col2, :col3, :minimized].each { |column| dashboard[column].delete(w) }
       ws = MiqWidgetSet.where_unique_on(@sb[:active_db], current_user).first
       w = MiqWidget.find_by(:id => w)
       ws.remove_member(w) if w


### PR DESCRIPTION
Fixed dashboard widget remove. When trying to remove a dashboard widget clicking remove does not actually remove the widget. This fix allows results in the widget being removed from the dashboard after clicking remove widget.