### PR TITLE
Remove miq_bootstrap from react pages

### DIFF
--- a/app/views/cloud_tenant/_show_dashboard.html.haml
+++ b/app/views/cloud_tenant/_show_dashboard.html.haml
@@ -9,6 +9,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent Images'),
        :config => 'recentImagesConfig', :apiUrl => 'cloud_tenant_dashboard/recent_images_data', :dataPoint => 'recentResources')
-  :javascript
-    ManageIQ.angular.app.value('#{@record.id}');
-    miq_bootstrap('.cloud-tenant-dashboard');

--- a/app/views/ems_cloud/_show_dashboard.html.haml
+++ b/app/views/ems_cloud/_show_dashboard.html.haml
@@ -9,6 +9,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent Images'),
        :config => 'recentImagesConfig', :apiUrl => 'ems_cloud_dashboard/recent_images_data', :dataPoint => 'recentResources')
-  :javascript
-    ManageIQ.angular.app.value('providerId', '#{@record.id}');
-    miq_bootstrap('.ems-cloud-dashboard');

--- a/app/views/ems_physical_infra/_show_dashboard.html.haml
+++ b/app/views/ems_physical_infra/_show_dashboard.html.haml
@@ -10,6 +10,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent Servers'), :config => 'recentServersConfig',
        :apiUrl => 'ems_physical_infra_dashboard/recent_servers_data', :dataPoint => 'recentServers')
-
-  :javascript
-    miq_bootstrap('.ems-physical-infra-dashboard');

--- a/app/views/physical_infra_overview/show.html.haml
+++ b/app/views/physical_infra_overview/show.html.haml
@@ -10,6 +10,3 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentVmGraph', :providerId => '', :title => _('Recent Servers'),
        :config => 'recentServersConfig', :apiUrl => 'ems_physical_infra_dashboard/recent_servers_data', :dataPoint => 'recentServers')
-
-  :javascript
-    miq_bootstrap('.ems-physical-infra-dashboard');


### PR DESCRIPTION
**Issue:** Part of https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

We already converted the components of this page to react. So, we don't need miq_bootstrap anymore to render these pages.

@miq-bot assign @Fryguy 
@miq-bot add-label technical_debt
@miq-bot add_reviewer @Fryguy 

