### PR TITLE
Adrian/462593 add search on missing objects

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -769,6 +769,7 @@ module ApplicationHelper
        flavor
        floating_ip
        host
+       host_initiator_group
        host_aggregate
        load_balancer
        miq_template
@@ -791,6 +792,7 @@ module ApplicationHelper
        services
        storage
        templates
+       volume_mapping
        vm].include?(@layout)
   end
 

--- a/app/helpers/application_helper/page_layouts.rb
+++ b/app/helpers/application_helper/page_layouts.rb
@@ -210,6 +210,7 @@ module ApplicationHelper::PageLayouts
       floating_ip
       host
       host_aggregate
+      host_initiator_group
       load_balancer
       miq_template
       network_port
@@ -231,6 +232,7 @@ module ApplicationHelper::PageLayouts
       storage_resource
       host_initiator
       templates
+      volume_mapping
       vm
     ]
 


### PR DESCRIPTION
Some pages didn't have the search button. Those are Volume Mapping and Host Initiator Group.

<img width="1530" alt="Screen Shot 2023-01-09 at 11 54 38" src="https://user-images.githubusercontent.com/50288766/212340064-4363a687-7797-4aa3-bc90-adc8c9029f1c.png">

So I added them

<img width="1526" alt="Screen Shot 2023-01-13 at 16 11 10" src="https://user-images.githubusercontent.com/50288766/212340110-c2a2ee2d-ab5d-40a2-a26e-a7c3d3ff509d.png">

I intended to add in this PR as well a search button for all the pages accessed through a storage manager (the do have it when accessed directly from 'storage'). But I couldn't find out how to do that, I'd appreciate some help over there...