### PR TITLE
Add --openssl-legacy-provider to NODE_OPTIONS

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -22,7 +22,7 @@ end
 
 newenv  = {
   "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
-  "NODE_OPTIONS" => "--max_old_space_size=4096 --openssl-legacy-provider expo start --web"
+  "NODE_OPTIONS" => "--max_old_space_size=4096 --openssl-legacy-provider"
 }
 cmdline = ["yarn", "run", "webpack", "--config", WEBPACK_CONFIG] + ARGV
 

--- a/bin/webpack
+++ b/bin/webpack
@@ -22,7 +22,7 @@ end
 
 newenv  = {
   "NODE_PATH"    => NODE_MODULES_PATH.shellescape,
-  "NODE_OPTIONS" => "--max_old_space_size=4096"
+  "NODE_OPTIONS" => "--max_old_space_size=4096 --openssl-legacy-provider expo start --web"
 }
 cmdline = ["yarn", "run", "webpack", "--config", WEBPACK_CONFIG] + ARGV
 


### PR DESCRIPTION
After upgrading to node 18 we get the below error during webpack compile
```
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /home/runner/work/manageiq-ui-classic/manageiq-ui-classic/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
```
This occurs Since Node 17 as the default OpenSSL implementation changed and the fix will be available only in webpack5 and for webpack we have to add  **--openssl-legacy-provider expo start --web** to our NODE_OPTIONS

More info on this issue : https://github.com/expo/expo-cli/issues/4575 