### PR TITLE
add host initiator groups to ems storage dashboard

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -86,6 +86,7 @@ module Mixins
           floating_ips
           host_aggregates
           host_initiators
+          host_initiator_groups
           volume_mappings
           hosts
           images

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -28,7 +28,7 @@ class EmsStorageDashboardService < EmsDashboardService
 
   def attributes_data
     attributes = if @ems.supports?(:block_storage)
-                   %i[physical_storages storage_resources cloud_volumes host_initiators volume_mappings]
+                   %i[physical_storages storage_resources cloud_volumes volume_mappings host_initiators host_initiator_groups]
                  else
                    %i[cloud_object_store_containers cloud_object_store_objects]
                  end
@@ -37,8 +37,9 @@ class EmsStorageDashboardService < EmsDashboardService
       :physical_storages             => 'pficon pficon-container-node',
       :storage_resources             => 'pficon pficon-resource-pool',
       :cloud_volumes                 => 'pficon pficon-volume',
+      :volume_mappings               => 'pficon pficon-service',
       :host_initiators               => 'pficon pficon-virtual-machine',
-      :volume_mappings               => 'pficon pficon-volume',
+      :host_initiator_groups         => 'ff ff-relationship',
       :cloud_object_store_containers => 'ff ff-cloud-object-store',
       :cloud_object_store_objects    => 'fa fa-star',
     }
@@ -47,8 +48,9 @@ class EmsStorageDashboardService < EmsDashboardService
       :storage_resources             => 'storage_resources',
       :cloud_volumes                 => 'cloud_volumes',
       :physical_storages             => 'physical_storages',
-      :host_initiators               => 'host_initiators',
       :volume_mappings               => 'volume_mappings',
+      :host_initiators               => 'host_initiators',
+      :host_initiator_groups         => 'host_initiator_groups',
       :cloud_object_store_containers => 'cloud_object_store_containers',
       :cloud_object_store_objects    => 'cloud_object_store_objects',
     }
@@ -57,8 +59,9 @@ class EmsStorageDashboardService < EmsDashboardService
       :storage_resources             => _('Resources (Pools)'),
       :cloud_volumes                 => _('Volumes'),
       :physical_storages             => _('Physical Storages'),
-      :host_initiators               => _('Host Initiators'),
       :volume_mappings               => _('Volume Mappings'),
+      :host_initiators               => _('Host Initiators'),
+      :host_initiator_groups         => _('Host Initiator Groups'),
       :cloud_object_store_containers => _('Containers'),
       :cloud_object_store_objects    => _('Objects'),
     }


### PR DESCRIPTION
and also changed volume mappings' icon

before:
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/106743023/211762690-a69c1af3-8f81-40a4-89f1-e29d398a1c93.png">

after:
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/106743023/211762850-20666934-f73f-4e69-94e8-833845548068.png">

clicking the new cube successfully leads here:
![image](https://user-images.githubusercontent.com/106743023/211763715-a5101ed5-17a3-4a84-8559-e465207fb448.png)

**resolved**:
but when pressing the new link of host initiator groups, I get:
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/106743023/211359442-9248c572-e1fc-486e-936b-0aad3f49b91c.png">

the error is raised in `app/views/shared/views/ems_common/_show.html.haml`. 
to my understanding, it was supposed to render according to lines 9-10 but seems like arr.include?(@display) returns `false`, even though `HostInitiatorGroupController.display_methods` references `cloud_volumes`.
adding `host_initiator_groups` to `CloudVolumeController.display_methods` didn't help..
and so it goes to lines 26-27

![image](https://user-images.githubusercontent.com/106743023/211360202-5de29139-32ef-4960-a813-a78233eb2e05.png)

any idea why?

