### PR TITLE
Fix main menu search error

### DIFF
--- a/app/javascript/menu/search-results.jsx
+++ b/app/javascript/menu/search-results.jsx
@@ -4,18 +4,21 @@ import PropTypes from 'prop-types';
 import { SideNavItems, SideNavMenuItem } from 'carbon-components-react/es/components/UIShell';
 import { itemId, linkProps } from './item-type';
 
-const ResultItem = ({ item, titles }) => (
-  <SideNavMenuItem id={itemId(item.id)} isActive={item.active} {...linkProps(item)}>
-    <p className="menu-search-title">
-      {titles[titles.length - 1]}
-    </p>
-    <p className="menu-search-parent">
-      {(titles.length > 1) && titles[0]}
-      {(titles.length > 2) && ' / '}
-      {(titles.length > 2) && titles[1]}
-    </p>
-  </SideNavMenuItem>
-);
+const ResultItem = ({ item, titles }) => {
+  const tLength = titles.length;
+  return (
+    <SideNavMenuItem id={itemId(item.id)} isActive={item.active} {...linkProps(item)}>
+      <p className="menu-search-title">
+        {titles[tLength - 1]}
+      </p>
+      <p className="menu-search-parent">
+        {(tLength > 1) && titles[0]}
+        {(tLength > 2) && ' / '}
+        {(tLength > 2) && titles[1]}
+      </p>
+    </SideNavMenuItem>
+  );
+};
 
 // can't use raw p as a descendant of items
 const Count = ({ length }) => <p>{sprintf(__('Results %s'), length)}</p>;
@@ -29,8 +32,8 @@ const SearchResults = ({ results }) => (
   <SideNavItems className="menu-results">
     <Count length={results.length} />
 
-    {results.map(({ item, titles }) => (
-      <ResultItem key={item.id} item={item} titles={titles} />
+    {results.map(({ item, titles }, index) => (
+      <ResultItem key={`${item.id}_${index.toString()}`} item={item} titles={titles} />
     ))}
   </SideNavItems>
 );
@@ -40,6 +43,14 @@ SearchResults.propTypes = {
     item: PropTypes.shape({}).isRequired,
     titles: PropTypes.arrayOf(PropTypes.string).isRequired,
   })).isRequired,
+};
+
+ResultItem.propTypes = {
+  item: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    active: PropTypes.bool.isRequired,
+  }).isRequired,
+  titles: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default SearchResults;


### PR DESCRIPTION
Navigation main menu search was returning the wrong number of results before.

**Search string: overview**
Before - 11
![image](https://user-images.githubusercontent.com/87487049/187610335-07105b65-8806-405a-bf0b-01aa8bacdb88.png)
After - 10
![image](https://user-images.githubusercontent.com/87487049/187610417-a5cf7ec1-f3b9-402f-a267-8e9dcf9549d7.png)

**Search string: about**
Before - 2
![image](https://user-images.githubusercontent.com/87487049/187610791-5932fc90-717b-49b2-a867-160c26bf3a93.png)
After - 1
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/87487049/187610888-b2043bcb-6765-4859-949b-690673298f7f.png">

**Search string: physical**
Before - 9
![image](https://user-images.githubusercontent.com/87487049/187611106-05570d8f-f8cc-474e-85c3-e78a9be71244.png)
After - 8
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/187611284-c9af7a8b-cc29-44a5-be90-282e511ea3d9.png">

**Search string: storage**
Before - 17
![image](https://user-images.githubusercontent.com/87487049/187611463-fe9ff8d9-2c62-4a18-b8b2-8012139c264f.png)
After - 13
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/87487049/187611650-cb26dc02-839b-43b0-bf68-7064f7d40dd1.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-label bug
@miq-bot assign @Fryguy