### PR TITLE
Fix lifecycle provision of template

### DIFF
--- a/app/helpers/vm_cloud_helper.rb
+++ b/app/helpers/vm_cloud_helper.rb
@@ -1,4 +1,5 @@
 module VmCloudHelper
   include VmHelper
+  include RequestInfoHelper
   include_concern 'TextualSummary'
 end


### PR DESCRIPTION
This PR is related to a partial fix for https://github.com/ManageIQ/manageiq-ui-classic/pull/8458#

**Before**
Compute / Cloud / Instance / All Instances / Lifecycle / provision instances / (Pick one to provision)
The error pops up
![](https://user-images.githubusercontent.com/12851112/194136288-06efaf7f-92d3-4bb9-910f-a38dc0f20ec3.png)

**After**
The previous error will be fixed. but it generates a different error.
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/87487049/194354887-49af066f-ff43-4ace-8ba5-73a35cdc1565.png">

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @agrare 
@miq-bot add-reviewer @GilbertCherrie
@miq-bot add-reviewer @MelsHyrule
@miq-bot add-reviewer @DavidResende0
@miq-bot add-label bug
@miq-bot assign @Fryguy

