### PR TITLE
Bump chrome_remote to 0.3.0

### DIFF
--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   # core because jasmine gem depends on major version only, meaning breakages when not the latest
   s.add_development_dependency "jasmine", "~> 3.4.0"
   s.add_development_dependency "jasmine-core", "~> 3.4.0"
-  s.add_development_dependency "chrome_remote", "~> 0.2.0"
+  s.add_development_dependency "chrome_remote", "~> 0.3.0"
 end


### PR DESCRIPTION
This should help alleviate some of the CI problems where Chrome isn't
completely ready, as the newer version of chrome_remote handles that by
retrying.

@kavyanekkalapu Please review.