### PR TITLE
Replace `Vmdb::Loggers.contents` with `Systemd::Journal`

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -368,7 +368,7 @@ module OpsController::Diagnostics
       entries.map do |entry|
         # This is the time in microseconds since the epoch UTC, formatted as a decimal string.
         seconds_since_epoch = entry._source_realtime_timestamp.to_f / 1_000_000.0
-        timestamp = Time.strptime(seconds_since_epoch.to_s, "%s").strftime("%Y-%m-%dT%H:%M:%S.%6N ")
+        timestamp = Time.zone.at(seconds_since_epoch).strftime("%Y-%m-%dT%H:%M:%S.%6N")
 
         "[#{timestamp} ##{entry._pid}]#{entry.message}"
       end.join("\n")

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -363,12 +363,9 @@ module OpsController::Diagnostics
     }
 
     require "systemd/journal"
-    journal = Systemd::Journal.new
-    begin
+    Systemd::Journal.open do |journal|
       journal.filter(filter_params)
       journal.map(&:message)
-    ensure
-      journal.close
     end
   end
 

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -365,7 +365,13 @@ module OpsController::Diagnostics
       journal.filter(filter_params)
 
       entries = max_count.nil? ? journal.all : journal.take(max_count)
-      entries.map(&:message).join("\n")
+      entries.map do |entry|
+        # This is the time in microseconds since the epoch UTC, formatted as a decimal string.
+        seconds_since_epoch = entry._source_realtime_timestamp.to_f / 1_000_000.0
+        timestamp = Time.strptime(seconds_since_epoch.to_s, "%s").strftime("%Y-%m-%dT%H:%M:%S.%6N ")
+
+        "[#{timestamp} ##{entry._pid}]#{entry.message}"
+      end.join("\n")
     end
   end
 


### PR DESCRIPTION
Replacement of `Vmdb::Loggers.contents` with `Systemd::Journal` on appliances

TODO:
- [x] check if systemd is present, otherwise return `nil`
- [ ] should this move to core and be accessible via the API?