### PR TITLE
Link component redirects correctly now

### DIFF
--- a/app/javascript/components/miq-structured-list/index.jsx
+++ b/app/javascript/components/miq-structured-list/index.jsx
@@ -112,7 +112,7 @@ const MiqStructuredList = ({
   const renderMultiContents = (row) => {
     const content = renderContent(row);
     return row.link
-      ? <Link to={row.link} onClick={(e) => onClick(row, e)} className="cell_link">{content}</Link>
+      ? <Link href={row.link} className="cell_link">{content}</Link>
       : content;
   };
 

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -194,8 +194,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=1&status=running"
+              href="/host/host_services/18?db=host&host_service_group=1&status=running"
             >
               <div
                 className="content"
@@ -243,8 +242,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=1&status=all"
+              href="/host/host_services/18?db=host&host_service_group=1&status=all"
             >
               <div
                 className="content"
@@ -328,8 +326,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=2&status=running"
+              href="/host/host_services/18?db=host&host_service_group=2&status=running"
             >
               <div
                 className="content"
@@ -377,8 +374,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=2&status=all"
+              href="/host/host_services/18?db=host&host_service_group=2&status=all"
             >
               <div
                 className="content"
@@ -462,8 +458,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=3&status=running"
+              href="/host/host_services/18?db=host&host_service_group=3&status=running"
             >
               <div
                 className="content"
@@ -511,8 +506,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=3&status=all"
+              href="/host/host_services/18?db=host&host_service_group=3&status=all"
             >
               <div
                 className="content"
@@ -596,8 +590,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=4&status=running"
+              href="/host/host_services/18?db=host&host_service_group=4&status=running"
             >
               <div
                 className="content"
@@ -645,8 +638,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=4&status=all"
+              href="/host/host_services/18?db=host&host_service_group=4&status=all"
             >
               <div
                 className="content"
@@ -730,8 +722,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=5&status=running"
+              href="/host/host_services/18?db=host&host_service_group=5&status=running"
             >
               <div
                 className="content"
@@ -779,8 +770,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=5&status=all"
+              href="/host/host_services/18?db=host&host_service_group=5&status=all"
             >
               <div
                 className="content"
@@ -864,8 +854,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=6&status=running"
+              href="/host/host_services/18?db=host&host_service_group=6&status=running"
             >
               <div
                 className="content"
@@ -913,8 +902,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=6&status=all"
+              href="/host/host_services/18?db=host&host_service_group=6&status=all"
             >
               <div
                 className="content"
@@ -1026,8 +1014,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=7&status=all"
+              href="/host/host_services/18?db=host&host_service_group=7&status=all"
             >
               <div
                 className="content"
@@ -1111,8 +1098,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=8&status=running"
+              href="/host/host_services/18?db=host&host_service_group=8&status=running"
             >
               <div
                 className="content"
@@ -1160,8 +1146,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=8&status=all"
+              href="/host/host_services/18?db=host&host_service_group=8&status=all"
             >
               <div
                 className="content"
@@ -1245,8 +1230,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=9&status=running"
+              href="/host/host_services/18?db=host&host_service_group=9&status=running"
             >
               <div
                 className="content"
@@ -1294,8 +1278,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
           >
             <Link
               className="cell_link"
-              onClick={[Function]}
-              to="/host/host_services/18?db=host&host_service_group=9&status=all"
+              href="/host/host_services/18?db=host&host_service_group=9&status=all"
             >
               <div
                 className="content"

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
@@ -704,14 +704,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=1&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=1&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=1&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=1&status=running"
                                         >
                                           <div
                                             className="content"
@@ -782,14 +780,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=1&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=1&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=1&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=1&status=all"
                                         >
                                           <div
                                             className="content"
@@ -924,14 +920,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=2&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=2&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=2&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=2&status=running"
                                         >
                                           <div
                                             className="content"
@@ -1002,14 +996,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=2&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=2&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=2&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=2&status=all"
                                         >
                                           <div
                                             className="content"
@@ -1144,14 +1136,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=3&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=3&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=3&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=3&status=running"
                                         >
                                           <div
                                             className="content"
@@ -1222,14 +1212,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=3&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=3&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=3&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=3&status=all"
                                         >
                                           <div
                                             className="content"
@@ -1364,14 +1352,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=4&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=4&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=4&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=4&status=running"
                                         >
                                           <div
                                             className="content"
@@ -1442,14 +1428,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=4&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=4&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=4&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=4&status=all"
                                         >
                                           <div
                                             className="content"
@@ -1584,14 +1568,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=5&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=5&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=5&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=5&status=running"
                                         >
                                           <div
                                             className="content"
@@ -1662,14 +1644,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=5&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=5&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=5&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=5&status=all"
                                         >
                                           <div
                                             className="content"
@@ -1804,14 +1784,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=6&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=6&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=6&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=6&status=running"
                                         >
                                           <div
                                             className="content"
@@ -1882,14 +1860,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=6&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=6&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=6&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=6&status=all"
                                         >
                                           <div
                                             className="content"
@@ -2074,14 +2050,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=7&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=7&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=7&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=7&status=all"
                                         >
                                           <div
                                             className="content"
@@ -2216,14 +2190,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=8&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=8&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=8&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=8&status=running"
                                         >
                                           <div
                                             className="content"
@@ -2294,14 +2266,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=8&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=8&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=8&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=8&status=all"
                                         >
                                           <div
                                             className="content"
@@ -2436,14 +2406,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=9&status=running"
+                                        href="/host/host_services/18?db=host&host_service_group=9&status=running"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=9&status=running"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=9&status=running"
                                         >
                                           <div
                                             className="content"
@@ -2514,14 +2482,12 @@ exports[`MultilinkTable renders just fine 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="/host/host_services/18?db=host&host_service_group=9&status=all"
+                                        href="/host/host_services/18?db=host&host_service_group=9&status=all"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="/host/host_services/18?db=host&host_service_group=9&status=all"
                                           rel={null}
-                                          to="/host/host_services/18?db=host&host_service_group=9&status=all"
                                         >
                                           <div
                                             className="content"

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
@@ -783,14 +783,12 @@ exports[`Simple Table renders just fine... 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="some_link"
+                                        href="some_link"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="some_link"
                                           rel={null}
-                                          to="some_link"
                                         >
                                           <div
                                             className="content"

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
@@ -292,14 +292,12 @@ exports[`TableListView renders just fine... 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
+                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                           rel={null}
-                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
                                         >
                                           <div
                                             className="content"
@@ -370,14 +368,12 @@ exports[`TableListView renders just fine... 1`] = `
                                     >
                                       <Link
                                         className="cell_link"
-                                        onClick={[Function]}
-                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
+                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                       >
                                         <a
                                           className="bx--link cell_link"
-                                          onClick={[Function]}
+                                          href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                           rel={null}
-                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
                                         >
                                           <div
                                             className="content"

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -1760,14 +1760,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=cloud_networks"
+                                                  href="/ems_network/39?display=cloud_networks"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=cloud_networks"
                                                     rel={null}
-                                                    to="/ems_network/39?display=cloud_networks"
                                                   >
                                                     <div
                                                       className="content"
@@ -1853,14 +1851,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=cloud_subnets"
+                                                  href="/ems_network/39?display=cloud_subnets"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=cloud_subnets"
                                                     rel={null}
-                                                    to="/ems_network/39?display=cloud_subnets"
                                                   >
                                                     <div
                                                       className="content"
@@ -1946,14 +1942,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=network_routers"
+                                                  href="/ems_network/39?display=network_routers"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=network_routers"
                                                     rel={null}
-                                                    to="/ems_network/39?display=network_routers"
                                                   >
                                                     <div
                                                       className="content"
@@ -2039,14 +2033,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=security_groups"
+                                                  href="/ems_network/39?display=security_groups"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=security_groups"
                                                     rel={null}
-                                                    to="/ems_network/39?display=security_groups"
                                                   >
                                                     <div
                                                       className="content"
@@ -2132,14 +2124,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=floating_ips"
+                                                  href="/ems_network/39?display=floating_ips"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=floating_ips"
                                                     rel={null}
-                                                    to="/ems_network/39?display=floating_ips"
                                                   >
                                                     <div
                                                       className="content"
@@ -2225,14 +2215,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=network_ports"
+                                                  href="/ems_network/39?display=network_ports"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=network_ports"
                                                     rel={null}
-                                                    to="/ems_network/39?display=network_ports"
                                                   >
                                                     <div
                                                       className="content"
@@ -2318,14 +2306,12 @@ exports[`TextualSummary renders just fine 1`] = `
                                               >
                                                 <Link
                                                   className="cell_link"
-                                                  onClick={[Function]}
-                                                  to="/ems_network/39?display=load_balancers"
+                                                  href="/ems_network/39?display=load_balancers"
                                                 >
                                                   <a
                                                     className="bx--link cell_link"
-                                                    onClick={[Function]}
+                                                    href="/ems_network/39?display=load_balancers"
                                                     rel={null}
-                                                    to="/ems_network/39?display=load_balancers"
                                                   >
                                                     <div
                                                       className="content"


### PR DESCRIPTION
Found a bug that the `Link` carbon component was not properly redirect users to the linked url when clicked. We has been using an `onClick` event rather than `href` per the [documentation](https://react.carbondesignsystem.com/?path=/story/components-link--default).

@miq-bot add-reviewer @DavidResende0
@miq-bot add-reviewer @akhilkr128
@miq-bot add-reviewer @jeffibm
@miq-bot assign @jeffibm