### PR TITLE
Fix typo preventing usage of the correct double

### DIFF
--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -93,7 +93,7 @@ describe OpsController do
                   :password   => "password2",
                   :uri        => "smb://samba_uri",
                   :uri_prefix => "smb"}
-      expect(controller.send(:build_uri_settings, :mocked_filedepot)).to include(settings)
+      expect(controller.send(:build_uri_settings, mocked_filedepot)).to include(settings)
     end
 
     it "uses the stored password for validation if params[:log_password] does not exist" do


### PR DESCRIPTION
Fixes a sporadic test failure where this one test runs first, skips setting the
depot correctly to the Smb depot double and this results in
test failures in both tests:

```
    1) OpsController#build_uri_settings uses params[:log_password] for validation if one exists
       Failure/Error: raise _("Invalid or unsupported file depot type.") if type.nil?

       RuntimeError:
         Invalid or unsupported file depot type.
       # ./app/controllers/ops_controller/settings/schedules.rb:764:in `build_uri_settings'
       # ./spec/controllers/ops_controller/settings/schedules_spec.rb:96:in `block (3 levels) in <top (required)>'

    2) OpsController#build_uri_settings uses the stored password for validation if params[:log_password] does not exist
       Failure/Error: raise _("Invalid or unsupported file depot type.") if type.nil?

       RuntimeError:
         Invalid or unsupported file depot type.
       # ./app/controllers/ops_controller/settings/schedules.rb:764:in `build_uri_settings'
       # ./spec/controllers/ops_controller/settings/schedules_spec.rb:109:in `block (3 levels) in <top (required)>'
```
