### PR TITLE
Allow changing UI worker memory threshold on UI

### DIFF
--- a/app/javascript/components/workers-form/workers-form.jsx
+++ b/app/javascript/components/workers-form/workers-form.jsx
@@ -59,6 +59,7 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
             count: wb.queue_worker_base.smart_proxy_worker.count || queueCount,
           },
           ui_worker: {
+            memory_threshold: parseWorker(wb.ui_worker).bytes || baseMem,
             count: wb.ui_worker.count || baseCount,
           },
           reporting_worker: {
@@ -137,6 +138,7 @@ const WorkersForm = ({ server: { id, name }, product, zone }) => {
         count: isDifferent('web_service_worker.count'),
       },
       ui_worker: {
+        memory_threshold: toRubyMethod(isDifferent('ui_worker.memory_threshold')),
         count: isDifferent('ui_worker.count'),
       },
       event_catcher: {

--- a/app/javascript/components/workers-form/workers.schema.js
+++ b/app/javascript/components/workers-form/workers.schema.js
@@ -162,6 +162,12 @@ const addSchema = (formValues) => {
           options: injectOption(rangeNine, formValues.ui_worker.count, true),
           label: __('Count'),
           helperText: __('Changing the UI Workers Count will immediately restart the webserver'),
+        }, {
+          component: componentTypes.SELECT,
+          id: 'ui_worker.memory_threshold',
+          name: 'ui_worker.memory_threshold',
+          options: injectOption(basicOptions, formValues.ui_worker.memory_threshold),
+          label: __('Memory threshold'),
         },
       ],
     },


### PR DESCRIPTION
Most other workers have the ability of changing the count and memory threshold via the Settings / Workers tab but the UI worker only has count.

Before:
![image](https://user-images.githubusercontent.com/12851112/169039314-8fdae039-9eca-41fb-a411-eb273539a8e7.png)

After:
![Screenshot from 2022-03-16 13-21-15](https://user-images.githubusercontent.com/12851112/158650418-930c1d2b-1caa-4c5a-84fa-72c6501f82a4.png)