### PR TITLE
Correct Missing Service Summary Tabs

### DIFF
--- a/app/views/service/show.html.haml
+++ b/app/views/service/show.html.haml
@@ -3,4 +3,4 @@
 - elsif @ownershipitems
   = render :partial => "shared/views/ownership"
 - elsif @showtype == 'main'
-  = render :partial => "layouts/textual_groups_generic"
+  = render :partial => "svcs_show", :locals => {:controller => "service"}


### PR DESCRIPTION
Returns a change that was undone in #8596 that was causing the tabs in the service summary page to not display correctly.

Before:
![image](https://user-images.githubusercontent.com/64800041/225409589-6943a96d-64b9-444c-8632-f584e815e86d.png)

After:
![image](https://user-images.githubusercontent.com/64800041/225409451-a0d27720-fcf2-461b-8151-14d1a8075c6a.png)
