### PR TITLE
Add toolbar buttons for server decommission/recommission

### DIFF
--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -76,7 +76,35 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
             :url_parms => "main_div",
             :enabled   => true,
             :klass     => ApplicationHelper::Button::ConfiguredSystemProvision
-          )
+          ),
+          api_button(
+            :physical_server_decommission,
+            nil,
+            N_('Decommission server'),
+            N_('Decommission'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'decommission_server',
+              :entity => 'physical_server'
+            },
+            :confirm => N_("Decommission this server?"),
+            :enabled => true,
+            :options => {:feature => :decommission}
+          ),
+          api_button(
+            :physical_server_recommission,
+            nil,
+            N_('Recommission server'),
+            N_('Recommission'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'recommission_server',
+              :entity => 'physical_server'
+            },
+            :confirm => N_("Recommission this server?"),
+            :enabled => true,
+            :options => {:feature => :recommission}
+          ),
         ]
       )
     ]

--- a/app/helpers/application_helper/toolbar/physical_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_servers_center.rb
@@ -247,7 +247,37 @@ class ApplicationHelper::Toolbar::PhysicalServersCenter < ApplicationHelper::Too
             :enabled      => false,
             :onwhen       => "1+",
             :klass     => ApplicationHelper::Button::PhysicalServerProvision
-          )
+          ),
+          api_button(
+            :physical_server_decommission,
+            nil,
+            N_('Decommission server'),
+            N_('Decommission'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'decommission_server',
+              :entity => 'physical_server'
+            },
+            :confirm => N_("Decommission this server?"),
+            :enabled => true,
+	    :onwhen  => "1+",
+            :options => {:feature => :decommission}
+          ),
+          api_button(
+            :physical_server_recommission,
+            nil,
+            N_('Recommission server'),
+            N_('Recommission'),
+            :icon    => "pficon pficon-off fa-lg",
+            :api     => {
+              :action => 'recommission_server',
+              :entity => 'physical_server'
+            },
+            :confirm => N_("Recommission this server?"),
+            :enabled => true,
+	    :onwhen  => "1+",
+            :options => {:feature => :recommission}
+          ),
         ]
       )
     ]


### PR DESCRIPTION
Cisco Intersight provider allows to decommission and recommission a
server from and to a pool of available servers. This commit adds toolbar
buttons that support this operation from a physical server toolbar.

Below is a screenshot of what it looks like in the physical servers view.

<img width="837" alt="Screenshot 2022-04-05 at 12 04 51" src="https://user-images.githubusercontent.com/1437960/161730595-a8f015f3-f1a0-45b9-a436-097044926c5e.png">

