### PR TITLE
Fix undefined name for infrastructure metric tables

### DIFF
--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/HeatMapChartGraph.js
@@ -5,7 +5,7 @@ import { getHeatMapData } from '../helpers';
 import EmptyChart from '../emptyChart';
 
 const HeatMapChartGraph = ({
-  data, dataPoint1, dataPoint2, dataPointAvailable,
+  data, dataPoint1, dataPoint2, dataPointAvailable, title,
 }) => {
   const heatmapCpuData = getHeatMapData(data[dataPoint1]);
   const heatmapMemoryData = getHeatMapData(data[dataPoint2]);
@@ -49,6 +49,7 @@ const HeatMapChartGraph = ({
   };
 
   const heatmapCpuOptions = {
+    title: sprintf(__('%s - CPU'), title),
     axes: {
       bottom: {
         visible: false,
@@ -83,6 +84,7 @@ const HeatMapChartGraph = ({
   };
 
   const heatmapMemoryOptions = {
+    title: sprintf(__('%s - Memory'), title),
     axes: {
       bottom: {
         visible: false,
@@ -156,6 +158,7 @@ HeatMapChartGraph.propTypes = {
   dataPoint1: PropTypes.string.isRequired,
   dataPoint2: PropTypes.string.isRequired,
   dataPointAvailable: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default HeatMapChartGraph;

--- a/app/javascript/components/provider-dashboard-charts/heat-map-chart/index.js
+++ b/app/javascript/components/provider-dashboard-charts/heat-map-chart/index.js
@@ -27,7 +27,13 @@ const HeatChart = ({
         <h2 className="card-pf-title">{title}</h2>
       </div>
       <div className="card-pf-body">
-        <HeatMapChartGraph data={data.vms} dataPoint1={dataPoint1} dataPoint2={dataPoint2} dataPointAvailable={dataPointAvailable} />
+        <HeatMapChartGraph
+          data={data.vms}
+          dataPoint1={dataPoint1}
+          dataPoint2={dataPoint2}
+          dataPointAvailable={dataPointAvailable}
+          title={title}
+        />
       </div>
     </div>
   );

--- a/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/index.js
+++ b/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/index.js
@@ -56,11 +56,25 @@ const UtilizationChartGraph = ({
       <div className="card-pf-body">
         <div className="row">
           <div className="col-xs-12 col-sm-12 col-md-12 col-lg-6 example-trend-container">
-            {processData.cpu.dataAvailable ? <UtilizationDonutChart data={data.metricsData} config={chartConfig[cpuConfig]} />
+            {processData.cpu.dataAvailable
+              ? (
+                <UtilizationDonutChart
+                  data={data.metricsData}
+                  config={chartConfig[cpuConfig]}
+                  title={title}
+                />
+              )
               : <EmptyChart />}
           </div>
           <div className="col-xs-12 col-sm-12 col-md-12 col-lg-6 example-trend-container">
-            {processData.memory.dataAvailable ? <UtilizationMemoryDonutChart data={data.metricsData} config={chartConfig[memoryConfig]} />
+            {processData.memory.dataAvailable
+              ? (
+                <UtilizationMemoryDonutChart
+                  data={data.metricsData}
+                  config={chartConfig[memoryConfig]}
+                  title={title}
+                />
+              )
               : <EmptyChart />}
           </div>
         </div>

--- a/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationDonutChart.js
+++ b/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationDonutChart.js
@@ -4,7 +4,7 @@ import { DonutChart, AreaChart } from '@carbon/charts-react';
 import { getConvertedData } from '../helpers';
 import EmptyChart from '../emptyChart';
 
-const UtilizationDonutChart = ({ data, config }) => {
+const UtilizationDonutChart = ({ data, config, title }) => {
   const cpuData = data.cpu ? data.cpu : data.xy_data.cpu;
   const donutChartData = [
     {
@@ -18,6 +18,7 @@ const UtilizationDonutChart = ({ data, config }) => {
   ];
 
   const donutOptions = {
+    title: `${title} - ${config.title}`,
     donut: {
       center: {
         label: __('Cores Used'),
@@ -119,6 +120,7 @@ UtilizationDonutChart.propTypes = {
     availableDataName: PropTypes.string.isRequired,
     sparklineTooltip: PropTypes.func.isRequired,
   }).isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default UtilizationDonutChart;

--- a/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationMemoryDonutChart.js
+++ b/app/javascript/components/provider-dashboard-charts/provider-dashboard-utilization-chart/utilizationMemoryDonutChart.js
@@ -4,7 +4,7 @@ import { DonutChart, AreaChart } from '@carbon/charts-react';
 import { getConvertedData } from '../helpers';
 import EmptyChart from '../emptyChart';
 
-const UtilizationMemoryDonutChart = ({ data, config }) => {
+const UtilizationMemoryDonutChart = ({ data, config, title }) => {
   const memoryData = data.memory ? data.memory : data.xy_data.memory;
   const donutChartData = [
     {
@@ -18,6 +18,7 @@ const UtilizationMemoryDonutChart = ({ data, config }) => {
   ];
 
   const donutOptions = {
+    title: `${title} - ${config.title}`,
     donut: {
       center: {
         label: __('GB Used'),
@@ -117,6 +118,7 @@ UtilizationMemoryDonutChart.propTypes = {
     availableDataName: PropTypes.string.isRequired,
     sparklineTooltip: PropTypes.func.isRequired,
   }).isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default UtilizationMemoryDonutChart;


### PR DESCRIPTION
**Normal Screen - Global Utilization - CPU**
After
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/87487049/233274744-b422b2c1-955e-40e4-af9a-2ab3a008a4d5.png">

**Full Screen - Global Utilization - CPU**
Before
![image](https://user-images.githubusercontent.com/87487049/233289451-69f1f1f2-3c07-4cc5-b199-fa2a6dd2c89f.png)
After
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/87487049/233275691-31e585ae-eac1-410f-94fc-a996040b243d.png">


**Normal Screen - Global Utilization - Memory**
Before
![image](https://user-images.githubusercontent.com/87487049/233289072-41b08182-5c7e-456b-b2b6-51cbffea7e56.png)
After
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/87487049/233275263-37671a31-147d-4792-9907-fb1e49617c31.png">

**Fullscreen- Global Utilization - Memory**
After
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/87487049/233276065-9c79720d-3118-4630-b203-2dbe566be146.png">

**Normal Screen - Cluster Utilization -CPU**
Before
<img width="974" alt="image" src="https://user-images.githubusercontent.com/87487049/233279296-3c49352f-f3cb-43fa-8f42-57ef598d11a9.png">
After
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/87487049/233275065-48f73fb9-0948-48fc-93f9-47d6864b04a0.png">

**Fullscreen - Cluster Utilization -CPU**
Before
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/87487049/233277263-30e80f91-223f-41f0-84c2-344c08852372.png">
After
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/87487049/233276209-b4573862-4701-4424-818d-f846f97f95dd.png">


**Normal Screen - Cluster Utilization - Memory**
Before
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/87487049/233277565-1b8ada0a-52fd-474a-821a-715ad85c71f6.png">
After
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/87487049/233275198-f12ed853-243b-4a4a-9b97-350504884899.png">

**Fullscreen - Cluster Utilization - Memory**
Before
<img width="909" alt="image" src="https://user-images.githubusercontent.com/87487049/233277381-39d064eb-2b4a-44af-9b73-6d83bd477c62.png">
After
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/87487049/233276286-4974d600-154d-4508-8ba9-9a509448d1f0.png">



