### PR TITLE
del host initiator

### DIFF
--- a/app/helpers/application_helper/toolbar/host_initiator_center.rb
+++ b/app/helpers/application_helper/toolbar/host_initiator_center.rb
@@ -19,6 +19,21 @@ class ApplicationHelper::Toolbar::HostInitiatorCenter < ApplicationHelper::Toolb
             :confirm => N_("Refresh relationships and power states for all items related to this Host Initiator?"),
             :options => {:feature => :refresh}
           ),
+          api_button(
+            :host_initiator_delete,
+            nil,
+            t = N_('Delete the Host Initiator'),
+            t,
+            :icon         => "pficon pficon-delete fa-lg",
+            :klass        => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+            :options      => {:feature => :delete},
+            :api          => {
+              :action => 'delete',
+              :entity => 'host_initiators'
+            },
+            :confirm      => N_("Are you sure you want to delete this host initiator?"),
+            :send_checked => true
+          ),
         ]
       ),
     ]

--- a/app/helpers/application_helper/toolbar/host_initiators_center.rb
+++ b/app/helpers/application_helper/toolbar/host_initiators_center.rb
@@ -26,6 +26,24 @@ class ApplicationHelper::Toolbar::HostInitiatorsCenter < ApplicationHelper::Tool
             t,
             :klass => ApplicationHelper::Button::HostInitiatorNew
           ),
+          api_button(
+            :host_initiator_delete,
+            nil,
+            t = N_('Delete the Host Initiator'),
+            t,
+            :icon         => "pficon pficon-delete fa-lg",
+            :klass        => ApplicationHelper::Button::PolymorphicConditionalButton,
+            :options      => {:feature      => :delete,
+                              :parent_class => "HostInitiator"},
+            :api          => {
+              :action => 'delete',
+              :entity => 'host_initiators'
+            },
+            :confirm      => N_("Are you sure you want to delete this host initiators?"),
+            :send_checked => true,
+            :enabled      => false,
+            :onwhen       => '1+'
+          ),
         ]
       ),
     ]


### PR DESCRIPTION
This PR add new feature for host-initiators (storage), the ability to **delete an existing host-initiator**.

<img width="884" alt="Screen Shot 2022-05-03 at 13 40 41" src="https://user-images.githubusercontent.com/6840118/166441274-073a8d0c-6a8c-4030-9123-85245a50b6fb.png">

<img width="858" alt="Screen Shot 2022-05-03 at 13 41 08" src="https://user-images.githubusercontent.com/6840118/166441293-54baa577-abc5-41e8-99af-b2cee3b877d0.png">


Links
----------------
* https://github.com/ManageIQ/manageiq/pull/21845
* https://github.com/ManageIQ/manageiq-providers-autosde/pull/147
* https://github.com/ManageIQ/manageiq-api/pull/1157