### PR TITLE
Remove angular code from ems common file

### DIFF
--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -8,10 +8,6 @@
   - arr = (controller_name.camelize + "Controller").constantize.display_methods
   - if arr.include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@ems.id}"}
-    - if %w(physical_servers).include?(@display)
-      %physical-server-toolbar#ems_physical_infra_show_list_form
-      :javascript
-        miq_bootstrap('#ems_physical_infra_show_list_form')
   - elsif @showtype == "details"
     = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
   - elsif @showtype ==  "item"


### PR DESCRIPTION
Issue: Part of https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

Remove unused angular code in ems common file. Similar to PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8201

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label technical debt