### PR TITLE
Add native_console button for ems_infra providers

### DIFF
--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -210,6 +210,10 @@ class EmsInfraController < ApplicationController
     true
   end
 
+  def launch_console
+    open_console('ems_native_console')
+  end
+
   def download_data
     assert_privileges('ems_infra_show_list')
     super

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -133,4 +133,25 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
       ]
     ),
   ])
+  button_group('ems_native_console', [
+    select(
+      :ems_native_console,
+      nil,
+      N_('Remote Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :ems_native_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a native console for this cloud provider'),
+          N_('Native Console'),
+          :keepSpinner => true,
+          :url         => "launch_console",
+          :confirm     => N_("Open native console for this provider"),
+          :klass       => ApplicationHelper::Button::NativeConsole,
+          :popup       => true
+        )
+      ]
+    ),
+  ])
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1146,6 +1146,7 @@ Rails.application.routes.draw do
         scaledown
         open_admin_ui
         open_admin_ui_done
+        launch_console
       ) +
                adv_search_post +
                compare_post +

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -512,4 +512,15 @@ describe EmsInfraController do
 
     include_examples 'hiding tenant column for non admin user', :name => "Name", :hostname => "Hostname"
   end
+
+  describe "When the console button is pressed" do
+    before do
+      allow(controller).to receive(:launch_console).and_return(true)
+    end
+
+    it "redirects to new url" do
+      post :launch_console
+      expect(response.status).to eq(302)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/8177 adding for ems_infra providers.
![Screenshot from 2022-03-25 13-27-52](https://user-images.githubusercontent.com/12851112/160173392-6bb35143-76a4-4764-9ef0-ca273212a4bd.png)

