### PR TITLE
Modified Servers By Role Tree to Prevent Undefined Method Error

### DIFF
--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -16,8 +16,6 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
   def x_get_tree_server_roles
     ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region
-      next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
-                  (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
       next if r.name == "database_owner"
       unless @sb[:diag_selected_id] # Set default selected record vars
         @sb[:diag_selected_model] = r.class.to_s
@@ -29,7 +27,7 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
 
   def x_get_tree_server_role_kids(parent, _count_only)
     parent.assigned_server_roles.sort_by { |asr| asr.miq_server.name }.select do |asr|
-      !parent.kind_of?(Zone) || asr.miq_server.my_zone == parent.name
+      !@root.kind_of?(Zone) || asr.miq_server.my_zone == @root.name
     end
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8460
Found in: Settings->Application Settings->Diagnostics->Servers By Roles

Fixes an issue where the Servers By Roles page was displaying all servers assigned to a role as opposed to only the servers belonging to the selected zone. Also changes the Servers By Roles page to display all roles regardless of whether or not they have a server assigned to them, which prevents the `ServersByRole` tree from being an empty object, causing an undefined method error.

**Before:**

When there are no servers assigned to any roles:
![image](https://user-images.githubusercontent.com/64800041/203591619-b8de9b3a-9739-4c08-a500-bae17a05d452.png)

When there is a least one server assigned to a role (EVM[16] does not belong to this zone): 
![image](https://user-images.githubusercontent.com/64800041/203591731-8ad19338-edba-4afa-8d09-8aad7e79f238.png)

**After:**

When there are no servers assigned to any roles:
![image](https://user-images.githubusercontent.com/64800041/203592451-9963e2ef-f5bf-474e-aee7-0d4518546fca.png)

When there is a least one server assigned to a role:
![image](https://user-images.githubusercontent.com/64800041/203592537-4245c461-f48b-482e-884d-a8355807fbd9.png)

@miq-bot add-reviewer @MelsHyrule, @jeffibm
@miq-bot add-label bug
@miq-bot assign @Fryguy