### PR TITLE
Fix for missing tab contents while adding service catalog item and provisioning instance

### DIFF
--- a/app/stylesheet/miq-custom-tab.scss
+++ b/app/stylesheet/miq-custom-tab.scss
@@ -1,5 +1,5 @@
 
-.miq_custom_tab_wrapper div[role='tabpanel'] {
+.miq_custom_tab_wrapper .bx--tab-content {
   display: none;
 }
 

--- a/app/views/miq_request/_prov_wf.html.haml
+++ b/app/views/miq_request/_prov_wf.html.haml
@@ -7,7 +7,8 @@
     - tabname = (@tabactive || options[:current_tab_key]).to_s
     - prov_tab_labels, prov_tab_keys = provision_tab_configuration(wf)
 
-    = react('MiqCustomTab', {:containerId => 'request-info-tabs',
+    .miq_custom_tab_wrapper
+      = react('MiqCustomTab', {:containerId => 'request-info-tabs',
                              :tabLabels => prov_tab_labels,
                              :type => 'CATALOG_REQUEST_INFO'})
 


### PR DESCRIPTION
Before
<img width="1532" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/c2edda59-9773-477f-ad8f-f81068bb1ecc">
<img width="769" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/006a2d8e-f994-4fd3-892c-22d36594e48d">

After
<img width="1534" alt="Screenshot 2023-05-12 at 11 21 50 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/428dc306-425a-4ce9-9cc6-d1ac7855d737">
<img width="1531" alt="Screenshot 2023-05-12 at 11 20 28 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/1b393089-34cb-4f57-8b72-17cb75f29ce8">

