### PR TITLE
Fix missing text in services page

### DIFF
--- a/app/javascript/components/service-detail-stdout/index.js
+++ b/app/javascript/components/service-detail-stdout/index.js
@@ -28,7 +28,7 @@ const ServiceDetailStdout = ({ taskid }) => {
         <>
           <p>
             {' '}
-            {_('Error loading data:')}
+            {__('Error loading data:')}
           </p>
           <p>
             {' '}
@@ -38,7 +38,7 @@ const ServiceDetailStdout = ({ taskid }) => {
       )}
       {Taskresults && (
         <>
-          <h3>{ _('Standard Output:')}</h3>
+          <h3>{__('Standard Output:')}</h3>
           <div className="content" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(Taskresults) }} />
         </>
       )}


### PR DESCRIPTION
Fix missing header text ('Standard Output') added in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8209

Before:
<img width="1389" alt="Screen Shot 2022-04-05 at 7 42 15 AM" src="https://user-images.githubusercontent.com/32444791/161747222-7354029e-b788-4569-bcaf-9f2581b22b64.png">

After:
<img width="1384" alt="Screen Shot 2022-04-05 at 7 43 45 AM" src="https://user-images.githubusercontent.com/32444791/161747242-74fb377d-dac5-48eb-ac41-52910c20563c.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label bug