### PR TITLE
[WIP] capability selection buttons in volume create

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -3,6 +3,7 @@ import { parseCondition } from '@data-driven-forms/react-form-renderer';
 import validateName from '../../helpers/storage_manager/validate-names';
 import filterResourcesByCapabilities from '../../helpers/storage_manager/filter-resources-by-capabilities';
 import filterServicesByCapabilities from '../../helpers/storage_manager/filter-service-by-capabilities';
+import { getProviderCapabilities } from '../../helpers/storage_manager/filter-by-capabilities-utils';
 
 const changeValue = (value, loadSchema, emptySchema) => {
   if (value === '-1') {
@@ -22,9 +23,6 @@ const storageManagers = (supports) =>
     });
 
 // storage manager functions:
-
-const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
-  .then((result) => result.capabilities);
 
 const validateServiceHasResources = (serviceId) =>
   API.get(`/api/storage_services/${serviceId}?attributes=name,storage_resources`)
@@ -92,7 +90,7 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         component: componentTypes.SUB_FORM,
         name: 'resource_type_selection',
         id: 'resource_type_selection',
-        condition: { when: 'required_capabilities', isNotEmpty: true },
+        condition: { when: 'compression', isNotEmpty: true },
         fields: [
           {
             component: 'enhanced-select',
@@ -108,7 +106,7 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
               async(value) => validateServiceHasResources(value),
             ],
             resolveProps: (_props, _field, { getState }) => {
-              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
+              const capabilityValues = [getState().values.compression, getState().values.thin_provision];
               const emsId = getState().values.ems_id;
               return {
                 key: JSON.stringify(capabilityValues),
@@ -133,7 +131,7 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
             ],
             isMulti: true,
             resolveProps: (_props, _field, { getState }) => {
-              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
+              const capabilityValues = [getState().values.compression, getState().values.thin_provision];
               const emsId = getState().values.ems_id;
               return {
                 key: JSON.stringify(capabilityValues),

--- a/app/javascript/components/storage-service-form/storage-service-form.schema.js
+++ b/app/javascript/components/storage-service-form/storage-service-form.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 import validateName from '../../helpers/storage_manager/validate-names';
-import loadProviderCapabilities from '../../helpers/storage_manager/load-provider-capabilities';
+import { loadProviderCapabilities } from '../../helpers/storage_manager/load-provider-capabilities';
 
 const loadProviders = () =>
   API.get(

--- a/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
+++ b/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
@@ -1,10 +1,12 @@
 /** function that use to filter the services/resources by capabilities. */
-const arrayIncludes = (including, included) => including.length >= included.length
-  && included.every((includedItem) => including.includes(includedItem));
+const arrayIncludes = (including, included) => included.every((includedItem) => including.includes(includedItem));
 
 const getCapabilityUuid = (providerCapabilities, capabilityName, capabilityValue) => {
   const capVals = providerCapabilities[capabilityName];
   return capVals.find((capVal) => capVal.value === capabilityValue).uuid;
 };
 
-export { arrayIncludes, getCapabilityUuid };
+const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
+  .then((result) => result.capabilities);
+
+export { arrayIncludes, getCapabilityUuid, getProviderCapabilities };

--- a/app/javascript/helpers/storage_manager/filter-resources-by-capabilities.js
+++ b/app/javascript/helpers/storage_manager/filter-resources-by-capabilities.js
@@ -11,6 +11,8 @@ const filterResourcesByCapabilities = async(filterArray, providerCapabilities) =
             resourceCapsUuids.push(getCapabilityUuid(providerCapabilities, capabilityName, capabilityValue));
           });
         });
+        resourceCapsUuids.push('-1'); // to filter-in the N/A option of capabilities
+
         if (arrayIncludes(resourceCapsUuids, filterArray)) {
           valueArray.push(resource);
         }

--- a/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
+++ b/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
@@ -9,7 +9,9 @@ const filterServicesByCapabilities = async(filterArray, providerCapabilities) =>
         Object.keys(resource.capabilities).forEach((key) => {
           capsToFilter.push(getCapabilityUuid(providerCapabilities, key, resource.capabilities[key]));
         });
-        if (arrayIncludes(filterArray, capsToFilter)) {
+        capsToFilter.push('-1'); // to filter-in the N/A option of capabilities
+
+        if (arrayIncludes(capsToFilter, filterArray)) {
           valueArray.push(resource);
         }
       });

--- a/app/javascript/helpers/storage_manager/load-provider-capabilities.js
+++ b/app/javascript/helpers/storage_manager/load-provider-capabilities.js
@@ -2,7 +2,7 @@
 // but in the storage_manager models the capability name is saved under different keys, instead of 'abstract_capability'.
 // the parameter fieldName enables to dynamically access the correct key.
 
-const loadProviderCapabilities = (providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
+export const loadProviderCapabilities = (providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
   .then(({ capabilities }) => {
     const options = [];
     Object.keys(capabilities).forEach((key) => {
@@ -11,5 +11,3 @@ const loadProviderCapabilities = (providerId) => API.get(`/api/providers/${provi
     });
     return options;
   });
-
-export default loadProviderCapabilities;


### PR DESCRIPTION
each capability for filtering services and resources in volume create basic/advanced now has its own radio buttons for n/a, true or false.

the capability fields are generated from the provider's cloud_volume model:
- [ ] [add here](https://github.com/ManageIQ/manageiq-providers-autosde/pull/217)

**before:**
![image](https://user-images.githubusercontent.com/106743023/224531779-5ecc6092-001e-4121-a756-4f72c317709f.png)

**after:**
![image](https://user-images.githubusercontent.com/106743023/224531820-cbc23033-5267-4963-854b-47b8c9af75a6.png)
