### PR TITLE
Add shared processor pool field option to provision form

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -240,7 +240,7 @@
                :floating_ip_address, :resource_group, :load_balancer,
                :sysprep_auto_logon_count, :sysprep_domain_name, :sysprep_server_license_mode,
                :vlan, :cloud_tenant, :src_configuration_profile_id, :vm_minimum_memory,
-               :vm_maximum_memory, :boot_disk_size, :subnet, :placement_group].include?(field)
+               :vm_maximum_memory, :boot_disk_size, :subnet, :placement_group, :shared_processor_pool].include?(field)
         -# Pull Down fields
         -# Multiple select Pull Down fields
         - multiple = %i[security_groups cloud_volumes].include?(field)

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -429,6 +429,13 @@
             :label                    => _("Placement Groups"),
             :prefix                   => "/miq_request/",
             :keys                     => keys})
+      - keys = [:shared_processor_pool]
+      = render(:partial => "/miq_request/prov_dialog_fieldset",
+        :locals         => {:workflow => wf,
+            :dialog                   => dialog,
+            :label                    => _("Shared Processor Pools"),
+            :prefix                   => "/miq_request/",
+            :keys                     => keys})
       - keys = %i[migratable pin_policy]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
         :locals         => {:workflow => wf,


### PR DESCRIPTION
Connected to https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/435
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/79273849/201970206-0ac6c0bb-416c-4204-b55b-0f6a16259fe1.png">
