### PR TITLE
Use array_including to fix sporadic tags failure

### DIFF
--- a/spec/controllers/application_controller/tags_spec.rb
+++ b/spec/controllers/application_controller/tags_spec.rb
@@ -163,8 +163,8 @@ describe ApplicationController do
         expected_options = {
           :model      => "Host",
           :object_ids => [host.id],
-          :add_ids    => [dept_finance.id, env_production.id],
-          :delete_ids => [dept_accounting.id, env_accounting.id]
+          :add_ids    => array_including(dept_finance.id, env_production.id),
+          :delete_ids => array_including(dept_accounting.id, env_accounting.id)
         }
         expect(Classification).to receive(:bulk_reassignment).with(expected_options)
 


### PR DESCRIPTION
Fix for a sporadic test failure in the tags_spec https://github.com/ManageIQ/manageiq-ui-classic/runs/7467314232?check_suite_focus=true#step:8:535

```
        #<Classification(id: integer, description: text, icon: string, read_only: boolean, syntax: string, single_value: boolean, example_text: text, tag_id: integer, parent_id: integer, show: boolean, default: boolean, perf_by_tag: boolean, href_slug: string, region_number: integer, region_description: string, name: string, ns: string) (class)> received :bulk_reassignment with unexpected arguments
         expected: ({:add_ids=>[69000000000208, 69000000000212], :delete_ids=>[69000000000207, 69000000000211], :model=>"Host", :object_ids=>[69000000000125]})
              got: ({:add_ids=>[69000000000208, 69000000000212], :delete_ids=>[69000000000211, 69000000000207], :model=>"Host", :object_ids=>[69000000000125]})
```