### PR TITLE
fixes for host initiator groups

### DIFF
--- a/app/controllers/mixins/ems_common.rb
+++ b/app/controllers/mixins/ems_common.rb
@@ -261,6 +261,7 @@ module Mixins
         when "physical_storage_new"             then javascript_redirect(:action => 'new', :controller => 'physical_storage', :storage_manager_id => block_storage_manager_id(params[:id]))
         when "physical_storage_edit"            then javascript_redirect(:action => "edit", :controller => "physical_storage", :id => checked_or_params)
         when "host_initiator_new"               then javascript_redirect(:action => 'new', :controller => 'host_initiator', :storage_manager_id => block_storage_manager_id(params[:id]))
+        when "host_initiator_group_new"         then javascript_redirect(:action => 'new', :controller => 'host_initiator_group', :storage_manager_id => block_storage_manager_id(params[:id]))
         when "volume_mapping_new"               then javascript_redirect(:action => 'new', :controller => 'volume_mapping', :storage_manager_id => block_storage_manager_id(params[:id]))
 
         # Edit Tags for Network Manager Relationship pages

--- a/app/helpers/application_helper/toolbar/host_initiator_group_center.rb
+++ b/app/helpers/application_helper/toolbar/host_initiator_group_center.rb
@@ -3,15 +3,15 @@ class ApplicationHelper::Toolbar::HostInitiatorGroupCenter < ApplicationHelper::
     'host_initiator_group_vmdb',
     [
       select(
-        :host_initiator_vmdb_choice,
+        :host_initiator_group_vmdb_choice,
         nil,
         t = N_('Configuration'),
         t,
         :items => [
           button(
-            :host_initiator_refresh,
+            :host_initiator_group_refresh,
             'fa fa-refresh fa-lg',
-            N_('Refresh relationships and power states for all items related to this Host Initiator Cluster'),
+            N_('Refresh relationships and power states for all items related to this Host Initiator Group'),
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',

--- a/app/helpers/application_helper/toolbar/host_initiator_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/host_initiator_groups_center.rb
@@ -3,15 +3,15 @@ class ApplicationHelper::Toolbar::HostInitiatorGroupsCenter < ApplicationHelper:
     'host_initiator_group_vmdb',
     [
       select(
-        :host_initiator_vmdb_choice,
+        :host_initiator_group_vmdb_choice,
         nil,
         t = N_('Configuration'),
         t,
         :items => [
           button(
-            :host_initiator_refresh,
+            :host_initiator_group_refresh,
             'fa fa-refresh fa-lg',
-            N_('Refresh relationships and power states for all items related to these Host Initiators Cluster'),
+            N_('Refresh relationships and power states for all items related to these Host Initiator Groups'),
             N_('Refresh Relationships and Power States'),
             :image   => "refresh",
             :data    => {'function'      => 'sendDataWithRx',

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -344,7 +344,7 @@ class ApplicationHelper::ToolbarChooser
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
     to_display = %w[availability_zones cloud_networks cloud_object_store_containers cloud_subnets configured_systems
-                    cloud_tenants cloud_volumes ems_clusters flavors floating_ips host_aggregates hosts host_initiators
+                    cloud_tenants cloud_volumes ems_clusters flavors floating_ips host_aggregates hosts host_initiators host_initiator_groups
                     volume_mappings network_ports network_routers network_services orchestration_stacks resource_pools
                     security_groups security_policies security_policy_rules storages physical_storages]
     to_display_center = %w[stack_orchestration_template cloud_object_store_objects generic_objects physical_servers guest_devices]
@@ -428,6 +428,7 @@ class ApplicationHelper::ToolbarChooser
             flavor
             host
             host_initiator
+            host_initiator_group
             volume_mapping
             container_build
             infra_networking

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -13,7 +13,7 @@ module EmsStorageHelper::TextualSummary
   def textual_group_relationships
     relationships = %i[
                        parent_ems_cloud cloud_volumes cloud_volume_snapshots cloud_volume_backups
-                       cloud_object_store_containers custom_button_events host_initiators volume_mappings physical_storages storage_resources
+                       cloud_object_store_containers custom_button_events host_initiators host_initiator_groups volume_mappings physical_storages storage_resources
       ]
     relationships.push(:cloud_volume_types) if @record.kind_of?(ManageIQ::Providers::Openstack::StorageManager::CinderManager)
     TextualGroup.new(_("Relationships"), relationships)
@@ -89,6 +89,10 @@ module EmsStorageHelper::TextualSummary
 
   def textual_host_initiators
     textual_link(@record.try(:host_initiators), :label => _('Host Initiators'))
+  end
+
+  def textual_host_initiator_groups
+    textual_link(@record.try(:host_initiator_groups), :label => _('Host Initiator Groups'))
   end
 
   def textual_physical_storages

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -157,7 +157,7 @@ module Menu
           Menu::Item.new('cloud_volume_type',            N_('Volume Types'),            'cloud_volume_type',            {:feature => 'cloud_volume_type_show_list'},            '/cloud_volume_type/show_list'),
           Menu::Item.new('volume_mapping',               N_('Volume Mappings'),         'volume_mapping',               {:feature => 'volume_mapping_show_list'},               '/volume_mapping/show_list'),
           Menu::Item.new('host_initiator',               N_('Host Initiators'),         'host_initiator',               {:feature => 'host_initiator_show_list'},               '/host_initiator/show_list'),
-          Menu::Item.new('host_initiator_group',         N_('Host Initiator Groups'),   'host_initiator_group',         {:feature => 'host_initiator_show_list'},               '/host_initiator_group/show_list'),
+          Menu::Item.new('host_initiator_group',         N_('Host Initiator Groups'),   'host_initiator_group',         {:feature => 'host_initiator_group_show_list'},         '/host_initiator_group/show_list'),
           Menu::Item.new('physical_storage',             N_('Storages'),                'physical_storage',             {:feature => 'physical_storage_show_list'},             '/physical_storage/show_list'),
           Menu::Item.new('storage_resource',             N_('Storage Resources'),       'storage_resource',             {:feature => 'storage_resource_show_list'},             '/storage_resource/show_list'),
           Menu::Item.new('cloud_object_store_container', N_('Object Store Containers'), 'cloud_object_store_container', {:feature => 'cloud_object_store_container_show_list'}, '/cloud_object_store_container/show_list'),

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -37,7 +37,7 @@ class EmsStorageDashboardService < EmsDashboardService
       :physical_storages             => 'pficon pficon-container-node',
       :storage_resources             => 'pficon pficon-resource-pool',
       :cloud_volumes                 => 'pficon pficon-volume',
-      :volume_mappings               => 'pficon pficon-service',
+      :volume_mappings               => 'pficon pficon-topology',
       :host_initiators               => 'pficon pficon-virtual-machine',
       :host_initiator_groups         => 'ff ff-relationship',
       :cloud_object_store_containers => 'ff ff-cloud-object-store',

--- a/spec/helpers/ems_storage_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_storage_helper/textual_summary_spec.rb
@@ -15,6 +15,7 @@ describe EmsStorageHelper::TextualSummary do
       cloud_object_store_containers
       custom_button_events
       host_initiators
+      host_initiator_groups
       volume_mappings
       physical_storages
       storage_resources
@@ -39,6 +40,7 @@ describe EmsStorageHelper::TextualSummary do
       cloud_object_store_containers
       custom_button_events
       host_initiators
+      host_initiator_groups
       volume_mappings
       physical_storages
       storage_resources


### PR DESCRIPTION
host initiator groups were added to the ems storage dashboard on PR https://github.com/ManageIQ/manageiq-ui-classic/pull/8593 but turns out there were further changes needed to enable the configuration toolbar button and to redirect the "new" action properly.

related PR in decorators repo:
https://github.com/ManageIQ/manageiq-decorators/pull/84


---

**before:**
![host_init_group_before](https://user-images.githubusercontent.com/106743023/214289773-147ed8ff-c3e7-4a43-abce-404329af3f87.png)

---

**after:**
![Screen Shot 2023-01-24 at 14 19 31](https://user-images.githubusercontent.com/106743023/214290088-9368d2a6-4c4e-42ca-86b5-f48230cbf722.png)
-

![image](https://user-images.githubusercontent.com/106743023/214290237-7f05e43b-01af-4f61-87be-059b1eb5d39f.png)
-

![image](https://user-images.githubusercontent.com/106743023/214290417-9635d079-9ad4-4d7a-b570-26af08b5ad1b.png)
