### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -43,7 +43,7 @@ class EmsCloudController < ApplicationController
   end
 
   def launch_console
-    open_console('ems_native_console')
+    open_console('ems_management_console')
   end
 
   menu_section :clo

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -211,7 +211,7 @@ class EmsInfraController < ApplicationController
   end
 
   def launch_console
-    open_console('ems_native_console')
+    open_console('ems_management_console')
   end
 
   def download_data

--- a/app/helpers/application_helper/button/management_console.rb
+++ b/app/helpers/application_helper/button/management_console.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ManagementConsole < ApplicationHelper::Button::Basic
+  needs(:@record)
+
+  def visible?
+    @record.supports?(:management_console)
+  end
+end

--- a/app/helpers/application_helper/button/native_console.rb
+++ b/app/helpers/application_helper/button/native_console.rb
@@ -1,7 +1,0 @@
-class ApplicationHelper::Button::NativeConsole < ApplicationHelper::Button::Basic
-  needs(:@record)
-
-  def visible?
-    @record.supports?(:native_console)
-  end
-end

--- a/app/helpers/application_helper/button/vm_management_console.rb
+++ b/app/helpers/application_helper/button/vm_management_console.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmManagementConsole < ApplicationHelper::Button
   needs :@record
 
   def visible?
-    @record.vendor == 'ibm_power_hmc'
+    @record.supports?(:management_console)
   end
 end

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -108,14 +108,14 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             :klass       => ApplicationHelper::Button::VmHtml5Console
           ),
           included_class.button(
-            :vm_native_console,
+            :vm_management_console,
             'pficon pficon-screen fa-lg',
             N_('Open a management console for this VM'),
             N_('Management Console'),
             :keepSpinner => true,
             :url         => "management_console",
             :klass       => ApplicationHelper::Button::GenericFeatureButton,
-            :options     => {:feature => :native_console}
+            :options     => {:feature => :management_console}
           ),
         ]
       ),

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -121,22 +121,22 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
       :url_parms => "?display=main"
     ),
   ])
-  button_group('ems_native_console', [
+  button_group('ems_management_console', [
     select(
-      :ems_native_console,
+      :ems_management_console,
       nil,
       N_('Remote Access'),
       N_('Access'),
       :items => [
         button(
-          :ems_native_console,
+          :ems_management_console,
           'pficon pficon-screen fa-lg',
-          N_('Open a native console for this cloud provider'),
-          N_('Native Console'),
+          N_('Open a management console for this cloud provider'),
+          N_('Management Console'),
           :keepSpinner => true,
           :url         => "launch_console",
-          :confirm     => N_("Open native console for this provider"),
-          :klass       => ApplicationHelper::Button::NativeConsole,
+          :confirm     => N_("Open management console for this provider"),
+          :klass       => ApplicationHelper::Button::ManagementConsole,
           :popup       => true
         )
       ]

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -133,22 +133,22 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
       ]
     ),
   ])
-  button_group('ems_native_console', [
+  button_group('ems_management_console', [
     select(
-      :ems_native_console,
+      :ems_management_console,
       nil,
       N_('Remote Access'),
       N_('Access'),
       :items => [
         button(
-          :ems_native_console,
+          :ems_management_console,
           'pficon pficon-screen fa-lg',
-          N_('Open a native console for this infrastructure provider'),
-          N_('Native Console'),
+          N_('Open a management console for this infrastructure provider'),
+          N_('Management Console'),
           :keepSpinner => true,
           :url         => "launch_console",
-          :confirm     => N_("Open native console for this provider"),
-          :klass       => ApplicationHelper::Button::NativeConsole,
+          :confirm     => N_("Open management console for this provider"),
+          :klass       => ApplicationHelper::Button::ManagementConsole,
           :popup       => true
         )
       ]

--- a/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_physical_infra_center.rb
@@ -92,7 +92,7 @@ class ApplicationHelper::Toolbar::EmsPhysicalInfraCenter < ApplicationHelper::To
           :keepSpinner => true,
           :url         => "launch_console",
           :confirm     => N_("Open management console for this provider"),
-          :klass       => ApplicationHelper::Button::NativeConsole,
+          :klass       => ApplicationHelper::Button::ManagementConsole,
           :options     => {:feature => :console})
       ]
     ),

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -309,14 +309,14 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :klass       => ApplicationHelper::Button::VmNativeConsole
         ),
         button(
-          :vm_native_console,
+          :vm_management_console,
           'pficon pficon-screen fa-lg',
           N_('Open a management console for this VM'),
           N_('Management Console'),
           :keepSpinner => true,
           :url         => "management_console",
           :klass       => ApplicationHelper::Button::VmManagementConsole,
-          :options     => {:feature => :native_console}
+          :options     => {:feature => :management_console}
         ),
       ]
     ),


### PR DESCRIPTION
Follow up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/8758

Changes the feature name for the IBM providers from `native_console` to `management_console` since `native_console` is already used by the RHV provider. Also still resolves the issue the above pr was attempting to fix.

Other PRs:
core -> https://github.com/ManageIQ/manageiq/pull/22474
Lenovo -> https://github.com/ManageIQ/manageiq-providers-lenovo/pull/389 
vmware -> https://github.com/ManageIQ/manageiq-providers-vmware/pull/874
ibm_power_hmc -> https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/136
ibm_terraform -> https://github.com/ManageIQ/manageiq-providers-ibm_terraform/pull/94
ibm_cloud -> https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/451
ibm_power_vc -> https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/90
