### PR TITLE
fix console route testcases

### DIFF
--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -441,7 +441,6 @@ EmsCloudController:
 - dynamic_radio_button_refresh
 - dynamic_text_box_refresh
 - index
-- launch_console
 - open_url_after_dialog
 - sections_field_changed
 - tl_chooser


### PR DESCRIPTION
**Issue**
Follow up of https://github.com/ManageIQ/manageiq-ui-classic/pull/8177. interestingly test cases failed in the original pr until i added this route. Now in master. testcases are failing once all prs for native console got merged.

```
Finished in 4 minutes 25.1 seconds (files took 12.54 seconds to load)
6224 examples, 1 failure, 1238 pending

Failed examples:

rspec './spec/routes_spec.rb[1:42:24:2:1]' # Application routes EmsCloudController#launch_console RBAC check is enforced

Randomized with seed 10116
```


@miq-bot assign @agrare 
@miq-bot add-label test
@miq-bot add_reviewer @agrare 