### PR TITLE
Add ssh_public_key option to provision dialogs

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -81,7 +81,7 @@
             :owner_manager_phone, :owner_phone, :owner_phone_mobile,
             :owner_state, :owner_title, :owner_zip, :request_notes,
             :subnet_mask, :memory_limit, :memory_reserve,
-            :root_username, :root_password, :sysprep_password, :sysprep_domain_admin,
+            :root_username, :root_password, :ssh_public_key, :sysprep_password, :sysprep_domain_admin,
             :sysprep_domain_password, :sysprep_workgroup_name,
             :sysprep_full_name, :sysprep_organization,
             :sysprep_product_id, :sysprep_computer_name,
@@ -292,7 +292,7 @@
         .col-md-10
           = react('TaggingWrapperConnected',
             :tags    => @tags,
-            :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true, 
+            :options => { :type => 'provision', :hideHeaders => true, :hideButtons => true,
                           :url => url, :isDisabled => @tags[:isDisabled]})
           - unless field_hash[:notes_display] == :hide || field_hash[:notes].blank?
             -# Display notes if available

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -146,7 +146,7 @@
     - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible,
-              :cpu_hot_add, :cpu_hot_remove, :memory_hot_add]
+              :cpu_hot_add, :cpu_hot_remove, :memory_hot_add, :ssh_public_key]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,


### PR DESCRIPTION
Some providers don't support saving SSH keys so when provisioning a VM
we need to allow the user to post an SSH public key rather than only
allowing selection from a dropdown.