### PR TITLE
[WIP] Upgrade Node v14 to v16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         ruby-version:
         - '3.0'
         node-version:
-        - 14
+        - 16
         test-suite:
         - spec
         - spec:compile
@@ -24,7 +24,7 @@ jobs:
         - spec:routes
         include:
         - ruby-version: '2.7'
-          node-version: 14
+          node-version: 16
           test-suite: spec
     services:
       postgres:

--- a/package.json
+++ b/package.json
@@ -170,8 +170,8 @@
     "webpack-stats-plugin": "^0.3.2"
   },
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0"
+    "node": ">= 16.0.0",
+    "npm": ">= 8.0.0"
   },
   "packageManager": "yarn@3.0.2",
   "resolutions": {


### PR DESCRIPTION
Upgrading `node` version from `14.0.0` to `16.0.0`

**Dependency**
Upgrading `npm` version from `6.0.0` to `8.0.0` 
You need to install npm version 7.0.0 or above in order to run node v16.

Previous - https://github.com/ManageIQ/manageiq-ui-classic/pull/8009

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8146

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-label enhancement
@miq-bot assign @Fryguy
