### PR TITLE
Fix service catalog form elements overlap with notifications

### DIFF
--- a/app/stylesheet/notifications.scss
+++ b/app/stylesheet/notifications.scss
@@ -63,7 +63,7 @@
   position: absolute;
   right: 0;
   width: 450px;
-  z-index: 2;
+  z-index: 3;
   display: flex;
   flex-direction: column;
   overflow-y: hidden;


### PR DESCRIPTION
Some elements from the Adding/Editing a new Service Catalog Item page overlap Notifications.

Before
<img width="1789" alt="Screenshot 2022-06-09 at 11 37 08 AM" src="https://user-images.githubusercontent.com/87487049/172776654-54bf97b1-9163-40a6-a960-d0cda2307590.png">

After
<img width="1792" alt="Screenshot 2022-06-09 at 11 36 45 AM" src="https://user-images.githubusercontent.com/87487049/172776687-b938f297-b7e6-417d-bcc4-c4a2ebbadddd.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-label bug
@miq-bot assign @Fryguy
