### PR TITLE
[WIP] Fix routes_spec for service report_data

### DIFF
--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1068,7 +1068,6 @@ ServiceController:
 - open_url_after_dialog
 - ownership_update
 - reload
-- report_data
 - tree_autoload
 - tree_select
 - wait_for_task


### PR DESCRIPTION
Routes specs were failing during `bundle exec rspec spec/routes_spec.rb    `

Before
<img width="1064" alt="Screenshot 2022-06-08 at 9 07 35 PM" src="https://user-images.githubusercontent.com/87487049/172660472-827cf891-58a3-489f-98ae-0a392971b2ef.png">

After
<img width="624" alt="Screenshot 2022-06-08 at 9 14 19 PM" src="https://user-images.githubusercontent.com/87487049/172660506-81598e2c-0bff-4b72-b5c2-d3d3e3f3482d.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-label technical_debt
@miq-bot assign @Fryguy 
