### PR TITLE
[MORPHY] Fix dashboard widget refresh and zoom

### DIFF
--- a/app/javascript/angular/dashboard/widget-wrapper.js
+++ b/app/javascript/angular/dashboard/widget-wrapper.js
@@ -1,4 +1,5 @@
 /* global miqDeferred */
+import * as registry from '../../miq-component/registry';
 
 ManageIQ.angular.app.component('widgetWrapper', {
   bindings: {
@@ -60,7 +61,13 @@ ManageIQ.angular.app.component('widgetWrapper', {
       $http.post(`/dashboard/widget_refresh/?widget=${vm.widgetId}`)
         .then((response) => {
           vm.widgetModel = null;
-          return API.wait_for_task(response.data.task_id).then(() => vm.refreshWidgetHTML(true));
+          return API.wait_for_task(response.data.task_id).then(() => {
+            const dashboardWidget = registry.getDefinition('DashboardWidget');
+            if (dashboardWidget && dashboardWidget.instances) {
+              dashboardWidget.instances = new Set([]);
+            }
+            vm.refreshWidgetHTML(true);
+          });
         })
         .catch((e) => {
           vm.error = true;


### PR DESCRIPTION
**Before** 
Go to Overview > Dashboard
Refresh a widget. e.g. Vendor and Guest OS Chart
![image](https://user-images.githubusercontent.com/87487049/200237651-b33fd317-dcea-44a3-aff4-76c1e35b801d.png)

Browser console error after the refresh action
![image](https://user-images.githubusercontent.com/87487049/203040814-0cdee53b-a275-4024-a9bc-62bc6a3232ff.png)

After the chart is refreshed, zoom in. The spinner will not disappear and zoom-in action is not completed.
![image](https://user-images.githubusercontent.com/87487049/200237711-a4849eef-362f-43e0-bbcc-1b9fbdeeced8.png)

Note: Refresh the page and clicking the zoom-in button will not throw an error

**After**
Able to zoom after refresh

https://user-images.githubusercontent.com/87487049/203041760-25a3bba5-9e1e-414a-9be8-69721be6cfe1.mov

