### PR TITLE
Set clone request_type based on the source object type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1544,10 +1544,11 @@ class ApplicationController < ActionController::Base
     @org_controller = "vm" # request originated from controller
     @refresh_partial = typ ? "prov_edit" : "pre_prov"
     if typ
-      @prov_id = find_record_with_rbac(VmOrTemplate, checked_or_params).id
+      prov_obj = find_record_with_rbac(VmOrTemplate, checked_or_params)
+      @prov_id = prov_obj.id
       case typ
       when "clone"
-        @prov_type = "clone_to_vm"
+        @prov_type = prov_obj.template? ? "clone_to_template" : "clone_to_vm"
       when "migrate"
         @prov_id = [@prov_id]
         @prov_type = "migrate"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1594,6 +1594,8 @@ class ApplicationController < ActionController::Base
   end
 
   def vm_clone
+    @record = identify_record(params[:id], controller_to_model)
+
     prov_redirect("clone")
   end
   alias image_clone vm_clone
@@ -1601,11 +1603,15 @@ class ApplicationController < ActionController::Base
   alias miq_template_clone vm_clone
 
   def vm_migrate
+    @record = identify_record(params[:id], controller_to_model)
+
     prov_redirect("migrate")
   end
   alias miq_template_migrate vm_migrate
 
   def vm_publish
+    @record = identify_record(params[:id], controller_to_model)
+
     prov_redirect("publish")
   end
   alias instance_publish vm_publish

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1208,7 +1208,7 @@ module VmCommon
       task_headers = {"clone"   => _("Clone %{vm_or_template}"),
                       "migrate" => _("Migrate %{vm_or_template}"),
                       "publish" => _("Publish %{vm_or_template}")}
-      header = task_headers[@sb[:action]] % {:vm_or_template => ui_lookup(:table => table)}
+      header = task_headers[@sb[:action]] % {:vm_or_template => model_for_vm(@record).display_name}
       action = "prov_edit"
     when "dialog_provision"
       partial = "shared/dialogs/dialog_provision"


### PR DESCRIPTION
If the provision type is "clone" set the request type to clone_to_vm or clone_to_template based on the source object being cloned.

TODO:
- [x] Check any other places where request_type is set
- [x] Check where `Clone to Virtual Machine` display string is set and update to look at destination type'

The `Clone Virtual Machine` comes from https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/vm_common.rb#L1208 which is using the source controller to lookup the string.

Before:
![image](https://user-images.githubusercontent.com/12851112/180842837-08e486fc-ed39-4b4a-8f68-f655c81c7f6a.png)

After:
![image](https://user-images.githubusercontent.com/12851112/180842692-6638b2c3-03f6-4dd2-96dc-cfa655a570b6.png)
