### PR TITLE
Fix button group form missing group_index on submit

### DIFF
--- a/app/javascript/components/button-group/helper.js
+++ b/app/javascript/components/button-group/helper.js
@@ -23,7 +23,7 @@ export const formatName = (buttonGroupName) => {
 };
 
 /** Function to update the field set_data's values during form submit */
-export const formatSetData = (setData, buttonIcon, appliesToClass, appliesToId) => {
+export const formatSetData = (setData, buttonIcon, appliesToClass, appliesToId, groupIndex) => {
   if (appliesToId) {
     return ({
       ...setData,
@@ -31,6 +31,7 @@ export const formatSetData = (setData, buttonIcon, appliesToClass, appliesToId) 
       button_icon: buttonIcon,
       applies_to_class: appliesToClass,
       applies_to_id: appliesToId,
+      group_index: groupIndex || Math.floor(Math.random() * 1000),
     });
   }
   return ({
@@ -38,6 +39,7 @@ export const formatSetData = (setData, buttonIcon, appliesToClass, appliesToId) 
     button_color: (setData && setData.button_color) ? setData.button_color : '#000',
     button_icon: buttonIcon,
     applies_to_class: appliesToClass,
+    group_index: groupIndex || Math.floor(Math.random() * 1000),
   });
 };
 

--- a/app/javascript/components/button-group/index.jsx
+++ b/app/javascript/components/button-group/index.jsx
@@ -80,7 +80,8 @@ const GroupForm = ({
       values.owner_id = appliesToId;
     }
     values.owner_type = appliesToClass;
-    values.set_data = formatSetData(values.set_data, buttonIcon, appliesToClass, appliesToId);
+    const groupIndex = initialValues ? initialValues.set_data.group_index : undefined;
+    values.set_data = formatSetData(values.set_data, buttonIcon, appliesToClass, appliesToId, groupIndex);
     if (values.set_data.display === undefined) {
       values.set_data.display = false;
     }


### PR DESCRIPTION
Fix issue with button group form where group_index value was not being submitted to the API causing bugs with the toolbar when the toolbar tries to load in the custom buttons.

Before:
<img width="1431" alt="Screen Shot 2022-08-04 at 2 53 34 PM" src="https://user-images.githubusercontent.com/32444791/182943064-b7fbc7e1-43eb-4c0d-aa84-44e60e0d2707.png">

After:
<img width="1442" alt="Screen Shot 2022-08-04 at 3 56 02 PM" src="https://user-images.githubusercontent.com/32444791/182942997-42371400-a6e3-49c5-9d0e-e56577320731.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug
