### PR TITLE
Add session id logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -980,7 +980,7 @@ class ApplicationController < ActionController::Base
     end
 
     pass = %w[button x_button].include?(action_name) ? handle_button_rbac : handle_generic_rbac(check_generic_rbac)
-    log_privileges(pass, "Action: #{action_name}")
+    log_privileges(pass)
   end
 
   def cleanup_action

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1875,11 +1875,12 @@ class ApplicationController < ActionController::Base
     # This is called with or without a current user and possibly a fake request such as in test.
     username    = current_userid rescue nil
     role_name   = current_user.miq_user_role.name rescue nil
-    http_method = request.respond_to?(:request_method) ? request.request_method : nil
-    path        = request.respond_to?(:filtered_path)  ? request.filtered_path  : nil
-    request_id  = request.respond_to?(:request_id)     ? request.request_id     : nil
+    http_method = request.respond_to?(:request_method) ? request.request_method   : nil
+    path        = request.respond_to?(:filtered_path)  ? request.filtered_path    : nil
+    request_id  = request.respond_to?(:request_id)     ? request.request_id       : nil
+    session_id  = request.respond_to?(:session)        ? request.session.try(:id) : nil
 
-    msg = "Username [#{username}], Role [#{role_name}], Request [#{request_id}], Method [#{http_method}], Path [#{path}] #{details}"
+    msg = "Username [#{username}], Role [#{role_name}], Session [#{session_id}], Request [#{request_id}], Method [#{http_method}], Path [#{path}] #{details}"
 
     pass ? $audit_log.success(msg) : $audit_log.failure(msg)
   end


### PR DESCRIPTION
* Drop the redundant action logging
* Add the session identifier to track requests made by the same user session

This now looks like this:

```
{"@timestamp":"2023-02-03T12:45:08.946675","pid":18362,"tid":"13e34","service":"audit","level":"info","message":"<AuditSuccess> Username [admin], Role [EvmRole-super_administrator], Session [6e91919b45f83463a6c541c987eda99f], Request [66bd4bde-cd07-4cfe-b9ed-1fbbfa3bb737], Method [GET], Path [/dashboard/widget_report_data/17] "}
{"@timestamp":"2023-02-03T12:45:08.947114","pid":18362,"tid":"13e34","service":"audit","level":"info","message":"<AuditSuccess> Username [admin], Role [EvmRole-super_administrator], Session [6e91919b45f83463a6c541c987eda99f], Request [66bd4bde-cd07-4cfe-b9ed-1fbbfa3bb737], Method [GET], Path [/dashboard/widget_report_data/17] Features checked: dashboard_view"}
```
