### PR TITLE
Remove escape characters from miq policy set helper

### DIFF
--- a/app/helpers/miq_policy_set_helper.rb
+++ b/app/helpers/miq_policy_set_helper.rb
@@ -1,7 +1,7 @@
 module MiqPolicySetHelper
   def miq_summary_policy_set_info(record)
     data = {:title => _("Basic Information"), :mode => "miq_policy_set_info"}
-    data[:rows] = [{:cells => {:label => _("Description"), :value => h(record.description)}}]
+    data[:rows] = [{:cells => {:label => _("Description"), :value => record.description}}]
     miq_structured_list(data)
   end
 
@@ -13,7 +13,7 @@ module MiqPolicySetHelper
     else
       profile_policies.each do |p|
         cells = [{:icon => p.decorate.fonticon, :bold => true, :value => "#{ui_lookup(:model => p.towhat)} #{p.mode.capitalize}"}]
-        cells.push(h(p.description))
+        cells.push(p.description)
         rows.push({
                     :cells   => cells,
                     :title   => _("View this %{model} Policy") % {:model => ui_lookup(:model => p.towhat)},

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -1,5 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Structured list component should render a miq_policy_set show page without double escaping strings 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_policy_set"
+>
+  <AccordionItem
+    open={true}
+    title="Policies"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_policy_set"
+    >
+      <FeatureToggle(StructuredListBody)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="0"
+          onClick={[Function]}
+          tabIndex={0}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Description
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                & Application SLA &
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className="clickable"
+          key="1"
+          onClick={[Function]}
+          tabIndex={1}
+          title="View this Policy"
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="cell icon"
+                title="View this Policy"
+              >
+                <i
+                  className="pficon pficon-image"
+                  style={
+                    Object {
+                      "background": undefined,
+                      "color": undefined,
+                    }
+                  }
+                  title="View this Policy"
+                />
+              </div>
+              <div
+                className="expand wrap_text"
+              >
+                description one &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className="clickable"
+          key="2"
+          onClick={[Function]}
+          tabIndex={2}
+          title="View this Policy"
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="cell icon"
+                title="View this Policy"
+              >
+                <i
+                  className="pficon pficon-container-node"
+                  style={
+                    Object {
+                      "background": undefined,
+                      "color": undefined,
+                    }
+                  }
+                  title="View this Policy"
+                />
+              </div>
+              <div
+                className="expand wrap_text"
+              >
+                description two &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className="clickable"
+          key="3"
+          onClick={[Function]}
+          tabIndex={3}
+          title="View this Policy"
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="cell icon"
+                title="View this Policy"
+              >
+                <i
+                  className="pficon pficon-virtual-machine"
+                  style={
+                    Object {
+                      "background": undefined,
+                      "color": undefined,
+                    }
+                  }
+                  title="View this Policy"
+                />
+              </div>
+              <div
+                className="expand wrap_text"
+              >
+                description three &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+      </FeatureToggle(StructuredListBody)>
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render a multilink_list table 1`] = `
 <Accordion
   align="start"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -13,6 +13,7 @@ import { catalogListData } from '../textual_summary/data/catalog_list';
 import { miqAeClassListData } from '../textual_summary/data/miq_ae_class_list';
 import { miqAePolicyListData } from '../textual_summary/data/miq_ae_policy_list';
 import { miqAlertListData } from '../textual_summary/data/miq_alert_list';
+import { miqPolicySetListData } from '../textual_summary/data/miq_policy_set_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -130,6 +131,17 @@ describe('Structured list component', () => {
       rows={catalogListData.items}
       title={catalogListData.title}
       mode="catalog_list_view"
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render a miq_policy_set show page without double escaping strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={miqPolicySetListData.items}
+      title={miqPolicySetListData.title}
+      mode={miqPolicySetListData.mode}
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/miq_policy_set_list.js
+++ b/app/javascript/spec/textual_summary/data/miq_policy_set_list.js
@@ -1,0 +1,28 @@
+export const miqPolicySetListData = {
+    items: [
+      {
+        label: 'Description',
+        value: '& Application SLA &'
+      }, 
+      {
+        icon:     "pficon pficon-image",
+        value:    "description one &&",
+        title:    "View this Policy",
+        onclick:  "DoNav('/miq_policy/show/1');"
+      },
+      {
+        icon:     "pficon pficon-container-node",
+        value:    "description two &&",
+        title:    "View this Policy",
+        onclick:  "DoNav('/miq_policy/show/2');"
+      },
+      {
+        icon:     "pficon pficon-virtual-machine",
+        value:    "description three &&",
+        title:    "View this Policy",
+        onclick:  "DoNav('/miq_policy/show/3');"
+      },
+    ],
+    title: 'Policies',
+    mode: 'miq_policy_set'
+  };


### PR DESCRIPTION
For the issue - https://github.com/ManageIQ/manageiq-ui-classic/issues/8526
Before:
<img width="1497" alt="Screenshot 2022-12-01 at 11 48 37 AM" src="https://user-images.githubusercontent.com/16753936/204983007-e5887a3d-4d57-489e-aff1-961e19abfe96.png">

After:
<img width="1493" alt="Screenshot 2022-12-01 at 11 51 08 AM" src="https://user-images.githubusercontent.com/16753936/204983059-022aa1c1-4e14-41f9-bcc0-6e2ab6af5d91.png">

