### PR TITLE
validate name in volumes

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -62,7 +62,24 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         label: __('Volume Name'),
         isRequired: true,
         validate: [
-          { type: validatorTypes.REQUIRED },
+          {
+            type: validatorTypes.REQUIRED,
+          },
+          {
+            type: 'pattern',
+            pattern: '^[a-zA-Z0-9\-_. ]*$',
+            message: __('The name can contain letters, numbers, spaces, periods, dashes and underscores'),
+          },
+          {
+            type: 'pattern',
+            pattern: '^[^ ]+( +[^ ]+)*$',
+            message: __('The name must not begin or end with a space'),
+          },
+          {
+            type: 'pattern',
+            pattern: '^[a-zA-Z_]',
+            message: __('The name must begin with a letter or an underscore'),
+          },
           async(value) => validateName('cloud_volumes', value, edit),
         ],
       },


### PR DESCRIPTION
Volume's names are accepting any string.
<img width="210" alt="Screen Shot 2023-02-05 at 14 18 29" src="https://user-images.githubusercontent.com/50288766/216818252-fe81ac41-aca3-4887-a39b-3f2432caa84e.png">

...while the requirements should be that it may contain letters, numbers, spaces, periods, dashes and underscores, it must not begin or end with a space, and it must begin with a letter or an underscore.
<img width="329" alt="Screen Shot 2023-02-05 at 14 18 47" src="https://user-images.githubusercontent.com/50288766/216818256-4dee08d8-397a-4cce-9236-d5079b41faba.png">
