### PR TITLE
Fixes Missing Id Error When Copying a Chargeback Rate

### DIFF
--- a/app/controllers/chargeback_rate_controller.rb
+++ b/app/controllers/chargeback_rate_controller.rb
@@ -231,7 +231,7 @@ class ChargebackRateController < ApplicationController
       end
       @edit = session[:edit] = nil # clean out the saved info
       session[:changed] = @changed = false
-      javascript_redirect(:action => @lastaction, :id => params[:id], :flash_msg => flash_msg)
+      javascript_redirect(:action => @lastaction, :id => @rate[:id], :flash_msg => flash_msg)
     else
       @rate.errors.each do |field, msg|
         add_flash("#{field.to_s.capitalize} #{msg}", :error)


### PR DESCRIPTION
Submits `@rate[:id]` instead of `params[:id]` to the `javascript_redirect` function to ensure that the chargeback rate's id is correctly submitted (`params[:id]` is not set when a new rate is created which caused issues when copying a chargeback rate from the details page).

Before:
<img src="https://user-images.githubusercontent.com/64800041/179837633-b42f6204-4c2a-438f-821b-409f103f8c9d.png" width="700">

After:
<img src="https://user-images.githubusercontent.com/64800041/179836051-eec89d4b-ccd9-45ec-8439-8ff2e1285a83.png" width="700">
