### PR TITLE
support character encoding in content_type

### DIFF
--- a/spec/controllers/tree_controller_spec.rb
+++ b/spec/controllers/tree_controller_spec.rb
@@ -7,7 +7,7 @@ describe TreeController do
         get endpoint
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
       end
     end
 
@@ -18,7 +18,7 @@ describe TreeController do
         get endpoint, :params => {:id => node_id}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
       end
     end
   end


### PR DESCRIPTION
rails 6.1 includes character encoding for the content_type
The distinction between the two does not seem relevant

```
       expected: "application/json"
            got: "application/json; charset=utf-8"
```

Instead, just match the content type allowing either definition
