### PR TITLE
Implement cloud snapshot collector, list page, create & delete methods

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb
@@ -6,11 +6,20 @@ class ApplicationHelper::Toolbar::CloudVolumeSnapshotCenter < ApplicationHelper:
                    t = N_('Configuration'),
                    t,
                    :items => [
-                     button(
+                     api_button(
                        :cloud_volume_snapshot_delete,
-                       'pficon pficon-delete fa-lg',
-                       t = N_('Delete Cloud Volume Snapshot'),
-                       t
+                       nil,
+                       t = N_('Delete the Cloud Volume Snapshot'),
+                       t,
+                       :icon         => "pficon pficon-delete fa-lg",
+                       :klass        => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+                       :options      => {:feature => :delete},
+                       :api          => {
+                         :action => 'delete',
+                         :entity => 'cloud_volume_snapshots'
+                       },
+                       :confirm      => N_("Are you sure you want to delete this cloud volume snapshot?"),
+                       :send_checked => true
                      ),
                    ]
                  ),

--- a/app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb
@@ -1,4 +1,32 @@
 class ApplicationHelper::Toolbar::CloudVolumeSnapshotsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('cloud_volume_snapshot_vmdb', [
+     select(
+       :cloud_volume_snapshot_vmdb_choice,
+       nil,
+       t = N_('Configuration'),
+       t,
+       :items => [
+         api_button(
+           :cloud_volume_snapshot_delete,
+           nil,
+           t = N_('Delete the Cloud Volume Snapshot'),
+           t,
+           :icon         => "pficon pficon-delete fa-lg",
+           :klass        => ApplicationHelper::Button::PolymorphicConditionalButton,
+           :options      => {:feature      => :delete,
+                             :parent_class => "CloudVolumeSnapshot"},
+           :api          => {
+             :action => 'delete',
+             :entity => 'cloud_volume_snapshots'
+           },
+           :confirm      => N_("Are you sure you want to delete this cloud volume snapshot?"),
+           :send_checked => true,
+           :enabled      => false,
+           :onwhen       => '1+'
+         ),
+       ]
+     )
+   ])
   button_group('cloud_volume_snapshot_policy', [
     select(
       :cloud_volume_snapshot_policy_choice,

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -344,7 +344,7 @@ class ApplicationHelper::ToolbarChooser
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
     to_display = %w[availability_zones cloud_networks cloud_object_store_containers cloud_subnets configured_systems
-                    cloud_tenants cloud_volumes ems_clusters flavors floating_ips host_aggregates hosts host_initiators host_initiator_groups
+                    cloud_tenants cloud_volumes cloud_volume_snapshots ems_clusters flavors floating_ips host_aggregates hosts host_initiators host_initiator_groups
                     volume_mappings network_ports network_routers network_services orchestration_stacks resource_pools
                     security_groups security_policies security_policy_rules storages physical_storages storage_services]
     to_display_center = %w[stack_orchestration_template cloud_object_store_objects generic_objects physical_servers guest_devices]

--- a/app/services/ems_storage_dashboard_service.rb
+++ b/app/services/ems_storage_dashboard_service.rb
@@ -28,7 +28,7 @@ class EmsStorageDashboardService < EmsDashboardService
 
   def attributes_data
     attributes = if @ems.supports?(:block_storage)
-                   %i[physical_storages storage_resources cloud_volumes volume_mappings host_initiators host_initiator_groups storage_services]
+                   %i[physical_storages storage_resources cloud_volumes cloud_volume_snapshots volume_mappings host_initiators host_initiator_groups storage_services]
                  else
                    %i[cloud_object_store_containers cloud_object_store_objects]
                  end
@@ -37,6 +37,7 @@ class EmsStorageDashboardService < EmsDashboardService
       :physical_storages             => 'pficon pficon-container-node',
       :storage_resources             => 'pficon pficon-resource-pool',
       :cloud_volumes                 => 'pficon pficon-volume',
+      :cloud_volume_snapshots        => 'fa fa-camera',
       :volume_mappings               => 'pficon pficon-topology',
       :host_initiators               => 'pficon pficon-virtual-machine',
       :host_initiator_groups         => 'ff ff-relationship',
@@ -48,6 +49,7 @@ class EmsStorageDashboardService < EmsDashboardService
     attr_url = {
       :storage_resources             => 'storage_resources',
       :cloud_volumes                 => 'cloud_volumes',
+      :cloud_volume_snapshots        => 'cloud_volume_snapshots',
       :physical_storages             => 'physical_storages',
       :volume_mappings               => 'volume_mappings',
       :host_initiators               => 'host_initiators',
@@ -60,6 +62,7 @@ class EmsStorageDashboardService < EmsDashboardService
     attr_hsh = {
       :storage_resources             => _('Resources (Pools)'),
       :cloud_volumes                 => _('Volumes'),
+      :cloud_volume_snapshots        => _('Volume Snapshots'),
       :physical_storages             => _('Physical Storages'),
       :volume_mappings               => _('Volume Mappings'),
       :host_initiators               => _('Host Initiators'),


### PR DESCRIPTION
We have developed an integration with a new resource type - "cloud volume snapshot" on the Autosde side. Now, we can provide a list of snapshots from the attached physical storage, create a new one based on a particular volume object and delete it - by using the Autosde rest endpoint (The Autosde GEM is already updated with these new features).
Following these new features, I have added to our (MIQ Autosde provider) collector and refresher to pull snapshots from Autosde and show them in the right place - Cloud Volume Snapshots. I also added the counter component to the provider dashboard.

List page:
![image](https://user-images.githubusercontent.com/33315712/218869146-daaa2529-3fdd-45e9-ac3c-2570896271a0.png)

Snapshot summary page:
![image](https://user-images.githubusercontent.com/33315712/218869307-c048bcaf-2d0c-4440-b424-dc4d41eac5da.png)

Dashboard:
![image](https://user-images.githubusercontent.com/33315712/218869365-be4953bf-936c-4728-bc7c-b682b6fb9078.png)

Create snapshot from cloud volume:
1.
![image](https://user-images.githubusercontent.com/33315712/220778117-7cc9327c-6ec9-4429-a310-8ddc7453c976.png)
2.
![image](https://user-images.githubusercontent.com/33315712/220781667-0899679b-7972-42c8-9dcd-87a2ffca9968.png)

Delete button exists as well at the snapshots page

# related PRs:
- https://github.com/ManageIQ/manageiq/pull/22359
- https://github.com/ManageIQ/manageiq-providers-autosde/pull/210
- https://github.com/ManageIQ/manageiq-api/pull/1205