### PR TITLE
Fix machine credentials privilege escalation submit value

### DIFF
--- a/app/javascript/components/ansible-credentials-form/index.jsx
+++ b/app/javascript/components/ansible-credentials-form/index.jsx
@@ -51,6 +51,11 @@ const AnsibleCredentialsForm = ({ recordId }) => {
   const onSubmit = (values) => {
     miqSparkleOn();
 
+    if (values.options && values.options.become_method) {
+      values.options.become_method = values.options.become_method.value;
+    } else {
+      values.options = { become_method: null };
+    }
     const request = recordId ? API.patch(`/api/authentications/${recordId}`, values) : API.post('/api/authentications', values);
     request.then(() => {
       const message = sprintf(


### PR DESCRIPTION
Fixed the privilege escalation field submit value on the ansible credentials form for machine credentials. The current form is submitting the value for this field as an object: { label: ..., value: ...} when it should just be submitting a string for the value. Also added a fix that will send a null value when the user clears the field or leaves it empty, allowing for no privilege escalation value to be set since this field is not required.

Before:
<img width="911" alt="Before" src="https://user-images.githubusercontent.com/32444791/172705146-ef6f34de-e362-4a39-84b2-c50f9734ae6a.png">

After:
<img width="935" alt="After" src="https://user-images.githubusercontent.com/32444791/172705192-696e0849-be7e-4b70-9c6b-4c6a70aac473.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug