### PR TITLE
Show/hide Physical Server Console button in Physical Infrastructure Servers Summary

### DIFF
--- a/app/helpers/application_helper/button/physical_server_console.rb
+++ b/app/helpers/application_helper/button/physical_server_console.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::PhysicalServerConsole < ApplicationHelper::Button::Basic
+  def visible?
+    @record.supports?(:console)
+  end
+end

--- a/app/helpers/application_helper/toolbar/physical_server_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_server_center.rb
@@ -119,6 +119,7 @@ class ApplicationHelper::Toolbar::PhysicalServerCenter < ApplicationHelper::Tool
             'pficon pficon-screen fa-lg',
             N_('Open a remote console for this Physical Server'),
             N_('Physical Server Console'),
+            :klass       => ApplicationHelper::Button::PhysicalServerConsole,
             :keepSpinner => true,
             :url         => "console",
             :method      => :get,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87487049/200480905-3b4a7f30-9215-48bc-be50-63ef2736a890.png)

![image](https://user-images.githubusercontent.com/87487049/200481006-6c7edf82-0908-4c58-8c2b-7ed507352f58.png)

Issue
[Najdorf / Physical Server Remote Console not working #22210](https://github.com/ManageIQ/manageiq/issues/22210)

Related PR's
[manageiq - Add PhysicalServer remote console supports feature #22211](https://github.com/ManageIQ/manageiq/pull/22211)
[manageiq-providers-lenovo - Add supports :console to PhysicalServers #379](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/379)

