### PR TITLE
Fixing host device page display

### DIFF
--- a/app/helpers/host_helper.rb
+++ b/app/helpers/host_helper.rb
@@ -36,24 +36,24 @@ module HostHelper
       devices = devices_details
       if devices.present?
         devices.each do |item|
-          rows.push(generate_row(h(item[:name]), h(item[:description]), item[:icon]))
+          rows.push(generate_row(item[:name], item[:description], item[:icon]))
         end
       end
     when "os_info"
       os_info = os_info_details
       if os_info.present?
         os_info.each do |item|
-          rows.push(generate_row(h(item[:osinfo]), h(item[:description])))
+          rows.push(generate_row(item[:osinfo], item[:description]))
         end
-        rows.push(generate_row(_('Hostname'), h(record.hostname)))
-        rows.push(generate_row(_('IP Address'), h(record.ipaddress)))
+        rows.push(generate_row(_('Hostname'), record.hostname))
+        rows.push(generate_row(_('IP Address'), record.ipaddress))
       end
 
     when "hv_info"
       vmm_info = vmm_info_details
       if vmm_info.present?
         vmm_info.each do |item|
-          rows.push(generate_row(h(item[:vmminfo]), h(item[:description])))
+          rows.push(generate_row(item[:vmminfo], item[:description]))
         end
       end
     end

--- a/app/helpers/textual_mixins/textual_devices.rb
+++ b/app/helpers/textual_mixins/textual_devices.rb
@@ -103,7 +103,7 @@ module TextualMixins::TextualDevices
       address = port.address
       filename = port.filename
       model = port.model
-      autodetect = port.auto_detect ? "" : _("Default Adapter")
+      autodetect = port.auto_detect ? nil : _("Default Adapter")
       desc = [location, address, filename, model, autodetect, network_name(port)].compact.join(', ')
       Device.new(name, desc, nil, port.decorate.fonticon) # TODO: look into this more if this can be SCSI, serial, parallel, usb, sound
     end

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -1972,3 +1972,52 @@ exports[`Structured list component should render a tag_group table 1`] = `
   </AccordionItem>
 </Accordion>
 `;
+
+exports[`Structured list component should render strings without double escaping strings 1`] = `
+<FeatureToggle(StructuredListWrapper)
+  ariaLabel="Structured list"
+  className="miq-structured-list miq_summary miq_host_devices"
+>
+  <FeatureToggle(StructuredListBody)>
+    <FeatureToggle(StructuredListRow)
+      className=""
+      key="0"
+      onClick={[Function]}
+      tabIndex={0}
+      title=""
+    >
+      <FeatureToggle(StructuredListCell)
+        className="label_header"
+      >
+        Catch All
+      </FeatureToggle(StructuredListCell)>
+      <FeatureToggle(StructuredListCell)
+        className="content_value object_item"
+      >
+        <div
+          className="content"
+        >
+          <div
+            className="cell icon"
+          >
+            <i
+              className="pficon pficon-unknown"
+              style={
+                Object {
+                  "background": undefined,
+                  "color": undefined,
+                }
+              }
+            />
+          </div>
+          <div
+            className="expand wrap_text"
+          >
+            &lt; A test to HTML's "Escape" logic Hello&Goodbye &gt;
+          </div>
+        </div>
+      </FeatureToggle(StructuredListCell)>
+    </FeatureToggle(StructuredListRow)>
+  </FeatureToggle(StructuredListBody)>
+</FeatureToggle(StructuredListWrapper)>
+`;

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -5,7 +5,7 @@ import MiqStructuredList from '../../components/miq-structured-list';
 import { genericGroupData } from '../textual_summary/data/generic_group';
 import { multilinkTableData } from '../textual_summary/data/multilink_table';
 import { operationRangesData } from '../textual_summary/data/operation_ranges';
-import { simpleTableData, buildInstance } from '../textual_summary/data/simple_table';
+import { simpleTableData, complexTableData, buildInstance } from '../textual_summary/data/simple_table';
 import { tableListViewData } from '../textual_summary/data/table_list_view';
 import { tagGroupData } from '../textual_summary/data/tag_group';
 
@@ -60,6 +60,16 @@ describe('Structured list component', () => {
       rows={simpleTableData.items}
       title={simpleTableData.title}
       mode="simple_table"
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render strings without double escaping strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={complexTableData.rows}
+      mode={complexTableData.mode}
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/simple_table.js
+++ b/app/javascript/spec/textual_summary/data/simple_table.js
@@ -35,3 +35,16 @@ export const buildInstance = {
     ],
   ],
 };
+
+export const complexTableData = {
+  "rows": [
+      {
+          "cells": {
+              "label": "Catch All",
+              "value": `< A test to HTML's "Escape" logic Hello&Goodbye >`,
+              "icon": "pficon pficon-unknown"
+          }
+      }
+  ],
+  "mode": "miq_summary miq_host_devices",
+}


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/8477

## BEFORE

![Screen Shot 2022-11-09 at 2 59 47 PM](https://user-images.githubusercontent.com/29209973/200935516-a6703adb-6fbe-4872-976e-4f39c1d72c6d.png)
Note the `&amp;` and trailing comma with whitepaces `, `

## AFTER
![Screen Shot 2022-11-09 at 3 24 20 PM](https://user-images.githubusercontent.com/29209973/200935466-6b17de5d-41b1-426d-8396-1d9670888da6.png)

NOTE: Changes will also affect the following pages
Compute / Infrastructure / Host / [Select and item]
- Properties > Devices
- Properties > Operating System
- Properties > VMM Information

@miq-bot add-reviewer @Fryguy
@miq-bot add-reviewer @jeffibm 
@miq-bot add-reviewer @DavidResende0 
@miq-bot assign @jeffibm 
@miq-bot add-label bug

