### PR TITLE
Adding "Management Console" access for a PowerVS VM

### DIFF
--- a/app/controllers/vm_remote.rb
+++ b/app/controllers/vm_remote.rb
@@ -13,6 +13,11 @@ module VmRemote
     native_console_launch_task
   end
 
+  def management_console
+    vm = identify_record(params[:id], VmOrTemplate)
+    javascript_open_window(vm.console_url.to_s) if vm
+  end
+
   def launch_native_console
     miq_task = MiqTask.find(params[:task_id])
     results = miq_task.task_results

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -105,7 +105,18 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('VM Console'),
             :keepSpinner => true,
             :url         => "html5_console",
-            :klass       => ApplicationHelper::Button::VmHtml5Console),
+            :klass       => ApplicationHelper::Button::VmHtml5Console
+          ),
+          included_class.button(
+            :vm_native_console,
+            'pficon pficon-screen fa-lg',
+            N_('Open a management console for this VM'),
+            N_('Management Console'),
+            :keepSpinner => true,
+            :url         => "management_console",
+            :klass       => ApplicationHelper::Button::GenericFeatureButton,
+            :options     => {:feature => :native_console}
+          ),
         ]
       ),
     ])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2914,6 +2914,7 @@ Rails.application.routes.draw do
         guest_applications
         groups
         html5_console
+        management_console
         kernel_drivers
         linux_initprocesses
         ownership_update
@@ -3118,6 +3119,7 @@ Rails.application.routes.draw do
         vmrc_console
         html5_console
         native_console
+        management_console
         wait_for_task
         win32_services
         x_button

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -1170,6 +1170,7 @@ VmCloudController:
 - launch_html5_console
 - launch_vmrc_console
 - linux_initprocesses
+- management_console
 - network_ports
 - network_routers
 - open_url_after_dialog
@@ -1263,6 +1264,7 @@ VmInfraController:
 - launch_native_console
 - launch_vmrc_console
 - linux_initprocesses
+- management_console
 - name_changed
 - native_console
 - open_url_after_dialog
@@ -1352,6 +1354,7 @@ VmOrTemplateController:
 - launch_native_console
 - launch_vmrc_console
 - linux_initprocesses
+- management_console
 - name_changed
 - native_console
 - network_ports


### PR DESCRIPTION
This term "native console" is confusing in the code base at this time. Cloud/Infra managers can open their "native console" that points to their respective provider instance page in the Cloud. In the same spirit, I'm trying to use this "native console" route and its little `MiqTask` based workflow to prepare and open the VM's page on IBM Cloud, though Ovirt seems to open its special console viewer through the same route. 

Hence, [WIP]. I know the current implementation in this PR is pretty hacky, and would love to get a clearer understanding of what's going on here, and to contribute for clarify however I can. Guidance please.

![image](https://user-images.githubusercontent.com/1767126/176462952-cb82d3a0-fd07-4765-94e9-a1e7aceca151.png)


Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>

Provider PR: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/396