### PR TITLE
add refresh button for the provider related to the volume

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -19,16 +19,17 @@ class CloudVolumeController < ApplicationController
     'cloud_volume_attach'          => [:attach,   'attach'],
     'cloud_volume_clone'           => [:clone,    'clone'],
     'cloud_volume_detach'          => [:detach,   'detach'],
-    'cloud_volume_edit'            => [:update,           'edit'],
+    'cloud_volume_edit'            => [:update, 'edit'],
     'cloud_volume_new'             => [nil,              'new'],
     'cloud_volume_snapshot_create' => [:snapshot_create, 'snapshot_new'],
     'cloud_volume_backup_create'   => [:backup_create,   'backup_new'],
     'cloud_volume_backup_restore'  => [:backup_restore,  'backup_select'],
-    'cloud_volume_refresh'  => [nil,  'cloud_volume_refresh'],
+    'cloud_volume_refresh'         => [nil, 'cloud_volume_refresh'],
   }.freeze
 
   def specific_buttons(pressed)
     return false unless BUTTON_TO_ACTION_MAPPING.include?(pressed)
+
     if pressed == "cloud_volume_refresh"
       @record = find_record_with_rbac(CloudVolume, checked_item_id)
       EmsRefresh.refresh(@record.ext_management_system)

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -118,6 +118,18 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                                                           :try_safe_delete => true,
                                                           :component_name  => 'RemoveGenericItemModal'}}
                      ),
+                     button(
+                       :cloud_volume_refresh,
+                       'fa fa-refresh fa-lg',
+                       N_('Refresh relationships and power states for all items related to this cloud volume'),
+                       N_('Refresh Relationships and Power States'),
+                       :image   => "refresh",
+                       :confirm => N_("Refresh relationships and power states for all items related to this Cloud volume?"),
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => '1',
+                       :options => {:feature => :refresh}
+                     ),
                    ]
                  )
                ])

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -93,9 +93,9 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        :url_parms    => 'main_div',
                        :send_checked => true,
                        :enabled      => false,
-                       :klass     => ApplicationHelper::Button::PolymorphicConditionalButton,
-                       :options   => {:feature      => :update,
-                                      :parent_class => "CloudVolume"},
+                       :klass        => ApplicationHelper::Button::PolymorphicConditionalButton,
+                       :options      => {:feature      => :update,
+                                         :parent_class => "CloudVolume"},
                        :onwhen       => '1'
                      ),
                      button(
@@ -123,35 +123,36 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        'fa fa-refresh fa-lg',
                        N_('Refresh relationships and power states for all items related to this cloud volume'),
                        N_('Refresh Relationships and Power States'),
-                       :image   => "refresh",
-                       :confirm => N_("Refresh relationships and power states for all items related to this Cloud volume?"),
+                       :image        => "refresh",
+                       :confirm      => N_("Refresh relationships and power states for all items related to this Cloud volume?"),
                        :send_checked => true,
                        :enabled      => false,
                        :onwhen       => '1',
-                       :options => {:feature => :refresh}
+                       :options      => {:feature => :refresh}
                      ),
                    ]
                  )
                ])
   button_group('cloud_volume_policy', [
-    select(
-      :cloud_volume_policy_choice,
-      nil,
-      t = N_('Policy'),
-      t,
-      :enabled => "false",
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :cloud_volume_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit tags for the selected items'),
-          N_('Edit Tags'),
-          :url_parms    => "main_div",
-          :send_checked => true,
-          :enabled      => false,
-          :onwhen       => "1+"),
-      ]
-    ),
-  ])
+                 select(
+                   :cloud_volume_policy_choice,
+                   nil,
+                   t = N_('Policy'),
+                   t,
+                   :enabled => "false",
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :cloud_volume_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit tags for the selected items'),
+                       N_('Edit Tags'),
+                       :url_parms    => "main_div",
+                       :send_checked => true,
+                       :enabled      => false,
+                       :onwhen       => "1+"
+                     ),
+                   ]
+                 ),
+               ])
 end


### PR DESCRIPTION
I added a button to refresh the storage provider on the volumes page.
Now its enabled after the volume is checked and only the related provider is refreshed.
![Screenshot 2023-04-02 at 11 48 29](https://user-images.githubusercontent.com/26038734/229342552-d34b6208-b80d-49c8-8049-6bf4507c2fb1.png)

this pr is related to the pr in the core manageiq to add this function to the miq roles.
https://github.com/ManageIQ/manageiq/pull/22439