### PR TITLE
Remove caching from menu manager custom loaders

### DIFF
--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -14,9 +14,7 @@ module Menu
       sections = []
       items = []
 
-      engines.map do |engine|
-        engine.try(:menu)
-      end.compact.flatten.each do |item|
+      engines.flat_map { |engine| engine.try(:menu) || [] }.each do |item|
         case item
         when Menu::Section
           sections << item

--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -1,35 +1,31 @@
 module Menu
-  module CustomLoader
-    class << self
-      def load
-        @cache ||= sections_items
-      end
+  class CustomLoader
+    def load
+      sections_items
+    end
 
-      def unload
-        @cache = nil
-      end
+    private
 
-      def engines
-        Vmdb::Plugins.all
-      end
+    def engines
+      Vmdb::Plugins.all
+    end
 
-      def sections_items
-        sections = []
-        items = []
+    def sections_items
+      sections = []
+      items = []
 
-        engines.map do |engine|
-          engine.try(:menu)
-        end.compact.flatten.each do |item|
-          case item
-          when Menu::Section
-            sections << item
-          when Menu::Item
-            items << item
-          end
+      engines.map do |engine|
+        engine.try(:menu)
+      end.compact.flatten.each do |item|
+        case item
+        when Menu::Section
+          sections << item
+        when Menu::Item
+          items << item
         end
-
-        [sections, items]
       end
+
+      [sections, items]
     end
   end
 end

--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -73,8 +73,8 @@ module Menu
 
     def initialize
       load_default_items
-      load_custom_items(Menu::YamlLoader)
-      load_custom_items(Menu::CustomLoader)
+      load_custom_items(Menu::YamlLoader.new)
+      load_custom_items(Menu::CustomLoader.new)
     end
 
     def merge_sections(sections)

--- a/app/presenters/menu/yaml_loader.rb
+++ b/app/presenters/menu/yaml_loader.rb
@@ -1,28 +1,22 @@
 module Menu
   class YamlLoader
-    include Singleton
-
-    def self.load
-      instance.load_custom_items
-    end
-
-    def load_custom_items
-      @sections = []
-      @items    = []
+    def load
+      sections = []
+      items    = []
       Dir.glob(Rails.root.join('product/menubar/*.yml')).each do |f|
-        load_custom_item(f)
+        load_custom_item(f, sections, items)
       end
-      [@sections, @items]
+      [sections, items]
     end
 
     private
 
-    def load_custom_item(file_name)
+    def load_custom_item(file_name, sections, items)
       properties = YAML.load(File.read(file_name))
       if properties['type'] == 'section'
-        @sections << create_custom_menu_section(properties)
+        sections << create_custom_menu_section(properties)
       else
-        @items << create_custom_menu_item(properties)
+        items << create_custom_menu_item(properties)
       end
     end
 

--- a/spec/presenters/menu/custom_loader_spec.rb
+++ b/spec/presenters/menu/custom_loader_spec.rb
@@ -1,7 +1,6 @@
 describe Menu::CustomLoader do
   before do
     Singleton.__init__(Menu::Manager)
-    Singleton.__init__(Menu::CustomLoader)
   end
 
   after do
@@ -17,7 +16,6 @@ describe Menu::CustomLoader do
   end
 
   def clean
-    Menu::CustomLoader.unload
     Menu::Manager.instance.send(:initialize)
   end
 

--- a/spec/presenters/menu/custom_menu_loader_spec.rb
+++ b/spec/presenters/menu/custom_menu_loader_spec.rb
@@ -6,7 +6,7 @@ describe Menu::YamlLoader do
     begin
       expect(Dir).to receive(:glob).and_return([temp_file.path])
 
-      sections, items = described_class.load
+      sections, items = described_class.new.load
       expect(sections.length).to be(1)
       expect(items.length).to be(0)
 
@@ -23,7 +23,7 @@ describe Menu::YamlLoader do
     begin
       expect(Dir).to receive(:glob).and_return([temp_file2.path, temp_file.path])
 
-      sections, items = described_class.load
+      sections, items = described_class.new.load
       expect(sections.length).to be(1)
       expect(items.length).to be(1)
 

--- a/spec/presenters/menu/menu_manager_spec.rb
+++ b/spec/presenters/menu/menu_manager_spec.rb
@@ -2,7 +2,6 @@ describe Menu::Manager do
   include Spec::Support::MenuHelper
 
   before do
-    Singleton.__init__(Menu::YamlLoader)
     Singleton.__init__(Menu::Manager)
   end
 
@@ -14,7 +13,7 @@ describe Menu::Manager do
     end
 
     it "loads custom menu items" do
-      expect(Menu::YamlLoader).to receive(:load).and_call_original
+      expect(Menu::YamlLoader).to receive(:new).and_call_original
       Menu::Manager.menu
     end
   end


### PR DESCRIPTION
Depends:

- [ ] https://github.com/ManageIQ/manageiq/pull/21793

All this data is stored in the menu manager
No reason to have separate caches nor a singleton

This is in an effort to remove a few Singleton classes
Related to https://github.com/ManageIQ/manageiq/pull/21770