### PR TITLE
update non_operational to match other non_operational status

### DIFF
--- a/lib/gtl_formatter.rb
+++ b/lib/gtl_formatter.rb
@@ -32,7 +32,7 @@ class GtlFormatter
     'archived'                  => 'fa fa-archive',
     'orphaned'                  => 'ff ff-orphaned',
     'retired'                   => 'fa fa-clock-o',
-    'non_operational'           => 'pficon pficon-exclamation',
+    'non_operational'           => 'fa fa-exclamation',
     'suspended'                 => 'pficon pficon-asleep',
     'standby'                   => 'pficon pficon-asleep',
     'paused'                    => 'pficon pficon-asleep',


### PR DESCRIPTION
the summary page uses fa-exclamation
Following suite

fixes #8776

@agrare I like the idea of changing the provider to return `error` instead.

https://github.com/ManageIQ/manageiq-ui-classic/pull/8776#issuecomment-1531875827