### PR TITLE
Move application settings link upwards in sub menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -233,9 +233,9 @@ module Menu
       def settings_menu_section
         Menu::Section.new(:set, N_("Settings"), 'carbon--Settings', [
           Menu::Item.new('configuration', N_('My Settings'), 'my_settings', {:feature => 'my_settings', :any => true}, '/configuration/index'),
+          Menu::Item.new('ops_explorer', N_('Application Settings'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer'),
           Menu::Item.new('my_tasks', N_('Tasks'), 'tasks', {:feature => 'tasks', :any => true}, '/miq_task/index?jobs_tab=tasks'),
           help_documentation,
-          Menu::Item.new('ops_explorer', N_('Application Settings'), 'ops_explorer', {:feature => 'ops_explorer', :any => true}, '/ops/explorer'),
           help_product,
           help_about,
         ])


### PR DESCRIPTION
When the `Application Settings` was moved from the header to the left nav, few users are missing the link and expecting it higher in the list.

Fixes for - https://github.ibm.com/katamari/dev-issue-tracking/issues/24855

Before
<img width="510" alt="image" src="https://user-images.githubusercontent.com/87487049/189335171-1a3c9e7c-ad7b-490f-8211-ded7617fa570.png">

After
<img width="513" alt="image" src="https://user-images.githubusercontent.com/87487049/189335011-4dfc8a1f-29ea-4f18-8968-1ea318ae6ec8.png">


@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-reviewer @DavidResende0
@miq-bot add-reviewer @MelsHyrule
@miq-bot add-label bug
@miq-bot assign @Fryguy 