### PR TITLE
add icon for non_operational

### DIFF
--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -32,6 +32,7 @@ class GtlFormatter
     'archived'                  => 'fa fa-archive',
     'orphaned'                  => 'ff ff-orphaned',
     'retired'                   => 'fa fa-clock-o',
+    'non_operational'           => 'pficon pficon-exclamation',
     'suspended'                 => 'pficon pficon-asleep',
     'standby'                   => 'pficon pficon-asleep',
     'paused'                    => 'pficon pficon-asleep',


### PR DESCRIPTION
Use fa-unplugged as an icon indicating non operational machine state

This state was introduced before 2015

I could not find any other states in the providers that were not already in the list of states in the ui helper.
Of note

- [OpenStack](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/cloud_manager/vm.rb#L27) links `error` to `non_operational`.
- [ibm power hmc](https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/blob/master/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb#L72) links `error` to `unknown`
- [kubevirt](https://github.com/kbrock/manageiq-providers-kubevirt/blob/master/app/models/manageiq/providers/kubevirt/infra_manager/vm.rb#L10) links `Failed` to `off`

---

I was not able to reproduce the problem.
But I feel pretty confident in this solution.