### PR TITLE
Fixed button permission issues for firmware registry and vm right siz…

### DIFF
--- a/app/helpers/application_helper/toolbar/firmware_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registries_center.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistriesCenter < ApplicationHelper::
     'firmware_registries_reloading',
     [
       button(
-        :firmware_registries_reload,
+        :firmware_view,
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         nil,

--- a/app/helpers/application_helper/toolbar/firmware_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/firmware_registry_center.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Toolbar::FirmwareRegistryCenter < ApplicationHelper::To
     'firmware_registry_reloading',
     [
       button(
-        :firmware_registry_reload,
+        :firmware_view,
         'fa fa-refresh fa-lg',
         N_('Refresh this page'),
         nil,

--- a/app/helpers/application_helper/toolbar/right_size_view.rb
+++ b/app/helpers/application_helper/toolbar/right_size_view.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Toolbar::RightSizeView < ApplicationHelper::Toolbar::Basic
   button_group('right_size_view', [
     button(
-      :right_size_print,
+      :vm_right_size,
       'pficon pficon-print fa-lg',
       N_('Print or export'),
       nil,


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8329

Fixed a missing feature bug for firmware registries and vm right size recommendations. This permission check was introduced in pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/7740.

Before:
<img width="1426" alt="Screen Shot 2022-06-29 at 9 41 05 AM" src="https://user-images.githubusercontent.com/32444791/176451040-ef3774db-b984-4bbe-b3e0-8790acc884fb.png">
<img width="1383" alt="Screen Shot 2022-06-22 at 12 31 24 PM" src="https://user-images.githubusercontent.com/32444791/175098411-258d1dee-a06c-409d-adea-bc03a6347cf0.png">
<img width="1368" alt="Screen Shot 2022-06-24 at 12 44 44 PM" src="https://user-images.githubusercontent.com/32444791/175604433-499ee028-eea3-4f80-9cc0-729816b6b4ef.png">

After:
<img width="1410" alt="Screen Shot 2022-06-23 at 3 07 23 PM" src="https://user-images.githubusercontent.com/32444791/175378268-2867378b-0fd1-4866-9ec6-83186c948a03.png">
<img width="1408" alt="Screen Shot 2022-06-22 at 1 18 23 PM" src="https://user-images.githubusercontent.com/32444791/175098556-00d2432b-f16a-40f6-9500-0d47b709128f.png">
<img width="1216" alt="Screen Shot 2022-06-24 at 12 45 07 PM" src="https://user-images.githubusercontent.com/32444791/175604689-9ca1d3cc-678d-4301-bdea-c92b47bd0862.png">

@miq-bot add_reviewer @jrafanie
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jrafanie
@miq-bot add-label bug