### PR TITLE
 Fix missing PDF content for summary pages

### DIFF
--- a/app/javascript/components/miq-structured-list/index.jsx
+++ b/app/javascript/components/miq-structured-list/index.jsx
@@ -10,6 +10,7 @@ import {
   Accordion,
   AccordionItem,
   TextArea,
+  Link,
 } from 'carbon-components-react';
 import MiqStructuredListHeader from './miq-structured-list-header';
 import {
@@ -98,7 +99,7 @@ const MiqStructuredList = ({
   const renderMultiContents = (row) => {
     const content = renderContent(row);
     return row.link
-      ? <a href={row.link} onClick={(e) => onClick(row, e)} className="cell_link">{content}</a>
+      ? <Link to={row.link} onClick={(e) => onClick(row, e)} className="cell_link">{content}</Link>
       : content;
   };
 

--- a/app/javascript/react/textual_summary_wrapper.jsx
+++ b/app/javascript/react/textual_summary_wrapper.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { TextualSummary } from '../components/textual_summary';
 import textualSummaryGenericClick from './textual_summary_click';
 
 export default (props) => {
   const onClick = props.onClick || textualSummaryGenericClick;
-  return <TextualSummary onClick={onClick} {...props} />;
+  const component = <TextualSummary onClick={onClick} {...props} />;
+  document.addEventListener('DOMContentLoaded', () => {
+    ReactDOM.render(component, document.body.appendChild(document.createElement('div')));
+  });
+  return component;
 };

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -38,10 +38,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=1&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=1&status=running"
             >
               <div
                 className="content"
@@ -66,7 +66,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -86,10 +86,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=1&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=1&status=all"
             >
               <div
                 className="content"
@@ -114,7 +114,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -169,10 +169,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=2&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=2&status=running"
             >
               <div
                 className="content"
@@ -197,7 +197,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -217,10 +217,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=2&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=2&status=all"
             >
               <div
                 className="content"
@@ -245,7 +245,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -300,10 +300,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=3&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=3&status=running"
             >
               <div
                 className="content"
@@ -328,7 +328,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -348,10 +348,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=3&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=3&status=all"
             >
               <div
                 className="content"
@@ -376,7 +376,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (3)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -431,10 +431,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=4&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=4&status=running"
             >
               <div
                 className="content"
@@ -459,7 +459,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (2)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -479,10 +479,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=4&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=4&status=all"
             >
               <div
                 className="content"
@@ -507,7 +507,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (2)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -562,10 +562,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=5&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=5&status=running"
             >
               <div
                 className="content"
@@ -590,7 +590,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (2)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -610,10 +610,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=5&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=5&status=all"
             >
               <div
                 className="content"
@@ -638,7 +638,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (2)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -693,10 +693,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=6&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=6&status=running"
             >
               <div
                 className="content"
@@ -721,7 +721,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (4)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -741,10 +741,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=6&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=6&status=all"
             >
               <div
                 className="content"
@@ -769,7 +769,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (4)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -852,10 +852,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=7&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=7&status=all"
             >
               <div
                 className="content"
@@ -880,7 +880,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (1)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -935,10 +935,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=8&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=8&status=running"
             >
               <div
                 className="content"
@@ -963,7 +963,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (5)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -983,10 +983,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=8&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=8&status=all"
             >
               <div
                 className="content"
@@ -1011,7 +1011,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (10)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -1066,10 +1066,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="0"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=9&status=running"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=9&status=running"
             >
               <div
                 className="content"
@@ -1094,7 +1094,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   Running (14)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"
@@ -1114,10 +1114,10 @@ exports[`Structured list component should render a multilink_list table 1`] = `
             className="content_value sub_items"
             key="2"
           >
-            <a
+            <Link
               className="cell_link"
-              href="/host/host_services/18?db=host&host_service_group=9&status=all"
               onClick={[Function]}
+              to="/host/host_services/18?db=host&host_service_group=9&status=all"
             >
               <div
                 className="content"
@@ -1142,7 +1142,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
                   All (14)
                 </div>
               </div>
-            </a>
+            </Link>
           </FeatureToggle(StructuredListCell)>
           <FeatureToggle(StructuredListCell)
             className="content_value sub_items"

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
@@ -702,35 +702,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=1&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=1&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=1&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Aodh"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Aodh"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Aodh"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -772,35 +779,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=1&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=1&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=1&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Aodh"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Aodh"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Aodh"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -905,35 +919,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=2&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=2&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=2&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Ceilometer"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Ceilometer"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Ceilometer"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -975,35 +996,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=2&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=2&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=2&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Ceilometer"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Ceilometer"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Ceilometer"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1108,35 +1136,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=3&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=3&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=3&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Cinder"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Cinder"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Cinder"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1178,35 +1213,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=3&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=3&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=3&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Cinder"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Cinder"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Cinder"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (3)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (3)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1311,35 +1353,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=4&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=4&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=4&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Glance"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Glance"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Glance"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (2)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (2)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1381,35 +1430,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=4&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=4&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=4&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Glance"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Glance"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Glance"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (2)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (2)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1514,35 +1570,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=5&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=5&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=5&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Gnocchi"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Gnocchi"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Gnocchi"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (2)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (2)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1584,35 +1647,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=5&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=5&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=5&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Gnocchi"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Gnocchi"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Gnocchi"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (2)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (2)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1717,35 +1787,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=6&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=6&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=6&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Heat"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Heat"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Heat"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (4)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (4)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1787,35 +1864,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=6&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=6&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=6&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Heat"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Heat"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Heat"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (4)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (4)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -1970,35 +2054,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=7&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=7&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=7&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Keystone"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Keystone"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Keystone"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (1)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (1)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -2103,35 +2194,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=8&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=8&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=8&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Nova"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Nova"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Nova"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (5)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (5)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -2173,35 +2271,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=8&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=8&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=8&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Nova"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Nova"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Nova"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (10)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (10)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -2306,35 +2411,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=9&status=running"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=9&status=running"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=9&status=running"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of running Swift"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-ok"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of running Swift"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-ok"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of running Swift"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              Running (14)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            Running (14)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -2376,35 +2488,42 @@ exports[`MultilinkTable renders just fine 1`] = `
                                       className="content_value sub_items bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="/host/host_services/18?db=host&host_service_group=9&status=all"
                                         onClick={[Function]}
+                                        to="/host/host_services/18?db=host&host_service_group=9&status=all"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="/host/host_services/18?db=host&host_service_group=9&status=all"
                                         >
                                           <div
-                                            className="cell icon"
-                                            title="Show list of all Swift"
+                                            className="content"
                                           >
-                                            <i
-                                              className="pficon pficon-service"
-                                              style={
-                                                Object {
-                                                  "background": undefined,
-                                                }
-                                              }
+                                            <div
+                                              className="cell icon"
                                               title="Show list of all Swift"
-                                            />
+                                            >
+                                              <i
+                                                className="pficon pficon-service"
+                                                style={
+                                                  Object {
+                                                    "background": undefined,
+                                                  }
+                                                }
+                                                title="Show list of all Swift"
+                                              />
+                                            </div>
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              All (14)
+                                            </div>
                                           </div>
-                                          <div
-                                            className="expand wrap_text"
-                                          >
-                                            All (14)
-                                          </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
@@ -781,33 +781,40 @@ exports[`Simple Table renders just fine... 1`] = `
                                       role="cell"
                                       title=""
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="some_link"
                                         onClick={[Function]}
+                                        to="some_link"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="some_link"
                                         >
                                           <div
-                                            className="multi_row_cell"
+                                            className="content"
                                           >
                                             <div
-                                              className="sub_row_item"
-                                              key="0"
-                                              title=""
+                                              className="multi_row_cell"
                                             >
                                               <div
-                                                className="sub_value"
+                                                className="sub_row_item"
+                                                key="0"
+                                                title=""
                                               >
                                                 <div
-                                                  className="wrap_text"
-                                                />
+                                                  className="sub_value"
+                                                >
+                                                  <div
+                                                    className="wrap_text"
+                                                  />
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
@@ -290,21 +290,28 @@ exports[`TableListView renders just fine... 1`] = `
                                       className="content_value object_item bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                         onClick={[Function]}
+                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                         >
                                           <div
-                                            className="expand wrap_text"
+                                            className="content"
                                           >
-                                            676,150
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              676,150
+                                            </div>
                                           </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -361,21 +368,28 @@ exports[`TableListView renders just fine... 1`] = `
                                       className="content_value object_item bx--structured-list-td"
                                       role="cell"
                                     >
-                                      <a
+                                      <Link
                                         className="cell_link"
-                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                         onClick={[Function]}
+                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                       >
-                                        <div
-                                          className="content"
+                                        <a
+                                          className="bx--link cell_link"
+                                          onClick={[Function]}
+                                          rel={null}
+                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                         >
                                           <div
-                                            className="expand wrap_text"
+                                            className="content"
                                           >
-                                            280,848
+                                            <div
+                                              className="expand wrap_text"
+                                            >
+                                              280,848
+                                            </div>
                                           </div>
-                                        </div>
-                                      </a>
+                                        </a>
+                                      </Link>
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -1757,35 +1757,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=cloud_networks"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=cloud_networks"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=cloud_networks"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Cloud Networks"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="ff ff-cloud-network"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Cloud Networks"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="ff ff-cloud-network"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Cloud Networks"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        1
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      1
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -1842,35 +1849,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=cloud_subnets"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=cloud_subnets"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=cloud_subnets"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Cloud Subnets"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="pficon pficon-network"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Cloud Subnets"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="pficon pficon-network"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Cloud Subnets"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        6
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      6
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -1927,35 +1941,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=network_routers"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=network_routers"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=network_routers"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Network Routers"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="pficon pficon-route"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Network Routers"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="pficon pficon-route"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Network Routers"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        1
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      1
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -2012,35 +2033,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=security_groups"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=security_groups"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=security_groups"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Security Groups"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="pficon pficon-cloud-security"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Security Groups"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="pficon pficon-cloud-security"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Security Groups"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        18
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      18
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -2097,35 +2125,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=floating_ips"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=floating_ips"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=floating_ips"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Floating IPs"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="ff ff-floating-ip"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Floating IPs"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="ff ff-floating-ip"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Floating IPs"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        14
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      14
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -2182,35 +2217,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=network_ports"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=network_ports"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=network_ports"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Network Ports"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="ff ff-network-port"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Network Ports"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="ff ff-network-port"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Network Ports"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        26
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      26
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>
@@ -2267,35 +2309,42 @@ exports[`TextualSummary renders just fine 1`] = `
                                                 className="content_value object_item bx--structured-list-td"
                                                 role="cell"
                                               >
-                                                <a
+                                                <Link
                                                   className="cell_link"
-                                                  href="/ems_network/39?display=load_balancers"
                                                   onClick={[Function]}
+                                                  to="/ems_network/39?display=load_balancers"
                                                 >
-                                                  <div
-                                                    className="content"
+                                                  <a
+                                                    className="bx--link cell_link"
+                                                    onClick={[Function]}
+                                                    rel={null}
+                                                    to="/ems_network/39?display=load_balancers"
                                                   >
                                                     <div
-                                                      className="cell icon"
-                                                      title="Show all Load Balancers"
+                                                      className="content"
                                                     >
-                                                      <i
-                                                        className="ff ff-load-balancer"
-                                                        style={
-                                                          Object {
-                                                            "background": undefined,
-                                                          }
-                                                        }
+                                                      <div
+                                                        className="cell icon"
                                                         title="Show all Load Balancers"
-                                                      />
+                                                      >
+                                                        <i
+                                                          className="ff ff-load-balancer"
+                                                          style={
+                                                            Object {
+                                                              "background": undefined,
+                                                            }
+                                                          }
+                                                          title="Show all Load Balancers"
+                                                        />
+                                                      </div>
+                                                      <div
+                                                        className="expand wrap_text"
+                                                      >
+                                                        2
+                                                      </div>
                                                     </div>
-                                                    <div
-                                                      className="expand wrap_text"
-                                                    >
-                                                      2
-                                                    </div>
-                                                  </div>
-                                                </a>
+                                                  </a>
+                                                </Link>
                                               </div>
                                             </StructuredListCell>
                                           </FeatureToggle(StructuredListCell)>

--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -56,6 +56,8 @@
     .cell_link {
       display: flex;
       color: $link-01;
+      cursor: pointer;
+      text-decoration: none;
     }
 
     .multi_row_cell {


### PR DESCRIPTION
Before
![](https://user-images.githubusercontent.com/37085529/161632332-6fae3e80-b4ee-45c3-ae97-d8c0b3864bc0.png)

After
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/87487049/161905064-7c59becc-f393-4cfe-a746-930633c92ae4.png">

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/8210

@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu