### PR TITLE
added name validation to provider and host initiator group forms

### DIFF
--- a/app/javascript/components/host-initiator-group-form/host-initiator-group-form.schema.js
+++ b/app/javascript/components/host-initiator-group-form/host-initiator-group-form.schema.js
@@ -1,4 +1,5 @@
 import { componentTypes, validatorTypes } from '@@ddf';
+import validateName from '../../helpers/storage_manager/validate-names';
 
 export const portTypes = [
   { label: __('ISCSI'), value: 'ISCSI' },
@@ -8,7 +9,8 @@ export const portTypes = [
 
 const loadProviders = () =>
   API.get(
-    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_create_host_initiator_group=true',
+    '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage='
+    + 'true&filter[]=supports_create_host_initiator_group=true',
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
 
@@ -46,7 +48,10 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         id: 'name',
         label: __('Name:'),
         isRequired: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
+        validate: [
+          { type: validatorTypes.REQUIRED },
+          async(value) => validateName('host_initiator_groups', value, false),
+        ],
       },
       {
         component: componentTypes.SELECT,

--- a/app/javascript/components/provider-form/index.jsx
+++ b/app/javascript/components/provider-form/index.jsx
@@ -12,6 +12,7 @@ import ProtocolSelector from './protocol-selector';
 import ProviderCredentials from './provider-credentials';
 import ValidateProviderCredentials from './validate-provider-credentials';
 import DetectButton from './detect-button';
+import validateName from '../../helpers/storage_manager/validate-names';
 
 const findSkipSubmits = (schema, items) => {
   const found = schema.skipSubmit && items.includes(schema.name) ? [schema.name] : [];
@@ -26,9 +27,12 @@ const commonFields = [
     name: 'name',
     label: __('Name'),
     isRequired: true,
-    validate: [{
-      type: validatorTypes.REQUIRED,
-    }],
+    validate: [
+      {
+        type: validatorTypes.REQUIRED,
+      },
+      async(value) => validateName('providers', value, false),
+    ],
   },
   {
     component: componentTypes.SELECT,

--- a/app/javascript/spec/host-initiator-group-form/__snapshots__/host-initiator-group.spec.js.snap
+++ b/app/javascript/spec/host-initiator-group-form/__snapshots__/host-initiator-group.spec.js.snap
@@ -58,6 +58,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                 Object {
                   "type": "required",
                 },
+                [Function],
               ],
             },
             Object {
@@ -163,6 +164,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                   Object {
                     "type": "required",
                   },
+                  [Function],
                 ],
               },
               Object {
@@ -260,6 +262,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                     Object {
                       "type": "required",
                     },
+                    [Function],
                   ],
                 },
                 Object {
@@ -358,6 +361,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                         Object {
                           "type": "required",
                         },
+                        [Function],
                       ]
                     }
                   />,
@@ -422,6 +426,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                         Object {
                           "type": "required",
                         },
+                        [Function],
                       ],
                     },
                     Object {
@@ -495,6 +500,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                           Object {
                             "type": "required",
                           },
+                          [Function],
                         ]
                       }
                     />,
@@ -565,6 +571,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                           Object {
                             "type": "required",
                           },
+                          [Function],
                         ],
                       },
                       Object {
@@ -653,6 +660,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                             Object {
                               "type": "required",
                             },
+                            [Function],
                           ]
                         }
                       />,
@@ -723,6 +731,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                             Object {
                               "type": "required",
                             },
+                            [Function],
                           ],
                         },
                         Object {
@@ -1022,6 +1031,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                               Object {
                                 "type": "required",
                               },
+                              [Function],
                             ]
                           }
                         >
@@ -1037,6 +1047,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                                   Object {
                                     "type": "required",
                                   },
+                                  [Function],
                                 ],
                               }
                             }
@@ -1055,6 +1066,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                                     Object {
                                       "type": "required",
                                     },
+                                    [Function],
                                   ]
                                 }
                               >
@@ -1585,6 +1597,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                                       Object {
                                         "type": "required",
                                       },
+                                      [Function],
                                     ]
                                   }
                                 />,
@@ -1691,7 +1704,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                                   "physical_storage_id": false,
                                 },
                                 "valid": false,
-                                "validating": false,
+                                "validating": true,
                                 "values": Object {
                                   "ems_id": "2",
                                   "name": "my_group",
@@ -1737,6 +1750,7 @@ exports[`Host Initiator Group Form  Loads data and renders  1`] = `
                                       Object {
                                         "type": "required",
                                       },
+                                      [Function],
                                     ],
                                   },
                                   Object {


### PR DESCRIPTION
**_provider_** with existing name failed on form submission, blocking that on field validation makes for a better UI:
**before:**
![image](https://user-images.githubusercontent.com/106743023/226165492-2b6082fd-2b77-49c9-85f4-dae73c1d9302.png)


**after:**
![image](https://user-images.githubusercontent.com/106743023/226165369-f67fc916-c8e9-4279-b3bd-2c390ec7c18c.png)

---
**_host initiator group_** with existing name failed in backend, better to block in the UI as well:
**before:**
![image](https://user-images.githubusercontent.com/106743023/226165635-71230499-327c-4e43-aceb-6af450ca521e.png)
(task failure msg seems to have picked up a bug, will fix this in a different PR)

**after:**
![image](https://user-images.githubusercontent.com/106743023/226165312-0d22c4e6-0422-4a51-85aa-cba1d20bf27f.png)

