### PR TITLE
Add a timeout for the setup-ruby job in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+      timeout-minutes: 30
     - name: Set up Node
       if: ${{ matrix.test-suite == 'spec:compile' || matrix.test-suite == 'spec:javascript' || matrix.test-suite == 'spec:jest' }}
       uses: actions/setup-node@v2


### PR DESCRIPTION
Occasionally setup-ruby will hang while downloading the package and run until it is manually canceled, holding up other workflows from running in the process.

On average this job runs in under 2min30sec so if it is taking more than the timeout it is extremely likely to be hung.