### PR TITLE
Fixed flavors form

### DIFF
--- a/app/javascript/components/flavor-form/flavor-form.schema.js
+++ b/app/javascript/components/flavor-form/flavor-form.schema.js
@@ -30,6 +30,7 @@ const createSchema = (emsId, setState) => ({
       labelText: __('Provider'),
       isRequired: true,
       isSearchable: true,
+      simpleValue: true,
       validate: [{ type: validatorTypes.REQUIRED }],
       loadOptions: () => API.get(providerUrl).then(({ resources }) => resources.map(({ id, name }) => ({ value: id, label: name }))),
       onChange: (value) => setState((state) => ({ ...state, emsId: value })),
@@ -112,6 +113,7 @@ const createSchema = (emsId, setState) => ({
       isMulti: true,
       isSearchable: true,
       isClearable: true,
+      simpleValue: true,
       condition: {
         and: [
           {

--- a/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
+++ b/app/javascript/spec/flavor-form/__snapshots__/flavor-form.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Flavor form component matches the snapshot 1`] = `
             "loadOptions": [Function],
             "name": "emsId",
             "onChange": [Function],
+            "simpleValue": true,
             "validate": Array [
               Object {
                 "type": "required",
@@ -192,6 +193,7 @@ exports[`Flavor form component matches the snapshot 1`] = `
             "loadOptions": [Function],
             "name": "cloud_tenant_refs",
             "placeholder": "Nothing selected",
+            "simpleValue": true,
           },
         ],
       }


### PR DESCRIPTION
Fixed a bug in the flavors form where using isSearchable was causing the emsID to be set to an object with `{label: ..., value: ...}` and this emsID object was being used in an API call causing an error since the API is just expecting the emsID as a value. By adding the simpleValue prop it allows only the value to be returned causing the correct API calls.

Before:
<img width="1435" alt="FlavorBefore" src="https://user-images.githubusercontent.com/32444791/175075311-f10d0121-313c-4864-a5f8-189468dfdd89.png">

After:
<img width="1456" alt="FlavorAfter" src="https://user-images.githubusercontent.com/32444791/175075337-416a9861-dbe9-4d45-9746-27e7f21cc6e3.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug