### PR TITLE
Fix images padding in summary pages

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -49,7 +49,7 @@
 
   .cell {
     &.image {
-      margin: 20px 0;
+      margin: 0 10px 0 0;
 
       img {
         max-height: 80px;


### PR DESCRIPTION
Removed additional padding for images in summary pages

Before
<img width="1792" alt="Screenshot 2022-08-11 at 10 24 17 AM" src="https://user-images.githubusercontent.com/87487049/184067187-07148d4d-c867-49d0-942f-a61638261fd5.png">

After
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/87487049/184067233-a60c9135-443a-4a65-a54d-71be639e1d7c.png">

@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label enhancement
@miq-bot assign @Fryguy
