### PR TITLE
Remove escape characters from miq alert helper

### DIFF
--- a/app/helpers/miq_alert_helper.rb
+++ b/app/helpers/miq_alert_helper.rb
@@ -199,7 +199,7 @@ module MiqAlertHelper
     else
       alert_profiles.each do |ap|
         rows.push({
-                    :cells   => [{:icon => 'pficon pficon-warning-triangle-o', :value => h(ap.description)}],
+                    :cells   => [{:icon => 'pficon pficon-warning-triangle-o', :value => ap.description}],
                     :title   => _("View this Alert Profile"),
                     :onclick => "DoNav('/miq_alert_set/show/#{ap.id}');",
                   })

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -2293,6 +2293,62 @@ exports[`Structured list component should render miq_ae_class_list_view with esc
 </Accordion>
 `;
 
+exports[`Structured list component should render miq_alert_show page without double escaping strings 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_alert_id"
+>
+  <AccordionItem
+    open={true}
+    title="Belongs to Alert profiles"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_alert_id"
+    >
+      <FeatureToggle(StructuredListBody)>
+        <FeatureToggle(StructuredListRow)
+          className="clickable"
+          key="0"
+          onClick={[Function]}
+          tabIndex={0}
+          title="View this Alert Profile"
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="cell icon"
+                title="View this Alert Profile"
+              >
+                <i
+                  className="pficon pficon-warning-triangle-o"
+                  style={
+                    Object {
+                      "background": undefined,
+                      "color": undefined,
+                    }
+                  }
+                  title="View this Alert Profile"
+                />
+              </div>
+              <div
+                className="expand wrap_text"
+              >
+                view this &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+      </FeatureToggle(StructuredListBody)>
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render settings list 1`] = `
 <FeatureToggle(StructuredListWrapper)
   ariaLabel="Structured list"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -12,6 +12,7 @@ import { diagnosticSettingsListData } from '../textual_summary/data/diagnostic_s
 import { catalogListData } from '../textual_summary/data/catalog_list';
 import { miqAeClassListData } from '../textual_summary/data/miq_ae_class_list';
 import { miqAePolicyListData } from '../textual_summary/data/miq_ae_policy_list';
+import { miqAlertListData } from '../textual_summary/data/miq_alert_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -98,6 +99,17 @@ describe('Structured list component', () => {
       rows={tableListViewData.items}
       title={tableListViewData.title}
       mode="table_list_view"
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render miq_alert_show page without double escaping strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={miqAlertListData.items}
+      title={miqAlertListData.title}
+      mode={miqAlertListData.mode}
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/miq_alert_list.js
+++ b/app/javascript/spec/textual_summary/data/miq_alert_list.js
@@ -1,0 +1,12 @@
+export const miqAlertListData = {
+    items: [
+      {
+        icon:     "pficon pficon-warning-triangle-o",
+        value:    "view this &&",
+        title:    "View this Alert Profile",
+        onclick:  "DoNav('/miq_alert_set/show/1');"
+      },
+    ],
+    title: 'Belongs to Alert profiles',
+    mode: 'miq_alert_id'
+  };


### PR DESCRIPTION
For the issue - https://github.com/ManageIQ/manageiq-ui-classic/issues/8526

Before:
<img width="1169" alt="Screenshot 2022-11-30 at 4 28 42 PM" src="https://user-images.githubusercontent.com/16753936/204977124-11f9e69c-1e22-4d10-9e5f-38359616770f.png">

After:
<img width="1352" alt="Screenshot 2022-11-30 at 4 30 22 PM" src="https://user-images.githubusercontent.com/16753936/204977164-7b2d66fb-2b15-49a2-8b64-e3a67096189a.png">

