### PR TITLE
Edited _request.haml to Make Code Clearer

### DIFF
--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -122,10 +122,10 @@
               :title                 => t)
           %span#buttons_off
             = button_tag(t, :class => "btn btn-primary disabled")
-  - if RequestLog.exists?(:resource_id => @miq_request.id)
+  - if @miq_request.request_logs.any?
     %h3
       = _("Request Logs")
-      = react('RequestsTable', {:initialData => RequestLog.where(:resource_id => @miq_request.id)})
+      = react('RequestsTable', {:initialData => @miq_request.request_logs})
     %br
   - if @miq_request.workflow_class
     = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, current_user), :show => true}


### PR DESCRIPTION
Found in Services -> Requests -> Summary Page

Makes a slight modification to the way the request logs are passed to the react data table in order to make the code easier to understand at first glance. Functionally identical to old code.

![image](https://user-images.githubusercontent.com/64800041/218836030-bc4ddba8-9e41-42e7-841b-c97123db2de1.png)
