### PR TITLE
Add 'dialog_load' to ems_physical_infra in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1175,6 +1175,7 @@ Rails.application.routes.draw do
 
     :ems_physical_infra                => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         protect

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -542,6 +542,7 @@ EmsNetworkController:
 - tl_chooser
 - wait_for_task
 EmsPhysicalInfraController:
+- dialog_load
 - dialog_field_changed
 - dialog_form_button_pressed
 - dynamic_checkbox_refresh


### PR DESCRIPTION
Triggering a custom dialog from an object type in the `Physical Infrastructure` section fails with an error.

Example error when clicking a custom button from a **Physical Infrastructure Provider**:
```
FATAL -- development: Error caught: [ActionController::UrlGenerationError] No route matches {:action=>"dialog_load", :controller=>"ems_physical_infra", :dialog_locals=>{:resource_action_id=>183, :target_id=>2, :target_type=>"ext_management_system", :real_target_type=>"ExtManagementSystem", :dialog_id=>3, :api_submit_endpoint=>"/api/providers/2", :api_action=>"Create Incident", :finish_submit_endpoint=>"/ems_infra", :cancel_endpoint=>"/ems_infra", :open_url=>false}, :id=>"2"}
```

This fixes the described error by adding the missing `ems_physical_infra -> dialog_load` route.

This refers to [manageiq-providers-cisco_intersight/issues/76](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/76).


##
*Edit:  added screenshots of UI*

| ![Screenshot from 2022-11-30 11-39-27](https://user-images.githubusercontent.com/67372390/204775388-ec67c89f-9de1-4066-8b7c-0b3da43ad049.png)| 
| :--: |
| *Triggering a dialog with a custom button from  a Physical Infrastructure Provider.* |
| ![Screenshot from 2022-11-30 11-41-05](https://user-images.githubusercontent.com/67372390/204775408-9a1e09a1-85d1-4d2f-bc64-35ecc91b1f23.png) |
| *Error returned before changes.* |
| ![Screenshot from 2022-11-30 11-37-43](https://user-images.githubusercontent.com/67372390/204775417-0dfd0dea-af33-4d94-ba50-a07d4cd8f52a.png) |
| *Dialog opened after changes.* |
