### PR TITLE
fix sort columns

### DIFF
--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -114,7 +114,7 @@ class GtlFormatter
         text = format_col_for_display(view, row, col)
         item = {:title      => text,
                 :icon       => icon,
-                :background => textual_power_state_whitelisted(record[col]),
+                :background => textual_power_state_whitelisted(row[col]),
                 :text       => text}.compact
       elsif COLUMN_WITH_ICON.key?(col)
         # Generate html for the list icon


### PR DESCRIPTION
This does not depend upon another PR, but it will not be exercisable without core PR:

- [ ] https://github.com/ManageIQ/manageiq/pull/21781

This does not change the view of the screen.

## Overview

If a report is sorting by a ruby field (and the values are cached),
the `record` will not have all the attributes and an error is thrown.

## Background

We noticed this when sorting by `power_state` and either toggling the `power_state` ascend/descend for sort, or viewing the next (i.e.: second) page.


## Solution

The fix is to access the `row` data instead of the `record` data. They have the same value but `row` always has the value. If you notice, all other gtl filters use `row[col]` to get the current value.

This fixes a bug introduced in b1a5e86c013e44

## Before

![before sort by property_name](https://user-images.githubusercontent.com/1930/159803729-6c3045cd-0eef-4092-b51d-078d52b2ec61.png)

![before error](https://user-images.githubusercontent.com/1930/159801779-8df01701-add0-4602-aa6f-b67fe429c95f.png)

```
[----] F, [2022-03-23T18:05:15.645121 #87884:b9244] FATAL -- : Error caught:
[ActiveModel::MissingAttributeError] missing attribute: normalized_state
gems/activemodel-6.0.4.7/lib/active_model/attribute.rb:221:in `value'
gems/activemodel-6.0.4.7/lib/active_model/attribute_set.rb:41:in `fetch_value'
gems/activerecord-6.0.4.7/lib/active_record/attribute_methods/read.rb:39:in `_read_attribute'
gems/activerecord-6.0.4.7/lib/active_record/attribute_methods/read.rb:32:in `read_attribute'
gems/activerecord-6.0.4.7/lib/active_record/attribute_methods.rb:323:in `[]'
manageiq-ui-classic/lib/gtl_formatter.rb:117:in `block in format_cols'
```

## After

You will notice that these have the same value, but at least the second page works.
I just noticed that `disconnected` has no icon

![after first page](https://user-images.githubusercontent.com/1930/159804208-2970d4b3-ded3-4619-a6ac-660742c19de8.png)

![after second page](https://user-images.githubusercontent.com/1930/159804355-25802906-2882-40dd-a76f-8f1da02cb144.png)

