### PR TITLE
remove remaining ad_hoc_references

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -349,9 +349,6 @@ module Mixins
         when "#{table_name}_perf"
           performance_pressed
           return
-        when "#{table_name}_ad_hoc_metrics"
-          ad_hoc_metrics_pressed
-          return
         when 'refresh_server_summary'
           javascript_redirect(:back)
           return


### PR DESCRIPTION
This was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/8093
But there were a few stragglers remaining.

Also of interest:

- [ ] https://github.com/ManageIQ/manageiq/pull/21999
- [ ] https://github.com/ManageIQ/manageiq-ui-service/pull/1800

There are a few references to `adhoc` (one word), either as a table column or purging results, but those are all reporting centric.