### PR TITLE
Fix Policies accessibility violations

### DIFF
--- a/app/stylesheet/legacy/patternfly_overrides.scss
+++ b/app/stylesheet/legacy/patternfly_overrides.scss
@@ -786,3 +786,29 @@ table.c3-tooltip td {
     width: 100%;
   }
 }
+
+.pf_input_container {
+  display: flex;
+  flex-direction: column;
+
+  &.miq_available_policies {
+    overflow: auto;
+    width: 400px;
+    border: 1px solid #999999;
+  }
+
+  .pf_input_container_label {
+    font-size: 12px;
+    height: 20px;
+    margin: 0;
+  }
+
+  .pf_input_container_content {
+    margin-top: -20px;
+  }
+
+}
+
+a.btn.disabled {
+  color: #666262 !important;
+}

--- a/app/views/layouts/_center_div_no_listnav.html.haml
+++ b/app/views/layouts/_center_div_no_listnav.html.haml
@@ -1,7 +1,8 @@
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden !important; height: 100%;"}
-  #breadcrumbs
-    = render :partial => "layouts/breadcrumbs"
-  .row.max-height
+  %header
+    #breadcrumbs
+      = render :partial => "layouts/breadcrumbs"
+  %main.row.max-height
     .col-md-12.max-height
       - if !@in_a_form && taskbar_in_header?
         .row.toolbar-pf#toolbar

--- a/app/views/miq_policy_export/_export.html.haml
+++ b/app/views/miq_policy_export/_export.html.haml
@@ -71,23 +71,30 @@
         %label.col-md-2.control-label
           = _("Export:")
         .col-md-8
-          = select_tag('dbtype',
-            options_for_select([[_("Policy Profiles"), "pp"], [_("Policies"), "p"], [_("Alerts"), "al"]], @sb[:dbtype]),
-            :class => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('dbtype', '#{url}')
+          .pf_input_container
+            %label{:for => "dbtype", :class => "pf_input_container_label"}
+              = _('Export')
+            .pf_input_container_content
+              = select_tag('dbtype',
+                options_for_select([[_("Policy Profiles"), "pp"], [_("Policies"), "p"], [_("Alerts"), "al"]], @sb[:dbtype]),
+                :class => "selectpicker")
+              :javascript
+                miqInitSelectPicker();
+                miqSelectPickerEvent('dbtype', '#{url}')
       .form-group
         %label.col-md-2.control-label
           = available_title
         .col-md-8
-          %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
-            = select_tag('choices_chosen[]',
-              options_for_select(@sb[:new][:choices].sort),
-              :class => "selected-policies",
-              :size              => 15,
-              :style             => "width: 400px",
-              :multiple          => true)
+          .pf_input_container
+            %label{:for => "choices_chosen_", :class => "pf_input_container_label"}
+              = available_title
+            .pf_input_container_content.miq_available_policies
+              = select_tag('choices_chosen[]',
+                options_for_select(@sb[:new][:choices].sort),
+                :class => "selected-policies",
+                :size  => 15,
+                :style => "width: 400px",
+                :multiple => true)
     %table{:width => "100%"}
       %tr
         %td{:align => "right"}


### PR DESCRIPTION
Before
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/214556070-95b83a73-459f-4f78-90e7-3f49feb487cb.png">

After
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/87487049/214555837-3ea61635-d6f9-4132-951f-98e2ee9ff166.png">

Note
- Few **violations** and **recommendations** will be fixed when the [PR#8611](https://github.com/ManageIQ/manageiq-ui-classic/pull/8611) will be merged
- 2 of the violations are related to the file-chooser input field. "_Label text is located after its associated text input or <select> element_" will be fixed when we convert this page from HAML form to react form. It cannot be fixed now because we do not have control over the code for this file-import tag.
