### PR TITLE
Rails 6.1: ActionView::Base new now has 3 required arguments

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -15,10 +15,11 @@ class StaticOrHaml
     return @rack_file.call(env) unless path.to_s.ends_with?('.haml')
 
     raw = File.read(path)
-    scope = ActionView::Base.new
-    scope.controller = ActionController::Base.new
-    scope.view_paths << File.expand_path("../app/views", __FILE__)
+    lookup_context = ActionView::LookupContext.new(File.expand_path("../app/views", __FILE__))
+    controller = ActionController::Base.new
 
+    # Rails 6.1 ActionView::Base now has 3 required arguments
+    scope = ActionView::Base.new(lookup_context, [], controller)
     scope.extend(ApplicationHelper)
 
     compiled = hamlit_compile(raw, scope)


### PR DESCRIPTION
Fixes this error on 6.1 jasmine specs: `TEST_SUITE=spec:javascript bundle exec rake`

```
  #<ArgumentError: wrong number of arguments (given 0, expected 3)>
  /Users/joerafaniello/.gem/ruby/2.7.5/gems/actionview-6.1.6.1/lib/action_view/base.rb:230:in `initialize'
  /Users/joerafaniello/Code/manageiq-ui-classic/spec/javascripts/support/jasmine_helper.rb:18:in `new'
  /Users/joerafaniello/Code/manageiq-ui-classic/spec/javascripts/support/jasmine_helper.rb:18:in `call'
  /Users/joerafaniello/.gem/ruby/2.7.5/gems/rack-2.2.4/lib/rack/urlmap.rb:74:in `block in call'
```

Note, this is a rails 6.1+ only change discovered by but not caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/8408.  This was broken with rails 6.1 but didn't get detected in cross repo.

I've added this to https://github.com/ManageIQ/manageiq/issues/21516#issuecomment-1212166941

Replaces https://github.com/ManageIQ/manageiq-ui-classic/pull/8410