### PR TITLE
added validation to volume and service names

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -1,5 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { parseCondition } from '@data-driven-forms/react-form-renderer';
+import validateName from '../../helpers/validate-names.js';
 
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
@@ -17,7 +18,7 @@ const storageManagers = (supports) => API.get(`/api/providers?expand=resources&a
     return storageManagersOptions;
   });
 
-// storage manager functions to filter by capabilities:
+// storage manager functions:
 const equalsUnsorted = (arr1, arr2) => arr1.length === arr2.length && arr2.every(arr2Item => arr1.includes(arr2Item)) && arr1.every(arr1Item => arr2.includes(arr1Item));
 
 const filterByCapabilities = (filterArray, modelToFilter) => API.get(`/api/${modelToFilter}?expand=resources&attributes=id,name,capabilities`)
@@ -56,7 +57,10 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         id: 'name',
         label: __('Volume Name'),
         isRequired: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
+        validate: [
+          { type: validatorTypes.REQUIRED },
+          async (value) => validateName("cloud_volumes", value)
+        ],
       },
       ...(idx === -1 ? fields : [
         ...fields.slice(0, idx),
@@ -116,7 +120,10 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
             label: __('Service Name'),
             condition: { when: 'mode', is: 'Advanced' },
             isRequired: true,
-            validate: [{ type: validatorTypes.REQUIRED }],
+            validate: [
+              { type: validatorTypes.REQUIRED },
+              async (value) => validateName("storage_services", value)
+            ],
           },
         ]
       },

--- a/app/javascript/helpers/validate-names.js
+++ b/app/javascript/helpers/validate-names.js
@@ -1,0 +1,5 @@
+const validateName = (target, name) => API.get(`/api/${target}?expand=resources&attributes=name`)
+  .then(({ resources }) => resources.map((resource) => resource.name))
+  .then((results) => (results.includes(name) ? sprintf(__('The name "%s" already exists in "%s"'), name, target) : undefined));
+
+export default validateName;


### PR DESCRIPTION
added validation to volume and service names, preventing from passing names that are already in use (which causes failure in the backend).

the validating function was added to a separate module in dir helpers, so we can import it in other schemas in the future.

**before**:
request is sent to the backend and fails there, causing unnecessary confusion for the user and work for the backend:
![image](https://user-images.githubusercontent.com/106743023/213439879-b2fb5401-d32c-4aea-804e-0f2b24b3c34d.png)

**after**:
the validators prevent the user from sending exiting names:
![image](https://user-images.githubusercontent.com/106743023/213440248-37b44a93-29b2-4224-88ae-810133bee985.png)

vs:
![image](https://user-images.githubusercontent.com/106743023/213440659-da08ef91-89eb-4eb4-a359-c3d338d19318.png)
