### PR TITLE
Fix dashboard widget legend items visibility

### DIFF
--- a/app/javascript/components/dashboard-widgets/widget-report/index.jsx
+++ b/app/javascript/components/dashboard-widgets/widget-report/index.jsx
@@ -6,7 +6,7 @@ const WidgetReport = ({ widgetModel }) => {
   let widget;
   if (widgetModel) {
     // eslint-disable-next-line react/no-danger
-    widget = (<div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(widgetModel) }} />);
+    widget = (<div className="widget-report" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(widgetModel) }} />);
   } else {
     widget = (
       <h1 id="empty-widget">

--- a/app/stylesheet/dashboard.scss
+++ b/app/stylesheet/dashboard.scss
@@ -30,7 +30,7 @@
         margin: 0;
         border: 0;
 
-        div[id^="dd_"] div:first-child {
+        div[id^="dd_"] div.widget-report {
           overflow-y: auto;
         }
 


### PR DESCRIPTION
Before
Some of the chart legend items do not fit in the widget frames.
<img width="766" alt="image" src="https://user-images.githubusercontent.com/87487049/189332800-d081e406-3620-4c9e-ad33-9368ed2f9e96.png">

After
<img width="760" alt="image" src="https://user-images.githubusercontent.com/87487049/189332550-5e1345cf-5a46-423b-b78d-f1178b1d9031.png">

Fixes for - https://github.ibm.com/katamari/dev-issue-tracking/issues/36853

@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-label bug
@miq-bot assign @Fryguy 
