### PR TITLE
host initiator name length validation

### DIFF
--- a/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
+++ b/app/javascript/components/host-initiator-form/host-initiator-form.schema.js
@@ -62,7 +62,16 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         id: 'name',
         label: __('Name:'),
         isRequired: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
+        validate: [
+          {
+            type: validatorTypes.REQUIRED,
+          },
+          {
+            type: 'max-length',
+            threshold: 15,
+            message: __('The name should have up to 15 characters.'),
+          },
+        ],
       },
       {
         component: componentTypes.SELECT,


### PR DESCRIPTION
Up to now, the length of the name of host initiator group was unlimited.

<img width="342" alt="Screen Shot 2023-03-05 at 11 14 55" src="https://user-images.githubusercontent.com/50288766/222952318-c319c112-1ee6-4d2f-9797-fa9ba0a4cfb7.png">

We're now limiting it to 15 characters.

<img width="303" alt="Screen Shot 2023-03-05 at 11 22 25" src="https://user-images.githubusercontent.com/50288766/222952327-00e4eb1c-4570-4e2a-ae73-4d9c7ccaac77.png">
