### PR TITLE
Remove angular code from physical chassis

### DIFF
--- a/app/views/physical_chassis/show.html.haml
+++ b/app/views/physical_chassis/show.html.haml
@@ -1,14 +1,6 @@
 #main_div
   - if %w(physical_rack physical_servers physical_storages).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
-    - if %w(physical_servers).include?(@display)
-      %physical-server-toolbar#ems_physical_infra_show_list_form
-      :javascript
-        miq_bootstrap('#ems_physical_infra_show_list_form')
-    - if %w(physical_storages).include?(@display)
-      %physical-storage-toolbar#ems_physical_infra_show_list_form
-      :javascript
-        miq_bootstrap('#ems_physical_infra_show_list_form')
   - else
     - case @showtype
     - when "main"


### PR DESCRIPTION
Parent Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

Removed unused angular code from physical chassis haml files.

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label cleanup