### PR TITLE
[PETROSIAN] Lock the petrosian release branch to test with ruby 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,6 @@ jobs:
         - spec:javascript
         - spec:jest
         - spec:routes
-        include:
-        - ruby-version: '2.7'
-          node-version: 14
-          test-suite: spec
     services:
       postgres:
         image: manageiq/postgresql:13


### PR DESCRIPTION
Lock the petrosian release branch to test with ruby 3.0