### PR TITLE
split service create capabilities to separate single select fields 

### DIFF
--- a/app/javascript/components/storage-service-form/storage-service-form.schema.js
+++ b/app/javascript/components/storage-service-form/storage-service-form.schema.js
@@ -1,52 +1,71 @@
 import { componentTypes, validatorTypes } from '@@ddf';
+import { parseCondition } from '@data-driven-forms/react-form-renderer';
 import validateName from '../../helpers/storage_manager/validate-names';
-import { loadProviderCapabilities } from '../../helpers/storage_manager/load-provider-capabilities';
 import filterResourcesByCapabilities from '../../helpers/storage_manager/filter-resources-by-capabilities';
 
-const loadProviders = () =>
-  API.get(
-    '/api/providers?expand=resources&attributes=id,name,supports_block_storage'
-    + '&filter[]=supports_block_storage=true&filter[]=supports_add_storage=true',
-  ).then(({ resources }) =>
-    resources.map(({ id, name }) => ({ value: id, label: name })));
+const changeValue = (value, loadSchema, emptySchema) => {
+  if (value === '-1') {
+    emptySchema();
+  } else {
+    miqSparkleOn();
+    API.options(`/api/storage_services?ems_id=${value}`).then(loadSchema()).then(miqSparkleOff);
+  }
+};
+
+const storageManagers = (supports) =>
+  API.get(`/api/providers?expand=resources&attributes=id,name,${supports}&filter[]=${supports}=true`)
+    .then(({ resources }) => {
+      const storageManagersOptions = resources.map(({ id, name }) => ({ label: name, value: id }));
+      storageManagersOptions.unshift({ label: `<${__('Choose')}>`, value: '-1' });
+      return storageManagersOptions;
+    });
 
 const getProviderCapabilities = async(providerId) => API.get(`/api/providers/${providerId}?attributes=capabilities`)
   .then((result) => result.capabilities);
 
-const createSchema = (edit, ems, initialValues, state, setState) => {
+const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
+  const idx = fields.findIndex((field) => field.name === 'required_capabilities');
+  const supports = edit ? 'supports_storage_service' : 'supports_storage_service_create';
   let providerCapabilities;
-  let emsId = state.ems_id;
-  if (initialValues && initialValues.ems_id) {
-    emsId = initialValues.ems_id;
-  }
 
   return ({
     fields: [
       {
         component: componentTypes.SELECT,
         name: 'ems_id',
-        key: `${emsId}`,
         id: 'ems_id',
         label: __('Storage Manager'),
-        placeholder: __('<Choose>'),
-        onChange: (value) => {
-          emsId = value;
-          return setState({ ...state, ems_id: value });
-        },
-        loadOptions: loadProviders,
+        onChange: (value) => changeValue(value, loadSchema, emptySchema),
+        loadOptions: () => storageManagers(supports),
         isDisabled: edit || ems,
         isRequired: true,
-        includeEmpty: true,
         validate: [{ type: validatorTypes.REQUIRED }],
       },
       {
         component: componentTypes.TEXT_FIELD,
         name: 'name',
         id: 'name',
-        label: __('Name:'),
+        label: __('Service Name'),
         isRequired: true,
         validate: [
-          { type: validatorTypes.REQUIRED },
+          {
+            type: validatorTypes.REQUIRED,
+          },
+          {
+            type: 'pattern',
+            pattern: '^[a-zA-Z0-9-_. ]*$',
+            message: __('The name can contain letters, numbers, spaces, periods, dashes and underscores'),
+          },
+          {
+            type: 'pattern',
+            pattern: '^[^ ]+( +[^ ]+)*$',
+            message: __('The name must not begin or end with a space'),
+          },
+          {
+            type: 'pattern',
+            pattern: '^[a-zA-Z_]',
+            message: __('The name must begin with a letter or an underscore'),
+          },
           async(value) => validateName('storage_services', value, edit),
         ],
       },
@@ -57,25 +76,22 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         label: __('Description:'),
         isRequired: false,
       },
-      {
-        component: componentTypes.SELECT,
-        name: 'required_capabilities',
-        id: 'required_capabilities',
-        label: __('Required Capabilities'),
-        placeholder: __('<Choose>'),
-        loadOptions: () => (emsId ? loadProviderCapabilities(emsId) : Promise.resolve([])),
-        isDisabled: edit,
-        isRequired: true,
-        isMulti: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
-        condition: { when: 'ems_id', isNotEmpty: true },
-      },
+      ...(idx === -1 ? fields : [
+        ...fields.slice(0, idx),
+        {
+          ...fields[idx],
+          resolveProps: ({ options }, _input, { getState }) => ({
+            options: options.filter(({ condition }) => !condition || parseCondition(condition, getState().values).result),
+          }),
+        },
+        ...fields.slice(idx + 1),
+      ]),
       {
         component: 'enhanced-select',
         name: 'storage_resource_id',
         id: 'storage_resource_id',
         label: __('Storage Resources'),
-        condition: { when: 'required_capabilities', isNotEmpty: true },
+        condition: { when: 'compression', isNotEmpty: true },
         onInputChange: () => null,
         isRequired: true,
         helperText: __('Select storage resources to attach to the new service. Volumes for this service will be created on these resources.'),
@@ -85,8 +101,14 @@ const createSchema = (edit, ems, initialValues, state, setState) => {
         ],
         isMulti: true,
         resolveProps: (_props, _field, { getState }) => {
-          const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
-          const emsId = getState().values.ems_id;
+          const stateValues = getState().values;
+          const emsId = stateValues.ems_id;
+          const capabilityValues = [];
+
+          const capabilityNames = fields.find((object) => object.id === 'required_capabilities')
+            .fields.map((capability) => capability.id);
+          capabilityNames.forEach((capabilityName) => capabilityValues.push(stateValues[capabilityName]));
+
           return {
             key: JSON.stringify(capabilityValues),
             loadOptions: async() => {


### PR DESCRIPTION
part of issue:
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/issues/8701
co-dependent on the provider-pr there (already merged)

before this change, capabilities were fetched from within the schema, and presented to the user as a multi-select field with all possible capability values, including conflicting ones (e.g. both "True" and "False" for "Compression").
after this change, the capabilities are generated from the autosde provider `storage_service` model one-by-one as single-select field. this makes more sense both in terms of ui and of architecture.
  
**before:**
<img width="481" alt="image" src="https://user-images.githubusercontent.com/106743023/224631206-29ce2528-9cfb-4ffb-a2a6-54be567b3174.png">

**after:**
<img width="605" alt="image" src="https://user-images.githubusercontent.com/106743023/226161201-d8c5d9da-1e7e-48e8-a8cb-bdf15e550cfc.png">

here also showing the Storage Resources multi-selection field:
![Screenshot 2023-04-17 at 13 24 38](https://user-images.githubusercontent.com/106743023/232464968-9d46024f-405b-45ca-a170-1b97f0ca479c.png)

-=-=-
but I get a react bug regarding a `resolveProps`
which I don't get in the volume form:
![image](https://user-images.githubusercontent.com/106743023/225454312-aa96fa06-1873-4e2f-b9d3-3373b4883c7a.png)

**edit:**
I seem to have found a solution - deleting the `resolveProps` property off of the schema field before passing the schema to the `MiqFormRenderer` component.
I still don't understand how come this `resolveProps` doesn't appear in schema field in volume from.. the code seems identical.