### PR TITLE
Remove escape characters from Miq policy helper

### DIFF
--- a/app/helpers/miq_policy_helper.rb
+++ b/app/helpers/miq_policy_helper.rb
@@ -9,10 +9,10 @@ module MiqPolicyHelper
   def miq_summary_policy_basic_information(record)
     rows = []
     data = {:title => _('Basic Information'), :mode => "miq_policy_basic_information"}
-    rows.push({:cells => {:label => _('Active'), :value => h(record.active ? _("Yes") : _("No"))}})
-    rows.push({:cells => {:label => _('Created'), :value => h(_("By Username %{username} %{created_on}") % {:username => record.created_by || _("N/A"), :created_on => format_timezone(record.created_on, session[:user_tz], "gtl")})}})
+    rows.push({:cells => {:label => _('Active'), :value => record.active ? _("Yes") : _("No")}})
+    rows.push({:cells => {:label => _('Created'), :value => _("By Username %{username} %{created_on}") % {:username => record.created_by || _("N/A"), :created_on => format_timezone(record.created_on, session[:user_tz], "gtl")}}})
     if @record.created_on != @record.updated_on
-      rows.push({:cells => {:label => _("Last Updated"), :value => h(_("By Username %{username} %{updated_on}") % {:username => record.updated_by || _("N/A"), :updated_on => format_timezone(record.updated_on, session[:user_tz], "gtl")})}})
+      rows.push({:cells => {:label => _("Last Updated"), :value => _("By Username %{username} %{updated_on}") % {:username => record.updated_by || _("N/A"), :updated_on => format_timezone(record.updated_on, session[:user_tz], "gtl")}}})
     end
     data[:rows] = rows
     miq_structured_list(data)
@@ -23,11 +23,7 @@ module MiqPolicyHelper
     data = {:title => _('Scope'), :mode => "miq_policy_scope"}
     if !expression_table.nil?
       expression_table.each do |token|
-        if ! ["AND", "OR", "(", ")"].include?([token].flatten.first)
-          rows.push({:cells => {:label => _(''), :value => h([token].flatten.first)}})
-        else
-          rows.push({:cells => {:label => _(''), :value => h([token].flatten.first)}})
-        end
+        rows.push({:cells => {:label => _(''), :value => [token].flatten.first}})
       end
     else
       data[:message] = _("No Policy scope defined, the scope of this policy includes all elements.")
@@ -47,9 +43,9 @@ module MiqPolicyHelper
         cells = [{:icon => c.decorate.fonticon, :value => c.description}]
         value = []
         if c.applies_to_exp.present?
-          value.push({:label => _("Scope"), :value => h(MiqExpression.to_human(c.applies_to_exp))})
+          value.push({:label => _("Scope"), :value => MiqExpression.to_human(c.applies_to_exp)})
         end
-        value.push({:label => _("Expression"), :value => h(MiqExpression.to_human(c.expression))})
+        value.push({:label => _("Expression"), :value => MiqExpression.to_human(c.expression)})
         cells.push(value)
         rows.push({
                     :cells   => cells,
@@ -73,7 +69,7 @@ module MiqPolicyHelper
         obj = {}
         obj['cells'] = [{
           :icon    => e.decorate.try(:fonticon),
-          :value   => h(e.description),
+          :value   => e.description,
           :title   => _("View this Event"),
           :onclick => "DoNav('/miq_event_definition/show/#{e.id}');"
         }]
@@ -82,7 +78,7 @@ module MiqPolicyHelper
         ta.each do |a|
           values.push({:value => {
                         :icon    => "pficon pficon-ok",
-                        :value   => h(a.description),
+                        :value   => a.description,
                         :title   => _("View this Action"),
                         :onclick => "DoNav('/miq_action/show/#{a.id}');"
                       }})
@@ -91,7 +87,7 @@ module MiqPolicyHelper
         fa.each do |a|
           values.push({:value => {
                         :icon    => "pficon pficon-close",
-                        :value   => h(a.description),
+                        :value   => a.description,
                         :title   => _("View this Action"),
                         :onclick => "DoNav('/miq_action/show/#{a.id}');"
                       }})

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -2071,6 +2071,130 @@ exports[`Structured list component should render catalog_data with escaped strin
 </Accordion>
 `;
 
+exports[`Structured list component should render miq policy data without double escaping strings 1`] = `
+<FeatureToggle(StructuredListWrapper)
+  ariaLabel="Structured list"
+  className="miq-structured-list miq_policy_details"
+>
+  <FeatureToggle(StructuredListBody)>
+    <FeatureToggle(StructuredListRow)
+      className=""
+      key="0"
+      onClick={[Function]}
+      tabIndex={0}
+      title=""
+    >
+      <FeatureToggle(StructuredListCell)
+        className="label_header"
+      >
+        Active
+      </FeatureToggle(StructuredListCell)>
+      <FeatureToggle(StructuredListCell)
+        className="content_value object_item"
+      >
+        <div
+          className="content"
+        >
+          <div
+            className="expand wrap_text"
+          >
+            Yes &
+          </div>
+        </div>
+      </FeatureToggle(StructuredListCell)>
+    </FeatureToggle(StructuredListRow)>
+    <FeatureToggle(StructuredListRow)
+      className=""
+      key="1"
+      onClick={[Function]}
+      tabIndex={1}
+      title=""
+    >
+      <FeatureToggle(StructuredListCell)
+        className="label_header"
+      >
+        Created
+      </FeatureToggle(StructuredListCell)>
+      <FeatureToggle(StructuredListCell)
+        className="content_value object_item"
+      >
+        <div
+          className="content"
+        >
+          <div
+            className="expand wrap_text"
+          >
+            By Username Thor Odinson && at 2020-10-10 15T $UTC
+          </div>
+        </div>
+      </FeatureToggle(StructuredListCell)>
+    </FeatureToggle(StructuredListRow)>
+    <FeatureToggle(StructuredListRow)
+      className=""
+      key="2"
+      onClick={[Function]}
+      tabIndex={2}
+      title=""
+    >
+      <FeatureToggle(StructuredListCell)
+        className="label_header"
+      >
+        Last Updated
+      </FeatureToggle(StructuredListCell)>
+      <FeatureToggle(StructuredListCell)
+        className="content_value object_item"
+      >
+        <div
+          className="content"
+        >
+          <div
+            className="expand wrap_text"
+          >
+            By Username Lord Loki && at 2020-10-10 15T $UTC &
+          </div>
+        </div>
+      </FeatureToggle(StructuredListCell)>
+    </FeatureToggle(StructuredListRow)>
+    <FeatureToggle(StructuredListRow)
+      className="clickable"
+      key="3"
+      onClick={[Function]}
+      tabIndex={3}
+      title="View this Action"
+    >
+      <FeatureToggle(StructuredListCell)
+        className="label_header object_item"
+      >
+        <div
+          className="content"
+        >
+          <div
+            className="cell icon"
+            title="View this Action"
+          >
+            <i
+              className="pficon pficon-close"
+              style={
+                Object {
+                  "background": undefined,
+                  "color": undefined,
+                }
+              }
+              title="View this Action"
+            />
+          </div>
+          <div
+            className="expand wrap_text"
+          >
+            Test &&
+          </div>
+        </div>
+      </FeatureToggle(StructuredListCell)>
+    </FeatureToggle(StructuredListRow)>
+  </FeatureToggle(StructuredListBody)>
+</FeatureToggle(StructuredListWrapper)>
+`;
+
 exports[`Structured list component should render miq_ae_class_list_view with escaped strings 1`] = `
 <Accordion
   align="start"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -11,6 +11,7 @@ import { tagGroupData } from '../textual_summary/data/tag_group';
 import { diagnosticSettingsListData } from '../textual_summary/data/diagnostic_settings_list';
 import { catalogListData } from '../textual_summary/data/catalog_list';
 import { miqAeClassListData } from '../textual_summary/data/miq_ae_class_list';
+import { miqAePolicyListData } from '../textual_summary/data/miq_ae_policy_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -129,6 +130,14 @@ describe('Structured list component', () => {
       title={miqAeClassListData.title}
       mode="table_list_view"
       onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render miq policy data without double escaping strings', () => {
+    const wrapper = shallow(<MiqStructuredList
+      rows={miqAePolicyListData.items}
+      mode={miqAePolicyListData.mode}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/app/javascript/spec/textual_summary/data/miq_ae_policy_list.js
+++ b/app/javascript/spec/textual_summary/data/miq_ae_policy_list.js
@@ -1,0 +1,24 @@
+export const miqAePolicyListData = {
+    items: [
+      {
+        label: 'Active',
+        value: 'Yes &'
+      },
+      {
+          label: 'Created',
+          value: 'By Username Thor Odinson && at 2020-10-10 15T $UTC'
+      },
+      {
+          label: 'Last Updated',
+          value: 'By Username Lord Loki && at 2020-10-10 15T $UTC &'
+      },
+      {
+        icon:     "pficon pficon-close",
+        value:    "Test &&",
+        title:    "View this Action",
+        onclick:  "DoNav('/miq_action/show/1');"
+      },
+    ],
+    title: 'Basic Information',
+    mode: 'miq_policy_details'
+  };


### PR DESCRIPTION
For the issue:- https://github.com/ManageIQ/manageiq-ui-classic/issues/8526

Before:-
<img width="1771" alt="Screenshot 2022-11-23 at 1 26 30 PM" src="https://user-images.githubusercontent.com/16753936/203500605-a6d0859e-27d3-43c6-b7a8-d3f486dadf50.png">

After:-
<img width="1775" alt="Screenshot 2022-11-23 at 1 58 21 PM" src="https://user-images.githubusercontent.com/16753936/203500924-21aef2ad-68ee-47e5-a029-500509b3273d.png">

Testing/QA
-------------------------------

Spec changes for the [MiqStructuredList](https://github.com/ManageIQ/manageiq-ui-classic/blob/f49cad584207bab59a3135c07c5367f362e3ca94/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js#L68) will cover this change also.