### PR TITLE
Fix missing selected items during compare

### DIFF
--- a/spec/controllers/application_controller/compare_spec.rb
+++ b/spec/controllers/application_controller/compare_spec.rb
@@ -226,7 +226,7 @@ describe EmsClusterController do
 
     it "sets session[:selected_sections] to empty array when last section on screen is unchecked" do
       session[:selected_sections] = [:_model_]
-      controller.params = {:id => "xx-group_Properties_xx-group_Properties%253A_model_", :check => "false"}
+      controller.params = {:all_checked => ["xx-group_Properties_xx-group_Properties:_model_"], :id => "xx-group_Properties_xx-group_Properties%3A_model_", :check => "false"}
       allow(controller).to receive(:render)
       controller.send(:sections_field_changed)
       expect(session[:selected_sections]).to eq([])
@@ -234,7 +234,7 @@ describe EmsClusterController do
 
     it "sets selected sections in session[:selected_sections]" do
       session[:selected_sections] = [:_model_]
-      controller.params = {:all_checked => ["xx-group_Properties_xx-group_Properties:_model_", "xx-group_Properties_xx-group_Properties:hardware"], :id => "xx-group_Properties_xx-group_Properties%253Ahardware", :check => "true"}
+      controller.params = {:all_checked => ["xx-group_Properties_xx-group_Properties:_model_", "xx-group_Properties_xx-group_Properties:hardware"], :id => "xx-group_Properties_xx-group_Properties%3Ahardware", :check => "true"}
       allow(controller).to receive(:render)
       controller.send(:sections_field_changed)
       expect(session[:selected_sections]).to eq(["_model_", "hardware"])


### PR DESCRIPTION
Issue- https://github.ibm.com/katamari/dev-issue-tracking/issues/33921

**1.** The Compare selected VMs button does not process the last selected item from the tree.
Before
![image](https://user-images.githubusercontent.com/87487049/190327606-eba96219-623d-4c91-9451-b1151112ad11.png)
After
No fixes were made here in this PR as this issue was fixed when the page was converted to react data table
![image](https://user-images.githubusercontent.com/87487049/190327826-47984a8a-e644-4ec0-a1f0-342c3aae75d0.png)

**2.** The last item from the tree was not getting selected for comparison
Before
![image](https://user-images.githubusercontent.com/87487049/190329146-f114173b-78e8-4731-9772-cb10f7ecedbf.png)
After
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/87487049/190329685-18793718-ca84-436a-810d-7f6b7cabe4d9.png">

@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-reviewer @MelsHyrule
@miq-bot add-reviewer @DavidResende0
@miq-bot add-label bug
@miq-bot assign @Fryguy