### PR TITLE
changes for s390x

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -8,6 +8,7 @@ namespace :update do
         end
         puts "== #{engine.name} =="
         system("which yarn >/dev/null") || abort("\n== You have to install yarn ==")
+        system("yarn set version 1.22.18") || abort("\n== yarn failed to set version to 1.22.18 in #{engine.path} ==") if RUBY_PLATFORM.include?("s390x")
         system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
       end
     end


### PR DESCRIPTION
Build with yarn 3 on IBM Z fails , so this change switches to yarn 1.22.18 only for Z builds to overcome the issue