### PR TITLE
Select storage resources to attach in storage service create

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -120,10 +120,11 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
             component: 'enhanced-select',
             name: 'storage_resource_id',
             id: 'storage_resource_id',
-            label: __('Storage Resource (if no option appears then no storage resource with selected capabilities was found)'),
+            label: __('Storage Resources (if no option appears then no storage resource with selected capabilities was found)'),
             condition: { when: 'mode', is: 'Advanced' },
             onInputChange: () => null,
             isRequired: true,
+            helperText: __('Select storage resources to attach to the new service. The new Volume(s) will be created on these resources.'),
             validate: [
               { type: validatorTypes.REQUIRED },
               { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: 'Required' },

--- a/app/javascript/components/storage-service-form/index.jsx
+++ b/app/javascript/components/storage-service-form/index.jsx
@@ -5,6 +5,8 @@ import { Loading } from 'carbon-components-react';
 import createSchema from './storage-service-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import EditingContext from '../physical-storage-form/editing-context';
+import mapper from '../../forms/mappers/componentMapper';
+import enhancedSelect from '../../helpers/enhanced-select';
 
 const StorageServiceForm = ({ recordId, storageManagerId }) => {
   const [state, setState] = useState({});
@@ -57,12 +59,18 @@ const StorageServiceForm = ({ recordId, storageManagerId }) => {
 
   if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
 
+  const componentMapper = {
+    ...mapper,
+    'enhanced-select': enhancedSelect,
+  };
+
   return (
     <div>
       { !isLoading && (
         <EditingContext.Provider value={{ storageManagerId, setState }}>
           <MiqFormRenderer
             schema={createSchema(!!recordId, !!storageManagerId, initialValues, state, setState)}
+            componentMapper={componentMapper}
             initialValues={initialValues}
             canReset={!!recordId}
             onSubmit={onSubmit}

--- a/app/javascript/components/storage-service-form/storage-service-form.schema.js
+++ b/app/javascript/components/storage-service-form/storage-service-form.schema.js
@@ -1,6 +1,7 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import validateName from '../../helpers/storage_manager/validate-names';
 import { loadProviderCapabilities } from '../../helpers/storage_manager/load-provider-capabilities';
+import filterResourcesByCapabilities from '../../helpers/storage_manager/filter-resources-by-capabilities';
 
 const loadProviders = () =>
   API.get(
@@ -9,7 +10,11 @@ const loadProviders = () =>
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
 
+const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
+  .then((result) => result.capabilities);
+
 const createSchema = (edit, ems, initialValues, state, setState) => {
+  let providerCapabilities;
   let emsId = state.ems_id;
   if (initialValues && initialValues.ems_id) {
     emsId = initialValues.ems_id;
@@ -64,6 +69,32 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         isMulti: true,
         validate: [{ type: validatorTypes.REQUIRED }],
         condition: { when: 'ems_id', isNotEmpty: true },
+      },
+      {
+        component: 'enhanced-select',
+        name: 'storage_resource_id',
+        id: 'storage_resource_id',
+        label: __('Storage Resources'),
+        condition: { when: 'required_capabilities', isNotEmpty: true },
+        onInputChange: () => null,
+        isRequired: true,
+        helperText: __('Select storage resources to attach to the new service. Volumes for this service will be created on these resources.'),
+        validate: [
+          { type: validatorTypes.REQUIRED },
+          { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: __('Required') },
+        ],
+        isMulti: true,
+        resolveProps: (_props, _field, { getState }) => {
+          const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
+          const emsId = getState().values.ems_id;
+          return {
+            key: JSON.stringify(capabilityValues),
+            loadOptions: async() => {
+              providerCapabilities = await getProviderCapabilities(emsId);
+              return filterResourcesByCapabilities(capabilityValues, providerCapabilities);
+            },
+          };
+        },
       },
     ],
   });


### PR DESCRIPTION
**this is based on changes from PR #8656 and will be rebased on master after that PR is merged**

- [x] #8656 
- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/214

before:
no field for attaching resources
![image](https://user-images.githubusercontent.com/106743023/220915757-3cf2731b-8b9b-4c9a-8846-62dc4c558eb3.png)

after:
after selecting capabilities, a multi-select field of resources appears, offering resources filtered by the selected capabilities.
![image](https://user-images.githubusercontent.com/106743023/220915897-5681da4c-70a1-497f-8afe-664c4b06ad69.png)