### PR TITLE
errors when using searchbar

### DIFF
--- a/app/javascript/components/search-bar/index.jsx
+++ b/app/javascript/components/search-bar/index.jsx
@@ -23,7 +23,7 @@ const SearchBar = ({ searchText, advancedSearch, action }) => {
 
   /** Function to filter the results through form submit. */
   const onSearch = () => {
-    http.post({ url: action });
+    http.post(action, null, { headers: {}, skipJsonParsing: true });
   };
 
   /** Function to clear the search input and submit the form. */

--- a/app/javascript/http_api/http.js
+++ b/app/javascript/http_api/http.js
@@ -6,7 +6,8 @@ export default {
 };
 
 function nonApiOnly(url) {
-  if (url.match(/^[^/]|(\/api($|\/))/)) {
+  const path = new URL(url, document.location.href);
+  if (path.pathname.match(/^\/api($|\/)/)) {
     throw new Error(`${url} is an API endpoint URL, try using 'API' instead of 'http'`);
   }
 


### PR DESCRIPTION
`app/javascript/http_api/http.nonApiOnly(url)` makes sure that the url is not an API endpoint, and has a mirror function in `app/javascript/http_api/api.apiOnly(url)` which makes sure that the url **is** an api endpoint. 

For some reason, `http.nonApiOnly` was not written similar to `api.apiOnly`, which caused a `TypeError`. 
After fixing the error, it appeared that the regex used in `http.nonApiOnly` was different from the one in `api.apiOnly `, which caused a false assessment of http-urls as api urls, and raised an error.

after the fix, `http.nonApiOnly` now correctly mirrors `api.apiOnly`.

before fixing TypeError:
![No records found](https://user-images.githubusercontent.com/106743023/182018874-12ed7798-c20b-451b-b397-2537999578ac.png)

after fixing TypeError, before fixing false negative
![Untitled](https://user-images.githubusercontent.com/106743023/182086738-8510c906-e422-496d-9a59-b141ee050e54.png)

after fixing false api error:
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/106743023/182019139-efc7f631-b0fd-4786-9f2d-19f22d7286eb.png">
