### PR TITLE
Hide Monitor menu

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -14,7 +14,9 @@ module Menu
           automation_menu_section,
 
           control_menu_section,
-          monitor_menu_section,
+
+          # TODO: Remove all monitor related code
+          # monitor_menu_section,
 
           settings_menu_section,
           logout_item,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -985,18 +985,6 @@ Rails.application.routes.draw do
       )
     },
 
-    :alerts_overview      => {
-      :get => %w(
-        show
-      )
-    },
-
-    :alerts_list      => {
-      :get => %w(
-        show
-        class_icons
-      )
-    },
 
     :dashboard                => {
       :get  => %w(


### PR DESCRIPTION
This change is required for the 3.7 release since the OpenStack update no longer supports this.

Through this PR, we are only hiding the monitor menu and removing the URLs from the system. Related code for this feature will be removed in a future PR.

Before
---------

![screenshot-localhost_3000-2023 02 16-14_19_16](https://user-images.githubusercontent.com/16753936/219315128-38a078b6-aa67-432c-9dff-ec17a9ac4659.png)
<img width="1413" alt="Screenshot 2023-02-16 at 2 20 41 PM" src="https://user-images.githubusercontent.com/16753936/219315250-f40180cd-f469-40ce-b36d-66aafadfba1f.png">
<img width="1440" alt="Screenshot 2023-02-16 at 2 21 00 PM" src="https://user-images.githubusercontent.com/16753936/219315286-66df099c-7490-4ade-8b36-898f46861282.png">

After
---------

<img width="1438" alt="Screenshot 2023-02-16 at 1 44 42 PM" src="https://user-images.githubusercontent.com/16753936/219315460-50d474fe-738c-484d-b099-396dcf953e6c.png">
<img width="1445" alt="Screenshot 2023-02-16 at 1 43 28 PM" src="https://user-images.githubusercontent.com/16753936/219315448-04e18846-a911-4125-a9ec-ca4dfba4fcc8.png">
<img width="1447" alt="Screenshot 2023-02-16 at 1 43 45 PM" src="https://user-images.githubusercontent.com/16753936/219315455-8f8b74a0-6110-4d0e-979d-c216f30441e4.png">

