### PR TITLE
Mark Strings in Request Details for Translation

### DIFF
--- a/app/controllers/mixins/breadcrumbs_mixin.rb
+++ b/app/controllers/mixins/breadcrumbs_mixin.rb
@@ -44,7 +44,7 @@ module Mixins
         # Append title breadcrumb if they exist and not same as previous breadcrumb (eg "Editing name")
         # Also do not append when user is on show_list page, the menu title is used instead of it
         if @title && !same_as_last_breadcrumb?(breadcrumbs, @title) && !show_list_page? && !options[:hide_title]
-          breadcrumbs.push(:title => @title)
+          breadcrumbs.push(:title => _(@title))
         end
       else
         options[:x_node] ||= x_node

--- a/app/helpers/request_details_helper.rb
+++ b/app/helpers/request_details_helper.rb
@@ -8,18 +8,18 @@ module RequestDetailsHelper
   def request_details_summary(miq_request, user)
     rows = [
       row_data(_('Request ID'), miq_request.id),
-      row_data(_('Status'), miq_request.status),
-      row_data(_('Request State'), miq_request.state.titleize)
+      row_data(_('Status'), _(miq_request.status)),
+      row_data(_('Request State'), _(miq_request.state.titleize))
     ]
     rows.push(row_data(_('Requester'), miq_request.requester_name)) if miq_request.requester
-    rows.push(row_data(_('Request Type'), miq_request.request_type_display))
-    rows.push(row_data(_('Description'), miq_request.description))
+    rows.push(row_data(_('Request Type'), _(miq_request.request_type_display)))
+    rows.push(row_data(_('Description'), _(miq_request.description)))
     rows.push(row_data(_('Last Message'), miq_request.message))
     rows.push(row_data(_('Created On'), format_timezone(miq_request.created_on)))
     rows.push(row_data(_('Last Update'), format_timezone(miq_request.updated_on)))
     rows.push(row_data_with_link(_("Parent Request"), "/miq_request/show/#{miq_request.parent_id}", "/miq_request/show/#{miq_request.parent_id}")) if miq_request.parent_id
     rows.push(row_data(_("Completed"), format_timezone(miq_request.fulfilled_on))) if miq_request.fulfilled_on
-    rows.push(row_data(_('Approval State'), miq_request.approval_state.titleize))
+    rows.push(row_data(_('Approval State'), _(miq_request.approval_state.titleize)))
     rows.push(row_data(_("Approved/Denied by"), miq_request.stamped_by + (user && " (#{user.name})"))) if miq_request.stamped_by
     rows.push(row_data(_("Approved/Denied on"), format_timezone(miq_request.stamped_on)))
     rows.push(row_data(_("Reason"), _(miq_request.reason)))

--- a/app/views/layouts/_tabs.html.haml
+++ b/app/views/layouts/_tabs.html.haml
@@ -60,4 +60,4 @@
           = safe_right_cell_text
     - else
       %h1
-        = @title
+        = _(@title)


### PR DESCRIPTION
Depends On: https://github.com/ManageIQ/manageiq/pull/22506

Found in: Services -> Requests -> Select Request From List

Marks strings for translation in the Request Details page. Most of these strings used to be marked prior to the recent form conversion.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/751c3eda-78ec-4c62-956a-73468ee5aad7)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/e403c82f-e1cd-476a-a88b-c35f48a69442)
