### PR TITLE
Fix tasks delete all bug

### DIFF
--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -120,8 +120,10 @@ class MiqTaskController < ApplicationController
   def delete_all_tasks
     assert_privileges("miq_task_deleteall")
     task_ids = []
-    session[:view].table.data.each do |rec|
-      task_ids.push(rec["id"])
+    if session[:view].table.present?
+      session[:view].table.data.each do |rec|
+        task_ids.push(rec["id"])
+      end
     end
     delete_tasks_from_table(task_ids, "Delete all finished tasks")
     jobs


### PR DESCRIPTION
Fixed a bug where delete all is clicked for an empty tasks table.

Before:
<img width="1432" alt="Screen Shot 2022-08-05 at 3 33 56 PM" src="https://user-images.githubusercontent.com/32444791/183148290-d7d19125-206d-4a67-acb4-93816b359457.png">

After:
<img width="1400" alt="Screen Shot 2022-08-05 at 3 32 31 PM" src="https://user-images.githubusercontent.com/32444791/183148062-cd36adcc-0331-409a-9c95-9715c1964208.png">


@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug