### PR TITLE
Supports changes to rhv provider form

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -122,6 +122,8 @@ const ProviderForm = ({
                 type,
                 endpoints,
                 authentications,
+                metricsEnable: !!endpoints.metrics ? 'enabled' : 'disabled',
+                keypairEnable: !!endpoints.ssh_keypair ? 'enabled' : 'disabled',
               },
             });
           }).then(miqSparkleOff);
@@ -147,6 +149,8 @@ const ProviderForm = ({
 
   const onSubmit = ({ type, ..._data }, { getState }) => {
     if (type !== '-1') {
+      delete _data.metricsEnable;
+      delete _data.keypairEnable;
       miqSparkleOn();
 
       const message = sprintf(__('%s %s was saved'), title, _data.name || initialValues.name);


### PR DESCRIPTION
This UI code supports the changes made to the red hat virtualization infrastructure provider form in this pr: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/606.

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/606

Allows for the metric and keypair tabs to be enabled when there is metric and keypair data available and if empty keeps them disabled by default in order to prevent a bug that does not allow users to submit the add provider form.