### PR TITLE
Fix for provider dashboard page where items were not being loaded

### DIFF
--- a/app/javascript/components/ems_container_dashboard/helper.js
+++ b/app/javascript/components/ems_container_dashboard/helper.js
@@ -19,20 +19,6 @@ export const getProviderInfo = (data) => {
   return providerStatus;
 };
 
-export const getAlertInfo = (data) => {
-  const alertStatus = {
-    title: __('Alerts'),
-    notifications: [
-      {
-        iconClass: data.alerts.notifications[0].iconClass,
-        href: data.alerts.href,
-        count: data.alerts.notifications[0].count,
-        dataAvailable: data.alerts.dataAvailable,
-      },
-    ],
-  };
-  return alertStatus;
-};
 export const getAggStatusInfo = (data, providerId) => {
   const attributes = ['nodes', 'containers', 'registries', 'projects', 'pods', 'services', 'images', 'routes'];
   const attrHsh = {

--- a/app/javascript/components/ems_container_dashboard/index.js
+++ b/app/javascript/components/ems_container_dashboard/index.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Loading } from 'carbon-components-react';
 import PfAggregateStatusCard from '../pf_aggregate_status_card';
-import { getProviderInfo, getAlertInfo, getAggStatusInfo } from './helper';
+import { getProviderInfo, getAggStatusInfo } from './helper';
 
 const ContainerDashboardCards = ({ providerId }) => {
   const [data, setCardData] = useState({ loading: true });
@@ -23,22 +23,14 @@ const ContainerDashboardCards = ({ providerId }) => {
 
   if (data.loading === false) {
     const providerStatus = getProviderInfo(data);
-    const alertStatus = getAlertInfo(data);
     const AggStatus = getAggStatusInfo(data, providerId);
 
     return !data.loading && (
       <div>
-        <div className="col-xs-12 col-sm-12 col-md-2 ">
+        <div className="col-xs-12 col-sm-12 col-md-4 ">
           <PfAggregateStatusCard
             layout="tall"
             data={providerStatus}
-            showTopBorder
-          />
-        </div>
-        <div className="col-xs-12 col-sm-12 col-md-2 e">
-          <PfAggregateStatusCard
-            layout="tall"
-            data={alertStatus}
             showTopBorder
           />
         </div>


### PR DESCRIPTION
**Before**
Earlier, we removed the alerts module and its routes.
The Provider dashboard page had a route referring to the alerts module.
<img width="1291" alt="image" src="https://user-images.githubusercontent.com/87487049/222069571-d48216d1-ba99-4ba6-8327-4c21da3437dd.png">

**After**
Removing the alerts block and its associated changes seems to fix the error.
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/87487049/222068937-5709c0b8-19b2-46b6-9012-b5c81d9f33e4.png">
