### PR TITLE
Fixed typo for services ownership title

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -194,7 +194,7 @@ class ServiceController < ApplicationController
       action = "dialog_form_button_pressed"
     when "ownership"
       partial = "shared/views/ownership"
-      header = _("Set Ownership for Service1")
+      header = _("Set Ownership for Service")
       action = "ownership_update"
     when "retire"
       partial = "shared/views/retire"


### PR DESCRIPTION
Fixed a typo for the services ownership title that was added in pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/8229.