### PR TITLE
Remove escape characters from report information helper

### DIFF
--- a/app/helpers/report_helper/report_information_helper.rb
+++ b/app/helpers/report_helper/report_information_helper.rb
@@ -50,8 +50,8 @@ module ReportHelper::ReportInformationHelper
           {:value => s.description},
           {:value => _(s.enabled)},
           {:value => s.run_at[:interval][:unit]},
-          {:value => s.last_run_on ? h(format_timezone(s.last_run_on, tz, "gtl")) : ""},
-          {:value => s.next_run_on ? h(format_timezone(s.next_run_on, tz, "gtl")) : ""},
+          {:value => s.last_run_on ? format_timezone(s.last_run_on, tz, "gtl") : ""},
+          {:value => s.next_run_on ? format_timezone(s.next_run_on, tz, "gtl") : ""},
           {:value => s.v_zone_name},
         ]
         cells.push({:value => s.userid}) if super_admin_user?
@@ -79,7 +79,7 @@ module ReportHelper::ReportInformationHelper
         widget_action = role_allows?(:feature => 'miq_report_widget_editor') ? report_action_url("xx-#{ReportController::Widgets::WIDGET_CONTENT_TYPE.invert[w.content_type]}_-#{w.id}", "widgets") : ""
         rows.push({
                     :cells   => [
-                      {:value => h(w.title), :icon => "fa fa-file-text-o"},
+                      {:value => w.title, :icon => "fa fa-file-text-o"},
                       {:value => w.description},
                       {:value => _(w.enabled)},
                     ],

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -1597,6 +1597,78 @@ exports[`Structured list component should render a operation_range table 1`] = `
 </Accordion>
 `;
 
+exports[`Structured list component should render a report_information page without double escaping strings 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_report_schedules"
+>
+  <AccordionItem
+    open={true}
+    title="report_information"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_report_schedules"
+    >
+      <FeatureToggle(StructuredListBody)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="0"
+          onClick={[Function]}
+          tabIndex={0}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Last Run Time
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                & 2022-12-07 02:00:00 UTC &
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="1"
+          onClick={[Function]}
+          tabIndex={1}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Next Run Time
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                & 2022-12-07 02:00:00 UTC &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+      </FeatureToggle(StructuredListBody)>
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render a simple_table 1`] = `
 <Accordion
   align="start"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -15,6 +15,7 @@ import { miqAePolicyListData } from '../textual_summary/data/miq_ae_policy_list'
 import { miqAlertListData } from '../textual_summary/data/miq_alert_list';
 import { miqPolicySetListData } from '../textual_summary/data/miq_policy_set_list';
 import { miqReportDashboardListData } from '../textual_summary/data/report_dashboard_list';
+import { reportInformationListData } from '../textual_summary/data/report_information_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -118,7 +119,6 @@ describe('Structured list component', () => {
   });
 
   it('should render settings list', () => {
-    const onClick = jest.fn();
     const wrapper = shallow(<MiqStructuredList
       rows={diagnosticSettingsListData.items}
       mode={diagnosticSettingsListData.mode}
@@ -154,6 +154,17 @@ describe('Structured list component', () => {
       rows={miqPolicySetListData.items}
       title={miqPolicySetListData.title}
       mode={miqPolicySetListData.mode}
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render a report_information page without double escaping strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={reportInformationListData.items}
+      title={reportInformationListData.title}
+      mode={reportInformationListData.mode}
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/report_information_list.js
+++ b/app/javascript/spec/textual_summary/data/report_information_list.js
@@ -1,0 +1,14 @@
+export const reportInformationListData = {
+  items: [
+    {
+      label: 'Last Run Time',
+      value: '& 2022-12-07 02:00:00 UTC &',
+    },
+    {
+      label: 'Next Run Time',
+      value: '& 2022-12-07 02:00:00 UTC &&',
+    },
+  ],
+  title: 'report_information',
+  mode: 'miq_report_schedules',
+};


### PR DESCRIPTION
For the issue - https://github.com/ManageIQ/manageiq-ui-classic/issues/8526

Before:

<img width="1379" alt="Screenshot 2022-12-06 at 6 45 09 PM" src="https://user-images.githubusercontent.com/16753936/205928427-6316bebd-db66-41a7-bc22-18029f36e51e.png">

After:-

<img width="1377" alt="Screenshot 2022-12-06 at 6 46 23 PM" src="https://user-images.githubusercontent.com/16753936/205928499-16ce1653-9951-42be-87c8-04852a6adb42.png">
