### PR TITLE
Sorting timeline data by date

### DIFF
--- a/app/javascript/components/timeline-options/timeline-helper.js
+++ b/app/javascript/components/timeline-options/timeline-helper.js
@@ -90,6 +90,7 @@ export const buildChartDataObject = (rawData) => {
       datasets.push(obj);
     }
   });
+  datasets.sort((a, b) => new Date(b.date) - new Date(a.date));
   return datasets;
 };
 


### PR DESCRIPTION
Timeline data was looping back and forth. 

## BEFORE

![Screen Shot 2023-03-16 at 3 27 28 PM](https://user-images.githubusercontent.com/29209973/225740470-8645d1ce-7b52-4f7b-9b06-7493812e82a9.png)

## AFTER

![Screen Shot 2023-03-16 at 3 44 44 PM](https://user-images.githubusercontent.com/29209973/225740513-b366d315-a638-4e05-84f3-39565c29a5ce.png)

![Screen Shot 2023-03-16 at 3 44 58 PM](https://user-images.githubusercontent.com/29209973/225740523-aaf84863-591e-490a-9247-938b85b88dde.png)