### PR TITLE
Remove angular quadicon code

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -221,7 +221,6 @@ module ApplicationController::ReportDownloads
       :page_size   => "us-letter",
       :run_date    => run_time.strftime("%m/%d/%y %l:%m %p %z"),
       :title       => "#{klass} \"#{get_record_display_name(@record)}\"".html_safe,
-      :quadicon    => true
     }
 
     if @display == "download_pdf"

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -505,7 +505,6 @@ module VmCommon
       :page_layout => "portrait",
       :page_size   => "us-letter",
       :title       => "\"#{@record.name}\"".html_safe,
-      :quadicon    => false
     }
 
     render :template => 'vm_common/_right_size', :layout => '/layouts/print'

--- a/app/stylesheet/legacy/compare_drift.scss
+++ b/app/stylesheet/legacy/compare_drift.scss
@@ -21,7 +21,6 @@
     }
 
     thead tr th {
-      height: 150px !important;
       white-space: nowrap;
 
       .rotated-text {
@@ -45,18 +44,8 @@
     }
 
     thead tr th {
-      height: 150px;
       position: relative;
       text-align: center;
-
-      .quadicon_grid {
-        bottom: 0;
-        height: 80px;
-        left: 0;
-        margin-left: auto;
-        position: absolute;
-        right: 0;
-      }
     }
 
     tbody tr td {

--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -12,9 +12,6 @@
     %style
       @media all { @page { size: #{pdf_page_size_style}; } }
   %body
-    - if @options[:quadicon]
-      .quadicon
-        = render :partial => 'shared/quadicon', :locals => {:record => @record}
     %h1.center=@options[:title]
     = yield
     .center=@options[:run_date]

--- a/app/views/shared/_compare_header_expanded.html.haml
+++ b/app/views/shared/_compare_header_expanded.html.haml
@@ -6,5 +6,3 @@
   - url = "/#{controller_name}/compare_choose_base/#{h["id"]}"
   %a{:title => _("Make %{name} the base") % {:name => h[:name]}, :onclick => "miqJqueryRequest('#{url}', {beforeSend: true, complete: true});", :href => '#'}
     = h[:name]
-.quadicon_grid
-  = render :partial => 'shared/quadicon', :locals => {:record => @sb[:compare_db].constantize.find(vm_id)}

--- a/app/views/shared/_quadicon.html.haml
+++ b/app/views/shared/_quadicon.html.haml
@@ -1,6 +1,0 @@
-- uid = unique_html_id("quad")
-%miq-quadicon.center-block{:id => uid}
-:javascript
-  var data = camelizeQuadicon(#{quadicon_hash(record).to_json});
-  document.querySelector("miq-quadicon##{uid}").setAttribute('data', JSON.stringify(data));
-  miq_bootstrap("miq-quadicon##{uid}");


### PR DESCRIPTION
Removed angular quadicon code as it was not actually being rendered anywhere.

Examples:

Before:
<img width="1684" alt="ProviderPrintQuadiconWithValidAuth" src="https://user-images.githubusercontent.com/32444791/169580754-017fcf58-e841-40f2-ab89-4ea05562625a.png">
<img width="1690" alt="HostsCompare" src="https://user-images.githubusercontent.com/32444791/169580773-476e2d3d-24e6-4a2d-a60e-f5abaa0880b7.png">

After:
<img width="1691" alt="Screen Shot 2022-05-20 at 1 34 14 PM" src="https://user-images.githubusercontent.com/32444791/169582989-c2b9de60-dba3-413a-a764-0918a6a9d096.png">
<img width="1429" alt="Screen Shot 2022-05-20 at 1 41 10 PM" src="https://user-images.githubusercontent.com/32444791/169583239-c2403044-1484-4f31-ba52-c01e432f776a.png">

@miq-bot add_reviewer @Fryguy
@miq-bot add_reviewer @jeffibm
@miq-bot assign @jeffibm
@miq-bot add-label technical debt