### PR TITLE
[WIP] Updating package minimist to >1.2.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,8 +3876,8 @@ __metadata:
   linkType: hard
 
 "babel-loader@npm:~8.2.0":
-  version: 8.2.4
-  resolution: "babel-loader@npm:8.2.4"
+  version: 8.2.5
+  resolution: "babel-loader@npm:8.2.5"
   dependencies:
     find-cache-dir: ^3.3.1
     loader-utils: ^2.0.0
@@ -3886,7 +3886,7 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
     webpack: ">=2"
-  checksum: 4968251fc4af4279c8e44adba523ed4ad18942f04b37061298e81640d09a570f66e6d53948e39a7d3c3d24ca2b025f0a07c606fadd8e3fbffa8912fd789fd4f0
+  checksum: a6605557885eabbc3250412405f2c63ca87287a95a439c643fdb47d5ea3d5326f72e43ab97be070316998cb685d5dfbc70927ce1abe8be7a6a4f5919287773fb
   languageName: node
   linkType: hard
 
@@ -11818,9 +11818,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "minimist@npm:^1.1.1, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+  version: 1.2.7
+  resolution: "minimist@npm:1.2.7"
+  checksum: 7346574a1038ca23c32e02252f603801f09384dd1d78b69a943a4e8c2c28730b80e96193882d3d3b22a063445f460e48316b29b8a25addca2d7e5e8f75478bec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updated minimist to `1.2.7`

NOTE: 
The package `ng-annotate-loader` is resolving minimist to `~0.0.1` and this package is already at it's latest version (`0.7.0` per [here](https://www.npmjs.com/package/ng-annotate-loader)). 

@miq-bot assign @Fryguy
@miq-bot add-label security fix
@miq-bot add_reviewer @Fryguy