### PR TITLE
Reordered textual group lists for physical servers

### DIFF
--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -51,8 +51,8 @@ class PhysicalServerController < ApplicationController
 
   def textual_group_list
     [
-      %i[properties management_networks relationships server_profiles],
-      %i[power_management firmware_compliance firmware_details asset_details smart_management],
+      %i[properties management_networks relationships smart_management],
+      %i[power_management server_profiles firmware_compliance firmware_details asset_details],
     ]
   end
   helper_method(:textual_group_list)


### PR DESCRIPTION
This PR reorders textual group lists when viewing physical server. This desire was expressed by the Cisco Intersight team.

- This is the server view before:

<img width="989" alt="image" src="https://user-images.githubusercontent.com/92620429/169502153-bb734826-c2e1-4d47-aaf9-264ea00fa9a1.png">

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/92620429/169502278-232f4601-f15b-4c6c-a197-899c9d065a93.png">

- This is the server view after the change:

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/92620429/169501909-a754c5ec-b54b-4710-aa3b-5103c97719f2.png">

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/92620429/169502479-8b03fdd7-4af4-4412-b63a-33127877db4f.png">
