### PR TITLE
Remove needless string interpolation

### DIFF
--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -99,7 +99,7 @@ class EmsStorageDashboardService < EmsDashboardService
   def agg_events
     event_hash = {}
     event_list = []
-    events = EmsEvent.where("ems_id=#{@ems_id}")
+    events = EmsEvent.where(:ems_id => @ems_id)
 
     events.each do |event|
       unless event_hash[event.physical_storage_name]


### PR DESCRIPTION
It was added in a just merged PR:
https://github.com/ManageIQ/manageiq-ui-classic/pull/8429

There is no need for interpolation here.

Fixes a brakeman warning:

https://github.com/ManageIQ/manageiq/actions/runs/3091508041/jobs/5001665151#step:8:8013

```
Confidence: Medium
Category: SQL Injection
Check: SQL
Message: Possible SQL injection
Code: EmsEvent.where("ems_id=#{@ems_id}")
File: ../../.gem/ruby/2.7.6/bundler/gems/manageiq-ui-classic-dd7330eae02e/app/services/ems_storage_dashboard_service.rb
Line: 102
```