### PR TITLE
Fixing dropdown values

### DIFF
--- a/app/views/report/_form_formatting.html.haml
+++ b/app/views/report/_form_formatting.html.haml
@@ -40,7 +40,7 @@
             - ci = MiqReport.get_col_info(f.last.split("__").first)
             - unless ci[:available_formats].blank?
               -# need to gsub the period out of the field name for pull down or observe doesn't work, replacing with "__"
-              - opts = [["<#{_('None')}>", "_none_"], ["<#{_('Reset to Default')}>", nil]] + Array(ci[:available_formats].invert).sort_by(&:first).map{|format| _(format[0])}
+              - opts = [["<#{_('None')}>", "_none_"], ["<#{_('Reset to Default')}>", nil]] + Array(ci[:available_formats].invert).sort_by(&:first).map{|format| [_(format[0]), format[1]]}
               = select_tag("fmt_#{f.last.gsub(".", "___")}",
                 options_for_select(opts, @edit[:new][:col_formats][f.last] || ci[:default_format]),
                 "data-miq_sparkle_on" => true,


### PR DESCRIPTION
Found a bug in Editing Reports > Formatting, where the column format drop-downs would use the labels as their values, causing an error.

Steps to reproduce:
1. Go to Overview > Reports > Reports
2. Configuration > Edit this Report
3. Formatting > Specify Column Headers and Formats
4. Change any Format column
5. Save and Queue the report
6. Once done go to Saved Reports, find the report you queued up and click it, you should see the error below. 

## BEFORE

![Screen Shot 2022-08-10 at 10 43 42 AM](https://user-images.githubusercontent.com/29209973/183931375-fa1ae74a-9fde-4614-b7c3-2c743f292d13.png)

## AFTER

![Screen Shot 2022-08-10 at 10 38 58 AM](https://user-images.githubusercontent.com/29209973/183929869-917da507-b517-4417-9702-8d3163d108ae.png)

@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-reviewer @jeffibm 
@miq-bot assign @jeffibm 
@miq-bot assign @Fryguy 
@miq-bot add-label bug