### PR TITLE
Fixed Configured Systems page advanced search

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2610,6 +2610,7 @@ Rails.application.routes.draw do
         tagging_edit
         wait_for_task
         launch_configured_system_console
+        listnav_search_selected
       ] +
         adv_search_post +
         dialog_runner_post +


### PR DESCRIPTION
Fixing routes error in advanced search in the Configured Systems page.

## BEFORE
![Screen Shot 2022-11-08 at 11 35 58 AM](https://user-images.githubusercontent.com/29209973/200623545-39c85bb0-2c71-494c-a28f-41c435a79faa.png)

## AFTER
![Screen Shot 2022-11-08 at 11 38 45 AM](https://user-images.githubusercontent.com/29209973/200623559-2c8ec82f-78cd-4e32-9b82-a3c1d2f465d5.png)

