### PR TITLE
Fixed missing fields bug in subnet edit form

### DIFF
--- a/app/javascript/components/subnet-form/subnet-form.schema.js
+++ b/app/javascript/components/subnet-form/subnet-form.schema.js
@@ -1,6 +1,8 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { API } from '../../http_api';
 
+let empty = true;
+
 const emsUrl = '/api/providers?expand=resources&attributes=id,name,supports_cloud_subnet_create&filter[]=supports_cloud_subnet_create=true';
 const networkManagers = () => API.get(emsUrl).then(({ resources }) => {
   let networkManagersOptions = [];
@@ -8,8 +10,6 @@ const networkManagers = () => API.get(emsUrl).then(({ resources }) => {
   networkManagersOptions.unshift({ label: `<${__('Choose')}>`, value: '-1' });
   return networkManagersOptions;
 });
-
-let empty = true;
 
 const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
   fields: [
@@ -32,7 +32,7 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
       isRequired: true,
       validate: [{ type: validatorTypes.REQUIRED }],
     },
-    ...(!empty ? [
+    ...(!empty || edit ? [
       {
         component: componentTypes.TEXT_FIELD,
         name: 'name',
@@ -40,10 +40,6 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
         label: __('Name'),
         isRequired: true,
         validate: [{ type: validatorTypes.REQUIRED }],
-        condition: {
-          when: 'ems_id',
-          isNotEmpty: true,
-        },
       },
       {
         component: componentTypes.TEXT_FIELD,
@@ -53,10 +49,6 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
         isRequired: true,
         isDisabled: edit,
         validate: [{ type: validatorTypes.REQUIRED }], // TODO: pattern for validating IPv4/mask or IPv6/mask
-        condition: {
-          when: 'ems_id',
-          isNotEmpty: true,
-        },
       },
       {
         component: componentTypes.FIELD_ARRAY,
@@ -77,10 +69,6 @@ const createSchema = (edit, fields = [], loadSchema, emptySchema) => ({
         fields: [{ // TODO: pattern for validating IPv4 or IPv6
           component: componentTypes.TEXT_FIELD,
         }],
-        condition: {
-          when: 'ems_id',
-          isNotEmpty: true,
-        },
       },
     ] : []),
     ...fields,


### PR DESCRIPTION
Fixes an issue introduced in this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/7815 causing missing fields in the subnet form.

Before:
<img width="1404" alt="Screen Shot 2022-04-13 at 3 40 19 PM" src="https://user-images.githubusercontent.com/32444791/163257403-0f2dc12b-7b38-4c8a-bde5-4532be8c4c8f.png">

After:
<img width="1404" alt="Screen Shot 2022-04-13 at 3 38 12 PM" src="https://user-images.githubusercontent.com/32444791/163257417-7e35b85c-e24e-4a38-a19b-32d0b065af83.png">

