### PR TITLE
Disable Remove service from inventory button when no services are sel…

### DIFF
--- a/app/helpers/application_helper/toolbar/service/vmdb_mixin.rb
+++ b/app/helpers/application_helper/toolbar/service/vmdb_mixin.rb
@@ -32,7 +32,8 @@ module ApplicationHelper::Toolbar::Service::VmdbMixin
                                                                       :api_url        => 'services',
                                                                       :async_delete   => true,
                                                                       :redirect_url   => '/service/show_list',
-                                                                      :component_name => 'RemoveGenericItemModal'}}
+                                                                      :component_name => 'RemoveGenericItemModal'}},
+                                        :onwhen       => "1+"
                                       ),
                                       included_class.separator,
                                       included_class.button(


### PR DESCRIPTION
My Services list page

**Before**
 Even if no records are selected, the 'Remove Service from Inventory' button is enabled
<img width="917" alt="image" src="https://user-images.githubusercontent.com/87487049/218109766-0b258a70-f72b-44d4-95c4-18da58bbd58c.png">

**After**
The  'Remove Service from Inventory'  button will br enabled only when records are selected from the list.
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/87487049/218109950-6494b9b9-42da-4cbe-b26f-db72d22f48bc.png">

Note: The Download buttons are available on other modules for no records condition

