### PR TITLE
validate iqn and wwpn according to rules

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -109,7 +109,27 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
             component: componentTypes.TEXT_FIELD,
             label: __('IQN'),
             isRequired: true,
-            validate: [{ type: validatorTypes.REQUIRED }],
+            validate: [
+              {
+                type: validatorTypes.REQUIRED
+              },
+              {
+                type: "pattern",
+                pattern: "iqn\\.(\\d{4}-\\d{2})\\.([^:]+)(:)([^,:\\s']+)",
+                message: __('The IQN should have the format: iqn.yyyy-mm.naming-authority:unique name')
+              },
+              {
+                type: "pattern",
+                pattern: "^[a-z0-9:.-]*$",
+                message: __('The IQN should contain only lower-case letters (a to z), digits (0 to 9), hyphens (-), ' +
+                  'periods (.) or colons (:)')
+              },
+              {
+                type: "max-length",
+                threshold: 223,
+                message: __('The IQN should have up to 223 characters.')
+              }
+            ],
           },
         ],
         condition: {
@@ -206,7 +226,16 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
             component: componentTypes.TEXT_FIELD,
             label: __('Custom WWPN'),
             isRequired: true,
-            validate: [{ type: validatorTypes.REQUIRED }],
+            validate: [
+              {
+                type: validatorTypes.REQUIRED
+              },
+              {
+                type: "exact-length",
+                threshold: 16,
+                message: __('The length of the WWPN should be exactly 16 characters.')
+              }
+            ],
           },
         ],
         condition: {

--- a/app/javascript/components/host-initiator-form/index.jsx
+++ b/app/javascript/components/host-initiator-form/index.jsx
@@ -32,14 +32,21 @@ const HostInitiatorForm = ({ redirect, storageManagerId }) => {
   };
 
   const onCancel = () => {
-    const message = __('defining of host initiator was cancelled by the user');
+    const message = __('Creation of host initiator was cancelled by the user.');
     miqRedirectBack(message, 'success', redirect);
   };
 
   const validate = (values) => {
     const errors = {};
-    if ((!values.wwpn || !values.wwpn.length) && (!values.custom_wwpn || !values.custom_wwpn.length)) {
-      errors.wwpn = 'Please provide at least one WWPN.';
+    if (values.port_type == "ISCSI") {
+      if (!values.iqn || !values.iqn.length) {
+        errors.iqn = __('Please provide at least one IQN.');
+      }
+    }
+    if (values.port_type == "FC" || values.port_type == "NVMeFC") {
+      if ((!values.wwpn || !values.wwpn.length) && (!values.custom_wwpn || !values.custom_wwpn.length)) {
+        errors.wwpn = __('Please provide at least one WWPN.');
+      }
     }
     return errors;
   };


### PR DESCRIPTION
When creating a new host initiator, and choosing ISCSI port type, the add button wouldn't get enabled when entering a IQN.
And when choosing FC, adding a custom WWPN would enable the add button but it didn't have any validation.

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/50288766/186384909-5d7eca5c-dac0-4d28-89a5-7152a4f2b77b.png)

I added validation for both IQN and WWPN (which also fixes the bug that was at the beginning).

<img width="698" alt="Screen Shot 2022-08-23 at 15 39 56" src="https://user-images.githubusercontent.com/50288766/186164663-58ca0818-f3ca-4b13-8f02-47e0840e5f7f.png">

Wwpn is valid only when it has 16 characters.
Iqn is valid in a format like this: iqn.yyyy-mm.naming-authority:unique name, it only allows characters a-z, 0-9, '-', '.', ':' and with a 223 characters max length.
<img width="742" alt="Screen Shot 2022-08-28 at 16 49 08" src="https://user-images.githubusercontent.com/50288766/187077159-e23c67d6-199e-4b33-8e2e-2d021e715298.png">

