### PR TITLE
volume-mapping: filter-out already mapped hosts and groups 

### DIFF
--- a/app/javascript/components/volume-mapping-form/index.jsx
+++ b/app/javascript/components/volume-mapping-form/index.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Loading } from 'carbon-components-react';
-
 import MiqFormRenderer from '@@ddf';
 import createSchema from './volume-mapping-form.schema';
 import miqRedirectBack from '../../helpers/miq-redirect-back';
+import mapper from '../../forms/mappers/componentMapper';
+import enhancedSelect from '../../helpers/enhanced-select';
 
 const VolumeMappingForm = ({ redirect, storageManagerId }) => {
   const [state, setState] = useState({});
@@ -12,7 +13,7 @@ const VolumeMappingForm = ({ redirect, storageManagerId }) => {
   const { isLoading, initialValues } = state;
   const [volumeId, setVolumeId] = useState(undefined);
   const [hostInitiatorId, setHostInitiatorId] = useState(undefined);
-  const [hostInitiatorGroupId, setHostInitiatorGroupId] =  useState(undefined);
+  const [hostInitiatorGroupId, setHostInitiatorGroupId] = useState(undefined);
 
   const loadSchema = (appendState = {}) => () => {
     setState((state) => ({
@@ -42,9 +43,16 @@ const VolumeMappingForm = ({ redirect, storageManagerId }) => {
 
   if (isLoading) return <Loading className="export-spinner" withOverlay={false} small />;
 
+  const componentMapper = {
+    ...mapper,
+    'enhanced-select': enhancedSelect,
+  };
+
   return !isLoading && (
     <MiqFormRenderer
-      schema={createSchema(state, setState, !!storageManagerId, initialValues, storageId, setStorageId, volumeId, setVolumeId, hostInitiatorId, setHostInitiatorId, hostInitiatorGroupId, setHostInitiatorGroupId)}
+      schema={createSchema(state, setState, !!storageManagerId, initialValues, storageId, setStorageId, volumeId,
+        setVolumeId, hostInitiatorId, setHostInitiatorId, hostInitiatorGroupId, setHostInitiatorGroupId)}
+      componentMapper={componentMapper}
       initialValues={initialValues}
       onSubmit={onSubmit}
       onCancel={onCancel}

--- a/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
+++ b/app/javascript/components/volume-mapping-form/volume-mapping-form.schema.js
@@ -9,6 +9,7 @@ export const portTypes = [
 
 const loadProviders = () =>
   API.get(
+    // eslint-disable-next-line max-len
     '/api/providers?expand=resources&attributes=id,name,supports_block_storage&filter[]=supports_block_storage=true&filter[]=supports_add_volume_mapping=true',
   ).then(({ resources }) =>
     resources.map(({ id, name }) => ({ value: id, label: name })));
@@ -25,22 +26,54 @@ const loadCloudVolumes = (storage_id) => API.get(`/api/cloud_volumes/?expand=res
     value: id,
   })));
 
-const loadHostInitiators = (storage_id) =>
-  API.get(`/api/host_initiators/?expand=resources&attributes=id,name&filter[]=physical_storage.id=${storage_id}`)
-    .then(({ resources }) => resources.map(({ name, id }) => ({
-      label: name,
-      value: id,
-    })));
+const loadHostInitiators = (storage_id, volume_id) =>
+  API.get(`/api/host_initiators/?expand=resources&attributes=id,name,cloud_volumes&filter[]=physical_storage.id=${storage_id}`)
+    .then(({ resources }) => {
+      const hostsUnmappedToVolume = resources.filter((host) => {
+        const volumeIds = host.cloud_volumes.map(({ id }) => id);
+        return !volumeIds.includes(volume_id);
+      });
 
-const loadHostInitiatorGroups = (storage_id) =>
-  API.get(`/api/host_initiators/?expand=resources&attributes=host_cluster_name,host_initiator_group_id&filter[]=host_initiator_group_id!=null&filter[]=physical_storage.id=${storage_id}`)
-    .then(({ resources }) => [...new Map(resources.map((item) => [item.host_initiator_group_id, ({
-      label: item.host_cluster_name,
-      value: item.host_initiator_group_id,
-    })])).values()]);
+      const options = hostsUnmappedToVolume.map(({ name, id }) => ({
+        label: name,
+        value: id,
+      }));
 
-const createSchema = (state, setState, ems, initialValues, storageId, setStorageId, volumeId, setVolumeId,
-  hostInitiatorId, setHostInitiatorId, hostInitiatorGroupId, setHostInitiatorGroupId) => {
+      if (options.length === 0) {
+        options.unshift({ label: sprintf(__('No Host Initiator found')), value: '-1' });
+      } else {
+        options.unshift({ label: `<${__('Choose')}>`, value: '-1' });
+      }
+
+      return options;
+    });
+
+const loadHostInitiatorGroups = (storage_id, volume_id) =>
+  // eslint-disable-next-line max-len
+  API.get(`/api/host_initiator_groups/?expand=resources&attributes=id,name,host_initiators,cloud_volumes&filter[]=physical_storage.id=${storage_id}`)
+    .then(({ resources }) => {
+      const nonEmptyGroups = resources.filter((group) => group.host_initiators.length > 0);
+
+      const groupsUnmappedToVolume = nonEmptyGroups.filter((group) => {
+        const volumeIds = group.cloud_volumes.map(({ id }) => id);
+        return !volumeIds.includes(volume_id);
+      });
+
+      const options = groupsUnmappedToVolume.map(({ name, id }) => ({
+        label: name,
+        value: id,
+      }));
+
+      if (options.length === 0) {
+        options.unshift({ label: sprintf(__('No Host Initiator Group found')), value: '-1' });
+      } else {
+        options.unshift({ label: `<${__('Choose')}>`, value: '-1' });
+      }
+
+      return options;
+    });
+
+const createSchema = (state, setState, ems, initialValues, storageId, setStorageId, volumeId, setVolumeId) => {
   let emsId = state.ems_id;
   if (initialValues && initialValues.ems_id) {
     emsId = initialValues.ems_id;
@@ -91,28 +124,38 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         key: `cloud_volume_id-${storageId}`,
         condition: {
           and: [
-            {when: 'physical_storage_id', isNotEmpty: true,},
-            {when: 'ems_id', isNotEmpty: true,},
-          ]
+            { when: 'physical_storage_id', isNotEmpty: true },
+            { when: 'ems_id', isNotEmpty: true },
+          ],
         },
       },
       {
-        component: componentTypes.SELECT,
+        component: 'enhanced-select',
         name: 'host_initiator_id',
         id: 'host_initiator_id',
         label: __('Host Initiator:'),
         isRequired: true,
-        includeEmpty: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
-        loadOptions: () => (storageId ? loadHostInitiators(storageId) : Promise.resolve([])),
-        onChange: (host_initiator_id) => setHostInitiatorId(host_initiator_id),
-        key: `host_initiator_id-${storageId}`,
+        validate: [
+          { type: validatorTypes.REQUIRED },
+          { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: __('Required') },
+        ],
+        onInputChange: () => null,
+        resolveProps: (_props, _field, { getState }) => {
+          const stateValues = getState().values;
+          const volume = stateValues.cloud_volume_id;
+
+          return {
+            key: JSON.stringify(volume),
+            loadOptions: async() => loadHostInitiators(storageId, volume),
+          };
+        },
         condition: {
           and: [
-            {when: 'physical_storage_id', isNotEmpty: true,},
-            {when: 'ems_id', isNotEmpty: true,},
-            {when: 'mapping_object', is: "host"}
-          ]
+            { when: 'ems_id', isNotEmpty: true },
+            { when: 'physical_storage_id', isNotEmpty: true },
+            { when: 'cloud_volume_id', isNotEmpty: true },
+            { when: 'mapping_object', is: 'host' },
+          ],
         },
       },
       {
@@ -121,43 +164,53 @@ const createSchema = (state, setState, ems, initialValues, storageId, setStorage
         id: 'host_initiator_group_id',
         label: __('Host Initiator Group:'),
         isRequired: true,
-        helperText: __("Note! Volume can't be mapped to an empty host-initiator-group (host-cluster). Empty host-initiator-groups are not listed."),
-        includeEmpty: true,
-        validate: [{ type: validatorTypes.REQUIRED }],
-        loadOptions: () => (storageId ? loadHostInitiatorGroups(storageId) : Promise.resolve([])),
-        onChange: (host_initiator_group_id) => setHostInitiatorGroupId(host_initiator_group_id),
-        key: `host_initiator_group_id-${storageId}`,
+        helperText: __('This list does not include host initiator groups which have no host initiators or which are '
+          + 'already mapped to the selected volume.'),
+        validate: [
+          { type: validatorTypes.REQUIRED },
+          { type: validatorTypes.PATTERN, pattern: '^(?!-)', message: __('Required') },
+        ],
+        onInputChange: () => null,
+        resolveProps: (_props, _field, { getState }) => {
+          const stateValues = getState().values;
+          const volume = stateValues.cloud_volume_id;
+
+          return {
+            key: JSON.stringify(volume),
+            loadOptions: async() => loadHostInitiatorGroups(storageId, volume),
+          };
+        },
         condition: {
           and: [
-            {when: 'physical_storage_id', isNotEmpty: true,},
-            {when: 'ems_id', isNotEmpty: true,},
-            {when: 'mapping_object', is: "host_group"}
-          ]
+            { when: 'ems_id', isNotEmpty: true },
+            { when: 'physical_storage_id', isNotEmpty: true },
+            { when: 'cloud_volume_id', isNotEmpty: true },
+            { when: 'mapping_object', is: 'host_group' },
+          ],
         },
       },
       {
-      "component": "radio",
-      "label": "Map directly to Host Initiator, or to a Group?",
-      "name": "mapping_object",
-      "initialValue": "host",
-      condition: {
-        and: [
-          {when: 'physical_storage_id', isNotEmpty: true,},
-          {when: 'ems_id', isNotEmpty: true,},
-        ]
-      },
-      "options": [
-        {
-          "label": "Host Initiator",
-          "value": "host"
+        component: 'radio',
+        label: 'Map directly to Host Initiator, or to a Group?',
+        name: 'mapping_object',
+        initialValue: 'host',
+        condition: {
+          and: [
+            { when: 'physical_storage_id', isNotEmpty: true },
+            { when: 'ems_id', isNotEmpty: true },
+          ],
         },
-        {
-          "label": "Host Initiator Group",
-          "value": "host_group"
-        }
-      ]
-    }
-
+        options: [
+          {
+            label: 'Host Initiator',
+            value: 'host',
+          },
+          {
+            label: 'Host Initiator Group',
+            value: 'host_group',
+          },
+        ],
+      },
 
     ],
   });


### PR DESCRIPTION
**before:**
volume mapping creation form didn't block user from requesting creation of volume mapping between already mapped volume-host or volume-host group: 
![b36bdd6c-22ad-405e-bb01-a1bee89793e6](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/17356e9e-19a0-47e3-940a-3a53359af01a)

![8a93aec4-47ac-4d28-8218-cbdb451ff84b](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/0ed8c32e-4942-4460-aa5a-7150b5023d9d)

this led to the following errors (for host and host-group respectively):

![9ea8174f-89b3-4beb-9589-1d744623f8a5](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/d3185407-3fb5-4e40-94c7-3b1abda30b01)

![6b452617-b940-4913-a328-a127fbb0bbb4](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/3b3da110-df9f-4c41-a5b7-417a2134285b)


**after:**
volume-mapping now filters out hosts and groups which are already mapped to the selected volume:
system has 3 hosts and 2 groups:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/ff27a441-8bb3-4a31-902f-98dc71228f9e)

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/561af2e4-c48e-47d1-a9a7-d14fc007d656)

volume1 is already mapped to all hosts/groups
volume2 is mapped only to host2
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/e717f09a-1399-4e96-b579-d1b01cae5b4e)

mapping creation now finds no candidate hosts or groups to map to volume1:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/8d999264-40e4-44ad-a7d2-34a325955660)

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/e75c392c-838d-4070-85d1-9059f9bbf5be)

volume2 can be mapped to hosts 1 and 3, excluding host 2, and to all groups
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/f9926ecd-62e5-41a2-9aa6-41c5ae504a6b)

![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/6e4885af-d4ff-4a56-9229-7ce32487052c)

volume3 can be mapped to everything:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/f064ef53-11ca-43eb-946a-fdc87c0153ed)


