### PR TITLE
Fix compare selected items during compare by adding default selected …

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -13,6 +13,8 @@ module ApplicationController::Compare
 
     rpt = get_compare_report(@sb[:compare_db])
     session[:miq_sections] = MiqCompare.sections(rpt)
+    selected_sections = session[:miq_sections]&.select { |_key, value| value[:checked] == true }
+    session[:selected_sections] = selected_sections ? selected_sections.keys.map(&:to_s) : []
     ids = session[:miq_selected].collect(&:to_i)
     @compare = MiqCompare.new({:ids     => ids,
                                :include => session[:miq_sections]},
@@ -413,7 +415,7 @@ module ApplicationController::Compare
   end
 
   def set_checked_sections
-    session[:selected_sections] = selections = []
+    selections = []
     params[:all_checked]&.each do |item|
       add_selections!(selection_names(item), selections)
     end


### PR DESCRIPTION
Issue : https://github.ibm.com/katamari/dev-issue-tracking/issues/33921

Partial fix : https://github.com/ManageIQ/manageiq-ui-classic/pull/8450

**Before**
- Go to "`Compute / Cloud / Instances / All Instances/ select some Instances `
- Click on "Configuration -> Compare Selected Items"
- Click the `Apply` button, the `Workload` disappears from the Compare table:
<img width="1539" alt="image" src="https://user-images.githubusercontent.com/87487049/194295192-9cd0fc81-b19e-4bcf-b21f-f8f07f2ccf8f.png">

**After**
Added default selected items to the session.
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/87487049/194294413-d2c8973f-a000-4171-8dfb-f8a21c5ddce2.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-reviewer @DavidResende0 
@miq-bot add-label bug
@miq-bot assign @Fryguy
