### PR TITLE
Give chargeback users sorting by date and project

### DIFF
--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -156,7 +156,9 @@
     %label.control-label.col-md-2
       = _('Group by')
     .col-md-8
-      - opts = [[(_("Date and %{chargeback_model}")  % {:chargeback_model => @edit[:new][:cb_model]} ), "date"], ["#{_('Date Only')}", "date-only"]]
+      - opts =  [[(_("%{chargeback_model} and Date") % {:chargeback_model => @edit[:new][:cb_model]} ), "date"]]
+      - opts += [[(_("Date and %{chargeback_model}") % {:chargeback_model => @edit[:new][:cb_model]} ), "date-first"]]
+      - opts += [["#{_('Date Only')}", "date-only"]]
       - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Project')}", "project"], [_('Label'), 'label'], ["#{_('Tag')}", "tag"]] if @edit[:new][:model] == "ChargebackContainerImage" || @edit[:new][:model] == "MeteringContainerImage"
       - opts += [["#{_('Tenant')}", "tenant"]] if %w(ChargebackVm MeteringVm).include?(@edit[:new][:model])


### PR DESCRIPTION
depends upon:
- [x] https://github.com/ManageIQ/manageiq/pull/22475

Currently users can view by project and then each line listed by date. Now, this PR allows users to have date as the first layer with projects listed underneath them.

This applies to all chargeback reports, not just containers/projects

## Existing

![chargebacks-1](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/67e056e1-792b-452a-b514-38e1387ffe91)

![chargebacks-3](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/5ce1a62e-434b-4008-a297-448baff304eb)

## Added

![chargebacks-2](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/4788d287-955a-4b3c-b255-a5159a5983c9)


