### PR TITLE
Fixed add new time profile error

### DIFF
--- a/app/views/configuration/timeprofile_edit.html.haml
+++ b/app/views/configuration/timeprofile_edit.html.haml
@@ -2,4 +2,4 @@
   = react('SettingsTimeProfileForm', :timeProfileId => "", :timezones => @all_timezones, :action => @timeprofile_action, :userid => @userid)
 - else
   = react('SettingsTimeProfileForm', :timeProfileId => @timeprofile.id.to_s, :timezones => @all_timezones, :action => @timeprofile_action, :userid => @userid)
-= render :partial => 'timeprofile_form'
+  = render :partial => 'timeprofile_form'


### PR DESCRIPTION
Fixed an error preventing the add new time profile page from loading.

Before:
<img width="1349" alt="Screen Shot 2022-03-18 at 2 48 30 PM" src="https://user-images.githubusercontent.com/32444791/159065741-283c9730-93cc-4169-b7b2-5dfc9c437069.png">

After:
<img width="1356" alt="Screen Shot 2022-03-18 at 2 43 56 PM" src="https://user-images.githubusercontent.com/32444791/159065778-e5543dc7-3213-4024-b505-3e1abe5460e1.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label bug
