### PR TITLE
Add Management Console to Infra VMs

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -290,6 +290,16 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :url         => "native_console",
           :klass       => ApplicationHelper::Button::VmNativeConsole
         ),
+        button(
+          :vm_native_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a management console for this VM'),
+          N_('Management Console'),
+          :keepSpinner => true,
+          :url         => "management_console",
+          :klass       => ApplicationHelper::Button::GenericFeatureButton,
+          :options     => {:feature => :native_console}
+        ),
       ]
     ),
   ])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3007,6 +3007,7 @@ Rails.application.routes.draw do
         groups
         kernel_drivers
         linux_initprocesses
+        management_console
         ownership_update
         patches
         perf_chart_chooser


### PR DESCRIPTION
Add a button to show the Management Console under Access on Infrastructure VMs
![Screenshot from 2022-09-30 12-53-49](https://user-images.githubusercontent.com/12851112/193323067-65c25d12-962f-41db-be8d-4a26c32c2cc7.png)

Related:
* https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/86