### PR TITLE
added name validation to name field

### DIFF
--- a/app/javascript/components/cloud-volume-form/clone-cloud-volume-form.jsx
+++ b/app/javascript/components/cloud-volume-form/clone-cloud-volume-form.jsx
@@ -1,15 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-
-import MiqFormRenderer, { useFormApi } from '@@ddf';
-import { FormSpy } from '@data-driven-forms/react-form-renderer';
-import { Button } from 'carbon-components-react';
+import MiqFormRenderer from '@@ddf';
 import createSchema from './clone-cloud-volume.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 
 const CloneCloudVolumeForm = ({ recordId }) => {
-  const [{ isLoading, fields }, setState] = useState({ isLoading: true, fields: [] });
-
+  const [{ isLoading, fields, initialValues }, setState] = useState({ isLoading: true, fields: [] });
   const loadSchema = (appendState = {}) => ({ data: { form_schema: { fields } } }) => {
     setState((state) => ({
       ...state,
@@ -39,7 +35,8 @@ const CloneCloudVolumeForm = ({ recordId }) => {
 
     request.then(() => {
       const message = sprintf(
-        __('Cloning of Cloud Volume has been successfully queued.'));
+        __('Cloning of Cloud Volume has been successfully queued.')
+      );
 
       miqRedirectBack(message, 'success', '/cloud_volume/show_list');
     }).catch(miqSparkleOff);
@@ -48,80 +45,23 @@ const CloneCloudVolumeForm = ({ recordId }) => {
   const onCancel = () => {
     miqSparkleOn();
     const message = sprintf(
-      __('Cloning Cloud Volume was cancelled by the user.'));
+      __('Cloning Cloud Volume was cancelled by the user.')
+    );
 
     miqRedirectBack(message, 'warning', '/cloud_volume/show_list');
   };
 
   return !isLoading && (
-    <div className="tasks-form">
-      <MiqFormRenderer
-        schema={createSchema(fields)}
-        onSubmit={onSubmit}
-        onCancel={onCancel}
-        canReset
-        FormTemplate={(props) => <FormTemplate {...props} fields={fields} />}
-        buttonsLabels={{ submitLabel: __('Clone')}}
-      />
-    </div>
+    <MiqFormRenderer
+      schema={createSchema(fields)}
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+      onCancel={onCancel}
+      canReset
+      buttonsLabels={{ submitLabel: __('Clone') }}
+    />
   );
 };
-
-const verifyIsDisabled = (values) => {
-  let isDisabled = true;
-  if (values.name){
-    isDisabled = false;
-  }
-  return isDisabled;
-};
-
-const FormTemplate = ({
-  fields, formFields,
-}) => {
-  const {
-    handleSubmit, onReset, onCancel, getState,
-  } = useFormApi();
-  const { valid, pristine } = getState();
-  const submitLabel = __('Clone');
-  return (
-    <form onSubmit={handleSubmit}>
-      {formFields}
-      <FormSpy>
-        {({ values }) => (
-          <div className="custom-button-wrapper">
-            <Button
-              disabled={verifyIsDisabled(values)}
-              kind="primary"
-              className="btnRight"
-              type="submit"
-              id="submit"
-              variant="contained"
-            >
-              {submitLabel}
-            </Button>
-
-            <Button
-              disabled={!valid && pristine}
-              kind="secondary"
-              className="btnRight"
-              variant="contained"
-              onClick={onReset}
-              type="button"
-              id="reset"
-            >
-              { __('Reset')}
-            </Button>
-
-            <Button variant="contained" type="button" onClick={onCancel} kind="secondary">
-              { __('Cancel')}
-            </Button>
-          </div>
-        )}
-      </FormSpy>
-    </form>
-  );
-};
-
 
 CloneCloudVolumeForm.propTypes = {
   recordId: PropTypes.string,
@@ -130,15 +70,4 @@ CloneCloudVolumeForm.defaultProps = {
   recordId: undefined,
 };
 
-FormTemplate.propTypes = {
-  fields: PropTypes.arrayOf(PropTypes.any),
-  formFields: PropTypes.arrayOf(PropTypes.any),
-};
-
-FormTemplate.defaultProps = {
-  fields: [],
-  formFields: [],
-};
-
 export default CloneCloudVolumeForm;
-

--- a/app/javascript/components/cloud-volume-form/clone-cloud-volume.schema.js
+++ b/app/javascript/components/cloud-volume-form/clone-cloud-volume.schema.js
@@ -1,7 +1,24 @@
-const createSchema = (dynamicFields) => ({
-  fields: [
-    dynamicFields,
-  ],
-});
+import { validatorTypes } from '../../forms/data-driven-form';
+import validateName from '../../helpers/storage_manager/validate-names';
+
+const createSchema = (fields) => {
+  const idx = fields.findIndex((field) => field.name === 'name');
+
+  return ({
+    fields: [
+      ...(idx === -1 ? fields : [
+        ...fields.slice(0, idx),
+        {
+          ...fields[idx],
+          validate: [
+            { type: validatorTypes.REQUIRED },
+            async(value) => validateName('cloud_volumes', value),
+          ],
+        },
+        ...fields.slice(idx + 1),
+      ]),
+    ],
+  });
+};
 
 export default createSchema;


### PR DESCRIPTION
Added name validation to the clone volume 'name' field, so cloning will be prevented if the volume name already exists. 
This is a validation necessary for our provider, but I assumed it is needed for all providers, please let me know if this is not the case.

AutoSDE provider PR: https://github.com/ManageIQ/manageiq-providers-autosde/pull/215

![Screenshot 2023-02-26 at 17 21 54](https://user-images.githubusercontent.com/62609377/221419847-9286a8f0-0209-4ce4-82c4-96bed4b71a31.png)
