### PR TITLE
Fix dashboard chart legend items in fullscreen in Firefox

### DIFF
--- a/app/stylesheet/dashboard.scss
+++ b/app/stylesheet/dashboard.scss
@@ -24,11 +24,20 @@
       margin-bottom: 15px;
       border: 1px solid $selected-ui;
 
+      .chart-holder.fullscreen .spacer {
+        margin-top: 2px;
+      }
+
       .card-pf {
         display: flex;
         flex-direction: column;
         margin: 0;
         border: 0;
+
+        .card-pf-body{
+          margin: 0;
+          padding: 0;
+        }
 
         div[id^="dd_"] div.widget-report {
           overflow-y: auto;


### PR DESCRIPTION
In Firefox, the legend items were not visible in fullscreen

Issue : https://github.ibm.com/katamari/dev-issue-tracking/issues/36853

Before
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/194234584-6aeb907c-872d-45a5-b933-b3d73f8a3fe9.png">

After
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/87487049/194234684-f19a2050-4968-40b4-b299-cb0079710bfd.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-label bug
@miq-bot assign @Fryguy
