### PR TITLE
VM Provision Environment Tab Fix

### DIFF
--- a/app/helpers/request_info_helper.rb
+++ b/app/helpers/request_info_helper.rb
@@ -280,7 +280,7 @@ module RequestInfoHelper
   def prov_ds_grid_cells(data, edit)
     cells = []
     edit[:ds_columns].each do |col|
-      cells += if %w[free_space total_space].include?(col)
+      cells << if %w[free_space total_space].include?(col)
                  prov_cell_data(number_to_human_size(data.send(col), :precision => 1))
                else
                  prov_cell_data(data.send(col))


### PR DESCRIPTION
Fixes a bug that was causing a "no implicit conversion of Hash into Array" error when selecting the Environment tab while trying to provision a vm.

Before:
![image](https://user-images.githubusercontent.com/64800041/210650301-f5147508-0943-4799-b6f3-25aba8d2e47d.png)

After:
![image](https://user-images.githubusercontent.com/64800041/210650325-cc41cbb0-8544-42a5-9a6c-f0c074c48125.png)