### PR TITLE
Added new Button Class to Ensure "Management Console" Button Only Appears When it Should

### DIFF
--- a/app/helpers/application_helper/button/vm_management_console.rb
+++ b/app/helpers/application_helper/button/vm_management_console.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::VmManagementConsole < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.vendor == 'ibm_power_hmc'
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -306,7 +306,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Management Console'),
           :keepSpinner => true,
           :url         => "management_console",
-          :klass       => ApplicationHelper::Button::GenericFeatureButton,
+          :klass       => ApplicationHelper::Button::VmManagementConsole,
           :options     => {:feature => :native_console}
         ),
       ]


### PR DESCRIPTION
This change ensures that only vms belonging to a `IbmPowerHmc` Provider will have the Management Console button under the Access dropdown

Before:
![image](https://user-images.githubusercontent.com/64800041/233199186-540e1ad4-8918-4afb-a3cd-eeb5483d4593.png)
![image](https://user-images.githubusercontent.com/64800041/233199221-ab56afd5-7597-4cfe-b29f-b91e77e5bc4f.png)

After:
![image](https://user-images.githubusercontent.com/64800041/233199283-9479e9f4-50c2-4f04-a4fe-0bf1e3d82204.png)
![image](https://user-images.githubusercontent.com/64800041/233199308-47b5aaaf-90a6-492d-9e94-95bbdec27e74.png)
