### PR TITLE
Re-enable Template Clone UI button for ibm_power_hmc provider

### DIFF
--- a/app/helpers/application_helper/button/button_template_clone.rb
+++ b/app/helpers/application_helper/button/button_template_clone.rb
@@ -1,8 +1,0 @@
-class ApplicationHelper::Button::ButtonTemplateClone < ApplicationHelper::Button::Basic
-  needs :@record
-
-  def disabled?
-    @error_message = _('Template cannot be cloned') if @record.type.eql?("ManageIQ::Providers::IbmPowerHmc::InfraManager")
-    @error_message.present?
-  end
-end

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -143,8 +143,7 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
           :url_parms    => "main_div",
           :send_checked => true,
           :enabled      => false,
-          :onwhen       => "1",
-          :klass        => ApplicationHelper::Button::ButtonTemplateClone),
+          :onwhen       => "1"),
       ]
     ),
  ])


### PR DESCRIPTION
Re-enable Template Clone UI menu button from the template list view of the ibm_power_hmc provider now that Template Clone was implemented in that provider.

Example URL of affected web page :
http://1.2.3.4:3000/ems_infra/2?display=miq_templates#/

Links
----------------

* PR being reverted https://github.com/ManageIQ/manageiq-ui-classic/pull/8108
* PR adding Template Clone support https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/68