### PR TITLE
[WIP] Service > Generic Objects List fix

### DIFF
--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -1,5 +1,8 @@
-- if @display == 'instances'
-  = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
+- if %w(generic_objects custom_button_events instances).include?(@display)
+  - if @lastaction == 'generic_object' && @item
+    = render :partial => 'layouts/textual_groups_generic'
+  - else
+    = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @ownershipitems
   = render :partial => "shared/views/ownership"
 - elsif @showtype == 'main'

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -92,8 +92,11 @@ describe ServiceController do
       controller.instance_variable_set(:@breadcrumbs, [])
 
       get :show, :params => {:id => service_with_go.id, :display => 'generic_objects'}
+
       expect(response.status).to eq(200)
       expect(assigns(:breadcrumbs)).to eq([{:name => "Services with a GO (All Generic Objects)", :url => "/service/show/#{service_with_go.id}?display=generic_objects"}])
+      expect(response.body).to have_content("Services with a GO")
+      expect(response.body).to have_content(service_with_go.generic_objects.first.name)
     end
 
     describe "#button" do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -17,7 +17,7 @@ describe ServiceController do
       :name                      => 'go_assoc',
       :services                  => [service]
     )
-    service.add_resource(go)
+    service.add_resource!(go)
 
     service
   end


### PR DESCRIPTION
Approach to debug and fix #8675. This is intended to help with the debugging.

First step improve the spec to reflect the issue. This lead to the issue of wrong test data.
As you can see in the commits I had to use `add_resource!` since `service_with_go.generics_objects` was empty and the spec went green with the wrong assumption. 

This should prob also backported since as far as I can tell the issue appears since the ui rework.