### PR TITLE
Fix container-dashboard's overview's breadcrumb link

### DIFF
--- a/app/controllers/container_dashboard_controller.rb
+++ b/app/controllers/container_dashboard_controller.rb
@@ -112,7 +112,7 @@ class ContainerDashboardController < ApplicationController
       :breadcrumbs => [
         {:title => _("Compute")},
         {:title => _("Containers")},
-        {:title => _("Overview"), :url => controller_url},
+        {:title => _("Overview"), :url => "#{controller_url}/show"},
       ],
     }
   end


### PR DESCRIPTION
Compute / Containers / Overview / Container Dashboard

**Before**
When clicking on the Overview link in breadcrumb it redirects to error page as it goes to an invalid route ` /container_dashboard`
![image](https://user-images.githubusercontent.com/87487049/198990636-adab0ed7-6c25-4f17-995a-85df3d9c23b5.png)

**After**
Now redirecting to ` /container_dashboard/show`
![image](https://user-images.githubusercontent.com/87487049/198990843-9645841b-876b-4e23-a29a-73e56415fab6.png)

@miq-bot assign @Fryguy
@miq-bot add-label bug

