### PR TITLE
Remove google-chrome-beta for jasmine tests

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -62,7 +62,6 @@ Jasmine.configure do |config|
     Jasmine::Runners::ChromeHeadless.new(formatter, jasmine_server_url, config)
   end
 
-  config.chrome_binary = 'google-chrome-beta'
   config.chrome_cli_options = {
     'headless' => nil,
     'disable-gpu' => nil,


### PR DESCRIPTION
google-chrome-beta seems to have changed their DNS resolution for localhost, and that is having problems in CI. For now, just remove it and use "normal" google-chrome.

This also fixes an issue where on Mac it doesn't use the installed Google Chrome.app

@jeffibm Please review. Note that in my tests there was a seemingly unrelated test failure, so even if this is red I recommend merging and we fix that separately.