### PR TITLE
change snapshot error to default error

### DIFF
--- a/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_add_spec.rb
@@ -37,7 +37,7 @@ describe ApplicationHelper::Button::VmSnapshotAdd do
     end
     context 'when creating snapshots is not available' do
       let(:record) { FactoryBot.create(:vm_amazon) }
-      it_behaves_like 'a disabled button', 'Operation not supported'
+      it_behaves_like 'a disabled button', 'Feature not available/supported'
     end
     context 'when user has permissions to create snapsnots' do
       it_behaves_like 'an enabled button'

--- a/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_snapshot_revert_spec.rb
@@ -33,7 +33,7 @@ describe ApplicationHelper::Button::VmSnapshotRevert do
     end
     context 'when reverting to a snapshot is not available' do
       let(:record) { FactoryBot.create(:vm_amazon) }
-      it_behaves_like 'a disabled button', 'Operation not supported'
+      it_behaves_like 'a disabled button', 'Feature not available/supported'
     end
   end
 end


### PR DESCRIPTION
The snapshot supports is now returning the default not supported message
Changed the test to reflect this

Goes with https://github.com/ManageIQ/manageiq/pull/21917 (since that is the PR that defaults the error message