### PR TITLE
Fixed pagination translations

### DIFF
--- a/app/javascript/components/miq-pagination.jsx
+++ b/app/javascript/components/miq-pagination.jsx
@@ -5,7 +5,7 @@ import { Pagination } from 'carbon-components-react';
 const getItemRangeText = (min, max, totalItems) => __(`${min}-${max} of ${totalItems} items`);
 
 // eslint-disable-next-line no-undef
-const getPageRangeText = (_current, total) => n__(`of ${total} page`, `of ${total} pages`, total);
+const getPageRangeText = (_current, total) => sprintf(n__(`of %d page`, `of %d pages`, total), total);
 
 const MiqPagination = ({
   pageOptions: {


### PR DESCRIPTION
Fixed string translation markings for table pagination. While testing I found that the strings inside of the function n__ were not being translated by this function so I added the string translation to the individual strings inside of the function to translate.

<img width="260" alt="Screen Shot 2022-05-30 at 4 06 18 PM" src="https://user-images.githubusercontent.com/32444791/171054103-7cb584bb-5c4e-4a10-81b7-7b20c288e8b5.png">
 
Test Strings:
Before: n__(`page`, `pages`, total);

<img width="1399" alt="Screen Shot 2022-05-30 at 4 12 24 PM" src="https://user-images.githubusercontent.com/32444791/171054565-40848030-35d9-4aad-9778-f4232c1d7611.png">
<img width="1402" alt="Screen Shot 2022-05-30 at 4 09 53 PM" src="https://user-images.githubusercontent.com/32444791/171054502-3af98422-6386-451b-88ac-861a8b5f1342.png">

After:  n__(__(`page`), __(`pages`), total);
<img width="1406" alt="Screen Shot 2022-05-30 at 4 19 46 PM" src="https://user-images.githubusercontent.com/32444791/171055271-4df09c20-c005-45ce-887e-0a3dbb58b944.png">
<img width="1416" alt="Screen Shot 2022-05-30 at 4 14 47 PM" src="https://user-images.githubusercontent.com/32444791/171054832-f6f280a8-70d7-4c9d-b1d6-6b1ea6f087d2.png">

@miq-bot add_reviewer @jeffibm 
@miq-bot add_reviewer @Fryguy 
@miq-bot assign @jeffibm 
@miq-bot add-label bug