### PR TITLE
Generalize cloud network factories

### DIFF
--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -93,7 +93,7 @@ describe CloudSubnetController do
       }
     end
     let(:cloud_tenant) { FactoryBot.create(:cloud_tenant) }
-    let(:cloud_network) { FactoryBot.create(:cloud_network_openstack) }
+    let(:cloud_network) { FactoryBot.create(:cloud_network) }
     let(:queue_options) do
       {
         :class_name  => ems.class.name,


### PR DESCRIPTION
- part of the effort to move provider-specific code out of core repositories

@miq-bot add_labels refactoring, test
@miq-bot assign @agrare 