### PR TITLE
Reload settings page after saving to allow changes to appear

### DIFF
--- a/app/javascript/components/visual-settings-form/index.jsx
+++ b/app/javascript/components/visual-settings-form/index.jsx
@@ -20,8 +20,8 @@ const VisualSettingsForm = ({ recordId }) => {
     settings.display.timezone = settings.display.timezone.value ? settings.display.timezone.value : settings.display.timezone;
     miqSparkleOn();
     API.patch(`/api/users/${recordId}`, { settings }).then(() => {
+      window.location.reload();
       add_flash(__('User Interface settings saved'), 'success');
-      miqSparkleOff();
     }).catch(miqSparkleOff);
   };
 


### PR DESCRIPTION
This change allows the settings page to be reloaded after clicking save, which allows any changes (such as language change) to take immediate effect instead of the user having to manually reload the page or navigate to a new page to see the changes take place.

<img width="1400" alt="Screen Shot 2022-06-29 at 4 17 54 PM" src="https://user-images.githubusercontent.com/32444791/176536957-9696028d-d76e-4741-8bc8-45b5cc58bfe5.png">

Before:
Change the language on the settings page and click save. Manage IQ will still be in the old language until you reload the page or navigate to a new page, which will then show everything in the new language.

After:
Change the language on the settings page and click save. The page should now reload and everything should be translated to the new language that you selected.
