### PR TITLE
Fix dashboard widget overflow menu list visibility

### DIFF
--- a/app/javascript/components/dashboard-widgets/widget-wrapper/index.jsx
+++ b/app/javascript/components/dashboard-widgets/widget-wrapper/index.jsx
@@ -59,6 +59,26 @@ const WidgetWrapper = ({
     }
   });
 
+  /** Function to assign style to the OverflowMenu to display the list on the top of its menu button.
+   * Note: The open={true} property for the OverflowMenu is not working as expected. Therefore,
+   * we are unable to set the direction={"top"|"bottom"}
+  */
+  const overflowMenuDirection = (widgetId, widgetButtons) => {
+    const widgetMenu = document.getElementById(`${widgetId}-menu`);
+    if (widgetMenu) {
+      const rowHeight = 30; // Height of a row item in the OverflowMenu list.
+      const dimensions = widgetMenu.getBoundingClientRect();
+      const overflowMenuHeight = rowHeight * JSON.parse(widgetButtons).length;
+      const visibleMenuHeight = dimensions.bottom + overflowMenuHeight;
+      if (visibleMenuHeight > window.innerHeight) {
+        const overflowMenu = document.getElementsByClassName('bx--overflow-menu-options--open')[0];
+        if (overflowMenu) {
+          overflowMenu.style.top = `${dimensions.top - overflowMenuHeight}px`;
+        }
+      }
+    }
+  };
+
   return (
     <div className="card-pf card-pf-view">
       <div className="card-pf-body">
@@ -67,6 +87,7 @@ const WidgetWrapper = ({
             className="widget-overflow-menu"
             id={`${widgetId}-menu`}
             flipped
+            onOpen={() => overflowMenuDirection(widgetId, widgetButtons)}
           >
             {getOverflowButtons(widgetButtons, widgetId, widgetType, widgetTitle, setState, widgetModel, widgetLastRun, widgetNextRun)}
           </OverflowMenu>


### PR DESCRIPTION
**Before**
When space is available to render the menu, it works as expected
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/87487049/217799959-3d03001e-88d4-45a8-a1cb-88c4154aef68.png">
but, when no space is available at the bottom of the page(for minimised widgets), the menu disappears.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/217799892-0d5eba24-c6c6-417c-a3cc-692c9b569ffa.png">

**After**
When space is available to render the menu, it works as expected - (no change here)
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/87487049/217799668-5681edec-a95b-4655-938b-e148d24ac77a.png">
but, when no space is available at the bottom of the page, the menu renders to the top.
<img width="1776" alt="image" src="https://user-images.githubusercontent.com/87487049/217799594-c8e96e7d-b1d9-4a12-8191-bb10dbf87a7c.png">
