### PR TITLE
Fix Provider charts style

### DIFF
--- a/app/stylesheet/charts.scss
+++ b/app/stylesheet/charts.scss
@@ -70,9 +70,11 @@
 
 .heatmap_charts_div {
   display: inline-flex;
+
   .chart-holder {
     margin-right: 55px;
   }
+
   .heat-chart-pf {
     margin-bottom: 50px;
     width: 300px;
@@ -86,6 +88,7 @@
 
 .empty-chart-contents {
   margin-bottom: 10px;
+
   span {
     vertical-align: middle;
     width: 100%;
@@ -99,3 +102,62 @@
   font-weight: 400 !important;
 }
 
+.card-pf-utilization {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  border: 1px solid $selected-ui;
+
+  .card-pf-heading {
+    border: 0;
+    margin: 0;
+    padding: 0 20px 0;
+
+    .card-pf-title {
+      font-weight: 300;
+    }
+  }
+
+  .card-pf-body {
+    padding: 0;
+    margin: 0;
+
+    .bx--cc--chart-wrapper {
+      .layout-child {
+        &.spacer {
+          margin-top: 0;
+        }
+
+        &.legend {
+          margin-top: 5px;
+        }
+      }
+
+      &:last-child {
+        display: flex;
+        flex-direction: column-reverse;
+        height: 113px;
+        width: 100%;
+      }
+    }
+  }
+
+  .card-pf-body > *:last-child {
+    margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .trend-footer-pf {
+    font-size: 12px;
+    border-top: 1px solid $selected-ui;
+    font-weight: 400;
+    color: #333;
+    padding: 20px;
+    background: #fafafa;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Fixes for - https://github.ibm.com/katamari/dev-issue-tracking/issues/25330

**Safari**

Before
<img width="1582" alt="image" src="https://user-images.githubusercontent.com/87487049/180424469-bb6a0f8e-9625-417f-b009-be58ab1a3e0a.png">

After
1. The overlapping of labels is solved by making the card design similar to the dashboard charts.
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/180425379-b269c8e2-3b40-43ae-8c2e-38c2f18f116b.png">

2. The issue for Click events to minimize the expanded charts are present within the carbon charts themselves. 

3. Legends are now visible
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/180423518-b1aa33c0-b440-4bec-ae82-4c6be13c9e3a.png">

**Firefox**
Before - 
![image](https://user-images.githubusercontent.com/87487049/180425101-769e105e-cb40-4083-9f57-42c41b12f3b9.png)

After - Legends are now visible
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/87487049/180423915-b1564b4e-76ca-4fac-80b1-2c70fa4e3df9.png">


@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-label bug
@miq-bot assign @Fryguy