### PR TITLE
remove db checks on every request and use in memory cache (dev only)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,7 +105,7 @@ module ApplicationHelper
     end
 
     # Detect if queried features are missing from the database and possibly invalid
-    if !Rails.env.production? && features.detect { |feature| ! MiqProductFeature.feature_exists?(feature) }
+    if !Rails.env.production? && features.detect { |feature| !MiqProductFeature.feature_exists?(feature) }
       message = "#{__method__} no feature was found with identifier: #{features.inspect}.  Correct the identifier or add it to miq_product_features.yml."
       identifiers = MiqProductFeature.features.keys
       if Rails.env.development?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,9 +105,9 @@ module ApplicationHelper
     end
 
     # Detect if queried features are missing from the database and possibly invalid
-    if !Rails.env.production? && MiqProductFeature.where(:identifier => features).count != features.length
+    if !Rails.env.production? && features.detect { |feature| ! MiqProductFeature.feature_exists?(feature) }
       message = "#{__method__} no feature was found with identifier: #{features.inspect}.  Correct the identifier or add it to miq_product_features.yml."
-      identifiers = MiqProductFeature.all.pluck(:identifier)
+      identifiers = MiqProductFeature.features.keys
       if Rails.env.development?
         raise message
       elsif Rails.env.test? && identifiers.length >= 5


### PR DESCRIPTION
## Before

*Development Only*

On every request, we check every miq_product_feature lookup against the database.
This helps us ensure the developer is using a valid feature.

The problem is these features get looked up a lot.
And they often are a recursive lookup when finding the parent feature.

So on the dashboard, there are around 50 lookups with a wall of
text with 215 more => around 265 database lookups.

Good news: most of these lookups are cached, but pages are added to the log
making them hard to read.

```
[----] D, [2022-06-27T18:20:37.786066 #57148:13f24] DEBUG -- :   CACHE  (0.0ms)  SELECT COUNT(*) FROM "miq_product_features" WHERE "miq_product_features"."identifier" = $1  [["identifier", "dashboard_view"]]
```

## After

Since the identifiers are cached in MiqProduceFeature we are instead using the in-memory cache to do these lookups.

250+ lines of noise disappear from the logs.
And potentially a dozen fewer queries are performed