### PR TITLE
Fix for `Service#service_retire_now` retiring VMs

### DIFF
--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -123,6 +123,10 @@ class ServiceController < ApplicationController
 
   private
 
+  def record_class
+    Service
+  end
+
   def sanitize_output(stdout)
     htm = stdout.gsub('"', '\"')
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -22,6 +22,32 @@ describe ServiceController do
     service
   end
 
+  describe "#service_retire_now" do
+    let(:service)          { FactoryBot.create(:service, :service_template => service_template, :name => "foo") }
+    let(:service_template) { FactoryBot.create(:service_template, :name => "bar") }
+
+    it "creates a ServiceRetireRequest" do
+      expect(controller).to receive(:assert_privileges)
+      expect(controller).to receive(:javascript_redirect).with({:action => "show_list", :controller => "miq_request"})
+
+      controller.instance_variable_set(:@record, service)
+      controller.params = {:id => service.id}
+      controller.send(:service_retire_now)
+
+      expect(ServiceRetireRequest.count).to eq(1)
+      expect(ServiceRetireRequest.first).to have_attributes(
+        :description    => "Service Retire for: #{service.name}",
+        :approval_state => "pending_approval",
+        :type           => "ServiceRetireRequest",
+        :request_type   => "service_retire",
+        :request_state  => "pending",
+        :message        => "Service Retire - Request Created",
+        :status         => "Ok",
+        :options        => {:src_ids => [service.id]}
+      )
+    end
+  end
+
   describe "#service_reconfigure" do
     let(:service) { instance_double("Service", :id => 321, :service_template => service_template, :name => "foo name") }
     let(:service_template) { instance_double("ServiceTemplate", :name => "the name") }


### PR DESCRIPTION
If you retire a service via the UI
![image](https://user-images.githubusercontent.com/12851112/226952052-c8507f3f-b712-4c14-8760-37df17f99d41.png)

This calls `ServiceController#service_retire_now`
```
Started POST "/service/button/1?pressed=service_retire_now" for 127.0.0.1 at 2023-03-22 11:14:00 -0400
Parameters: {"pressed"=>"service_retire_now", "id"=>"1"}
```

This is aliased in the `CiProcessing` mixin as `retirevms_now`: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L389

This ends up calling `generic_button_operation` and finding the record based on `record_class`: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L603-L604

`record_class` defaults to `VmOrTemplate` in `CiProcessing`: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/ci_processing.rb#L243-L245

`ServiceController#record_class` was removed during the Service De-Exploration: https://github.com/ManageIQ/manageiq-ui-classic/commit/dd84f568494215781642238b9d01431c6dd1acef#diff-9f30f45de34f12165b8fce7741243deeb55697dd75f465c09eaf4a3c5d07eb6aL211-L212

This means we end up retiring a VM with the same ID as the service you tried to retire:
```
[----] I, [2023-03-22T10:52:29.785818 #46104:97e0]  INFO -- evm: MIQ(MiqQueue.put) Message id: [3018], Zone: [], Role: [automate], Server: [], MiqTask id: [], Handler id: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [MiqAeEngine.deliver], Timeout: [3600], Priority: [20], State: [ready], Deliver On: [], Data: [], Args: [{:object_type=>"VmRetireRequest", :object_id=>1, :attrs=>{:event_type=>"request_created", "EventStream::event_stream"=>2257, :event_stream_id=>2257}, :instance_name=>"Event", :user_id=>1, :miq_group_id=>2, :tenant_id=>1, :automate_message=>nil}]
```

Fixes https://github.com/ManageIQ/manageiq/issues/22367