### PR TITLE
Refactored subnet edit form to use params for edit

### DIFF
--- a/app/javascript/components/subnet-form/index.jsx
+++ b/app/javascript/components/subnet-form/index.jsx
@@ -12,11 +12,6 @@ const SubnetForm = ({ recordId }) => {
   const submitLabel = !!recordId ? __('Save') : __('Add');
 
   const loadSchema = (appendState = {}) => ({ data: { form_schema: { fields } } }) => {
-    if (!!recordId && appendState.initialValues.type === 'ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet') {
-      Object.assign(fields[0], { isDisabled: true });
-      Object.assign(fields[1], { isDisabled: true });
-      Object.assign(fields[4], { isDisabled: true });
-    }
     setState((state) => ({
       ...state,
       ...appendState,
@@ -42,7 +37,9 @@ const SubnetForm = ({ recordId }) => {
         if (typeof initialValues.cloud_tenant_id === 'string') {
           initialValues.cloud_tenant_id = Number(initialValues.cloud_tenant_id);
         }
-        API.options(`/api/cloud_subnets?ems_id=${initialValues.ems_id}`).then(loadSchema({ initialValues, isLoading: false }));
+        miqSparkleOn();
+        API.options(`/api/cloud_subnets/${recordId}`).then(loadSchema({ initialValues, isLoading: false }));
+        miqSparkleOff();
       });
     }
   }, [recordId]);

--- a/app/javascript/components/subnet-form/subnet-form.schema.js
+++ b/app/javascript/components/subnet-form/subnet-form.schema.js
@@ -68,6 +68,7 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
         },
         fields: [{ // TODO: pattern for validating IPv4 or IPv6
           component: componentTypes.TEXT_FIELD,
+          label: __('IP Address'),
         }],
       },
     ] : []),

--- a/app/javascript/spec/subnet-form/subnet-form.spec.js
+++ b/app/javascript/spec/subnet-form/subnet-form.spec.js
@@ -25,7 +25,7 @@ describe('Subnet form component', () => {
       resources: [{ label: 'foo', value: 1 }],
     });
     fetchMock.getOnce('/api/cloud_subnets/1', { name: 'foo', ems_id: 1 });
-    fetchMock.mock('/api/cloud_subnets?ems_id=1', { data: { form_schema: { fields: [] } } }, { method: 'OPTIONS' });
+    fetchMock.mock('/api/cloud_subnets/1', { data: { form_schema: { fields: [] } } }, { method: 'OPTIONS' });
     let wrapper;
     await act(async() => {
       wrapper = mount(<SubnetForm recordId="1" />);


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-api/pull/1148, https://github.com/ManageIQ/manageiq-providers-openstack/pull/792

Refactored the cloud subnet edit form to use params for edit instead of using params for create and disabling the fields.

<img width="1402" alt="Screen Shot 2022-04-12 at 12 42 10 PM" src="https://user-images.githubusercontent.com/32444791/163012421-7fd36fc6-2f3b-4ec3-bf80-e20cee6b7d13.png">

@miq-bot add_reviewer @kavyanekkalapu
@miq-bot assign @kavyanekkalapu
@miq-bot add-label refactoring