### PR TITLE
[WIP] Fixed reconfigure button

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -28,6 +28,8 @@ class ServiceController < ApplicationController
       service_retire
     when 'service_retire_now'
       service_retire_now
+    when 'service_reconfigure'
+      service_reconfigure
     end
   end
 
@@ -60,11 +62,15 @@ class ServiceController < ApplicationController
 
   def service_reconfigure
     service = Service.find_by(:id => params[:id])
-    service_template = service.service_template
+    service_template = ServiceTemplate.find_by(:id => service.service_template_id)
     resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
-
-    @right_cell_text = _("Reconfigure Service \"%{name}\"") % {:name => service.name}
     dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
+    @resource_action_id = resource_action.id
+    @target_id = service.id
+    @angular_form = true
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Reconfigure Service\"%{name}\"") % {:name => service.name})
+    javascript_redirect(:action => 'reconfigure_dialog', :id => checked_item_id)
   end
 
   def service_form_fields

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -60,15 +60,29 @@ class ServiceController < ApplicationController
     drop_breadcrumb(:name => _("Edit Service\"%{name}\"") % {:name => @service.name}, :url => "/service/edit/#{@service.id}")
   end
 
-  def service_reconfigure
+  def reconfigure_dialog
     service = Service.find_by(:id => params[:id])
     service_template = ServiceTemplate.find_by(:id => service.service_template_id)
-    resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
+    #resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
+    resource_action = service_template.resource_actions.first
     dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
     @resource_action_id = resource_action.id
     @target_id = service.id
     @angular_form = true
     @in_a_form = true
+    drop_breadcrumb(:name => _("Reconfigure Service\"%{name}\"") % {:name => service.name})
+  end
+
+  def service_reconfigure
+    service = Service.find_by(:id => params[:id])
+    # service_template = ServiceTemplate.find_by(:id => service.service_template_id)
+    # #resource_action = service_template.resource_actions.find_by(:action => 'Reconfigure') if service_template
+    # resource_action = service_template.resource_actions.first
+    # dialog_locals = {:resource_action_id => resource_action.id, :target_id => service.id}
+    # @resource_action_id = resource_action.id
+    # @target_id = service.id
+    # @angular_form = true
+    # @in_a_form = true
     drop_breadcrumb(:name => _("Reconfigure Service\"%{name}\"") % {:name => service.name})
     javascript_redirect(:action => 'reconfigure_dialog', :id => checked_item_id)
   end
@@ -210,6 +224,8 @@ class ServiceController < ApplicationController
       partial = "shared/dialogs/reconfigure_dialog"
       header = @right_cell_text
       action = nil
+      puts "params=====#{params.inspect}"
+      locals = params[:dialog_locals]
     when "service_edit"
       partial = "service_form"
       header = _("Editing Service \"%{name}\"") % {:name => @service.name}
@@ -221,6 +237,7 @@ class ServiceController < ApplicationController
     else
       action = nil
     end
+    locals ||= {}
     return partial, action, header
   end
 

--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -40,8 +40,8 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
                        'pficon pficon-edit fa-lg',
                        N_('Reconfigure the options of this Service'),
                        N_('Reconfigure this Service'),
-                       :klass   => ApplicationHelper::Button::GenericFeatureButton,
-                       :options => {:feature => :reconfigure}
+                       #:klass   => ApplicationHelper::Button::GenericFeatureButton,
+                       #:options => {:feature => :reconfigure}
                      ),
                    ]
                  ),

--- a/app/javascript/oldjs/controllers/dialog_user/dialog_user_reconfigure_controller.js
+++ b/app/javascript/oldjs/controllers/dialog_user/dialog_user_reconfigure_controller.js
@@ -13,8 +13,10 @@ ManageIQ.angular.app.controller('dialogUserReconfigureController', ['API', 'dial
   };
 
   function init(data) {
-    vm.dialogId = data.reconfigure_dialog[0].id;
-    vm.dialog = data.reconfigure_dialog[0];
+    if(data.reconfigure_dialog) {
+      vm.dialogId = data.reconfigure_dialog[0].id;
+      vm.dialog = data.reconfigure_dialog[0];
+    }
     vm.dialogLoaded = true;
   }
 

--- a/app/views/service/_reconfigure_form.html.haml
+++ b/app/views/service/_reconfigure_form.html.haml
@@ -1,0 +1,25 @@
+#main_div
+  .row.wrapper{"ng-controller" => "dialogUserReconfigureController as vm"}
+    .spinner{'ng-show' => "!vm.dialogLoaded"}
+
+    .col-md-12.col-lg-12{'ng-if' => 'vm.dialog'}
+      %dialog-user{"dialog" => "vm.dialog", "refresh-field" => "vm.refreshField(field)", "on-update" => "vm.setDialogData(data)", "reconfigure-mode" => true}
+
+      .clearfix
+      .pull-right.button-group{'ng-show' => "vm.dialogLoaded"}
+        %miq-button{:name      => t = _("Submit"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'vm.saveable()',
+                    'on-click' => "vm.submitButtonClicked()",
+                    :primary   => 'true'}
+        %miq-button{:name      => t = _("Cancel"),
+                    :title     => t,
+                    :alt       => t,
+                    :enabled   => 'true',
+                    'on-click' => "vm.cancelClicked($event)"}
+
+  :javascript
+    ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
+    ManageIQ.angular.app.value('targetId', '#{target_id}');
+    miq_bootstrap('.wrapper');

--- a/app/views/service/_reconfigure_form.html.haml
+++ b/app/views/service/_reconfigure_form.html.haml
@@ -1,3 +1,4 @@
+= resource_action_id
 #main_div
   .row.wrapper{"ng-controller" => "dialogUserReconfigureController as vm"}
     .spinner{'ng-show' => "!vm.dialogLoaded"}
@@ -20,6 +21,6 @@
                     'on-click' => "vm.cancelClicked($event)"}
 
   :javascript
-    ManageIQ.angular.app.value('resourceActionId', '#{resource_action_id}');
-    ManageIQ.angular.app.value('targetId', '#{target_id}');
+    ManageIQ.angular.app.value('resourceActionId', #{ resource_action_id });
+    ManageIQ.angular.app.value('targetId', #{ target_id });
     miq_bootstrap('.wrapper');

--- a/app/views/service/reconfigure_dialog.html.haml
+++ b/app/views/service/reconfigure_dialog.html.haml
@@ -1,0 +1,2 @@
+= render :partial => "service/reconfigure_form", :locals  => {:resource_action_id => @resource_action_id, :target_id => @target_id}
+= @resource_action_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2736,6 +2736,7 @@ Rails.application.routes.draw do
         show
         show_list
         edit
+        reconfigure_dialog
         ownership
         tagging_edit
       ),
@@ -2745,6 +2746,7 @@ Rails.application.routes.draw do
         quick_search
         reload
         edit
+        reconfigure_dialog
         show
         button
         show_list


### PR DESCRIPTION
The reconfigure service button functionality was unintentionally removed in this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/8229

<img width="1447" alt="Screen Shot 2022-08-29 at 5 00 34 PM" src="https://user-images.githubusercontent.com/32444791/187299532-41431f7c-c49a-4352-bff8-1da2f8cda318.png">

This PR is adding that button functionality back, however the reconfigure form is still broken and nothing renders on that page. I was thinking this should be fixed in a new PR or should just be fixed by converting this page to react all together.

<img width="1438" alt="Screen Shot 2022-08-29 at 5 00 11 PM" src="https://user-images.githubusercontent.com/32444791/187299606-3b29e748-a835-415e-9496-5eaa1eed7687.png">
