### PR TITLE
rename Vm Operation context

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -620,8 +620,7 @@ module ApplicationController::CiProcessing
   # Params:
   #   action      - a string indicating the operation user wants to execute
   # Returns:
-  #   symbol      - a feature implemented by using AvailabilityMixin or
-  #                 SupportsFeatureMixin
+  #   symbol      - a feature implemented by using SupportsFeatureMixin
   def action_to_feature(action)
     feature_aliases = {
       "scan"                   => :smartstate_analysis,


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/issues/21179

removing a comment reference to `AvailabilityMixin`