### PR TITLE
Convert assert_rbac from Rbac.search to Rbac.filtered

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1889,14 +1889,10 @@ class ApplicationController < ActionController::Base
   # Params:
   #   klass - class of accessed objects
   #   ids   - array of accessed object ids
+  # TODO: drop this method and just use Rbac in sql queries
   def assert_rbac(klass, ids)
-    filtered, = Rbac.search(
-      :targets        => ids.map(&:to_i),
-      :user           => current_user,
-      :class          => klass,
-      :results_format => :ids
-    )
-    raise _("Unauthorized object or action") unless ids.length == filtered.length
+    num_visible = Rbac.filtered(klass.where(:id => ids), :user => current_user).count
+    raise _("Unauthorized object or action") unless ids.length == num_visible
   end
 
   def last_screen_url


### PR DESCRIPTION
We are not using the attributes portion of Rbac.search() So there is no need to calculate the record counts

Also, passing in the ids will bring back all records and we will also sort them to put them in the order of the ids passed in.

Converting to a sql count cuts the query down to only bringing back the ids (if we fetch these records again later, then we may have incurred an extra query here)

Now, in the end, I would like to drop assert_rbac all together. It is only used in a few places and they are relatively simple to remove, but I didn't want to add the testing effort at this time.
