### PR TITLE
choose host initiator group on host creation

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -20,6 +20,13 @@ const loadStorages = (id) => API.get(`/api/providers/${id}?attributes=type,physi
     value: id,
   })));
 
+const loadGroups = (id) => API.get(`/api/physical_storages/${id}?attributes=host_initiator_groups`)
+  .then(({ host_initiator_groups }) => {
+    let groupOptions = host_initiator_groups.map(({ id, name }) => ({ label: name, value: id }));
+    groupOptions.unshift({ label: `<${__('None')}>`, value: '' });
+    return groupOptions;
+  });
+
 const loadWwpns = (id) => API.get(`/api/physical_storages/${id}?attributes=wwpn_candidates`)
   // eslint-disable-next-line camelcase
   .then(({ wwpn_candidates }) => wwpn_candidates.map(({ candidate }) =>
@@ -246,6 +253,18 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         condition: {
           or: [{ when: 'port_type', is: 'FC' }, { when: 'port_type', is: 'NVMeFC' }],
         },
+      },
+      {
+        component: componentTypes.SELECT,
+        id: 'host_initiator_group',
+        name: 'host_initiator_group',
+        label: __('host initiator group:'),
+        isRequired: false,
+        // includeEmpty: true,
+        validate: [{ type: validatorTypes.REQUIRED }],
+        loadOptions: () => (storageId ? loadGroups(storageId) : Promise.resolve([])),
+        isSearchable: true,
+        condition: { and: [{ when: 'physical_storage_id', isNotEmpty: true }, { when: 'port_type', isNotEmpty: true }] },
       },
     ],
   });


### PR DESCRIPTION
added a host initiator group field to host initiator form, which enables choosing an existing host group from the specified storage system, or choose None for no group.

this also requires a change in the provider plug-in:
https://github.com/ManageIQ/manageiq-providers-autosde/pull/186

the new field: 
<img width="1075" alt="Screen Shot 2022-10-31 at 15 52 35" src="https://user-images.githubusercontent.com/106743023/199042449-5f4330ed-ae63-495d-83b6-b1731b9c5dad.png">
