### PR TITLE
Fix dashboard toolbar urls

### DIFF
--- a/app/javascript/components/dashboard_toolbar.jsx
+++ b/app/javascript/components/dashboard_toolbar.jsx
@@ -5,12 +5,12 @@ import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 import { ChevronDown20 } from '@carbon/icons-react';
 
 const addClick = (item) =>
-  window.miqJqueryRequest(`widget_add?widget=${item.id}`, { beforeSend: true, complete: true });
+  window.miqJqueryRequest(`/dashboard/widget_add?widget=${item.id}`, { beforeSend: true, complete: true });
 
 const resetClick = () => {
   /* eslint no-alert: off */
   if (window.confirm(__("Are you sure you want to reset this Dashboard's Widgets to the defaults?"))) {
-    window.miqJqueryRequest('reset_widgets', { beforeSend: true });
+    window.miqJqueryRequest('/dashboard/reset_widgets', { beforeSend: true });
   }
 };
 


### PR DESCRIPTION
**Before**
After clicking on the tabs and resetting the widgets redirects to a undefined url
`ActionController::RoutingError (No route matches [POST] "/dashboard/change_tab/reset_widgets"): 
`
![Peek 2022-11-28 09-03](https://user-images.githubusercontent.com/87487049/204320016-4e00f160-8c3f-4ac3-a7ba-08e0f0af44d3.gif)

**After**
The dashboard page is loaded after the `reset_widget` action

Note : similar case with `widget_add` action

Fixes #8550 