### PR TITLE
fix refresh ems storage manager for physical storage refresh button

### DIFF
--- a/app/controllers/physical_storage_controller.rb
+++ b/app/controllers/physical_storage_controller.rb
@@ -107,6 +107,11 @@ class PhysicalStorageController < ApplicationController
       @record = find_record_with_rbac(PhysicalStorage, params[:id])
       show_timeline
       javascript_redirect(:action => 'show', :id => @record.id, :display => 'timeline')
+    when "physical_storage_refresh"
+      @record = find_record_with_rbac(PhysicalStorage, checked_item_id)
+      EmsRefresh.refresh(@record.ext_management_system)
+      add_flash(_("Refresh storage manager successfully initiated for physical storage- #{@record.name}"))
+      render_flash
     else
       return false
     end

--- a/app/helpers/application_helper/toolbar/physical_storages_center.rb
+++ b/app/helpers/application_helper/toolbar/physical_storages_center.rb
@@ -14,9 +14,10 @@ class ApplicationHelper::Toolbar::PhysicalStoragesCenter < ApplicationHelper::To
             N_('Refresh relationships and power states for all items related to these Physical Storages'),
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
-            :data    => {'function'      => 'sendDataWithRx',
-                         'function-data' => {:type => "refresh", :controller => "physicalStorageToolbarController"}},
             :confirm => N_("Refresh relationships and power states for all items related to these Physical Storages?"),
+            :send_checked => true,
+            :enabled      => false,
+            :onwhen       => '1',
             :options => {:feature => :refresh}
           ),
           button(


### PR DESCRIPTION
The refresh button on the physical storage list page doesn't work.
I made change to call the refresh of the storage manager that connected to this physical storage.
The refresh button will be enabled when one physical storage is selected.

<img width="1782" alt="Screen Shot 2023-01-17 at 8 52 27" src="https://user-images.githubusercontent.com/26038734/212829654-216de941-6a42-417d-8fa7-b4a0d059c3d3.png">
