### PR TITLE
Rbac Group summary conversion from HAML to React

### DIFF
--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -12,6 +12,7 @@ module OpsHelper
   include SettingsUsersHelper
   include SettingsZoneHelper
   include SettingsRbacTagHelper
+  include GroupRbacDetailsHelper
 
   def row_data(label, value)
     {:cells => {:label => label, :value => value}}

--- a/app/helpers/ops_helper/group_rbac_details_helper.rb
+++ b/app/helpers/ops_helper/group_rbac_details_helper.rb
@@ -1,0 +1,80 @@
+module OpsHelper::GroupRbacDetailsHelper
+  private
+
+  def row_data_for_role(label, value, icon)
+    {:cells => {:label => label, :value => value, :icon => icon}}
+  end
+
+  def row_data_for_users(icon, value, style)
+    {:cells => {:icon => icon, :value => value, :style => style}}
+  end
+
+  def group_rbac_details_summary(group)
+    summary = [
+      group_information_summary(group),
+      users_summary_info(group),
+    ]
+    safe_join(summary)
+  end
+
+  def group_information_summary(group)
+    rows = [
+      row_data(_('ID'), group.id),
+      row_data(_('Description'), group.description),
+      row_data(_('Detailed Description'), group.detailed_description),
+    ]
+
+    if group.miq_user_role
+      row = row_data_for_role(_('Role'), group.miq_user_role.name, "ff ff-user-role")
+      if role_allows?(:feature => "rbac_group_show")
+        row[:cells][:link] = group.miq_user_role.name
+        row[:cells][:onclick] = "miqOnClickSelectRbacTreeNode('ur-#{group.miq_user_role.id}')"
+        row[:cells][:title] = _("View this Role")
+      else
+        row[:cells][:link] = "#"
+      end
+      rows.push(row)
+    else
+      rows.push(row_data(_('Role'), ''))
+    end
+
+    if group.tenant
+      row = row_data_for_role(_('Project/Tenant'), group.tenant.name, "pficon pficon-#{group.tenant.divisible ? "tenant" : "project"}")
+      if role_allows?(:feature => "rbac_tenant_view")
+        row[:cells][:link] = group.tenant.name
+        row[:cells][:onclick] = "miqTreeActivateNode('rbac_tree', 'tn-#{group.tenant.id}');"
+        row[:cells][:title] = group.tenant.divisible ? _("View this Tenant") : _("View this Project")
+      end
+      rows.push(row)
+    else
+      rows.push(row_data(_('Project/Tenant'), ''))
+    end
+
+    miq_structured_list({
+                          :title => _("Group Information"),
+                          :mode  => "group_information_summary",
+                          :rows  => rows
+                        })
+  end
+
+  def users_summary_info(group)
+    rows = []
+    group.users.sort_by { |a| a.name.downcase }.each do |u|
+      if role_allows?(:feature => "rbac_group_show")
+        row = row_data_for_users("pficon pficon-user", u.name, "display_flex cursor_pointer")
+        row[:cells][:link] = u.name
+        row[:cells][:onclick] = "miqOnClickSelectRbacTreeNode('u-#{u.id}')"
+        row[:cells][:title] = _("View this User")
+      else
+        row[:cells][:link] = u.name, "#"
+      end
+      rows.push(row)
+    end
+
+    miq_structured_list({
+                          :title => _("Users in this Group"),
+                          :mode  => "users_summary_info",
+                          :rows  => rows
+                        })
+  end
+end

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -1,6 +1,3 @@
-- if @edit
-  - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
-  - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
 - mode = ::Settings.authentication.mode
 - oidc_enabled = ::Settings.authentication.oidc_enabled
 - saml_enabled = ::Settings.authentication.saml_enabled
@@ -22,26 +19,20 @@
               - @deleted_belongsto_filters.each do |deleted_filter|
                 %li
                   %strong= h(deleted_filter)
-#group_info
+- if @edit
+  - url = url_for_only_path(:action => 'rbac_group_field_changed', :id => (@edit[:group_id] || "new"))
+  - combo_url = "/ops/rbac_group_field_changed/#{@edit[:group_id] || 'new'}"
+  = render :partial => "ldap_auth_users"
+
+  #group_info
   %h3
     = _("Group Information")
-  - if @edit
-    = render :partial => "ldap_auth_users"
   .form-horizontal
-    - unless @edit
-      .form-group
-        %label.col-md-2.control-label
-          = _("ID")
-        .col-md-8
-          %p.form-control-static
-            = h(@group.id)
     .form-group
       %label.col-md-2.control-label
         = _("Description")
       .col-md-8
-        - if !@edit
-          = h(@group.description)
-        - else
+        - if @edit
           = text_field_tag("description",
                            @edit[:new][:description],
                            :maxlength         => 50,
@@ -59,9 +50,7 @@
       %label.col-md-2.control-label
         = _("Detailed Description")
       .col-md-8
-        - if !@edit
-          = h(@group.detailed_description)
-        - else
+        - if @edit
           = text_field_tag("detailed_description",
                            @edit[:new][:detailed_description],
                            :maxlength         => 255,
@@ -72,17 +61,7 @@
       %label.col-md-2.control-label
         = _("Role")
       .col-md-8
-        - if !@edit
-          - if @group.miq_user_role
-            - if role_allows?(:feature => "rbac_role_show")
-              - params = {:class   => "pointer",
-                          :onclick => "miqOnClickSelectRbacTreeNode('ur-#{@group.miq_user_role.id}');",
-                          :title   => _("View this Role")}
-            - else
-              - params = {}
-            %i.ff.ff-user-role{params}
-            = link_to(@group.miq_user_role.name, "#", params)
-        - else
+        - if @edit
           - disabled_item = ["<Choose a Role>", nil]
           - selected_item = @edit[:new][:role] || disabled_item
           = select_tag('group_role',
@@ -95,43 +74,12 @@
       %label.col-md-2.control-label
         = _("Project/Tenant")
       .col-md-8
-        - if !@edit
-          - if @group.tenant
-            - tenant = @group.tenant
-            - params = {:class => "pficon pficon-#{tenant.divisible ? "tenant" : "project"}"}
-            - if role_allows?(:feature => "rbac_tenant_view")
-              - params[:class] = "#{params[:class]} pointer"
-              - params[:onclick] = "miqTreeActivateNode('rbac_tree', 'tn-#{tenant.id}');"
-              - params[:title] = tenant.divisible ? _("View this Tenant") : _("View this Project")
-            %i{params}
-            = h(tenant.name)
-        - else
+        - if @edit
           = select_tag('group_tenant',
               grouped_options_for_select(@edit[:projects_tenants], @edit[:new][:group_tenant]),
                :class  => "selectpicker")
           :javascript
             miqSelectPickerEvent("group_tenant", "#{combo_url}")
-
-    - unless @edit
-      .form-group
-        %label.col-md-2.control-label
-          = _("Users in this Group")
-        .col-md-8
-          - if role_allows?(:feature => "rbac_user_show")
-            - @group.users.sort_by { |a| a.name.downcase }.each do |u|
-              - params = {:class => "pointer",
-                          :onclick => "miqOnClickSelectRbacTreeNode('u-#{u.id}');",
-                          :title => _("View this User")}
-              %i.pficon.pficon-user{params}
-              = link_to(u.name, "#", params)
-              %br
-          - else
-            - @group.users.sort_by { |a| a.name.downcase }.each do |u|
-              %i.pficon.pficon-user
-              = link_to(u.name, "#")
-              %br
-    - unless @edit
-      = render :partial => "rbac_tag_box"
     - if @edit
       #group_lookup{:style => "display:none"}
         %hr
@@ -148,18 +96,6 @@
                                :class             => "form-control",
                                "data-miq_observe" => {:interval => '.5',
                                                       :url      => url}.to_json)
-
-          - unless mode == "httpd"
-            .form-group#user_name_form_group
-              %label.col-md-2.control-label
-                = _("Username")
-              .col-md-8
-                = text_field_tag("user_id",
-                                 @edit[:new][:user_id],
-                                 :maxlength         => 255,
-                                 :class             => "form-control",
-                                 "data-miq_observe" => {:interval => '.5',
-                                                        :url      => url}.to_json)
 
             .form-group#user_password_form_group
               %label.col-md-2.control-label
@@ -183,27 +119,28 @@
                       :remote                => true,
                       "data-method"          => :post,
                       :title                 => t)
+- unless @edit
+  = group_rbac_details_summary(@group)
+  = render :partial => "rbac_tag_box"
+%hr
+%h3
+  = @edit ? _("Assign Filters") : _("Assigned Filters (read only)")
 
-  %hr
-  %h3
-    = @edit ? _("Assign Filters") : _("Assigned Filters (read only)")
+#rbac_group_tabs
+  %ul.nav.nav-tabs{'role' => 'tablist'}
+    = miq_tab_header('rbac_customer_tags', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_customer_tags')"}) do
+      = _("%{current_tenant} Tags") % {:current_tenant => current_tenant.name}
+    = miq_tab_header('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_hosts_clusters')"}) do
+      = _("Clusters, Datastores, Hosts, Managers & Providers")
+    = miq_tab_header('rbac_vms_templates', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_vms_templates')"}) do
+      = _("VMs & Templates")
 
-  #rbac_group_tabs
-    %ul.nav.nav-tabs{'role' => 'tablist'}
-      = miq_tab_header('rbac_customer_tags', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_customer_tags')"}) do
-        = _("%{current_tenant} Tags") % {:current_tenant => current_tenant.name}
-      = miq_tab_header('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_hosts_clusters')"}) do
-        = _("Clusters, Datastores, Hosts, Managers & Providers")
-      = miq_tab_header('rbac_vms_templates', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_vms_templates')"}) do
-        = _("VMs & Templates")
-
-    .tab-content
-      = miq_tab_content('rbac_customer_tags', @sb[:active_rbac_group_tab], {:lazy => true}) do
-        = render :partial => 'ops/rbac_group/customer_tags'
-      = miq_tab_content('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:lazy => true}) do
-        = render :partial => 'ops/rbac_group/hosts_clusters'
-      = miq_tab_content('rbac_vms_templates', @sb[:active_rbac_group_tab], {:lazy => true}) do
-        = render :partial => 'ops/rbac_group/vms_templates'
-
+  .tab-content
+    = miq_tab_content('rbac_customer_tags', @sb[:active_rbac_group_tab], {:lazy => true}) do
+      = render :partial => 'ops/rbac_group/customer_tags'
+    = miq_tab_content('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:lazy => true}) do
+      = render :partial => 'ops/rbac_group/hosts_clusters'
+    = miq_tab_content('rbac_vms_templates', @sb[:active_rbac_group_tab], {:lazy => true}) do
+      = render :partial => 'ops/rbac_group/vms_templates'
 :javascript
   miq_tabs_init('#rbac_group_tabs');


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/125852394/226871333-e0867c2e-3ea6-4d5d-9716-63e8bd36356f.png)

After:

<img width="1557" alt="image" src="https://user-images.githubusercontent.com/125852394/227907112-6ea308f0-cd40-4c0b-824e-2d1db501f315.png">

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/125852394/227907246-37f1bbb9-8e55-4f6f-a4fb-6f5ce7944485.png">

Converted summary logic for view part only, Here the rbac_tag_box haml file at the end is not converted. It has been done by Dinesh in the PR https://github.com/ManageIQ/manageiq-ui-classic/pull/8717
Will integrate rbac_tag_box here after Dinesh's PR got merged.