### PR TITLE
auto call calculate_properties when testing enabled and disabled buttons

### DIFF
--- a/spec/helpers/application_helper/buttons/ae_copy_simulate_spec.rb
+++ b/spec/helpers/application_helper/buttons/ae_copy_simulate_spec.rb
@@ -3,9 +3,7 @@ describe ApplicationHelper::Button::AeCopySimulate do
   let(:resolve) { {:button_class => button_class} }
   let(:button) { described_class.new(view_context, {}, {'resolve' => resolve}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when object attribute is specified' do
       let(:button_class) { 'some_button_class' }
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/availability_zone_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/availability_zone_performance_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::AvailabilityZonePerformance do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_perf_data?).and_return(has_perf_data) }
-    before { button.calculate_properties }
 
     context 'and record has events' do
       let(:has_perf_data) { true }

--- a/spec/helpers/application_helper/buttons/availability_zone_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/availability_zone_timeline_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::AvailabilityZoneTimeline do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_events?).and_return(has_events) }
-    before { button.calculate_properties }
 
     context 'and record has events' do
       let(:has_events) { true }

--- a/spec/helpers/application_helper/buttons/collect_logs_spec.rb
+++ b/spec/helpers/application_helper/buttons/collect_logs_spec.rb
@@ -9,13 +9,12 @@ describe ApplicationHelper::Button::CollectLogs do
     MiqTask.delete_all
   end
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     let(:setup_log_files) {}
     let(:setup_tasks) {}
     before do
       setup_log_files
       setup_tasks
-      button.calculate_properties
     end
     after(:each) { tear_down }
 

--- a/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
@@ -25,19 +25,14 @@ describe ApplicationHelper::Button::CustomizationTemplateNew do
     end
   end
 
-  describe '#calculate_properties' do
-    before do
-      allow(PxeImageType).to receive(:count).and_return(count)
-      button.calculate_properties
-    end
-
+  describe '#disabled?' do
     context 'when there are no System Image Types available' do
-      let(:count) { 0 }
+      before { allow(PxeImageType).to receive(:count).and_return(0) }
       it_behaves_like 'a disabled button', 'No System Image Types available, Customization Template cannot be added'
     end
 
     context 'when there are System Image Types available' do
-      let(:count) { 1 }
+      before { allow(PxeImageType).to receive(:count).and_return(1) }
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/dashboard_delete_spec.rb
@@ -3,9 +3,7 @@ describe ApplicationHelper::Button::DashboardDelete do
   let(:dashboard) { FactoryBot.create(:miq_widget_set, :read_only => read_only) }
   let(:button) { described_class.new(view_context, {}, {:dashboard => dashboard}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when dashboard is read-only' do
       let(:read_only) { true }
       it_behaves_like 'a disabled button', 'Default Dashboard cannot be deleted'

--- a/spec/helpers/application_helper/buttons/db_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/db_new_spec.rb
@@ -4,9 +4,7 @@ describe ApplicationHelper::Button::DbNew do
   let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryBot.create(:miq_widget_set) } }
   let(:button) { described_class.new(view_context, {}, {'widgetsets' => widgetsets}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when dashboard group is full' do
       let(:dashboard_count) { 10 }
       it_behaves_like 'a disabled button', 'Only 10 Dashboards are allowed for a group'

--- a/spec/helpers/application_helper/buttons/db_seq_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/db_seq_edit_spec.rb
@@ -4,9 +4,7 @@ describe ApplicationHelper::Button::DbSeqEdit do
   let(:widgetsets) { Array.new(dashboard_count) { |_i| FactoryBot.create(:miq_widget_set) } }
   let(:button) { described_class.new(view_context, {}, {'widgetsets' => widgetsets}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when there is enough dashboards to edit sequence' do
       it_behaves_like 'an enabled button'
     end

--- a/spec/helpers/application_helper/buttons/ems_cluster_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_cluster_performance_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::EmsClusterPerformance do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_perf_data?).and_return(has_perf_data) }
-    before { button.calculate_properties }
 
     context 'and record has events' do
       let(:has_perf_data) { true }

--- a/spec/helpers/application_helper/buttons/ems_cluster_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_cluster_timeline_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::EmsClusterTimeline do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_events?).and_return(has_events) }
-    before { button.calculate_properties }
 
     context 'and record has events' do
       let(:has_events) { true }

--- a/spec/helpers/application_helper/buttons/host_check_compliance_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_check_compliance_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::HostCheckCompliance do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_compliance_policies?).and_return(has_compliance_policies) }
-    before { button.calculate_properties }
 
     context 'and record has compliance policies' do
       let(:has_compliance_policies) { true }

--- a/spec/helpers/application_helper/buttons/host_performance_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_performance_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::HostPerformance do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_perf_data?).and_return(has_perf_data) }
-    before { button.calculate_properties }
 
     context 'and record has performance data' do
       let(:has_perf_data) { true }

--- a/spec/helpers/application_helper/buttons/host_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_timeline_spec.rb
@@ -6,7 +6,6 @@ describe ApplicationHelper::Button::HostTimeline do
   describe '#disabled?' do
     subject { button[:title] }
     before { allow(record).to receive(:has_events?).and_return(has_events) }
-    before { button.calculate_properties }
 
     context 'and record has events' do
       let(:has_events) { true }

--- a/spec/helpers/application_helper/buttons/iso_datastore_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/iso_datastore_new_spec.rb
@@ -2,11 +2,10 @@ describe ApplicationHelper::Button::IsoDatastoreNew do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {}, {}) }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     context 'when there is a RedHat InfraManager without iso datastores' do
       before do
         FactoryBot.create(:ems_redhat)
-        button.calculate_properties
       end
 
       it_behaves_like 'an enabled button'
@@ -15,7 +14,6 @@ describe ApplicationHelper::Button::IsoDatastoreNew do
     context 'when all RedHat InfraManagers have iso datastores' do
       before do
         FactoryBot.create(:iso_datastore, :ems_id => FactoryBot.create(:ems_redhat).id)
-        button.calculate_properties
       end
 
       it_behaves_like 'a disabled button', 'No Providers are available to create an ISO Datastore on'

--- a/spec/helpers/application_helper/buttons/miq_action_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_delete_spec.rb
@@ -7,7 +7,6 @@ describe ApplicationHelper::Button::MiqActionDelete do
     subject { button[:title] }
     before { allow(record).to receive(:miq_policies).and_return(miq_policies) }
     before { allow(record).to receive(:action_type).and_return(action_type) }
-    before { button.calculate_properties }
 
     context 'and record has no policies' do
       let(:miq_policies) { [] }

--- a/spec/helpers/application_helper/buttons/miq_action_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_edit_spec.rb
@@ -7,7 +7,6 @@ describe ApplicationHelper::Button::MiqActionEdit do
     subject { button[:title] }
     before { allow(record).to receive(:action_type).and_return(action_type) }
     before { allow(view_context).to receive(:x_node).and_return('node') }
-    before { button.calculate_properties }
 
     context 'and record has no policies' do
       let(:action_type) { "Non-default" }

--- a/spec/helpers/application_helper/buttons/miq_alert_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_alert_delete_spec.rb
@@ -7,7 +7,6 @@ describe ApplicationHelper::Button::MiqAlertDelete do
     subject { button[:title] }
     before { allow(record).to receive(:owning_miq_actions).and_return(owning_miq_actions) }
     before { allow(record).to receive(:memberof).and_return(memberof) }
-    before { button.calculate_properties }
 
     context 'and record doesnt own any action and is not memberof any group' do
       let(:owning_miq_actions) { [] }

--- a/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_delete_spec.rb
@@ -17,8 +17,6 @@ describe ApplicationHelper::Button::MiqRequestDelete do
     let(:requester_name) { {:requester_name => current_user.name} }
     let(:resource_type) { 'knedlik' }
 
-    before { button.calculate_properties }
-
     context 'requester is admin' do
       let(:requester_name) { {:requester_name => 'FrantaSkocDoPole'} }
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_cloud_tenant_spec.rb
@@ -6,15 +6,12 @@ describe ApplicationHelper::Button::NewCloudTenant do
     subject { button[:title] }
 
     context 'no provider available' do
-      before { button.calculate_properties }
-
       it_behaves_like 'a disabled button'
     end
 
     context 'provider available' do
       before do
         FactoryBot.create(:ems_openstack)
-        button.calculate_properties
       end
 
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/new_flavor_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_flavor_spec.rb
@@ -10,8 +10,6 @@ describe ApplicationHelper::Button::NewFlavor do
     subject { button[:title] }
 
     context 'no provider available' do
-      before { button.calculate_properties }
-
       it_behaves_like 'a disabled button'
     end
 
@@ -19,7 +17,6 @@ describe ApplicationHelper::Button::NewFlavor do
       before do
         provider = FactoryBot.create(:ems_openstack)
         allow(provider.class::Flavor).to receive(:create).and_return(true)
-        button.calculate_properties
       end
 
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
+++ b/spec/helpers/application_helper/buttons/new_host_aggregate_spec.rb
@@ -19,7 +19,6 @@ describe ApplicationHelper::Button::NewHostAggregate do
 
     context 'no provider available' do
       let(:provider) { nil }
-      before { button.calculate_properties }
 
       it_behaves_like 'a disabled button', 'No cloud provider supports creating host aggregates.'
     end
@@ -30,15 +29,12 @@ describe ApplicationHelper::Button::NewHostAggregate do
       before do
         entitlement.set_managed_filters([["/managed/environment/prod"]])
         entitlement.set_belongsto_filters([])
-        button.calculate_properties
       end
 
       it_behaves_like 'a disabled button', 'No cloud provider supports creating host aggregates.'
     end
 
     context 'a provider is available' do
-      before { button.calculate_properties }
-
       it_behaves_like 'an enabled button'
     end
   end

--- a/spec/helpers/application_helper/buttons/orchestration_stack_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/orchestration_stack_retire_now_spec.rb
@@ -3,9 +3,7 @@ describe ApplicationHelper::Button::OrchestrationStackRetireNow do
   let(:record) { FactoryBot.create(:orchestration_stack, :retired => retired) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when Orchestration Stack is retired' do
       let(:retired) { true }
       it_behaves_like 'a disabled button', 'Orchestration Stack is already retired'

--- a/spec/helpers/application_helper/buttons/rbac_role_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_role_delete_spec.rb
@@ -4,24 +4,13 @@ describe ApplicationHelper::Button::RbacRoleDelete do
   let(:record) { FactoryBot.create(:miq_user_role, :read_only => read_only) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    let(:setup_miq_groups) {}
-    before do
-      setup_miq_groups
-      button.calculate_properties
-    end
-    after(:each) { tear_down }
-
-    def tear_down
-      MiqGroup.delete_all
-    end
-
+  describe '#disabled?' do
     context 'when role is writable' do
       context 'when role is not in use by any Group' do
         it_behaves_like 'an enabled button'
       end
       context 'when role is in use by one or more Groups' do
-        let(:setup_miq_groups) { FactoryBot.create(:miq_group, :miq_user_role => record) }
+        before { FactoryBot.create(:miq_group, :miq_user_role => record) }
         it_behaves_like 'a disabled button', 'This Role is in use by one or more Groups and can not be deleted'
       end
     end

--- a/spec/helpers/application_helper/buttons/rbac_role_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_role_edit_spec.rb
@@ -2,10 +2,8 @@ describe ApplicationHelper::Button::RbacRoleEdit do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     let(:record) { FactoryBot.create(:miq_user_role, :read_only => read_only) }
-    before { button.calculate_properties }
-
     context 'when role is writable' do
       let(:read_only) { false }
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/rbac_tenant_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_tenant_delete_spec.rb
@@ -3,9 +3,7 @@ describe ApplicationHelper::Button::RbacTenantDelete do
   let(:record) { FactoryBot.create(:tenant, :parent => tenant_parent) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when record is a child tenant' do
       let(:tenant_parent) { FactoryBot.create(:tenant) }
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/rbac_user_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_user_copy_spec.rb
@@ -2,9 +2,7 @@ describe ApplicationHelper::Button::RbacUserCopy do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when user is an administrator' do
       let(:record) { FactoryBot.create(:user_admin) }
       it_behaves_like 'a disabled button', 'Super Administrator can not be copied'

--- a/spec/helpers/application_helper/buttons/rbac_user_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/rbac_user_delete_spec.rb
@@ -2,9 +2,7 @@ describe ApplicationHelper::Button::RbacUserDelete do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when user is the root administrator' do
       let(:record) { FactoryBot.create(:user_admin, :userid => 'admin') }
       it_behaves_like 'a disabled button', 'Default Administrator can not be deleted'

--- a/spec/helpers/application_helper/buttons/report_only_spec.rb
+++ b/spec/helpers/application_helper/buttons/report_only_spec.rb
@@ -7,11 +7,10 @@ describe ApplicationHelper::Button::ReportOnly do
   let(:instance_data) { {'record' => record, 'report' => report, 'report_result_id' => report_result_id} }
   let(:button) { described_class.new(view_context, {}, instance_data, {}) }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     let(:setup_report_result_details) { record.miq_report_result_details << result_detail if record }
     before do
       setup_report_result_details
-      button.calculate_properties
     end
 
     context 'when record not present' do

--- a/spec/helpers/application_helper/buttons/service_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/service_retire_now_spec.rb
@@ -3,9 +3,7 @@ describe ApplicationHelper::Button::ServiceRetireNow do
   let(:record) { FactoryBot.create(:service, :retired => retired) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when Service is retired' do
       let(:retired) { true }
       it_behaves_like 'a disabled button', 'Service is already retired'

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -9,9 +9,7 @@ describe ApplicationHelper::Button::SetOwnership do
 
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when provider has tenant mapping enabled' do
       let(:tenant_mapping_enabled) { true }
       it_behaves_like 'a disabled button', 'Ownership is controlled by tenant mapping'

--- a/spec/helpers/application_helper/buttons/storage_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_delete_spec.rb
@@ -5,9 +5,7 @@ describe ApplicationHelper::Button::StorageDelete do
   let(:record) { FactoryBot.create(:storage, :vms_and_templates => vms, :hosts => hosts) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when with VMs' do
       let(:vms) { [FactoryBot.create(:vm_or_template)] }
       it_behaves_like 'a disabled button', 'Only Datastore without VMs and Hosts can be removed'

--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -13,11 +13,7 @@ describe ApplicationHelper::Button::StorageScan do
   end
 
   context 'when feature is supported' do
-    describe '#calculate_properties' do
-      before do
-        button.calculate_properties
-      end
-
+    describe '#disabled?' do
       context 'but no EMSs are present' do
         it_behaves_like 'a disabled button', 'Smartstate Analysis cannot be performed on selected Datastore'
       end

--- a/spec/helpers/application_helper/buttons/view_dashboard_spec.rb
+++ b/spec/helpers/application_helper/buttons/view_dashboard_spec.rb
@@ -2,8 +2,7 @@ describe ApplicationHelper::Button::ViewDashboard do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'showtype' => showtype}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
+  describe '#disabled?' do
     context 'when showtype == dashboard' do
       let(:showtype) { 'dashboard' }
       it_behaves_like 'a disabled button'

--- a/spec/helpers/application_helper/buttons/view_summary_spec.rb
+++ b/spec/helpers/application_helper/buttons/view_summary_spec.rb
@@ -2,9 +2,7 @@ describe ApplicationHelper::Button::ViewSummary do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'showtype' => showtype}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when showtype == dashboard' do
       let(:showtype) { 'dashboard' }
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
@@ -27,7 +27,7 @@ describe ApplicationHelper::Button::VmInstanceTemplateScan do
     end
   end
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     let(:has_active_proxy?) { true }
     before do
       EvmSpecHelper.local_guid_miq_server_zone
@@ -38,7 +38,6 @@ describe ApplicationHelper::Button::VmInstanceTemplateScan do
       before do
         roles = %w(smartproxy smartstate).collect { |role| FactoryBot.create(:server_role, :name => role) }
         FactoryBot.create(:miq_server, :zone => MiqServer.my_server.zone, :active_roles => roles)
-        button.calculate_properties
       end
 
       context 'when record has active proxy' do

--- a/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_native_console_spec.rb
@@ -10,21 +10,16 @@ describe ApplicationHelper::Button::VmNativeConsole do
     it { is_expected.to be true }
   end
 
-  describe '#calculate_properties' do
-    before(:each) do
-      remote_console_validation
-      button.calculate_properties
-    end
-
+  describe '#disabled?' do
     context 'and remote control is supported' do
-      let(:remote_console_validation) do
+      let!(:remote_console_validation) do
         allow(record).to receive(:validate_native_console_support).and_return(true)
       end
       it_behaves_like 'an enabled button'
     end
     context 'and remote control is not supported' do
       let(:err_msg) { 'Remote console is not supported' }
-      let(:remote_console_validation) do
+      let!(:remote_console_validation) do
         allow(record).to receive(:validate_native_console_support)
           .and_raise(MiqException::RemoteConsoleNotSupportedError, err_msg)
       end

--- a/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
@@ -9,10 +9,9 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
   let(:active) { true }
   let(:button) { described_class.new(view_context, {}, {'record' => record, 'active' => active}, {}) }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     before do
       stub_user(:features => :all)
-      button.calculate_properties
     end
     context 'when creating snapshots is available' do
       let(:current) { 1 }
@@ -47,7 +46,6 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
   describe 'user lacks permissions to create snapshots' do
     before do
       stub_user(:features => :none)
-      button.calculate_properties
     end
     context 'when user lacks permissions to create snapsnots' do
       it_behaves_like 'a disabled button', 'Current user lacks permissions to create a new snapshot for this VM'

--- a/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
@@ -27,9 +27,7 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
     end
   end
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when reverting to a snapshot is available' do
       it_behaves_like 'an enabled button'
     end

--- a/spec/helpers/application_helper/buttons/vm_vmrc_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_vmrc_console_spec.rb
@@ -7,21 +7,16 @@ describe ApplicationHelper::Button::VmVmrcConsole do
     it_behaves_like 'vm_console_visible?', 'VMRC'
   end
 
-  describe '#calculate_properties' do
-    before do
-      remote_console_validation
-      button.calculate_properties
-    end
-
+  describe '#disabled?' do
     context 'and remote control is supported' do
-      let(:remote_console_validation) do
+      let!(:remote_console_validation) do
         allow(record).to receive(:validate_remote_console_vmrc_support).and_return(true)
       end
       it_behaves_like 'an enabled button'
     end
     context 'and remote control is not supported' do
       let(:err_msg) { 'Remote console is not supported' }
-      let(:remote_console_validation) do
+      let!(:remote_console_validation) do
         allow(record).to receive(:validate_remote_console_vmrc_support)
           .and_raise(MiqException::RemoteConsoleNotSupportedError, err_msg)
       end

--- a/spec/helpers/application_helper/buttons/zone_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/zone_delete_spec.rb
@@ -3,11 +3,10 @@ describe ApplicationHelper::Button::ZoneDelete do
   let(:selected_zone) { FactoryBot.create(:zone) }
   let(:button)        { described_class.new(view_context, {}, {'selected_zone' => selected_zone}, {}) }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     context "when a message is returned" do
       before do
         expect(selected_zone).to receive(:message_for_invalid_delete).and_return("an error message")
-        button.calculate_properties
       end
 
       it_behaves_like 'a disabled button', "an error message"
@@ -16,7 +15,6 @@ describe ApplicationHelper::Button::ZoneDelete do
     context "when a message is not returned" do
       before do
         expect(selected_zone).to receive(:message_for_invalid_delete).and_return(nil)
-        button.calculate_properties
       end
 
       it_behaves_like 'an enabled button'

--- a/spec/support/examples_group/shared_examples_for_analysis_profile_action_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_analysis_profile_action_buttons.rb
@@ -1,10 +1,8 @@
 shared_examples 'an analysis profile action button' do |action|
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     let(:view_context) { setup_view_context_with_sandbox({}) }
     let(:record) { FactoryBot.create(:scan_item_set, :read_only => read_only) }
     let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
-
-    before { button.calculate_properties }
 
     context 'when Analysis Profile is read-only' do
       let(:read_only) { true }

--- a/spec/support/examples_group/shared_examples_for_check_compliance_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_check_compliance_buttons.rb
@@ -1,9 +1,7 @@
 shared_examples_for 'a check_compliance button' do |entity|
   before { allow(record).to receive(:has_compliance_policies?).and_return(has_policies) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'when record has compliance policies' do
       let(:has_policies) { true }
       it_behaves_like 'an enabled button'

--- a/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
@@ -1,6 +1,7 @@
 shared_examples_for 'a disabled button' do |err_msg|
   subject { button }
   it do
+    subject.calculate_properties
     expect(subject[:enabled]).to be_falsey
     expect(subject[:title]).to eq(err_msg)
   end

--- a/spec/support/examples_group/shared_examples_for_enabled_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_enabled_buttons.rb
@@ -1,6 +1,7 @@
 shared_examples_for 'an enabled button' do
   subject { button }
   it do
+    subject.calculate_properties
     expect(subject[:enabled]).to be_truthy
     expect(subject[:title]).to be_nil
   end

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -34,11 +34,10 @@ shared_examples_for 'a generic feature button with disabled' do
 end
 
 shared_examples_for 'GenericFeatureButtonWithDisabled#calculate_properties' do
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     before do
       allow(record).to receive("supports?").with(feature.to_sym).and_return(support)
       allow(record).to receive(:unsupported_reason).with(feature).and_return("Feature not available/supported") if !support
-      button.calculate_properties
     end
 
     context 'when feature is supported' do

--- a/spec/support/examples_group/shared_examples_for_performance_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_performance_buttons.rb
@@ -1,8 +1,7 @@
 shared_examples_for 'a performance button' do |entity|
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     before do
       record.metric_rollups << metric_rollup if metric_rollup
-      button.calculate_properties
     end
 
     context 'when performance data has not been collected' do

--- a/spec/support/examples_group/shared_examples_for_rbac_group_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_rbac_group_buttons.rb
@@ -2,9 +2,7 @@ shared_examples 'an rbac_group_action button' do |action|
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     context 'record is read-only' do
       let(:record) { FactoryBot.create(:miq_group, :system_type) }
       it_behaves_like 'a disabled button', "This Group is Read Only and can not be #{action}"

--- a/spec/support/examples_group/shared_examples_for_render_report_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_render_report_buttons.rb
@@ -8,9 +8,7 @@ shared_examples_for 'a render_report button' do
   let(:report) { FactoryBot.create(:miq_report, :extras => {:grouping => grouping}) }
   let(:button) { described_class.new(view_context, {}, {'report' => report, 'html' => html, 'render_chart' => render_chart}, {}) }
 
-  describe '#calculate_properties' do
-    before { button.calculate_properties }
-
+  describe '#disabled?' do
     shared_examples_for 'a report with tabular or graph view available' do
       context 'when report has data about records' do
         context 'and total number of records is 0' do

--- a/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_smart_state_scan_buttons.rb
@@ -4,11 +4,10 @@ shared_examples_for 'a smart state scan button' do
   let(:smartproxy_role) { FactoryBot.create(:server_role, :name => 'smartproxy') }
   let(:smartscan_role) { FactoryBot.create(:server_role, :name => 'smartstate') }
 
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     before do
       EvmSpecHelper.local_guid_miq_server_zone
       server
-      button.calculate_properties
     end
 
     MiqServer::ServerSmartProxy::SMART_ROLES.each do |role|

--- a/spec/support/examples_group/shared_examples_for_timeline_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_timeline_buttons.rb
@@ -1,8 +1,7 @@
 shared_examples_for 'a timeline button' do |options|
-  describe '#calculate_properties' do
+  describe '#disabled?' do
     before do
       allow(record).to receive(:has_events?).and_return(has_events)
-      button.calculate_properties
     end
 
     %i(ems_events policy_events).each do |event_type|


### PR DESCRIPTION
When testing titles, we have to call calculate_properties quite often.

moving `calculate_properties` into the actual testing piece removes a bunch of extra calls.

```ruby
it_behaves_like 'an enabled button'
it_behaves_like 'a disabled button'
```