### PR TITLE
Upgrade Node v14 to v18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         ruby-version:
         - '3.0'
         node-version:
-        - 14
+        - 18
         test-suite:
         - spec
         - spec:compile
@@ -24,7 +24,7 @@ jobs:
         - spec:routes
         include:
         - ruby-version: '2.7'
-          node-version: 14
+          node-version: 18
           test-suite: spec
     services:
       postgres:

--- a/package.json
+++ b/package.json
@@ -170,8 +170,8 @@
     "webpack-stats-plugin": "^0.3.2"
   },
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0"
+    "node": ">= 18.0.0",
+    "npm": ">= 8.6.0"
   },
   "packageManager": "yarn@3.0.2",
   "resolutions": {


### PR DESCRIPTION
Upgrading node version from **14.0.0 to 18.0.0**
Upgrading npm version from **6.0.0 to 8.6.0**

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8690