### PR TITLE
Remove escape characters from Miq ae class helper

### DIFF
--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -282,11 +282,11 @@ module MiqAeClassHelper
   def class_properties_data(name, record)
     data = {:title => _("Properties"), :mode => "class_props", :clickable => false}
     data[:rows] = [
-      {:cells => {:label => _('Fully Qualified Name'), :value => h(name)}},
+      {:cells => {:label => _('Fully Qualified Name'), :value => name}},
       {:cells => {:label => _('Name'), :value => record.name}},
       {:cells => {:label => _('Display Name'), :value => record.display_name}},
       {:cells => {:label => _('Description'), :value => record.try(:description)}},
-      {:cells => {:label => _('Instances'), :value => h(record.ae_instances.length)}},
+      {:cells => {:label => _('Instances'), :value => record.ae_instances.length}},
     ]
     miq_structured_list(data)
   end

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -2071,6 +2071,104 @@ exports[`Structured list component should render catalog_data with escaped strin
 </Accordion>
 `;
 
+exports[`Structured list component should render miq_ae_class_list_view with escaped strings 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion table_list_view"
+>
+  <AccordionItem
+    open={true}
+    title="Properties"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list table_list_view"
+    >
+      <FeatureToggle(StructuredListBody)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="0"
+          onClick={[Function]}
+          tabIndex={0}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Fully Qualified Name
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                ManageIQ / Automation Management / Test &
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="1"
+          onClick={[Function]}
+          tabIndex={1}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Name
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                Thor Odinson
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="2"
+          onClick={[Function]}
+          tabIndex={2}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Instances
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                1 &
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+      </FeatureToggle(StructuredListBody)>
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render settings list 1`] = `
 <FeatureToggle(StructuredListWrapper)
   ariaLabel="Structured list"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -10,6 +10,7 @@ import { tableListViewData } from '../textual_summary/data/table_list_view';
 import { tagGroupData } from '../textual_summary/data/tag_group';
 import { diagnosticSettingsListData } from '../textual_summary/data/diagnostic_settings_list';
 import { catalogListData } from '../textual_summary/data/catalog_list';
+import { miqAeClassListData } from '../textual_summary/data/miq_ae_class_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -116,6 +117,17 @@ describe('Structured list component', () => {
       rows={catalogListData.items}
       title={catalogListData.title}
       mode="catalog_list_view"
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render miq_ae_class_list_view with escaped strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={miqAeClassListData.items}
+      title={miqAeClassListData.title}
+      mode="table_list_view"
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/miq_ae_class_list.js
+++ b/app/javascript/spec/textual_summary/data/miq_ae_class_list.js
@@ -1,0 +1,17 @@
+export const miqAeClassListData = {
+    items: [
+      {
+        label: 'Fully Qualified Name',
+        value: 'ManageIQ / Automation Management / Test &'
+      },
+      {
+          label: 'Name',
+          value: 'Thor Odinson'
+      },
+      {
+          label: 'Instances',
+          value: '1 &'
+      },
+    ],
+    title: 'Properties'
+  };


### PR DESCRIPTION
For the issue:- https://github.com/ManageIQ/manageiq-ui-classic/issues/8526
Before:-
<img width="1321" alt="Screenshot 2022-11-23 at 12 47 07 PM" src="https://user-images.githubusercontent.com/16753936/203499663-c4e1e39b-d4d0-4d23-b033-4f660c9f7827.png">
After:-
<img width="1378" alt="Screenshot 2022-11-23 at 12 49 36 PM" src="https://user-images.githubusercontent.com/16753936/203499734-902d87bb-4feb-4067-9ff2-962b972ac0c7.png">


Testing/QA 
-------------------------------

Spec changes for the [MiqStructuredList](https://github.com/ManageIQ/manageiq-ui-classic/blob/f49cad584207bab59a3135c07c5367f362e3ca94/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js#L68) will cover this change also.
