### PR TITLE
Fix saved report filter search

### DIFF
--- a/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
+++ b/app/javascript/components/data-tables/report-data-table/report-data-table.jsx
@@ -111,7 +111,7 @@ const initialState = {
 
 const filterToString = (filter) => (
   filter && filter.field && filter.string
-    ? `${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
+    ? `&filter_column=${filter.field}&filter_string=${encodeURIComponent(filter.string)}`
     : ''
 );
 


### PR DESCRIPTION
**Before**
Unable to filter and sort in Reports / Saved Reports
![image](https://user-images.githubusercontent.com/87487049/202619749-f558cc8f-36c6-4385-8cc9-0003d8e227b0.png)

**After**
Able to filter and sort after adding `filter_column` key in the api params
![image](https://user-images.githubusercontent.com/87487049/202619591-9191d6ba-1140-492c-9968-3aecf5a7b2bd.png)

