### PR TITLE
Remove escape characters from Chargeback Rate helper

### DIFF
--- a/app/helpers/chargeback_rate_helper.rb
+++ b/app/helpers/chargeback_rate_helper.rb
@@ -40,7 +40,7 @@ module ChargebackRateHelper
         @cur_group = detail.chargeable_field[:group]
       end
       num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
-      cells.push({:text => h(rate_detail_group(detail.chargeable_field[:group]))})
+      cells.push({:text => rate_detail_group(detail.chargeable_field[:group])})
       cells.push({:text => [
         _(detail.chargeable_field[:description]), 
         Dictionary.gettext(detail.chargeable_field.metric_key, :type => :column, :notfound => :titleize)

--- a/app/javascript/spec/miq-data-table/__snapshots__/miq-data-table.spec.js.snap
+++ b/app/javascript/spec/miq-data-table/__snapshots__/miq-data-table.spec.js.snap
@@ -1730,3 +1730,24 @@ exports[`Data table component should render a static-gtl-view data table with ic
   />
 </div>
 `;
+
+exports[`Data table component should render strings without double escaping strings 1`] = `
+<div
+  className="miq-data-table list"
+>
+  <DataTable
+    filterRows={[Function]}
+    headers={Array []}
+    isSortable={false}
+    locale="en"
+    overflowMenuOnHover={true}
+    rows={Array []}
+    size="normal"
+    sortDirection="ASC"
+    sortRow={[Function]}
+    translateWithId={[Function]}
+  >
+    <Component />
+  </DataTable>
+</div>
+`;

--- a/app/javascript/spec/miq-data-table/data.js
+++ b/app/javascript/spec/miq-data-table/data.js
@@ -372,3 +372,33 @@ export const chargebackRateData = () => {
   const { headers, rows } = chargebackTableData(initialData, true);
   return { headers, rows };
 };
+
+/** Table data with multiple rows within a cell, ie 'text' contains an array or a string.
+ * Usage eg: Overview / Chargeback / Rates / Item (Summary)
+ */
+ export const complexTableData = () => {
+  const cells = [
+    { text: 'CPU&amp;' },
+    { text: ['Allocated CPU Count', 'vCPUs Allocated over Time Period'] },
+    { text: [0, 100] },
+    { text: [100, 'Infinity'] },
+    { text: [1.5, 0.5], align: 'right' },
+    { text: [0], align: 'right' },
+    { text: '€ [Euro] / Hour / Cpu' },
+  ];
+  const initialData = [
+    { id: '0', clickable: false, cells },
+    { id: '1', clickable: false, cells },
+    { id: '2', clickable: false, cells },
+    { id: '3', clickable: false, cells },
+    { id: '4', clickable: false, cells },
+    { id: '5', clickable: false, cells },
+    { id: '6', clickable: false, cells },
+    { id: '7', clickable: false, cells },
+    { id: '8', clickable: false, cells },
+    { id: '9', clickable: false, cells },
+  ];
+
+  const { headers, rows } = chargebackTableData(initialData, true);
+  return { headers, rows };
+};

--- a/app/javascript/spec/miq-data-table/miq-data-table.spec.js
+++ b/app/javascript/spec/miq-data-table/miq-data-table.spec.js
@@ -3,7 +3,7 @@ import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';
 import MiqDataTable from '../../components/miq-data-table';
 import {
-  simpleData, containerNodesData, hostData, catalogData, timeProfileReportsData, chargebackRateData,
+  simpleData, containerNodesData, hostData, catalogData, timeProfileReportsData, chargebackRateData, complexTableData
 } from './data';
 
 describe('Data table component', () => {
@@ -21,6 +21,17 @@ describe('Data table component', () => {
 
   it('should render a simple non-clickable data table', () => {
     const { miqHeaders, miqRows } = timeProfileReportsData();
+    const wrapper = shallow(<MiqDataTable
+      headers={miqHeaders}
+      rows={miqRows}
+      mode="list"
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render strings without double escaping strings', () => {
+    const onClick = jest.fn();
+    const { miqHeaders, miqRows } = complexTableData();
     const wrapper = shallow(<MiqDataTable
       headers={miqHeaders}
       rows={miqRows}


### PR DESCRIPTION
For the issue:- https://github.com/ManageIQ/manageiq-ui-classic/issues/8526

Before: 
<img width="1335" alt="Screenshot 2022-11-21 at 8 26 11 PM" src="https://user-images.githubusercontent.com/16753936/203086368-7e7a253f-b942-422a-8e3a-a02e704c0430.png">


After:
<img width="1792" alt="Screenshot 2022-11-17 at 3 05 27 PM" src="https://user-images.githubusercontent.com/16753936/202415483-b67fa816-0fd3-4cc4-aa79-5d0614601ca4.png">

Links [Optional]
----------------

Chargeback Rate initial PR: [https://github.com/ManageIQ/manageiq-ui-classic/pull/8012/files](https://github.com/ManageIQ/manageiq-ui-classic/pull/8012/files)
