### PR TITLE
Fix Utilisation accessibility violation and tabs conversion from HAML to React

### DIFF
--- a/app/helpers/utilization_helper.rb
+++ b/app/helpers/utilization_helper.rb
@@ -1,0 +1,24 @@
+module UtilizationHelper
+  def utilization_tab_configuration
+    [:summary, :details, :report].map do |item|
+      {:name => item, :text => utilization_tabs_types[item]}
+    end
+  end
+
+  def utilization_tab_content(key_name, &block)
+    if utilization_tabs_types[key_name]
+      class_name = key_name == :summary ? 'tab_content active' : 'tab_content'
+      tag.div(:id => key_name, :class => class_name, &block)
+    end
+  end
+
+  private
+
+  def utilization_tabs_types
+    {
+      :summary => _('Summary'),
+      :details => _('Details'),
+      :report  => _('Report'),
+    }
+  end
+end

--- a/app/javascript/components/miq-custom-tab/index.jsx
+++ b/app/javascript/components/miq-custom-tab/index.jsx
@@ -8,6 +8,7 @@ const MiqCustomTab = ({ containerId, tabLabels, type }) => {
     { type: 'CATALOG_SUMMARY' },
     { type: 'CATALOG_EDIT' },
     { type: 'CATALOG_REQUEST_INFO', url: `/miq_request/prov_field_changed?tab_id=${name}&edit_mode=true` },
+    { type: 'UTILIZATION' },
   ];
 
   const configuration = (name) => tabConfigurations(name).find((item) => item.type === type);

--- a/app/stylesheet/miq-custom-tab.scss
+++ b/app/stylesheet/miq-custom-tab.scss
@@ -1,9 +1,12 @@
 
+.miq_custom_tab_wrapper div[role='tabpanel'] {
+  display: none;
+}
+
 .miq_custom_tabs_container {
   display: flex;
   flex-direction: column;
   width: 100%;
-  margin-top: -32px;
 
   .tab_content {
     display: flex;

--- a/app/views/catalog/_form.html.haml
+++ b/app/views/catalog/_form.html.haml
@@ -1,7 +1,8 @@
 - catalog_tab_labels, catalog_condition = catalog_tab_edit_configuration(@edit[:new])
-= react('MiqCustomTab', {:containerId => 'catalog-tabs-edit',
-                         :tabLabels => catalog_tab_labels,
-                         :type => 'CATALOG_EDIT'})
+.miq_custom_tab_wrapper
+  = react('MiqCustomTab', {:containerId => 'catalog-tabs-edit',
+                          :tabLabels => catalog_tab_labels,
+                          :type => 'CATALOG_EDIT'})
 
 #catalog-tabs-edit.miq_custom_tabs_container
   = catalog_tab_content(:basic) do

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -1,10 +1,10 @@
 = render :partial => "layouts/flash_msg"
 - record, sb, tenants_tree, options, no_wf_msg = @record, @sb, @tenants_tree, @options, @no_wf_msg
 - tab_labels, condition = catalog_tab_configuration(record)
-
-= react('MiqCustomTab', {:containerId => 'catalog-tabs',
-                         :tabLabels => tab_labels,
-                         :type => 'CATALOG_SUMMARY'})
+.miq_custom_tab_wrapper
+  = react('MiqCustomTab', {:containerId => 'catalog-tabs',
+                          :tabLabels => tab_labels,
+                          :type => 'CATALOG_SUMMARY'})
 
 #catalog-tabs.miq_custom_tabs_container
   = catalog_tab_content(:basic) do

--- a/app/views/catalog/_st_angular_form.html.haml
+++ b/app/views/catalog/_st_angular_form.html.haml
@@ -1,7 +1,8 @@
 - @angular_form = true
-= react('MiqCustomTab', {:containerId => 'catalog-tabs-generic-edit',
-                         :tabLabels => catalog_tab_edit_generic_configuration,
-                         :type => 'CATALOG_EDIT'})
+.miq_custom_tab_wrapper
+  = react('MiqCustomTab', {:containerId => 'catalog-tabs-generic-edit',
+                          :tabLabels => catalog_tab_edit_generic_configuration,
+                          :type => 'CATALOG_EDIT'})
 
 
 %form.form-horizontal#form_div{"name" => "angularForm",

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -4,12 +4,13 @@
       = yield
 - elsif inner_layout_present?
   .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus.max-height{:style => "overflow: hidden !important"}
-    #breadcrumbs
-      = render :partial => "layouts/breadcrumbs"
-    .row.toolbar-pf#toolbar.miq-toolbar-menu
-      .col-sm-12
-        = miq_toolbar toolbar_from_hash
-    .row.max-height.content-focus-order
+    %header
+      #breadcrumbs
+        = render :partial => "layouts/breadcrumbs"
+      .row.toolbar-pf#toolbar.miq-toolbar-menu
+        .col-sm-12
+          = miq_toolbar toolbar_from_hash
+    %main.row.max-height.content-focus-order
       - if simulate?
         #left_div.sidebar-pf.sidebar-pf-left.scrollable.max-height.col-sm-5.col-md-4.col-sm-pull-7.col-md-pull-8
           #default_left_cell

--- a/app/views/miq_request/_prov_wf.html.haml
+++ b/app/views/miq_request/_prov_wf.html.haml
@@ -1,7 +1,7 @@
 -# wf					The workflow object currently in use
 -# dialog			The name (symbol) of the selected dialog
 - if (@options && @options[:wf]) || (@edit && @edit[:wf])
-  #prov_wf_div
+  #prov_wf_div.miq_custom_tab_wrapper
     - options = @options || @edit[:new]
     - wf = options[:wf] || @edit[:wf]
     - tabname = (@tabactive || options[:current_tab_key]).to_s

--- a/app/views/utilization/_utilization_tabs.html.haml
+++ b/app/views/utilization/_utilization_tabs.html.haml
@@ -1,18 +1,11 @@
-#utilization_tabs
-  %ul.nav.nav-tabs{'role' => 'tablist'}
-    = miq_tab_header('summary', @sb[:active_tab]) do
-      = _('Summary')
-    = miq_tab_header('details', @sb[:active_tab]) do
-      = _('Details')
-    = miq_tab_header('report', @sb[:active_tab]) do
-      = _('Report')
-  .tab-content
-    = miq_tab_content('summary', @sb[:active_tab]) do
+#utilization-tabs-wrapper.miq_custom_tab_wrapper
+  = react('MiqCustomTab', {:containerId => 'utilization-tabs',
+                           :tabLabels => utilization_tab_configuration,
+                           :type => 'UTILIZATION'})
+  #utilization-tabs.miq_custom_tabs_container
+    = utilization_tab_content(:summary) do
       = render :partial => "utilization_summary"
-    = miq_tab_content('details', @sb[:active_tab]) do
+    = utilization_tab_content(:details) do
       = render :partial => "utilization_details"
-    = miq_tab_content('report', @sb[:active_tab]) do
+    = utilization_tab_content(:report) do
       = render :partial => "utilization_report"
-
-:javascript
-  miq_tabs_init('#utilization_tabs', '/utilization/change_tab');


### PR DESCRIPTION
**Tabs conversion**
Before
Tab Panels fields were not selectable using the keyboard
<img width="1529" alt="image" src="https://user-images.githubusercontent.com/87487049/231061563-30acd8c7-81e4-43d2-a194-ff8a42af90b1.png">

After
Tab Panels fields can be selected using the keyboard
<img width="1534" alt="image" src="https://user-images.githubusercontent.com/87487049/231059949-783d50b0-62f3-439e-9546-871967ac6a5b.png">

**Accessibility violations fixes**
Before
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/87487049/231061671-5886db79-aa78-4a73-9265-8c1d8f0ec03a.png">

After
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/87487049/231060127-9314d428-7482-42a4-a1d3-5b57a1efe00c.png">

