### PR TITLE
Fixed copy dashboard form bug

### DIFF
--- a/app/javascript/components/copy-dashboard-form/copy-dashboard-form.schema.js
+++ b/app/javascript/components/copy-dashboard-form/copy-dashboard-form.schema.js
@@ -58,6 +58,7 @@ export default (miqGroups, name, dashboardId) => {
           label: __('Select Group'),
           placeholder: __('Nothing selected'),
           isSearchable: true,
+          simpleValue: true,
           validate: [{
             type: validatorTypes.REQUIRED,
             message: __('Required'),


### PR DESCRIPTION
Fixed a bug in the copy dashboard form where the selected object was being sent to the submit instead of just the value. This was due to the `isSearchable` prop but is fixed by using `simpleValue: true`.

Before:
<img width="1045" alt="Screen Shot 2022-06-27 at 4 43 12 PM" src="https://user-images.githubusercontent.com/32444791/176036878-5dddee9e-3d00-4f2c-b1de-b50a19b61085.png">


After:
<img width="1057" alt="Screen Shot 2022-06-27 at 4 44 37 PM" src="https://user-images.githubusercontent.com/32444791/176036917-72d15731-9e9c-4f79-ab18-cff2f7467da1.png">

