### PR TITLE
Remove special UI code to handle Ovirt metrics/keypair selectors

### DIFF
--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -122,8 +122,6 @@ const ProviderForm = ({
                 type,
                 endpoints,
                 authentications,
-                metricsEnable: !!endpoints.metrics ? 'enabled' : 'disabled',
-                keypairEnable: !!endpoints.ssh_keypair ? 'enabled' : 'disabled',
               },
             });
           }).then(miqSparkleOff);
@@ -149,8 +147,6 @@ const ProviderForm = ({
 
   const onSubmit = ({ type, ..._data }, { getState }) => {
     if (type !== '-1') {
-      delete _data.metricsEnable;
-      delete _data.keypairEnable;
       miqSparkleOn();
 
       const message = sprintf(__('%s %s was saved'), title, _data.name || initialValues.name);


### PR DESCRIPTION
Reverts #8312 which added code to the core UI in which to handle Ovirt specific logic which should be handled in the ovirt provider plugin itself.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/608