### PR TITLE
handle ids that are bigger than bigint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1104,10 +1104,11 @@ class ApplicationController < ActionController::Base
                "%#{stxt}%"
              end
 
-      id = @search_text if /^\d+$/.match?(@search_text)
+      id = @search_text.to_i if /^\d+$/.match?(@search_text)
       condition = [[]]
-      if id
-        add_to_search_condition(condition, "#{view.db_class.table_name}.id = ?", id.to_i)
+      # also search by id if it is an int and not bigger then the max of bigint
+      if id && id <= 9223372036854775807
+        add_to_search_condition(condition, "#{view.db_class.table_name}.id = ?", id)
       end
 
       if ::Settings.server.case_sensitive_name_search


### PR DESCRIPTION
This is a continuation for 040029066e61dcde2cedbe77a4ffd799d7f6eacb

If the id that comes in is bigger than a valid id, then don't look it up by id.

This is for a few reasons:

- Postgres gets stage fright if the id coming in is too big, throwing an exception
- No need to add an OR clause for something that will never match
- Just looking up by the numeric will force the query to sequential table scan

This also helps us with a CVE (actually a potential DOS and not a real one) So it closes the gap and removes any questions / debates

- https://github.com/ManageIQ/manageiq-ui-classic/issues/7692
- https://github.com/ManageIQ/manageiq-ui-classic/pull/7702
- https://github.com/ManageIQ/manageiq/pull/22321
- https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L25