### PR TITLE
Translations for strings in textual_summary.rb

### DIFF
--- a/app/helpers/cloud_database_helper/textual_summary.rb
+++ b/app/helpers/cloud_database_helper/textual_summary.rb
@@ -20,11 +20,11 @@ module CloudDatabaseHelper::TextualSummary
   #
 
   def textual_type
-    ui_lookup(:model => @record.type)
+    {:label => _('Type'), :value => ui_lookup(:model => @record.type)}
   end
 
   def textual_status
-    @record.status
+    {:label => _("Status"), :value => _(@record.status)}
   end
 
   def textual_ems_ref

--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -23,11 +23,11 @@ module CloudNetworkHelper::TextualSummary
   # Items
   #
   def textual_type
-    ui_lookup(:model => @record.type)
+    {:label => _('Type'), :value => ui_lookup(:model => @record.type)}
   end
 
   def textual_status
-    @record.status
+    {:label => _("Status"), :value => _(@record.status)}
   end
 
   def textual_ems_ref
@@ -50,15 +50,15 @@ module CloudNetworkHelper::TextualSummary
   end
 
   def textual_cloud_tenant
-    @record.cloud_tenant
+    textual_link(@record.cloud_tenant, :label => _('Cloud Tenant'))
   end
 
   def textual_network_routers
-    @record.network_routers
+    textual_link(@record.network_routers, :label => _('Network Routers'))
   end
 
   def textual_cloud_subnets
-    @record.cloud_subnets
+    textual_link(@record.cloud_subnets, :label => _('Cloud Subnets'))
   end
 
   def textual_floating_ips

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -57,7 +57,7 @@ module SecurityGroupHelper::TextualSummary
   # Items
   #
   def textual_type
-    ui_lookup(:model => @record.type)
+    {:label => _('Type'), :value => ui_lookup(:model => @record.type)}
   end
 
   def textual_parent_ems_cloud
@@ -79,11 +79,11 @@ module SecurityGroupHelper::TextualSummary
   end
 
   def textual_cloud_tenant
-    @record.cloud_tenant
+    textual_link(@record.cloud_tenant, :label => _('Cloud Tenant'))
   end
 
   def textual_network_ports
-    @record.network_ports
+    textual_link(@record.network_ports, :label => _('Network Ports'))
   end
 
   def textual_network_router


### PR DESCRIPTION
Certain strings were not being translated within the code so we're exporting them here. 


### Compute > Clouds > Cloud Databases

BEFORE

![Screen Shot 2022-07-25 at 2 21 45 PM](https://user-images.githubusercontent.com/29209973/180847628-844cb2ea-ae77-4c4a-abe8-236fb5284e86.png)

AFTER

![Screen Shot 2022-07-25 at 2 18 54 PM](https://user-images.githubusercontent.com/29209973/180846917-e4a134da-30de-4c6e-8399-1af4a51420e2.png)



### Network > Networks

BEFORE 

![Screen Shot 2022-07-25 at 2 22 38 PM](https://user-images.githubusercontent.com/29209973/180847671-ab430d9d-325d-4fa0-ad3a-8d8782e392db.png)

AFTER

![Screen Shot 2022-07-25 at 2 19 31 PM](https://user-images.githubusercontent.com/29209973/180846936-4e403f85-b3eb-4867-9f5f-1bd02f59c646.png)



## Network > Security Groups

BEFORE

![Screen Shot 2022-07-25 at 2 23 38 PM](https://user-images.githubusercontent.com/29209973/180847691-9d59afdf-be6a-4afc-a25b-d0665e34f5e7.png)

AFTER

![Screen Shot 2022-07-25 at 2 19 46 PM](https://user-images.githubusercontent.com/29209973/180846969-185f5012-85f9-4281-907c-ab3a01921b67.png)