### PR TITLE
Fix charts download  PNG/JPG issue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,7 +130,7 @@ class ApplicationController < ActionController::Base
   end
 
   def allow_websocket
-    override_content_security_policy_directives(:connect_src => ["'self'", websocket_origin])
+    override_content_security_policy_directives(:connect_src => ["'self'", 'https://fonts.gstatic.com', websocket_origin])
   end
   private :allow_websocket
 

--- a/app/stylesheet/carbon.scss
+++ b/app/stylesheet/carbon.scss
@@ -18,6 +18,8 @@ $carbon--theme: $carbon--theme--white;
 
 @include carbon--theme();
 
+//we need this import statement for charts PNG and JPG download
+@import 'https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed%7CIBM+Plex+Sans:400,600&display=swap';
 @import '~@carbon/charts/styles.css';
 @import '~carbon-components/scss/globals/scss/styles.scss';
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
     %meta{"http-equiv" => "cache-control", :content => "no-cache, no-store"}
 
     = miq_favicon_link_tag
+    %link{:rel => "preconnect", "crossorigin" => "anonymous", "href" => "https://fonts.gstatic.com"}
     = stylesheet_link_tag '/custom.css'
     = javascript_dependencies
     = csrf_meta_tag


### PR DESCRIPTION
depends:
- [x] https://github.com/ManageIQ/manageiq/pull/21822

## Before


<img width="1400" alt="Screen Shot 2022-04-13 at 2 39 15 PM" src="https://user-images.githubusercontent.com/37085529/163249514-ea132496-279e-485b-a28c-3566cd1252e6.png">


== After

<img width="1653" alt="Screen Shot 2022-04-13 at 2 36 01 PM" src="https://user-images.githubusercontent.com/37085529/163249548-bd56650c-e79f-4fff-81c3-c31f773fdadf.png">
