### PR TITLE
split volume create capabilities to separate single select fields

### DIFF
--- a/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
+++ b/app/javascript/components/cloud-volume-form/cloud-volume-form.schema.js
@@ -89,7 +89,7 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         component: componentTypes.SUB_FORM,
         name: 'resource_type_selection',
         id: 'resource_type_selection',
-        condition: { when: 'required_capabilities', isNotEmpty: true },
+        condition: { when: 'compression', isNotEmpty: true },
         fields: [
           {
             component: 'enhanced-select',
@@ -101,12 +101,18 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
             isRequired: true,
             validate: [
               { type: validatorTypes.REQUIRED },
-              { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: 'Required' },
+              { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: 'No storage service supports all selected capabilities' },
               async(value) => validateServiceHasResources(value),
             ],
             resolveProps: (_props, _field, { getState }) => {
-              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
-              const emsId = getState().values.ems_id;
+              const stateValues = getState().values;
+              const emsId = stateValues.ems_id;
+              const capabilityValues = [];
+
+              const capabilityNames = fields.find((object) => object.id === 'required_capabilities')
+                .fields.map((capability) => capability.id);
+              capabilityNames.forEach((capabilityName) => capabilityValues.push(stateValues[capabilityName]));
+
               return {
                 key: JSON.stringify(capabilityValues),
                 loadOptions: async() => {
@@ -120,19 +126,25 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
             component: 'enhanced-select',
             name: 'storage_resource_id',
             id: 'storage_resource_id',
-            label: __('Storage Resources (if no option appears then no storage resource with selected capabilities was found)'),
+            label: __('Storage Resource(s)'),
             condition: { when: 'mode', is: 'Advanced' },
             onInputChange: () => null,
             isRequired: true,
-            helperText: __('Select storage resources to attach to the new service. The new Volume(s) will be created on these resources.'),
+            helperText: __('Select storage resources to attach to the service. The new Volume(s) will be created on these resources.'),
             validate: [
               { type: validatorTypes.REQUIRED },
               { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: 'Required' },
             ],
             isMulti: true,
             resolveProps: (_props, _field, { getState }) => {
-              const capabilityValues = getState().values.required_capabilities.map(({ value }) => value);
-              const emsId = getState().values.ems_id;
+              const stateValues = getState().values;
+              const emsId = stateValues.ems_id;
+              const capabilityValues = [];
+
+              const capabilityNames = fields.find((object) => object.id === 'required_capabilities')
+                .fields.map((capability) => capability.id);
+              capabilityNames.forEach((capabilityName) => capabilityValues.push(stateValues[capabilityName]));
+
               return {
                 key: JSON.stringify(capabilityValues),
                 loadOptions: async() => {

--- a/app/javascript/components/cloud-volume-form/index.jsx
+++ b/app/javascript/components/cloud-volume-form/index.jsx
@@ -40,6 +40,8 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
     }
   }, [recordId, storageManagerId]);
 
+  const redirectUrl = storageManagerId ? `/ems_storage/${storageManagerId}?display=cloud_volumes#/` : '/cloud_volume/show_list';
+
   const onSubmit = ({ edit: _edit, ...values }) => {
     if (values.ems_id !== '-1') {
       miqSparkleOn();
@@ -52,7 +54,7 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
             : __('Add of Cloud Volume "%s" has been successfully queued.'),
           values.name,
         );
-        miqRedirectBack(message, undefined, '/cloud_volume/show_list');
+        miqRedirectBack(message, undefined, redirectUrl);
       }).catch(miqSparkleOff);
     }
   };
@@ -64,7 +66,7 @@ const CloudVolumeForm = ({ recordId, storageManagerId }) => {
         : __('Add of new Cloud Volume was cancelled by the user.'),
       initialValues && initialValues.name,
     );
-    miqRedirectBack(message, 'warning', '/cloud_volume/show_list');
+    miqRedirectBack(message, 'warning', redirectUrl);
   };
 
   const validation = (values) => {

--- a/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
+++ b/app/javascript/helpers/storage_manager/filter-by-capabilities-utils.js
@@ -1,6 +1,5 @@
 /** function that use to filter the services/resources by capabilities. */
-const arrayIncludes = (including, included) => including.length >= included.length
-  && included.every((includedItem) => including.includes(includedItem));
+const arrayIncludes = (including, included) => included.every((includedItem) => including.includes(includedItem));
 
 const getCapabilityUuid = (providerCapabilities, capabilityName, capabilityValue) => {
   const capVals = providerCapabilities[capabilityName];

--- a/app/javascript/helpers/storage_manager/filter-resources-by-capabilities.js
+++ b/app/javascript/helpers/storage_manager/filter-resources-by-capabilities.js
@@ -11,6 +11,8 @@ const filterResourcesByCapabilities = async(filterArray, providerCapabilities) =
             resourceCapsUuids.push(getCapabilityUuid(providerCapabilities, capabilityName, capabilityValue));
           });
         });
+        resourceCapsUuids.push('-1'); // to filter-in the N/A option of capabilities
+
         if (arrayIncludes(resourceCapsUuids, filterArray)) {
           valueArray.push(resource);
         }

--- a/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
+++ b/app/javascript/helpers/storage_manager/filter-service-by-capabilities.js
@@ -9,6 +9,8 @@ const filterServicesByCapabilities = async(filterArray, providerCapabilities) =>
         Object.keys(resource.capabilities).forEach((key) => {
           capsToFilter.push(getCapabilityUuid(providerCapabilities, key, resource.capabilities[key]));
         });
+        capsToFilter.push('-1'); // to filter-in the N/A option of capabilities
+
         if (arrayIncludes(capsToFilter, filterArray)) {
           valueArray.push(resource);
         }
@@ -17,7 +19,7 @@ const filterServicesByCapabilities = async(filterArray, providerCapabilities) =>
       const options = valueArray.map(({ name, id }) => ({ label: name, value: id }));
 
       if (options.length === 0) {
-        options.unshift({ label: sprintf(__('No storage service with selected capabilities.')), value: '-1' });
+        options.unshift({ label: sprintf(__('Not found')), value: '-1' });
       }
 
       options.unshift({ label: `<${__('Choose')}>`, value: '-2' });


### PR DESCRIPTION
each capability for filtering services and resources in volume create basic/advanced now has its own single-select field for n/a, true or false.

this prevents users from selecting conflicting capabilities (compression true and compression false) and enables to select the N/A option for a specific capability (or for all of them).

PR in providers repo:

- [x] https://github.com/ManageIQ/manageiq-providers-autosde/pull/219

**before:**
![image](https://user-images.githubusercontent.com/106743023/224545779-16d7ac6e-82f9-4f3c-9c4e-0408d9adbe45.png)


**after:**
![image](https://user-images.githubusercontent.com/106743023/224545670-adcf9e02-4780-45d6-bb80-3aeffe1d0465.png)
