### PR TITLE
Fix vertical label for translated strings for data table

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -12,6 +12,7 @@
 
     .bx--table-header-label {
       line-height: 20px;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
Translated labels are vertically aligned in data table headers

**1. Chinese**
Before
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/172769878-18bab3e3-3843-49e3-ab45-7ec6064d7ce1.png">
After
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/172770081-0776eb4e-11fd-446e-b13c-e75115cb1758.png">

**2. Japanese**
Before
<img width="897" alt="image" src="https://user-images.githubusercontent.com/87487049/172770410-2b2202d4-527d-44d0-a84c-8fad73c9d5ad.png">
After
<img width="899" alt="image" src="https://user-images.githubusercontent.com/87487049/172770458-fe352bec-2014-4c2b-816c-d26e7e783839.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label technical_debt
@miq-bot assign @Fryguy

