### PR TITLE
HeatmapChartGraph: show an empty chart when data is not null but undefined

### DIFF
--- a/app/helpers/application_helper/button/button_template_clone.rb
+++ b/app/helpers/application_helper/button/button_template_clone.rb
@@ -1,8 +1,0 @@
-class ApplicationHelper::Button::ButtonTemplateClone < ApplicationHelper::Button::Basic
-  needs :@record
-
-  def disabled?
-    @error_message = _('Template cannot be cloned') if @record.type.eql?("ManageIQ::Providers::IbmPowerHmc::InfraManager")
-    @error_message.present?
-  end
-end

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -143,8 +143,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,
-          :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::ButtonTemplateClone),
+          :onwhen       => "1"),
       ]
     ),
  ])

--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -9,7 +9,7 @@ const HeatMapChartGraph = ({
 }) => {
   const heatData1 = data[dataPoint1];
   const heatData2 = data[dataPoint2];
-  const heatmapCpuData = (heatData1 === null || heatData1[0]['node'] === undefined) ? [] : getHeatMapData(heatData1);
+  const heatmapCpuData = (heatData1 === null) ? [] : getHeatMapData(heatData1);
   const heatmapMemoryData = (heatData2 === null) ? [] : getHeatMapData(heatData2);
 
   const heatmapCpuTooltip = () => (data) => {

--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -7,20 +7,13 @@ import EmptyChart from '../emptyChart';
 const HeatMapChartGraph = ({
   data, dataPoint1, dataPoint2, dataPointAvailable,
 }) => {
-  const heatData1 = data[dataPoint1];
-  const heatData2 = data[dataPoint2];
-  const heatmapCpuData = (heatData1 === null) ? [] : getHeatMapData(heatData1);
-  const heatmapMemoryData = (heatData2 === null) ? [] : getHeatMapData(heatData2);
+  const heatmapCpuData = getHeatMapData(data[dataPoint1]);
+  const heatmapMemoryData = getHeatMapData(data[dataPoint2]);
 
   const heatmapCpuTooltip = () => (data) => {
-    let d1;
-
-    if (dataPoint1 === 'resourceUsage') {
-      d1 = heatmapCpuData.find((item) => item.node === data[1].value);
-    }
-    else {
-      d1 = heatmapCpuData[0];
-    }
+    const d1 = (dataPoint1 === 'resourceUsage')
+      ? heatmapCpuData.find((item) => item.node === data[1].value)
+      : heatmapCpuData[0];
 
     let percent = -1;
     let tooltip = sprintf(__('Cluster: %s'), data[1].value) + `<br>` + sprintf(__('Provider: %s'), d1.provider)

--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -9,7 +9,7 @@ const HeatMapChartGraph = ({
 }) => {
   const heatData1 = data[dataPoint1];
   const heatData2 = data[dataPoint2];
-  const heatmapCpuData = (heatData1 === null) ? [] : getHeatMapData(heatData1);
+  const heatmapCpuData = (heatData1 === null || heatData1[0]['node'] === undefined) ? [] : getHeatMapData(heatData1);
   const heatmapMemoryData = (heatData2 === null) ? [] : getHeatMapData(heatData2);
 
   const heatmapCpuTooltip = () => (data) => {

--- a/app/javascript/components/provider-dashboard-charts/helpers.js
+++ b/app/javascript/components/provider-dashboard-charts/helpers.js
@@ -27,7 +27,7 @@ export const getLatestValue = (data) => {
 };
 
 export const getHeatMapData = (data) => {
-  if (data) {
+  if (data && data.node !== undefined) {
     const arr = [];
     data.forEach((item) => {
       const obj = {};

--- a/app/javascript/components/provider-dashboard-charts/helpers.js
+++ b/app/javascript/components/provider-dashboard-charts/helpers.js
@@ -27,8 +27,8 @@ export const getLatestValue = (data) => {
 };
 
 export const getHeatMapData = (data) => {
+  const arr = [];
   if (data && data.node !== undefined) {
-    const arr = [];
     data.forEach((item) => {
       const obj = {};
       obj.percent = item.percent;
@@ -39,9 +39,8 @@ export const getHeatMapData = (data) => {
       obj.unit = item.unit;
       arr.push(obj);
     });
-    return arr;
   }
-  return [];
+  return arr;
 };
 
 export const getPodsData = (data, createdlabel, deletedLabel) => {

--- a/app/stylesheet/charts.scss
+++ b/app/stylesheet/charts.scss
@@ -70,9 +70,11 @@
 
 .heatmap_charts_div {
   display: inline-flex;
+
   .chart-holder {
     margin-right: 55px;
   }
+
   .heat-chart-pf {
     margin-bottom: 50px;
     width: 300px;
@@ -86,6 +88,7 @@
 
 .empty-chart-contents {
   margin-bottom: 10px;
+
   span {
     vertical-align: middle;
     width: 100%;
@@ -99,3 +102,62 @@
   font-weight: 400 !important;
 }
 
+.card-pf-utilization {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  border: 1px solid $selected-ui;
+
+  .card-pf-heading {
+    border: 0;
+    margin: 0;
+    padding: 0 20px 0;
+
+    .card-pf-title {
+      font-weight: 300;
+    }
+  }
+
+  .card-pf-body {
+    padding: 0;
+    margin: 0;
+
+    .bx--cc--chart-wrapper {
+      .layout-child {
+        &.spacer {
+          margin-top: 0;
+        }
+
+        &.legend {
+          margin-top: 5px;
+        }
+      }
+
+      &:last-child {
+        display: flex;
+        flex-direction: column-reverse;
+        height: 113px;
+        width: 100%;
+      }
+    }
+  }
+
+  .card-pf-body > *:last-child {
+    margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .trend-footer-pf {
+    font-size: 12px;
+    border-top: 1px solid $selected-ui;
+    font-weight: 400;
+    color: #333;
+    padding: 20px;
+    background: #fafafa;
+    margin: 0;
+  }
+}

--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -163,8 +163,8 @@ describe ApplicationController do
         expected_options = {
           :model      => "Host",
           :object_ids => [host.id],
-          :add_ids    => [dept_finance.id, env_production.id],
-          :delete_ids => [dept_accounting.id, env_accounting.id]
+          :add_ids    => array_including(dept_finance.id, env_production.id),
+          :delete_ids => array_including(dept_accounting.id, env_accounting.id)
         }
         expect(Classification).to receive(:bulk_reassignment).with(expected_options)
 

--- a/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
@@ -37,7 +37,7 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
     end
     context 'when creating snapshots is not available' do
       let(:record) { FactoryBot.create(:vm_amazon) }
-      it_behaves_like 'a disabled button', 'Operation not supported'
+      it_behaves_like 'a disabled button', 'Feature not available/supported'
     end
     context 'when user has permissions to create snapsnots' do
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
@@ -33,7 +33,7 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
     end
     context 'when reverting to a snapshot is not available' do
       let(:record) { FactoryBot.create(:vm_amazon) }
-      it_behaves_like 'a disabled button', 'Operation not supported'
+      it_behaves_like 'a disabled button', 'Feature not available/supported'
     end
   end
 end


### PR DESCRIPTION
bug description: 
when invalid data is sent to the `HeatMapChartGraph`, for instance due to connection problems in the backend, a broken chart is rendered instead of an empty one.
This is because `heatData1` is not null, but holds invalid data.

fix: change check from `heatData1 === null` to `heatData1 === null || heatData1[0]['node'] === undefined`

to reproduce the bug on the master branch:
in line 10 assign `heatData1` with a dummy non-empty array, for instance `[1, 2, 3]`

bug reproduction:
![image](https://user-images.githubusercontent.com/106743023/180207980-b308259e-68b6-42d9-a84a-9c698c29394e.png)

after fix:
![image](https://user-images.githubusercontent.com/106743023/180208683-49ae316e-a12f-458a-b103-d0f732ac43c1.png)
