### PR TITLE
Removed emstype and parent ems type from cloud object store container

### DIFF
--- a/app/javascript/components/cloud-object-store-container-form/index.jsx
+++ b/app/javascript/components/cloud-object-store-container-form/index.jsx
@@ -42,20 +42,13 @@ const CloudObjectStoreContainerForm = () => {
       submitData.cloud_tenant_id = values.cloud_tenant_id;
     }
     miqSparkleOn();
-    API.get(`/api/providers/${values.storage_manager_id}?attributes=type,parent_manager.type`)
-      .then((data) => {
-        submitData.emsType = data.type;
-        submitData.parent_emstype = data.parent_manager.type;
-      })
-      .then(() => {
-        API.post('/api/cloud_object_store_containers/', submitData).then(() => {
-          const message = __(`Add of Cloud Object Store Container ${values.name} has been successfully queued.`);
-          miqRedirectBack(message, 'success', url);
-        })
-          .catch((error) => {
-            const message = __(`Add of Cloud Object Store Container ${values.name} has failed with error: ${error.data.error.message}`);
-            miqRedirectBack(message, 'warning', url);
-          });
+    API.post('/api/cloud_object_store_containers/', submitData).then(() => {
+      const message = __(`Add of Cloud Object Store Container ${values.name} has been successfully queued.`);
+      miqRedirectBack(message, 'success', url);
+    })
+      .catch((error) => {
+        const message = __(`Add of Cloud Object Store Container ${values.name} has failed with error: ${error.data.error.message}`);
+        miqRedirectBack(message, 'warning', url);
       });
   };
 

--- a/app/javascript/spec/cloud-object-store-container-form/cloud-object-store-container-form.spec.js
+++ b/app/javascript/spec/cloud-object-store-container-form/cloud-object-store-container-form.spec.js
@@ -52,8 +52,6 @@ describe('Cloud Object Store Container form component', () => {
       name: 'test',
       ems_id: '6',
       cloud_tenant_id: '1',
-      emsType: 'ManageIQ::Providers::Openstack::StorageManager::SwiftManager',
-      parent_emstype: 'ManageIQ::Providers::Openstack::CloudManager',
     };
     fetchMock.get(
       // eslint-disable-next-line max-len
@@ -77,8 +75,6 @@ describe('Cloud Object Store Container form component', () => {
       name: 'test',
       ems_id: '87',
       providerRegion: 'us-gov-west-1',
-      emsType: 'ManageIQ::Providers::Amazon::StorageManager::S3',
-      parent_emstype: 'ManageIQ::Providers::Amazon::CloudManager',
     };
     fetchMock.get(
       // eslint-disable-next-line max-len


### PR DESCRIPTION
The emsType and parent_emstype are not used in the api or provider code so they are removed from the form submit function and its spec test. Both api calls are successful and hit the no credentials defined on their respective provider functions.

Before and after functionality is same after this change.

Before:
<img width="1492" alt="Screen Shot 2022-04-21 at 11 34 36 AM" src="https://user-images.githubusercontent.com/32444791/164497415-b655d452-368b-4ab4-8101-3c315eaa81b7.png">

After:
<img width="1484" alt="Screen Shot 2022-04-21 at 11 30 57 AM" src="https://user-images.githubusercontent.com/32444791/164497501-162d574a-1e9c-443b-b13f-3089759adfc7.png">


