### PR TITLE
storage service edit mode: check which attached resources are compliant to selected capabilities

### DIFF
--- a/app/javascript/components/async-action-button.jsx
+++ b/app/javascript/components/async-action-button.jsx
@@ -1,0 +1,160 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  isEqual, flatMap, get, set,
+} from 'lodash';
+import { Button, InlineLoading } from 'carbon-components-react';
+
+import {
+  useFormApi, useFieldApi, validatorTypes, FormSpy,
+} from '@@ddf';
+import HelperTextBlock from '../forms/helper-text-block';
+
+const extractNames = (schema) => {
+  const childFields = schema.fields ? flatMap(schema.fields, (field) => extractNames(field)) : [];
+  return schema.name ? [...childFields, schema.name] : childFields;
+};
+
+const AsyncAction = ({
+  actionLabel,
+  actionProgressLabel,
+  actionSuccessLabel,
+  actionDefaultError,
+  helperText,
+  fields,
+  name,
+  asyncAction,
+  actionDependencies,
+  isRequired,
+  edit,
+}) => {
+  const formOptions = useFormApi();
+
+  const dependencies = useMemo(() => [...extractNames({ fields }), ...actionDependencies], [fields, actionDependencies]);
+
+  const snapshot = (values = formOptions.getState().values) => dependencies.reduce((obj, key) => set(obj, key, get(values, key)), {});
+
+  const [{
+    performing,
+    lastState,
+    errorMessage,
+    successMessage,
+    depsValid,
+  }, setState] = useState(() => ({}));
+
+  const { input, meta } = useFieldApi({
+    initialValue: !!edit || !isRequired, // The field is initially valid in edit mode or if the field is optional
+    name,
+    validate: [{ type: validatorTypes.REQUIRED }],
+  });
+
+  const processDependentFields = () => {
+    const registeredFields = formOptions.getRegisteredFields();
+
+    return dependencies.filter((value) => registeredFields.includes(value)).every((dependency) => {
+      const state = formOptions.getFieldState(dependency);
+      // The field is valid if its state is not available or its state is set to valid
+      return !state || state.valid;
+    });
+  };
+
+  const onClick = () => {
+    const { values } = formOptions.getState();
+    setState((state) => ({
+      ...state, performing: true, errorMessage: undefined, successMessage: undefined,
+    }));
+
+    asyncAction(values, dependencies).then((resolvedValue) => {
+      formOptions.change(name, true);
+      setState((state) => ({
+        ...state,
+        performing:
+        false,
+        lastState: snapshot(values),
+        errorMessage: undefined,
+        successMessage: resolvedValue || actionSuccessLabel,
+      }));
+    }).catch((error) => {
+      formOptions.change(name, undefined);
+      setState((state) => ({ ...state, performing: false, errorMessage: error }));
+    });
+  };
+
+  return (
+    <>
+      {formOptions.renderForm(fields.map((field) => ({
+        ...field,
+        ...(field.component === 'password-field' ? { parent: name, edit } : undefined),
+        isDisabled: field.isDisabled,
+      })), formOptions)}
+      <>
+        <input type="hidden" {...input} />
+
+        <FormSpy subscription={{ values: true, dirtyFields: true }}>
+          {({ dirtyFields, values }) => {
+            const currentValues = snapshot(values);
+
+            // The field itself is dirty when any of its children is dirty
+            const isDirty = Object.keys(dirtyFields).some((field) =>
+              dirtyFields[field] && dependencies.includes(field));
+
+            // The field itself is valid if there are no modifications since the last validation or the initial values
+            const isValid = isEqual(currentValues, lastState) || !isDirty;
+            const dv = processDependentFields();
+
+            useEffect(() => {
+              // The list of registered fields shows up after this render, so the validation has to happen
+              // with a delay and has to be pulled back via the state.
+              setTimeout(() => setState((state) => ({ ...state, depsValid: dv })));
+              formOptions.change(name, isValid);
+            }, [isValid, name, dv]);
+
+            return (
+              <>
+                <HelperTextBlock
+                  helperText={helperText}
+                />
+                <Button size="small" kind="tertiary" onClick={onClick} disabled={!depsValid || performing}>
+                  {performing && <InlineLoading /> }
+                  {performing ? actionProgressLabel : actionLabel}
+                </Button>
+                <HelperTextBlock
+                  warnText={!meta.error && isEqual(currentValues, lastState) && successMessage}
+                  errorText={meta.error && !performing && (errorMessage || actionDefaultError)}
+                />
+              </>
+            );
+          }}
+        </FormSpy>
+      </>
+    </>
+  );
+};
+
+AsyncAction.propTypes = {
+  actionLabel: PropTypes.string,
+  actionProgressLabel: PropTypes.string,
+  actionSuccessLabel: PropTypes.string,
+  actionDefaultError: PropTypes.string,
+  asyncAction: PropTypes.func,
+  helperText: PropTypes.string,
+  edit: PropTypes.bool,
+  fields: PropTypes.arrayOf(PropTypes.any).isRequired,
+  isRequired: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  actionDependencies: PropTypes.arrayOf(PropTypes.string),
+};
+
+AsyncAction.defaultProps = {
+  actionLabel: __('Perform Action'),
+  actionProgressLabel: __('In Progress'),
+  actionSuccessLabel: __('Action successful'),
+  actionDefaultError: __('Action Required'),
+  asyncAction: undefined,
+  helperText: undefined,
+  edit: false,
+  actionDependencies: [],
+  isRequired: undefined,
+};
+
+export default AsyncAction;

--- a/app/javascript/components/storage-service-form/get-compliant-resources.jsx
+++ b/app/javascript/components/storage-service-form/get-compliant-resources.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { pick } from 'lodash';
+import AsyncAction from '../async-action-button';
+
+const getResourceNames = (emsRefList) =>
+  API.get(`/api/storage_resources?expand=resources&attributes=name,ems_ref`)
+    .then(({ resources }) => {
+      const nameArray = [];
+      resources.forEach((resource) => {
+        if (emsRefList.includes(resource.ems_ref)) {
+          nameArray.push(resource.name);
+        }
+      });
+
+      return __('Compliant resources: ') + nameArray.join(', ');
+    });
+
+const GetCompliantResources = ({ ...props }) => {
+  const buttonLabel = __('Check Compliant Resources');
+  const progressMsg = __('Checking');
+  const defaultText = __(' ');
+  const helperText = 'Check which currently attached resources comply with the selected capabilities:';
+  const noCompliantMsg = __('No currently attached storage resource will comply with the selected capabilities. '
+    + 'Attach resources which will comply with them or select other capabilities.');
+  const asyncGetCompliance = (fields, fieldNames) => new Promise((resolve, reject) => {
+    const url = '/api/storage_services/';
+    fieldNames.push('id', 'ems_id', 'compression', 'thin_provision');
+    const resource = pick(fields, fieldNames);
+
+    API.post(url, { action: 'check_compliant_resources', resource })
+      // eslint-disable-next-line camelcase
+      .then(({ results: [compliant_resources] = [], ...single }) => {
+        // eslint-disable-next-line camelcase
+        const { task_id, success } = compliant_resources || single;
+        return success ? API.wait_for_task(task_id) : Promise.reject(compliant_resources);
+      })
+      .then((result) => (result.task_results.compliant_resources.length
+        ? resolve(getResourceNames(result.task_results.compliant_resources))
+        : reject(noCompliantMsg)))
+      .catch(({ message }) => reject([__('compliance check failed:'), message].join(' ')));
+  });
+
+  return (
+    <AsyncAction
+      {...props}
+      asyncAction={asyncGetCompliance}
+      actionLabel={buttonLabel}
+      actionProgressLabel={progressMsg}
+      actionDefaultError={defaultText}
+      helperText={helperText}
+    />
+  );
+};
+
+GetCompliantResources.propTypes = {
+  ...AsyncAction.propTypes,
+};
+
+GetCompliantResources.defaultPrps = {
+  ...AsyncAction.defaultProps,
+};
+
+export default GetCompliantResources;

--- a/app/javascript/components/storage-service-form/index.jsx
+++ b/app/javascript/components/storage-service-form/index.jsx
@@ -5,9 +5,12 @@ import createSchema from './storage-service-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
 import mapper from '../../forms/mappers/componentMapper';
 import enhancedSelect from '../../helpers/enhanced-select';
+import GetCompliantResources from './get-compliant-resources';
 
 const StorageServiceForm = ({ recordId, storageManagerId }) => {
-  const [{ fields, initialValues, isLoading }, setState] = useState({ fields: [], isLoading: !!recordId || !!storageManagerId });
+  const [{ fields, initialValues, isLoading }, setState] = useState({
+    fields: [], isLoading: !!recordId || !!storageManagerId,
+  });
   const submitLabel = !!recordId ? __('Save') : __('Add');
 
   const loadSchema = (appendState = {}) => ({ data: { form_schema: { fields } } }) => {
@@ -86,6 +89,7 @@ const StorageServiceForm = ({ recordId, storageManagerId }) => {
   const componentMapper = {
     ...mapper,
     'enhanced-select': enhancedSelect,
+    'compliance-button': GetCompliantResources,
   };
 
   const schema = createSchema(fields, !!recordId, !!storageManagerId, loadSchema, emptySchema);

--- a/app/javascript/components/storage-service-form/storage-service-form.schema.js
+++ b/app/javascript/components/storage-service-form/storage-service-form.schema.js
@@ -92,6 +92,21 @@ const createSchema = (fields, edit, ems, loadSchema, emptySchema) => {
         ...fields.slice(idx + 1),
       ]),
       {
+        component: 'compliance-button',
+        name: 'Compliance',
+        id: 'compliant-resources-button',
+        skipSubmit: true,
+        hideField: !edit,
+        condition: { when: 'compression', isNotEmpty: true },
+        fields: [
+          {
+            component: componentTypes.SWITCH,
+            name: 'Check Compliance',
+            hideField: true,
+          },
+        ],
+      },
+      {
         component: 'enhanced-select',
         name: 'storage_resource_id',
         id: 'storage_resource_id',


### PR DESCRIPTION
issue: #8749 

added a button in service edit mode which enables the user to check what currently attached resources will comply with the selected capabilities.

this includes a new async-action-button.jsx which is based on async-credentials.jsx, and enables sending an async request to the provider's backend and display the resolved results (or an error message if needed).

if there's a way to beautify the returning string, or even render it in a table, it could be a great improvement.

the enhancement is based on the yet to be merged https://github.com/ManageIQ/manageiq-ui-classic/issues/8728, and should be rebased on master after that issue is merged.

https://user-images.githubusercontent.com/106743023/230888143-5709af13-8461-4b62-89cc-d40ff4c47dae.mov

