### PR TITLE
Bring back the tabs in service page

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -16,6 +16,11 @@ class ServiceController < ApplicationController
     process_show_list(:dbname => :service, :gtl_dbname => :service)
   end
 
+  def show
+    super
+    @view, @pages = get_view(Vm, :parent => @record, :parent_method => :all_vms, :all_pages => true)
+  end
+
   def button
     case params[:pressed]
     when 'service_tag'

--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -3,4 +3,4 @@
 - elsif @ownershipitems
   = render :partial => "shared/views/ownership"
 - elsif @showtype == 'main'
-  = render :partial => "layouts/textual_groups_generic"
+  = render :partial => "svcs_show", :locals => {:controller => "service"}


### PR DESCRIPTION
When the services page was de-explorised, the `explorer.html.haml` page was removed during https://github.com/ManageIQ/manageiq-ui-classic/pull/8229

The `Details, Provisioning, Retirement, Job` tabs were used in the removed page.

This PR brings back the removed tabs.

**Details and Jobs** 
Before (in morphy)
![Screenshot 2022-11-01 at 2 23 42 PM](https://user-images.githubusercontent.com/87487049/199205184-99ecea0f-ec09-48b5-a934-7252006fefd7.png)
After
![image](https://user-images.githubusercontent.com/87487049/199227923-5e8e5bf6-f3e3-4be8-9002-5c304caa0cdd.png)

**No Tabs**
Before
![Screenshot 2022-11-01 at 2 24 14 PM](https://user-images.githubusercontent.com/87487049/199205203-1e9213c0-847c-4dfa-a3a7-a026c541c474.png)
After
![image](https://user-images.githubusercontent.com/87487049/199228042-513ffe86-4e99-4488-9c78-352461c39299.png)

**Details and Provisioning**
Before
![Screenshot 2022-11-01 at 2 25 42 PM](https://user-images.githubusercontent.com/87487049/199205222-661ee2e4-6697-419a-ae2d-241668401402.png)
After
![image](https://user-images.githubusercontent.com/87487049/199170736-15a59279-85b2-453e-bd08-0937e1eb9c44.png)

**No Tabs - VM's list**
Before
![Screenshot 2022-11-01 at 2 26 20 PM](https://user-images.githubusercontent.com/87487049/199205246-20ceccd5-c937-42d2-b37b-09e76140e39d.png)
After
![image](https://user-images.githubusercontent.com/87487049/199227781-faca4b06-4f93-4f03-98fe-48ab9affc47d.png)








@miq-bot add-reviewer @DavidResende0
@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-reviewer @GilbertCherrie
@miq-bot assign @Fryguy
@miq-bot add-label bug
 