### PR TITLE
add customizable disk_size to vm post-provision 

### DIFF
--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -72,7 +72,7 @@
         - if @edit && field_hash[:required] && field_hash[:display] == :edit
           *
       -# Text fields
-      - if [:cpu_limit, :cpu_reserve, :entitled_processors, :dns_servers, :dns_suffixes, :gateway,
+      - if [:allocated_disk_storage, :cpu_limit, :cpu_reserve, :entitled_processors, :dns_servers, :dns_suffixes, :gateway,
             :hostname, :ip_addr, :linux_host_name, :linux_domain_name,
             :mac_address, :owner_address, :owner_city, :owner_company,
             :owner_country, :owner_department, :owner_email,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -144,7 +144,7 @@
             :keys                       => keys})
   - when :hardware
     - keys = [:instance_type, :sys_type,  :cloud_volumes, :storage_type, :number_of_cpus, :entitled_processors, :number_of_sockets, :cores_per_socket,
-              :vm_memory, :network_adapters, :disk_format, :disk_sparsity, :guest_access_key_pair, :monitoring,
+              :vm_memory, :network_adapters, :disk_format, :allocated_disk_storage, :disk_sparsity, :guest_access_key_pair, :monitoring,
               :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible,
               :cpu_hot_add, :cpu_hot_remove, :memory_hot_add, :ssh_public_key]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")


### PR DESCRIPTION
add the field to the necessary `haml`s

Depends on 
- [x] https://github.com/ManageIQ/manageiq/pull/22251
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/839

![](https://user-images.githubusercontent.com/106743023/204128420-8d87eadb-76d8-4fcc-98c5-5798bdfda701.png)


