### PR TITLE
changing backticks to single quotes

### DIFF
--- a/app/helpers/settings_schedule_helper.rb
+++ b/app/helpers/settings_schedule_helper.rb
@@ -48,7 +48,7 @@ module SettingsScheduleHelper
     unless schedule.sched_action[:method] == "automation_request"
       if schedule.miq_search
         search = schedule.miq_search
-        filter_data = search.search_type == "user" ? `_("My Filter: ") #{search.description}` : `_("Global Filter: ") #{search.description}`
+        filter_data = search.search_type == "user" ? '_("My Filter: ") #{search.description}' : '_("Global Filter: ") #{search.description}'
         rows.push({:cells => [{:value => filter_data}]})
       elsif schedule.filter.kind_of?(MiqExpression)
         operators = ["AND", "OR", "(", ")"]


### PR DESCRIPTION
Follow upto https://github.com/ManageIQ/manageiq-ui-classic/pull/8686#discussion_r1134524503 .  converted the backticks to single quotes to fix the security issue

@miq-bot add-reviewer @MelsHyrule 
@miq-bot add-reviewer @jeffibm
@miq-bot assign @jeffibm