### PR TITLE
Fix storage resource heatmap

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -13,7 +13,15 @@ const HeatMapChartGraph = ({
   const heatmapMemoryData = (heatData2 === null) ? [] : getHeatMapData(heatData2);
 
   const heatmapCpuTooltip = () => (data) => {
-    const d1 = heatmapCpuData[0];
+    let d1;
+
+    if (dataPoint1 === 'resourceUsage') {
+      d1 = heatmapCpuData.find((item) => item.node === data[1].value);
+    }
+    else {
+      d1 = heatmapCpuData[0];
+    }
+
     let percent = -1;
     let tooltip = sprintf(__('Cluster: %s'), data[1].value) + `<br>` + sprintf(__('Provider: %s'), d1.provider)
     if (data[2].value === null || data[1].value === null) {

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -76,9 +76,11 @@ class EmsStorageDashboardService < EmsDashboardService
       system.storage_resources.each do |resource|
         resource_usage << {
           :id       => resource.id,
-          :resource => resource.name,
+          :node     => resource.name,
           :provider => resource.ext_management_system.name,
-          :percent  => ((resource.logical_total.to_f - resource.logical_free.to_f) / resource.logical_total.to_f).round(2)
+          :percent  => ((resource.logical_total.to_f - resource.logical_free.to_f) / resource.logical_total.to_f).round(2),
+          :total    => number_to_human_size(resource.logical_total, :precision => 2).to_i,
+          :unit     => "GB"
         }
       end
     end


### PR DESCRIPTION
Resource pool widget under storage manager dashboard was broken (probably because of the move from angular to react).
This is the fix.

Before
----
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/74841666/175937507-38f5d4d1-243d-4eba-837f-3260bac5582e.png">



After
----
<img width="1785" alt="Screen Shot 2022-06-27 at 14 59 38" src="https://user-images.githubusercontent.com/74841666/175937553-8e158709-cff1-49fd-b11c-cd4790880aa8.png">

