### PR TITLE
[WIP] fix textual links in textual summary tables

### DIFF
--- a/app/helpers/storage_service_helper/textual_summary.rb
+++ b/app/helpers/storage_service_helper/textual_summary.rb
@@ -15,7 +15,7 @@ module StorageServiceHelper::TextualSummary
 
   def textual_group_capabilities
     capabilities = @record.capabilities.map do |c|
-      [c["name"], c["value"]]
+      [c.first, c.last]
     end
 
     TextualMultilabel.new(
@@ -43,10 +43,9 @@ module StorageServiceHelper::TextualSummary
       [textual_link(v), number_to_human_size(v.size), v.health_state, textual_link(v.storage_resource)]
     end
 
-    TextualMultilabel.new(
-      _("Volumes"),
-      :labels => [_("Volume"), _("Size"), _("Health State"), _("Storage Resource")],
-      :values => volumes
+    TextualMiqDataTable.new(
+      :headers => [_("Volume"), _("Size"), _("Health State"), _("Storage Resource")],
+      :rows    => volumes
     )
   end
 

--- a/app/helpers/textual_miqdatatable.rb
+++ b/app/helpers/textual_miqdatatable.rb
@@ -1,0 +1,5 @@
+TextualMiqDataTable = Struct.new(:options) do
+  def locals
+    {:headers => options[:headers], :rows => options[:rows], :component => 'DataTable', :wide => options[:wide]}
+  end
+end

--- a/app/javascript/components/textual_summary/data_table.jsx
+++ b/app/javascript/components/textual_summary/data_table.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/no-array-index-key */
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import MiqDataTable from '../miq-data-table';
+
+export default function DataTable(props) {
+  const { rows, headers } = props;
+
+  return (
+    <MiqDataTable
+      headers={headers}
+      rows={rows}
+      mode="data_table"
+      onClick={() => props.onClick}
+    />
+  );
+}
+
+DataTable.propTypes = {
+  headers: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({ value: PropTypes.string.isRequired, sortable: PropTypes.string }),
+  ])),
+  rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
+  onClick: PropTypes.func.isRequired,
+};
+
+DataTable.defaultProps = {
+  rows: [],
+  headers: '',
+};

--- a/app/javascript/components/textual_summary/textual_group.jsx
+++ b/app/javascript/components/textual_summary/textual_group.jsx
@@ -7,6 +7,7 @@ import OperationRanges from './operation_ranges';
 import MultilinkTable from './multilink_table';
 import TableListView from './table_list_view';
 import EmptyGroup from './empty_group';
+import DataTable from './data_table';
 
 const renderComponent = (props) => {
   const { group, onClick } = props;
@@ -45,6 +46,14 @@ const renderComponent = (props) => {
           headers={group.headers}
           values={group.values}
           colOrder={group.colOrder}
+        />
+      );
+    case 'DataTable':
+      return (
+        <DataTable
+          headers={group.headers}
+          rows={group.rows}
+          onClick={onClick}
         />
       );
     case 'EmptyGroup':


### PR DESCRIPTION
textual links don't work inside the currently available textual table components:
 
![image](https://user-images.githubusercontent.com/106743023/220961715-bb64757b-cf2a-4691-8d76-5917f1386626.png)

this is an attempt to add a textual data table component which uses MiqDataTable.
