### PR TITLE
Fix summary label wrapping for long text without spaces

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -41,6 +41,7 @@
     min-width: 20%;
     width: 250px;
     padding-left: 0;
+    overflow-wrap: anywhere;
   }
 
   .cell {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/87487049/225531847-117a4f7a-7e90-418a-8a40-7806ec76026a.png)

After
![image](https://user-images.githubusercontent.com/87487049/225531910-746bfa11-fb04-4000-8c93-97154f78914a.png)
