### PR TITLE
Fix chargeback preview server error

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -184,7 +184,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :vm_chargeback,
           'fa fa-file-text-o fa-lg',
           N_('Show Chargeback preview'),
-          N_('Chargeback Preview')
+          N_('Chargeback Preview'),
+          :klass => ApplicationHelper::Button::VmPerf
         ),
       ]
     ),

--- a/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
+++ b/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
@@ -111,7 +111,7 @@ const initialState = {
 
 const filterToString = (filter) => (
   filter && filter.field && filter.string
-    ? `&filter_column=${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
+    ? `${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
     : ''
 );
 
@@ -127,21 +127,25 @@ const fetchReportPage = (dispatch, reportResultId, sortingColumns, pagination, a
     ? filterToString(activeFilters[0])
     : '';
 
-  API.get(`/api/results/${reportResultId}?\
-expand_value_format=true&\
-hash_attribute=result_set&\
-sort_by=${sortBy}&sort_order=${sortDirection}&\
-limit=${limit}&offset=${offset}${filterString}`).then((data) => {
-    dispatch({
-      type: 'dataLoaded',
-      data,
-      sortingColumns,
-      pagination,
-      activeFilters,
-    });
+  if (reportResultId) {
+    const params = `expand_value_format=true&hash_attribute=result_set`
+    + `&sort_by=${sortBy}&sort_order=${sortDirection}&`
+    + `limit=${limit}&offset=${offset}${filterString}`;
 
+    API.get(`/api/results/${reportResultId}?${params}`).then((data) => {
+      dispatch({
+        type: 'dataLoaded',
+        data,
+        sortingColumns,
+        pagination,
+        activeFilters,
+      });
+
+      miqSparkleOff();
+    });
+  } else {
     miqSparkleOff();
-  });
+  }
 };
 
 const ReportDataTable = (props) => {

--- a/app/javascript/spec/report-data-table.spec.js
+++ b/app/javascript/spec/report-data-table.spec.js
@@ -26,15 +26,17 @@ describe('<ReportDataTable />', () => {
   });
 
   const requestUrl = () => {
-    const sortBy = '';
-    const sortDirection = '';
-    const limit = 20;
-    const offset = 0;
-    return `/api/results/${initialProps.reportResultId}?\
-expand_value_format=true&\
-hash_attribute=result_set&\
-sort_by=${sortBy}&sort_order=${sortDirection}&\
-limit=${limit}&offset=${offset}`;
+    const data = {
+      sortBy: '',
+      sortDirection: '',
+      limit: 20,
+      offset: 0,
+    };
+    const params = `expand_value_format=true&hash_attribute=result_set`
+    + `&sort_by=${data.sortBy}&sort_order=${data.sortDirection}&`
+    + `limit=${data.limit}&offset=${data.offset}`;
+
+    return `/api/results/${initialProps.reportResultId}?${params}`;
   };
 
   it('should fetch and display report data when instantiated', async(done) => {


### PR DESCRIPTION
**Before**
Was able to click "Chargeback Preview" even if the performance (capacity and utilization) data is available, which resulted in 
server error (API) 
![image](https://user-images.githubusercontent.com/87487049/174628378-37b9dbbd-97bd-4f22-bb73-82fdb616eddf.png)

**After**
Links "`Monitoring/Chargeback Preview`" are disabled if corresponding records are not available
![image](https://user-images.githubusercontent.com/87487049/174628719-737ab2fb-b3ba-452f-a88d-4fc969b664a8.png)

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @agrare 
@miq-bot add-reviewer @jrafanie  
@miq-bot add-label bug
@miq-bot assign @Fryguy
