### PR TITLE
allow deletion of VMs in infra manager

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -446,6 +446,7 @@ module ApplicationController::CiProcessing
     generic_button_operation('vm_destroy', _('Terminate'), vm_button_action)
   end
   alias instance_terminate terminatevms
+  alias vm_terminate terminatevms
 
   # Stop all selected or single displayed vm(s)
   def stopvms

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -290,6 +290,17 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :confirm      => N_("Reset the selected items?"),
           :enabled      => false,
           :onwhen       => "1+"),
+        button(
+          :vm_terminate,
+          nil,
+          N_('Delete the selected items'),
+          N_('Delete'),
+          :icon         => "pficon pficon-delete fa-lg",
+          :url_parms    => "main_div",
+          :send_checked => true,
+          :confirm      => N_("Delete the selected items?"),
+          :enabled      => false,
+          :onwhen       => "1+"),
       ]
     ),
   ])


### PR DESCRIPTION
It is currently not possible to delete a VM with infra provider.
This would be useful for HMC provider, see https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/127.
This PR adds the following menu item:

![image](https://user-images.githubusercontent.com/48122102/204487773-c6dd47c2-310a-40c5-b8e7-d689f779597d.png)
