### PR TITLE
Removing flash message

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -21,7 +21,6 @@ module ApplicationController::Timelines
     end
 
     @timeline = true
-    add_flash(_("No events available for this timeline"), :warning) if @tl_options.date.start.nil? && @tl_options.date.end.nil?
     render :update do |page|
       page << javascript_prologue
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")


### PR DESCRIPTION
Removing the `No events available for this timeline` timeline page flash as it can cause confusion for the users. 

Currently the pop up will only appear when the timeline page loads in and there are no available events (meaning it is displaying the correct behavior). However because of the dynamic nature of `events`, an event can load in moments after seeing this message and so the user even after seeing the message can use the form and search and see new events, hence the message stops being accurate. 

## BEFORE
  
![Screenshot 2023-03-28 at 1 45 46 PM](https://user-images.githubusercontent.com/29209973/228324659-de5589d8-f68e-47d9-b91b-5bccac654542.png)

## AFTER

![Screenshot 2023-03-28 at 1 46 15 PM](https://user-images.githubusercontent.com/29209973/228324697-c80b5f4b-a127-402f-a479-3ac7c8a1dc2f.png)

@miq-bot add-reviewer @DavidResende0
@miq-bot add-reviewer @akhilkr128
@miq-bot add-reviewer @jeffibm
@miq-bot assign @jeffibm