### PR TITLE
Fix forbidden page notifications for configurations page

### DIFF
--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -20,6 +20,7 @@ class ConfigurationController < ApplicationController
   end
 
   def index
+    assert_privileges('my_settings')
     @breadcrumbs = []
     active_tab = nil
     if role_allows?(:feature => "my_settings_visuals")

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -263,7 +263,6 @@ ConditionController:
 - reload
 - search_clear
 ConfigurationController:
-- index
 - report_data
 - show
 - tree_autoload


### PR DESCRIPTION
Continuation of https://github.com/ManageIQ/manageiq-ui-classic/pull/8685

Before
![image](https://user-images.githubusercontent.com/87487049/224933902-2cadb452-869e-4976-92d0-841d40025017.png)

After
![image](https://user-images.githubusercontent.com/87487049/224933738-e819a921-c359-436a-aa47-c0d022a2b0ae.png)
