### PR TITLE
Exporting labels from the timeline form

### DIFF
--- a/app/javascript/components/timeline-options/timeline-options.jsx
+++ b/app/javascript/components/timeline-options/timeline-options.jsx
@@ -38,9 +38,9 @@ const TimelineOptions = ({ url }) => {
           policyGroupNames.push({ label: value, value: key });
         });
         // NOTE: data.MiqEvent.group_levels does not have the expected `Both` option
-        policyGroupLevels.push({ label: 'Success', value: 'success' });
-        policyGroupLevels.push({ label: 'Failure', value: 'failure' });
-        policyGroupLevels.push({ label: 'Both', value: 'both' });
+        policyGroupLevels.push({ label: __('Success'), value: 'success' });
+        policyGroupLevels.push({ label: __('Failure'), value: 'failure' });
+        policyGroupLevels.push({ label: __('Both'), value: 'both' });
 
         // TODO: is there a way to make the above more elegant/shorter?
         // NOTE: group_names for MiqEvents and MiqEvents includes the 'Other' option,


### PR DESCRIPTION
Exporting strings in the Timeline Form page
These screenshots are from `Compute > Infrastructure > Hosts > Timelines for Host "aramis"`

## Before
![Screen Shot 2022-11-10 at 1 13 34 PM](https://user-images.githubusercontent.com/29209973/201174498-6753d3a5-4cde-4a0d-94fa-b84e57d958bf.png)

## After
![Screen Shot 2022-11-10 at 1 12 34 PM](https://user-images.githubusercontent.com/29209973/201174487-0e706037-4b16-4ed0-80bb-e14b27c1e2ef.png)

NOTE: The reason the `Success` and `Failure` labels show as translated but `Both` does not is because these strings have been previously translated and such they can be replaced with the localized string. `Both` has not had this treatment yet. 

@miq-bot add-reviewer @jeffibm
@miq-bot add-reviewer @DavidResende0
@miq-bot assign @jeffibm
@miq-bot add-label enhancement
@miq-bot add-label internationalization