### PR TITLE
change name of variable according to proptypes definition

### DIFF
--- a/app/javascript/components/physical-storage-form/validate-storage-credentials.jsx
+++ b/app/javascript/components/physical-storage-form/validate-storage-credentials.jsx
@@ -8,7 +8,7 @@ import EditingContext from './editing-context';
 const ValidateStorageCredentials = ({ ...props }) => {
   const { storageId } = useContext(EditingContext);
 
-  const validateStorage = (fields, fieldNames) => new Promise((resolve, reject) => {
+  const asyncValidate = (fields, fieldNames) => new Promise((resolve, reject) => {
     const url = storageId ? `/api/physical_storages/${storageId}` : '/api/physical_storages';
     const resource = pick(fields, fieldNames);
 
@@ -37,12 +37,12 @@ const ValidateStorageCredentials = ({ ...props }) => {
   });
 
   // The order of props is important here, because they have to be overridden
-  return <AsyncCredentials {...props} asyncValidate={validateStorage} edit={!!storageId} />;
+  return <AsyncCredentials {...props} asyncValidate={asyncValidate} edit={!!storageId} />;
 };
 
 ValidateStorageCredentials.propTypes = {
   ...AsyncCredentials.propTypes,
-  validateStorage: PropTypes.func,
+  asyncValidate: PropTypes.func,
   validation: PropTypes.bool,
 };
 ValidateStorageCredentials.defaultProps = {


### PR DESCRIPTION
When opening the page of "Add New Physical Storages", we encountered this error in the console:

<img width="932" alt="Screen Shot 2022-10-27 at 9 00 53" src="https://user-images.githubusercontent.com/50288766/198204918-a9c57b67-0ba5-45c9-92df-41a5753941ae.png">

The reason is because in the proptypes definition below we had defined the name of the variable instead of the parameter, and then it expected it to be required as defined in the async-credentials page. So I just changed the name there (and also changed name of the variable for uniformity reasons, as it is in validate-provider-credentials.jsx).