### PR TITLE
Fix EmbeddedAnsible Repositories/Credentials

### DIFF
--- a/app/javascript/components/ansible-credentials-form/index.jsx
+++ b/app/javascript/components/ansible-credentials-form/index.jsx
@@ -25,7 +25,7 @@ const AnsibleCredentialsForm = ({ recordId }) => {
 
   useEffect(() => {
     // eslint-disable-next-line camelcase
-    API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager').then(({ resources: [manager_resource] }) => {
+    API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager').then(({ resources: [manager_resource] }) => {
       if (!recordId) {
         setState((state) => ({
           ...state,

--- a/app/javascript/components/ansible-repository-form/index.jsx
+++ b/app/javascript/components/ansible-repository-form/index.jsx
@@ -31,7 +31,7 @@ const AnsibleRepositoryForm = ({ repositoryId }) => {
         });
       miqSparkleOff();
     } else if (isLoading) {
-      API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager')
+      API.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager')
         .then((response) => {
           if (!response.resources.length) {
             add_flash('error', __('Embedded Ansible Provider not found.'));

--- a/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
+++ b/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
@@ -35,7 +35,7 @@ describe('Ansible Credential Form Component', () => {
   };
 
   beforeEach(() => {
-    fetchMock.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAutomationManager', { 
+    fetchMock.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager', { 
         "resources": [
             {
               "href": "http://localhost:3000/api/providers/1"


### PR DESCRIPTION
Now that there are 2 EmbeddedAutomationManagers we can't just assume that EmbeddedAnsible::AutomationManager == EmbeddedAutomationManager

**Automation / Ansible / Repositories**
Before
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/87487049/232391268-b5b2dc38-7935-4bd9-ac01-e8e552adc2c9.png">

After
<img width="1577" alt="image" src="https://user-images.githubusercontent.com/87487049/232392319-fa11c6aa-171b-40c0-96ac-bd3de3801bbe.png">

**Automation / Ansible / Credentials /** 
Before
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/87487049/232389654-f9a343b4-1cec-485a-a8fb-8fbb8fab46f9.png">

After
<img width="1790" alt="Screenshot 2023-04-17 at 10 57 22 AM" src="https://user-images.githubusercontent.com/87487049/232388811-d1afd4ee-2746-433f-b9ee-a62875852b41.png">




