### PR TITLE
remove the request section in autosde catalog item

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -624,7 +624,7 @@ class CatalogController < ApplicationController
   private :get_ae_tree_edit_key
 
   def need_prov_dialogs?(type)
-    !type.starts_with?('generic')
+    !(type.starts_with?('generic') or type.starts_with?('autosde'))
   end
   helper_method :need_prov_dialogs?
 

--- a/app/views/catalog/_form.html.haml
+++ b/app/views/catalog/_form.html.haml
@@ -4,7 +4,7 @@
       = _('Basic Info')
     = miq_tab_header('details', @sb[:st_form_active_tab]) do
       = _('Details')
-    - unless @edit[:new][:st_prov_type].try(:start_with?, "generic_")
+    - unless @edit[:new][:st_prov_type].try(:start_with?, "generic_")  ||  @edit[:new][:st_prov_type].try(:start_with?, "autosde")
       - if @edit[:new][:service_type] == "composite"
         = miq_tab_header('resources', @sb[:st_form_active_tab]) do
           = _('Resources')


### PR DESCRIPTION
disable the request tab for autosde catalog item.

related to 
manageiq-content:SDE-262253_service_catalog_automation
manageiq-providers-autosde:SDE-737_add_autosde_catalog_auto

