### PR TITLE
storage manager volume create: basic and advanced modes

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -12,10 +12,25 @@ const changeValue = (value, loadSchema, emptySchema) => {
 
 const storageManagers = (supports) => API.get(`/api/providers?expand=resources&attributes=id,name,${supports}&filter[]=${supports}=true`)
   .then(({ resources }) => {
-    let storageManagersOptions = [];
-    storageManagersOptions = resources.map(({ id, name }) => ({ label: name, value: id }));
+    const storageManagersOptions = resources.map(({ id, name }) => ({ label: name, value: id }));
     storageManagersOptions.unshift({ label: `<${__('Choose')}>`, value: '-1' });
     return storageManagersOptions;
+  });
+
+// storage manager functions to filter by capabilities:
+const equalsUnsorted = (arr1, arr2) => arr1.length === arr2.length && arr2.every(arr2Item => arr1.includes(arr2Item)) && arr1.every(arr1Item => arr2.includes(arr1Item));
+
+const filterByCapabilities = (filterArray, modelToFilter) => API.get(`/api/${modelToFilter}?expand=resources&attributes=id,name,capabilities`)
+  .then(({ resources }) => {
+    const valueArray = [];
+    resources.forEach((resource) => {
+      const capsToFilter = resource["capabilities"].map(({ uuid }) => uuid);
+      if (equalsUnsorted(filterArray, capsToFilter)) { valueArray.push(resource) }
+    });
+    if (valueArray.length === 0 && modelToFilter !== 'storage_resources') {
+      return [{label: `no ${modelToFilter} with selected capabilities`, value: -1}]
+    }
+    return valueArray.map(({ name, id }) => ({ label: name, value: id }));
   });
 
 const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
@@ -53,7 +68,59 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         },
         ...fields.slice(idx + 1),
       ]),
-    ],
+      {
+        component: componentTypes.SUB_FORM,
+        name: 'resource_type_selection',
+        id: 'resource_type_selection',
+        condition: { when: 'required_capabilities', isNotEmpty: true },
+        fields: [
+          {
+            component: 'enhanced-select',
+            name: 'storage_service_id',
+            id: 'storage_service_id',
+            label: __('Storage Service'),
+            condition: { when: 'mode', is: 'Basic' },
+            onInputChange: () => null,
+            isRequired: true,
+            validate: [{ type: validatorTypes.REQUIRED }],
+            resolveProps: (_props, _field, { getState }) => {
+              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
+              return {
+                key: JSON.stringify(capabilityValues),
+                loadOptions: () => filterByCapabilities(capabilityValues, 'storage_services'),
+              };
+            },
+          },
+          {
+            component: 'enhanced-select',
+            name: 'storage_resource_id',
+            id: 'storage_resource_id',
+            label: __('Storage Resource (if no option appears then no storage resource with selected capabilities was found)'),
+            condition: { when: 'mode', is: 'Advanced' },
+            onInputChange: () => null,
+            isRequired: true,
+            validate: [{ type: validatorTypes.REQUIRED }],
+            isMulti: true,
+            resolveProps: (_props, _field, { getState }) => {
+              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
+              return {
+                key: JSON.stringify(capabilityValues),
+                loadOptions: () => filterByCapabilities(capabilityValues, 'storage_resources'),
+              };
+            },
+          },
+          {
+            component: componentTypes.TEXT_FIELD,
+            name: 'new_service_name',
+            id: 'new_service_name',
+            label: __('Service Name'),
+            condition: { when: 'mode', is: 'Advanced' },
+            isRequired: true,
+            validate: [{ type: validatorTypes.REQUIRED }],
+          },
+        ]
+      },
+    ]
   });
 };
 

--- a/app/javascript/components/cloud-volume-form/index.jsx
+++ b/app/javascript/components/cloud-volume-form/index.jsx
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types';
 import MiqFormRenderer from '@@ddf';
 import createSchema from './cloud-volume-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
+import { FormSpy } from '../../forms/data-driven-form';
+import mapper from '../../forms/mappers/componentMapper';
+import Select from '../select';
 
 const CloudVolumeForm = ({ recordId, storageManagerId }) => {
   const [{ fields, initialValues, isLoading }, setState] = useState({ fields: [], isLoading: !!recordId || !!storageManagerId });
@@ -73,9 +76,17 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
     return errors;
   };
 
+  const enhancedSelect = (props) => <FormSpy subscription={{ values: true }}>{() => <Select {...props} />}</FormSpy>;
+
+  const componentMapper = {
+    ...mapper,
+    'enhanced-select': enhancedSelect,
+  }
+
   return !isLoading && (
     <MiqFormRenderer
       schema={createSchema(fields, !!recordId, !!storageManagerId, loadSchema, emptySchema)}
+      componentMapper={componentMapper}
       initialValues={initialValues}
       canReset={!!recordId}
       validate={validation}


### PR DESCRIPTION
filter services and resources by capabilities on volume create:
- Basic: filter services by required capabilities and choose an existing service from the filtered list.
- Advanced: choose a name for a new service, filter resources by required capabilities, and choose resources to attach to the new service from the filtered list. the new volume(s) will be created for the new service, on one of the attached resources.
- although changes were made to the general `cloud-volume-form.schema.js`, they will only appear for storage_manager volumes, due to a data-driven-form condition on receiving a `required_capabilities` field, which is only provided in `app/models/manageiq/providers/autosde/storage_manager/cloud_volume.rb`. see related PR in providers-autosde: https://github.com/ManageIQ/manageiq-providers-autosde/pull/194/files. this solution was chosen after discussion in gitter: https://gitter.im/ManageIQ/manageiq/ui?at=6390aa53a151003b5a59e693 

**this change requires a gem update in autosde client before merging**
   
- 
**before**:
![image](https://user-images.githubusercontent.com/106743023/210175905-8c621e4b-9798-42bc-954a-541c9dd8b4ad.png)

![image](https://user-images.githubusercontent.com/106743023/210175926-0ea06e5c-55e9-47a7-a56b-9cebf21f0af8.png)


**after**:
![image](https://user-images.githubusercontent.com/106743023/210175732-0a1ff975-67bc-4852-90c6-f26d3986cce5.png)

**basic**:
![image](https://user-images.githubusercontent.com/106743023/210175948-f47510ae-10d8-44bb-8128-be4542ed3311.png)

**advanced**:
![image](https://user-images.githubusercontent.com/106743023/210175988-171c5a18-c126-4285-af14-06bdcaf90cc6.png)