### PR TITLE
Always display the Provision instance action buttons at the bottom

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -162,3 +162,21 @@
     }
   }
 }
+
+.provision-instance-container {
+  display: flex;
+  flex-direction: column;
+
+  .provision-instance-list {
+    height: calc(100vh - 210px);
+    overflow: auto;
+  }
+  .provision-instance-actions {
+
+    #pre_prov_form_buttons_div {
+      display: flex;
+      justify-content: end;
+    }
+  }
+
+}

--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -13,11 +13,15 @@
              :onclick => "miqAjax('#{hide_depricated_url}')",
              :checked => @edit[:hide_deprecated_templates]}
         = _('Hide deprecated')
-  = render :partial => "layouts/x_gtl"
+  
+  .provision-instance-container
+    .provision-instance-list
+      = render :partial => "layouts/x_gtl"
 
-  #pre_prov_form_buttons_div.pull-right
-    = render :partial => 'layouts/x_edit_buttons', :locals => {:action_url      => 'pre_prov',
-                                                               :continue_button => true,
-                                                               :no_reset        => true}
+    .provision-instance-actions
+      #pre_prov_form_buttons_div.pull-right
+        = render :partial => 'layouts/x_edit_buttons', :locals => {:action_url => 'pre_prov',
+                                                                  :continue_button => true,
+                                                                  :no_reset => true}
   :javascript
     $(provisioningListenToRx);


### PR DESCRIPTION
On the IM UI, navigated to Cloud > Instances. After an item in the "Instances by Provider" tree is selected, a few instances appeared in the right pane.

**Before**
The continue and cancel button were displayed at the bottom of the table confusing the user only to click the row and not click on the continue
![image](https://user-images.githubusercontent.com/87487049/198977280-d79242aa-5109-48e4-9e9e-1d9177bb8170.png)

**After**
The continue and cancel buttons are always visible.
![image](https://user-images.githubusercontent.com/87487049/198976708-b0596d58-6a19-43c6-a026-eb62ab7bdaf4.png)

@miq-bot add-reviewer @DavidResende0
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @Fryguy 
@miq-bot add-label bug
