### PR TITLE
[WIP] Remove infra manager check from HostFeatureButton

### DIFF
--- a/app/helpers/application_helper/button/host_feature_button.rb
+++ b/app/helpers/application_helper/button/host_feature_button.rb
@@ -1,15 +1,8 @@
 class ApplicationHelper::Button::HostFeatureButton < ApplicationHelper::Button::GenericFeatureButton
 
   def visible?
-    # TODO: @feature.nil? || @record.nil? || @record.supports?(@feature)
-    # TODO: ensure start stop are supported in openstack
     unless @feature.nil? || @record.nil?
-      if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
-        return true if %w[start stop].include?(@feature.to_s)
-        return false
-      end
-
-      return @record.supports?(@feature) if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
+      return @record.supports?(@feature)
     end
     true
   end


### PR DESCRIPTION
- When viewing all the hosts in an infra manager, we are checking if `ManageIQ::Providers::Openstack::InfraManager` supports host operations (start and stop)
- Ideally we would like to remove this check as it is incorrect to check if the infra manager supports host lifecycle operations, since this check should only occur on `::Host` objects 
- As a result we can utilize the supports feature to check only for `::Host` objects that support host lifecycle operations (currently in place)
- this will also help to remove provider-specific code 

@miq-bot assign @jeffibm 
@miq-bot add_reviewer @agrare 
@miq-bot add_label enhancement