### PR TITLE
Fix View yaml to point to valid fields

### DIFF
--- a/product/views/PhysicalServer.yaml
+++ b/product/views/PhysicalServer.yaml
@@ -21,6 +21,11 @@ cols:
 
 
 include:
+  asset_detail:
+    columns:
+    - product_name
+    - manufacturer
+    - location_led_state
 
 
 include_for_find:

--- a/product/views/PhysicalStorage.yaml
+++ b/product/views/PhysicalStorage.yaml
@@ -14,10 +14,12 @@ cols:
 - type
 - health_state
 - power_state
-- asset_detail
-
 
 include:
+  asset_detail:
+    columns:
+    - product_name
+    - manufacturer
 
 
 include_for_find:

--- a/product/views/Storage.yaml
+++ b/product/views/Storage.yaml
@@ -20,7 +20,6 @@ db: Storage
 # Columns to fetch from the main table
 cols:
 - name
-- ext_management_system
 - store_type
 - total_space
 - free_space
@@ -38,6 +37,9 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  ext_management_system:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -46,7 +48,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
-- ext_management_system
+- ext_management_system.name
 - store_type
 - total_space
 - free_space


### PR DESCRIPTION
- PhysicalServer/PhysicalStorage
  - fix includes to properly identify associations and fix N+1
- Storage
  - change ems to ems.name
- ~~Vm/Templates: remove the unneeded os_image_name column~~
- ~~PhysicalStorage: remove invalid attribute `power_state` from the view~~

A few more details are in the individual commits

There is also an associated fix: https://github.com/ManageIQ/manageiq/pull/21781

---

Although `PhysicalStorage#power_state` looks like an error, the page seems to be working fine, leaving it alone
Here is what I found:

- pr to add `power_state` to the switch: https://github.com/ManageIQ/manageiq-schema/pull/160
- pr to add 'power_state` to the server: https://github.com/ManageIQ/manageiq-schema/commit/8e95341be28e5d33662c51c17a055573b0641b6a
- No pr to add `power_state` to the physical storage

UPDATE: I am leaning towards only removing glaring errors. Some of these changes may still be needed to fix these pages but I do not have a database with these values, so I can not verify one way or the other