### PR TITLE
Fixes Component Overlapping in Service -> Catalog Form

### DIFF
--- a/app/stylesheet/ddf_override.scss
+++ b/app/stylesheet/ddf_override.scss
@@ -5,13 +5,12 @@
 }
 
 #dual-list-sub-form-catalog {
-  .bx--row--condensed {
-    svg {
-      height: 48px;
-    }
-  }
   #move-right, #move-all-right, #move-all-left, #move-left {
-    width: 130px;
+    svg {
+      position: unset;
+    }
+
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Modifies css to prevent the dual-list-select buttons from overlapping with the rest of the component

Before:
![image](https://user-images.githubusercontent.com/64800041/184949401-dbca0ed5-e09f-4f97-ab9f-bef5bb42ffa3.png)

After:
![image](https://user-images.githubusercontent.com/64800041/184948930-b46ac816-8cb6-451b-b2ae-21eadd9c3884.png)
