### PR TITLE
Fix initialization of cypress

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -47,5 +47,4 @@ import './commands/search.js'
 import './commands/toolbar.js'
 
 // Assertions
-import './assertions/expect_explorer_title.js'
-import './assertions/expect_show_list_title.js'
+import './assertions/expect_title.js'


### PR DESCRIPTION
This bug was introduced in #7257.

@kavyanekkalapu Please review.  Most of the cypress tests still fail, but at least it is runnable now, and also login now passes.