### PR TITLE
Fix infrastructure hosts power menu selection

### DIFF
--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -204,7 +204,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :send_checked => true,
           :confirm      => N_("Power On the selected items?"),
           :klass        => ApplicationHelper::Button::HostFeatureButton,
-          :options      => {:feature => :start}),
+          :options      => {:feature => :start},
+          :enabled      => false,
+          :onwhen       => "1+"),
         button(
           :host_stop,
           nil,
@@ -215,7 +217,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :send_checked => true,
           :confirm      => N_("Power Off the selected items?"),
           :klass        => ApplicationHelper::Button::HostFeatureButton,
-          :options      => {:feature => :stop}),
+          :options      => {:feature => :stop},
+          :enabled      => false,
+          :onwhen       => "1+"),
         button(
           :host_reset,
           nil,
@@ -226,7 +230,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :send_checked => true,
           :confirm      => N_("Reset the selected items?"),
           :klass        => ApplicationHelper::Button::HostFeatureButtonWithDisable,
-          :options      => {:feature => :reset}),
+          :options      => {:feature => :reset},
+          :enabled      => false,
+          :onwhen       => "1+"),
       ]
     ),
   ])


### PR DESCRIPTION
Issue : https://github.com/ManageIQ/manageiq-ui-classic/issues/8465
Power on, Power Off and Reset buttons are enabled even if no items were selected

Before
![Screenshot 2022-09-30 at 4 08 42 PM](https://user-images.githubusercontent.com/87487049/193253021-5bd92ca9-f0f3-4b3d-b387-5c71b6e9449d.png)

After
![Screenshot 2022-09-30 at 4 09 41 PM](https://user-images.githubusercontent.com/87487049/193253040-50d75688-305f-4872-8741-842d508cc24b.png)
![Screenshot 2022-09-30 at 4 09 55 PM](https://user-images.githubusercontent.com/87487049/193253057-f8a53339-5b55-43c7-8391-22cae37d9134.png)

@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @Fryguy 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-label bug
@miq-bot assign @Fryguy 
