### PR TITLE
Fixed IBM Cloud edit provider authentication issue

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -162,7 +162,11 @@ const ProviderForm = ({
       const { endpoints: _endpoints = { default: {} }, authentications: _authentications = {}, ...rest } = pick(_data, toSubmit);
       // Convert endpoints and authentications back to an array
       const endpoints = Object.keys(_endpoints).map((key) => ({ role: key, ..._endpoints[key] }));
-      const authentications = Object.keys(_authentications).map((key) => ({ authtype: key, ..._authentications[key] }));
+      let authentications = Object.keys(_authentications).map((key) => ({ authtype: key, ..._authentications[key] }));
+
+      if (authentications.length === 0) {
+        authentications = Object.keys(initialValues.authentications).map((key) => ({ authtype: key }));
+      }
 
       // Construct the full form data with all the necessary items
       const data = {


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/371

Fixed an issue where the authentication values were not being sent as part of the API post / patch data for the edit provider form for the IBM Cloud VPC provider. The issue involves this line:
`const authentications = Object.keys(_authentications).map((key) => ({ authtype: key, ..._authentications[key] }));`

This line takes all the fields from the Default Endpoints tab and pulls them out to add the to data object that is submitted to the API. This process however will ignore any credentials fields since those are handled by the validation button separately. This means that since the IBM Cloud VPC provider only has a credentials field the `_authentications` object is empty and therefore the resulting `authentications` array that is submitted to the API is also empty.
<img width="1388" alt="Screen Shot 2022-05-18 at 1 58 18 PM" src="https://user-images.githubusercontent.com/32444791/169110971-51ad55a2-df86-40e4-8f9e-bd0f078c2bff.png">
 
 As a solution I added a check to ensure if this is the case where `authentications` is an empty array than it will add the `authkey` to the object in the array based on the initial values from the get API call. The resulting data obtained by the API is:

<img width="946" alt="API result" src="https://user-images.githubusercontent.com/32444791/169112338-8c033066-cb91-45dd-95ba-e4153bd3d603.png">

This issue also seems to affect the Google and IBM Power VS providers and any other provider without password field endpoint fields. This pr fixes the issue for these providers as well.

@miq-bot add_reviewer @agrare
@miq-bot add_reviewer @Fryguy 
@miq-bot assign @agrare 
@miq-bot add-label bug
 