### PR TITLE
`componentClass` prop in `PasswordField` caused an error

### DIFF
--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -12,7 +12,7 @@ const PasswordField = ({
   helperText,
   edit,
   parent,
-  componentClass,
+  componentclass,
   ...rest
 }) => {
   const formOptions = useFormApi();
@@ -24,8 +24,8 @@ const PasswordField = ({
     validateOnMount: rest.validateOnMount,
     helperText,
     ...rest,
-    component: edit ? 'edit-password-field' : componentClass,
-    componentClass,
+    component: edit ? 'edit-password-field' : componentclass,
+    componentclass,
   };
 
   const newProps = { ...secretField };
@@ -88,7 +88,7 @@ PasswordField.propTypes = {
   helperText: PropTypes.string,
   edit: PropTypes.bool,
   parent: PropTypes.string,
-  componentClass: PropTypes.string,
+  componentclass: PropTypes.string,
 };
 
 PasswordField.defaultProps = {
@@ -97,7 +97,7 @@ PasswordField.defaultProps = {
   helperText: undefined,
   edit: false,
   parent: undefined,
-  componentClass: componentTypes.TEXT_FIELD,
+  componentclass: componentTypes.TEXT_FIELD,
 };
 
 export default PasswordField;

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -4,7 +4,7 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  componentClass="text-field"
+  componentclass="text-field"
   edit={true}
   name="foo"
 >
@@ -154,21 +154,21 @@ exports[`Secret switch field component should render correctly in non edit mode 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  componentClass="text-field"
+  componentclass="text-field"
   edit={false}
   name="foo"
 >
   <MockDummyComponent
     autoComplete="new-password"
     component="text-field"
-    componentClass="text-field"
+    componentclass="text-field"
     name="foo"
     type="password"
   >
     <button
       autoComplete="new-password"
       component="text-field"
-      componentClass="text-field"
+      componentclass="text-field"
       name="foo"
       type="button"
     >


### PR DESCRIPTION
`componentClass` prop in `PasswordField` caused an error, since React didn't expect this DOM element attribute to be `camelCase`, but rather lowercase (`componentclass`).

before:
![2f40fa3c-3240-4c95-8400-0127f30029b1](https://user-images.githubusercontent.com/106743023/187935533-b73c719d-90c3-42f4-ad20-f31a80a95047.png)

![9484c458-4d03-4ab8-af57-1a1a4572b613](https://user-images.githubusercontent.com/106743023/187935365-5daf437e-f364-4bf0-a2b1-c465d99755fe.png)

after - no error:
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/106743023/187936107-1216b72e-e281-4a76-a299-cfbf4ff4a93d.png">
