### PR TITLE
Fixed no VMWare templates in Provision Requests

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -164,7 +164,7 @@ module ApplicationController::MiqRequestMethods
   end
 
   def provisioning_is_cloud?
-    params[:template_klass] == 'cloud' || %w[auth_key_pair_cloud availability_zone cloud_tenant ems_cloud host_aggregate orchestration_stack vm_cloud miq_request].include?(params[:controller])
+    params[:template_klass] == 'cloud' || %w[auth_key_pair_cloud availability_zone cloud_tenant ems_cloud host_aggregate orchestration_stack vm_cloud].include?(params[:controller])
   end
 
   def provisioning_is_infra?

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -1,5 +1,3 @@
-= render :partial => "layouts/flash_msg"
-
 #pre_prov_div
   - typ = request.parameters[:controller] == "vm_cloud" ? ui_lookup(:table => "template_cloud") : ui_lookup(:table => "template_infra")
   %h3
@@ -7,8 +5,12 @@
   %label
     - id = @edit[:req_id] || "new"
     - unless @edit[:hide_deprecated_templates].nil?
+      - hide_depricated_url = url_for_only_path({:action => "vm_pre_prov",
+                                              :template_klass => params[:template_klass],
+                                              :id => id.to_s,
+                                              :hide_deprecated_templates => !@edit[:hide_deprecated_templates]})
       %input{:type => "checkbox",
-             :onclick => "miqAjax('" + url_for_only_path({:action => "vm_pre_prov", :id => id.to_s, :hide_deprecated_templates => !@edit[:hide_deprecated_templates]}) + "')",
+             :onclick => "miqAjax('#{hide_depricated_url}')",
              :checked => @edit[:hide_deprecated_templates]}
         = _('Hide deprecated')
   = render :partial => "layouts/x_gtl"

--- a/spec/controllers/application_controller/miq_request_methods_spec.rb
+++ b/spec/controllers/application_controller/miq_request_methods_spec.rb
@@ -85,7 +85,7 @@ describe MiqRequestController do
       let(:kls) { 'infra' }
 
       it 'returns proper template klass' do
-        expect(subject).to eq(ManageIQ::Providers::CloudManager::Template)
+        expect(subject).to eq(ManageIQ::Providers::InfraManager::Template)
       end
     end
 


### PR DESCRIPTION
Compute -> Infrastructure -> Providers -> Select VMWare provider -> Click on VMs -> Click on 'Lifecycle' -> Select 'Provision VMs'

**Before**

1. Was loading the ProvisionCloudTemplates.yaml
2. Checkbox to Show/Hide deprecated is displayed
3. There are no VMWare templates in the 'Provision Requests based on the selected Template ' table.

<img width="1792" alt="Screenshot 2022-05-31 at 4 36 40 PM" src="https://user-images.githubusercontent.com/87487049/171162760-aadaedf0-2716-42c3-aba6-1e357d64713d.png">

**After**

1. Loading ProvisionInfraTemplates.yaml
2. Checkbox to Show/Hide deprecated is not displayed
3. VMWare templates are displayed

<img width="1792" alt="Screenshot 2022-05-31 at 4 46 21 PM" src="https://user-images.githubusercontent.com/87487049/171162781-c914599f-9b4b-4a3d-bf1b-f993b855bf38.png">


@miq-bot add-reviewer @Fryguy 
@miq-bot add-reviewer @GilbertCherrie  
@miq-bot add-label bug
@miq-bot assign @Fryguy
