### PR TITLE
Safe delete saved reports

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1006,7 +1006,7 @@ class ApplicationController < ActionController::Base
   def process_saved_reports(saved_reports, task)
     success_count = 0
     failure_count = 0
-    params[:miq_grid_checks] = params[:miq_grid_checks].split(",")
+    params[:miq_grid_checks] = params[:miq_grid_checks]&.split(",")
     MiqReportResult.for_user(current_user).where(:id => saved_reports).order(MiqReportResult.arel_table[:name].lower).each do |rep|
       rep.public_send(task) if rep.respond_to?(task) # Run the task
     rescue StandardError
@@ -1020,7 +1020,7 @@ class ApplicationController < ActionController::Base
           :target_class => "MiqReportResult",
           :userid       => current_userid
         )
-        params[:miq_grid_checks].delete(rep[:id].to_s)
+        params[:miq_grid_checks]&.delete(rep[:id].to_s)
         success_count += 1
       else
         add_flash(_("\"%{record}\": %{task} successfully initiated") % {:record => rep.name, :task => task})


### PR DESCRIPTION
Added safe navigation operator (`&.`) so that we check if `params[:miq_grid_checks]` nil before calling  `split` or `delete`.

## BEFORE

![Screen Shot 2022-10-05 at 3 58 40 PM](https://user-images.githubusercontent.com/29209973/194151511-57e8a710-2719-493a-a39b-f60a0785868b.png)

## AFTER

![Screen Shot 2022-10-05 at 3 57 34 PM](https://user-images.githubusercontent.com/29209973/194151289-a27120f1-ae0b-4fa0-8e99-21288e994a25.png)

Related to changes made here https://github.com/ManageIQ/manageiq-ui-classic/pull/8448

@miq-bot add-reviewer @jeffibm
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-label bug
@miq-bot assign @Fryguy