### PR TITLE
Added Missing Buttons to miq_policy/show_list

### DIFF
--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -11,6 +11,14 @@ module MiqPolicyController::Events
       javascript_redirect(:action => @lastaction, :id => params[:id], :flash_msg => flash_msg)
     when "reset", nil # Reset or first time in
       @_params[:id] ||= find_checked_items[0]
+
+      @policy = MiqPolicy.find_by(:id => params[:id]) # Get existing record
+      if @policy.read_only
+        add_flash(_("This Policy is read only and cannot be modified"), :error)
+        flash_to_session
+        redirect_to(:action => @lastaction, :id => params[:id])
+      end
+
       event_build_edit_screen
       javascript_redirect(:action        => 'miq_event_edit',
                           :id            => params[:id],

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -165,7 +165,15 @@ module MiqPolicyController::Policies
       javascript_redirect(:action => @lastaction, :id => params[:id], :flash_msg => flash_msg)
     when "reset", nil # Reset or first time in
       @in_a_form = true
+      params[:id] ||= find_checked_items[0]
       @policy = MiqPolicy.find_by(:id => params[:id]) # Get existing record
+
+      if @policy.read_only
+        add_flash(_("This Policy is read only and cannot be modified"), :error)
+        flash_to_session
+        redirect_to(:action => @lastaction, :id => params[:id])
+      end
+
       policy_build_edit_screen("events")
       javascript_redirect(:action        => 'miq_policy_edit_events',
                           :id            => params[:id],
@@ -192,7 +200,15 @@ module MiqPolicyController::Policies
       javascript_redirect(:action => @lastaction, :id => params[:id], :flash_msg => flash_msg)
     when "reset", nil # Reset or first time in
       @in_a_form = true
+      params[:id] ||= find_checked_items[0]
       @policy = MiqPolicy.find_by(:id => params[:id]) # Get existing record
+
+      if @policy.read_only
+        add_flash(_("This Policy is read only and cannot be modified"), :error)
+        flash_to_session
+        redirect_to(:action => @lastaction, :id => params[:id])
+      end
+
       policy_build_edit_screen("conditions")
       javascript_redirect(:action        => 'miq_policy_edit_conditions',
                           :id            => params[:id],

--- a/app/helpers/application_helper/toolbar/miq_policies_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_policies_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::MiqPoliciesCenter < ApplicationHelper::Toolbar
           :onwhen       => "1"),
         button(
           :miq_policy_copy,
-          'pficon pficon-edit fa-lg',
+          'fa fa-files-o fa-lg',
           t = N_('Copy the selected Policy'),
           t,
           :url          => "/copy",
@@ -33,6 +33,55 @@ class ApplicationHelper::Toolbar::MiqPoliciesCenter < ApplicationHelper::Toolbar
           :send_checked => true,
           :enabled      => false,
           :onwhen       => "1"),
+        button(
+          :miq_policy_delete,
+          'pficon pficon-delete fa-lg',
+          N_('Delete the selected Policies'),
+          N_('Delete Policies'),
+          :enabled      => false,
+          :onwhen       => "1+",
+          :data    => {'function'      => 'sendDataWithRx',
+                       'function-data' => {:api_url        => 'policies',
+                                            :component_name => 'RemoveGenericItemModal',
+                                            :controller     => 'provider_dialogs',
+                                            :modal_text     => N_("Are you sure you want to delete these Policies?"),
+                                            :modal_title    => N_("Delete Policies"),
+                                            :redirect_url   => '/miq_policy/show_list',
+                                            :display_field  => 'description'}}
+        ),
+        button(
+          :miq_policy_conditions_assignment,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit the selected Policy\'s Condition assignments'),
+          t,
+          :url       => "/miq_policy_edit_conditions",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1"
+        ),
+        button(
+          :miq_policy_events_assignment,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit the selected Policy\'s Event assignments'),
+          t,
+          :url       => "/miq_policy_edit_events",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1"
+        ),
+        button(
+          :miq_policy_event_edit,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit Actions for the selected Policy\'s Event'),
+          t,
+          :url          => "/miq_event_edit",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :enabled      => false,
+          :onwhen       => "1"
+        ),
       ]
     ),
   ])


### PR DESCRIPTION
Found in: Control->Policies

Adds some missing buttons found in the `miq_policy/show` page to `show_list` page.

Before:
<img src="https://user-images.githubusercontent.com/64800041/203819581-87909a1f-c022-4daa-891c-f4bcce1607a0.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/64800041/203819640-dc9dce90-4c77-4427-8c31-4ce926717392.png" width="400">

@miq-bot add-reviewer @MelsHyrule, @jeffibm
@miq-bot add-label enhancement
@Fryguy