### PR TITLE
Fixes Issue in validate Function Preventing Form Submission

### DIFF
--- a/app/javascript/components/host-initiator-form/index.jsx
+++ b/app/javascript/components/host-initiator-form/index.jsx
@@ -38,7 +38,7 @@ const HostInitiatorForm = ({ redirect, storageManagerId }) => {
 
   const validate = (values) => {
     const errors = {};
-    if ((!values.wwpn || !values.wwpn.length) && (!values.custom_wwpn || !values.custom_wwpn.length)) {
+    if ((!values.wwpn || !values.wwpn.length) && (!values.custom_wwpn || !values.custom_wwpn.length) && (values.port_type === 'FC' || values.port_type === 'NVMeFC')) {
       errors.wwpn = 'Please provide at least one WWPN.';
     }
     return errors;


### PR DESCRIPTION
Changes the `validate` function so that it no longer throws errors when a WWPN is not provided in cases where it shouldn't be (i.e. when Port Type is set to "ISCSI").

Before:
![image](https://user-images.githubusercontent.com/64800041/184925284-3265cf74-81ca-4050-a3b9-47a45e9fe2b5.png)

After:
![image](https://user-images.githubusercontent.com/64800041/184925354-094619ad-03e5-44b5-8dbe-1006634d0f6f.png)
