### PR TITLE
Create physical storage with capabilities

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -3,6 +3,7 @@ import { parseCondition } from '@data-driven-forms/react-form-renderer';
 import validateName from '../../helpers/storage_manager/validate-names';
 import filterResourcesByCapabilities from '../../helpers/storage_manager/filter-resources-by-capabilities';
 import filterServicesByCapabilities from '../../helpers/storage_manager/filter-service-by-capabilities';
+import { getProviderCapabilities } from '../../helpers/storage_manager/filter-by-capabilities-utils';
 
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
@@ -22,10 +23,6 @@ const storageManagers = (supports) =>
     });
 
 // storage manager functions:
-
-const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
-  .then((result) => result.capabilities);
-
 const validateServiceHasResources = (serviceId) =>
   API.get(`/api/storage_services/${serviceId}?attributes=name,storage_resources`)
     .then((response) => (response.storage_resources.length === 0

--- a/app/javascript/components/storage-service-form/storage-service-form.schema.js
+++ b/app/javascript/components/storage-service-form/storage-service-form.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import validateName from '../../helpers/storage_manager/validate-names';
-import loadProviderCapabilities from '../../helpers/storage_manager/load-provider-capabilities';
+import { loadProviderCapabilities } from '../../helpers/storage_manager/load-provider-capabilities';
 
 const loadProviders = () =>
   API.get(

--- a/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
+++ b/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
@@ -7,4 +7,7 @@ const getCapabilityUuid = (providerCapabilities, capabilityName, capabilityValue
   return capVals.find((capVal) => capVal.value === capabilityValue).uuid;
 };
 
-export { arrayIncludes, getCapabilityUuid };
+const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
+  .then((result) => result.capabilities);
+
+export { arrayIncludes, getCapabilityUuid, getProviderCapabilities };

--- a/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
+++ b/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
@@ -9,7 +9,7 @@ const filterServicesByCapabilities = async(filterArray, providerCapabilities) =>
         Object.keys(resource.capabilities).forEach((key) => {
           capsToFilter.push(getCapabilityUuid(providerCapabilities, key, resource.capabilities[key]));
         });
-        if (arrayIncludes(filterArray, capsToFilter)) {
+        if (arrayIncludes(capsToFilter, filterArray)) {
           valueArray.push(resource);
         }
       });

--- a/app/javascript/helpers/storage_manager/load-provider-capabilities.js
+++ b/app/javascript/helpers/storage_manager/load-provider-capabilities.js
@@ -2,6 +2,8 @@
 // but in the storage_manager models the capability name is saved under different keys, instead of 'abstract_capability'.
 // the parameter fieldName enables to dynamically access the correct key.
 
+import { getCapabilityUuid } from './filter-by-capabilities-utils';
+
 const loadProviderCapabilities = (providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
   .then(({ capabilities }) => {
     const options = [];
@@ -12,4 +14,19 @@ const loadProviderCapabilities = (providerId) => API.get(`/api/providers/${provi
     return options;
   });
 
-export default loadProviderCapabilities;
+const parseCapabilitiesForPhysical = async(providerCapabilities, id) =>
+  API.get(`/api/physical_storage_families/${id}?attributes=capabilities`)
+    .then(({ capabilities }) => {
+      const valueArray = [];
+      Object.keys(capabilities).forEach((capabilityName) => {
+        capabilities[capabilityName].forEach((capabilityValue) => {
+          valueArray.push({
+            label: sprintf(__('%s: %s'), capabilityName, capabilityValue),
+            value: getCapabilityUuid(providerCapabilities, capabilityName, capabilityValue),
+          });
+        });
+      });
+      return valueArray;
+    });
+
+export { loadProviderCapabilities, parseCapabilitiesForPhysical };

--- a/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
+++ b/app/javascript/spec/physical-storage-form/__snapshots__/physical-storage-form.spec.js.snap
@@ -95,6 +95,54 @@ exports[`Physical storage form component should render adding form variant 1`] =
                   "label": "System Type:",
                   "loadOptions": [Function],
                   "name": "physical_storage_family_id",
+                  "onChange": [Function],
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "radio",
+                  "condition": Object {
+                    "isNotEmpty": true,
+                    "when": "physical_storage_family_id",
+                  },
+                  "id": "capabilities",
+                  "isRequired": true,
+                  "label": "Capabilities",
+                  "name": "capabilities",
+                  "options": Array [
+                    Object {
+                      "label": "Default",
+                      "value": "Default",
+                    },
+                    Object {
+                      "label": "Custom",
+                      "value": "Custom",
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required",
+                    },
+                  ],
+                },
+                Object {
+                  "component": "select",
+                  "condition": Object {
+                    "is": "Custom",
+                    "when": "capabilities",
+                  },
+                  "id": "enabled_capability_values",
+                  "includeEmpty": false,
+                  "isDisabled": false,
+                  "isMulti": true,
+                  "isRequired": true,
+                  "label": "Enabled capability values:",
+                  "loadOptions": [Function],
+                  "name": "enabled_capability_values",
+                  "simpleValue": true,
                   "validate": Array [
                     Object {
                       "type": "required",
@@ -319,6 +367,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                     "label": "System Type:",
                     "loadOptions": [Function],
                     "name": "physical_storage_family_id",
+                    "onChange": [Function],
+                    "validate": Array [
+                      Object {
+                        "type": "required",
+                      },
+                    ],
+                  },
+                  Object {
+                    "component": "radio",
+                    "condition": Object {
+                      "isNotEmpty": true,
+                      "when": "physical_storage_family_id",
+                    },
+                    "id": "capabilities",
+                    "isRequired": true,
+                    "label": "Capabilities",
+                    "name": "capabilities",
+                    "options": Array [
+                      Object {
+                        "label": "Default",
+                        "value": "Default",
+                      },
+                      Object {
+                        "label": "Custom",
+                        "value": "Custom",
+                      },
+                    ],
+                    "validate": Array [
+                      Object {
+                        "type": "required",
+                      },
+                    ],
+                  },
+                  Object {
+                    "component": "select",
+                    "condition": Object {
+                      "is": "Custom",
+                      "when": "capabilities",
+                    },
+                    "id": "enabled_capability_values",
+                    "includeEmpty": false,
+                    "isDisabled": true,
+                    "isMulti": true,
+                    "isRequired": true,
+                    "label": "Enabled capability values:",
+                    "loadOptions": [Function],
+                    "name": "enabled_capability_values",
+                    "simpleValue": true,
                     "validate": Array [
                       Object {
                         "type": "required",
@@ -526,6 +622,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                       "label": "System Type:",
                       "loadOptions": [Function],
                       "name": "physical_storage_family_id",
+                      "onChange": [Function],
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "radio",
+                      "condition": Object {
+                        "isNotEmpty": true,
+                        "when": "physical_storage_family_id",
+                      },
+                      "id": "capabilities",
+                      "isRequired": true,
+                      "label": "Capabilities",
+                      "name": "capabilities",
+                      "options": Array [
+                        Object {
+                          "label": "Default",
+                          "value": "Default",
+                        },
+                        Object {
+                          "label": "Custom",
+                          "value": "Custom",
+                        },
+                      ],
+                      "validate": Array [
+                        Object {
+                          "type": "required",
+                        },
+                      ],
+                    },
+                    Object {
+                      "component": "select",
+                      "condition": Object {
+                        "is": "Custom",
+                        "when": "capabilities",
+                      },
+                      "id": "enabled_capability_values",
+                      "includeEmpty": false,
+                      "isDisabled": true,
+                      "isMulti": true,
+                      "isRequired": true,
+                      "label": "Enabled capability values:",
+                      "loadOptions": [Function],
+                      "name": "enabled_capability_values",
+                      "simpleValue": true,
                       "validate": Array [
                         Object {
                           "type": "required",
@@ -725,6 +869,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                         "label": "System Type:",
                         "loadOptions": [Function],
                         "name": "physical_storage_family_id",
+                        "onChange": [Function],
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "radio",
+                        "condition": Object {
+                          "isNotEmpty": true,
+                          "when": "physical_storage_family_id",
+                        },
+                        "id": "capabilities",
+                        "isRequired": true,
+                        "label": "Capabilities",
+                        "name": "capabilities",
+                        "options": Array [
+                          Object {
+                            "label": "Default",
+                            "value": "Default",
+                          },
+                          Object {
+                            "label": "Custom",
+                            "value": "Custom",
+                          },
+                        ],
+                        "validate": Array [
+                          Object {
+                            "type": "required",
+                          },
+                        ],
+                      },
+                      Object {
+                        "component": "select",
+                        "condition": Object {
+                          "is": "Custom",
+                          "when": "capabilities",
+                        },
+                        "id": "enabled_capability_values",
+                        "includeEmpty": false,
+                        "isDisabled": true,
+                        "isMulti": true,
+                        "isRequired": true,
+                        "label": "Enabled capability values:",
+                        "loadOptions": [Function],
+                        "name": "enabled_capability_values",
+                        "simpleValue": true,
                         "validate": Array [
                           Object {
                             "type": "required",
@@ -923,6 +1115,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                             "label": "System Type:",
                             "loadOptions": [Function],
                             "name": "physical_storage_family_id",
+                            "onChange": [Function],
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
+                          },
+                          Object {
+                            "component": "radio",
+                            "condition": Object {
+                              "isNotEmpty": true,
+                              "when": "physical_storage_family_id",
+                            },
+                            "id": "capabilities",
+                            "isRequired": true,
+                            "label": "Capabilities",
+                            "name": "capabilities",
+                            "options": Array [
+                              Object {
+                                "label": "Default",
+                                "value": "Default",
+                              },
+                              Object {
+                                "label": "Custom",
+                                "value": "Custom",
+                              },
+                            ],
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
+                          },
+                          Object {
+                            "component": "select",
+                            "condition": Object {
+                              "is": "Custom",
+                              "when": "capabilities",
+                            },
+                            "id": "enabled_capability_values",
+                            "includeEmpty": false,
+                            "isDisabled": true,
+                            "isMulti": true,
+                            "isRequired": true,
+                            "label": "Enabled capability values:",
+                            "loadOptions": [Function],
+                            "name": "enabled_capability_values",
+                            "simpleValue": true,
                             "validate": Array [
                               Object {
                                 "type": "required",
@@ -1087,6 +1327,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                             "label": "System Type:",
                             "loadOptions": [Function],
                             "name": "physical_storage_family_id",
+                            "onChange": [Function],
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
+                          },
+                          Object {
+                            "component": "radio",
+                            "condition": Object {
+                              "isNotEmpty": true,
+                              "when": "physical_storage_family_id",
+                            },
+                            "id": "capabilities",
+                            "isRequired": true,
+                            "label": "Capabilities",
+                            "name": "capabilities",
+                            "options": Array [
+                              Object {
+                                "label": "Default",
+                                "value": "Default",
+                              },
+                              Object {
+                                "label": "Custom",
+                                "value": "Custom",
+                              },
+                            ],
+                            "validate": Array [
+                              Object {
+                                "type": "required",
+                              },
+                            ],
+                          },
+                          Object {
+                            "component": "select",
+                            "condition": Object {
+                              "is": "Custom",
+                              "when": "capabilities",
+                            },
+                            "id": "enabled_capability_values",
+                            "includeEmpty": false,
+                            "isDisabled": true,
+                            "isMulti": true,
+                            "isRequired": true,
+                            "label": "Enabled capability values:",
+                            "loadOptions": [Function],
+                            "name": "enabled_capability_values",
+                            "simpleValue": true,
                             "validate": Array [
                               Object {
                                 "type": "required",
@@ -1260,6 +1548,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                               "label": "System Type:",
                               "loadOptions": [Function],
                               "name": "physical_storage_family_id",
+                              "onChange": [Function],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
+                                },
+                              ],
+                            },
+                            Object {
+                              "component": "radio",
+                              "condition": Object {
+                                "isNotEmpty": true,
+                                "when": "physical_storage_family_id",
+                              },
+                              "id": "capabilities",
+                              "isRequired": true,
+                              "label": "Capabilities",
+                              "name": "capabilities",
+                              "options": Array [
+                                Object {
+                                  "label": "Default",
+                                  "value": "Default",
+                                },
+                                Object {
+                                  "label": "Custom",
+                                  "value": "Custom",
+                                },
+                              ],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
+                                },
+                              ],
+                            },
+                            Object {
+                              "component": "select",
+                              "condition": Object {
+                                "is": "Custom",
+                                "when": "capabilities",
+                              },
+                              "id": "enabled_capability_values",
+                              "includeEmpty": false,
+                              "isDisabled": true,
+                              "isMulti": true,
+                              "isRequired": true,
+                              "label": "Enabled capability values:",
+                              "loadOptions": [Function],
+                              "name": "enabled_capability_values",
+                              "simpleValue": true,
                               "validate": Array [
                                 Object {
                                   "type": "required",
@@ -1430,6 +1766,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                               "label": "System Type:",
                               "loadOptions": [Function],
                               "name": "physical_storage_family_id",
+                              "onChange": [Function],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
+                                },
+                              ],
+                            },
+                            Object {
+                              "component": "radio",
+                              "condition": Object {
+                                "isNotEmpty": true,
+                                "when": "physical_storage_family_id",
+                              },
+                              "id": "capabilities",
+                              "isRequired": true,
+                              "label": "Capabilities",
+                              "name": "capabilities",
+                              "options": Array [
+                                Object {
+                                  "label": "Default",
+                                  "value": "Default",
+                                },
+                                Object {
+                                  "label": "Custom",
+                                  "value": "Custom",
+                                },
+                              ],
+                              "validate": Array [
+                                Object {
+                                  "type": "required",
+                                },
+                              ],
+                            },
+                            Object {
+                              "component": "select",
+                              "condition": Object {
+                                "is": "Custom",
+                                "when": "capabilities",
+                              },
+                              "id": "enabled_capability_values",
+                              "includeEmpty": false,
+                              "isDisabled": true,
+                              "isMulti": true,
+                              "isRequired": true,
+                              "label": "Enabled capability values:",
+                              "loadOptions": [Function],
+                              "name": "enabled_capability_values",
+                              "simpleValue": true,
                               "validate": Array [
                                 Object {
                                   "type": "required",
@@ -1618,6 +2002,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 "label": "System Type:",
                                 "loadOptions": [Function],
                                 "name": "physical_storage_family_id",
+                                "onChange": [Function],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              },
+                              Object {
+                                "component": "radio",
+                                "condition": Object {
+                                  "isNotEmpty": true,
+                                  "when": "physical_storage_family_id",
+                                },
+                                "id": "capabilities",
+                                "isRequired": true,
+                                "label": "Capabilities",
+                                "name": "capabilities",
+                                "options": Array [
+                                  Object {
+                                    "label": "Default",
+                                    "value": "Default",
+                                  },
+                                  Object {
+                                    "label": "Custom",
+                                    "value": "Custom",
+                                  },
+                                ],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              },
+                              Object {
+                                "component": "select",
+                                "condition": Object {
+                                  "is": "Custom",
+                                  "when": "capabilities",
+                                },
+                                "id": "enabled_capability_values",
+                                "includeEmpty": false,
+                                "isDisabled": true,
+                                "isMulti": true,
+                                "isRequired": true,
+                                "label": "Enabled capability values:",
+                                "loadOptions": [Function],
+                                "name": "enabled_capability_values",
+                                "simpleValue": true,
                                 "validate": Array [
                                   Object {
                                     "type": "required",
@@ -1788,6 +2220,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                 "label": "System Type:",
                                 "loadOptions": [Function],
                                 "name": "physical_storage_family_id",
+                                "onChange": [Function],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              },
+                              Object {
+                                "component": "radio",
+                                "condition": Object {
+                                  "isNotEmpty": true,
+                                  "when": "physical_storage_family_id",
+                                },
+                                "id": "capabilities",
+                                "isRequired": true,
+                                "label": "Capabilities",
+                                "name": "capabilities",
+                                "options": Array [
+                                  Object {
+                                    "label": "Default",
+                                    "value": "Default",
+                                  },
+                                  Object {
+                                    "label": "Custom",
+                                    "value": "Custom",
+                                  },
+                                ],
+                                "validate": Array [
+                                  Object {
+                                    "type": "required",
+                                  },
+                                ],
+                              },
+                              Object {
+                                "component": "select",
+                                "condition": Object {
+                                  "is": "Custom",
+                                  "when": "capabilities",
+                                },
+                                "id": "enabled_capability_values",
+                                "includeEmpty": false,
+                                "isDisabled": true,
+                                "isMulti": true,
+                                "isRequired": true,
+                                "label": "Enabled capability values:",
+                                "loadOptions": [Function],
+                                "name": "enabled_capability_values",
+                                "simpleValue": true,
                                 "validate": Array [
                                   Object {
                                     "type": "required",
@@ -1967,6 +2447,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                   "label": "System Type:",
                                   "loadOptions": [Function],
                                   "name": "physical_storage_family_id",
+                                  "onChange": [Function],
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "component": "radio",
+                                  "condition": Object {
+                                    "isNotEmpty": true,
+                                    "when": "physical_storage_family_id",
+                                  },
+                                  "id": "capabilities",
+                                  "isRequired": true,
+                                  "label": "Capabilities",
+                                  "name": "capabilities",
+                                  "options": Array [
+                                    Object {
+                                      "label": "Default",
+                                      "value": "Default",
+                                    },
+                                    Object {
+                                      "label": "Custom",
+                                      "value": "Custom",
+                                    },
+                                  ],
+                                  "validate": Array [
+                                    Object {
+                                      "type": "required",
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "component": "select",
+                                  "condition": Object {
+                                    "is": "Custom",
+                                    "when": "capabilities",
+                                  },
+                                  "id": "enabled_capability_values",
+                                  "includeEmpty": false,
+                                  "isDisabled": true,
+                                  "isMulti": true,
+                                  "isRequired": true,
+                                  "label": "Enabled capability values:",
+                                  "loadOptions": [Function],
+                                  "name": "enabled_capability_values",
+                                  "simpleValue": true,
                                   "validate": Array [
                                     Object {
                                       "type": "required",
@@ -2125,6 +2653,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                       "label": "System Type:",
                                       "loadOptions": [Function],
                                       "name": "physical_storage_family_id",
+                                      "onChange": [Function],
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    },
+                                    Object {
+                                      "component": "radio",
+                                      "condition": Object {
+                                        "isNotEmpty": true,
+                                        "when": "physical_storage_family_id",
+                                      },
+                                      "id": "capabilities",
+                                      "isRequired": true,
+                                      "label": "Capabilities",
+                                      "name": "capabilities",
+                                      "options": Array [
+                                        Object {
+                                          "label": "Default",
+                                          "value": "Default",
+                                        },
+                                        Object {
+                                          "label": "Custom",
+                                          "value": "Custom",
+                                        },
+                                      ],
+                                      "validate": Array [
+                                        Object {
+                                          "type": "required",
+                                        },
+                                      ],
+                                    },
+                                    Object {
+                                      "component": "select",
+                                      "condition": Object {
+                                        "is": "Custom",
+                                        "when": "capabilities",
+                                      },
+                                      "id": "enabled_capability_values",
+                                      "includeEmpty": false,
+                                      "isDisabled": true,
+                                      "isMulti": true,
+                                      "isRequired": true,
+                                      "label": "Enabled capability values:",
+                                      "loadOptions": [Function],
+                                      "name": "enabled_capability_values",
+                                      "simpleValue": true,
                                       "validate": Array [
                                         Object {
                                           "type": "required",
@@ -2284,6 +2860,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                         "label": "System Type:",
                                         "loadOptions": [Function],
                                         "name": "physical_storage_family_id",
+                                        "onChange": [Function],
+                                        "validate": Array [
+                                          Object {
+                                            "type": "required",
+                                          },
+                                        ],
+                                      },
+                                      Object {
+                                        "component": "radio",
+                                        "condition": Object {
+                                          "isNotEmpty": true,
+                                          "when": "physical_storage_family_id",
+                                        },
+                                        "id": "capabilities",
+                                        "isRequired": true,
+                                        "label": "Capabilities",
+                                        "name": "capabilities",
+                                        "options": Array [
+                                          Object {
+                                            "label": "Default",
+                                            "value": "Default",
+                                          },
+                                          Object {
+                                            "label": "Custom",
+                                            "value": "Custom",
+                                          },
+                                        ],
+                                        "validate": Array [
+                                          Object {
+                                            "type": "required",
+                                          },
+                                        ],
+                                      },
+                                      Object {
+                                        "component": "select",
+                                        "condition": Object {
+                                          "is": "Custom",
+                                          "when": "capabilities",
+                                        },
+                                        "id": "enabled_capability_values",
+                                        "includeEmpty": false,
+                                        "isDisabled": true,
+                                        "isMulti": true,
+                                        "isRequired": true,
+                                        "label": "Enabled capability values:",
+                                        "loadOptions": [Function],
+                                        "name": "enabled_capability_values",
+                                        "simpleValue": true,
                                         "validate": Array [
                                           Object {
                                             "type": "required",
@@ -2447,6 +3071,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                           "label": "System Type:",
                                           "loadOptions": [Function],
                                           "name": "physical_storage_family_id",
+                                          "onChange": [Function],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "radio",
+                                          "condition": Object {
+                                            "isNotEmpty": true,
+                                            "when": "physical_storage_family_id",
+                                          },
+                                          "id": "capabilities",
+                                          "isRequired": true,
+                                          "label": "Capabilities",
+                                          "name": "capabilities",
+                                          "options": Array [
+                                            Object {
+                                              "label": "Default",
+                                              "value": "Default",
+                                            },
+                                            Object {
+                                              "label": "Custom",
+                                              "value": "Custom",
+                                            },
+                                          ],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "select",
+                                          "condition": Object {
+                                            "is": "Custom",
+                                            "when": "capabilities",
+                                          },
+                                          "id": "enabled_capability_values",
+                                          "includeEmpty": false,
+                                          "isDisabled": true,
+                                          "isMulti": true,
+                                          "isRequired": true,
+                                          "label": "Enabled capability values:",
+                                          "loadOptions": [Function],
+                                          "name": "enabled_capability_values",
+                                          "simpleValue": true,
                                           "validate": Array [
                                             Object {
                                               "type": "required",
@@ -2886,6 +3558,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                       label="System Type:"
                                       loadOptions={[Function]}
                                       name="physical_storage_family_id"
+                                      onChange={[Function]}
                                       validate={
                                         Array [
                                           Object {
@@ -2911,6 +3584,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                             "label": "System Type:",
                                             "loadOptions": [Function],
                                             "name": "physical_storage_family_id",
+                                            "onChange": [Function],
                                             "validate": Array [
                                               Object {
                                                 "type": "required",
@@ -2936,6 +3610,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                               "label": "System Type:",
                                               "loadOptions": [Function],
                                               "name": "physical_storage_family_id",
+                                              "onChange": [Function],
                                               "validate": Array [
                                                 Object {
                                                   "type": "required",
@@ -2974,6 +3649,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                                   "label": "System Type:",
                                                   "loadOptions": [Function],
                                                   "name": "physical_storage_family_id",
+                                                  "onChange": [Function],
                                                   "validate": Array [
                                                     Object {
                                                       "type": "required",
@@ -3005,6 +3681,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                                     "label": "System Type:",
                                                     "loadOptions": [Function],
                                                     "name": "physical_storage_family_id",
+                                                    "onChange": [Function],
                                                     "validate": Array [
                                                       Object {
                                                         "type": "required",
@@ -3035,6 +3712,7 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                                       "label": "System Type:",
                                                       "loadOptions": [Function],
                                                       "name": "physical_storage_family_id",
+                                                      "onChange": [Function],
                                                       "validate": Array [
                                                         Object {
                                                           "type": "required",
@@ -3045,6 +3723,435 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                                   values={
                                                     Object {
                                                       "ems_id": "",
+                                                    }
+                                                  }
+                                                />
+                                              </ConditionTriggerWrapper>
+                                            </ConditionTriggerDetector>
+                                          </ForwardRef(Field)>
+                                        </ConditionTriggerDetector>
+                                      </FormConditionWrapper>
+                                    </SingleField>
+                                    <SingleField
+                                      component="radio"
+                                      condition={
+                                        Object {
+                                          "isNotEmpty": true,
+                                          "when": "physical_storage_family_id",
+                                        }
+                                      }
+                                      id="capabilities"
+                                      isRequired={true}
+                                      key="capabilities"
+                                      label="Capabilities"
+                                      name="capabilities"
+                                      options={
+                                        Array [
+                                          Object {
+                                            "label": "Default",
+                                            "value": "Default",
+                                          },
+                                          Object {
+                                            "label": "Custom",
+                                            "value": "Custom",
+                                          },
+                                        ]
+                                      }
+                                      validate={
+                                        Array [
+                                          Object {
+                                            "type": "required",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <FormConditionWrapper
+                                        condition={
+                                          Object {
+                                            "isNotEmpty": true,
+                                            "when": "physical_storage_family_id",
+                                          }
+                                        }
+                                        field={
+                                          Object {
+                                            "component": "radio",
+                                            "id": "capabilities",
+                                            "isDisabled": undefined,
+                                            "isRequired": true,
+                                            "label": "Capabilities",
+                                            "name": "capabilities",
+                                            "options": Array [
+                                              Object {
+                                                "label": "Default",
+                                                "value": "Default",
+                                              },
+                                              Object {
+                                                "label": "Custom",
+                                                "value": "Custom",
+                                              },
+                                            ],
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                      >
+                                        <ConditionTriggerDetector
+                                          condition={
+                                            Object {
+                                              "isNotEmpty": true,
+                                              "when": "physical_storage_family_id",
+                                            }
+                                          }
+                                          field={
+                                            Object {
+                                              "component": "radio",
+                                              "id": "capabilities",
+                                              "isDisabled": undefined,
+                                              "isRequired": true,
+                                              "label": "Capabilities",
+                                              "name": "capabilities",
+                                              "options": Array [
+                                                Object {
+                                                  "label": "Default",
+                                                  "value": "Default",
+                                                },
+                                                Object {
+                                                  "label": "Custom",
+                                                  "value": "Custom",
+                                                },
+                                              ],
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          triggers={
+                                            Array [
+                                              "physical_storage_family_id",
+                                            ]
+                                          }
+                                        >
+                                          <ForwardRef(Field)
+                                            name="physical_storage_family_id"
+                                            subscription={
+                                              Object {
+                                                "value": true,
+                                              }
+                                            }
+                                          >
+                                            <ConditionTriggerDetector
+                                              condition={
+                                                Object {
+                                                  "isNotEmpty": true,
+                                                  "when": "physical_storage_family_id",
+                                                }
+                                              }
+                                              field={
+                                                Object {
+                                                  "component": "radio",
+                                                  "id": "capabilities",
+                                                  "isDisabled": undefined,
+                                                  "isRequired": true,
+                                                  "label": "Capabilities",
+                                                  "name": "capabilities",
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "Default",
+                                                      "value": "Default",
+                                                    },
+                                                    Object {
+                                                      "label": "Custom",
+                                                      "value": "Custom",
+                                                    },
+                                                  ],
+                                                  "validate": Array [
+                                                    Object {
+                                                      "type": "required",
+                                                    },
+                                                  ],
+                                                }
+                                              }
+                                              triggers={Array []}
+                                              values={
+                                                Object {
+                                                  "physical_storage_family_id": "",
+                                                }
+                                              }
+                                            >
+                                              <ConditionTriggerWrapper
+                                                condition={
+                                                  Object {
+                                                    "isNotEmpty": true,
+                                                    "when": "physical_storage_family_id",
+                                                  }
+                                                }
+                                                field={
+                                                  Object {
+                                                    "component": "radio",
+                                                    "id": "capabilities",
+                                                    "isDisabled": undefined,
+                                                    "isRequired": true,
+                                                    "label": "Capabilities",
+                                                    "name": "capabilities",
+                                                    "options": Array [
+                                                      Object {
+                                                        "label": "Default",
+                                                        "value": "Default",
+                                                      },
+                                                      Object {
+                                                        "label": "Custom",
+                                                        "value": "Custom",
+                                                      },
+                                                    ],
+                                                    "validate": Array [
+                                                      Object {
+                                                        "type": "required",
+                                                      },
+                                                    ],
+                                                  }
+                                                }
+                                                values={
+                                                  Object {
+                                                    "physical_storage_family_id": "",
+                                                  }
+                                                }
+                                              >
+                                                <Component
+                                                  condition={
+                                                    Object {
+                                                      "isNotEmpty": true,
+                                                      "when": "physical_storage_family_id",
+                                                    }
+                                                  }
+                                                  field={
+                                                    Object {
+                                                      "component": "radio",
+                                                      "id": "capabilities",
+                                                      "isDisabled": undefined,
+                                                      "isRequired": true,
+                                                      "label": "Capabilities",
+                                                      "name": "capabilities",
+                                                      "options": Array [
+                                                        Object {
+                                                          "label": "Default",
+                                                          "value": "Default",
+                                                        },
+                                                        Object {
+                                                          "label": "Custom",
+                                                          "value": "Custom",
+                                                        },
+                                                      ],
+                                                      "validate": Array [
+                                                        Object {
+                                                          "type": "required",
+                                                        },
+                                                      ],
+                                                    }
+                                                  }
+                                                  values={
+                                                    Object {
+                                                      "physical_storage_family_id": "",
+                                                    }
+                                                  }
+                                                />
+                                              </ConditionTriggerWrapper>
+                                            </ConditionTriggerDetector>
+                                          </ForwardRef(Field)>
+                                        </ConditionTriggerDetector>
+                                      </FormConditionWrapper>
+                                    </SingleField>
+                                    <SingleField
+                                      component="select"
+                                      condition={
+                                        Object {
+                                          "is": "Custom",
+                                          "when": "capabilities",
+                                        }
+                                      }
+                                      id="enabled_capability_values"
+                                      includeEmpty={false}
+                                      isDisabled={true}
+                                      isMulti={true}
+                                      isRequired={true}
+                                      key="enabled_capability_values"
+                                      label="Enabled capability values:"
+                                      loadOptions={[Function]}
+                                      name="enabled_capability_values"
+                                      simpleValue={true}
+                                      validate={
+                                        Array [
+                                          Object {
+                                            "type": "required",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <FormConditionWrapper
+                                        condition={
+                                          Object {
+                                            "is": "Custom",
+                                            "when": "capabilities",
+                                          }
+                                        }
+                                        field={
+                                          Object {
+                                            "component": "select",
+                                            "id": "enabled_capability_values",
+                                            "includeEmpty": false,
+                                            "isDisabled": true,
+                                            "isMulti": true,
+                                            "isRequired": true,
+                                            "label": "Enabled capability values:",
+                                            "loadOptions": [Function],
+                                            "name": "enabled_capability_values",
+                                            "simpleValue": true,
+                                            "validate": Array [
+                                              Object {
+                                                "type": "required",
+                                              },
+                                            ],
+                                          }
+                                        }
+                                      >
+                                        <ConditionTriggerDetector
+                                          condition={
+                                            Object {
+                                              "is": "Custom",
+                                              "when": "capabilities",
+                                            }
+                                          }
+                                          field={
+                                            Object {
+                                              "component": "select",
+                                              "id": "enabled_capability_values",
+                                              "includeEmpty": false,
+                                              "isDisabled": true,
+                                              "isMulti": true,
+                                              "isRequired": true,
+                                              "label": "Enabled capability values:",
+                                              "loadOptions": [Function],
+                                              "name": "enabled_capability_values",
+                                              "simpleValue": true,
+                                              "validate": Array [
+                                                Object {
+                                                  "type": "required",
+                                                },
+                                              ],
+                                            }
+                                          }
+                                          triggers={
+                                            Array [
+                                              "capabilities",
+                                            ]
+                                          }
+                                        >
+                                          <ForwardRef(Field)
+                                            name="capabilities"
+                                            subscription={
+                                              Object {
+                                                "value": true,
+                                              }
+                                            }
+                                          >
+                                            <ConditionTriggerDetector
+                                              condition={
+                                                Object {
+                                                  "is": "Custom",
+                                                  "when": "capabilities",
+                                                }
+                                              }
+                                              field={
+                                                Object {
+                                                  "component": "select",
+                                                  "id": "enabled_capability_values",
+                                                  "includeEmpty": false,
+                                                  "isDisabled": true,
+                                                  "isMulti": true,
+                                                  "isRequired": true,
+                                                  "label": "Enabled capability values:",
+                                                  "loadOptions": [Function],
+                                                  "name": "enabled_capability_values",
+                                                  "simpleValue": true,
+                                                  "validate": Array [
+                                                    Object {
+                                                      "type": "required",
+                                                    },
+                                                  ],
+                                                }
+                                              }
+                                              triggers={Array []}
+                                              values={
+                                                Object {
+                                                  "capabilities": "",
+                                                }
+                                              }
+                                            >
+                                              <ConditionTriggerWrapper
+                                                condition={
+                                                  Object {
+                                                    "is": "Custom",
+                                                    "when": "capabilities",
+                                                  }
+                                                }
+                                                field={
+                                                  Object {
+                                                    "component": "select",
+                                                    "id": "enabled_capability_values",
+                                                    "includeEmpty": false,
+                                                    "isDisabled": true,
+                                                    "isMulti": true,
+                                                    "isRequired": true,
+                                                    "label": "Enabled capability values:",
+                                                    "loadOptions": [Function],
+                                                    "name": "enabled_capability_values",
+                                                    "simpleValue": true,
+                                                    "validate": Array [
+                                                      Object {
+                                                        "type": "required",
+                                                      },
+                                                    ],
+                                                  }
+                                                }
+                                                values={
+                                                  Object {
+                                                    "capabilities": "",
+                                                  }
+                                                }
+                                              >
+                                                <Component
+                                                  condition={
+                                                    Object {
+                                                      "is": "Custom",
+                                                      "when": "capabilities",
+                                                    }
+                                                  }
+                                                  field={
+                                                    Object {
+                                                      "component": "select",
+                                                      "id": "enabled_capability_values",
+                                                      "includeEmpty": false,
+                                                      "isDisabled": true,
+                                                      "isMulti": true,
+                                                      "isRequired": true,
+                                                      "label": "Enabled capability values:",
+                                                      "loadOptions": [Function],
+                                                      "name": "enabled_capability_values",
+                                                      "simpleValue": true,
+                                                      "validate": Array [
+                                                        Object {
+                                                          "type": "required",
+                                                        },
+                                                      ],
+                                                    }
+                                                  }
+                                                  values={
+                                                    Object {
+                                                      "capabilities": "",
                                                     }
                                                   }
                                                 />
@@ -4504,6 +5611,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                           "label": "System Type:",
                                           "loadOptions": [Function],
                                           "name": "physical_storage_family_id",
+                                          "onChange": [Function],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "radio",
+                                          "condition": Object {
+                                            "isNotEmpty": true,
+                                            "when": "physical_storage_family_id",
+                                          },
+                                          "id": "capabilities",
+                                          "isRequired": true,
+                                          "label": "Capabilities",
+                                          "name": "capabilities",
+                                          "options": Array [
+                                            Object {
+                                              "label": "Default",
+                                              "value": "Default",
+                                            },
+                                            Object {
+                                              "label": "Custom",
+                                              "value": "Custom",
+                                            },
+                                          ],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "select",
+                                          "condition": Object {
+                                            "is": "Custom",
+                                            "when": "capabilities",
+                                          },
+                                          "id": "enabled_capability_values",
+                                          "includeEmpty": false,
+                                          "isDisabled": true,
+                                          "isMulti": true,
+                                          "isRequired": true,
+                                          "label": "Enabled capability values:",
+                                          "loadOptions": [Function],
+                                          "name": "enabled_capability_values",
+                                          "simpleValue": true,
                                           "validate": Array [
                                             Object {
                                               "type": "required",
@@ -4739,6 +5894,54 @@ exports[`Physical storage form component should render editing form variant 1`] 
                                           "label": "System Type:",
                                           "loadOptions": [Function],
                                           "name": "physical_storage_family_id",
+                                          "onChange": [Function],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "radio",
+                                          "condition": Object {
+                                            "isNotEmpty": true,
+                                            "when": "physical_storage_family_id",
+                                          },
+                                          "id": "capabilities",
+                                          "isRequired": true,
+                                          "label": "Capabilities",
+                                          "name": "capabilities",
+                                          "options": Array [
+                                            Object {
+                                              "label": "Default",
+                                              "value": "Default",
+                                            },
+                                            Object {
+                                              "label": "Custom",
+                                              "value": "Custom",
+                                            },
+                                          ],
+                                          "validate": Array [
+                                            Object {
+                                              "type": "required",
+                                            },
+                                          ],
+                                        },
+                                        Object {
+                                          "component": "select",
+                                          "condition": Object {
+                                            "is": "Custom",
+                                            "when": "capabilities",
+                                          },
+                                          "id": "enabled_capability_values",
+                                          "includeEmpty": false,
+                                          "isDisabled": true,
+                                          "isMulti": true,
+                                          "isRequired": true,
+                                          "label": "Enabled capability values:",
+                                          "loadOptions": [Function],
+                                          "name": "enabled_capability_values",
+                                          "simpleValue": true,
                                           "validate": Array [
                                             Object {
                                               "type": "required",

--- a/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
+++ b/app/javascript/spec/physical-storage-form/physical-storage-form.spec.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import PhysicalStorageForm from '../../components/physical-storage-form';
 import { mount } from '../helpers/mountForm';
-import miqRedirectBack from "../../helpers/miq-redirect-back";
+import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 require('../helpers/miqSparkle.js');
 require('../helpers/miqAjaxButton.js');
@@ -19,41 +19,83 @@ describe('Physical storage form component', () => {
   };
 
   const physicalStorageMock = {
-    href:"https://9.151.190.197/api/physical_storages/1",
-    id:"1",
-    ems_ref:"d5ed1342-10a6-4604-9de5-f3cbaae5d467",
-    uid_ems:null,
-    name:"svc-178",
-    type:"ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage",
-    access_state:null,
-    health_state:null,
-    overall_health_state:null,
-    ems_id:"2",
-    physical_rack_id:null,
-    drive_bays:null,
-    enclosures:null,
-    canister_slots:null,
-    created_at:"2021-08-19T08:54:41Z",
-    updated_at:"2021-08-19T08:56:22Z",
-    physical_chassis_id:null,
-    total_space:null,
-    physical_storage_family_id:"1",
-    actions:[
-      {"name":"edit","method":"patch","href":"https://9.151.190.197/api/physical_storages/1"},
-      {"name":"edit","method":"put","href":"https://9.151.190.197/api/physical_storages/1"},
-      {"name":"refresh","method":"post","href":"https://9.151.190.197/api/physical_storages/1"},
-      {"name":"delete","method":"post","href":"https://9.151.190.197/api/physical_storages/1"}
-    ]
+    href: 'https://9.151.190.197/api/physical_storages/1',
+    id: '1',
+    ems_ref: 'd5ed1342-10a6-4604-9de5-f3cbaae5d467',
+    uid_ems: null,
+    name: 'svc-178',
+    type: 'ManageIQ::Providers::Autosde::StorageManager::PhysicalStorage',
+    access_state: null,
+    health_state: null,
+    overall_health_state: null,
+    ems_id: '2',
+    physical_rack_id: null,
+    drive_bays: null,
+    enclosures: null,
+    canister_slots: null,
+    created_at: '2021-08-19T08:54:41Z',
+    updated_at: '2021-08-19T08:56:22Z',
+    physical_chassis_id: null,
+    total_space: null,
+    physical_storage_family_id: '1',
+    capabilities: {
+      compression: [
+        'False',
+        'True',
+      ],
+      thin_provision: [
+        'False',
+        'True',
+      ],
+    },
+    actions: [
+      { name: 'edit', method: 'patch', href: 'https://9.151.190.197/api/physical_storages/1' },
+      { name: 'edit', method: 'put', href: 'https://9.151.190.197/api/physical_storages/1' },
+      { name: 'refresh', method: 'post', href: 'https://9.151.190.197/api/physical_storages/1' },
+      { name: 'delete', method: 'post', href: 'https://9.151.190.197/api/physical_storages/1' },
+    ],
   };
 
   const physicalStorageFamilyMock = {
-    href:"https://9.151.190.130/api/providers/2",
-    type:"ManageIQ::Providers::Autosde::StorageManager",
-    id:"2",
-    physical_storage_families:[
-      {"id":"1","name":"svc","version":"1.1","ems_id":"2","ems_ref":"4689c707-3064-4b1c-b001-7688bd9b5655","created_at":"2021-08-29T10:40:21Z","updated_at":"2021-08-29T10:40:21Z"},
-      {"id":"2","name":"xiv","version":"1.1","ems_id":"2","ems_ref":"b91e94ab-8056-4c61-bec6-00430e9c1e4c","created_at":"2021-08-29T10:40:21Z","updated_at":"2021-08-29T10:40:21Z"}
-    ]};
+    href: 'https://9.151.190.130/api/providers/2',
+    type: 'ManageIQ::Providers::Autosde::StorageManager',
+    capabilities: {
+      compression: [
+        'False',
+        'True',
+      ],
+      thin_provision: [
+        'False',
+        'True',
+      ],
+    },
+    id: '2',
+    physical_storage_families: [
+      {
+        id: '1',
+        name: 'svc',
+        version: '1.1',
+        ems_id: '2',
+        ems_ref: '4689c707-3064-4b1c-b001-7688bd9b5655',
+        created_at: '2021-08-29T10:40:21Z',
+        updated_at: '2021-08-29T10:40:21Z',
+        capabilities: {
+          compression: [
+            'False',
+            'True',
+          ],
+          thin_provision: [
+            'False',
+            'True',
+          ],
+        },
+      },
+
+      {
+        id: '2', namec: 'xiv', version: '1.1', ems_id: '2', ems_ref: 'b91e94ab-8056-4c61-bec6-00430e9c1e4c', created_at: '2021-08-29T10:40:21Z', updated_at: '2021-08-29T10:40:21Z',
+      },
+    ],
+  };
 
   beforeEach(() => {
 


### PR DESCRIPTION
This followup pr's after the pr's of the Schema and Api repos. 
This enhancement to the storage manager add the option for creating a new physical storage with enabled capabilities (default or custom)

Related Pr: (need to be merge together)
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/204

<img width="1914" alt="Screenshot 2023-01-29 at 15 08 03" src="https://user-images.githubusercontent.com/74841666/215328510-31b448bc-d5c5-4ac0-8009-3bbb0e17888b.png">
