### PR TITLE
modified host initiator form to accept multiple iqns

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -87,12 +87,31 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         condition: { when: 'physical_storage_id', isNotEmpty: true },
       },
       {
-        component: componentTypes.TEXT_FIELD,
+        component: componentTypes.FIELD_ARRAY,
         name: 'iqn',
         id: 'iqn',
-        label: __('iqn:'),
+        label: __('IQN:'),
+        fieldKey: 'field_array',
         isRequired: true,
         validate: [{ type: validatorTypes.REQUIRED }],
+        buttonLabels: {
+          add: __('Add'),
+          remove: __('Remove'),
+        },
+        AddButtonProps: {
+          size: 'small',
+        },
+        RemoveButtonProps: {
+          size: 'small',
+        },
+        fields: [
+          {
+            component: componentTypes.TEXT_FIELD,
+            label: __('IQN'),
+            isRequired: true,
+            validate: [{ type: validatorTypes.REQUIRED }],
+          },
+        ],
         condition: {
           when: 'port_type',
           is: 'ISCSI',


### PR DESCRIPTION
Modified the IQN component in host_initiator_form, to support multiple IQNs to be added at once (as it was in the WWPN component). The change will be also reflected in a PR in the autosde_providers repo: 
https://github.com/ManageIQ/manageiq-providers-autosde/pull/160

The IQN details will now be passed as an array, not as a text field.
Add/Remove buttons were added.

when selecting ISCSI as the port type, this will appear:
![Screen Shot 2022-08-07 at 14 38 41](https://user-images.githubusercontent.com/62609377/183288725-c80f328f-7c92-4135-a0b9-de44101c260e.png)

clicking add will open a text field:
![Screen Shot 2022-08-07 at 14 39 56](https://user-images.githubusercontent.com/62609377/183288767-af66e427-7889-478f-8b55-09cd6c8baf35.png)

multiple fields can be added and removed, when submitting the form, the strings will be passed as an array
