### PR TITLE
CSS Enhancements

### DIFF
--- a/app/javascript/components/remove-catalog-item-modal.jsx
+++ b/app/javascript/components/remove-catalog-item-modal.jsx
@@ -96,7 +96,7 @@ class RemoveCatalogItemModal extends React.Component {
     });
     dispatch({
       type: 'FormButtons.customLabel',
-      payload: __('Delete'),
+      payload: 'Delete', // NOTE: This will be translated in <MiqButton />
     });
   }
 
@@ -172,7 +172,7 @@ class RemoveCatalogItemModal extends React.Component {
 
 RemoveCatalogItemModal.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  recordId: PropTypes.number,
+  recordId: PropTypes.string,
   gridChecks: PropTypes.arrayOf(PropTypes.any),
 };
 

--- a/app/javascript/components/vm-edit-form/vm-edit-form.schema.js
+++ b/app/javascript/components/vm-edit-form/vm-edit-form.schema.js
@@ -61,16 +61,24 @@ function createSchema(emsId, parentOptions) {
           filterOptionsTitle: __('Filter options'),
           filterValuesTitle: __('Filter values'),
           AddButtonProps: {
+            id: 'addButtonProps',
+            className: 'addButtonProps',
             size: 'small',
+            iconDescription: "Add Selected",
           },
           AddAllButtonProps: {
             size: 'small',
+            iconDescription: "Add All",
           },
           RemoveButtonProps: {
+            id: 'removeButtonProps',
+            className: 'removeButtonProps',
             size: 'small',
+            iconDescription: "Remove Selected",
           },
           RemoveAllButtonProps: {
             size: 'small',
+            iconDescription: "Remove All",
           },
           options: parentOptions,
         },

--- a/app/javascript/forms/form-buttons.jsx
+++ b/app/javascript/forms/form-buttons.jsx
@@ -7,8 +7,9 @@ function FormButtons(props) {
   const primaryTitle = props.customLabel || (props.newRecord ? __('Add') : __('Save'));
   const primaryHandler = (props.newRecord ? props.addClicked : props.saveClicked) || props.addClicked || props.saveClicked;
 
-  const resetTitle = __('Reset');
-  const cancelTitle = __('Cancel');
+  // NOTE: These strings will be translated by <MiqButton />
+  const resetTitle = 'Reset';
+  const cancelTitle = 'Cancel';
 
   const { btnType } = props;
   if (btnType === 'deleteModal') {

--- a/app/javascript/forms/miq-button.jsx
+++ b/app/javascript/forms/miq-button.jsx
@@ -38,7 +38,7 @@ function MiqButton(props) {
         onKeyPress={buttonClicked}
         title={title}
       >
-        {props.name}
+        {__(props.name)}
       </Button>
     );
   }
@@ -49,7 +49,7 @@ function MiqButton(props) {
       onKeyPress={buttonClicked}
       title={title}
     >
-      {props.name}
+      {__(props.name)}
     </Button>
   );
 }

--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -286,6 +286,7 @@
 
         .Cancel {
           background-color: #393939;
+          width: 200px;
         }
 
         .Delete {
@@ -342,4 +343,19 @@
     margin-top: 2.2rem;
     margin-left: 32px;
   }
+}
+
+#addButtonProps.addButtonProps {
+  display: flex;
+  padding-right: 30px;
+}
+
+#removeButtonProps.removeButtonProps {
+  display: flex;
+  padding-right: 30px;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link {
+  min-width: 10rem;
+  width: fit-content;
 }

--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -17,11 +17,15 @@
     padding: 0;
   }
 
+  .bx--side-nav__navigation.bx--side-nav.bx--side-nav--expanded.secondary {
+    width: fit-content;
+    max-width: 30rem;
+    min-width: 16rem;
+  }
+
   // sizing
   .bx--side-nav.secondary {
     left: 16rem;
-    max-width: 14rem;
-    width: 14rem;
 
     .bx--side-nav__link-text {
       font-weight: 400;
@@ -174,11 +178,11 @@
 .miq-main-menu-overlay {
   background-color: #000;
   bottom: 0;
-  left: 30rem;
+  left: 10rem;
   opacity: 0.5;
   position: fixed;
   right: 0;
-  z-index: 10000;
+  z-index: 1000;
 }
 
 .navbar-brand-name {


### PR DESCRIPTION
A collection of various fixes to the UI

## Arrows no longer overlap with the text
To reproduce: Compute > Clouds > Instances > Select one instance > Configuration - Edit this Instance

### Before

![Screen Shot 2022-07-29 at 1 17 41 PM](https://user-images.githubusercontent.com/29209973/181811087-443b2c2b-f78c-4fa0-b468-555bf80c09b7.png)

### After

![Screen Shot 2022-07-29 at 1 01 34 PM](https://user-images.githubusercontent.com/29209973/181808832-6e1f6ee1-bb14-4e89-a4af-62078f63b195.png)

## Dynamic resizing of menu so as to not truncate options

### Before

![Screen Shot 2022-07-29 at 1 12 51 PM](https://user-images.githubusercontent.com/29209973/181810398-ee3efea0-a2ec-47e3-b2b3-1bdc1d9fb39e.png)

### After

![Screen Shot 2022-07-29 at 1 04 36 PM](https://user-images.githubusercontent.com/29209973/181809230-069ed0f5-7c22-4ee8-b7e5-34df76df854e.png)

## Buttons are the correct color as well as all text is in one line
To reproduce: Services > Catalogs > Catalog Items - Unassigned > Select one Catalog Item > Configuration - Delete Catalog Item

### Before

![Screen Shot 2022-07-29 at 1 15 12 PM](https://user-images.githubusercontent.com/29209973/181810671-42db4bbf-5b19-41b5-bd9d-6c1cc89b4d3c.png)

### After

![Screen Shot 2022-07-29 at 1 07 09 PM](https://user-images.githubusercontent.com/29209973/181809576-f4daa6f5-22f9-404f-93ae-3771652b866f.png)

## Dynamically resizing tabs in accordance to text length
To reproduce: Compute > Clouds > Providers > Click Configuration - Add a new Cloud Provider > Select IBM PowerVC from the Type dropdown list

### Before

![Screen Shot 2022-07-29 at 1 11 45 PM](https://user-images.githubusercontent.com/29209973/181810198-c97db231-6789-4dd8-bb4a-ae0a23714b36.png)

### After

![Screen Shot 2022-07-29 at 1 08 21 PM](https://user-images.githubusercontent.com/29209973/181809761-28c99c03-cfe5-441d-892e-3551f0efa23b.png)