### PR TITLE
Removed angular code from physical storage files

### DIFF
--- a/app/views/physical_storage/show.html.haml
+++ b/app/views/physical_storage/show.html.haml
@@ -7,8 +7,3 @@
       = render :partial => 'layouts/textual_groups_generic'
     - when "timeline"
       = render :partial => 'layouts/tl_show_async'
-
-  %physical-storage-toolbar#physical_storage_show_form{'physical-storage-id' => @record.id}
-
-:javascript
-  miq_bootstrap('#physical_storage_show_form');

--- a/app/views/physical_storage/show_list.html.haml
+++ b/app/views/physical_storage/show_list.html.haml
@@ -1,7 +1,2 @@
 #main_div
   = render :partial => 'layouts/gtl'
-
-  %physical-switch-toolbar#physical_storage_show_list_form
-
-:javascript
-  miq_bootstrap('#physical_storage_show_list_form');


### PR DESCRIPTION
Issue: Part of https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

Remove unused angular code in physical storage files. Similar to PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8201

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label technical debt