### PR TITLE
Convert Host power ops to supports feature

### DIFF
--- a/app/controllers/mixins/actions/host_actions/misc.rb
+++ b/app/controllers/mixins/actions/host_actions/misc.rb
@@ -131,13 +131,24 @@ module Mixins
           end
         end
 
-        def process_hosts_generic(hosts, task, display_name)
+        def process_hosts_compliance(hosts, task, display_name)
           each_host(hosts, display_name) do |host|
             if host.supports?(task.to_sym)
               host.send(task.to_sym)
               add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => host.name, :task => display_name})
             else
               add_flash(_("\"%{task}\": not available for %{hostname}") % {:hostname => host.name, :task => display_name}, :error)
+            end
+          end
+        end
+
+        def process_hosts_generic(hosts, task, display_name)
+          each_host(hosts, display_name) do |host|
+            if host.supports?(task.to_sym)
+              host.send(task.to_sym)
+              add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => host.name, :task => display_name})
+            else
+              add_flash(host.unsupported_reason(task), :error)
             end
           end
         end
@@ -158,6 +169,8 @@ module Mixins
           when 'manageable'         then process_hosts_manageable(hosts, display_name)
           when 'introspect'         then process_hosts_introspect(hosts, display_name)
           when 'provide'            then process_hosts_provide(hosts, display_name)
+          when 'check_compliance_queue', 'scan_and_check_compliance_queue'
+            process_hosts_compliance(hosts, task, display_name)
           else                           process_hosts_generic(hosts, task, display_name)
           end
         end

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -1,4 +1,6 @@
 describe StorageController do
+  include Spec::Support::SupportsHelper
+
   let(:storage) { FactoryBot.create(:storage, :name => 'test_storage1') }
   let(:storage_cluster) { FactoryBot.create(:storage_cluster, :name => 'test_storage_cluster1') }
   let(:storage_with_miq_templates) do


### PR DESCRIPTION
Currently most Host operations still use AvailabilityMixin, convert to use supports feature

Depends:
- [ ] https://github.com/ManageIQ/manageiq/pull/21847