### PR TITLE
Gal/311498 visualize events to physical storage page  

### DIFF
--- a/app/javascript/components/carbon-charts/stackBarChart.js
+++ b/app/javascript/components/carbon-charts/stackBarChart.js
@@ -24,7 +24,7 @@ const StackBarChartGraph = ({ data, title, chart_options=null }) => {
   };
 
   return (
-    <StackedBarChart data={data} options={chart_options? chart_options : options} />
+    <StackedBarChart data={data} options={chart_options ? chart_options : options} />
   );
 };
 


### PR DESCRIPTION
related to PR #8429

This PR is about the new widget added to the storage system manager page , that shows the event on a graph (per storage system) that show the distribution between fix and unfixed event.



![](https://user-images.githubusercontent.com/74841666/187501530-73fca2a0-c4ca-49b1-b3eb-c4c552b920a8.png)
