### PR TITLE
Run db:migrate db:seed from bin/update in ui-classic

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -12,6 +12,8 @@ end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
 ManageIQ::Environment.manageiq_plugin_update(gem_root)
+ManageIQ::Environment.migrate_database
+ManageIQ::Environment.seed_database
 
 puts "\n== Updating UI assets =="
 ManageIQ::Environment.update_ui


### PR DESCRIPTION
Running `bin/update` in core will run database migrations and also run db:seed after updating all of the plugins.  In ui-classic this is not done leading to issues where core and plugins are updated by bundle update but pending migrations are not run.