### PR TITLE
Remove byebug require

### DIFF
--- a/app/controllers/mixins/actions/vm_actions/ownership.rb
+++ b/app/controllers/mixins/actions/vm_actions/ownership.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 module Mixins
   module Actions
     module VmActions


### PR DESCRIPTION
I found an old `require 'byebug'` that was left behind.