### PR TITLE
SupportsFeatureMixin use stub_supports

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -14,10 +14,6 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::VmActions::RightSize
     include Mixins::Actions::VmActions::Reconfigure
     helper_method(:item_supports?)
-    helper_method(:supports_reconfigure_disks?)
-    helper_method(:supports_reconfigure_disksize?)
-    helper_method(:supports_reconfigure_network_adapters?)
-    helper_method(:supports_reconfigure_cdroms?)
     include Mixins::Actions::VmActions::PolicySimulation
     include Mixins::Actions::VmActions::Transform
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -13,6 +13,7 @@ module ApplicationController::CiProcessing
     include Mixins::Actions::VmActions::Resize
     include Mixins::Actions::VmActions::RightSize
     include Mixins::Actions::VmActions::Reconfigure
+    helper_method(:item_supports?)
     helper_method(:supports_reconfigure_disks?)
     helper_method(:supports_reconfigure_disksize?)
     helper_method(:supports_reconfigure_network_adapters?)

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -274,11 +274,11 @@ module Mixins
           if @reconfigureitems.size == 1
             vm = @reconfigureitems.first
 
-            if vm.supports_reconfigure_network_adapters?
+            if vm.supports?(:reconfigure_network_adapters)
               network_adapters = build_network_adapters_list(vm)
             end
 
-            if vm.supports_reconfigure_cdroms?
+            if vm.supports?(:reconfigure_cdroms)
               # CD-ROMS
               vmcdroms = build_vmcdrom_list(vm)
             end
@@ -299,7 +299,7 @@ module Mixins
         end
 
         def supports_reconfigure_disks?
-          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disks?
+          item_supports?(:reconfigure_disks)
         end
 
         def build_network_adapters_list(vm)
@@ -315,6 +315,18 @@ module Mixins
             end
           end
           network_adapters
+        end
+
+        def supports_reconfigure_disksize?
+          item_supports?(:reconfigure_disksize)
+        end
+
+        def supports_reconfigure_network_adapters?
+          item_supports?(:reconfigure_network_adapters)
+        end
+
+        def supports_reconfigure_cdroms?
+          item_supports?(:reconfigure_cdroms)
         end
 
         def filename_string(name)
@@ -338,19 +350,13 @@ module Mixins
           end
         end
 
-        def supports_reconfigure_disksize?
-          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disksize? && @reconfigitems.first.supports_reconfigure_disks?
-        end
-
-        def supports_reconfigure_network_adapters?
-          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_network_adapters?
-        end
-
-        def supports_reconfigure_cdroms?
-          @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_cdroms?
-        end
-
         private
+
+        def item_supports?(*features)
+          features << :reconfigure_disks if features.include?(:reconfigure_disksize) # special case
+          item = @reconfigitems.first if @reconfigitems&.size == 1
+          item && features.all? { |feature| item.supports?(feature) }
+        end
 
         # 'true' => true
         # 'false' => false

--- a/app/controllers/mixins/actions/vm_actions/reconfigure.rb
+++ b/app/controllers/mixins/actions/vm_actions/reconfigure.rb
@@ -298,10 +298,6 @@ module Mixins
            :disk_default_type      => @reconfigureitems.first.try(:disk_default_type) || 'thin'}
         end
 
-        def supports_reconfigure_disks?
-          item_supports?(:reconfigure_disks)
-        end
-
         def build_network_adapters_list(vm)
           network_adapters = []
           vm.hardware.guest_devices.order(:device_name => 'asc').each do |guest_device|
@@ -315,18 +311,6 @@ module Mixins
             end
           end
           network_adapters
-        end
-
-        def supports_reconfigure_disksize?
-          item_supports?(:reconfigure_disksize)
-        end
-
-        def supports_reconfigure_network_adapters?
-          item_supports?(:reconfigure_network_adapters)
-        end
-
-        def supports_reconfigure_cdroms?
-          item_supports?(:reconfigure_cdroms)
         end
 
         def filename_string(name)

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -111,7 +111,7 @@
                                   "auto-focus"     => ""}
               %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
                 = _(" Total processors value larger than the maximum allowed")
-  - if supports_reconfigure_disks? && role_allows?(:feature => 'vm_reconfigure_disks')
+  - if item_supports?(:reconfigure_disks) && role_allows?(:feature => 'vm_reconfigure_disks')
     %hr
     %div
       %h3
@@ -137,7 +137,7 @@
           %th{"ng-if" => "vm.vm_vendor == 'vmware' && vm.vm_type.includes('InfraManager')"}= _('Dependent')
           %th{"ng-hide" => "vm.isVmwareCloud()"}= _('Delete Backing')
           %th{"ng-if" => "vm.vm_vendor == 'redhat'"}= _('Bootable')
-          - if supports_reconfigure_disksize?
+          - if item_supports?(:reconfigure_disksize)
             %th{:colspan => 2}= _('Actions')
           - else
             %th= _('Actions')
@@ -202,7 +202,7 @@
                      "ng-model"      => "disk.cb_bootable",
                      "ng-readonly"   => true,
                      "switch-active" => false}
-            - if supports_reconfigure_disksize?
+            - if item_supports?(:reconfigure_disksize)
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                               "ng-if"    => "disk.add_remove == ''",
@@ -295,11 +295,11 @@
               %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                 "ng-click" => "vm.addDisk()",
                                                                 "ng-disabled" => "rowForm.dvcSize.$invalid"}= _(' Add ')
-            - if supports_reconfigure_disksize?
+            - if item_supports?(:reconfigure_disksize)
               %td.action-cell
                 %button.btn.btn-default.btn-block.btn-sm{:type => "button",
                                                                   "ng-click" => "vm.hideAddDisk()"}= _('Cancel Add')
-  - if supports_reconfigure_network_adapters? && role_allows?(:feature => 'vm_reconfigure_networks')
+  - if item_supports?(:reconfigure_network_adapters) && role_allows?(:feature => 'vm_reconfigure_networks')
     %hr
     %div
       %h3
@@ -402,7 +402,7 @@
 
   %hr
 
-  - if supports_reconfigure_cdroms? && role_allows?(:feature => 'vm_reconfigure_drives')
+  - if item_supports?(:reconfigure_cdroms) && role_allows?(:feature => 'vm_reconfigure_drives')
     %div{"ng-if" => "vm.reconfigureModel.vmCDRoms"}
       %h3
         = _('CD/DVD Drives')

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -650,38 +650,34 @@ describe ApplicationController do
     end
   end
 
-  describe "#supports_reconfigure_disks?" do
+  describe "#item_supports? (private)" do
     let(:vm) { FactoryBot.create(:vm_redhat) }
 
     context "when a single is vm selected" do
-      let(:supports_reconfigure_disks) { true }
-
-      before do
-        allow(vm).to receive(:supports_reconfigure_disks?).and_return(supports_reconfigure_disks)
-        controller.instance_variable_set(:@reconfigitems, [vm])
-      end
+      before { controller.instance_variable_set(:@reconfigitems, [vm]) }
 
       context "when vm supports reconfiguring disks" do
+        before { stub_supports(Vm, :reconfigure_disks) }
         it "enables reconfigure disks" do
-          expect(controller.send(:supports_reconfigure_disks?)).to be_truthy
+          expect(controller.send(:item_supports?, :reconfigure_disks)).to be_truthy
         end
       end
 
       context "when vm does not supports reconfiguring disks" do
-        let(:supports_reconfigure_disks) { false }
-
+        before { stub_supports_not(Vm, :reconfigure_disks) }
         it "disables reconfigure disks" do
-          expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
+          expect(controller.send(:item_supports?, :reconfigure_disks)).to be_falsey
         end
       end
     end
 
     context "when multiple vms selected" do
+      before { stub_supports(Vm, :reconfigure_disks) }
       let(:vm1) { FactoryBot.create(:vm_redhat) }
 
       it "disables reconfigure disks" do
         controller.instance_variable_set(:@reconfigitems, [vm, vm1])
-        expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
+        expect(controller.send(:item_supports?, :reconfigure_disks)).to be_falsey
       end
     end
   end

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -2,7 +2,6 @@ describe CloudObjectStoreContainerController do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     @container = FactoryBot.create(:cloud_object_store_container, :name => "cloud-object-store-container-01")
-    allow_any_instance_of(CloudObjectStoreContainer).to receive(:supports?).and_return(true)
   end
 
   describe "#tags_edit" do

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -6,7 +6,6 @@ describe CloudObjectStoreObjectController do
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    allow_any_instance_of(CloudObjectStoreObject).to receive(:supports?).and_return(true)
     FactoryBot.create(:tagging, :tag => tag1.tag, :taggable => object)
     FactoryBot.create(:tagging, :tag => tag2.tag, :taggable => object)
     stub_user(:features => :all)
@@ -98,6 +97,8 @@ describe CloudObjectStoreObjectController do
     end
 
     it "delete shows expected flash" do
+      stub_supports(CloudObjectStoreObject, :delete)
+
       post :button, :params => {
         :pressed => "cloud_object_store_object_delete", :format => :js, :id => object.id
       }

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,5 +1,4 @@
 describe SecurityGroupController do
-  include Spec::Support::SupportsHelper
   include_examples :shared_examples_for_security_group_controller, %w(openstack azure google amazon)
 
   let(:ems) { FactoryBot.create(:ems_openstack).network_manager }

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -90,7 +90,7 @@ describe StorageController do
 
         host = FactoryBot.create(:host)
         command = button.split('_', 2)[1]
-        allow_any_instance_of(Host).to receive(:supports?).with(command.to_sym).and_return(true)
+        stub_supports(Host, command)
 
         controller.params = {:pressed => button, :miq_grid_checks => host.id.to_s}
         controller.instance_variable_set(:@lastaction, "show_list")

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -1,6 +1,4 @@
 describe VmInfraController do
-  include Spec::Support::SupportsHelper
-
   let(:host_1x1)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu1x1, :ram1GB)) }
   let(:host_2x2)  { FactoryBot.create(:host_vmware_esx, :hardware => FactoryBot.create(:hardware, :cpu2x2, :ram1GB)) }
   let(:vm_vmware) { FactoryBot.create(:vm_vmware) }

--- a/spec/helpers/application_helper/buttons/auth_key_pair_cloud_create_spec.rb
+++ b/spec/helpers/application_helper/buttons/auth_key_pair_cloud_create_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::AuthKeyPairCloudCreate do
-  include Spec::Support::SupportsHelper
-
   let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {}, {}) }
   let(:ems)    { FactoryBot.create(:ems_cloud) }
 

--- a/spec/helpers/application_helper/buttons/ems_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_timeline_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::EmsTimeline do
-  include Spec::Support::SupportsHelper
-
   # there are no events. reference event to create it
   let(:event)        { FactoryBot.create(:ems_event, :vm_or_template => record) }
   let(:record)       { FactoryBot.build(:vm_cloud) }

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -1,9 +1,9 @@
 describe ApplicationHelper::Button::GenericFeatureButton do
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:record) { Vm.new }
-  let(:feature) { :some_feature }
+  let(:feature) { :create }
   let(:props) { {:options => {:feature => feature}} }
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
 
-  it_behaves_like 'a generic feature button'
+  include_examples 'a feature button'
 end

--- a/spec/helpers/application_helper/buttons/host_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/host_feature_button_spec.rb
@@ -24,15 +24,14 @@ describe ApplicationHelper::Button::HostFeatureButton do
     end
     context 'when record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)' do
       let(:record) { FactoryBot.create(:host_openstack_infra) }
-      before { allow(record).to receive(:supports?).and_return(available) }
       context 'and feature is available' do
         let(:feature) { :stop }
-        let(:available) { true }
+        before { stub_supports(record, feature) }
         it { expect(subject).to be_truthy }
       end
       context 'and feature is unavailable' do
         let(:feature) { :shutdown }
-        let(:available) { false }
+        before { stub_supports_not(record, feature) }
         it { expect(subject).to be_falsey }
       end
     end

--- a/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_associate_floating_ip_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::InstanceAssociateFloatingIp do
-  include Spec::Support::SupportsHelper
-
   let(:floating_ips) { FactoryBot.build_list(:floating_ip, 1) }
   let(:cloud_tenant) { FactoryBot.build(:cloud_tenant, :floating_ips => floating_ips) }
   let(:record)       { FactoryBot.build(:vm_cloud, :cloud_tenant => cloud_tenant) }

--- a/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_disassociate_floating_ip_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::InstanceDisassociateFloatingIp do
-  include Spec::Support::SupportsHelper
-
   let(:floating_ips) { FactoryBot.build_list(:floating_ip, 1) }
   let(:record)       { FactoryBot.build(:vm_cloud, :floating_ips => floating_ips) }
   let(:view_context) { setup_view_context_with_sandbox({}) }

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::InstanceReset do
-  include Spec::Support::SupportsHelper
-
   describe '#visible?' do
     context "when record is resetable" do
       before do

--- a/spec/helpers/application_helper/buttons/storage_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/storage_scan_spec.rb
@@ -6,25 +6,21 @@ describe ApplicationHelper::Button::StorageScan do
   let(:button) { described_class.new(view_context, {}, {'record' => record}, props) }
   let(:ems) { nil }
 
-  it_behaves_like 'a generic feature button after initialization'
+  it_behaves_like 'a feature button with disabled'
 
-  context 'when feature is not supported' do
-    it_behaves_like 'GenericFeatureButtonWithDisabled#calculate_properties'
-  end
+  describe '#disabled?' do
+    context 'when no EMSs are present' do
+      it_behaves_like 'a disabled button', 'Smartstate Analysis cannot be performed on selected Datastore'
+    end
 
-  context 'when feature is supported' do
-    describe '#disabled?' do
-      context 'but no EMSs are present' do
-        it_behaves_like 'a disabled button', 'Smartstate Analysis cannot be performed on selected Datastore'
-      end
-      context 'but no EMS has valid credentials for the Datastore' do
-        let(:ems) { FactoryBot.create(:ems_vmware) }
-        it_behaves_like 'a disabled button', 'There are no EMSs with valid credentials for this Datastore'
-      end
-      context 'with valid credentials for this Datastore' do
-        let(:ems) { FactoryBot.create(:ems_vmware_with_authentication) }
-        it_behaves_like 'an enabled button'
-      end
+    context 'when no EMS has valid credentials for the Datastore' do
+      let(:ems) { FactoryBot.create(:ems_vmware) }
+      it_behaves_like 'a disabled button', 'There are no EMSs with valid credentials for this Datastore'
+    end
+
+    context 'when EMS has valid credentials' do
+      let(:ems) { FactoryBot.create(:ems_vmware_with_authentication) }
+      it_behaves_like 'an enabled button'
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_template_scan_spec.rb
@@ -4,25 +4,23 @@ describe ApplicationHelper::Button::VmInstanceTemplateScan do
   let(:button) { described_class.new(view_context, {}, {'record' => record}, {}) }
 
   describe '#visible?' do
-    let(:has_proxy?) { true }
     subject { button.visible? }
-    before do
-      allow(record).to receive(:supports?).with(:smartstate_analysis).and_return(supports_feature?)
-      allow(record).to receive(:has_proxy?).and_return(has_proxy?)
-    end
 
     context 'when record supports smartstate analysis' do
-      let(:supports_feature?) { true }
+      before { stub_supports(record, :smartstate_analysis) }
       context 'when record has proxy' do
+        before { allow(record).to receive(:has_proxy?).and_return(true) }
         it { is_expected.to be_truthy }
       end
+
       context 'when record does not have proxy' do
-        let(:has_proxy?) { false }
+        before { allow(record).to receive(:has_proxy?).and_return(false) }
         it { is_expected.to be_falsey }
       end
     end
+
     context 'when record does not support smartstate analysis' do
-      let(:supports_feature?) { false }
+      before { stub_supports_not(record, :smartstate_analysis) }
       it { is_expected.to be_falsey }
     end
   end

--- a/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::VmRetireNow do
-  include Spec::Support::SupportsHelper
-
   describe '#visible?' do
     context "when record is retireable" do
       before do

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::VmRetire do
-  include Spec::Support::SupportsHelper
-
   describe '#visible?' do
     context "when record is retireable" do
       before do

--- a/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_remove_one_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::VmSnapshotRemoveOne do
-  include Spec::Support::SupportsHelper
-
   let(:view_context) { setup_view_context_with_sandbox({}) }
   let(:zone) { EvmSpecHelper.local_miq_server(:is_master => true).zone }
   let(:ems) { FactoryBot.create(:ems_redhat, :zone => zone, :name => 'Test EMS') }

--- a/spec/helpers/application_helper/buttons/volume_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_attach_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::VolumeAttach do
-  include Spec::Support::SupportsHelper
-
   let(:volume_name)  { "TestVolume" }
   let(:cloud_volume) { CloudVolume.new(:name => volume_name) }
   let(:unsupported_reason) { "Reasons" }

--- a/spec/helpers/application_helper/buttons/volume_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/volume_detach_spec.rb
@@ -1,6 +1,4 @@
 describe ApplicationHelper::Button::VolumeDetach do
-  include Spec::Support::SupportsHelper
-
   let(:button) do
     described_class.new(
       setup_view_context_with_sandbox({}), {}, {"record" => CloudVolume.new}, {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
     config.example_status_persistence_file_path = Rails.root.join("tmp/rspec_example_store.txt")
   end
 
+  config.include Spec::Support::SupportsHelper
   config.include Spec::Support::AuthHelper, :type => :view
   config.include Spec::Support::ViewHelper, :type => :view
   config.include ApplicationHelper, :type => :view

--- a/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_generic_feature_buttons.rb
@@ -1,21 +1,14 @@
-shared_examples_for 'a generic feature button' do
+shared_examples_for 'a feature button' do
   include_examples 'a generic feature button after initialization'
 
   describe '#visible?' do
     subject { button.visible? }
-    before do
-      allow(record).to receive("respond_to?").with("supports_#{feature}?").and_return(true)
-      # HACK: to mock Array.wrap method for Double
-      allow(record).to receive("respond_to?").with(:to_ary).and_return(false)
-      allow(record).to receive("supports?").with(feature.to_sym).and_return(supports_feature)
-    end
-
     context "when record supports #{feature}" do
-      let(:supports_feature) { true }
+      before { stub_supports(record, feature) }
       it { expect(subject).to be_truthy }
     end
     context "when record does not support #{feature}" do
-      let(:supports_feature) { false }
+      before { stub_supports_not(record, feature, "Feature not available/supported") }
       it { expect(subject).to be_falsey }
     end
   end
@@ -28,24 +21,29 @@ shared_examples_for 'a generic feature button after initialization' do
   end
 end
 
-shared_examples_for 'a generic feature button with disabled' do
-  include_examples 'a generic feature button'
-  include_examples 'GenericFeatureButtonWithDisabled#calculate_properties'
-end
+shared_examples_for 'a feature button with disabled' do
+  include_examples 'a generic feature button after initialization'
 
-shared_examples_for 'GenericFeatureButtonWithDisabled#calculate_properties' do
-  describe '#disabled?' do
-    before do
-      allow(record).to receive("supports?").with(feature.to_sym).and_return(support)
-      allow(record).to receive(:unsupported_reason).with(feature).and_return("Feature not available/supported") if !support
+  # always visible  (not sure if we need to test)
+  describe '#visible?' do
+    subject { button.visible? }
+    context "when record supports #{feature}" do
+      before { stub_supports(record, feature) }
+      it { expect(subject).to be_truthy }
     end
+    context "when record does not support #{feature}" do
+      before { stub_supports_not(record, feature, "Feature not available/supported") }
+      it { expect(subject).to be_truthy }
+    end
+  end
 
-    context 'when feature is supported' do
-      let(:support) { true }
+  describe '#disabled?' do
+    context "when records support #{feature}" do
+      before { stub_supports(record, feature) }
       it_behaves_like 'an enabled button'
     end
-    context 'when feature is not supported' do
-      let(:support) { false }
+    context "when records do not support #{feature}" do
+      before { stub_supports_not(record, feature, "Feature not available/supported") }
       it_behaves_like 'a disabled button', 'Feature not available/supported'
     end
   end


### PR DESCRIPTION
Depends: (built upon)
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8267
- [x] https://github.com/ManageIQ/manageiq/pull/21881 (tests only)

The goals:

- use `stub_supports` instead of `allow().to receive(:supports)`
- convert any remaining `supports_feature` to `supports?(:feature)`

Extras (please share if you don't like):
- made `stub_supports` part of the standard specs
- ~~moved the individual ui helpers like `supports_reconfigure_disks` to just an `item_supports(:feature)` mechanism.~~
