### PR TITLE
Fixed Various UI Issues Related to the Provider Dashboard Charts

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/charts_config.js
+++ b/app/javascript/components/provider-dashboard-charts/charts_config.js
@@ -107,6 +107,9 @@ export const chartConfig = {
     units: __('KBps'),
     dataName: __('KBps'),
     tooltipFn: hourlyTimeTooltip,
+    size: { height: '150px' },
+    createdLabel: __('Network'),
+    valueType: 'actual',
   },
   dailyPodUsageConfig: {
     chartId: 'podUsageDailyChart',

--- a/app/javascript/components/provider-dashboard-charts/pod-trend-charts/podsAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/pod-trend-charts/podsAreaChart.js
@@ -46,7 +46,7 @@ const PodsAreaChart = ({
   const areaData = getPodsData(usageData.xy_data, config.createdLabel, config.deletedLabel);
 
   return (
-    <div>
+    <div className='pods_area_chart_section'>
       { (config.valueType === 'actual') && (
         <span>
           <span className="trend-title-big-pf">

--- a/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationDonutChart.js
+++ b/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationDonutChart.js
@@ -76,7 +76,7 @@ const UtilizationDonutChart = ({ data, config }) => {
   const areaChartData = getConvertedData(cpuData, config.units);
 
   return (
-    <div>
+    <div className="utilization-cpu-chart-pf">
       <div className="utilization-trend-chart-pf">
         <h3>{config.title}</h3>
         <div className="current-values">

--- a/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationMemoryDonutChart.js
+++ b/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationMemoryDonutChart.js
@@ -76,7 +76,7 @@ const UtilizationMemoryDonutChart = ({ data, config }) => {
   const areaChartData = getConvertedData(memoryData, config.units);
 
   return (
-    <div>
+    <div className="utilization-memory-chart-pf">
       <div className="utilization-trend-chart-pf">
         <h3>{config.title}</h3>
         <div className="current-values">

--- a/app/javascript/components/provider-dashboard-charts/recent-host-chart/hostLineChart.js
+++ b/app/javascript/components/provider-dashboard-charts/recent-host-chart/hostLineChart.js
@@ -47,7 +47,7 @@ const HostLineChart = ({ data, config }) => {
   const lineData = getConvertedData(data, config.units);
 
   return (
-    <div>
+    <div className='host_line_charts_section'>
       {data.dataAvailable ? <LineChart data={lineData} options={areaOptions} /> : <EmptyChart />}
       <span className={`trend-footer-pf ${!data.dataAvailable ? 'chart-transparent-text' : ''}`}>{config.legendLeftText}</span>
     </div>

--- a/app/javascript/components/provider-dashboard-charts/recent-vm-chart/vmAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/recent-vm-chart/vmAreaChart.js
@@ -43,7 +43,7 @@ const VmAreaChart = ({
 
   const areaData = getConvertedData(usageData, config.units);
   return (
-    <div>
+    <div className='vm_area_charts_section'>
       {usageData.dataAvailable ? <AreaChart data={areaData} options={areaOptions} /> : <EmptyChart />}
       <span className={`trend-footer-pf ${!usageData.dataAvailable ? 'chart-transparent-text' : ''}`}>{config.legendLeftText}</span>
     </div>

--- a/app/javascript/components/provider-dashboard-charts/servers-pie-chart/serversAvailablePieChart.js
+++ b/app/javascript/components/provider-dashboard-charts/servers-pie-chart/serversAvailablePieChart.js
@@ -30,7 +30,7 @@ const ServersAvailablePieChart = ({ data, config }) => {
   };
 
   return (
-    <div>
+    <div className='servers_available_pie_chart_section'>
       <div className="utilization-trend-chart-pf">
         <h3>{config.title}</h3>
         <div className="current-values" />

--- a/app/javascript/components/provider-dashboard-charts/servers-pie-chart/serversHealthPieChart.js
+++ b/app/javascript/components/provider-dashboard-charts/servers-pie-chart/serversHealthPieChart.js
@@ -38,7 +38,7 @@ const ServersHealthPieChart = ({ data, config }) => {
   };
 
   return (
-    <div>
+    <div className='servers_health_pie_chart_section'>
       <div className="utilization-trend-chart-pf">
         <h3>{config.title}</h3>
         <div className="current-values" />

--- a/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/usageAreaChart.js
+++ b/app/javascript/components/provider-dashboard-charts/usage-network-image-charts/usageAreaChart.js
@@ -50,7 +50,7 @@ const UsageAreaChart = ({
   const areaData = getConvertedData(usageData.xy_data, config.createdLabel);
 
   return (
-    <div>
+    <div className='usage_area_charts_section'>
       { (config.valueType === 'actual') && (
         <span>
           <span className="trend-title-big-pf">

--- a/app/stylesheet/charts.scss
+++ b/app/stylesheet/charts.scss
@@ -77,13 +77,18 @@
 
   .heat-chart-pf {
     margin-bottom: 50px;
-    width: 300px;
+    width: 50%;
+
+    .chart-holder.bx--chart-holder {
+      width: 100% !important;
+    }
   }
 }
 
 .heatmap_charts_section {
   display: inline-flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .empty-chart-contents {
@@ -103,61 +108,32 @@
 }
 
 .card-pf-utilization {
-  display: flex;
-  flex-direction: column;
-  margin: 0;
-  border: 0;
-  padding: 0;
-  border: 1px solid $selected-ui;
+  .chart-holder.bx--chart-holder {
+    margin-bottom: 40px;
+  }
 
-  .card-pf-heading {
-    border: 0;
-    margin: 0;
-    padding: 0 20px 0;
-
-    .card-pf-title {
-      font-weight: 300;
+  .utilization-cpu-chart-pf, .servers_available_pie_chart_section {
+    .trend-footer-pf {
+      border-right: 0.5px solid #d1d1d1;
     }
   }
 
-  .card-pf-body {
-    padding: 0;
-    margin: 0;
-
-    .bx--cc--chart-wrapper {
-      .layout-child {
-        &.spacer {
-          margin-top: 0;
-        }
-
-        &.legend {
-          margin-top: 5px;
-        }
-      }
-
-      &:last-child {
-        display: flex;
-        flex-direction: column-reverse;
-        height: 113px;
-        width: 100%;
-      }
+  .utilization-memory-chart-pf, .servers_health_pie_chart_section {
+    .trend-footer-pf {
+      border-left: 0.5px solid #d1d1d1;
     }
-  }
-
-  .card-pf-body > *:last-child {
-    margin-bottom: 0;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
   }
 
   .trend-footer-pf {
-    font-size: 12px;
     border-top: 1px solid $selected-ui;
+    border-bottom: 1px solid #d1d1d1;
+    margin: 0 -20px -20px;
+    padding: 20px;
+    padding-bottom: 21px;
+    font-size: 12px;
     font-weight: 400;
     color: #333;
-    padding: 20px;
     background: #fafafa;
-    margin: 0;
+    display: block;
   }
 }

--- a/app/stylesheet/cloud-container-projects-dashboard.scss
+++ b/app/stylesheet/cloud-container-projects-dashboard.scss
@@ -63,8 +63,9 @@
   }
 
   #pods-area-chart {
-    margin-left: -25px;
-    width: 95%;
+    .layout-child.graph-frame {
+      text-align: justify;
+    }
   }
 
   #pods-table {
@@ -84,7 +85,17 @@
   }
 
   .trend-footer-pf {
-    margin-left: -500px;
+    display: block;
+    text-align: initial;
+    border-top: 1px solid #e0e0e0;
+    border-bottom: 1px solid #d1d1d1;
+    margin: 20px -10px -10px;
+    padding: 20px;
+    padding-bottom: 21px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #333;
+    background: #fafafa;
   }
 
   .card-title {
@@ -99,7 +110,7 @@
 
   .card-text {
     text-align: left;
-    margin-left: -500px;
+    margin-left: -69%;
     display: inline-table;
     width: 200px;
     font-size: 36px;

--- a/app/views/ems_infra/_show_dashboard.html.haml
+++ b/app/views/ems_infra/_show_dashboard.html.haml
@@ -13,7 +13,7 @@
     .col-xs-12.col-sm-12.col-md-6
       = react('RecentHostGraph', :providerId => @record.id.to_s)
     .col-xs-12.col-sm-12.col-md-6
-      = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent VMs'), :config => 'recentVmsConfig',
+      = react('RecentVmGraph', :providerId => @record.id.to_s, :title => _('Recent VMs and Templates'), :config => 'recentVmsConfig',
        :apiUrl => 'ems_infra_dashboard/recent_vms_data', :dataPoint => 'recentResources')
 
   :javascript


### PR DESCRIPTION
This pr mainly fixes three different issues related to the provider dashboard pages (cloud, containers, infrastructure, and physical infrastructure) as well as one issue related to the containers -> projects page:

**Issue 1: "Recent VMs" chart displays both recent vms and recent templates, so chart title was changed to "Recent VMs and Templates"**
<img src="https://user-images.githubusercontent.com/64800041/188725831-9a53a89e-a47b-473b-96ef-f350072be45e.png" width="400">

**Issue 2: Provider dashboard charts not being displayed correctly (found in all provider dashboards)**
Before:
![image](https://user-images.githubusercontent.com/64800041/188727048-080c36fa-fdc2-472a-a94e-f6ecf147fe21.png)
After:
![image](https://user-images.githubusercontent.com/64800041/188725592-0721f9b8-4966-4cd9-82d1-9b6793b7f79c.png)

**Issue 3: "Hourly Node Utilization Trend" chart not displaying in Containers -> Provider Dashboard**
Before:
![image](https://user-images.githubusercontent.com/64800041/188727166-c526607e-806c-470e-89ff-ccb52baf59a1.png)
After:
![image](https://user-images.githubusercontent.com/64800041/188727468-e4d7db0c-5809-4696-a7e6-2c126d8cbf5a.png)

**Issue 4: Fixed UI issues in Containers -> Projects page and updated "Pod Creation and Deletion Trends" Chart to match other Provider dashboard charts**
Before:
![image](https://user-images.githubusercontent.com/64800041/188728390-be0f27e4-5a69-4780-8600-9197b53623ac.png)
After:
![image](https://user-images.githubusercontent.com/64800041/188728620-f3f8814c-4b11-490e-b1a6-554d531e3c61.png)

@miq-bot add-label bug, oparin/yes?
@miq-bot assign @Fryguy
@miq-bot add-reviewer @MelsHyrule, @jeffibm