### PR TITLE
Fix rails 6.1 errors is now array warnings

### DIFF
--- a/app/controllers/application_controller/advanced_search.rb
+++ b/app/controllers/application_controller/advanced_search.rb
@@ -64,8 +64,8 @@ module ApplicationController::AdvancedSearch
         @edit[@expkey][:exp_token] = nil
         true
       else
-        s.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        s.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         false
       end

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -460,9 +460,9 @@ module ApplicationController::Buttons
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
       replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
     else
-      @custom_button.errors.each do |field, msg|
+      @custom_button.errors.each do |error|
         add_flash(_("Error during 'add': %{error_message}") %
-          {:error_message => @custom_button.errors.full_message(field, msg)}, :error)
+          {:error_message => @custom_button.errors.full_message(error.attribute, error.message)}, :error)
       end
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
@@ -508,9 +508,9 @@ module ApplicationController::Buttons
       build_filter_exp_table
       replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
     else
-      @custom_button.errors.each do |field, msg|
+      @custom_button.errors.each do |error|
         add_flash(_("Error during 'edit': %{field_name} %{error_message}") %
-          {:field_name => field.to_s.capitalize, :error_message => msg}, :error)
+          {:field_name => error.attribute.to_s.capitalize, :error_message => error.message}, :error)
       end
       @breadcrumbs = []
       drop_breadcrumb(:name => "Edit of Button", :url => "/miq_ae_customization/button_edit")

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -161,7 +161,7 @@ module ApplicationController::CiProcessing
         AuditEvent.success(audit)
         add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => model_name, :name => record_name})
       else
-        error_msg = element.errors.collect { |_attr, msg| msg }.join(';')
+        error_msg = element.errors.collect { |error| error.message }.join(';')
         add_flash(_("%{model} \"%{name}\": Error during delete: %{error_msg}") %
                  {:model => model_name, :name => record_name, :error_msg => error_msg}, :error)
       end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -467,8 +467,8 @@ class CatalogController < ApplicationController
           @edit = session[:edit] = @record = nil
           replace_right_cell(:replace_trees => trees_to_replace(%i[sandt svccat stcat]))
         else
-          @st.errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          @st.errors.each do |error|
+            add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
           end
           @changed = session[:changed] = (@edit[:new] != @edit[:current])
           javascript_flash
@@ -1005,8 +1005,8 @@ class CatalogController < ApplicationController
     if @edit[:wf] && need_prov_dialogs?(@edit[:new][:st_prov_type])
       request = @edit[:wf].make_request(@edit[:req_id], @edit[:new])
       if request && request&.errors.present?
-        request.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        request.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
       else
         validate_fields
@@ -1058,8 +1058,8 @@ class CatalogController < ApplicationController
       @edit = session[:edit] = @record = nil
       replace_right_cell(:replace_trees => trees_to_replace(%i[sandt svccat stcat]))
     else
-      st.errors.each do |field, msg|
-        add_flash("#{field.to_s.capitalize} #{msg}", :error)
+      st.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
       javascript_flash

--- a/app/controllers/chargeback_rate_controller.rb
+++ b/app/controllers/chargeback_rate_controller.rb
@@ -233,8 +233,8 @@ class ChargebackRateController < ApplicationController
       session[:changed] = @changed = false
       javascript_redirect(:action => @lastaction, :id => @rate[:id], :flash_msg => flash_msg)
     else
-      @rate.errors.each do |field, msg|
-        add_flash("#{field.to_s.capitalize} #{msg}", :error)
+      @rate.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
       @rate_details.each do |detail|
         display_detail_errors(detail, detail.errors)
@@ -407,7 +407,7 @@ class ChargebackRateController < ApplicationController
   end
 
   def display_detail_errors(detail, errors)
-    errors.each { |field, msg| add_flash("'#{detail.chargeable_field.description}' #{field.to_s.humanize.downcase} #{msg}", :error) }
+    errors.each { |error| add_flash("'#{detail.chargeable_field.description}' #{error.attribute.to_s.humanize.downcase} #{error.message}", :error) }
   end
 
   def add_row(i, pos, code_currency)

--- a/app/controllers/condition_controller.rb
+++ b/app/controllers/condition_controller.rb
@@ -104,8 +104,8 @@ class ConditionController < ApplicationController
           session[:changed] = @changed = false
           javascript_redirect(:action => params[:button] == "add" ? "show_list" : @lastaction, :id => params[:id], :flash_msg => flash_msg)
         else
-          condition.errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          condition.errors.each do |error|
+            add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
           end
           javascript_flash
         end

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -184,8 +184,8 @@ class HostController < ApplicationController
           nil
         else
           @errors.each { |msg| add_flash(msg, :error) }
-          @host.errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          @host.errors.each do |error|
+            add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
           end
           drop_breadcrumb(:name => _("Edit Host '%{name}'") % {:name => @host.name}, :url => "/host/edit/#{@host.id}")
           @in_a_form = true

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1402,8 +1402,8 @@ class MiqAeClassController < ApplicationController
       add_active_node_to_open_nodes
       replace_right_cell(:replace_trees => [:ae])
     else
-      add_ae_ns.errors.each do |field, msg|
-        add_flash("#{field.to_s.capitalize} #{msg}", :error)
+      add_ae_ns.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
       javascript_flash(:spinner_off => true)
     end
@@ -2855,8 +2855,8 @@ class MiqAeClassController < ApplicationController
   end
 
   def flash_validation_errors(am_obj)
-    am_obj.errors.each do |field, msg|
-      add_flash("#{field.to_s.capitalize} #{msg}", :error)
+    am_obj.errors.each do |error|
+      add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
     end
   end
 

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -250,8 +250,8 @@ module MiqAeCustomizationController::OldDialogs
       begin
         dialog.save!
       rescue StandardError
-        dialog.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        dialog.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @changed = true
         javascript_flash

--- a/app/controllers/miq_alert_controller.rb
+++ b/app/controllers/miq_alert_controller.rb
@@ -37,8 +37,8 @@ class MiqAlertController < ApplicationController
     alert_set_record_vars(alert)
 
     unless alert_valid_record?(alert) && alert.valid? && !@flash_array && alert.save
-      alert.errors.each do |field, msg|
-        add_flash("#{field.to_s.capitalize} #{msg}", :error)
+      alert.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
       javascript_flash
       return

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -43,8 +43,8 @@ module MiqPolicyController::Policies
     policy.expression = @edit[:new][:expression]["???"] ? nil : MiqExpression.new(@edit[:new][:expression])
 
     if !policy.valid? || @flash_array || !policy.save
-      policy.errors.each do |field, msg|
-        add_flash("#{field.to_s.capitalize} #{msg}", :error)
+      policy.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
       javascript_flash
       return
@@ -204,8 +204,8 @@ module MiqPolicyController::Policies
       @policy.conditions.collect { |pc| pc }.each { |c| @policy.conditions.delete(c) unless mems.key?(c.id) } # Remove any conditions no longer in members
       mems.each_key { |m| @policy.conditions.push(Condition.find(m)) unless @policy.conditions.collect(&:id).include?(m) } # Add any new conditions
       if !@policy.valid? || @flash_array || !@policy.save
-        @policy.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        @policy.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         javascript_flash
         return

--- a/app/controllers/mixins/manager_controller_mixin.rb
+++ b/app/controllers/mixins/manager_controller_mixin.rb
@@ -48,8 +48,8 @@ module Mixins
         end
         javascript_redirect(:action => @lastaction, :id => params[:id])
       else
-        @provider.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        @provider.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         render_flash
       end

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -379,8 +379,8 @@ module OpsController::OpsRbac
         if group.save
           AuditEvent.success(build_saved_audit(group, params[:button] == "add"))
         else
-          group.errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          group.errors.each do |error|
+            add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
           end
           err = true
         end
@@ -732,7 +732,7 @@ module OpsController::OpsRbac
     end
 
     @changed = session[:changed] = (@edit[:new] != @edit[:current])
-    record.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+    record.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
 
     render_flash
   end

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -294,8 +294,8 @@ module OpsController::Settings::AnalysisProfiles
             get_node_info(x_node)
             replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
           else
-            scanitemset.errors.each do |field, msg|
-              add_flash("#{_(field.to_s.capitalize)} #{msg}", :error)
+            scanitemset.errors.each do |error|
+              add_flash("#{_(error.attribute.to_s.capitalize)} #{error.message}", :error)
             end
             @edit[:new] = ap_sort_array(@edit[:new])
             @edit[:current] = ap_sort_array(@edit[:current])

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -339,8 +339,8 @@ module OpsController::Settings::LabelTagMapping
         page.replace_html('settings_label_tag_mapping', :partial => 'settings_label_tag_mapping_tab')
       end
     else
-      mapping.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
-      category.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      mapping.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
+      category.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
       javascript_flash
     end
   end

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -32,7 +32,7 @@ module OpsController::Settings::Tags
         page.replace_html('settings_co_categories', :partial => 'settings_co_categories_tab')
       end
     else
-      category.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      category.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
       javascript_flash
     end
   end
@@ -95,8 +95,8 @@ module OpsController::Settings::Tags
         begin
           update_category.save!
         rescue
-          update_category.errors.each do |field, msg|
-            add_flash("#{field.to_s.capitalize} #{msg}", :error)
+          update_category.errors.each do |error|
+            add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
           end
           @in_a_form = true
           session[:changed] = @changed
@@ -208,7 +208,7 @@ module OpsController::Settings::Tags
       end
     end
     unless entry.errors.empty?
-      entry.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      entry.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
       javascript_flash(:focus => 'entry_name')
       return
     end
@@ -247,7 +247,7 @@ module OpsController::Settings::Tags
         page.replace(:tab_div, :partial => "settings_co_tags_tab")
       end
     else
-      entry.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      entry.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
       javascript_flash(:focus => 'entry_name')
     end
   end

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -86,7 +86,7 @@ module OpsController::Settings::Upload
       rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
       else
-        imp.errors.each { |_field, msg| add_flash(msg, :error) }
+        imp.errors.each { |error| add_flash(error.message, :error) }
         add_flash(_("Import validation complete: %{good_record}, %{bad_record}") % {
           :good_record => n_("%{num} good record", "%{num} good records", imp.stats[:good]) % {:num => imp.stats[:good]},
           :bad_record  => n_("%{num} bad record", "%{num} bad records", imp.stats[:bad]) % {:num => imp.stats[:bad]}

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -20,7 +20,7 @@ module OpsController::Settings::Zones
       zone.destroy
     rescue => bang
       add_flash(bang.to_s, :error)
-      zone.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      zone.errors.each { |error| add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error) }
       self.x_node = "z-#{zone.id}"
       get_node_info(x_node)
     else

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -104,8 +104,8 @@ module PxeController::PxeServers
         get_node_info(x_node)
         replace_right_cell(:nodetype => x_node, :replace_trees => refresh_trees)
       else
-        update_img.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        update_img.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @in_a_form = true
         @changed = true
@@ -143,8 +143,8 @@ module PxeController::PxeServers
         get_node_info(x_node)
         replace_right_cell(:nodetype => x_node)
       else
-        update_wimg.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        update_wimg.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @in_a_form = true
         @changed = true

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -23,8 +23,8 @@ module ReportController::Dashboards
       if g.save
         AuditEvent.success(build_saved_audit(g, @edit))
       else
-        g.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        g.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         err = true
       end
@@ -152,8 +152,8 @@ module ReportController::Dashboards
         @edit = session[:edit] = nil # clean out the saved info
         replace_right_cell(:replace_trees => [:db])
       else
-        @dashboard.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        @dashboard.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @changed = session[:changed] = (@edit[:new] != @edit[:current])
         javascript_flash

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -253,8 +253,8 @@ module ReportController::Menus
         @in_a_form = false
         replace_right_cell(:replace_trees => [:reports])
       else
-        rec.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        rec.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @in_a_form = true
         session[:changed] = @changed

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -96,8 +96,8 @@ module ReportController::Reports::Editor
         end
         replace_right_cell(:replace_trees => [:reports])
       else
-        rpt.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        rpt.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @in_a_form = true
         session[:changed] = !!@changed
@@ -1641,8 +1641,8 @@ module ReportController::Reports::Editor
     end
 
     unless rpt.valid? # Check the model for errors
-      rpt.errors.each do |field, message|
-        add_flash("#{field.to_s.capitalize} #{message}", :error)
+      rpt.errors.each do |error|
+        add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
       end
     end
     @sb[:miq_tab] = active_tab if flash_errors?

--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -231,8 +231,8 @@ module ReportController::Schedules
         self.x_node = "msc-#{schedule.id}"
         replace_right_cell(:replace_trees => [:schedules])
       else
-        schedule.errors.each do |field, msg|
-          add_flash("#{field.to_s.capitalize} #{msg}", :error)
+        schedule.errors.each do |error|
+          add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
         end
         @changed = session[:changed] = (@edit[:new] != @edit[:current])
         drop_breadcrumb(:name => "Edit Schedule", :url => "/miq_schedule/edit")

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -85,8 +85,8 @@ module ReportController::Widgets
         # @schedule = nil
         replace_right_cell(:replace_trees => [:widgets])
       else
-        @widget.errors.each do |field, msg|
-          add_flash("#{_(field.to_s.capitalize)} #{msg}", :error)
+        @widget.errors.each do |error|
+          add_flash("#{_(error.attribute.to_s.capitalize)} #{error.message}", :error)
         end
         @changed = session[:changed] = (@edit[:new] != @edit[:current])
         javascript_flash


### PR DESCRIPTION
Fixes this warning in several places in the test suite:
```
  In Rails 6.1, `errors` is an array of Error objects,
  therefore it should be accessed by a block with a single block
  parameter like this:

  person.errors.each do |error|
    attribute = error.attribute
    message = error.message
  end

  You are passing a block expecting two parameters,
  so the old hash behavior is simulated. As this is deprecated,
  this will result in an ArgumentError in Rails 7.0.
```