### PR TITLE
Upgrading Attach/Detach functionality

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -16,8 +16,8 @@ class CloudVolumeController < ApplicationController
   end
 
   BUTTON_TO_ACTION_MAPPING = {
-    'cloud_volume_attach'          => [:attach_volume,   'attach'],
-    'cloud_volume_detach'          => [:detach_volume,   'detach'],
+    'cloud_volume_attach'          => [:attach,   'attach'],
+    'cloud_volume_detach'          => [:detach,   'detach'],
     'cloud_volume_edit'            => [:update,           'edit'],
     'cloud_volume_new'             => [nil,              'new'],
     'cloud_volume_snapshot_create' => [:snapshot_create, 'snapshot_new'],

--- a/app/javascript/components/cloud-volume-form/attach-detach-cloud-volume.schema.js
+++ b/app/javascript/components/cloud-volume-form/attach-detach-cloud-volume.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes } from '@@ddf';
 
-const createSchema = (isAttach, vmOptions, deviceMountpointRequired) => ({
+const createSchema = (vmOptions, dynamicFields) => ({
   fields: [
     {
       component: componentTypes.SELECT,
@@ -11,15 +11,7 @@ const createSchema = (isAttach, vmOptions, deviceMountpointRequired) => ({
       includeEmpty: true,
       options: vmOptions,
     },
-    ...(isAttach
-      ? [{
-        component: componentTypes.TEXT_FIELD,
-        id: 'device_mountpoint',
-        name: 'device_mountpoint',
-        label: deviceMountpointRequired ? __('Device Mountpoint') : __('Device Mountpoint (Optional)'),
-        isRequired: deviceMountpointRequired,
-      }] : []
-    ),
+    dynamicFields,
   ],
 });
 

--- a/app/javascript/spec/cloud-volume-form/__snapshots__/attach-detach-cloud-volume-form.spec.js.snap
+++ b/app/javascript/spec/cloud-volume-form/__snapshots__/attach-detach-cloud-volume-form.spec.js.snap
@@ -91,13 +91,20 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                   },
                 ],
               },
-              Object {
-                "component": "text-field",
-                "id": "device_mountpoint",
-                "isRequired": false,
-                "label": "Device Mountpoint (Optional)",
-                "name": "device_mountpoint",
-              },
+              Array [
+                Object {
+                  "component": "text-field",
+                  "id": "device_mountpoint",
+                  "isRequired": true,
+                  "label": "Device Mountpoint",
+                  "name": "device_mountpoint",
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+              ],
             ],
           }
         }
@@ -182,13 +189,20 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                     },
                   ],
                 },
-                Object {
-                  "component": "text-field",
-                  "id": "device_mountpoint",
-                  "isRequired": false,
-                  "label": "Device Mountpoint (Optional)",
-                  "name": "device_mountpoint",
-                },
+                Array [
+                  Object {
+                    "component": "text-field",
+                    "id": "device_mountpoint",
+                    "isRequired": true,
+                    "label": "Device Mountpoint",
+                    "name": "device_mountpoint",
+                    "validate": Array [
+                      Object {
+                        "type": "required",
+                      },
+                    ],
+                  },
+                ],
               ],
             }
           }
@@ -265,13 +279,20 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                       },
                     ],
                   },
-                  Object {
-                    "component": "text-field",
-                    "id": "device_mountpoint",
-                    "isRequired": false,
-                    "label": "Device Mountpoint (Optional)",
-                    "name": "device_mountpoint",
-                  },
+                  Array [
+                    Object {
+                      "component": "text-field",
+                      "id": "device_mountpoint",
+                      "isRequired": true,
+                      "label": "Device Mountpoint",
+                      "name": "device_mountpoint",
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                  ],
                   Object {
                     "component": "spy-field",
                     "initialize": undefined,
@@ -349,13 +370,22 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                         ]
                       }
                     />,
-                    <SingleField
-                      component="text-field"
-                      id="device_mountpoint"
-                      isRequired={false}
-                      label="Device Mountpoint (Optional)"
-                      name="device_mountpoint"
-                    />,
+                    Array [
+                      <SingleField
+                        component="text-field"
+                        id="device_mountpoint"
+                        isRequired={true}
+                        label="Device Mountpoint"
+                        name="device_mountpoint"
+                        validate={
+                          Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ]
+                        }
+                      />,
+                    ],
                     <SingleField
                       component="spy-field"
                       name="spy-field"
@@ -395,13 +425,20 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                           },
                         ],
                       },
-                      Object {
-                        "component": "text-field",
-                        "id": "device_mountpoint",
-                        "isRequired": false,
-                        "label": "Device Mountpoint (Optional)",
-                        "name": "device_mountpoint",
-                      },
+                      Array [
+                        Object {
+                          "component": "text-field",
+                          "id": "device_mountpoint",
+                          "isRequired": true,
+                          "label": "Device Mountpoint",
+                          "name": "device_mountpoint",
+                          "validate": Array [
+                            Object {
+                              "type": "required",
+                            },
+                          ],
+                        },
+                      ],
                       Object {
                         "component": "spy-field",
                         "initialize": undefined,
@@ -412,7 +449,22 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                 }
               >
                 <FormTemplate
-                  fields={Array []}
+                  fields={
+                    Array [
+                      Object {
+                        "component": "text-field",
+                        "id": "device_mountpoint",
+                        "isRequired": true,
+                        "label": "Device Mountpoint",
+                        "name": "device_mountpoint",
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                    ]
+                  }
                   formFields={
                     Array [
                       <SingleField
@@ -447,13 +499,22 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                           ]
                         }
                       />,
-                      <SingleField
-                        component="text-field"
-                        id="device_mountpoint"
-                        isRequired={false}
-                        label="Device Mountpoint (Optional)"
-                        name="device_mountpoint"
-                      />,
+                      Array [
+                        <SingleField
+                          component="text-field"
+                          id="device_mountpoint"
+                          isRequired={true}
+                          label="Device Mountpoint"
+                          name="device_mountpoint"
+                          validate={
+                            Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ]
+                          }
+                        />,
+                      ],
                       <SingleField
                         component="spy-field"
                         name="spy-field"
@@ -494,13 +555,20 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                             },
                           ],
                         },
-                        Object {
-                          "component": "text-field",
-                          "id": "device_mountpoint",
-                          "isRequired": false,
-                          "label": "Device Mountpoint (Optional)",
-                          "name": "device_mountpoint",
-                        },
+                        Array [
+                          Object {
+                            "component": "text-field",
+                            "id": "device_mountpoint",
+                            "isRequired": true,
+                            "label": "Device Mountpoint",
+                            "name": "device_mountpoint",
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
+                          },
+                        ],
                         Object {
                           "component": "spy-field",
                           "initialize": undefined,
@@ -960,19 +1028,31 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                     <SingleField
                       component="text-field"
                       id="device_mountpoint"
-                      isRequired={false}
+                      isRequired={true}
                       key="device_mountpoint"
-                      label="Device Mountpoint (Optional)"
+                      label="Device Mountpoint"
                       name="device_mountpoint"
+                      validate={
+                        Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ]
+                      }
                     >
                       <FormConditionWrapper
                         field={
                           Object {
                             "component": "text-field",
                             "id": "device_mountpoint",
-                            "isRequired": false,
-                            "label": "Device Mountpoint (Optional)",
+                            "isRequired": true,
+                            "label": "Device Mountpoint",
                             "name": "device_mountpoint",
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
                           }
                         }
                       >
@@ -982,9 +1062,16 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                           <TextField
                             component="text-field"
                             id="device_mountpoint"
-                            isRequired={false}
-                            label="Device Mountpoint (Optional)"
+                            isRequired={true}
+                            label="Device Mountpoint"
                             name="device_mountpoint"
+                            validate={
+                              Array [
+                                Object {
+                                  "type": "required",
+                                },
+                              ]
+                            }
                           >
                             <TextInput
                               disabled={false}
@@ -994,7 +1081,11 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                               invalid={false}
                               invalidText=""
                               key="device_mountpoint"
-                              labelText="Device Mountpoint (Optional)"
+                              labelText={
+                                <IsRequired>
+                                  Device Mountpoint
+                                </IsRequired>
+                              }
                               light={false}
                               name="device_mountpoint"
                               onBlur={[Function]}
@@ -1013,7 +1104,15 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                                   className="bx--label"
                                   htmlFor="device_mountpoint"
                                 >
-                                  Device Mountpoint (Optional)
+                                  <IsRequired>
+                                    <span
+                                      aria-hidden="true"
+                                      className="ddorg__carbon-component-mapper_is-required isRequired-0-2-1"
+                                    >
+                                      *
+                                    </span>
+                                    Device Mountpoint
+                                  </IsRequired>
                                 </label>
                                 <div
                                   className="bx--text-input__field-outer-wrapper"
@@ -1115,7 +1214,7 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                         <Button
                           className="btnRight"
                           dangerDescription="danger"
-                          disabled={false}
+                          disabled={true}
                           id="reset"
                           isExpressive={false}
                           kind="secondary"
@@ -1130,8 +1229,8 @@ exports[`Attach / Detach form component should render attach form variant 1`] = 
                           <button
                             aria-describedby={null}
                             aria-pressed={null}
-                            className="btnRight bx--btn bx--btn--secondary"
-                            disabled={false}
+                            className="btnRight bx--btn bx--btn--secondary bx--btn--disabled"
+                            disabled={true}
                             id="reset"
                             onBlur={[Function]}
                             onClick={[Function]}
@@ -1280,6 +1379,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                   },
                 ],
               },
+              Array [],
             ],
           }
         }
@@ -1364,6 +1464,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                     },
                   ],
                 },
+                Array [],
               ],
             }
           }
@@ -1440,6 +1541,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                       },
                     ],
                   },
+                  Array [],
                   Object {
                     "component": "spy-field",
                     "initialize": undefined,
@@ -1517,6 +1619,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                         ]
                       }
                     />,
+                    Array [],
                     <SingleField
                       component="spy-field"
                       name="spy-field"
@@ -1556,6 +1659,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                           },
                         ],
                       },
+                      Array [],
                       Object {
                         "component": "spy-field",
                         "initialize": undefined,
@@ -1601,6 +1705,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                           ]
                         }
                       />,
+                      Array [],
                       <SingleField
                         component="spy-field"
                         name="spy-field"
@@ -1641,6 +1746,7 @@ exports[`Attach / Detach form component should render detach form variant 1`] = 
                             },
                           ],
                         },
+                        Array [],
                         Object {
                           "component": "spy-field",
                           "initialize": undefined,

--- a/app/javascript/spec/cloud-volume-form/attach-detach-cloud-volume-form.spec.js
+++ b/app/javascript/spec/cloud-volume-form/attach-detach-cloud-volume-form.spec.js
@@ -15,13 +15,26 @@ describe('Attach / Detach form component', () => {
     ['server5', 5],
   ];
 
-  const initialValues = {
-    type: 'test',
+  const response = {
+    data: {
+      form_schema: {
+        fields: [
+          {
+            component: 'text-field',
+            name: 'device_mountpoint',
+            id: 'device_mountpoint',
+            label: _('Device Mountpoint'),
+            isRequired: true,
+            validate: [{ type: 'required' }],
+          },
+        ],
+      },
+    },
   };
 
   beforeEach(() => {
     fetchMock
-      .mock('/api/cloud_volumes/1', initialValues);
+      .once('/api/cloud_volumes/1?option_action=attach', response);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Implements `option_action=attach` from https://github.com/ManageIQ/manageiq-api/pull/1147
Implements `attach` vs `attach_volume` renaming from https://github.com/ManageIQ/manageiq/pull/21841

Part of fixing attach / detach from [7603](https://github.com/ManageIQ/manageiq-ui-classic/issues/7603#event-6292073380). Spiritual successor to https://github.com/ManageIQ/manageiq-ui-classic/pull/8205

Depends on schema to be implemented in providers that support `attach` 
- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/797
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/756
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/376

## AFTER

Attach
![Screen Shot 2022-05-10 at 10 09 54 AM](https://user-images.githubusercontent.com/29209973/167649119-1817896e-cab1-496a-98ac-ea15978c47b0.png)

![Screen Shot 2022-05-10 at 10 09 58 AM](https://user-images.githubusercontent.com/29209973/167649164-c38f4a7d-41f6-493e-af07-edcff043b0b5.png)

Detach
![Screen Shot 2022-05-10 at 10 09 34 AM](https://user-images.githubusercontent.com/29209973/167649178-712cd226-67a4-475c-a221-4a6a8bc54ec3.png)

![Screen Shot 2022-05-10 at 10 09 39 AM](https://user-images.githubusercontent.com/29209973/167649099-4e4335f6-b2d1-4167-8bbe-8f0a43ef5bb3.png)

