### PR TITLE
Add public_network option to GCE provisioning

### DIFF
--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -135,7 +135,7 @@
       - if wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - has_cloud_network = (@edit && @edit[:new] && (!@edit[:new][:cloud_network_selection_method] || @edit[:new][:cloud_network_selection_method][0] == "network")) || (@options && (!@options[:cloud_network_selection_method] || @options[:cloud_network_selection_method][0] == "network"))
         - has_network_port = (@edit && @edit[:new] && @edit[:new][:cloud_network_selection_method] && @edit[:new][:cloud_network_selection_method][0] == "port") || (@options && @options[:cloud_network_selection_method] && @options[:cloud_network_selection_method][0] == "port")
-        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network_selection_method, has_cloud_network ? :cloud_network : nil, has_network_port ? :network_port : nil, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group].compact
+        - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network_selection_method, has_cloud_network ? :cloud_network : nil, has_network_port ? :network_port : nil, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group, :public_network].compact
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,


### PR DESCRIPTION
Add a public_network option to the environment tab

![image](https://user-images.githubusercontent.com/12851112/181601981-26c758b4-a879-46bf-8cc7-720c7e484ba8.png)

Dependent:
* https://github.com/ManageIQ/manageiq/pull/22020
* https://github.com/ManageIQ/manageiq-providers-google/pull/232

https://github.com/ManageIQ/manageiq-providers-google/issues/231