### PR TITLE
Remove recent resource haml file

### DIFF
--- a/app/views/static/recent-resource.html.haml
+++ b/app/views/static/recent-resource.html.haml
@@ -1,9 +1,0 @@
-%div
-  .card-pf
-    .card-pf-heading
-      %h2.card-pf-title
-        {{vm.data.config.title}}
-    .card-pf-body
-      %pf-line-chart{'ng-if' => "vm.loadingDone", 'ng-attr-id' => "{{vm.id}}", 'config' => "vm.config", 'chart-data' => "vm.data", 'set-area-chart' => "vm.custAreaChart", 'show-x-axis' => "vm.custShowXAxis", 'show-y-axis' => "vm.custShowYAxis"}
-      %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': vm.data.dataAvailable === false }"}
-        {{vm.timeframeLabel}}


### PR DESCRIPTION
Parent Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7603

The recent resource haml file was introduced in this commit: https://github.com/ManageIQ/manageiq-ui-classic/commit/848d778b3bf48cfd61dd68f004fb03149af21a83

The recent resource javascript component has been removed since and this haml file is now not used or called anywhere so it can be removed.

The dashboard page looks the same after removing this haml file.
<img width="1272" alt="Screen Shot 2022-05-27 at 4 02 33 PM" src="https://user-images.githubusercontent.com/32444791/170782026-dfe0062d-249c-446b-b83a-3538743c35cb.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label technical debt
