### PR TITLE
Modified Allowed Function to Include Provision Dialog Forms

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -290,7 +290,7 @@ class MiqAeCustomizationController < ApplicationController
 
   # allowed function is used to show form buttons in custom-button form page.
   def allowed(action)
-    allowed = ['ab_button_new', 'ab_button_edit']
+    allowed = ['ab_button_new', 'ab_button_edit', 'old_dialogs_new', 'old_dialogs_edit', 'old_dialogs_copy']
     action ? allowed.include?(action.to_s) : false
   end
 


### PR DESCRIPTION
Adds `old_dialogs_new`, `old_dialogs_edit`, and `old_dialogs_copy` to list of actions so that save/cancel/reset buttons appear in these forms.

Before:
![image](https://user-images.githubusercontent.com/64800041/185986131-7e4a539f-e1a5-4bc4-932b-89c9be559d8a.png)

After:
![image](https://user-images.githubusercontent.com/64800041/185985508-17f08004-1abe-4c5b-a2e8-ec0f859fe59e.png)

@miq-bot add-label bug, oparin/yes?
@miq-bot assign @Fryguy 
@miq-bot add-reviewer @MelsHyrule, @GilbertCherrie 