### PR TITLE
Add Banner to Server By Roles Page

### DIFF
--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -16,6 +16,8 @@ class TreeBuilderServersByRole < TreeBuilderDiagnostics
   def x_get_tree_server_roles
     ServerRole.all.sort_by(&:description).each_with_object([]) do |r, objects|
       next if @root.kind_of?(MiqRegion) && !r.regional_role? # Only regional roles under Region
+      next unless (@root.kind_of?(Zone) && r.miq_servers.any? { |s| s.my_zone == @root.name }) ||
+                  (@root.kind_of?(MiqRegion) && !r.miq_servers.empty?) # Skip if no assigned servers in this zone
       next if r.name == "database_owner"
       unless @sb[:diag_selected_id] # Set default selected record vars
         @sb[:diag_selected_model] = r.class.to_s

--- a/app/views/ops/_diagnostics_servers_roles_tab.html.haml
+++ b/app/views/ops/_diagnostics_servers_roles_tab.html.haml
@@ -1,10 +1,13 @@
 - if @sb[:active_tab] == "diagnostics_servers_roles"
   = render(:partial => "layouts/flash_msg")
   - if @server_tree
-    .row
-      .col-md-12.col-lg-6
-        = render :partial => "zone_tree"
-      .col-md-12.col-lg-6
-        = render :partial => "selected"
+    - if @server_tree.bs_tree == "[]"
+      = render :partial => 'layouts/info_msg', :locals => {:message => _("No Servers Assigned to Roles found.")}
+    - else
+      .row
+        .col-md-12.col-lg-6
+          = render :partial => "zone_tree"
+        .col-md-12.col-lg-6
+          = render :partial => "selected"
   - else
     = render :partial => 'layouts/info_msg', :locals => {:message => _("No Servers found.")}


### PR DESCRIPTION
Found in: Settings->Application Settings->Diagnostics->Servers By Roles

Adds a banner to the Server By Roles Page when there are no servers assigned to any roles. Also partially undoes a change made in https://github.com/ManageIQ/manageiq-ui-classic/pull/8541 by returning the filtering logic that prevented unassigned roles from being displayed.

Before:
![image](https://user-images.githubusercontent.com/64800041/203804887-9a5430cd-dbd0-43b9-acd0-6c6a24a23bcf.png)
![image](https://user-images.githubusercontent.com/64800041/203804928-aed26779-cd23-4956-bfad-d87eff19c842.png)

After:
![image](https://user-images.githubusercontent.com/64800041/203805030-60fdb398-e019-4974-9b90-f71f82581ea5.png)
![image](https://user-images.githubusercontent.com/64800041/203804994-9bcd76cc-16e5-46de-9f6a-0a07c894f4fe.png)

@miq-bot add-reviewer @MelsHyrule, @jeffibm
@miq-bot add-label enhancement
@Fryguy