### PR TITLE
List resource capabilities in summary page

### DIFF
--- a/app/helpers/storage_resource_helper/textual_summary.rb
+++ b/app/helpers/storage_resource_helper/textual_summary.rb
@@ -12,6 +12,7 @@ module StorageResourceHelper::TextualSummary
         name
         logical_free
         logical_total
+        capabilities
       ]
     )
   end
@@ -33,5 +34,16 @@ module StorageResourceHelper::TextualSummary
 
   def textual_logical_total
     {:label => _("Total Size"), :value => number_to_human_size(@record.logical_total, :precision => 2)}
+  end
+
+  def textual_capabilities
+    {:label => _("Capabilities"), :value => parse_capabilities(@record.capabilities)}
+  end
+
+  def parse_capabilities(capabilities)
+    caps = capabilities.map do |capability|
+      "#{capability['name']}: #{capability['value']}"
+    end
+    caps.join(", ")
   end
 end


### PR DESCRIPTION
Added enabled capabilities list in the textual summery page. 
related pr:
 https://github.com/ManageIQ/manageiq-providers-autosde/pull/195
https://github.com/ManageIQ/manageiq-schema/pull/677

<img width="1479" alt="Screen Shot 2023-01-03 at 11 12 49" src="https://user-images.githubusercontent.com/74841666/210328177-a523ad01-0c74-47b4-8eab-a0726347cc6b.png">
