### PR TITLE
Remove double flash message

### DIFF
--- a/app/helpers/gtl_helper.rb
+++ b/app/helpers/gtl_helper.rb
@@ -53,6 +53,7 @@ module GtlHelper
       :hideSelect        => options[:selected_records].kind_of?(Array),
       :showUrl           => gtl_show_url(options),
       :pages             => options[:pages],
+      :noFlashDiv        => options[:no_flash_div],
     )
   end
 

--- a/app/javascript/components/gtl-view.jsx
+++ b/app/javascript/components/gtl-view.jsx
@@ -289,6 +289,7 @@ const GtlView = ({
   hideSelect,
   showUrl,
   pages,
+  noFlashDiv,
 }) => {
   // const { settings, data } = props;
   const initState = {
@@ -302,7 +303,9 @@ const GtlView = ({
 
   useEffect(() => {
     // eslint-disable-next-line no-unused-expressions
-    flashMessages && flashMessages.forEach((message) => add_flash(message.message, message.level));
+    if (!noFlashDiv) {
+      flashMessages && flashMessages.forEach((message) => add_flash(message.message, message.level));
+    }
   }, [state.namedScope]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes [#7795](https://github.com/ManageIQ/manageiq-ui-classic/issues/7795).

## Before

![Screen Shot 2022-03-17 at 12 57 09 PM](https://user-images.githubusercontent.com/29209973/158853664-afebc076-d255-49c3-8ec5-e8ecffe9508d.png)

## After

![Screen Shot 2022-03-17 at 12 56 08 PM](https://user-images.githubusercontent.com/29209973/158853619-6a4c46cd-cfa5-4236-8168-d5e163dfd732.png)

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu