### PR TITLE
Upgrading nwsapi to ^2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
   "packageManager": "yarn@3.0.2",
   "resolutions": {
     "terser": "~4.8.1",
-    "d3-color": "~3.1.0"
+    "d3-color": "~3.1.0",
+    "nwsapi": "^2.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12427,10 +12427,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nwsapi@npm:^2.0.7":
-  version: 2.2.0
-  resolution: "nwsapi@npm:2.2.0"
-  checksum: 5ef4a9bc0c1a5b7f2e014aa6a4b359a257503b796618ed1ef0eb852098f77e772305bb0e92856e4bbfa3e6c75da48c0113505c76f144555ff38867229c2400a7
+"nwsapi@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "nwsapi@npm:2.2.2"
+  checksum: 43769106292bc95f776756ca2f3513dab7b4d506a97c67baec32406447841a35f65f29c1f95ab5d42785210fd41668beed33ca16fa058780be43b101ad73e205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrading dependency `nwsapi` to ^2.2.1 per information found in [Snyk Vulnerability Database](https://security.snyk.io/vuln/SNYK-JS-NWSAPI-2841516)

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label security fix