### PR TITLE
Fixed No Route Matches Error in Services Requests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -353,7 +353,7 @@ module ApplicationHelper
     when "ActionSet"
       controller = "miq_action"
       action = "show_set"
-    when "AutomationRequest"
+    when "AutomationRequest", "MiqProvision"
       controller = "miq_request"
       action = "show"
     when "ConditionSet"


### PR DESCRIPTION
Added `MiqProvision` to the `db_to_controller` function to prevent a no matching routes error when viewing the provisioned vms from a Request

Before: 
![image](https://user-images.githubusercontent.com/64800041/191060270-72cbf405-29ba-477d-842f-c7d8232e4f69.png)

After: 
![image](https://user-images.githubusercontent.com/64800041/191060401-f08593b6-fdf4-4f3d-9df6-1cfecf0adb2b.png)

@miq-bot add-reviewer @MelsHyrule, @jeffibm
@miq-bot add-label bug
@miq-bot assign @Fryguy