### PR TITLE
Fixed services page bug

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -324,10 +324,6 @@ class ServiceController < ApplicationController
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
 
-    # Set session properly - the same as when the filter is cleared
-    # No need to edit session here again if adv_search_clear was called
-    listnav_search_selected(0) if session[:adv_search] && %w[adv_search_button adv_search_clear x_search_by_name].exclude?(params[:action])
-
     @edit = session[:edit]
 
     case TreeBuilder.get_model_for_prefix(@nodetype)

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -434,11 +434,11 @@ describe ServiceController do
 
       let(:new_expression) do
         ApplicationController::Filter::Expression.new.tap do |e|
-          e.expression = {'???' => '???', :token => 3}
+          e.expression = {'???' => '???', :token => 2}
           e.exp_key = '???'
           e.exp_orig_key = '???'
-          e.exp_table = [['???', 3]]
-          e.exp_token = 3
+          e.exp_table = [['???', 2]]
+          e.exp_token = 2
           e.history = ApplicationController::Filter::ExpressionEditHistory.new([{'???' => '???'}])
           e.selected = {:id => 0, :description => 'All'}
           e.val1 = e.val2 = {:type => nil}
@@ -458,11 +458,6 @@ describe ServiceController do
         controller.send(:get_node_info, 'xx-asrv')
         expect(controller.session[:edit][:expression]).to eq(new_expression)
         expect(controller.session[:edit]).to eq(controller.session[:adv_search]["Service"])
-      end
-
-      it 'calls listnav_search_selected' do
-        expect(controller).to receive(:listnav_search_selected).with(0)
-        controller.send(:get_node_info, 'xx-rsrv')
       end
     end
   end


### PR DESCRIPTION
Fixed bugs preventing the services -> my services page from loading.

Before:
<img width="1409" alt="Screen Shot 2022-04-08 at 11 02 35 AM" src="https://user-images.githubusercontent.com/32444791/162469302-7bff4d4e-b9ed-4113-8f56-500e2a7dcf4d.png">
<img width="1412" alt="Screen Shot 2022-04-08 at 11 02 16 AM" src="https://user-images.githubusercontent.com/32444791/162469306-5f7dd092-a422-44e1-906d-4fe35f19bb60.png">

After:
<img width="1408" alt="Screen Shot 2022-04-08 at 10 58 55 AM" src="https://user-images.githubusercontent.com/32444791/162469439-b0c95f3f-5fbb-40f2-9eda-e7a811ba8d1e.png">
<img width="1408" alt="Screen Shot 2022-04-08 at 10 59 09 AM" src="https://user-images.githubusercontent.com/32444791/162469436-ed7a02bb-e8e4-480f-bd21-c42b6ba44073.png">
<img width="1396" alt="Screen Shot 2022-04-08 at 10 59 30 AM" src="https://user-images.githubusercontent.com/32444791/162469433-6cd40e72-a52c-4639-8277-718075792bf6.png">

These lines were added in pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/6709 but after testing with these lines removed the issue mentioned in this pr no longer exists and the advanced search is still functional.
<img width="1393" alt="Screen Shot 2022-04-08 at 10 53 45 AM" src="https://user-images.githubusercontent.com/32444791/162469697-f7a5a628-c704-49fb-9e07-e53192494a38.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label bug
