### PR TITLE
Fix group switching dropdown visibility

### DIFF
--- a/app/javascript/menu/group-switcher.jsx
+++ b/app/javascript/menu/group-switcher.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dropdown from 'carbon-components-react/es/components/Dropdown';
+import { Dropdown } from 'carbon-components-react';
 import { SideNavItems, SideNavItem } from 'carbon-components-react/es/components/UIShell';
 import { Collaborate20 } from '@carbon/icons-react';
 import TooltipIcon from 'carbon-components-react/es/components/TooltipIcon';
@@ -41,13 +41,24 @@ const GroupSwitcher = ({ miqGroups, currentGroup, expanded: isExpanded }) => {
     </SideNavItem>
   );
 
-  const multiGroup = (
+  const multiGroup_old = (
     <Dropdown
       ariaLabel={__('Change current group')}
       id="miq-nav-group-switch-dropdown"
       initialSelectedItem={currentOption}
       items={options}
       label={__('Change current group')}
+      onChange={groupChange}
+    />
+  );
+  
+  const multiGroup = (
+    <Dropdown
+      hideLabel
+      id="miq-nav-group-switch-dropdown"
+      label={__('Change current group')}
+      items={options}
+      selectedItem={currentOption}
       onChange={groupChange}
     />
   );

--- a/app/stylesheet/menu.scss
+++ b/app/stylesheet/menu.scss
@@ -121,6 +121,13 @@
     height: 32px;
     margin-bottom: 8px;
 
+    .bx--list-box--expanded .bx--list-box__menu {
+      position: fixed;
+      width: 224px;
+      margin-left: 16px;
+      margin-top: 1px;
+    }
+
     & .bx--dropdown,
     & > li {
       height: 32px;


### PR DESCRIPTION
Before
<img width="257" alt="image" src="https://user-images.githubusercontent.com/87487049/223089721-627007d3-67cd-4427-b661-d863c1963662.png">

After
<img width="257" alt="image" src="https://user-images.githubusercontent.com/87487049/223089562-4c423019-0ec4-4336-9217-6085b9c8ac60.png">

Suggestion: change this to the OverflowMenu component, we can remove the additional CSS.
