### PR TITLE
Fixed catalog items button group form

### DIFF
--- a/app/javascript/components/button-group/helper.js
+++ b/app/javascript/components/button-group/helper.js
@@ -41,7 +41,7 @@ export const formatSetData = (setData, buttonIcon, appliesToClass, appliesToId) 
   });
 };
 
-export const getGenericObjectButtonList = (buttonGroups, data, recId) => {
+export const getButtonList = (buttonGroups, data, recId) => {
   const buttons = [];
   const assignedButtons = [];
   let unassignedButtons = [];

--- a/app/javascript/components/button-group/index.jsx
+++ b/app/javascript/components/button-group/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import createSchema from './group-form.schema';
 import {
-  formatButton, formatName, formatSetData, getGenericObjectButtonList,
+  formatButton, formatName, formatSetData, getButtonList,
 } from './helper';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import { API } from '../../http_api';
@@ -32,19 +32,19 @@ const GroupForm = ({
           ...state,
           initialValues: { ...initialValues, name: formatName(initialValues.name) },
           buttonIcon: (initialValues && initialValues.set_data) ? initialValues.set_data.button_icon : '',
-          options: isGenericObject ? buttons : buttonOptions,
+          options: isGenericObject || appliesToClass === 'ServiceTemplate' ? buttons : buttonOptions,
           isLoading: false,
         }));
       });
   };
 
   useEffect(() => {
-    if (isGenericObject) {
-      API.get(`/api/custom_buttons?expand=resources&filter[]=applies_to_class=GenericObjectDefinition&filter[]=applies_to_id=${appliesToId}`)
+    if (isGenericObject || appliesToClass === 'ServiceTemplate') {
+      API.get(`/api/custom_buttons?expand=resources&filter[]=applies_to_class=${appliesToClass}&filter[]=applies_to_id=${appliesToId}`)
         .then((data) => {
-          API.get(`/api/custom_button_sets?expand=resources&filter[]=owner_type=GenericObjectDefinition&filter[]=owner_id=${appliesToId}`)
+          API.get(`/api/custom_button_sets?expand=resources&filter[]=owner_type=${appliesToClass}&filter[]=owner_id=${appliesToId}`)
             .then((buttonGroups) => {
-              const buttons = getGenericObjectButtonList(buttonGroups, data, recId);
+              const buttons = getButtonList(buttonGroups, data, recId);
               if (recId) {
                 getInitialValues(buttons);
               } else {


### PR DESCRIPTION
Fixed catalog items button group form bug where the unassigned buttons list in the dual select field was empty due to the form not loading the button list correctly.

Before:
<img width="1419" alt="Screen Shot 2022-07-25 at 3 39 02 PM" src="https://user-images.githubusercontent.com/32444791/180860807-d8edefae-fe56-493d-9b72-2735bdbda63d.png">

After:
<img width="1438" alt="Screen Shot 2022-07-25 at 3 31 47 PM" src="https://user-images.githubusercontent.com/32444791/180860862-ec753161-b1b7-4190-a0ad-c43442149476.png">
<img width="1435" alt="Screen Shot 2022-07-25 at 3 31 57 PM" src="https://user-images.githubusercontent.com/32444791/180860859-c995b174-6900-4983-9298-6e0db5ffd3cf.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug