### PR TITLE
Fix for Service catalog item for Ansible Playbook tabs change

### DIFF
--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -3,14 +3,15 @@
                          :tabLabels => catalog_tab_edit_generic_configuration,
                          :type => 'CATALOG_EDIT'})
 
-#catalog-tabs-generic-edit.miq_custom_tabs_container
-  %form.form-horizontal#form_div{"name" => "angularForm",
-                                "ng-controller" => "catalogItemFormController as vm",
-                                "miq-form" => 'true',
-                                "model" => "vm.catalogItemModel",
-                                "model-copy" => 'vm.modelCopy',
-                                "ng-cloak" => ''}
-    = render :partial => "layouts/flash_msg"
+
+%form.form-horizontal#form_div{"name" => "angularForm",
+                              "ng-controller" => "catalogItemFormController as vm",
+                              "miq-form" => 'true',
+                              "model" => "vm.catalogItemModel",
+                              "model-copy" => 'vm.modelCopy',
+                              "ng-cloak" => ''}
+  = render :partial => "layouts/flash_msg"
+  #catalog-tabs-generic-edit.miq_custom_tabs_container
     = catalog_tab_content(:basic) do
       %h3= _('Basic Information')
       %div{"ng-if" => "vm.afterGet"}
@@ -116,7 +117,7 @@
 
     = render :partial => "layouts/angular/multi_tab_ansible_form_options",
              :locals => {:record => @record, :ng_model => "vm.catalogItemModel"}
-    = render :partial => "layouts/angular/x_edit_buttons_angular"
+  = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('catalogItemFormId', '#{@record.id || "new"}');


### PR DESCRIPTION
**Before** 
No change in tab contents when the `Provision` and `Retirement` tabs are selected, hence making it unable to save

![image](https://user-images.githubusercontent.com/87487049/202419881-ffb1cfd8-f13c-4158-a660-f4cbfc7243f6.png)

**After**
Able to change the tab contents and save the form
![image](https://user-images.githubusercontent.com/87487049/202419073-e109e319-b8d3-4d00-b34d-8c9dba99deb8.png)
![image](https://user-images.githubusercontent.com/87487049/202419112-222fbdd8-4fb9-456d-ad30-564b00acde00.png)
![image](https://user-images.githubusercontent.com/87487049/202419172-3d890243-c9c2-4739-a9ab-7e7afb857925.png)

https://user-images.githubusercontent.com/87487049/202419787-5601a258-6969-427e-993f-64d7cc545bde.mov


