### PR TITLE
Order Container#hourly_metrics for widgets

### DIFF
--- a/app/services/container_service_mixin.rb
+++ b/app/services/container_service_mixin.rb
@@ -206,6 +206,7 @@ module ContainerServiceMixin
   def hourly_metrics
     MetricRollup.with_interval_and_time_range("hourly", (1.day.ago.beginning_of_hour.utc)..(Time.now.utc))
                 .where(:resource => @resource)
+                .order('timestamp')
   end
 
   def daily_metrics
@@ -214,6 +215,7 @@ module ContainerServiceMixin
 
     @daily_metrics ||= Metric::Helper.find_for_interval_name('daily', tp)
                                      .where(:resource => @resource)
-                                     .where('timestamp > ?', 30.days.ago.utc).order('timestamp')
+                                     .where('timestamp > ?', 30.days.ago.utc)
+                                     .order('timestamp')
   end
 end


### PR DESCRIPTION
For metrics, when we have a `where` clause on `timetamp` we also order by `timestamp`. (trend. not 100%. thinking it should be 100%)

Typically the records come back from the database in inserted order (read: ordered by timestamp), so this tends to be in the right order.

A sporadic test found this issue:

spec/services/container_dashboard_service_spec.rb:460

```
  1) ContainerDashboardService network trends show daily hourly network trends from last 24 hours only
     Failure/Error:
       expect(hourly_network_trends).to eq(
         :dataAvailable => true,
         :xData => [previous_date.beginning_of_hour.utc, current_date.beginning_of_hour.utc],
         :yData => [2000, 2500]
       )

       expected: {:dataAvailable=>true, :xData=>[2023-02-28 11:00:00.000000000 +0000, 2023-02-28 12:00:00.000000000 +0000], :yData=>[2000, 2500]}
            got: {:dataAvailable=>true, :xData=>[2023-02-28 12:00:00.000000000 +0000, 2023-02-28 11:00:00.000000000 +0000], :yData=>[2500, 2000]}
```