### PR TITLE
Fix for chargeback saved reports with undefined method

### DIFF
--- a/app/helpers/chargeback_report_helper.rb
+++ b/app/helpers/chargeback_report_helper.rb
@@ -1,0 +1,3 @@
+module ChargebackReportHelper
+  include DataTableHelper
+end


### PR DESCRIPTION
**Before**
- Recently, we converted the string tables to carbon tables for reports and dashboards.
- For this, we introduced a helper module which was included in various helper files.
- The file used to render the list here used a method from the new module which was not included in the chargeback reports module, causing the error.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/87487049/222095945-2436539d-245e-4d05-92fe-94865f98b288.png">

**After**

- Including the helper methods seems to fix this issue
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/87487049/222095802-d62ef135-e14b-419f-8e68-b9269ef7f309.png">
