### PR TITLE
Put `physical_storage_timeline` redirect in `specific_buttons`

### DIFF
--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -58,14 +58,6 @@ class PhysicalStorageController < ApplicationController
     process_show_list
   end
 
-  def button
-    if params[:pressed] == "physical_storage_timeline"
-      @record = find_record_with_rbac(PhysicalStorage, params[:id])
-      show_timeline
-      javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
-    end
-  end
-
   def download_summary_pdf
     assert_privileges('physical_storage_show')
     super
@@ -101,6 +93,10 @@ class PhysicalStorageController < ApplicationController
       javascript_redirect(:action => 'new')
     when 'physical_storage_edit'
       javascript_redirect(:action => 'edit', :id => checked_item_id)
+    when "physical_storage_timeline"
+      @record = find_record_with_rbac(PhysicalStorage, params[:id])
+      show_timeline
+      javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
     else
       return false
     end


### PR DESCRIPTION
### Bug
when I press on `Attach a new storage system` from physical-storage page(physical_storage/show_list#) the redirect not working and its stay in same page. The **new physical-storage page** look fine when I open it directly (physical_storage/new#).

### Solution
Then I found that the `physical_storage_timeline` redirect was created in wrong place so I remove `button` function and put the `physical_storage_timeline` in `specific_buttons`