### PR TITLE
Ofer/765865 disable volume validation when editing

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import { parseCondition } from '@data-driven-forms/react-form-renderer';
-import validateName from '../../helpers/validate-names.js';
+import validateName from '../../helpers/validate-names';
 
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
@@ -19,14 +19,18 @@ const storageManagers = (supports) => API.get(`/api/providers?expand=resources&a
   });
 
 // storage manager functions:
-const equalsUnsorted = (arr1, arr2) => arr1.length === arr2.length && arr2.every(arr2Item => arr1.includes(arr2Item)) && arr1.every(arr1Item => arr2.includes(arr1Item));
+const equalsUnsorted = (arr1, arr2) => arr1.length === arr2.length
+  && arr2.every(arr2Item => arr1.includes(arr2Item))
+  && arr1.every(arr1Item => arr2.includes(arr1Item));
 
 const filterByCapabilities = (filterArray, modelToFilter) => API.get(`/api/${modelToFilter}?expand=resources&attributes=id,name,capabilities`)
   .then(({ resources }) => {
     const valueArray = [];
     resources.forEach((resource) => {
       const capsToFilter = resource["capabilities"].map(({ uuid }) => uuid);
-      if (equalsUnsorted(filterArray, capsToFilter)) { valueArray.push(resource) }
+      if (equalsUnsorted(filterArray, capsToFilter)) {
+        valueArray.push(resource);
+      }
     });
     if (valueArray.length === 0 && modelToFilter !== 'storage_resources') {
       return [{label: `no ${modelToFilter} with selected capabilities`, value: -1}]
@@ -59,7 +63,7 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         isRequired: true,
         validate: [
           { type: validatorTypes.REQUIRED },
-          async (value) => validateName("cloud_volumes", value)
+          async(value) => validateName('cloud_volumes', value, edit),
         ],
       },
       ...(idx === -1 ? fields : [

--- a/app/javascript/helpers/validate-names.js
+++ b/app/javascript/helpers/validate-names.js
@@ -1,5 +1,10 @@
-const validateName = (target, name) => API.get(`/api/${target}?expand=resources&attributes=name`)
-  .then(({ resources }) => resources.map((resource) => resource.name))
-  .then((results) => (results.includes(name) ? sprintf(__('The name "%s" already exists in "%s"'), name, target) : undefined));
+const validateName = (target, name, isEditMode) => {
+  if (!isEditMode) {
+    return API.get(`/api/${target}?expand=resources&attributes=name`)
+      .then(({ resources }) => resources.map((resource) => resource.name))
+      .then((results) => (results.includes(name) ? sprintf(__('The name "%s" already exists in "%s"'), name, target) : undefined));
+  }
+  return undefined;
+};
 
 export default validateName;


### PR DESCRIPTION
Added a conditional validation, so when editing a cloud volume we are not required to edit the volume name.
This is a fix to a recent commit that added the duplication validation.

Before: (I should be able to edit the size only, the save button is disabled)
![Screenshot 2023-02-01 at 10 14 55](https://user-images.githubusercontent.com/62609377/215987652-43482e93-68e9-49dd-bec9-5ccd273cca86.png)

