### PR TITLE
Updating default value of <Choose> to be nil in drop-downs

### DIFF
--- a/app/controllers/miq_policy_rsop_controller.rb
+++ b/app/controllers/miq_policy_rsop_controller.rb
@@ -80,18 +80,18 @@ class MiqPolicyRsopController < ApplicationController
   def rsop_option_changed
     assert_privileges('policy_simulation')
     if params[:event_typ]
-      @sb[:rsop][:event] = params[:event_typ] == "<Choose>" ? nil : params[:event_typ]
+      @sb[:rsop][:event] = params[:event_typ].presence
       @sb[:rsop][:event_value] = nil
     end
     if params[:event_value]
-      @sb[:rsop][:event_value] = params[:event_value] == "<Choose>" ? nil : params[:event_value]
+      @sb[:rsop][:event_value] = params[:event_value].presence
     end
     if params[:filter_typ]
-      @sb[:rsop][:filter] = params[:filter_typ] == "<Choose>" ? nil : params[:filter_typ]
+      @sb[:rsop][:filter] = params[:filter_typ].presence
       @sb[:rsop][:filter_value] = nil
     end
     if params[:filter_value]
-      @sb[:rsop][:filter_value] = params[:filter_value] == "<Choose>" ? nil : params[:filter_value]
+      @sb[:rsop][:filter_value] = params[:filter_value].presence
     end
     @rsop_events = MiqEventDefinitionSet.all.collect { |e| [_(e.description), e.id.to_s] }.sort
     @rsop_event_sets = MiqEventDefinitionSet.find(@sb[:rsop][:event]).miq_event_definitions.collect { |e| [_(e.description), e.id.to_s] }.sort unless @sb[:rsop][:event].nil?

--- a/app/views/miq_policy_rsop/_rsop_form.html.haml
+++ b/app/views/miq_policy_rsop/_rsop_form.html.haml
@@ -8,7 +8,7 @@
       %label.control-label
         = _("Type")
       = select_tag('event_typ',
-        options_for_select([["<#{_('Choose')}>", "<Choose>"]] + @rsop_events, @sb[:rsop][:event]),
+        options_for_select([["<#{_('Choose')}>", nil]] + @rsop_events, @sb[:rsop][:event]),
         :class => "selectpicker form-control")
 
       :javascript
@@ -20,7 +20,7 @@
         %label.control-label
           = _("Event")
         = select_tag('event_value',
-          options_for_select([["<#{_('Choose')}>", "<Choose>"]] + @rsop_event_sets, @sb[:rsop][:event_value]),
+          options_for_select([["<#{_('Choose')}>", nil]] + @rsop_event_sets, @sb[:rsop][:event_value]),
           :class => "selectpicker form-control")
         :javascript
           miqSelectPickerEvent("event_value", "#{url}");


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/8291

For this particular set of drop-downs, the value of the default `<Choose>` was set to the string `"<Choose>"` instead of `nil`. This caused mismatched font colors and is inconsistent with the rest of the codebase. 

## Before

Note the mismatched colors of `<Choose>`

![Screen Shot 2022-06-03 at 2 41 10 PM](https://user-images.githubusercontent.com/29209973/171926652-04896ea9-aa3b-4743-8cb5-cef9d6924609.png)

![Screen Shot 2022-06-03 at 2 41 41 PM](https://user-images.githubusercontent.com/29209973/171926658-b0c0e3f5-e1fb-48dc-b34d-fcf72f09a806.png)


## After

![Screen Shot 2022-06-03 at 2 34 36 PM](https://user-images.githubusercontent.com/29209973/171926395-d83e9cbf-779f-4f3f-9e32-a59d16eb805d.png)

![Screen Shot 2022-06-03 at 2 42 50 PM](https://user-images.githubusercontent.com/29209973/171926767-54b52984-08f4-47c5-bc0d-e86409c23a9f.png)

