### PR TITLE
Fix dashboard widget tables scaling

### DIFF
--- a/app/stylesheet/dashboard.scss
+++ b/app/stylesheet/dashboard.scss
@@ -30,6 +30,10 @@
         margin: 0;
         border: 0;
 
+        div[id^="dd_"] div:first-child {
+          overflow-y: auto;
+        }
+
         div.bx--cc--legend {
           height: auto !important;
         }


### PR DESCRIPTION
Issue - https://github.ibm.com/katamari/dev-issue-tracking/issues/33679

Fix for tables in the dashboard page when scaled.

Before
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/184296583-d0a52221-300f-41ef-9b7f-6d1292291e1e.png">

After
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/87487049/184296523-a5751666-9b19-46da-8a5f-a721882f8692.png">

@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label bug
@miq-bot assign @Fryguy