### PR TITLE
Server Placement Group

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -103,6 +103,7 @@ module Mixins
           physical_servers_with_host
           physical_switches
           physical_storages
+          placement_groups
           security_groups
           security_policies
           security_policy_rules

--- a/app/controllers/placement_group_controller.rb
+++ b/app/controllers/placement_group_controller.rb
@@ -24,12 +24,12 @@ class PlacementGroupController < ApplicationController
   end
 
   def download_data
-    assert_privileges('flavor_show_list')
+    assert_privileges('placement_group_view')
     super
   end
 
   def download_summary_pdf
-    assert_privileges('flavor_show')
+    assert_privileges('placement_group_view')
     super
   end
 

--- a/app/controllers/placement_group_controller.rb
+++ b/app/controllers/placement_group_controller.rb
@@ -1,0 +1,55 @@
+class PlacementGroupController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  include Mixins::GenericListMixin
+  include Mixins::GenericSessionMixin
+  include Mixins::MoreShowActions
+  include Mixins::GenericShowMixin
+  include Mixins::EmsCommon
+  include Mixins::BreadcrumbsMixin
+
+  def self.display_methods
+    %w[instances]
+  end
+
+  def breadcrumb_name(_model)
+    _("Placement Groups")
+  end
+
+  def self.table_name
+    @table_name ||= "placement_group"
+  end
+
+  def download_data
+    assert_privileges('flavor_show_list')
+    super
+  end
+
+  def download_summary_pdf
+    assert_privileges('flavor_show')
+    super
+  end
+
+  private
+
+  def textual_group_list
+    [%i[relationships properties], %i[tags]]
+  end
+  helper_method :textual_group_list
+
+  def breadcrumbs_options
+    {
+      :breadcrumbs => [
+        {:title => _("Compute")},
+        {:title => _("Clouds")},
+        {:title => _("Placement Groups"), :url => controller_url},
+      ],
+    }
+  end
+
+  menu_section :clo
+  feature_for_actions "#{controller_name}_show_list", *ADV_SEARCH_ACTIONS
+end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -358,6 +358,10 @@ module VmCommon
     show_association('floating_ips', _('Floating IPs'), :floating_ips, FloatingIp)
   end
 
+  def placement_group
+    show_association('placement_groups', _('Placement Groups'), :placement_groups, PlacementGroup)
+  end
+
   def cloud_subnets
     show_association('cloud_subnets', _('Subnets'), :cloud_subnets, CloudSubnet)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -391,6 +391,9 @@ module ApplicationHelper
     when "MiqAeInstance"
       controller = "miq_ae_class"
       action = "show_details"
+    when "PlacementGroup"
+      controller = "placement_group"
+      action = "show"
     when "SecurityGroup"
       controller = "security_group"
       action = "show"
@@ -777,6 +780,7 @@ module ApplicationHelper
        orchestration_stack
        persistent_volume
        physical_server
+       placement_group
        provider_foreman
        resource_pool
        retired
@@ -1092,6 +1096,7 @@ module ApplicationHelper
                              physical_storage
                              physical_server
                              persistent_volume
+                             placement_group
                              policy
                              policy_group
                              security_policy

--- a/app/helpers/application_helper/listnav.rb
+++ b/app/helpers/application_helper/listnav.rb
@@ -4,6 +4,7 @@ module ApplicationHelper
       common_layouts = %w[
         physical_storage
         auth_key_pair_cloud
+        placement_group
         automation_manager_configured_system
         availability_zone
         cloud_database

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -221,6 +221,7 @@ module ApplicationHelper::PageLayouts
       persistent_volume
       physical_server
       physical_storage
+      placement_group
       resource_pool
       retired
       security_group

--- a/app/helpers/application_helper/toolbar/placement_group_center.rb
+++ b/app/helpers/application_helper/toolbar/placement_group_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::PlacementGroupCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar/placement_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/placement_groups_center.rb
@@ -1,0 +1,2 @@
+class ApplicationHelper::Toolbar::PlacementGroupsCenter < ApplicationHelper::Toolbar::Basic
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -437,6 +437,7 @@ class ApplicationHelper::ToolbarChooser
             physical_server
             physical_switch
             physical_storage
+            placement_group
             container_template
             resource_pool
             timeline

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -19,7 +19,7 @@ module EmsCloudHelper::TextualSummary
       _("Relationships"),
       %i[
         ems_infra network_manager availability_zones host_aggregates cloud_tenants flavors
-        security_groups instances images cloud_volumes orchestration_stacks storage_managers cloud_databases
+        security_groups placement_groups instances images cloud_volumes orchestration_stacks storage_managers cloud_databases
         custom_button_events tenant
       ]
     )
@@ -117,6 +117,16 @@ module EmsCloudHelper::TextualSummary
     if num.positive? && role_allows?(:feature => "ems_storage_show_list")
       h[:title] = _("Show all Storage Managers")
       h[:link] = ems_cloud_path(@record.id, :display => 'storage_managers')
+    end
+    h
+  end
+
+  def textual_placement_groups
+    num   = @record.try(:placement_groups) ? @record.number_of(:placement_groups) : 0
+    h     = {:label => _('Placement Groups'), :icon => "fa fa-database", :value => num}
+    if num.positive?
+      h[:title] = _("Show all Placement Groups")
+      h[:link] = ems_cloud_path(@record.id, :display => 'placement_groups')
     end
     h
   end

--- a/app/helpers/placement_group.rb
+++ b/app/helpers/placement_group.rb
@@ -1,0 +1,3 @@
+module PlacementGroupHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/placement_group_helper.rb
+++ b/app/helpers/placement_group_helper.rb
@@ -1,0 +1,3 @@
+module PlacementGroupHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/placement_group_helper/textual_summary.rb
+++ b/app/helpers/placement_group_helper/textual_summary.rb
@@ -1,0 +1,38 @@
+module PlacementGroupHelper::TextualSummary
+  include TextualMixins::TextualEmsCloud
+  include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualName
+  include TextualMixins::TextualCustomButtonEvents
+  #
+  # Groups
+  #
+
+  def textual_group_relationships
+    TextualGroup.new(_("Relationships"), %i[ems_cloud instances])
+  end
+
+  def textual_group_properties
+    TextualGroup.new(_("Properties"), %i[name policy])
+  end
+
+  #
+  # Items
+  #
+  def textual_type
+    ui_lookup(:model => @record.type)
+  end
+
+  def textual_policy
+    ui_lookup(:model => @record.policy)
+  end
+
+  def textual_instances
+    num   = @record.number_of(:vms)
+    h     = {:label => _('Instances'), :icon => "pficon pficon-virtual-machine", :value => num}
+    if num.positive? && role_allows?(:feature => "vm_show_list")
+      h[:link]  = url_for_only_path(:action => 'show', :id => @record, :display => 'instances')
+      h[:title] = _("Show all Instances")
+    end
+    h
+  end
+end

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -70,8 +70,8 @@ module VmHelper::TextualSummary
       _("Relationships"),
       %i[
         ems ems_infra cluster host availability_zone cloud_tenant flavor vm_template drift scan_history service genealogy
-        cloud_network cloud_subnet orchestration_stack cloud_networks cloud_subnets network_routers security_groups
-        floating_ips network_ports cloud_volumes custom_button_events
+        cloud_network cloud_subnet placement_group orchestration_stack cloud_networks cloud_subnets network_routers
+        security_groups floating_ips network_ports cloud_volumes custom_button_events
       ]
     )
   end
@@ -397,6 +397,19 @@ module VmHelper::TextualSummary
       h[:title] = _("Show all Cloud Subnets")
       h[:explorer] = true
       h[:link]  = url_for_only_path(:action => 'cloud_subnets', :id => @record, :display => "cloud_subnets")
+    end
+    h
+  end
+
+  def textual_placement_group
+    my_placement_group = @record.placement_group
+    h = {:label => _('Placement Group'),
+         :icon  => "pficon-flavor",
+         :value => (my_placement_group.nil? ? _("None") : my_placement_group.name)}
+    if placement_group && role_allows?(:feature => "placement_group_show")
+      h[:title] = _("Show Placement Group")
+      textual_link(@record.placement_group, :label => _('Placement Group'))
+      h[:link]  = url_for_only_path(:controller => 'placement_group', :action => 'show', :id => my_placement_group.id)
     end
     h
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -84,6 +84,7 @@ module Menu
           Menu::Item.new('vm_cloud',            N_('Instances'),          'vm_cloud_explorer',   {:feature => 'vm_cloud_explorer', :any => true}, '/vm_cloud/explorer'),
           Menu::Item.new('orchestration_stack', N_('Stacks'),             'orchestration_stack', {:feature => 'orchestration_stack_show_list'},   '/orchestration_stack/show_list'),
           Menu::Item.new('auth_key_pair_cloud', N_('Key Pairs'),          'auth_key_pair_cloud', {:feature => 'auth_key_pair_cloud_show_list'},   '/auth_key_pair_cloud/show_list'),
+          Menu::Item.new('placement_group',     N_('Placement Groups'),   'placement_group',     {:feature => 'placement_group_list'},            '/placement_group/show_list'),
           Menu::Item.new('cloud_databases',     N_('Databases'),          'cloud_database',      {:feature => 'cloud_database'},                  '/cloud_database/show_list'),
         ])
       end

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -80,7 +80,7 @@
             :owner_office, :owner_manager, :owner_manager_mail,
             :owner_manager_phone, :owner_phone, :owner_phone_mobile,
             :owner_state, :owner_title, :owner_zip, :request_notes,
-            :subnet_mask, :memory_limit, :memory_reserve,
+            :subnet_mask, :memory_limit, :memory_reserve, :placement_group,
             :root_username, :root_password, :ssh_public_key, :sysprep_password, :sysprep_domain_admin,
             :sysprep_domain_password, :sysprep_workgroup_name,
             :sysprep_full_name, :sysprep_organization,

--- a/app/views/placement_group/show.html.haml
+++ b/app/views/placement_group/show.html.haml
@@ -1,0 +1,13 @@
+#main_div
+  - if ["instances"].include?(@display) && @showtype != "compare"
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+  - elsif @showtype == "compare"
+    = raise 'compare partial called through "show"'
+  - elsif @showtype == "drift_history"
+    = render :partial => "layouts/drift_history"
+  - elsif @showtype == "drift"
+    = raise 'drift partial called through "show"'
+  - elsif @showtype == "item"
+    = render :partial => "layouts/item"
+  - elsif @showtype == 'main'
+    = render :partial => "layouts/textual_groups_generic"

--- a/app/views/placement_group/show_list.html.haml
+++ b/app/views/placement_group/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -422,6 +422,13 @@
               :label                      => _("Upload File"),
               :prefix                     => "/miq_request/",
               :keys                       => keys})
+      - keys = [:placement_group]
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
+        :locals         => {:workflow => wf,
+            :dialog                   => dialog,
+            :label                    => _("Placement Groups"),
+            :prefix                   => "/miq_request/",
+            :keys                     => keys})
       - keys = %i[migratable pin_policy]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,23 @@ Rails.application.routes.draw do
         save_post
     },
 
+    :placement_group => {
+      :get  => %w(
+        show_list
+        index
+        show
+        download_data
+        download_summary_pdf
+      ),
+      :post => %w(
+        quick_search
+        show_list
+        show
+      ) +
+        adv_search_post +
+        exp_post
+    },
+
     :automation_manager_configured_system => {
       :get => %w(
         download_data

--- a/product/views/PlacementGroup.yaml
+++ b/product/views/PlacementGroup.yaml
@@ -1,0 +1,64 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Placement Group
+
+# Menu name
+name: PlacementGroup
+
+# Main DB table report is based on
+db: PlacementGroup
+
+# Columns to fetch from the main table
+cols:
+- name
+- id
+- total_vms
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+  cloud_tenant:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- id
+- total_vms
+
+# Column titles, in order
+headers:
+- Name
+- ID
+- Total VMs
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+graph:
+dims:

--- a/product/views/PlacementGroup.yml
+++ b/product/views/PlacementGroup.yml
@@ -1,0 +1,78 @@
+#
+ # This is an MIQ Report configuration file
+ #   Single value parameters are specified as:
+ #     single_value_parm: value
+ #   Multiple value parameters are specified as:
+ #     multi_value_parm:
+ #       - value 1
+ #       - value 2
+ #
+
+ # Report title
+title: Placement Groups
+
+# Menu name
+name: Placement Groups
+
+# Main DB table report is based on
+db: PlacementGroup
+
+# Columns to fetch from the main table
+cols:
+- name
+- policy
+- ems_ref
+
+ # Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- ext_management_system.name
+- status
+- ems_ref
+
+
+# Column titles, in order
+headers:
+- Name
+- Provider
+- Status
+- Id
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -963,6 +963,23 @@ PictureController:
 - show
 PingController:
 - index
+PlacementGroupController:
+- compare_cancel
+- compare_choose_base
+- compare_compress
+- compare_miq
+- compare_miq_all
+- compare_miq_differences
+- compare_miq_same
+- compare_mode
+- compare_remove
+- compare_set_state
+- compare_to_csv
+- compare_to_pdf
+- compare_to_txt
+- index
+- protect
+- sections_field_changed
 PxeController:
 - accordion_select
 - log_depot_validate

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -41,13 +41,13 @@ describe EmsCloudHelper::TextualSummary do
       cloud_tenants
       flavors
       security_groups
+      placement_groups
       instances
       images
       cloud_volumes
       orchestration_stacks
       storage_managers
       cloud_databases
-      placement_groups
       custom_button_events
       tenant
     )

--- a/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cloud_helper/textual_summary_spec.rb
@@ -47,6 +47,7 @@ describe EmsCloudHelper::TextualSummary do
       orchestration_stacks
       storage_managers
       cloud_databases
+      placement_groups
       custom_button_events
       tenant
     )

--- a/spec/helpers/placement_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/placement_group_helper/textual_summary_spec.rb
@@ -1,0 +1,4 @@
+describe PlacementGroupHelper::TextualSummary do
+  include_examples "textual_group", "Relationships", %i(ems_cloud)
+  include_examples "textual_group", "Properties", %i(name type status ems_ref)
+end

--- a/spec/helpers/placement_group_helper/textual_summary_spec.rb
+++ b/spec/helpers/placement_group_helper/textual_summary_spec.rb
@@ -1,4 +1,4 @@
 describe PlacementGroupHelper::TextualSummary do
-  include_examples "textual_group", "Relationships", %i(ems_cloud)
-  include_examples "textual_group", "Properties", %i(name type status ems_ref)
+  include_examples "textual_group", "Relationships", %i(ems_cloud instances)
+  include_examples "textual_group", "Properties", %i(name policy)
 end

--- a/spec/helpers/vm_helper/textual_summary_spec.rb
+++ b/spec/helpers/vm_helper/textual_summary_spec.rb
@@ -78,6 +78,7 @@ describe VmHelper::TextualSummary do
     genealogy
     cloud_network
     cloud_subnet
+    placement_group
     orchestration_stack
     cloud_networks
     cloud_subnets

--- a/spec/routing/placement_group_routing_spec.rb
+++ b/spec/routing/placement_group_routing_spec.rb
@@ -1,0 +1,31 @@
+require "routing/shared_examples"
+
+describe "routes for PlacementGroupController" do
+  let(:controller_name) { "placement_group" }
+
+  it_behaves_like "A controller that has advanced search routes"
+
+  %w(
+    show_list
+    show
+    index
+  ).each do |task|
+    describe "##{task}" do
+      it 'routes with GET' do
+        expect(get("/#{controller_name}/#{task}")).to route_to("#{controller_name}##{task}")
+      end
+    end
+  end
+
+  %w(
+    quick_search
+    show_list
+    show
+  ).each do |task|
+    describe "##{task}" do
+      it 'routes with POST' do
+        expect(post("/#{controller_name}/#{task}")).to route_to("#{controller_name}##{task}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
These files are for Server Placement Group.

This is a dependent PR for adding and enabling Server Placement Group as Menu in the Core

1. Manageiq schema changes.
    https://github.com/ManageIQ/manageiq-schema/pull/644
2. Server Placement Group in ManageIQ User Interface.
     https://github.com/ManageIQ/manageiq-ui-classic/pull/8214
3. PowerVS changes.
    https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/363
4. ManageIQ Core changes
    https://github.com/ManageIQ/manageiq/pull/21807