### PR TITLE
Allow other Host supports feature calls

### DIFF
--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -90,6 +90,8 @@ describe StorageController do
 
         host = FactoryBot.create(:host)
         command = button.split('_', 2)[1]
+
+        stub_supports_all_others(Host)
         stub_supports(Host, command)
 
         controller.params = {:pressed => button, :miq_grid_checks => host.id.to_s}


### PR DESCRIPTION
Fix the storage_controller_spec,
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21922