### PR TITLE
Add physical storage column to volumes list

### DIFF
--- a/product/views/CloudVolume.yaml
+++ b/product/views/CloudVolume.yaml
@@ -34,6 +34,9 @@ include:
   ext_management_system:
     columns:
     - name
+  physical_storage:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 # include_for_find:
@@ -47,6 +50,7 @@ col_order:
 - volume_type
 - bootable
 - availability_zone.name
+- physical_storage.name
 - ext_management_system.name
 
 # Column titles, in order
@@ -58,6 +62,7 @@ headers:
 - Type
 - Bootable?
 - Availability Zone
+- Physical Storage
 - Storage Manager
 
 # Condition(s) string for the SQL query


### PR DESCRIPTION
Edited the column order and added another column to specify the physical storage the volume is connected to. 

Before:
![Screenshot 2023-02-05 at 11 15 06](https://user-images.githubusercontent.com/62609377/216810948-6e5e0aea-1f03-4f11-bbd4-043605d1c018.png)

After:
![Screenshot 2023-02-05 at 10 54 27](https://user-images.githubusercontent.com/62609377/216810253-37410184-a3ab-4b6f-9eb0-c72bdd62f0d3.png)

Can we create a file that will override this table for our provider? 
That will be better for us, as some columns are not necessary for our provider