### PR TITLE
[WIP] Fix tabs label translation

### DIFF
--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -1,9 +1,81 @@
 module RequestInfoHelper
   private
 
+  REQUEST_INFO_TAB_TYPES = {
+    :requester   => N_('Requester'),
+    :purpose     => N_('Purpose'),
+    :catalog     => N_('Catalog'),
+    :environment => N_('Environment'),
+    :properties  => N_('Properties'),
+    :volumes     => N_('Volumes'),
+    :customize   => N_('Customize'),
+    :schedule    => N_('Schedule'),
+    :hardware    => N_('Hardware'),
+    :network     => N_('Network'),
+  }.freeze
+
+  PROV_FIELD_LABLES = {
+    # Catalog
+    :name                         => N_('Name'),
+    :count                        => N_('Count'),
+    :provision_type               => N_('Provision Type'),
+    :linked_clone                 => N_('Linked Clone'),
+    :vm_name                      => N_('Vm Name'),
+    # Environment
+    :instance_name                => N_('Instance Name'),
+    # Hardware
+    :number_of_sockets            => N_('Number of sockets'),
+    :cores_per_socket             => N_('Cores per socket'),
+    :memory_mb                    => N_('Memory mb'),
+    :disk_format                  => N_('Disk format'),
+    :disk_sparsity                => N_('Disk sparsity'),
+    # Network
+    :network                      => N_('Network'),
+    # Properties
+    :choose_automatically         => N_('Choose Automatically'),
+    :cloud_tenant                 => N_('Cloud Tenant'),
+    :availability_zones           => N_('Availability Zones'),
+    :network_selection_method     => N_('Network Selection Method'),
+    :cloud_network                => N_('Cloud Network'),
+    :security_groups              => N_('Security Groups'),
+    :public_ip_address            => N_('Public IP Address'),
+    # Volumes
+    :volume_name                  => N_('Volume Name'),
+    :size_gigabytes               => N_('Size (gigabytes)'),
+    :delete_on_instance_terminate => N_('Delete on Instance Terminate'),
+    # Customize
+    :instance_type                => N_('Instance Type'),
+    :guest_access_key_pair        => N_('Guest Access Key Pair'),
+    :cloudwatch                   => N_('CloudWatch'),
+    :root_password                => N_('Root Password'),
+    :address_mode                 => N_('Address Mode'),
+    :host_name                    => N_('Host Name'),
+    :subnet_mask                  => N_('Subnet Mask'),
+    :gateway                      => N_('Gateway'),
+    :dns_server_list              => N_('DNS Server list'),
+    :dns_suffix_list              => N_('DNS Suffix List"'),
+    :script_name                  => N_('Script Name'),
+    :script_text                  => N_('Script Text'),
+    # Schedule
+    :time_until_retirement        => N_('Time until Retirement'),
+    :retirement_warning           => N_('Retirement Warning'),
+  }.freeze
+
+  def tab_label_key(label)
+    label.gsub(/[^a-zA-Z ]/, "").downcase.tr(' ', '_').to_sym
+  end
+
+  def request_info_tab_label(label)
+    label ? (_(REQUEST_INFO_TAB_TYPES[tab_label_key(label)]) || label) : ""
+  end
+
+  def prov_field_label(label)
+    label ? (_(PROV_FIELD_LABLES[tab_label_key(label)]) || label) : ""
+  end
+
   def provision_tab_configuration(workflow)
     prov_tab_labels = workflow.provisioning_tab_list.map do |dialog|
-      {:name => dialog[:name], :text => dialog[:description]}
+      {:name => dialog[:name], :text => request_info_tab_label(dialog[:description])}
     end
     return prov_tab_labels, workflow.get_dialog_order
   end

--- a/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
+++ b/app/views/miq_request/_prov_dialog_volume_fieldset.html.haml
@@ -21,6 +21,7 @@
       - keys.each do |key|
         .form-group
           %label.col-md-4.control-label{:valign => "top"}
+            = prov_field_label(workflow.get_field(key, dialog)[:description])
             = _(workflow.get_field(key, dialog)[:description])
             - if @edit && workflow.get_field(key, dialog)[:required] && workflow.get_field(key, dialog)[:display] == :edit
               *

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -16,7 +16,7 @@
     - unless field_hash[:values].blank?
       .form-group
         %label.col-md-2.control-label
-          = field_hash[:description]
+          = prov_field_label(field_hash[:description])
           - if @edit && field_hash[:required] && field_hash[:display] == :edit
             *
         .col-md-8
@@ -46,7 +46,7 @@
   - else
     .form-group
       %label.col-md-2.control-label{:valign => "top"}
-        = field_hash[:description]
+        = prov_field_label(field_hash[:description])
         - len =  field_hash[:max_length] ? field_hash[:max_length] : ViewHelper::MAX_NAME_LEN
         - if field_hash[:help]
           %a{:id               => "popover-#{field_hash.object_id}",


### PR DESCRIPTION
Service / Catalogs / Catalog Items / summary / Request Info tab 

Tab Labels and the labels in the tab contents are marked for translation in the constants named `REQUEST_INFO_TAB_TYPES` and `PROV_FIELD_LABLES` in `RequestInfoHelper`

**1. Catalog**
Before
![image](https://user-images.githubusercontent.com/87487049/200837119-3c1520f2-e24e-4153-9843-eb342f804a5d.png)
After
`Instance Name` is not translated
![image](https://user-images.githubusercontent.com/87487049/200835607-eaf58651-00a8-4100-8c7d-02d4518dba48.png)

**2. Environment**
Before
![image](https://user-images.githubusercontent.com/87487049/200837364-e391db98-dfc5-4e35-99f5-c4596ce0de22.png)
After
`Choose Automatically` is not translated
![image](https://user-images.githubusercontent.com/87487049/200835825-1bc69c09-afcd-4e37-8018-1a2df583ba27.png)

**3. Properties**
Before
![image](https://user-images.githubusercontent.com/87487049/200837418-ec58472c-cccb-4505-9d97-1c7b00c3facd.png)
After
`Instance Type, Guest Access Key Pair, CloudWatch` is not translated
![image](https://user-images.githubusercontent.com/87487049/200835941-f8d23e19-8345-41a4-b729-7f347816a653.png)

**4. Customize**
Before
![image](https://user-images.githubusercontent.com/87487049/200837503-890334bc-b799-48f3-a081-286fbaf76ff4.png)
After
`Customize, Root Password, Address Mode, DNS Server list, DNS Suffix List, Script Name, Script Text` is not translated
![image](https://user-images.githubusercontent.com/87487049/200836172-38fbdad3-878b-475e-9527-cb2711d4618b.png)

**6.Schedule**
Before
![image](https://user-images.githubusercontent.com/87487049/200837565-1b57141f-509a-41ec-b031-735cc97fd26d.png)
After
`Lifespan, Time until Retirement` is not translated
![image](https://user-images.githubusercontent.com/87487049/200836635-dce05e53-d9d6-4536-b36a-b89f89966e2e.png)
