### PR TITLE
Cisco catalog item form

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,7 +7,6 @@ class CatalogController < ApplicationController
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
-  require 'byebug'
   helper ProvisionCustomizeHelper
   helper MiqAeClassHelper # need the playbook_label
 
@@ -1040,7 +1039,6 @@ class CatalogController < ApplicationController
       add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
       add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower) || st.kind_of?(ServiceTemplateAwx)
       add_server_profile_template_vars(st) if @edit[:new][:st_prov_type] == 'cisco_intersight'
-
       st.service_type = "atomic"
 
       if request
@@ -1393,7 +1391,8 @@ class CatalogController < ApplicationController
     if params[:currency]
       @edit[:new][:currency] = params[:currency].blank? ? nil : params[:currency].to_i
       @edit[:new][:code_currency] = @edit[:new][:currency] ? code_currency_label(params[:currency]) : _('Price / Month')
-      end
+    end
+
     if params[:server_profile_template_id]
       @edit[:new][:server_profile_template_id] = params[:server_profile_template_id]
     end
@@ -2357,4 +2356,3 @@ class CatalogController < ApplicationController
   menu_section :svc
   feature_for_actions %w[ab_button_new ab_button_edit ab_group_new ab_group_edit], *EXP_EDITOR_ACTIONS
 end
-

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1039,6 +1039,8 @@ class CatalogController < ApplicationController
       common_st_record_vars(st)
       add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
       add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower) || st.kind_of?(ServiceTemplateAwx)
+      add_server_profile_template_vars(st) if @edit[:new][:st_prov_type] == 'cisco_intersight'
+
       st.service_type = "atomic"
 
       if request
@@ -1391,6 +1393,9 @@ class CatalogController < ApplicationController
     if params[:currency]
       @edit[:new][:currency] = params[:currency].blank? ? nil : params[:currency].to_i
       @edit[:new][:code_currency] = @edit[:new][:currency] ? code_currency_label(params[:currency]) : _('Price / Month')
+      end
+    if params[:server_profile_template_id]
+      @edit[:new][:server_profile_template_id] = params[:server_profile_template_id]
     end
 
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
@@ -1518,6 +1523,10 @@ class CatalogController < ApplicationController
 
   def add_ansible_tower_job_template_vars(st)
     st.job_template = @edit[:new][:template_id].nil? ? nil : ConfigurationScript.find(@edit[:new][:template_id])
+  end
+
+  def add_server_profile_template_vars(st)
+    st.options[:server_profile_template_id] = @edit[:new][:server_profile_template_id].nil? ? nil : @edit[:new][:server_profile_template_id]
   end
 
   def add_container_template_vars
@@ -2005,7 +2014,6 @@ class CatalogController < ApplicationController
   end
 
   def fetch_form_vars_server_profile_templates
-    byebug
     form_available_server_profile_templates if params[:st_prov_type]
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,7 +7,7 @@ class CatalogController < ApplicationController
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
-
+  require 'byebug'
   helper ProvisionCustomizeHelper
   helper MiqAeClassHelper # need the playbook_label
 
@@ -1396,6 +1396,7 @@ class CatalogController < ApplicationController
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
     fetch_form_vars_ansible_or_ct if %w[generic_ansible_tower generic_awx generic_container_template].include?(@edit[:new][:st_prov_type])
     fetch_form_vars_ovf_template if @edit[:new][:st_prov_type] == 'generic_ovf_template'
+    fetch_form_vars_server_profile_templates if @edit[:new][:st_prov_type] == 'cisco_intersight'
   end
 
   def code_currency_label(currency)
@@ -2003,6 +2004,15 @@ class CatalogController < ApplicationController
     add_flash(_("VM Name already exists, Please select a different VM Name"), :error) if VmOrTemplate.find_by(:name => @edit[:new][:vm_name], :ems_id => ems_id).present?
   end
 
+  def fetch_form_vars_server_profile_templates
+    byebug
+    form_available_server_profile_templates if params[:st_prov_type]
+  end
+
+  def form_available_server_profile_templates
+    @edit[:available_server_profile_templates] = PhysicalServerProfileTemplate.all.collect { |m| [m.name, m.id] }.sort
+  end
+
   def automate_tree_needed?
     options = %i[display template_id manager_id ovf_template_id datacenter_id resource_pool_id ems_folder_id host_id storage_id]
     options.any? { |x| params[x] }
@@ -2339,3 +2349,4 @@ class CatalogController < ApplicationController
   menu_section :svc
   feature_for_actions %w[ab_button_new ab_button_edit ab_group_new ab_group_edit], *EXP_EDITOR_ACTIONS
 end
+

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1524,8 +1524,8 @@ class CatalogController < ApplicationController
     st.job_template = @edit[:new][:template_id].nil? ? nil : ConfigurationScript.find(@edit[:new][:template_id])
   end
 
-  def add_server_profile_template_vars(st)
-    st.options[:server_profile_template_id] = @edit[:new][:server_profile_template_id].nil? ? nil : @edit[:new][:server_profile_template_id]
+  def add_server_profile_template_vars(service_template)
+    service_template.options[:server_profile_template_id] = @edit[:new][:server_profile_template_id].nil? ? nil : @edit[:new][:server_profile_template_id]
   end
 
   def add_container_template_vars

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -2,7 +2,7 @@
   :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
 %h3= _('Basic Information')
 #basic_info_div
-  
+
   = hidden_div_if(@edit && @edit[:ae_tree_select] != true, :id => "ae_tree_select_div") do
     = render(:partial => 'layouts/ae_tree_select')
   .form-horizontal
@@ -228,4 +228,6 @@
       = render(:partial => "tenants_tree_show")
   - if @edit[:new][:st_prov_type] == "generic_ovf_template"
     = render(:partial => "form_ovf_template_options")
+  - if @edit[:new][:st_prov_type] == "cisco_intersight"
+    = render(:partial => "form_server_profile_template_options")
 

--- a/app/views/catalog/_form_server_profile_template_options.html.haml
+++ b/app/views/catalog/_form_server_profile_template_options.html.haml
@@ -8,8 +8,8 @@
         = _('Server Profile Template')
       .col-md-8
         = select_tag('server_profile_template_id',
-                          options_for_select(opts, @edit[:new][:server_profile_template_id]),
-                          "data-miq_sparkle_on" => true,
-                          :class                => "selectpicker")
+                      options_for_select(opts, @edit[:new][:server_profile_template_id]),
+                      "data-miq_sparkle_on" => true,
+                      :class => "selectpicker")
         :javascript
           miqSelectPickerEvent('server_profile_template_id', '#{url}')

--- a/app/views/catalog/_form_server_profile_template_options.html.haml
+++ b/app/views/catalog/_form_server_profile_template_options.html.haml
@@ -1,4 +1,4 @@
-- url = url_for(:id => "#{@edit[:rec_id] || "new"}", :action => "atomic_form_field_changed")
+- url = url_for(:id => (@edit[:rec_id]&.to_s || "new"), :action => "atomic_form_field_changed")
 
 #options_div
   .form-horizontal
@@ -12,4 +12,4 @@
                           "data-miq_sparkle_on" => true,
                           :class                => "selectpicker")
         :javascript
-              miqSelectPickerEvent('server_profile_template_id', '#{url}')Ï
+          miqSelectPickerEvent('server_profile_template_id', '#{url}')

--- a/app/views/catalog/_form_server_profile_template_options.html.haml
+++ b/app/views/catalog/_form_server_profile_template_options.html.haml
@@ -1,0 +1,15 @@
+- url = url_for(:id => "#{@edit[:rec_id] || "new"}", :action => "atomic_form_field_changed")
+
+#options_div
+  .form-horizontal
+    - opts = [["<#{_('Choose')}>", nil]] + @edit[:available_server_profile_templates]
+    .form-group
+      %label.col-md-2.control-label
+        = _('Server Profile Template')
+      .col-md-8
+        = select_tag('server_profile_template_id',
+                          options_for_select(opts, @edit[:new][:server_profile_template_id]),
+                          "data-miq_sparkle_on" => true,
+                          :class                => "selectpicker")
+        :javascript
+              miqSelectPickerEvent('server_profile_template_id', '#{url}')Ï


### PR DESCRIPTION
I added the server profile template field to the catalog item dialog if the cisco intersight catalog item type has been selected.
It will add the option for the administrator to create a service catalog item that will use the server profile template that the administrator selects instead of the choice of the regular user. 

**Before**
<img width="1584" alt="Screen Shot 2022-12-27 at 10 44 24" src="https://user-images.githubusercontent.com/26038734/209639060-1263100a-235d-444c-8fa7-0aadd622eea3.png">

**After**
<img width="1584" alt="Screen Shot 2022-12-27 at 10 44 08" src="https://user-images.githubusercontent.com/26038734/209639098-65f47586-c44d-4e6a-8aa0-959c22cacd47.png">

**Related pr**
https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/83

