### PR TITLE
Fixed private key field for provider forms

### DIFF
--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -29,7 +29,6 @@ const PasswordField = ({
   };
 
   const newProps = { ...secretField };
-  delete newProps.componentClass;
   if (rest.label === undefined) {
     rest.label = '';
   }

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -161,12 +161,14 @@ exports[`Secret switch field component should render correctly in non edit mode 
   <MockDummyComponent
     autoComplete="new-password"
     component="text-field"
+    componentClass="text-field"
     name="foo"
     type="password"
   >
     <button
       autoComplete="new-password"
       component="text-field"
+      componentClass="text-field"
       name="foo"
       type="button"
     >


### PR DESCRIPTION
Removed a line added in this commit: https://github.com/ManageIQ/manageiq-ui-classic/commit/efb863b9221d07919b873430528e0bf02f439b9b that was preventing the provider / credential forms from rendering a text area box and instead always rendering the `edit-password-field` component as a password field with `*` placeholder characters.

Before:
<img width="1410" alt="Screen Shot 2022-08-09 at 12 53 34 PM" src="https://user-images.githubusercontent.com/32444791/183713141-d971084a-097d-463e-835f-13f9aa18c423.png">

After:
<img width="1392" alt="Screen Shot 2022-08-09 at 12 57 25 PM" src="https://user-images.githubusercontent.com/32444791/183713161-db1ba0bf-b436-40a7-a774-5bf8a640be81.png">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @DavidResende0 
@miq-bot add_reviewer @MelsHyrule 
@miq-bot assign @agrare 
@miq-bot add-label bug
