### PR TITLE
Custom buttons and actions for Physical Infrastructure Objects

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -203,7 +203,7 @@ module ApplicationController::Buttons
     @sb[:action] if features_in_action.include?(@sb[:action])
   end
 
-  BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Switch, Tenant, User, Vm].freeze
+  BASE_MODEL_EXPLORER_CLASSES = [MiqGroup, MiqTemplate, Service, Tenant, User, Vm].freeze
 
   def custom_button_done
     external_url = ExternalUrl.find_by(

--- a/app/controllers/physical_chassis_controller.rb
+++ b/app/controllers/physical_chassis_controller.rb
@@ -46,4 +46,12 @@ class PhysicalChassisController < ApplicationController
     assert_privileges('physical_chassis_show_list')
     super
   end
+
+  def button
+    if params[:pressed] == "custom_button"
+      custom_buttons
+    end
+  end
+
+  has_custom_buttons
 end

--- a/app/controllers/physical_rack_controller.rb
+++ b/app/controllers/physical_rack_controller.rb
@@ -60,4 +60,12 @@ class PhysicalRackController < ApplicationController
     assert_privileges('physical_rack_show_list')
     super
   end
+
+  def button
+    if params[:pressed] == "custom_button"
+      custom_buttons
+    end
+  end
+
+  has_custom_buttons
 end

--- a/app/controllers/physical_server_controller.rb
+++ b/app/controllers/physical_server_controller.rb
@@ -63,10 +63,13 @@ class PhysicalServerController < ApplicationController
 
     return if %w[physical_server_protect physical_server_tag].include?(params[:pressed]) &&
               @flash_array.nil? # Some other screen is showing, so return
-    if params[:pressed] == "physical_server_timeline"
+    case params[:pressed]
+    when "physical_server_timeline"
       @record = find_record_with_rbac(PhysicalServer, params[:id])
       show_timeline
       javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
+    when "custom_button"
+      custom_buttons
     end
   end
 
@@ -158,4 +161,5 @@ class PhysicalServerController < ApplicationController
     super
   end
 
+  has_custom_buttons
 end

--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -85,6 +85,14 @@ class PhysicalStorageController < ApplicationController
     super
   end
 
+  def button
+    if params[:pressed] == "custom_button"
+      custom_buttons
+    end
+  end
+
+  has_custom_buttons
+
   private
 
   def specific_buttons(pressed)

--- a/app/controllers/physical_switch_controller.rb
+++ b/app/controllers/physical_switch_controller.rb
@@ -67,4 +67,11 @@ class PhysicalSwitchController < ApplicationController
     super
   end
 
+  def button
+    if params[:pressed] == "custom_button"
+      custom_buttons
+    end
+  end
+
+  has_custom_buttons
 end

--- a/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
+++ b/app/helpers/application_helper/toolbar/mixins/custom_button_toolbar_mixin.rb
@@ -7,7 +7,8 @@ module ApplicationHelper::Toolbar::Mixins::CustomButtonToolbarMixin
                                     GenericObject GenericObjectDefinition Host LoadBalancer
                                     MiqGroup MiqTemplate NetworkRouter NetworkService OrchestrationStack
                                     SecurityGroup SecurityPolicy SecurityPolicyRule Service ServiceTemplate Storage
-                                    Switch Tenant User Vm VmOrTemplate].freeze
+                                    Switch Tenant User Vm VmOrTemplate
+                                    PhysicalServer PhysicalRack PhysicalChassis PhysicalStorage PhysicalSwitch].freeze
 
   def custom_button_appliable_class?(model)
     # FIXME: merge with model replacement in 'custom_button_class_model'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1204,6 +1204,7 @@ Rails.application.routes.draw do
 
     :physical_switch    =>  {
       :get  =>  %w(
+        dialog_load
         download_data
         download_summary_pdf
         show_list
@@ -1211,14 +1212,16 @@ Rails.application.routes.draw do
       ),
 
       :post   =>  %w(
+        button
         listnav_search_selected
         show_list
         quick_search
-      ) + adv_search_post + save_post,
+      ) + adv_search_post + save_post + dialog_runner_post,
     },
 
     :physical_server    =>  {
       :get  =>  %w(
+        dialog_load
         download_data
         download_summary_pdf
         perf_top_chart
@@ -1243,22 +1246,24 @@ Rails.application.routes.draw do
       ) +
           adv_search_post +
           exp_post +
-          save_post
+          save_post +
+          dialog_runner_post
     },
 
     :physical_rack    =>  {
       :get  =>  %w(
+        dialog_load
         download_data
         download_summary_pdf
         protect
         show_list
         show
       ),
-
       :post   =>  %w(
+        button
         show_list
         quick_search
-      )
+      ) + dialog_runner_post
     },
 
     :physical_network_port    => {
@@ -1276,6 +1281,7 @@ Rails.application.routes.draw do
 
     :physical_storage   => {
       :get  => %w[
+        dialog_load
         download_data
         download_summary_pdf
         edit
@@ -1290,11 +1296,12 @@ Rails.application.routes.draw do
         listnav_search_selected
         quick_search
         show_list
-      ] + adv_search_post + save_post + exp_post
+      ] + adv_search_post + save_post + exp_post + dialog_runner_post,
     },
 
     :physical_chassis    => {
       :get  => %w(
+        dialog_load
         download_data
         download_summary_pdf
         protect
@@ -1303,9 +1310,10 @@ Rails.application.routes.draw do
       ),
 
       :post  => %w(
+        button
         show_list
         quick_search
-      )
+      ) + dialog_runner_post,
     },
 
     :guest_device    =>  {

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -542,6 +542,7 @@ EmsNetworkController:
 - tl_chooser
 - wait_for_task
 EmsPhysicalInfraController:
+- dialog_load
 - dialog_field_changed
 - dialog_form_button_pressed
 - dynamic_checkbox_refresh
@@ -933,6 +934,14 @@ PersistentVolumeController:
 - open_url_after_dialog
 - sections_field_changed
 PhysicalChassisController:
+- dialog_load
+- dialog_field_changed
+- dialog_form_button_pressed
+- dynamic_checkbox_refresh
+- dynamic_date_refresh
+- dynamic_radio_button_refresh
+- dynamic_text_box_refresh
+- open_url_after_dialog
 - download_summary_pdf
 - index
 - protect
@@ -944,20 +953,52 @@ PhysicalNetworkPortController:
 - index
 - report_data
 PhysicalRackController:
+- dialog_load
+- dialog_field_changed
+- dialog_form_button_pressed
+- dynamic_checkbox_refresh
+- dynamic_date_refresh
+- dynamic_radio_button_refresh
+- dynamic_text_box_refresh
+- open_url_after_dialog
 - download_summary_pdf
 - index
 - protect
 - quick_search
 PhysicalServerController:
+- dialog_load
+- dialog_field_changed
+- dialog_form_button_pressed
+- dynamic_checkbox_refresh
+- dynamic_date_refresh
+- dynamic_radio_button_refresh
+- dynamic_text_box_refresh
+- open_url_after_dialog
 - index
 - perf_top_chart
 - tl_chooser
 - wait_for_task
 PhysicalStorageController:
+- dialog_load
+- dialog_field_changed
+- dialog_form_button_pressed
+- dynamic_checkbox_refresh
+- dynamic_date_refresh
+- dynamic_radio_button_refresh
+- dynamic_text_box_refresh
+- open_url_after_dialog
 - index
 - tl_chooser
 - wait_for_task
 PhysicalSwitchController:
+- dialog_load
+- dialog_field_changed
+- dialog_form_button_pressed
+- dynamic_checkbox_refresh
+- dynamic_date_refresh
+- dynamic_radio_button_refresh
+- dynamic_text_box_refresh
+- open_url_after_dialog
 - index
 PictureController:
 - show


### PR DESCRIPTION
Currently it is not possible to create custom buttons or actions for **_Physical Server, Physical Chassis, Physical Storage, Physical Switch and Physical Rack_**.

To enable them, ui had to be updated and api and core accordingly.

*NOTE*:  `Switch` class has been removed from the button's `BASE_EXPLORER_CLASSES` as those classes require `replace_right_cell` defined, which Switch does not have.

*Edit: Added screenshots of UI*

**_Refers to_**: 
  -  [ManageIQ/manageiq-providers-cisco_intersight/issues/76](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/76)
  
**_Depends on_**: 
  - [ManageIQ/manageiq/pull/22263](https://github.com/ManageIQ/manageiq/pull/22263)
  - [ManageIQ/manageiq-api/pull/1189](https://github.com/ManageIQ/manageiq-api/pull/1189)

| ![Screenshot from 2022-11-30 12-14-42](https://user-images.githubusercontent.com/67372390/204782390-b2dd0684-860e-4c5e-8d64-26a3ce5aeaaa.png) |
| :--: |
| *Custom button available from a Physical Server* |
| ![Screenshot from 2022-11-30 12-14-50](https://user-images.githubusercontent.com/67372390/204782515-15c717b3-6d5e-4460-b802-3c4a3e9910e2.png)  |
| *Dialog opened from a Physical Server's custom button* |
| ![Screenshot from 2022-12-02 08-07-31](https://user-images.githubusercontent.com/67372390/205255623-4cbe520a-4201-4b67-b668-8b47ad214f89.png)  |
| *Error displayed when clicking a custom button from `Physical Switch` class before the `Switch` has been removed from the button's `BASE_EXPLORER_CLASSES`*  |
| ![Screenshot from 2022-12-02 09-44-08](https://user-images.githubusercontent.com/67372390/205255942-7cb97a99-bdb2-4d0c-b5ef-49b5eb57f806.png) |
| *Physical infrastructure object types enabled in customization due to changes in [ManageIQ/manageiq](https://github.com/ManageIQ/manageiq/pull/22263)*
***NOTE***: Physical Switch is available under Virtual Infra Switch |
