### PR TITLE
Fixed icon picker console errors

### DIFF
--- a/app/javascript/components/fonticon-picker/icon-list.jsx
+++ b/app/javascript/components/fonticon-picker/icon-list.jsx
@@ -21,7 +21,7 @@ const findIcons = (family) => _.chain(document.styleSheets)
   .map((icon) => `${family} ${icon}`);
 
 const IconList = ({
-  type, activeIcon, activeTab, setState,
+  type, activeIcon, setState,
 }) => {
   const icons = useMemo(() => findIcons(type), [type]);
 
@@ -29,7 +29,7 @@ const IconList = ({
     <Grid>
       <Row>
         { icons.map((icon) => (
-          <Column key={icon} className="fonticon" onClick={() => setState((state) => ({ ...state, activeIcon: icon }))}>
+          <Column key={`${icon}-${Math.random()}`} className="fonticon" onClick={() => setState((state) => ({ ...state, activeIcon: icon }))}>
             <span className={classNames({ active: icon === activeIcon })}>
               <i className={icon} title={icon.replace(' ', '.')} />
             </span>
@@ -43,13 +43,11 @@ const IconList = ({
 IconList.propTypes = {
   type: PropTypes.string.isRequired,
   activeIcon: PropTypes.string,
-  activeTab: PropTypes.string,
   setState: PropTypes.func.isRequired,
 };
 
 IconList.defaultProps = {
   activeIcon: undefined,
-  activeTab: undefined,
 };
 
 export default IconList;

--- a/app/javascript/components/fonticon-picker/icon-modal.jsx
+++ b/app/javascript/components/fonticon-picker/icon-modal.jsx
@@ -9,7 +9,7 @@ import {
 import IconList from './icon-list';
 
 const IconModal = ({
-  showModal, hide, activeTab, activeIcon, iconTypes, onModalApply, setState,
+  showModal, hide, activeIcon, iconTypes, onModalApply, setState,
 }) =>
 
   (
@@ -26,7 +26,6 @@ const IconModal = ({
         <div className="fonticon-picker-modal">
           <Tabs
             id="font-icon-tabs"
-            onClick={(activeTab) => setState((state) => ({ ...state, activeTab }))}
           >
             { Object.keys(iconTypes).map((type) => (
               <Tab key={type} label={iconTypes[type]}>
@@ -34,7 +33,6 @@ const IconModal = ({
                   {...{
                     type,
                     activeIcon,
-                    activeTab,
                     setState,
                   }}
                 />

--- a/app/javascript/components/fonticon-picker/index.jsx
+++ b/app/javascript/components/fonticon-picker/index.jsx
@@ -10,13 +10,11 @@ const FontIconPicker = ({ iconTypes, selected, onChangeURL }) => {
   const [{
     showModal,
     selectedIcon,
-    activeTab,
     activeIcon,
   }, setState] = useState({
     showModal: false,
     selectedIcon: selected,
     activeIcon: selected,
-    activeTab: selected ? selected.split(' ')[0] : Object.keys(iconTypes)[0],
   });
 
   const onModalApply = () => {
@@ -36,7 +34,6 @@ const FontIconPicker = ({ iconTypes, selected, onChangeURL }) => {
       <IconModal
         showModal={showModal}
         hide={hide}
-        activeTab={activeTab}
         selectedIcon={selectedIcon}
         activeIcon={activeIcon}
         iconTypes={iconTypes}


### PR DESCRIPTION
Fixed console errors for the icon picker component found on the add/edit button group form.
<img width="1408" alt="Screen Shot 2022-04-07 at 2 24 27 PM" src="https://user-images.githubusercontent.com/32444791/162271360-e3dc07ca-204b-4712-9b34-a933998bc83a.png">

Fixed key error for the icon picker component:
<img width="1526" alt="key error" src="https://user-images.githubusercontent.com/32444791/162269881-0f51193b-37a1-401e-9888-3ecea1f1c3c9.png">

Fixing the above error leads to this error being displayed from a separate issue when changing tabs in the icon picker component. This error is also fixed.
<img width="1519" alt="tab error" src="https://user-images.githubusercontent.com/32444791/162269870-bd6512f6-2b0c-4522-b084-b1d8f765e3ce.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label enhancement


