### PR TITLE
Fix selected items during compare

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -689,7 +689,7 @@ module VmCommon
   # Tree node selected in explorer
   def tree_select
     assert_accordion_and_tree_privileges(x_active_tree)
-
+    params[:miq_grid_checks] = []
     @explorer = true
     @lastaction = "explorer"
     @sb[:action] = nil


### PR DESCRIPTION
Compute / Cloud / Instances / Images

Select 2 items to compare
<img width="1792" alt="Screenshot 2023-02-01 at 2 29 12 PM" src="https://user-images.githubusercontent.com/87487049/215997518-bc73244e-e6ce-4fe4-9d4c-60c054b25032.png">

**Before**
Additional (Previous selection) items appear in the compare page
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/215997409-f489480c-01e0-47ea-8eeb-4f772d4ade57.png">
https://user-images.githubusercontent.com/87487049/216001891-3379108e-d0a5-44f1-a0fd-8a3ac1b4e030.mov

**After**
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/87487049/215998392-1a5bfa7b-7c3d-4b61-ad2d-e23a8c10d0eb.png">
https://user-images.githubusercontent.com/87487049/216002107-d3c55ef9-3360-469c-a8ee-95ea562a1729.mov




