### PR TITLE
Fix No record id available for Publishing VM to template

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -89,7 +89,7 @@ module ApplicationController::Explorer
       # don't need to set params[:id] and do find_checked_items for methods
       # like ownership, the code in those methods handle it
       if %w[edit right_size resize attach detach clone live_migrate evacuate
-            associate_floating_ip disassociate_floating_ip].include?(action)
+            associate_floating_ip disassociate_floating_ip publish migrate].include?(action)
         @_params[:id] = (params[:id] ? [params[:id]] : find_checked_items)[0]
       end
       if %w[protect tag].include?(action)


### PR DESCRIPTION
**Before**
Unable to publish VM in Template. `Can't access records without an id` error is displayed.
![image](https://user-images.githubusercontent.com/87487049/203220018-0701a7bb-6079-4222-a432-c88266599c1e.png)
Note -
- This is only an issue from the `Compute / Infrastructure / Virtual Machines` menu, breadcrumb path `Compute / Infrastructure / Virtual Machines / VMs & Templates / All VMs & Templates.`
- If we go to the provider and select VMs we can publish to a template from both the list view and the VM details page.

**After**
- The selected checkbox value was being accessed as `params[:id]` was available in the `x_node` variable.
![image](https://user-images.githubusercontent.com/87487049/203220262-10b2801b-f954-4d5d-8670-ebbc81d48837.png)
