### PR TITLE
run super if it's not custom_button

### DIFF
--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -88,6 +88,8 @@ class PhysicalStorageController < ApplicationController
   def button
     if params[:pressed] == "custom_button"
       custom_buttons
+    else
+      super
     end
   end
 


### PR DESCRIPTION
After the pr:
https://github.com/ManageIQ/manageiq-ui-classic/pull/8545
we notice that the button to create new physical storage does not trigger the redirect to the form.
I have added a call to the super of the button function if in the parameters it is not "custom_button"
