### PR TITLE
[wip] add search bar for manager pages

### DIFF
--- a/app/views/layouts/_searchbar.html.haml
+++ b/app/views/layouts/_searchbar.html.haml
@@ -1,4 +1,5 @@
-- if @lastaction == 'show_list' && !session[:menu_click] && !@in_a_form
+- if (@lastaction == 'show_list' || (@lastaction == 'show' && @layout == "ems_storage")) && |
+  !session[:menu_click] && !@in_a_form |
   = render :partial => 'layouts/quick_search' if display_adv_search?
   #searchbox
     = react('SearchBar', :searchText => @search_text, :action => 'show_list', :advancedSearch => display_adv_search?)


### PR DESCRIPTION
When accessing cloud_volumes through "storage", we can see its search bar:
<img width="1509" alt="Screen Shot 2023-02-01 at 21 44 16" src="https://user-images.githubusercontent.com/50288766/216148472-1a43f5d2-2f19-4f48-b8e3-f52faf3fd7dd.png">

While accessing through a manager we don't:
<img width="1515" alt="Screen Shot 2023-02-01 at 21 45 17" src="https://user-images.githubusercontent.com/50288766/216148483-2375a762-2619-4805-963a-fc7da745fd98.png">

So this PR is intended to fix that.

So far, I've able to add the search box itself.
But the problem is with the action. From what I understand till now, if the action is "show_list", it will effectively work being in cloud_volumes/show_list#
Actually, it works anyway no matter what we write there. It returns an error in the console but then it knows to redirect itself.
<img width="511" alt="Screen Shot 2023-02-01 at 21 56 13" src="https://user-images.githubusercontent.com/50288766/216149790-6d0cb5c7-f268-4305-9a33-eca5d63d5d59.png">
On the other hand, from an url like: ems_storage/2?display=cloud_volumes#/ , of course the action "show_list" won't work. I've tried to give it the action "2?display=cloud_volumes" only for the sake of trying but even that didn't work:
<img width="1495" alt="Screen Shot 2023-02-01 at 17 16 29" src="https://user-images.githubusercontent.com/50288766/216150317-47c6a0e6-a6d3-4b46-9a9d-9fcabdebb904.png">

So I'm still trying to find out how to make this work.
