### PR TITLE
Convert catalog summary request-info tabs from HAML to react

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -78,7 +78,7 @@ module CatalogHelper
   def catalog_tab_content(key_name, &block)
     if catalog_tabs_types[key_name]
       class_name = key_name == :basic ? 'tab_content active' : 'tab_content'
-      content_tag(:div, :id => "tab_#{key_name}", :class => class_name, &block)
+      content_tag(:div, :id => key_name, :class => class_name, &block)
     end
   end
 

--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -1,4 +1,11 @@
 module RequestInfoHelper
+  def provision_tab_configuration(workflow)
+    prov_tab_labels = workflow.provisioning_tab_list.map do |dialog|
+      {:name => dialog[:name], :text => dialog[:description]}
+    end
+    return prov_tab_labels, workflow.get_dialog_order
+  end
+
   def prov_grid_data(edit, vms, vm)
     none_index = '__VM__NONE__'
     rows = []

--- a/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
+++ b/app/javascript/spec/miq-custom-tab/__snapshots__/miq-custom-tab.spec.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MiqCustomTab component should render tabs for catalog summery page 1`] = `
+<Tabs
+  className="miq_custom_tabs"
+  id="catalog_summary_static"
+  scrollDebounceWait={150}
+  scrollIntoView={true}
+  selected={0}
+  selectionMode="automatic"
+  type="default"
+>
+  <Tab
+    key="tabbasic"
+    label={"Basic Information"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabdetail"
+    label={"Details"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabresource"
+    label={"Selected Resources"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+</Tabs>
+`;
+
+exports[`MiqCustomTab component should render tabs for request info page under catalog summary page 1`] = `
+<Tabs
+  className="miq_custom_tabs"
+  id="catalog_request_info_dynamic"
+  scrollDebounceWait={150}
+  scrollIntoView={true}
+  selected={0}
+  selectionMode="automatic"
+  type="default"
+>
+  <Tab
+    key="tabrequester"
+    label={"Requester"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabpurpose"
+    label={"Purpose"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabservice"
+    label={"Catalog"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabenvironment"
+    label={"Environment"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabhardware"
+    label={"Properties"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabcustomize"
+    label={"Customize"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+  <Tab
+    key="tabschedule"
+    label={"Schedule"}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    selected={false}
+  />
+</Tabs>
+`;

--- a/app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js
+++ b/app/javascript/spec/miq-custom-tab/miq-custom-tab.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { shallow } from 'enzyme';
+import MiqCustomTab from '../../components/miq-custom-tab';
+
+describe('MiqCustomTab component', () => {
+  it('should render tabs for catalog summery page', () => {
+    const tabLabels = [
+      { name: 'basic', text: _('Basic Information') },
+      { name: 'detail', text: _('Details') },
+      { name: 'resource', text: _('Selected Resources') },
+    ];
+    const wrapper = shallow(<MiqCustomTab
+      containerId="catalog-tabs"
+      tabLabels={tabLabels}
+      type="CATALOG_SUMMARY"
+    />);
+    expect(wrapper.find('#catalog_summary_static')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render tabs for request info page under catalog summary page', () => {
+    const tabLabels = [
+      { name: 'requester', text: _('Requester') },
+      { name: 'purpose', text: _('Purpose') },
+      { name: 'service', text: _('Catalog') },
+      { name: 'environment', text: _('Environment') },
+      { name: 'hardware', text: _('Properties') },
+      { name: 'customize', text: _('Customize') },
+      { name: 'schedule', text: _('Schedule') },
+    ];
+    const wrapper = shallow(<MiqCustomTab
+      containerId="request-info-tabs"
+      tabLabels={tabLabels}
+      type="CATALOG_REQUEST_INFO"
+    />);
+    expect(wrapper.find('#catalog_request_info_dynamic')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/app/stylesheet/application-webpack.scss
+++ b/app/stylesheet/application-webpack.scss
@@ -8,7 +8,7 @@
 @import './breadcrumbs.scss';
 @import './button-forms.scss';
 @import './carbon.scss';
-@import './catalog-custom-image.scss';
+@import './catalog-custom-component.scss';
 @import './charts.scss';
 @import './dashboard.scss';
 @import './data-table.scss';

--- a/app/stylesheet/catalog-custom-component.scss
+++ b/app/stylesheet/catalog-custom-component.scss
@@ -1,11 +1,12 @@
-.catalog-custom-image-wrapper {
+.catalog-custom-component-wrapper {
   padding-left: 15px;
   border-top: 1px solid lightgray;
 
-  .custom-image-title {
+  .custom-component-title {
     font-size: 0.875rem;
     font-weight: 400;
-    padding-bottom: 5px;
+    padding: 0.770rem 0;
+    margin: 0;
   }
 
   .custom-image-wrapper {

--- a/app/views/catalog/_sandt_tree_custom_image_form.html.haml
+++ b/app/views/catalog/_sandt_tree_custom_image_form.html.haml
@@ -1,5 +1,5 @@
-.catalog-custom-image-wrapper
-  %h3.custom-image-title
+.catalog-custom-component-wrapper
+  %h3.custom-component-title
     = _('Custom Image') # This partial file can be removed once API is ready
   .form-horizontal
     - if record.picture

--- a/app/views/catalog/_sandt_tree_request.html.haml
+++ b/app/views/catalog/_sandt_tree_request.html.haml
@@ -1,6 +1,7 @@
 - if options && options[:wf]
-  %h3
-    = _('Request Info')
+  .catalog-custom-component-wrapper
+    %h3.custom-component-title
+      = _('Request Info')
     = render :partial => "miq_request/prov_wf", :locals => {:wf => options[:wf], :show => true}
 - else
   %span{:style => "color:red"}= no_wf_msg

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -2,10 +2,11 @@
 - record, sb, tenants_tree, options, no_wf_msg = @record, @sb, @tenants_tree, @options, @no_wf_msg
 - tab_labels, condition = catalog_tab_configuration(record)
 
-= react('MiqCustomTab', {:containerId => 'catalog-tabs', :tabLabels => tab_labels})
+= react('MiqCustomTab', {:containerId => 'catalog-tabs',
+                         :tabLabels => tab_labels,
+                         :type => 'CATALOG_SUMMARY'})
 
 #catalog-tabs.miq_custom_tabs_container
-
   = catalog_tab_content(:basic) do
     = catalog_basic_information(record, sb, tenants_tree)
     = catalog_smart_management(record)

--- a/app/views/miq_request/_prov_wf.html.haml
+++ b/app/views/miq_request/_prov_wf.html.haml
@@ -5,26 +5,22 @@
     - options = @options || @edit[:new]
     - wf = options[:wf] || @edit[:wf]
     - tabname = (@tabactive || options[:current_tab_key]).to_s
-    #prov_tabs
-      %ul.nav.nav-tabs{'role' => 'tablist'}
-        - wf.provisioning_tab_list.each do |dialog|
-          = miq_tab_header(dialog[:name], tabname) do
-            = dialog[:description]
+    - prov_tab_labels, prov_tab_keys = provision_tab_configuration(wf)
 
-      .tab-content
-        - current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
-        - wf.get_dialog_order.each do |dialog_name|
-          = miq_tab_content(dialog_name, current_tab) do
-            - if dialog_name == current_tab
-              - dialog = wf.get_dialog(dialog_name)
-              - unless dialog.blank? || dialog[:display] == :ignore
-                - partial_locals = {:wf => wf, :dialog => dialog_name}
+    = react('MiqCustomTab', {:containerId => 'request-info-tabs',
+                             :tabLabels => prov_tab_labels,
+                             :type => 'CATALOG_REQUEST_INFO'})
 
-                - if wf.kind_of?(MiqProvisionWorkflow)
-                  = render :partial => "/shared/views/prov_dialog", :locals => partial_locals
-                - elsif wf.kind_of?(VmMigrateWorkflow)
-                  = render :partial => "/miq_request/prov_vm_migrate_dialog", :locals => partial_locals
+    #request-info-tabs.miq_custom_tabs_container
+      - current_tab = @edit && @edit[:new] ? @edit[:new][:current_tab_key] : @options[:current_tab_key]
+      - prov_tab_keys.each do |dialog_name|
+        = miq_tab_content(dialog_name, current_tab, :class => 'tab_content') do
+          - if dialog_name == current_tab
+            - dialog = wf.get_dialog(dialog_name)
+            - unless dialog.blank? || dialog[:display] == :ignore
+              - partial_locals = {:wf => wf, :dialog => dialog_name}
 
-:javascript
-  miq_tabs_init('#prov_tabs', '/miq_request/prov_field_changed', {edit_mode: 'true'});
-
+              - if wf.kind_of?(MiqProvisionWorkflow)
+                = render :partial => "/shared/views/prov_dialog", :locals => partial_locals
+              - elsif wf.kind_of?(VmMigrateWorkflow)
+                = render :partial => "/miq_request/prov_vm_migrate_dialog", :locals => partial_locals


### PR DESCRIPTION
The tabs under the catalog summary's Request Info tabs (Catalog, Environments, Properties, Customize, Schedule) converted from HAML to React 
Before
![image](https://user-images.githubusercontent.com/87487049/191762385-4eb82934-f50b-4518-8c97-cd01666e6435.png)

After
![image](https://user-images.githubusercontent.com/87487049/191761349-d67c3d99-8a99-4eab-a565-17f7c2acd40f.png)
