### PR TITLE
add validation to wwpn to be hexadecimal

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -234,6 +234,11 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
                 type: "exact-length",
                 threshold: 16,
                 message: __('The length of the WWPN should be exactly 16 characters.')
+              },
+              {
+                type: "pattern",
+                pattern: "^[0-9A-Fa-f]+$",
+                message: __('The WWPN should be a hexadecimal expression (0-9, A-F)')
               }
             ],
           },


### PR DESCRIPTION
The WWPN address added to a host initiator should be a hexadecimal expression. Up till now it's only validating its length to be 16 characters, but not to be hexadecimal necessarily:

<img width="366" alt="Screen Shot 2022-10-18 at 13 41 09" src="https://user-images.githubusercontent.com/50288766/196410021-db15bfcd-f91c-4b0d-a461-ff87123455cc.png">

After fixing this:

<img width="408" alt="Screen Shot 2022-10-18 at 13 51 21" src="https://user-images.githubusercontent.com/50288766/196410421-3fc89a63-e184-406d-9762-4285da22330c.png">
