### PR TITLE
move cloud volume snapshot from provider to core

### DIFF
--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -59,9 +59,10 @@ describe CloudVolumeSnapshotController do
 
     context "#delete" do
       let(:task_options) do
+        userid = controller.current_user.userid
         {
-          :action => "deleting volume snapshot #{@snapshot.inspect} in #{@ems.inspect}",
-          :userid => controller.current_user.userid
+          :action => "deleting volume snapshot for #{userid} in #{@ems.name}",
+          :userid => userid
         }
       end
       let(:queue_options) do


### PR DESCRIPTION
Sorry, forgot to include this with the others

part of: https://github.com/ManageIQ/manageiq-api/pull/1134

## Fixes

```
Failures:

  1) CloudVolumeSnapshotController#delete #delete queues the delete action
     Failure/Error: snapshot.delete_snapshot_queue(session[:userid])

       #<MiqTask (class)> received :generic_action_with_callback with unexpected arguments
[...]

rspec ./spec/controllers/cloud_volume_snapshot_controller_spec.rb:76 # CloudVolumeSnapshotController#delete #delete queues the delete action
```
