### PR TITLE
put the login into a form

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -37,11 +37,11 @@
                         "data-submit"         => 'login_div')
 
               %div#saml-login.text-center
-                %hr#saml-login
+                %hr
                 &nbsp;
                 = _('Or')
                 &nbsp;
-                %hr#saml-login
+                %hr
 
         .form-group
           %label.col-md-3.control-label= _('Username')

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -10,7 +10,7 @@
         %img{:src => ::Settings.server.custom_brand ? '/upload/custom_brand.png' : image_path("layout/brand.svg"), :alt => "ManageIQ"}
 
     .col-md-6.col-lg-5.login
-      .form-horizontal#login_div
+      %form.form-horizontal#login_div
         = render(:partial => "layouts/spinner",
                  :locals  => {:login => true})
 

--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -9,18 +9,18 @@ describe "dashboard/login.html.haml" do
 
     it "when authentication is 'database'" do
       render
-      expect(response).to have_selector("div#login_div:has(input#browser_name)")
-      expect(response).to have_selector("div#login_div:has(input#browser_version)")
-      expect(response).to have_selector("div#login_div:has(input#browser_os)")
-      expect(response).to have_selector("div#login_div:has(input#user_TZO)")
+      expect(response).to have_selector("form#login_div:has(input#browser_name)")
+      expect(response).to have_selector("form#login_div:has(input#browser_version)")
+      expect(response).to have_selector("form#login_div:has(input#browser_os)")
+      expect(response).to have_selector("form#login_div:has(input#user_TZO)")
     end
 
     it "when authentication is not 'database'" do
       render
-      expect(response).to have_selector("div#login_div:has(input#browser_name)")
-      expect(response).to have_selector("div#login_div:has(input#browser_version)")
-      expect(response).to have_selector("div#login_div:has(input#browser_os)")
-      expect(response).to have_selector("div#login_div:has(input#user_TZO)")
+      expect(response).to have_selector("form#login_div:has(input#browser_name)")
+      expect(response).to have_selector("form#login_div:has(input#browser_version)")
+      expect(response).to have_selector("form#login_div:has(input#browser_os)")
+      expect(response).to have_selector("form#login_div:has(input#user_TZO)")
     end
   end
 


### PR DESCRIPTION
put a form around the login form.

I only tested this with database authentication. using an enter to submit.
I did not bother adding an action to the form, since it is mostly driven by javascript anyway

fixes:

```
[DOM] Password field is not contained in a form:
```

This does not fix any errors, I just noticed this warning in my chrome console.

Since 2015 this has not been a form. I do not know if there is a technological reason that this would not be a form.