### PR TITLE
AWX template support for catalog

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -956,7 +956,7 @@ class CatalogController < ApplicationController
     end
 
     # for Ansible Tower items, check for Provider first
-    if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
+    if @edit[:new][:st_prov_type] == 'generic_ansible_tower' || @edit[:new][:st_prov_type] == 'generic_awx'
       if @edit[:new][:manager_id].blank?
         add_flash(_("Provider is required, please select one from the list"), :error)
       elsif @edit[:new][:template_id].blank?
@@ -1038,7 +1038,7 @@ class CatalogController < ApplicationController
            end
       common_st_record_vars(st)
       add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
-      add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower)
+      add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower) || st.kind_of?(ServiceTemplateAwx)
       st.service_type = "atomic"
 
       if request
@@ -1234,7 +1234,7 @@ class CatalogController < ApplicationController
     @available_catalogs = available_catalogs.sort # Get available catalogs with tenants and ancestors
     @additional_tenants = @edit[:new][:tenant_ids].map(&:to_s) # Get ids of selected Additional Tenants in the Tenants tree
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
-    available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower)
+    available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower) || @record.kind_of?(ServiceTemplateAwx)
     available_container_managers if @record.kind_of?(ServiceTemplateContainerTemplate)
     fetch_zones
     @edit[:new][:zone_id] = @record.zone_id
@@ -1394,7 +1394,7 @@ class CatalogController < ApplicationController
     end
 
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
-    fetch_form_vars_ansible_or_ct if %w[generic_ansible_tower generic_container_template].include?(@edit[:new][:st_prov_type])
+    fetch_form_vars_ansible_or_ct if %w[generic_ansible_tower generic_awx generic_container_template].include?(@edit[:new][:st_prov_type])
     fetch_form_vars_ovf_template if @edit[:new][:st_prov_type] == 'generic_ovf_template'
   end
 
@@ -1447,7 +1447,7 @@ class CatalogController < ApplicationController
         @edit[:new][:manager_id]          = nil
       else
         @edit[:new][:manager_id] = params[:manager_id]
-        available_job_templates(params[:manager_id]) if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
+        available_job_templates(params[:manager_id]) if @edit[:new][:st_prov_type] == 'generic_ansible_tower' || @edit[:new][:st_prov_type] == 'generic_awx'
         available_container_templates(params[:manager_id]) if @edit[:new][:st_prov_type] == 'generic_container_template'
       end
     end
@@ -1478,7 +1478,7 @@ class CatalogController < ApplicationController
   end
 
   def available_container_templates(manager_id)
-    method = @edit[:new][:st_prov_type] == 'generic_ansible_tower' ? 'configuration_scripts' : 'container_templates'
+    method = @edit[:new][:st_prov_type] == 'generic_ansible_tower' || @edit[:new][:st_prov_type] == 'generic_awx' ? 'configuration_scripts' : 'container_templates'
     @edit[:new][:available_templates] =
       ExtManagementSystem.find_by(:id => manager_id).send(method).collect { |t| [t.name, t.id] }.sort
   end
@@ -1497,14 +1497,14 @@ class CatalogController < ApplicationController
 
   def fetch_all_templates(manager_id)
     all_templates = ExtManagementSystem.find_by(:id => manager_id).configuration_scripts.sort_by(&:name)
-    job_templates = all_templates.collect { |t| [t.name, t.id] if t.type == 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript' }.compact
-    workflow_templates = all_templates.collect { |t| [t.name, t.id] if t.type == 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow' }.compact
+    workflow_templates = all_templates.collect { |t| [t.name, t.id] if t.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationWorkflow) }.compact
+    job_templates = all_templates.collect { |t| [t.name, t.id] if t.kind_of?(ManageIQ::Providers::AutomationManager::ConfigurationScript) }.compact - workflow_templates
     return job_templates, workflow_templates
   end
 
   def available_ansible_tower_managers
     @edit[:new][:available_managers] =
-      ManageIQ::Providers::AnsibleTower::AutomationManager.all.collect { |t| [t.name, t.id] }.sort
+      ManageIQ::Providers::AutomationManager.all.collect { |t| [t.name, t.id] }.sort
     @edit[:new][:template_id] = @record.job_template.try(:id)
     @edit[:new][:manager_id] = @record.job_template.try(:manager).try(:id)
     available_job_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -130,7 +130,7 @@
                          :class               => "selectpicker")
             :javascript
               miqSelectPickerEvent('manager_id', '#{url}')
-    - elsif %w(generic_ansible_tower generic_container_template).include?(@edit[:new][:st_prov_type])
+    - elsif %w(generic_ansible_tower generic_awx generic_container_template).include?(@edit[:new][:st_prov_type])
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
       .form-group
         %label.col-md-2.control-label
@@ -145,9 +145,9 @@
       - if @edit[:new][:manager_id]
         .form-group
           %label.col-md-2.control-label
-            = @edit[:new][:st_prov_type] == "generic_ansible_tower" ? _('Ansible Tower Template') : _('Container Template')
+            = @edit[:new][:st_prov_type] == "generic_ansible_tower" || @edit[:new][:st_prov_type] == "generic_awx" ? _('Ansible Template') : _('Container Template')
           .col-md-8
-            - if @edit[:new][:st_prov_type] == "generic_ansible_tower"
+            - if @edit[:new][:st_prov_type] == "generic_ansible_tower" || @edit[:new][:st_prov_type] == "generic_awx"
               = select_tag('template_id',
                             grouped_options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
                             "data-miq_sparkle_on" => true,

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -77,7 +77,7 @@
                 = _('Provider')
               .col-md-9
                 = h(@record.orchestration_manager.name)
-        - elsif @record.prov_type == "generic_ansible_tower"
+        - elsif @record.prov_type == "generic_ansible_tower" || @record.prov_type == "generic_awx"
           .form-group
             %label.col-md-3.control-label
               = _('Ansible Tower Template')

--- a/app/views/service/_svcs_show.html.haml
+++ b/app/views/service/_svcs_show.html.haml
@@ -11,7 +11,7 @@
         - if retirement_job
           = miq_tab_header("retirement") do
             = _("Retirement")
-      -if @record.type == "ServiceAnsibleTower"
+      -if @record.type == "ServiceAnsibleTower" || @record.type == "ServiceAwx"
         - job = @record.try(:job)
         = miq_tab_header("tower_job") do
           = _("Job")
@@ -38,7 +38,7 @@
               = _('VMs')
             - if @view
               = render :partial => "layouts/gtl", :locals => {:view => @view, :no_flash_div => true}
-      - if @record.type == "ServiceAnsibleTower"
+      - if @record.type == "ServiceAnsibleTower" || @record.type == "ServiceAwx"
         = miq_tab_content("tower_job", 'default', :class => 'cm-tab') do
           = render :partial => "layouts/textual_groups_tabs", :locals => {:textual_group_list => textual_tower_job_group_list, :tab_id => "tower_job"}
           - if job && job.respond_to?(:raw_stdout_via_worker)


### PR DESCRIPTION
- added the ability choose AWX catalog items and select job templates to be used in service provisioning

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/282
- [x] Approval and transfer of https://github.com/nasark/manageiq-providers-awx

Screenshots:
<img width="971" alt="Screen Shot 2022-06-29 at 2 41 49 PM" src="https://user-images.githubusercontent.com/48186199/176513705-3e9d1cd6-91e7-4716-9752-ce29d228d4ff.png">
<img width="1360" alt="Screen Shot 2022-06-29 at 2 42 54 PM" src="https://user-images.githubusercontent.com/48186199/176513723-949ccabd-ce6e-43bf-bee1-c4cb95338284.png">


@miq-bot assign @agrare 
@miq-bot assign @jeffibm 
@miq-bot add_label enhancement