### PR TITLE
Fix quota list visibility for tenants

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -163,7 +163,13 @@ module OpsHelper::TextualSummary
 
   def textual_tenant_quota_allocations
     h = {:title     => _("Tenant Quota"),
-         :headers   => [_("Name"), _("Total Quota"), _("In Use"), _("Allocated"), _("Available")],
+         :headers   => [
+           {:key => :name,         :label => _("Name")},
+           {:key => :total_quota,  :label => _("Total Quota")},
+           {:key => :in_use,       :label => _("In Use")},
+           {:key => :allocated,    :label => _("Allocated")},
+           {:key => :available,    :label => _("Available")},
+         ],
          :col_order => %w[name total in_use allocated available]}
     h[:value] = get_tenant_quota_allocations
     h
@@ -194,17 +200,18 @@ module OpsHelper::TextualSummary
 
   def get_tenant_quota_allocations
     rows = @record.combined_quotas.values.to_a
+
     rows.collect do |row|
       {
-        :title     => row[:description],
-        :name      => row[:description],
-        :in_use    => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:used], :in_use),
-        :allocated => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:allocated],
-                                                          :allocated),
-        :available => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:available],
-                                                          :available),
-        :total     => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:value], :total),
-        :explorer  => true
+        :title       => row[:description],
+        :name        => row[:description],
+        :in_use      => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:used], :in_use),
+        :allocated   => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:allocated],
+                                                            :allocated),
+        :available   => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:available],
+                                                            :available),
+        :total_quota => convert_to_format_with_default_text(row[:format], row[:text_modifier], row[:value], :total),
+        :explorer    => true
       }
     end
   end

--- a/app/javascript/components/miq-structured-list/index.jsx
+++ b/app/javascript/components/miq-structured-list/index.jsx
@@ -25,7 +25,7 @@ const MiqStructuredList = ({
 }) => {
   const clickEvents = hasClickEvents(mode);
 
-  const borderedList = ['simple_table', 'multilink_table'];
+  const borderedList = ['simple_table', 'multilink_table', 'table_list_view'];
 
   const hasBorder = borderedList.includes(mode);
 

--- a/app/javascript/components/textual_summary/table_list_view.jsx
+++ b/app/javascript/components/textual_summary/table_list_view.jsx
@@ -30,14 +30,13 @@ export default function TableListView(props) {
 
   /** Function to generate rows for structured list. */
   const miqListRows = (list) => {
-    const data = [];
-    list.map((item) => data.push({ ...item, label: item.name }));
-    return data;
+    const headerKeys = props.headers.map((item) => (item.key));
+    return list.map((item) => (headerKeys.map((header) => item[header])));
   };
 
   return (
     <MiqStructuredList
-      headers={headers}
+      headers={headers.map((item) => item.label)}
       rows={miqListRows(values)}
       title={title}
       mode="table_list_view"
@@ -48,7 +47,7 @@ export default function TableListView(props) {
 
 TableListView.propTypes = {
   title: PropTypes.string.isRequired,
-  headers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  headers: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string, label: PropTypes.string })).isRequired,
   values: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClick: PropTypes.func.isRequired,
 };

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -2478,7 +2478,7 @@ exports[`Structured list component should render miq_ae_class_list_view with esc
   >
     <FeatureToggle(StructuredListWrapper)
       ariaLabel="Structured list"
-      className="miq-structured-list table_list_view"
+      className="miq-structured-list bordered-list table_list_view"
     >
       <FeatureToggle(StructuredListBody)>
         <FeatureToggle(StructuredListRow)

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
@@ -39,30 +39,22 @@ exports[`TableListView renders just fine... 1`] = `
   <MiqStructuredList
     headers={
       Array [
-        "Name",
-        "Rows",
+        undefined,
+        undefined,
       ]
     }
     mode="table_list_view"
     onClick={[Function]}
     rows={
       Array [
-        Object {
-          "explorer": true,
-          "label": "vim_performance_states",
-          "link": "miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');",
-          "name": "vim_performance_states",
-          "title": "vim_performance_states",
-          "value": "676,150",
-        },
-        Object {
-          "explorer": true,
-          "label": "miq_report_result_details",
-          "link": "miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');",
-          "name": "miq_report_result_details",
-          "title": "miq_report_result_details",
-          "value": "280,848",
-        },
+        Array [
+          undefined,
+          undefined,
+        ],
+        Array [
+          undefined,
+          undefined,
+        ],
       ]
     }
     title="Tables with the Most Rows"
@@ -146,25 +138,25 @@ exports[`TableListView renders just fine... 1`] = `
             >
               <FeatureToggle(StructuredListWrapper)
                 ariaLabel="Structured list"
-                className="miq-structured-list table_list_view"
+                className="miq-structured-list bordered-list table_list_view"
               >
                 <StructuredListWrapper
                   ariaLabel="Structured list"
-                  className="miq-structured-list table_list_view"
+                  className="miq-structured-list bordered-list table_list_view"
                   isCondensed={false}
                   isFlush={false}
                   selection={false}
                 >
                   <div
                     aria-label="Structured list"
-                    className="bx--structured-list miq-structured-list table_list_view"
+                    className="bx--structured-list miq-structured-list bordered-list table_list_view"
                     role="table"
                   >
                     <MiqStructuredListHeader
                       headers={
                         Array [
-                          "Name",
-                          "Rows",
+                          undefined,
+                          undefined,
                         ]
                       }
                     >
@@ -201,9 +193,7 @@ exports[`TableListView renders just fine... 1`] = `
                                       <div
                                         className="list_header bx--structured-list-th"
                                         role="columnheader"
-                                      >
-                                        Name
-                                      </div>
+                                      />
                                     </StructuredListCell>
                                   </FeatureToggle(StructuredListCell)>
                                   <FeatureToggle(StructuredListCell)
@@ -219,9 +209,7 @@ exports[`TableListView renders just fine... 1`] = `
                                       <div
                                         className="list_header bx--structured-list-th"
                                         role="columnheader"
-                                      >
-                                        Rows
-                                      </div>
+                                      />
                                     </StructuredListCell>
                                   </FeatureToggle(StructuredListCell)>
                                 </div>
@@ -263,60 +251,52 @@ exports[`TableListView renders just fine... 1`] = `
                                 title=""
                               >
                                 <FeatureToggle(StructuredListCell)
-                                  className="label_header"
+                                  className="content_value array_item"
+                                  key="0"
+                                  onClick={[Function]}
+                                  title=""
                                 >
                                   <StructuredListCell
-                                    className="label_header"
+                                    className="content_value array_item"
                                     head={false}
                                     noWrap={false}
+                                    onClick={[Function]}
+                                    title=""
                                   >
                                     <div
-                                      className="label_header bx--structured-list-td"
+                                      className="content_value array_item bx--structured-list-td"
+                                      onClick={[Function]}
                                       role="cell"
+                                      title=""
                                     >
-                                      vim_performance_states
+                                      <div
+                                        className="wrap_text"
+                                      />
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
                                 <FeatureToggle(StructuredListCell)
-                                  className="content_value object_item"
-                                  title="vim_performance_states"
+                                  className="content_value array_item"
+                                  key="1"
+                                  onClick={[Function]}
+                                  title=""
                                 >
                                   <StructuredListCell
-                                    className="content_value object_item"
+                                    className="content_value array_item"
                                     head={false}
                                     noWrap={false}
-                                    title="vim_performance_states"
+                                    onClick={[Function]}
+                                    title=""
                                   >
                                     <div
-                                      className="content_value object_item bx--structured-list-td"
+                                      className="content_value array_item bx--structured-list-td"
+                                      onClick={[Function]}
                                       role="cell"
-                                      title="vim_performance_states"
+                                      title=""
                                     >
-                                      <Link
-                                        className="cell_link"
-                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
-                                        onClick={[Function]}
-                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
-                                      >
-                                        <a
-                                          className="bx--link cell_link"
-                                          href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
-                                          onClick={[Function]}
-                                          rel={null}
-                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
-                                        >
-                                          <div
-                                            className="content"
-                                          >
-                                            <div
-                                              className="expand wrap_text"
-                                            >
-                                              676,150
-                                            </div>
-                                          </div>
-                                        </a>
-                                      </Link>
+                                      <div
+                                        className="wrap_text"
+                                      />
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
@@ -346,60 +326,52 @@ exports[`TableListView renders just fine... 1`] = `
                                 title=""
                               >
                                 <FeatureToggle(StructuredListCell)
-                                  className="label_header"
+                                  className="content_value array_item"
+                                  key="0"
+                                  onClick={[Function]}
+                                  title=""
                                 >
                                   <StructuredListCell
-                                    className="label_header"
+                                    className="content_value array_item"
                                     head={false}
                                     noWrap={false}
+                                    onClick={[Function]}
+                                    title=""
                                   >
                                     <div
-                                      className="label_header bx--structured-list-td"
+                                      className="content_value array_item bx--structured-list-td"
+                                      onClick={[Function]}
                                       role="cell"
+                                      title=""
                                     >
-                                      miq_report_result_details
+                                      <div
+                                        className="wrap_text"
+                                      />
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>
                                 <FeatureToggle(StructuredListCell)
-                                  className="content_value object_item"
-                                  title="miq_report_result_details"
+                                  className="content_value array_item"
+                                  key="1"
+                                  onClick={[Function]}
+                                  title=""
                                 >
                                   <StructuredListCell
-                                    className="content_value object_item"
+                                    className="content_value array_item"
                                     head={false}
                                     noWrap={false}
-                                    title="miq_report_result_details"
+                                    onClick={[Function]}
+                                    title=""
                                   >
                                     <div
-                                      className="content_value object_item bx--structured-list-td"
+                                      className="content_value array_item bx--structured-list-td"
+                                      onClick={[Function]}
                                       role="cell"
-                                      title="miq_report_result_details"
+                                      title=""
                                     >
-                                      <Link
-                                        className="cell_link"
-                                        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
-                                        onClick={[Function]}
-                                        to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
-                                      >
-                                        <a
-                                          className="bx--link cell_link"
-                                          href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
-                                          onClick={[Function]}
-                                          rel={null}
-                                          to="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
-                                        >
-                                          <div
-                                            className="content"
-                                          >
-                                            <div
-                                              className="expand wrap_text"
-                                            >
-                                              280,848
-                                            </div>
-                                          </div>
-                                        </a>
-                                      </Link>
+                                      <div
+                                        className="wrap_text"
+                                      />
                                     </div>
                                   </StructuredListCell>
                                 </FeatureToggle(StructuredListCell)>

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -1,7 +1,7 @@
 = render :partial => 'layouts/textual_groups_generic'
 #tenant_info
   .row
-    .col-md-12.col-lg-10
+    .col-md-12.col-lg-12
       = react 'TableListViewWrapper', TextualListview.data(textual_tenant_quota_allocations)
       %p
         = _("Note: Total quota can be restricted by quotas defined at upper levels")


### PR DESCRIPTION
Before
unable to view the tenant quota details
<img width="1526" alt="image" src="https://user-images.githubusercontent.com/87487049/236155914-3c189176-f04b-4562-8e4b-35fa6aa0b98d.png">

After

- Modified the keyword from `total` to `total_quota` to match header and its row-cell item
- Adjusted the width of the Tenant Quota block to screen width (lg-10 to lg-12)
- Modified the **TableListView** component to prepare the data necessary for the **MiqStructuredList**
- Added border to the mode `table_list_view`

<img width="1539" alt="image" src="https://user-images.githubusercontent.com/87487049/236154978-b9887d4c-b893-4a6b-a314-d374948f4ffa.png">
