### PR TITLE
Update carbon-components package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "bootstrap-filestyle": "~1.2.1",
     "bootstrap-switch": "3.3.4",
-    "carbon-components": "~10.46.0",
+    "carbon-components": "~10.56.0",
     "carbon-components-react": "~7.46.0",
     "carbon-icons": "~7.0.7",
     "classnames": "~2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4840,7 +4840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@npm:10.56.0":
+"carbon-components@npm:10.56.0, carbon-components@npm:~10.56.0":
   version: 10.56.0
   resolution: "carbon-components@npm:10.56.0"
   dependencies:
@@ -4849,18 +4849,6 @@ __metadata:
     lodash.debounce: ^4.0.8
     warning: ^3.0.0
   checksum: 399e53d8072c9094230ab83ffe1f2eb2361e029b80efe0332e7ca2503954c7a7b3b5f43427b68c4302377be0f8ed756eb15f3f3a06501137184f367b7c88693c
-  languageName: node
-  linkType: hard
-
-"carbon-components@npm:~10.46.0":
-  version: 10.46.0
-  resolution: "carbon-components@npm:10.46.0"
-  dependencies:
-    "@carbon/telemetry": 0.0.0-alpha.6
-    flatpickr: 4.6.1
-    lodash.debounce: ^4.0.8
-    warning: ^3.0.0
-  checksum: 421f07f9239a8efaa9225659190a52990265260b2c6b0148d18504d27507d16abffeddb2a154b70c8abb9270393d6d3ec660c555dd1f1d12a09bb5101a4b6194
   languageName: node
   linkType: hard
 
@@ -11748,7 +11736,7 @@ fsevents@^1.2.7:
     babel-loader: ~8.2.0
     bootstrap-filestyle: ~1.2.1
     bootstrap-switch: 3.3.4
-    carbon-components: ~10.46.0
+    carbon-components: ~10.56.0
     carbon-components-react: ~7.46.0
     carbon-icons: ~7.0.7
     classnames: ~2.2.6


### PR DESCRIPTION
Upgrading `carbon-components` package from `10.46.0` to `10.56.0` to fix a security vulnerability issue

The` yarn.lock` file already had the new version -` 10.56.0`

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8324

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-label enhancement
@miq-bot assign @Fryguy