### PR TITLE
Update moment to 2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jquery.hotkeys": "~0.1.0",
     "jquery.observe_field": "~0.1.0",
     "lodash": "~4.17.10",
-    "moment": "~2.29.2",
+    "moment": "~2.29.4",
     "moment-duration-format": "~2.2.2",
     "moment-strftime": "~0.5.0",
     "moment-timezone": "~0.5.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11793,7 +11793,7 @@ fsevents@^1.2.7:
     jquery.observe_field: ~0.1.0
     js-yaml: ~3.13.1
     lodash: ~4.17.10
-    moment: ~2.29.2
+    moment: ~2.29.4
     moment-duration-format: ~2.2.2
     moment-strftime: ~0.5.0
     moment-timezone: ~0.5.21
@@ -12331,10 +12331,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"moment@npm:~2.29.2":
-  version: 2.29.3
-  resolution: "moment@npm:2.29.3"
-  checksum: 2e780e36d9a1823c08a1b6313cbb08bd01ecbb2a9062095820a34f42c878991ccba53abaa6abb103fd5c01e763724f295162a8c50b7e95b4f1c992ef0772d3f0
+"moment@npm:~2.29.4":
+  version: 2.29.4
+  resolution: "moment@npm:2.29.4"
+  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8352

Upgraded moment package to 2.29.4.

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label security-fix