### PR TITLE
Change provider status notification type

### DIFF
--- a/spec/helpers/textual_mixins/textual_refresh_status_spec.rb
+++ b/spec/helpers/textual_mixins/textual_refresh_status_spec.rb
@@ -1,0 +1,23 @@
+describe TextualMixins::TextualRefreshStatus do
+  describe "#status_type" do
+    context "will not display success notification if refresh time is < 2 days" do
+      subject { helper.status_type('success', 3.hours.ago) }
+      it { is_expected.to eq({:stale => false, :type => 'success'}) }
+    end
+
+    context "will display error notification regardless of refresh time 3.hours.ago" do
+      subject { helper.status_type('error', 3.hours.ago) }
+      it { is_expected.to eq({:stale => false, :type => 'error'}) }
+    end
+
+    context "will display error notification regardless of refresh time 30.days.ago" do
+      subject { helper.status_type('error', 30.days.ago) }
+      it { is_expected.to eq({:stale => true, :type => 'error'}) }
+    end
+
+    context "will dispay warning notification if refresh time is > 2 days" do
+      subject { helper.status_type('success', 30.days.ago) }
+      it { is_expected.to eq({:stale => true, :type => 'warning'}) }
+    end
+  end
+end


### PR DESCRIPTION
Issue - https://github.com/ManageIQ/manageiq-ui-classic/issues/8558

**Before**
<img width="898" alt="image" src="https://user-images.githubusercontent.com/87487049/207237141-b289e3d3-cd2b-496d-84bf-811110963147.png">

**After**
When `status=error`, then displays an **Error** message
<img width="909" alt="image" src="https://user-images.githubusercontent.com/87487049/208090136-2080027a-4736-491b-8814-1e816f21ce0b.png">

When `status=success`, `time > than 2 days ago` then stale=true and displays **Warning** message
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/207237049-709a638d-12ae-4e2a-aee4-7e0a2cd8fbb4.png">

When `status=success`, `time < 2 days ago` then notifications will not be displayed
<img width="897" alt="image" src="https://user-images.githubusercontent.com/87487049/208099153-81a59b08-a020-4a99-afea-9d54f9674fff.png">



