### PR TITLE
[MORPHY] Manually backport #7834

### DIFF
--- a/lib/manageiq/ui/classic/engine.rb
+++ b/lib/manageiq/ui/classic/engine.rb
@@ -11,7 +11,6 @@ require 'sprockets/railtie'
 # For this to work properly, it is dependent on patternfly/patternfly-sass#150
 if ENV["RAILS_ENV"] != "production" || defined?(Rake)
   require 'sass-rails'
-  require 'coffee-rails'
   require 'font-fabulous'
   require 'patternfly-sass'
 else

--- a/manageiq-ui-classic.gemspec
+++ b/manageiq-ui-classic.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 6.0.0"
 
-  s.add_dependency "coffee-rails"
   s.add_dependency "execjs", "2.8.1" # Note: 2.8.1 requires uglifier 4.2.0 to defer uglifier asset compilation until asset compilation time: https://github.com/rails/execjs/issues/105
   s.add_dependency "font-fabulous", "~> 1.0.5"
   s.add_dependency "high_voltage", "~> 3.0.0"


### PR DESCRIPTION
Note, this is needed to fix #8300 on morphy since #7834 was merged on master after morphy so it's in najdorf.

From 27403b0b24c:

No more coffee for ruby

We have removed all coffee script files
This is removing the dependency
