### PR TITLE
Remove image when no text is available in data tables

### DIFF
--- a/app/javascript/components/miq-data-table/miq-table-cell.jsx
+++ b/app/javascript/components/miq-data-table/miq-table-cell.jsx
@@ -101,7 +101,7 @@ const MiqTableCell = ({
     if (isObject(data)) {
       if (isArray(data.text)) return { ...content, component: cellArrayList(data), cellClick: false };
 
-      if (hasImage(keys, data)) return { ...content, component: cellImage(data) };
+      if (data.text && hasImage(keys, data)) return { ...content, component: cellImage(data) };
 
       const { showIcon, showText } = hasIcon(keys, data);
       if (showIcon) return { ...content, component: cellIcon(data, showText), showText };


### PR DESCRIPTION
Issue - https://github.ibm.com/katamari/dev-issue-tracking/issues/26497

Removing the `image` when `text` is not available

Before
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/87487049/180714892-d136056c-3f2f-4ba3-a1aa-f95a46064544.png">

After
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/87487049/180714781-6047a220-637e-477f-8c92-dc82b6b152ba.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label bug
@miq-bot assign @Fryguy
