### PR TITLE
Fix for selected item missing in genealogy compare selector

### DIFF
--- a/app/javascript/components/tree-view/redux.jsx
+++ b/app/javascript/components/tree-view/redux.jsx
@@ -160,7 +160,7 @@ TreeView.propTypes = {
   click_url: PropTypes.string,
   callBack: PropTypes.func.isRequired,
   hierarchical_check: PropTypes.bool,
-  silent_activate: PropTypes.objectOf(PropTypes.any),
+  silent_activate: PropTypes.bool || undefined,
   select_node: PropTypes.string,
 };
 

--- a/app/javascript/oldjs/miq_tree.js
+++ b/app/javascript/oldjs/miq_tree.js
@@ -149,13 +149,9 @@ window.miqTreeToggleExpand = function(treename, expand_mode) {
  * @param  {Object} tree  The tree object itself.
  * @return {Array}        Array of keys.
  */
-window.miqGetSelectedKeys = function(tree) {
-  return Object.values(tree).filter(function(entry) {
-    return (entry.state && entry.state.checked);
-  }).map(function(entry) {
-    return entry.attr.key;
-  });
-}
+window.miqGetSelectedKeys = (tree) => Object.values(tree)
+  .filter((entry) => (entry.state && entry.state.checked))
+  .map((entry) => entry.attr.key);
 
 // Generic OnCheck handler for the checkboxes in tree
 window.miqOnCheckGeneric = function(key, checked) {
@@ -173,14 +169,16 @@ window.miqOnCheckSections = function(key, checked, tree) {
 }
 
 // Compute -> Infrastructure -> VMs -> Select one vm and click on genealogy
-window.miqOnCheckGenealogy = function(key, checked, tree) {
-  var selectedKeys = miqGetSelectedKeys(tree);
+window.miqOnCheckGenealogy = (key, checked, tree) => {
+  Object.values(tree).find((item) => item.attr && item.attr.key === key).state.checked = checked;
+  const selectedKeys = window.miqGetSelectedKeys(tree);
 
   // Activate toolbar items according to the selection
   miqSetToolbarCount(selectedKeys.length);
   // Inform the backend about the checkbox changes
-  miqJqueryRequest(ManageIQ.tree.checkUrl + '?all_checked=' + selectedKeys, {beforeSend: true, complete: true});
-}
+  miqJqueryRequest(`${ManageIQ.tree.checkUrl}?all_checked=${selectedKeys}`,
+    { beforeSend: true, complete: true });
+};
 
 // Services -> Catalogs -> Catalog Items -> Edit item -> Tenants tree
 window.miqOnCheckTenantTree = function(key) {
@@ -193,7 +191,6 @@ window.miqOnCheckTenantTree = function(key) {
 window.miqCheckAll = function(cb, treeName) {
   // Set the checkboxes according to the master checkbox
   ManageIQ.redux.store.dispatch({namespace: treeName, type: '@@tree/checkAll', value: cb.checked});
-
   // Map the selected nodes into an array of keys
   var selectedKeys = [];
   var tree = ManageIQ.redux.store.getState()[treeName];

--- a/app/stylesheet/tree.scss
+++ b/app/stylesheet/tree.scss
@@ -20,7 +20,7 @@
   }
 }
 
-#roles_by_server_treebox, #servers_by_role_treebox {
+#roles_by_server_treebox, #servers_by_role_treebox, #genealogy_treebox {
   
   .react-tree-view {
     ul li{


### PR DESCRIPTION
**Before**

- Select 2 items to compare
- Compare buttons are disabled since the first selected item is not saved for comparison.
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/87487049/222344012-df905287-d1e0-4ea5-872d-71a0b935209e.png">

- Therefore, Select 3 items
- Now, only 2 of the selected items are displayed for comparison.
- Now the compare buttons will be enabled.
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/87487049/222343728-5328da57-4ee1-4ee9-9d07-3a5c60526c91.png">

**After**
- Select (2 or) 3 items.
- Compare buttons will be enabled.
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/87487049/222343210-09b904da-e006-4b6b-93ee-3a2622a3a3fc.png">

- The selected 3 items are displayed for comparison.
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/87487049/222343357-6ddd79e9-0510-4f2d-8e73-980350f77f9b.png">

Note:

- Had made style improvements in the tree.
- Had fixed a react prop type error displayed in the browser console.


