### PR TITLE
[MORPHY] Handle nil return from class_by_ems

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -45,7 +45,7 @@ class CloudNetworkController < ApplicationController
     when "add"
       options = form_params
       ems = ExtManagementSystem.find(options[:ems_id])
-      if CloudNetwork.class_by_ems(ems).supports_create?
+      if CloudNetwork.class_by_ems(ems)&.supports_create?
         options.delete(:ems_id)
         task_id = ems.create_cloud_network_queue(session[:userid], options)
         unless task_id.kind_of?(Integer)

--- a/app/controllers/floating_ip_controller.rb
+++ b/app/controllers/floating_ip_controller.rb
@@ -46,7 +46,7 @@ class FloatingIpController < ApplicationController
       options = form_params
       ems = ExtManagementSystem.find(options[:ems_id])
 
-      if FloatingIp.class_by_ems(ems).supports_create?
+      if FloatingIp.class_by_ems(ems)&.supports_create?
         options.delete(:ems_id)
         task_id = ems.create_floating_ip_queue(session[:userid], options)
 

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -55,7 +55,7 @@ class SecurityGroupController < ApplicationController
       @security_group = SecurityGroup.new
       options = form_params
       ems = ExtManagementSystem.find(options[:ems_id])
-      if SecurityGroup.class_by_ems(ems).supports_create?
+      if SecurityGroup.class_by_ems(ems)&.supports_create?
         options.delete(:ems_id)
         task_id = ems.create_security_group_queue(session[:userid], options)
 

--- a/app/helpers/application_helper/button/cloud_network_new.rb
+++ b/app/helpers/application_helper/button/cloud_network_new.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::CloudNetworkNew < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    ::EmsNetwork.all.any? { |ems| CloudNetwork.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.any? { |ems| CloudNetwork.class_by_ems(ems)&.supports_create? }
   end
 
   def role_allows_feature?

--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -12,6 +12,6 @@ class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::But
 
   # disable button if no active providers support create action
   def disabled?
-    ::EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems)&.supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/floating_ip_new.rb
+++ b/app/helpers/application_helper/button/floating_ip_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::FloatingIpNew < ApplicationHelper::Button::Butt
 
   # disable button if no active providers support create action
   def disabled?
-    ::EmsNetwork.all.none? { |ems| ::FloatingIp.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| ::FloatingIp.class_by_ems(ems)&.supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/network_router_new.rb
+++ b/app/helpers/application_helper/button/network_router_new.rb
@@ -12,6 +12,6 @@ class ApplicationHelper::Button::NetworkRouterNew < ApplicationHelper::Button::B
 
   # disable button if no active providers support create action
   def disabled?
-    ::EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| NetworkRouter.class_by_ems(ems)&.supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/network_service_entry_new.rb
+++ b/app/helpers/application_helper/button/network_service_entry_new.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::NetworkServiceEntryNew < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    ::EmsNetwork.all.any? { |ems| NetworkServiceEntry.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.any? { |ems| NetworkServiceEntry.class_by_ems(ems)&.supports_create? }
   end
 
   def role_allows_feature?

--- a/app/helpers/application_helper/button/network_service_new.rb
+++ b/app/helpers/application_helper/button/network_service_new.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::NetworkServiceNew < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    ::EmsNetwork.all.any? { |ems| NetworkService.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.any? { |ems| NetworkService.class_by_ems(ems)&.supports_create? }
   end
 
   def role_allows_feature?

--- a/app/helpers/application_helper/button/security_group_new.rb
+++ b/app/helpers/application_helper/button/security_group_new.rb
@@ -8,6 +8,6 @@ class ApplicationHelper::Button::SecurityGroupNew < ApplicationHelper::Button::B
 
   # disable button if no active providers support create action
   def disabled?
-    ::EmsNetwork.all.none? { |ems| SecurityGroup.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.none? { |ems| SecurityGroup.class_by_ems(ems)&.supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/security_policy_new.rb
+++ b/app/helpers/application_helper/button/security_policy_new.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::SecurityPolicyNew < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    ::EmsNetwork.all.any? { |ems| SecurityPolicy.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.any? { |ems| SecurityPolicy.class_by_ems(ems)&.supports_create? }
   end
 
   def role_allows_feature?

--- a/app/helpers/application_helper/button/security_policy_rule_new.rb
+++ b/app/helpers/application_helper/button/security_policy_rule_new.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::SecurityPolicyRuleNew < ApplicationHelper::Button::ButtonNewDiscover
   def supports_button_action?
-    ::EmsNetwork.all.any? { |ems| SecurityPolicyRule.class_by_ems(ems).supports_create? }
+    ::EmsNetwork.all.any? { |ems| SecurityPolicyRule.class_by_ems(ems)&.supports_create? }
   end
 
   def role_allows_feature?


### PR DESCRIPTION
Morphy direct backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/8447

(cherry picked from commit 21e9653c7386b292976e01f72fac3f6eacb84dd6)

On master these were changed to `.supports?(:create)` from `.supports_create` earlier, but I left these as `&.supports_create?` to minimize the changes to only what this PR was doing (adding `&.` to handle the `nil` return possibility)