### PR TITLE
Server profile details

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -51,7 +51,7 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i[properties management_networks relationships],
+      %i[properties management_networks relationships server_profiles],
       %i[power_management firmware_compliance firmware_details asset_details smart_management],
     ]
   end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -44,6 +44,13 @@ module PhysicalServerHelper::TextualSummary
     )
   end
 
+  def textual_group_server_profiles
+    TextualGroup.new(
+      _("Server Profile"),
+      %i[assigned_server_profile associated_server_profile]
+    )
+  end
+
   def textual_group_smart_management
     TextualTags.new(_("Smart Management"), %i[tags])
   end
@@ -224,5 +231,13 @@ module PhysicalServerHelper::TextualSummary
 
   def textual_compliance_status
     {:label => _("Status"), :value => @record.ems_compliance_status }
+  end
+
+  def textual_assigned_server_profile
+    {:label => _("Assigned Server Profile"), :value => @record.assigned_server_profile&.name }
+  end
+
+  def textual_associated_server_profile
+    {:label => _("Associated Server Profile"), :value => @record.associated_server_profile&.name }
   end
 end

--- a/app/helpers/physical_server_helper/textual_summary.rb
+++ b/app/helpers/physical_server_helper/textual_summary.rb
@@ -234,10 +234,10 @@ module PhysicalServerHelper::TextualSummary
   end
 
   def textual_assigned_server_profile
-    {:label => _("Assigned Server Profile"), :value => @record.assigned_server_profile&.name }
+    {:label => _("Assigned Server Profile"), :value => @record.assigned_server_profile&.name}
   end
 
   def textual_associated_server_profile
-    {:label => _("Associated Server Profile"), :value => @record.associated_server_profile&.name }
+    {:label => _("Associated Server Profile"), :value => @record.associated_server_profile&.name}
   end
 end

--- a/product/views/PhysicalServer.yaml
+++ b/product/views/PhysicalServer.yaml
@@ -16,6 +16,8 @@ cols:
 - power_state
 - hostname
 - asset_detail
+- assigned_server_profile
+- associated_server_profile
 
 
 include:
@@ -35,6 +37,8 @@ col_order:
 - hostname
 - asset_detail.product_name
 - asset_detail.manufacturer
+- assigned_server_profile.name
+- associated_server_profile.name
 
 col_formats:
 -
@@ -49,6 +53,8 @@ headers:
 - Hostname
 - Product Name
 - Manufacturer
+- Assigned Profile
+- Associated Profile
 
 
 conditions:


### PR DESCRIPTION
This PR adds additional info, related to server profiles, to the list of physical servers as well as to the server details page. This is specific to Cisco Intersight provider, so it may be better to have it as customization, just not sure how best to do it.

Screenshots below show the effect of this change.

List of servers:
<img width="1686" alt="Screenshot 2022-05-02 at 11 21 00" src="https://user-images.githubusercontent.com/1437960/166212733-b8a5ab3b-f62d-4939-8ad9-de7c69e9092d.png">

Server details:

<img width="784" alt="Screenshot 2022-05-02 at 11 21 17" src="https://user-images.githubusercontent.com/1437960/166212768-92fe3977-398e-4fbd-a9df-4fa69ab2117c.png">

