### PR TITLE
Fixed missing title/breadcrumb translations

### DIFF
--- a/app/controllers/host_initiator_group_controller.rb
+++ b/app/controllers/host_initiator_group_controller.rb
@@ -15,6 +15,10 @@ class HostInitiatorGroupController < ApplicationController
     %w[cloud_volumes]
   end
 
+  def breadcrumb_name(_model)
+    _('Host Initiator Groups')
+  end
+
   def new
     assert_privileges("host_initiator_group_new")
 

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -15,6 +15,10 @@ class PhysicalStorageController < ApplicationController
 
   toolbar :physical_storage, :physical_storages
 
+  def breadcrumb_name(_model)
+    _('Physical Storages')
+  end
+
   def new
     @in_a_form = true
     if params[:storage_manager_id]

--- a/app/controllers/storage_resource_controller.rb
+++ b/app/controllers/storage_resource_controller.rb
@@ -19,6 +19,10 @@ class StorageResourceController < ApplicationController
     super
   end
 
+  def breadcrumb_name(_model)
+    _('Storage Resources')
+  end
+
   def download_summary_pdf
     assert_privileges('storage_resource_view')
     super


### PR DESCRIPTION
Fixed missing translations for the Physical Storages, Host Initiator Groups and Storage Resources titles and Storage Resources breadcrumbs.

Before:
<img width="1209" alt="Screen Shot 2022-06-15 at 4 24 23 PM" src="https://user-images.githubusercontent.com/32444791/173921089-34d8ed0d-0d51-4596-926c-565c8af02a9a.png">
<img width="1224" alt="Screen Shot 2022-06-15 at 4 24 13 PM" src="https://user-images.githubusercontent.com/32444791/173921093-95d51671-edc8-4afb-99ba-4b9b424bb33e.png">
<img width="1231" alt="Screen Shot 2022-06-15 at 4 23 52 PM" src="https://user-images.githubusercontent.com/32444791/173921095-9e70ab08-cf5c-4f07-b462-7c6b45d6f7f1.png">

After:
<img width="1249" alt="Screen Shot 2022-06-15 at 4 20 24 PM" src="https://user-images.githubusercontent.com/32444791/173921173-fa347da7-5e97-4684-95f3-4a74b6e2e093.png">
<img width="1194" alt="Screen Shot 2022-06-15 at 4 20 54 PM" src="https://user-images.githubusercontent.com/32444791/173921213-1096605a-f9b8-48fe-ac60-4a8dc2ae5f6e.png">
<img width="1228" alt="Screen Shot 2022-06-15 at 4 20 42 PM" src="https://user-images.githubusercontent.com/32444791/173921224-637494dc-897d-4255-b976-eb982755ef26.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @jrafanie 
@miq-bot assign @jeffibm
@miq-bot add-label bug
