### PR TITLE
Added miq_bootstrap back to fix container dashboard

### DIFF
--- a/app/views/ems_container/_show_dashboard.html.haml
+++ b/app/views/ems_container/_show_dashboard.html.haml
@@ -43,3 +43,4 @@
 
   :javascript
     ManageIQ.angular.app.value('providerId', '#{@record ? @record.id : ''}');
+    miq_bootstrap('.containers-dashboard');


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/8073

I just noticed we still have added one angular file reference in that file. so kept bootstrap back for rerouting.
**Before**

<img width="1381" alt="Screen Shot 2022-03-16 at 5 00 10 PM" src="https://user-images.githubusercontent.com/37085529/158690065-39ba98e1-bfee-4171-99cd-5ff24a690877.png">


**After**

<img width="1401" alt="Screen Shot 2022-03-16 at 4 59 23 PM" src="https://user-images.githubusercontent.com/37085529/158690005-06deb913-85bf-4846-ba1a-2f693df1a0cc.png">

@miq-bot assign @Fryguy 
@miq-bot add-label bug
@miq-bot add_reviewer @Fryguy 


