### PR TITLE
Fix for displaying host summary's cloud-tenants page

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -35,6 +35,8 @@ module ApplicationController::CiProcessing
     db = params[:db] if params[:db]
 
     case params[:pressed]
+    when "cloud_tenant_edit"
+      @redirect_controller = "cloud_tenant"
     when "miq_template_edit"
       @redirect_controller = "miq_template"
     when "image_edit", "instance_edit", "vm_edit"
@@ -44,7 +46,6 @@ module ApplicationController::CiProcessing
       session[:host_items] = obj.length > 1 ? obj : nil
     end
     @redirect_id = obj[0] if obj.length == 1 # not redirecting to an id if multi host are selected for credential edit
-
     @refresh_partial = case db
                        when 'ScanItemSet'
                          ScanItemSet.find(obj[0]).read_only ? 'show_list_set' : 'edit'
@@ -758,6 +759,11 @@ module ApplicationController::CiProcessing
   def deletehosts
     assert_privileges("host_delete")
     delete_elements(Host, :process_hosts)
+  end
+
+  def delete_cloud_tenant
+    assert_privileges("cloud_tenant_delete")
+    delete_elements(CloudTenant, :process_cloud_tenants)
   end
 
   # Delete all selected or single displayed stack(s)

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -14,7 +14,7 @@ class HostController < ApplicationController
   def self.display_methods
     %w[
       hv_info os_info devices network storage_adapters performance timeline storages
-      resource_pools vms miq_templates compliance_history custom_button_events cloud_networks cloud_subnets
+      resource_pools vms miq_templates compliance_history custom_button_events cloud_networks cloud_subnets cloud_tenants
     ]
   end
 
@@ -272,6 +272,8 @@ class HostController < ApplicationController
       case params[:pressed]
       when 'common_drift' then drift_analysis
       when 'custom_button' then custom_buttons
+      when 'cloud_tenant_edit' then edit_record
+      when 'cloud_tenant_delete' then delete_cloud_tenant
       when 'host_analyze_check_compliance' then analyze_check_compliance_hosts
       when 'host_check_compliance' then check_compliance_hosts
       when 'host_cloud_service_scheduling_toggle' then toggleservicescheduling


### PR DESCRIPTION
Getting an error when the cloud tenants link is clicked from host summary.

Before
![](https://user-images.githubusercontent.com/37085529/162023254-d55f77d5-3c2e-4376-8e5f-53add93292d2.png)

After
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/162228491-f246a208-1a70-4f9c-b860-4b70a9ddb21b.png">

@miq-bot add-reviewer @kavyanekkalapu
@miq-bot add-label bug
@miq-bot assign @kavyanekkalapu
