### PR TITLE
add storage resource to volume Relationships

### DIFF
--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -25,7 +25,7 @@ module CloudVolumeHelper::TextualSummary
     TextualGroup.new(
       _("Relationships"),
       %i[
-        parent_ems_cloud ems availability_zone cloud_tenant base_snapshot cloud_volume_backups
+        parent_ems_cloud ems storage_resource availability_zone cloud_tenant base_snapshot cloud_volume_backups
         cloud_volume_snapshots attachments custom_button_events host_initiators
       ]
     )
@@ -53,6 +53,12 @@ module CloudVolumeHelper::TextualSummary
 
   def textual_ems
     textual_link(@record.ext_management_system)
+  end
+
+  def textual_storage_resource
+    @record.ext_management_system.storage_resources.find(@record.storage_resource_id)
+  rescue
+    nil
   end
 
   def textual_availability_zone

--- a/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
+++ b/spec/helpers/cloud_volume_helper/textual_summary_spec.rb
@@ -2,6 +2,7 @@ describe CloudVolumeHelper::TextualSummary do
   include_examples "textual_group", "Relationships", %i(
     parent_ems_cloud
     ems
+    storage_resource
     availability_zone
     cloud_tenant
     base_snapshot


### PR DESCRIPTION
The Volume detail page shows to which storage it belongs and a lot of other properties.

I added to the Relationships detail the Storage Resource it belongs to (which its respective link).

<img width="691" alt="Screen Shot 2022-07-25 at 14 05 39" src="https://user-images.githubusercontent.com/50288766/180781762-95fbd9b9-2d91-4e0e-9ff0-6db9590a6b4a.png">
<img width="673" alt="Screen Shot 2022-07-25 at 14 06 27" src="https://user-images.githubusercontent.com/50288766/180781771-7f089663-cec9-45cd-aea0-69e2f565d4ce.png">

