### PR TITLE
[Najdorf] Updated Najdorf carbon charts to fix download bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@carbon/charts": "^0.41.100",
-    "@carbon/charts-react": "^0.41.100",
+    "@carbon/charts": "^0.58.0",
+    "@carbon/charts-react": "^0.58.0",
     "@carbon/icons-react": "~10.26.0",
     "@carbon/themes": "~10.28.0",
     "@data-driven-forms/carbon-component-mapper": "~3.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,36 +1301,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/charts-react@npm:^0.41.100":
-  version: 0.41.103
-  resolution: "@carbon/charts-react@npm:0.41.103"
+"@carbon/charts-react@npm:^0.58.0":
+  version: 0.58.2
+  resolution: "@carbon/charts-react@npm:0.58.2"
   dependencies:
-    "@carbon/charts": ^0.41.103
-    "@carbon/icons-react": ^10.32.0
-    "@carbon/telemetry": 0.0.0-alpha.6
+    "@carbon/charts": ^0.58.2
+    "@carbon/icons-react": ^10.49.0
+    "@carbon/telemetry": 0.1.0
   peerDependencies:
-    react: ^16.0.0 || ^17.0.0
-    react-dom: ^16.0.0 || ^17.0.0
-  checksum: d1bad95f6b75c8362159d9396d72262c90530fd87ab185c3119ab511fe948695f982ceef6ecb4182a5a8574f199f56ab015930ba1c6ab90c5425472a7ce33aa4
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 19f4cc35e4e4baff2e220a83a8f04472c4680a0c79ebd60147d696064678c060b33bb45c2a3eca3fe76e6f614a08d532ec161c294fe477ef29171450ff622503
   languageName: node
   linkType: hard
 
-"@carbon/charts@npm:^0.41.100, @carbon/charts@npm:^0.41.103":
-  version: 0.41.103
-  resolution: "@carbon/charts@npm:0.41.103"
+"@carbon/charts@npm:^0.58.0, @carbon/charts@npm:^0.58.2":
+  version: 0.58.2
+  resolution: "@carbon/charts@npm:0.58.2"
   dependencies:
     "@carbon/colors": 10.29.0
-    "@carbon/telemetry": 0.0.0-alpha.6
+    "@carbon/telemetry": 0.1.0
     "@carbon/utils-position": 1.1.1
-    carbon-components: 10.40.0
+    carbon-components: 10.56.0
     d3-cloud: 1.2.5
+    d3-sankey: 0.12.3
     date-fns: 2.8.1
     dom-to-image: 2.6.0
     lodash-es: 4.17.21
     resize-observer-polyfill: 1.5.0
   peerDependencies:
     d3: 7.x
-  checksum: e7b144068ba6d00d75c075d8f448890ae6684a57cc06a6af92a79fa042d309b0b457e9254c3364fbd75cc2ac0fc4b217308b075af813864b54c28d576cb2f73f
+  checksum: 9e8926fa76e2e1a9a7cc632a94fe626ece6553ce38356dee8da051419c0ec6e352fb7b371e98607a51982447b743b01e820d434830175baf06cd9657f4145bca
   languageName: node
   linkType: hard
 
@@ -1362,7 +1363,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^10.32.0, @carbon/icons-react@npm:^10.41.0":
+"@carbon/icon-helpers@npm:^10.28.0":
+  version: 10.31.0
+  resolution: "@carbon/icon-helpers@npm:10.31.0"
+  checksum: f0fe2dae4c2b69e2974781e827dcf20946c88a5e537f86da9fc9d8470f5f18f3b92ee4f8be0bed07ff1928a60ac7a4c084c8ee8daff279a959be2befdc43382d
+  languageName: node
+  linkType: hard
+
+"@carbon/icons-react@npm:^10.41.0":
   version: 10.43.0
   resolution: "@carbon/icons-react@npm:10.43.0"
   dependencies:
@@ -1372,6 +1380,19 @@ __metadata:
   peerDependencies:
     react: ">=16"
   checksum: 3c571e0ad80af054b5847edf82642df4982f8f1c9427d3d3afd1f7f2746e252cc4d36a4a006473b6c3aa674d5b06ce68fe4152fb84ae66ef50014c299525bf02
+  languageName: node
+  linkType: hard
+
+"@carbon/icons-react@npm:^10.49.0":
+  version: 10.49.0
+  resolution: "@carbon/icons-react@npm:10.49.0"
+  dependencies:
+    "@carbon/icon-helpers": ^10.28.0
+    "@carbon/telemetry": 0.1.0
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ">=16"
+  checksum: dd3aec2718ba80a40100f9015aea60f3cc39aa2e08580c07fa342c36034053f29ee5575446b0641692ef2555ca27a3f305561f271a2de2e0ddab564030d94de7
   languageName: node
   linkType: hard
 
@@ -1418,6 +1439,15 @@ __metadata:
   bin:
     carbon-telemetry: bin/carbon-telemetry.js
   checksum: 2f3cb8c0b6c8513cd3d9c1c0024108145474ad472800133732f382e007e75d926d274f5fca0e557b651616d065f28b7a149fe0f5f132cd6e018f714056a39f76
+  languageName: node
+  linkType: hard
+
+"@carbon/telemetry@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@carbon/telemetry@npm:0.1.0"
+  bin:
+    carbon-telemetry: bin/carbon-telemetry.js
+  checksum: e93039763ed40b612a1cb5c70001d5e7e92ff034f1559676d47ce9a98e6285ba2856f6a59146b03e6349702eb96d61f2fe91349e981ca858e45c4527a3c1e876
   languageName: node
   linkType: hard
 
@@ -4813,15 +4843,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@npm:10.40.0":
-  version: 10.40.0
-  resolution: "carbon-components@npm:10.40.0"
+"carbon-components@npm:10.56.0":
+  version: 10.56.0
+  resolution: "carbon-components@npm:10.56.0"
   dependencies:
-    "@carbon/telemetry": 0.0.0-alpha.6
+    "@carbon/telemetry": 0.1.0
     flatpickr: 4.6.1
     lodash.debounce: ^4.0.8
     warning: ^3.0.0
-  checksum: 61ba98295c6f5b79bbbcb52e04512d6a36471b753ad5b08b37544cc1e7eec15e675884f6874954b0593d3a59d3cd2f106fe1050622c40e764031f06dc9a9eaf4
+  checksum: 399e53d8072c9094230ab83ffe1f2eb2361e029b80efe0332e7ca2503954c7a7b3b5f43427b68c4302377be0f8ed756eb15f3f3a06501137184f367b7c88693c
   languageName: node
   linkType: hard
 
@@ -6031,6 +6061,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:1 - 2":
+  version: 2.12.1
+  resolution: "d3-array@npm:2.12.1"
+  dependencies:
+    internmap: ^1.0.0
+  checksum: 97853b7b523aded17078f37c67742f45d81e88dda2107ae9994c31b9e36c5fa5556c4c4cf39650436f247813602dfe31bf7ad067ff80f127a16903827f10c6eb
+  languageName: node
+  linkType: hard
+
 "d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3":
   version: 3.1.1
   resolution: "d3-array@npm:3.1.1"
@@ -6207,6 +6246,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-path@npm:1":
+  version: 1.0.9
+  resolution: "d3-path@npm:1.0.9"
+  checksum: d4382573baf9509a143f40944baeff9fead136926aed6872f7ead5b3555d68925f8a37935841dd51f1d70b65a294fe35c065b0906fb6e42109295f6598fc16d0
+  languageName: node
+  linkType: hard
+
 "d3-path@npm:1 - 3, d3-path@npm:3":
   version: 3.0.1
   resolution: "d3-path@npm:3.0.1"
@@ -6232,6 +6278,16 @@ __metadata:
   version: 3.0.1
   resolution: "d3-random@npm:3.0.1"
   checksum: a70ad8d1cabe399ebeb2e482703121ac8946a3b336830b518da6848b9fdd48a111990fc041dc716f16885a72176ffa2898f2a250ca3d363ecdba5ef92b18e131
+  languageName: node
+  linkType: hard
+
+"d3-sankey@npm:0.12.3":
+  version: 0.12.3
+  resolution: "d3-sankey@npm:0.12.3"
+  dependencies:
+    d3-array: 1 - 2
+    d3-shape: ^1.2.0
+  checksum: df1cb9c9d02dd8fd14040e89f112f0da58c03bd7529fa001572a6925a51496d1d82ff25d9fedb6c429a91645fbd2476c19891e535ac90c8bc28337c33ee21c87
   languageName: node
   linkType: hard
 
@@ -6271,6 +6327,15 @@ __metadata:
   dependencies:
     d3-path: 1 - 3
   checksum: 958f15369d18ffba405a59efec08f2774e09ad80717a33f8f3f76bf83dbfc1eef8c5a474f2383168d468a98d6657eaef29fb127d8ec05c5e0126eb549af92581
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:^1.2.0":
+  version: 1.3.7
+  resolution: "d3-shape@npm:1.3.7"
+  dependencies:
+    d3-path: 1
+  checksum: 46566a3ab64a25023653bf59d64e81e9e6c987e95be985d81c5cedabae5838bd55f4a201a6b69069ca862eb63594cd263cac9034afc2b0e5664dfe286c866129
   languageName: node
   linkType: hard
 
@@ -9509,6 +9574,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"internmap@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "internmap@npm:1.0.1"
+  checksum: 9d00f8c0cf873a24a53a5a937120dab634c41f383105e066bb318a61864e6292d24eb9516e8e7dccfb4420ec42ca474a0f28ac9a6cc82536898fa09bbbe53813
+  languageName: node
+  linkType: hard
+
 "interpret@npm:^1.4.0":
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
@@ -11648,8 +11720,8 @@ fsevents@^1.2.7:
     "@babel/preset-react": ~7.9.1
     "@babel/register": ~7.9.0
     "@babel/runtime-corejs3": ~7.9.0
-    "@carbon/charts": ^0.41.100
-    "@carbon/charts-react": ^0.41.100
+    "@carbon/charts": ^0.58.0
+    "@carbon/charts-react": ^0.58.0
     "@carbon/icons-react": ~10.26.0
     "@carbon/themes": ~10.28.0
     "@data-driven-forms/carbon-component-mapper": ~3.18.2


### PR DESCRIPTION
Upgraded carbon charts version on Najdorf in order to fix an issue preventing charts from being downloaded as pngs and jpegs.

When trying to download a chart on najdorf as either a png or jpeg it produces infinite react warnings as shown here and prevents downloads:
<img width="1000" alt="Screen Shot 2022-07-21 at 4 50 57 PM" src="https://user-images.githubusercontent.com/32444791/180316121-6cbd818b-d8b0-4e8b-8065-607678428acc.png">

By upgrading the carbon charts version it fixes this issue and allows downloads to proceed.

<img width="1675" alt="Screen Shot 2022-07-21 at 5 32 03 PM" src="https://user-images.githubusercontent.com/32444791/180318794-a967bafc-a67d-4f10-abc4-6ed8bb72f07e.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug