### PR TITLE
Fixes Password Field so it is Correctly Rendered as a Text Area

### DIFF
--- a/app/javascript/components/async-credentials/password-field.jsx
+++ b/app/javascript/components/async-credentials/password-field.jsx
@@ -12,7 +12,7 @@ const PasswordField = ({
   helperText,
   edit,
   parent,
-  componentclass,
+  componentClass,
   ...rest
 }) => {
   const formOptions = useFormApi();
@@ -24,8 +24,8 @@ const PasswordField = ({
     validateOnMount: rest.validateOnMount,
     helperText,
     ...rest,
-    component: edit ? 'edit-password-field' : componentclass,
-    componentclass,
+    component: edit ? 'edit-password-field' : componentClass,
+    ...(edit) && { componentClass },
   };
 
   const newProps = { ...secretField };
@@ -88,7 +88,7 @@ PasswordField.propTypes = {
   helperText: PropTypes.string,
   edit: PropTypes.bool,
   parent: PropTypes.string,
-  componentclass: PropTypes.string,
+  componentClass: PropTypes.string,
 };
 
 PasswordField.defaultProps = {
@@ -97,7 +97,7 @@ PasswordField.defaultProps = {
   helperText: undefined,
   edit: false,
   parent: undefined,
-  componentclass: componentTypes.TEXT_FIELD,
+  componentClass: componentTypes.TEXT_FIELD,
 };
 
 export default PasswordField;

--- a/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
+++ b/app/javascript/spec/async-credentials/__snapshots__/password-field.spec.js.snap
@@ -4,7 +4,7 @@ exports[`Secret switch field component should render correctly in edit mode 1`] 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  componentclass="text-field"
+  componentClass="text-field"
   edit={true}
   name="foo"
 >
@@ -154,21 +154,19 @@ exports[`Secret switch field component should render correctly in non edit mode 
 <PasswordField
   cancelEditLabel="Cancel"
   changeEditLabel="Change"
-  componentclass="text-field"
+  componentClass="text-field"
   edit={false}
   name="foo"
 >
   <MockDummyComponent
     autoComplete="new-password"
     component="text-field"
-    componentclass="text-field"
     name="foo"
     type="password"
   >
     <button
       autoComplete="new-password"
       component="text-field"
-      componentclass="text-field"
       name="foo"
       type="button"
     >


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-classic/pull/8432 inadvertently broke all text-area password-fields, reverting them to regular text-fields, which recreated the following issue https://github.com/ManageIQ/manageiq-ui-classic/issues/7647. This fix resolves both issues.