### PR TITLE
Fixed pagination translations

### DIFF
--- a/app/javascript/components/miq-pagination.jsx
+++ b/app/javascript/components/miq-pagination.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Pagination } from 'carbon-components-react';
 
-const getItemRangeText = (min, max, totalItems) => __(`${min}-${max} of ${totalItems} items`);
+const getItemRangeText = (min, max, totalItems) => sprintf(__(`%d-%d of %d items`), min, max, totalItems);
 
 // eslint-disable-next-line no-undef
 const getPageRangeText = (_current, total) => sprintf(n__(`of %d page`, `of %d pages`, total), total);


### PR DESCRIPTION
Fixed pagination translation string to use sprintf for variable item numbers.

<img width="754" alt="Screen Shot 2022-06-09 at 11 56 58 AM" src="https://user-images.githubusercontent.com/32444791/172891718-e22b3581-5d7f-4d33-90ea-9cc950b640a7.png">

@miq-bot add_reviewer @jrafanie 
@miq-bot add_reviewer @MelsHyrule 
@miq-bot add_reviewer @jeffibm 
@miq-bot assign @jeffibm 
@miq-bot add-label bug
@miq-bot add-label internationalization 