### PR TITLE
Fix report's filter overlap issue with notification drawer

### DIFF
--- a/app/stylesheet/notifications.scss
+++ b/app/stylesheet/notifications.scss
@@ -63,7 +63,7 @@
   position: absolute;
   right: 0;
   width: 450px;
-  z-index: 3;
+  z-index: 1000;
   display: flex;
   flex-direction: column;
   overflow-y: hidden;


### PR DESCRIPTION
Fix for the Notification Bar covered by the Filter Table/ Search Box

**Overview / Reports / Reports / ###**
Before
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/87487049/176364006-05a4cea2-f56e-422b-9e5b-e086ea1a1e59.png">

After
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/176364210-58e80853-3eac-4da5-bb37-fce20d4974db.png">

**Overview / Reports / Saved Reports / ###**
Before
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/176364964-5ed6f4b2-5359-420a-8e77-3030d9b46a41.png">

After
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/87487049/176364858-17c4a0ed-baf8-461b-875d-c3076b8ca5db.png">


@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label bug
@miq-bot assign @Fryguy

