### PR TITLE
Use lazy loaded default uglifier

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -38,14 +38,7 @@ module ManageIQ
         config.assets.paths << root.join('vendor', 'assets', 'stylesheets').to_s
 
         if Rails.env.production? || Rails.env.test?
-          require 'uglifier'
-          config.assets.js_compressor = Uglifier.new(
-            :compress => {
-              :unused      => false,
-              :keep_fargs  => true,
-              :keep_fnames => true
-            }
-          )
+          config.assets.js_compressor = :uglifier
         end
 
         def self.vmdb_plugin?


### PR DESCRIPTION
Part of #8300

Previously, we eager loaded uglifier to provide a custom configuration.

This was added in https://github.com/ManageIQ/manageiq/pull/9878

In #8300, we verified we no longer need this custom configuration.
Additionally, if we use symbolic :uglifier, Uglifier won't be eager loaded,
execjs won't be loaded from uglifier, and therefore node wouldn't be needed.

This should allow us to only need node when we compile assets at build time.