### PR TITLE
Fix javascript specs by moving to new Chrome headless mode

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -63,7 +63,7 @@ Jasmine.configure do |config|
   end
 
   config.chrome_cli_options = {
-    'headless' => nil,
+    'headless' => 'new',
     'disable-gpu' => nil,
     'remote-debugging-port' => 9222,
   }


### PR DESCRIPTION
Recent versions of Chrome introduced a new headless mode[^1]. The old headless mode is still the default, but it seems they broke the old mode such that the /json endpoint of the devtools (which should return a JSON payload with info about the instance) returns an empty payload[^2]. This commit switches to the new headless mode, where that data is correct.

Note that in local testing, the new headless mode cannot run simultaneously as other Chrome instances, so you need to close any Chrome instance before running the specs. This will not be necessary in CI.

[^1]: https://developer.chrome.com/articles/new-headless/
[^2]: https://bugs.chromium.org/p/chromium/issues/detail?id=1418675
