### PR TITLE
Remove escape character from report schedule helper

### DIFF
--- a/app/helpers/report_helper/report_schedule_helper.rb
+++ b/app/helpers/report_helper/report_schedule_helper.rb
@@ -4,24 +4,24 @@ module ReportHelper::ReportScheduleHelper
     rows = []
     rows.push(row_data(_('Description'), schedule.description))
     rows.push(row_data(_('Active'), _(schedule.enabled.to_s.capitalize)))
-    email_run = h(schedule.sched_action[:options] && schedule.sched_action[:options][:send_email] ? _("True") : _("False"))
+    email_run = schedule.sched_action[:options] && schedule.sched_action[:options][:send_email] ? _("True") : _("False")
     rows.push(row_data(_('E-Mail after Running'), email_run))
     if schedule.sched_action[:options] && schedule.sched_action[:options][:send_email] && schedule.sched_action[:options][:email]
       if schedule.sched_action[:options][:email][:from].blank?
-        rows.push(row_data(_('From E-mail'), _("(Default: %{email_from})") % {:email_from => h(::Settings.smtp.from)}))
+        rows.push(row_data(_('From E-mail'), _("(Default: %{email_from})") % {:email_from => ::Settings.smtp.from}))
       else
-        rows.push(row_data(_('From E-mail'), h(schedule.sched_action[:options][:email][:from])))
+        rows.push(row_data(_('From E-mail'), schedule.sched_action[:options][:email][:from]))
       end
     end
     email = email_to.blank? ? "" : email_to.join(';')
-    rows.push(row_data(_('To E-mail'), h(email)))
+    rows.push(row_data(_('To E-mail'), email))
     rows.push(row_data(_('Report Filter'), rep_filter))
-    rows.push(row_data(_('Run At'), h(schedule.run_at_to_human(timezone).to_s)))
+    rows.push(row_data(_('Run At'), schedule.run_at_to_human(timezone).to_s))
     last_run = schedule.last_run_on.blank? ? "" : format_timezone(schedule.last_run_on, timezone, "view")
-    rows.push(row_data(_('Last Run Time'), h(last_run)))
+    rows.push(row_data(_('Last Run Time'), last_run))
     next_run = schedule.next_run_on.blank? ? "" : format_timezone(schedule.next_run_on, timezone, "view")
-    rows.push(row_data(_('Next Run Time'), h(next_run)))
-    rows.push(row_data(_('Zone'), h(schedule.v_zone_name)))
+    rows.push(row_data(_('Next Run Time'), next_run))
+    rows.push(row_data(_('Zone'), schedule.v_zone_name))
 
     data[:rows] = rows
     miq_structured_list(data)

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -2729,6 +2729,156 @@ exports[`Structured list component should render miq_reports_data without double
 </Accordion>
 `;
 
+exports[`Structured list component should render report_schedule page without double escaping strings 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_report_schedule_info"
+>
+  <AccordionItem
+    open={true}
+    title="Schedule Info"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_report_schedule_info"
+    >
+      <FeatureToggle(StructuredListBody)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="0"
+          onClick={[Function]}
+          tabIndex={0}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Description
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                My_Host Network Information &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="1"
+          onClick={[Function]}
+          tabIndex={1}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Active
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                True &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="2"
+          onClick={[Function]}
+          tabIndex={2}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            E-Mail after Running
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                True &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="3"
+          onClick={[Function]}
+          tabIndex={3}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            From E-mail
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                (Default: test@test.com) &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+        <FeatureToggle(StructuredListRow)
+          className=""
+          key="4"
+          onClick={[Function]}
+          tabIndex={4}
+          title=""
+        >
+          <FeatureToggle(StructuredListCell)
+            className="label_header"
+          >
+            Run At
+          </FeatureToggle(StructuredListCell)>
+          <FeatureToggle(StructuredListCell)
+            className="content_value object_item"
+          >
+            <div
+              className="content"
+            >
+              <div
+                className="expand wrap_text"
+              >
+                && Run once on Thu Nov 15 01:10:00 UTC 2018 &&
+              </div>
+            </div>
+          </FeatureToggle(StructuredListCell)>
+        </FeatureToggle(StructuredListRow)>
+      </FeatureToggle(StructuredListBody)>
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render settings list 1`] = `
 <FeatureToggle(StructuredListWrapper)
   ariaLabel="Structured list"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -16,6 +16,7 @@ import { miqAlertListData } from '../textual_summary/data/miq_alert_list';
 import { miqPolicySetListData } from '../textual_summary/data/miq_policy_set_list';
 import { miqReportDashboardListData } from '../textual_summary/data/report_dashboard_list';
 import { reportInformationListData } from '../textual_summary/data/report_information_list';
+import { reportScheduleListData } from '../textual_summary/data/report_schedule_list';
 
 describe('Structured list component', () => {
   it('should render a simple_table with generic data', () => {
@@ -185,6 +186,17 @@ describe('Structured list component', () => {
     const wrapper = shallow(<MiqStructuredList
       rows={miqAePolicyListData.items}
       mode={miqAePolicyListData.mode}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render report_schedule page without double escaping strings', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={reportScheduleListData.items}
+      title={reportScheduleListData.title}
+      mode={reportScheduleListData.mode}
+      onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/app/javascript/spec/textual_summary/data/report_schedule_list.js
+++ b/app/javascript/spec/textual_summary/data/report_schedule_list.js
@@ -1,0 +1,26 @@
+export const reportScheduleListData = {
+  items: [
+    {
+      label: 'Description',
+      value: 'My_Host Network Information &&',
+    },
+    {
+      label: 'Active',
+      value: 'True &&',
+    },
+    {
+      label: 'E-Mail after Running',
+      value: 'True &&',
+    },
+    {
+      label: 'From E-mail',
+      value: '(Default: test@test.com) &&',
+    },
+    {
+      label: 'Run At',
+      value: '&& Run once on Thu Nov 15 01:10:00 UTC 2018 &&',
+    },
+  ],
+  title: 'Schedule Info',
+  mode: 'miq_report_schedule_info',
+};


### PR DESCRIPTION
For the issue - https://github.com/ManageIQ/manageiq-ui-classic/issues/8526

Before:
<img width="1534" alt="Screenshot 2022-12-07 at 6 28 26 PM" src="https://user-images.githubusercontent.com/16753936/206197055-93b542cf-a24a-488e-aa73-05cea9f59849.png">


After:
<img width="1537" alt="Screenshot 2022-12-07 at 6 32 23 PM" src="https://user-images.githubusercontent.com/16753936/206197162-1295b96e-6904-40b8-be3f-87ce8d9c1643.png">
