### PR TITLE
Treat our locale json files as binary in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+app/javascript/oldjs/locale/*.json -text -diff


### PR DESCRIPTION
This suppresses git grep/diff or any of the patch(-p) commands (add/checkout/stash/etc) from showing possibly enormous json blobs.

This was done because it's seldom useful to see these enormous json blobs when looking at git grep or even git diff.

You can still tell git diff to treat it as text using `git diff --text`.

### Before

```
manageiq-ui-classic % git grep Resides
app/javascript/oldjs/locale/de.json:{"domain":"app","locale_data":{"app":{"":{"Generated-By":"Globalization Pipeline","Project-Id-Version":"manageiq 1.0.0","Report-Msgid-Bugs-To":"","POT-Creation-Date":"2022-08-09 08:49-0400","PO-Revision-Date":"2022-08-09 08:49-0400","Last-Translator":"FULL NAME <EMAIL@ADDRESS>","Language-Team":"LANGUAGE <LL@li.org>","Language":"de","MIME-Version":"1.0","Content-Type":"text/plain; charset=UTF-8","Content-Transfer-Encoding":"8bit","Plural-Forms":"nplurals=2; plural=n != 1;","lang":"de","domain":"app","plural_forms":"nplurals=2; plural=n != 1;"}," ":[" "],"  Unable to add the following tags to %{class_name} %{id}: %{names}.":["  Die folgenden Tags können nicht zu %{class_name} %{id} hinzugefügt werden: %{names}."],"  Unable to remove the following tags from %{class_name} %{id}: %{names}.":["  Die f
...many pages of json results
```

### After

```
manageiq-ui-classic % git grep Resides
Binary file app/javascript/oldjs/locale/de.json matches
Binary file app/javascript/oldjs/locale/en.json matches
Binary file app/javascript/oldjs/locale/es.json matches
Binary file app/javascript/oldjs/locale/fr.json matches
Binary file app/javascript/oldjs/locale/it.json matches
Binary file app/javascript/oldjs/locale/ja.json matches
Binary file app/javascript/oldjs/locale/ko.json matches
Binary file app/javascript/oldjs/locale/pt_BR.json matches
Binary file app/javascript/oldjs/locale/zh_CN.json matches
Binary file app/javascript/oldjs/locale/zh_TW.json matches
app/views/ops/_settings_server_tab.html.haml:        = _("Resides on VM")
```
