### PR TITLE
Refactor build_audit_* methods and reuse password masking from core

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -179,7 +179,7 @@ class HostController < ApplicationController
         valid_host = find_record_with_rbac(Host, params[:id])
         set_record_vars(valid_host, :validate) # Set the record variables, but don't save
         if valid_record? && set_record_vars(@host) && @host.save
-          AuditEvent.success(build_saved_audit_hash_angular(old_host_attributes, @host, false))
+          AuditEvent.success(build_saved_audit(@host, :new => @host.attributes.clone, :current => old_host_attributes))
           flash_and_redirect(_("Host \"%{name}\" was saved") % {:name => @host.name})
           nil
         else

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1174,7 +1174,7 @@ class MiqAeClassController < ApplicationController
       javascript_flash(:spinner_off => true)
     else
       add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => @edit[:typ]), :name => get_record_display_name(ae_ns)})
-      AuditEvent.success(build_saved_audit_hash_angular(old_namespace_attributes, ae_ns, false))
+      AuditEvent.success(build_saved_audit(ae_ns, :new => ae_ns.attributes.clone, :current => old_namespace_attributes))
       @sb[:action] = session[:edit] = nil # clean out the saved info
       @in_a_form = false
       replace_right_cell(:replace_trees => [:ae])
@@ -1193,6 +1193,8 @@ class MiqAeClassController < ApplicationController
 
   def add_update_method_add
     method = params[:id] != "new" ? find_record_with_rbac(MiqAeMethod, params[:id]) : MiqAeMethod.new
+    old_method_attributes = method.attributes.clone
+
     method.name = params["name"]
     method.display_name = params["display_name"]
     method.location = params["location"]
@@ -1211,9 +1213,12 @@ class MiqAeClassController < ApplicationController
       add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
       javascript_flash
     else
-      old_method_attributes = method.attributes.clone
       add_flash(_('Automate Method "%{name}" was saved') % {:name => method.name})
-      AuditEvent.success(build_saved_audit_hash_angular(old_method_attributes, method, params[:button] == "add"))
+      if params[:button] == "add"
+        AuditEvent.success(build_created_audit(method, :new => method.attributes.clone))
+      else
+        AuditEvent.success(build_saved_audit(method, :new => method.attributes.clone, :current => old_method_attributes))
+      end
       replace_right_cell(:replace_trees => [:ae])
       nil
     end

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -814,42 +814,6 @@ class OpsController < ApplicationController
     reload_trees_by_presenter(presenter, trees)
   end
 
-  # Build the audit object when a profile is saved
-  def build_saved_audit(record, add = false)
-    name = record.respond_to?(:name) ? record.name : record.description
-    msg = if add
-            "[%{name}] Record added (" % {:name => name}
-          else
-            "[%{name}] Record updated (" % {:name => name}
-          end
-    event = "#{record.class.to_s.downcase}_record_#{add ? "add" : "update"}"
-    i = 0
-    @edit[:new].each_key do |k|
-      if @edit[:new][k] != @edit[:current][k]
-        if k.to_s.ends_with?("password", "_pwd") # Asterisk out password fields
-          msg = "%{message} %{key}:[*] to [*]" % {:message => msg, :key => k.to_s}
-        else
-          msg += ", " if i.positive?
-          i += 1
-          msg = if k == :members
-                  "%{message} %{key}:[%{old_value}] to [new_value]" %
-                    {:message   => msg,
-                     :key       => k.to_s,
-                     :old_value => @edit[:current][k].keys.join(","),
-                     :new_value => @edit[:new][k].keys.join(",")}
-                else
-                  "%{message} %{key}:[%{old_value}] to [%{new_value}]" % {:message   => msg,
-                                                                          :key       => k.to_s,
-                                                                          :old_value => @edit[:current][k].to_s,
-                                                                          :new_value => @edit[:new][k].to_s}
-                end
-        end
-      end
-    end
-    msg += ")"
-    {:event => event, :target_id => record.id, :target_class => record.class.base_class.name, :userid => session[:userid], :message => msg}
-  end
-
   def identify_tl_or_perf_record
     identify_record(@sb[:record_id], @sb[:record_class].constantize)
   end

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -343,7 +343,7 @@ module OpsController::OpsRbac
         group = MiqGroup.find_by(:description => grp)
         group.sequence = i + 1
         if group.save
-          AuditEvent.success(build_saved_audit(group, params[:button] == "add"))
+          AuditEvent.success(build_saved_audit(group, @edit))
         else
           group.errors.each do |error|
             add_flash("#{error.attribute.to_s.capitalize} #{error.message}", :error)
@@ -677,7 +677,7 @@ module OpsController::OpsRbac
       record.update!(:miq_groups => Rbac.filtered(MiqGroup.where(:id => rbac_user_get_group_ids))) if key == :user # only set miq_groups if everything is valid
       populate_role_features(record) if what == "role"
       self.current_user = record if what == 'user' && @edit[:current][:userid] == current_userid
-      AuditEvent.success(build_saved_audit(record, add_pressed))
+      AuditEvent.success(build_saved_audit(record, @edit))
       subkey = key == :group ? :description : :name
       add_flash(_("%{model} \"%{name}\" was saved") % {:model => what.titleize, :name => @edit[:new][subkey]})
       add_flash(_("Outdated filters were removed from group \"%{name}\"") % {:name => @edit[:new][subkey]}) if what == "group" && @edit[:current][:deleted_belongsto_filters].present?

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -421,7 +421,7 @@ module OpsController::Settings::Common
         else
           MiqServer.my_server.add_settings_for_resource(@update)
         end
-        AuditEvent.success(build_config_audit(@edit[:new], @edit[:current]))
+        AuditEvent.success(build_config_audit(@edit))
         if @sb[:active_tab] == "settings_server"
           add_flash(_("Configuration settings saved for %{product} Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\"") %
                       {:name => server.name, :server_id => server.id, :zone => server.my_zone, :product => Vmdb::Appliance.PRODUCT_NAME})

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -94,7 +94,11 @@ module OpsController::Settings::Schedules
         add_flash(_("Error when adding a new schedule: %{message}") % {:message => bang.message}, :error)
         javascript_flash
       else
-        AuditEvent.success(build_saved_audit_hash_angular(old_schedule_attributes, schedule, params[:button] == "add"))
+        if params[:button] == "add"
+          AuditEvent.success(build_created_audit(schedule, :new => schedule.attributes.clone))
+        else
+          AuditEvent.success(build_saved_audit(schedule, :new => schedule.attributes.clone, :current => old_schedule_attributes))
+        end
         add_flash(_("Schedule \"%{name}\" was saved") % {:name => schedule.name})
         if params[:button] == "add"
           self.x_node = "xx-msc"

--- a/spec/controllers/application_controller/build_audit_spec.rb
+++ b/spec/controllers/application_controller/build_audit_spec.rb
@@ -1,25 +1,24 @@
 describe ApplicationController do
   context "audit events" do
-    it "tests build_config_audit" do
+    it "#build_config_audit (private)" do
       edit = {:current => {:changing_value => "test",  :static_value => "same", :password => "pw1"},
               :new     => {:changing_value => "test2", :static_value => "same", :password => "pw2"}}
-      expect(controller.send(:build_config_audit, edit[:new], edit[:current]))
+      expect(controller.send(:build_config_audit, edit))
         .to eq(:event   => "vmdb_config_update",
                :userid  => nil,
-               :message => "VMDB config updated (changing_value:[test] to [test2], password:[*] to [*])")
+               :message => "VMDB config updated (changing_value:[test] to [test2], password:[********] to [********])")
     end
 
-    it "tests build_config_audit password filtering" do
+    it "#build_config_audit (private) password filtering" do
       edit = {:current => {:user_proxies => [{:ldapport => "389", :bind_pwd => "secret"}]},
               :new     => {:user_proxies => [{:ldapport => "636", :bind_pwd => "super_secret"}]}}
-      expect(controller.send(:build_config_audit, edit[:new], edit[:current]))
+      expect(controller.send(:build_config_audit, edit))
         .to eq(:event   => "vmdb_config_update",
                :userid  => nil,
-               :message => 'VMDB config updated (user_proxies:[[{:ldapport=>"389", :bind_pwd=>"[FILTERED]"}]] ' \
-                           'to [[{:ldapport=>"636", :bind_pwd=>"[FILTERED]"}]])')
+               :message => "VMDB config updated (user_proxies/0/ldapport:[389] to [636], user_proxies/0/bind_pwd:[********] to [********])")
     end
 
-    it "tests build_created_audit" do
+    it "#build_created_audit (private)" do
       category = FactoryBot.create(:classification)
       edit = {:new => {:name => "the-name", :changing_value => "test2", :static_value => "same",
                            :hash_value => {:h1 => "first", :h2 => "second", :hash_password => "pw1"},
@@ -29,11 +28,10 @@ describe ApplicationController do
                :target_id    => category.id,
                :target_class => category.class.name,
                :userid       => nil,
-               :message      => "[the-name] Record created (name:[the-name], changing_value:[test2], " \
-                                "static_value:[same], h1:[first], h2:[second], hash_password:[*], password:[*])")
+               :message      => "[the-name] Record created (name:[the-name], changing_value:[test2], static_value:[same], hash_value/h1:[first], hash_value/h2:[second], hash_value/hash_password:[********], password:[********])")
     end
 
-    it "tests build_saved_audit" do
+    it "#build_saved_audit (private)" do
       category = FactoryBot.create(:classification)
       edit = {:current => {:name => "the-name", :changing_value => "test",  :static_value => "same",
                            :hash_value => {:h1 => "first", :h2 => "second", :hash_password => "pw1"}},
@@ -44,8 +42,7 @@ describe ApplicationController do
                :target_id    => category.id,
                :target_class => category.class.name,
                :userid       => nil,
-               :message      => "[the-name] Record updated (changing_value:[test] to [test2], " \
-                                "h1:[first] to [firsts], h2:[second] to [seconds], hash_password:[*] to [*])")
+               :message      => "[the-name] Record updated (changing_value:[test] to [test2], hash_value/h1:[first] to [firsts], hash_value/h2:[second] to [seconds], hash_value/hash_password:[********] to [********])")
     end
   end
 end

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -201,7 +201,7 @@ describe OpsController do
     expect(response).to have_http_status(204)
 
     audit_event = AuditEvent.where(:target_id => schedule.id).first
-    expect(audit_event.attributes['message']).to include("description changed to new_description")
+    expect(audit_event.attributes['message']).to include("description:[old_schedule_desc] to [new_description]")
   end
 
   describe "#settings_update" do
@@ -213,7 +213,7 @@ describe OpsController do
                                   :name        => "not the default",
                                   :description => "Not the Default Zone")
 
-        current = double("current", :[] => {:server => {:zone => "default"}}).as_null_object
+        current = Settings.to_hash.deep_merge(:server => {:zone => "default"})
         new = Settings.to_hash.deep_merge(:server => {:zone => zone.name})
 
         edit = {:new => new, :current => current}


### PR DESCRIPTION
This commit refactors a lot of duplication and redundancy around the build_audit_* methods as well as multiple implementations of password masking. Instead it reuses password masking from
Vmdb::Settings.mask_passwords!. Additionally it removes all special cases for auditing and moves those into a single set of auditing methods.

@jrafanie Please review.

Depends on https://github.com/ManageIQ/manageiq/pull/22372 which changes Vmdb::Settings.mask_passwords! to do partial matching and includes all matching patterns defined in the old custom implementations here.