### PR TITLE
Remove name field for ph storage

### DIFF
--- a/app/javascript/components/physical-storage-form/index.jsx
+++ b/app/javascript/components/physical-storage-form/index.jsx
@@ -37,7 +37,7 @@ const PhysicalStorageForm = ({ recordId, storageManagerId }) => {
       const message = sprintf(
         recordId
           ? __('Modification of Physical Storage "%s" has been successfully queued.')
-          : __('Add of Physical Storage "%s" has been successfully queued.'),
+          : __('Add of Physical Storage has been successfully queued.'),
         values.name,
       );
       miqRedirectBack(message, undefined, '/physical_storage/show_list');

--- a/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
+++ b/app/javascript/components/physical-storage-form/physical-storage-form.schema.js
@@ -38,8 +38,8 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         name: 'name',
         id: 'name',
         label: __('Name:'),
-        isRequired: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
+        isDisabled: true,
+        hideField: !edit,
       },
       {
         component: componentTypes.SELECT,

--- a/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
+++ b/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
@@ -33,15 +33,11 @@ exports[`Physical storage form component should render adding form variant 1`] =
         },
         Object {
           "component": "text-field",
+          "hideField": true,
           "id": "name",
-          "isRequired": true,
+          "isDisabled": true,
           "label": "Name:",
           "name": "name",
-          "validate": Array [
-            Object {
-              "type": "required",
-            },
-          ],
         },
         Object {
           "component": "select",
@@ -213,15 +209,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
             },
             Object {
               "component": "text-field",
+              "hideField": false,
               "id": "name",
-              "isRequired": true,
+              "isDisabled": true,
               "label": "Name:",
               "name": "name",
-              "validate": Array [
-                Object {
-                  "type": "required",
-                },
-              ],
             },
             Object {
               "component": "select",
@@ -408,15 +400,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
               },
               Object {
                 "component": "text-field",
+                "hideField": false,
                 "id": "name",
-                "isRequired": true,
+                "isDisabled": true,
                 "label": "Name:",
                 "name": "name",
-                "validate": Array [
-                  Object {
-                    "type": "required",
-                  },
-                ],
               },
               Object {
                 "component": "select",
@@ -595,15 +583,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                 },
                 Object {
                   "component": "text-field",
+                  "hideField": false,
                   "id": "name",
-                  "isRequired": true,
+                  "isDisabled": true,
                   "label": "Name:",
                   "name": "name",
-                  "validate": Array [
-                    Object {
-                      "type": "required",
-                    },
-                  ],
                 },
                 Object {
                   "component": "select",
@@ -782,17 +766,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                   />,
                   <SingleField
                     component="text-field"
+                    hideField={false}
                     id="name"
-                    isRequired={true}
+                    isDisabled={true}
                     label="Name:"
                     name="name"
-                    validate={
-                      Array [
-                        Object {
-                          "type": "required",
-                        },
-                      ]
-                    }
                   />,
                   <SingleField
                     component="select"
@@ -951,15 +929,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                     },
                     Object {
                       "component": "text-field",
+                      "hideField": false,
                       "id": "name",
-                      "isRequired": true,
+                      "isDisabled": true,
                       "label": "Name:",
                       "name": "name",
-                      "validate": Array [
-                        Object {
-                          "type": "required",
-                        },
-                      ],
                     },
                     Object {
                       "component": "select",
@@ -1113,17 +1087,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                     />,
                     <SingleField
                       component="text-field"
+                      hideField={false}
                       id="name"
-                      isRequired={true}
+                      isDisabled={true}
                       label="Name:"
                       name="name"
-                      validate={
-                        Array [
-                          Object {
-                            "type": "required",
-                          },
-                        ]
-                      }
                     />,
                     <SingleField
                       component="select"
@@ -1288,15 +1256,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                       },
                       Object {
                         "component": "text-field",
+                        "hideField": false,
                         "id": "name",
-                        "isRequired": true,
+                        "isDisabled": true,
                         "label": "Name:",
                         "name": "name",
-                        "validate": Array [
-                          Object {
-                            "type": "required",
-                          },
-                        ],
                       },
                       Object {
                         "component": "select",
@@ -1465,17 +1429,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                       />,
                       <SingleField
                         component="text-field"
+                        hideField={false}
                         id="name"
-                        isRequired={true}
+                        isDisabled={true}
                         label="Name:"
                         name="name"
-                        validate={
-                          Array [
-                            Object {
-                              "type": "required",
-                            },
-                          ]
-                        }
                       />,
                       <SingleField
                         component="select"
@@ -1640,15 +1598,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                         },
                         Object {
                           "component": "text-field",
+                          "hideField": false,
                           "id": "name",
-                          "isRequired": true,
+                          "isDisabled": true,
                           "label": "Name:",
                           "name": "name",
-                          "validate": Array [
-                            Object {
-                              "type": "required",
-                            },
-                          ],
                         },
                         Object {
                           "component": "select",
@@ -2014,32 +1968,21 @@ exports[`Physical storage form component should render editing form variant 1`] 
                         </SingleField>
                         <SingleField
                           component="text-field"
+                          hideField={false}
                           id="name"
-                          isRequired={true}
+                          isDisabled={true}
                           key="name"
                           label="Name:"
                           name="name"
-                          validate={
-                            Array [
-                              Object {
-                                "type": "required",
-                              },
-                            ]
-                          }
                         >
                           <FormConditionWrapper
                             field={
                               Object {
                                 "component": "text-field",
                                 "id": "name",
-                                "isRequired": true,
+                                "isDisabled": true,
                                 "label": "Name:",
                                 "name": "name",
-                                "validate": Array [
-                                  Object {
-                                    "type": "required",
-                                  },
-                                ],
                               }
                             }
                           >
@@ -2049,30 +1992,19 @@ exports[`Physical storage form component should render editing form variant 1`] 
                               <TextField
                                 component="text-field"
                                 id="name"
-                                isRequired={true}
+                                isDisabled={true}
                                 label="Name:"
                                 name="name"
-                                validate={
-                                  Array [
-                                    Object {
-                                      "type": "required",
-                                    },
-                                  ]
-                                }
                               >
                                 <TextInput
-                                  disabled={false}
+                                  disabled={true}
                                   helperText=""
                                   id="name"
                                   inline={false}
                                   invalid={false}
                                   invalidText=""
                                   key="name"
-                                  labelText={
-                                    <IsRequired>
-                                      Name:
-                                    </IsRequired>
-                                  }
+                                  labelText="Name:"
                                   light={false}
                                   name="name"
                                   onBlur={[Function]}
@@ -2088,18 +2020,10 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                     className="bx--form-item bx--text-input-wrapper"
                                   >
                                     <label
-                                      className="bx--label"
+                                      className="bx--label bx--label--disabled"
                                       htmlFor="name"
                                     >
-                                      <IsRequired>
-                                        <span
-                                          aria-hidden="true"
-                                          className="ddorg__carbon-component-mapper_is-required isRequired-0-2-4"
-                                        >
-                                          *
-                                        </span>
-                                        Name:
-                                      </IsRequired>
+                                      Name:
                                     </label>
                                     <div
                                       className="bx--text-input__field-outer-wrapper"
@@ -2110,7 +2034,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                       >
                                         <input
                                           className="bx--text-input"
-                                          disabled={false}
+                                          disabled={true}
                                           id="name"
                                           name="name"
                                           onBlur={[Function]}
@@ -3673,17 +3597,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 />,
                                 <SingleField
                                   component="text-field"
+                                  hideField={false}
                                   id="name"
-                                  isRequired={true}
+                                  isDisabled={true}
                                   label="Name:"
                                   name="name"
-                                  validate={
-                                    Array [
-                                      Object {
-                                        "type": "required",
-                                      },
-                                    ]
-                                  }
                                 />,
                                 <SingleField
                                   component="select"
@@ -3911,15 +3829,11 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                   },
                                   Object {
                                     "component": "text-field",
+                                    "hideField": false,
                                     "id": "name",
-                                    "isRequired": true,
+                                    "isDisabled": true,
                                     "label": "Name:",
                                     "name": "name",
-                                    "validate": Array [
-                                      Object {
-                                        "type": "required",
-                                      },
-                                    ],
                                   },
                                   Object {
                                     "component": "select",


### PR DESCRIPTION
physical storage name is populate from REST API response from the storage manager (e.g. autosde) and shouldnt be entered by the user. 
The name field was therefore removed from add form, and disabled from edit form.

before
----
![1](https://user-images.githubusercontent.com/53213107/157213514-639587ae-12d9-4658-994b-fbfc80b89568.jpg)

![2](https://user-images.githubusercontent.com/53213107/157213566-2524237a-bc54-42ee-a0c1-a683eaa059d9.jpg)

after
---

![6](https://user-images.githubusercontent.com/53213107/157213686-17d1f6f5-9941-4e6d-8d3f-497d903019d5.jpg)

![4](https://user-images.githubusercontent.com/53213107/157213728-6776e67c-b2a5-4fa7-8164-d490868ff9aa.jpg)


links
----
https://github.com/ManageIQ/manageiq-providers-autosde/pull/139
