### PR TITLE
Fix RemoveGenericItemModal Controlled Component Warning

### DIFF
--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -104,6 +104,7 @@ class RemoveGenericItemModal extends React.Component {
     this.state = {
       data: [],
       loaded: false,
+      force: false,
     };
   }
 


### PR DESCRIPTION
the following warning is shown when calling RemoveGenericItemModal (e.g. when deleting volumes):
```
Warning: A component is changing an uncontrolled input of type %s to be controlled. 
Input elements should not switch from uncontrolled to controlled (or vice versa). 
Decide between using a controlled or uncontrolled input element for the lifetime of 
the component. 
More info: https://fb.me/react-controlled-components%s,checkbox, in input
 (created by RemoveGenericItemModal) in label (created by RemoveGenericItemModal)
 in div (created by ModalBody) in ModalBody (created by RemoveGenericItemModal)
 in RemoveGenericItemModal (created by Connect(RemoveGenericItemModal))
 in Connect(RemoveGenericItemModal) (created by inner) 
 in inner in div (created by ModalBody)
 in ModalBody
 in div (created by ComposedModal) 
 in div (created by ComposedModal)
 in ComposedModal
 in Provider
```

![image](https://user-images.githubusercontent.com/53213107/168460846-d563aada-2b53-4a17-8649-813dd25b4137.png)


I added the force to the state making the React state be the “single source of truth”.