### PR TITLE
Bump decode-uri-component from 0.2.0 to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "d3-color": "~3.1.0",
     "nwsapi": "^2.2.1",
     "minimatch": "~3.1.2",
-    "qs": "~6.5.3"
+    "qs": "~6.5.3",
+    "decode-uri-component": "^0.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6400,10 +6400,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "decode-uri-component@npm:0.2.0"
-  checksum: f3749344ab9305ffcfe4bfe300e2dbb61fc6359e2b736812100a3b1b6db0a5668cba31a05e4b45d4d63dbf1a18dfa354cd3ca5bb3ededddabb8cd293f4404f94
+"decode-uri-component@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/8566

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label security fix