### PR TITLE
Add native console for ems cloud provider

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -42,6 +42,10 @@ class EmsCloudController < ApplicationController
     true
   end
 
+  def launch_console
+    open_console('ems_native_console')
+  end
+
   menu_section :clo
   feature_for_actions "#{controller_name}_show_list", *ADV_SEARCH_ACTIONS
   has_custom_buttons

--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -24,10 +24,7 @@ class EmsPhysicalInfraController < ApplicationController
   end
 
   def launch_console
-    assert_privileges('ems_physical_infra_console')
-    @ems = find_record_with_rbac(model, params[:id])
-    $log.info('Console URL - ' + @ems.console_url.to_s)
-    javascript_open_window(@ems.console_url.to_s)
+    open_console('ems_physical_infra_console')
   end
 
   def change_password_ems_physical_infra_path(id = nil)

--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -551,5 +551,11 @@ module Mixins
         @refresh_partial = "layouts/gtl"
       end
     end
+
+    def open_console(identifier)
+      assert_privileges(identifier)
+      @ems = find_record_with_rbac(model, params[:id])
+      javascript_open_window(@ems.console_url.to_s)
+    end
   end
 end

--- a/app/helpers/application_helper/button/configuration_profile_console.rb
+++ b/app/helpers/application_helper/button/configuration_profile_console.rb
@@ -1,7 +1,0 @@
-class ApplicationHelper::Button::ConfigurationProfileConsole < ApplicationHelper::Button::Basic
-  needs :@record
-
-  def visible?
-    @record.supports_console?
-  end
-end

--- a/app/helpers/application_helper/button/configured_system_console.rb
+++ b/app/helpers/application_helper/button/configured_system_console.rb
@@ -1,7 +1,0 @@
-class ApplicationHelper::Button::ConfiguredSystemConsole < ApplicationHelper::Button::Basic
-  needs :@record
-
-  def visible?
-    @record.supports_console?
-  end
-end

--- a/app/helpers/application_helper/button/native_console.rb
+++ b/app/helpers/application_helper/button/native_console.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::NativeConsole < ApplicationHelper::Button::Basic
+  needs(:@record)
+
+  def visible?
+    @record.supports?(:native_console)
+  end
+end

--- a/app/helpers/application_helper/button/physical_infra_console.rb
+++ b/app/helpers/application_helper/button/physical_infra_console.rb
@@ -1,7 +1,0 @@
-class ApplicationHelper::Button::PhysicalInfraConsole < ApplicationHelper::Button::Basic
-  needs(:@record)
-
-  def visible?
-    @record.supports_console?
-  end
-end

--- a/app/helpers/application_helper/toolbar/configuration_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_profile_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::ConfigurationProfileCenter < ApplicationHelper
           N_('Open the Configuration Profile console'),
           N_('Configuration Profile console'),
           :url   => "launch_configuration_profile_console",
-          :klass => ApplicationHelper::Button::ConfigurationProfileConsole
+          :klass => ApplicationHelper::Button::NativeConsole
         ),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/configured_system_center.rb
+++ b/app/helpers/application_helper/toolbar/configured_system_center.rb
@@ -27,7 +27,7 @@ class ApplicationHelper::Toolbar::ConfiguredSystemCenter < ApplicationHelper::To
           N_('Open the Configured System console'),
           N_('Configured System console'),
           :url   => "launch_configured_system_console",
-          :klass => ApplicationHelper::Button::ConfiguredSystemConsole
+          :klass => ApplicationHelper::Button::NativeConsole
         ),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -121,4 +121,25 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
       :url_parms => "?display=main"
     ),
   ])
+  button_group('ems_native_console', [
+    select(
+      :ems_native_console,
+      nil,
+      N_('Remote Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :ems_native_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a native console for this cloud provider'),
+          N_('Native Console'),
+          :keepSpinner => true,
+          :url         => "launch_console",
+          :confirm     => N_("Open native console for this provider"),
+          :klass       => ApplicationHelper::Button::NativeConsole,
+          :popup       => true
+        )
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -92,7 +92,7 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
           :keepSpinner => true,
           :url         => "launch_console",
           :confirm     => N_("Open management console for this provider"),
-          :klass       => ApplicationHelper::Button::PhysicalInfraConsole,
+          :klass       => ApplicationHelper::Button::NativeConsole,
           :options     => {:feature => :console})
       ]
     ),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1063,6 +1063,7 @@ Rails.application.routes.draw do
         tagging_edit
         tl_chooser
         wait_for_task
+        launch_console
       ) +
                adv_search_post +
                compare_post +

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -441,6 +441,7 @@ EmsCloudController:
 - dynamic_radio_button_refresh
 - dynamic_text_box_refresh
 - index
+- launch_console
 - open_url_after_dialog
 - sections_field_changed
 - tl_chooser

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -297,4 +297,15 @@ describe EmsCloudController do
       end
     end
   end
+
+  describe "When the console button is pressed" do
+    before do
+      allow(controller).to receive(:launch_console).and_return(true)
+    end
+
+    it "redirects to new url" do
+      post :launch_console
+      expect(response.status).to eq(302)
+    end
+  end
 end


### PR DESCRIPTION
original pr opened by @Kuldip-Nanda  -> https://github.com/ManageIQ/manageiq-ui-classic/pull/8149
Part of: https://github.com/ManageIQ/manageiq/pull/21778

Add a native console button to the cloud provider toolbar

**After**

<img width="1393" alt="Screen Shot 2022-03-15 at 8 55 02 PM" src="https://user-images.githubusercontent.com/37085529/158497789-43db0f42-b452-46e5-b2bc-c0d728edf6d3.png">

<img width="1381" alt="Screen Shot 2022-03-15 at 8 55 41 PM" src="https://user-images.githubusercontent.com/37085529/158497791-4e262fb3-234b-45fd-98cb-dc0db1512c5c.png">

@miq-bot assign @agrare 
@miq-bot add-label enhancement
@miq-bot add_reviewer @agrare 
