### PR TITLE
Deleted Reports Still Counting as Being Selected in Saved Reports

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1006,6 +1006,7 @@ class ApplicationController < ActionController::Base
   def process_saved_reports(saved_reports, task)
     success_count = 0
     failure_count = 0
+    params[:miq_grid_checks] = params[:miq_grid_checks].split(",")
     MiqReportResult.for_user(current_user).where(:id => saved_reports).order(MiqReportResult.arel_table[:name].lower).each do |rep|
       rep.public_send(task) if rep.respond_to?(task) # Run the task
     rescue StandardError
@@ -1019,6 +1020,7 @@ class ApplicationController < ActionController::Base
           :target_class => "MiqReportResult",
           :userid       => current_userid
         )
+        params[:miq_grid_checks].delete(rep[:id].to_s)
         success_count += 1
       else
         add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => rep.name, :task => task})
@@ -1032,6 +1034,7 @@ class ApplicationController < ActionController::Base
       add_flash(n_("Error during Saved Report delete from the %{product} Database",
                    "Error during Saved Reports delete from the %{product} Database", failure_count) % {:product => Vmdb::Appliance.PRODUCT_NAME})
     end
+    params[:miq_grid_checks] || []
   end
 
   # Common timeprofiles button handler routines

--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -125,7 +125,7 @@ module ReportController::SavedReports
       @report = nil
       r = MiqReportResult.for_user(current_user).find(savedreports[0])
       @sb[:miq_report_id] = r.miq_report_id
-      process_saved_reports(savedreports, "destroy") unless savedreports.empty?
+      params[:miq_grid_checks] = process_saved_reports(savedreports, "destroy") unless savedreports.empty?
       add_flash(_("The selected Saved Report was deleted")) if @flash_array.nil?
       @report_deleted = true
     end


### PR DESCRIPTION
Ensures that Saved Reports that get deleted are removed from `params[:miq_grid_checks]` in order to prevent an error if the user decides to delete more reports (attempts to delete the already deleted reports alongside newly selected reports)

![image](https://user-images.githubusercontent.com/64800041/189436841-6e1b4789-b734-4ec7-b734-53c0ec6078b2.png)

@miq-bot add-reviewer @jeffibm
@miq-bot add-reviewer @MelsHyrule
@miq-bot add-label bug, oparin/yes?
@miq-bot assign @Fryguy