### PR TITLE
Fixed Text Overlap in NavMenu Search Bar

### DIFF
--- a/app/javascript/menu/search.jsx
+++ b/app/javascript/menu/search.jsx
@@ -36,7 +36,7 @@ const MenuSearch = ({
         <SideNavItems>
           <SideNavItem className="padded vertical-center">
             <fieldset className="miq-fieldset">
-              <legend className="miq-fieldset-legend legend-search">{__('Choose a Filter')}</legend>
+              <legend className="miq-fieldset-legend legend-search">{expanded ? __('Choose a Filter') : undefined}</legend>
               <div className="miq-fieldset-content">
                 <div
                   tabIndex="0"


### PR DESCRIPTION
Changes the legend on the search bar in the nav menu to only display when the menu is expanded in order to prevent the `Choose a Filter` text from getting squished when the menu is condensed.

Before:
<div style="display:flex">
<img width="250" src="https://user-images.githubusercontent.com/64800041/225428974-f9993e68-286f-4051-b719-be5b5d53e0eb.png">
<img width="250" src="https://user-images.githubusercontent.com/64800041/225432251-c803be53-1419-4e70-bb14-fab6accf9458.png">
</div>

After:
<div style="display:flex">
<img width="250" src="https://user-images.githubusercontent.com/64800041/225428974-f9993e68-286f-4051-b719-be5b5d53e0eb.png">
<img width="250" src="https://user-images.githubusercontent.com/64800041/225429410-acd1fabf-364a-41f3-80e9-845a80857ed7.png">
</div>