### PR TITLE
HeatmapChartGraph: show an empty chart when data is not null but undefined - new PR

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -7,20 +7,12 @@ import EmptyChart from '../emptyChart';
 const HeatMapChartGraph = ({
   data, dataPoint1, dataPoint2, dataPointAvailable,
 }) => {
-  const heatData1 = data[dataPoint1];
-  const heatData2 = data[dataPoint2];
-  const heatmapCpuData = (heatData1 === null) ? [] : getHeatMapData(heatData1);
-  const heatmapMemoryData = (heatData2 === null) ? [] : getHeatMapData(heatData2);
-
+  const heatmapCpuData = getHeatMapData(data[dataPoint1]);
+  const heatmapMemoryData = getHeatMapData(data[dataPoint2]);
   const heatmapCpuTooltip = () => (data) => {
-    let d1;
-
-    if (dataPoint1 === 'resourceUsage') {
-      d1 = heatmapCpuData.find((item) => item.node === data[1].value);
-    }
-    else {
-      d1 = heatmapCpuData[0];
-    }
+    const d1 = (dataPoint1 === 'resourceUsage')
+      ? heatmapCpuData.find((item) => item.node === data[1].value)
+      : heatmapCpuData[0];
 
     let percent = -1;
     let tooltip = sprintf(__('Cluster: %s'), data[1].value) + `<br>` + sprintf(__('Provider: %s'), d1.provider)

--- a/app/javascript/components/provider-dashboard-charts/helpers.js
+++ b/app/javascript/components/provider-dashboard-charts/helpers.js
@@ -27,8 +27,8 @@ export const getLatestValue = (data) => {
 };
 
 export const getHeatMapData = (data) => {
-  if (data) {
-    const arr = [];
+  const arr = [];
+  if (data && data[0]['node'] !== undefined) {
     data.forEach((item) => {
       const obj = {};
       obj.percent = item.percent;
@@ -39,9 +39,8 @@ export const getHeatMapData = (data) => {
       obj.unit = item.unit;
       arr.push(obj);
     });
-    return arr;
   }
-  return [];
+  return arr;
 };
 
 export const getPodsData = (data, createdlabel, deletedLabel) => {


### PR DESCRIPTION
new clean branch for PR after review of:
https://github.com/ManageIQ/manageiq-ui-classic/pull/8365#

changes:

`helpers.getHeatMapData`: 
- now checks both for `data` existence and validity, and returns an empty array if false.
- improved function structure.

`HeatMapChartGraph.js`:
- `heatData1/2` are no longer necessary due to the above, `getHeatMapData` is passed `data[datapoint1/2]`.
- improved syntax at `heatmapCpuTooltip`

-=-=-

bug description:
when invalid data is sent to the HeatMapChartGraph, for instance due to connection problems in the backend, a broken chart is rendered instead of an empty one.
This is because the data is not null, but is invalid.

to reproduce the bug on the master branch: assign heatData1 with a dummy non-empty array, for instance [1, 2, 3]

bug reproduction:

![](https://user-images.githubusercontent.com/106743023/180207980-b308259e-68b6-42d9-a84a-9c698c29394e.png)

after fix:

![](https://user-images.githubusercontent.com/106743023/180208683-49ae316e-a12f-458a-b103-d0f732ac43c1.png)
