### PR TITLE
Add Delete Server Button to Zone and Region Server Tab

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -240,6 +240,7 @@ class OpsController < ApplicationController
     assert_privileges(x_active_tree == :settings_tree ? "ops_settings" : "ops_diagnostics")
 
     @explorer = true
+    params[:miq_grid_checks] = []
     session[:changed] = false
     session[:flash_msgs] = @flash_array = nil # clear out any messages from previous screen i.e import tab
     if params[:tab]

--- a/app/helpers/application_helper/button/servers_delete_server.rb
+++ b/app/helpers/application_helper/button/servers_delete_server.rb
@@ -1,0 +1,6 @@
+class ApplicationHelper::Button::ServersDeleteServer < ApplicationHelper::Button::Basic
+  def visible?
+    @view_context.x_active_tree == :diagnostics_tree &&
+      %w[diagnostics_server_list].include?(@sb[:active_tab])
+  end
+end

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -30,6 +30,22 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
           :klass => ApplicationHelper::Button::DeleteServer
         ),
         button(
+          :delete_server,
+          'pficon pficon-delete fa-lg',
+          N_('Delete selected Servers'),
+          :enabled => false,
+          :onwhen  => "1+",
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => {:api_url        => 'servers',
+                                           :component_name => 'RemoveGenericItemModal',
+                                           :controller     => 'provider_dialogs',
+                                           :display_field  => 'name',
+                                           :modal_text     => N_("Are you sure you want to delete the selected Servers?"),
+                                           :modal_title    => N_("Delete Servers"),
+                                           :redirect_url   => '/ops/explorer/'}},
+          :klass   => ApplicationHelper::Button::ServersDeleteServer
+        ),
+        button(
           :role_start,
           'fa fa-play-circle-o fa-lg',
           server_role_string_proc(_('Start the %{server_role_description} Role on Server %{server_name} [%{server_id}]')),

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -32,6 +32,22 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
           :klass   => ApplicationHelper::Button::ZoneDeleteServer
         ),
         button(
+          :delete_server,
+          'pficon pficon-delete fa-lg',
+          N_('Delete selected Servers'),
+          :enabled => false,
+          :onwhen  => "1+",
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => {:api_url        => 'servers',
+                                           :component_name => 'RemoveGenericItemModal',
+                                           :controller     => 'provider_dialogs',
+                                           :display_field  => 'name',
+                                           :modal_text     => N_("Are you sure you want to delete the selected Servers?"),
+                                           :modal_title    => N_("Delete Servers"),
+                                           :redirect_url   => '/ops/explorer/'}},
+          :klass   => ApplicationHelper::Button::ServersDeleteServer
+        ),
+        button(
           :zone_role_start,
           'fa fa-play-circle-o fa-lg',
           server_role_string_proc(_('Start the %{server_role_description} Role on Server %{server_name} [%{server_id}]')),

--- a/app/javascript/components/remove-generic-item-modal.jsx
+++ b/app/javascript/components/remove-generic-item-modal.jsx
@@ -22,7 +22,11 @@ const apiTransformFunctions = {
 const parseApiError = (error) => {
   // eslint-disable-next-line no-prototype-builtins
   if (error.hasOwnProperty('data')) {
-    return error.data.error.message;
+    // eslint-disable-next-line no-prototype-builtins
+    if (error.data.hasOwnProperty('error')) {
+      return error.data.error.message;
+    }
+    return error.data.message;
   // eslint-disable-next-line no-prototype-builtins
   } if (error.hasOwnProperty('message')) {
     return error.message;


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22229
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8459

Adds a delete server button to the server tab in the Diagnostic->Zone/Region pages.
![image](https://user-images.githubusercontent.com/64800041/201409811-2dca7a2f-fb72-4121-8ef6-2cc0beba1733.png)
![image](https://user-images.githubusercontent.com/64800041/201409931-e2017c5c-f9d9-4319-9af8-409283db030f.png)

@miq-bot add-reviewer @jeffibm
@miq-bot add-reviewer @MelsHyrule
@Fryguy, @jrafanie
@miq-bot add-label enhancement