### PR TITLE
Set ems storage "Region" label to provider_region

### DIFF
--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module EmsStorageHelper::TextualSummary
   #
   def textual_provider_region
     return nil if @record.provider_region.nil?
-    {:label => _("Region"), :value => @record.description}
+    {:label => _("Region"), :value => @record.provider_region}
   end
 
   def textual_hostname


### PR DESCRIPTION
The 'description' instance method is not defined in the base
StorageManager class, or in
ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager.
As far as I can tell this is the only place it is used.

Setting the "Region" label directly to the 'provider_region' value
removes the dependency on defining a 'description' instance method (and
seems more relevant).

Before:
![image](https://user-images.githubusercontent.com/1637291/181772575-3098db2c-d68d-42a3-8cca-0f5acd1c3def.png)
After:
![image](https://user-images.githubusercontent.com/1637291/181771146-f7f8da08-5d2f-4164-a2b8-c0708307b69d.png)