### PR TITLE
[WIP] convert console_supported? to supports?

### DIFF
--- a/app/helpers/application_helper/button/vm_html5_console.rb
+++ b/app/helpers/application_helper/button/vm_html5_console.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::VmHtml5Console < ApplicationHelper::Button::Bas
   needs :@record
 
   def visible?
-    %w[vnc webmks spice].any? { |type| @record.send(:console_supported?, type) }
+    @record.supports?(:html5_console)
   end
 
   def disabled?

--- a/spec/helpers/application_helper/buttons/vm_html5_console_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_html5_console_spec.rb
@@ -6,21 +6,15 @@ describe ApplicationHelper::Button::VmHtml5Console do
   describe '#visible?' do
     subject { button.visible? }
 
-    SUPPORTED_CONSOLE_TYPES = %i[vnc spice webmks].freeze
-
-    SUPPORTED_CONSOLE_TYPES.each do |type|
-      context("#{type} console") do
-        before do
-          SUPPORTED_CONSOLE_TYPES.each do |t|
-            allow(record).to receive(:console_supported?).with(t.to_s).and_return(t == type)
-          end
-        end
-
-        it { is_expected.to be_truthy }
-      end
+    context("html5_console supported") do
+      before { stub_supports(record, :html5_console) }
+      it { is_expected.to be_truthy }
     end
 
-    it { is_expected.to be_falsey }
+    context("html5_console supported") do
+      before { stub_supports_not(record, :html5_console) }
+      it { is_expected.to be_falsey }
+    end
   end
 
   describe '#disabled?' do


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/21990

I could have sworn that there was a `@record.supports?(@feature)` in a button, but couldn't find something immediately obvious