### PR TITLE
Pluralization of Table Items String

### DIFF
--- a/app/javascript/components/miq-pagination.jsx
+++ b/app/javascript/components/miq-pagination.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Pagination } from 'carbon-components-react';
 
-const getItemRangeText = (min, max, totalItems) => sprintf(__(`%d-%d of %d items`), min, max, totalItems);
+const getItemRangeText = (min, max, totalItems) => sprintf(n__(`%d-%d of %d item`, `%d-%d of %d items`, totalItems), min, max, totalItems);
 
 // eslint-disable-next-line no-undef
 const getPageRangeText = (_current, total) => sprintf(n__(`of %d page`, `of %d pages`, total), total);


### PR DESCRIPTION
Adding logic so that when there is only one item in a table it will be pluralized accordingly. 

## BEFORE

![Screen Shot 2022-08-16 at 1 18 48 PM](https://user-images.githubusercontent.com/29209973/184940005-5b34c220-2aac-4de3-81cf-b7039b4e3de1.png)

## AFTER 

![Screen Shot 2022-08-16 at 1 17 48 PM](https://user-images.githubusercontent.com/29209973/184939848-23650fe9-b310-4b32-a383-2ae58ed10e2b.png)

@miq-bot add-reviewer @DavidResende0 
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot assign @Fryguy 
@miq-bot add-label enhancement
@miq-bot add-label internationalization  