### PR TITLE
Fixed catalog item summary page

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -29,12 +29,11 @@
           .col-md-9
             &nbsp;
             = check_box_tag("display", true, @record.display, :disabled => true)
-        - if @record.display
-          .form-group
-            %label.col-md-3.control-label
-              = _('Catalog')
-            .col-md-9
-              = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
+        .form-group
+          %label.col-md-3.control-label
+            = _('Catalog')
+          .col-md-9
+            = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
         - unless @record.composite?
           .form-group
             %label.col-md-3.control-label


### PR DESCRIPTION
Fixes an issue where the catalog name is not displayed for a catalog item that has "Display in Catalog" unchecked.

Before:
<img width="1018" alt="Screen Shot 2022-06-02 at 4 21 41 PM" src="https://user-images.githubusercontent.com/32444791/171731516-55f1b958-bc95-45f2-a03a-0f62a94df38a.png">

After:

<img width="996" alt="Screen Shot 2022-06-02 at 4 20 51 PM" src="https://user-images.githubusercontent.com/32444791/171731534-cf60462e-9e28-44cb-b77c-0f69a11049bc.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug