### PR TITLE
[WIP] Revert "Merge pull request #8262 from vibhaKulka/s390x-patch"

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -8,7 +8,6 @@ namespace :update do
         end
         puts "== #{engine.name} =="
         system("which yarn >/dev/null") || abort("\n== You have to install yarn ==")
-        system("yarn set version 1.22.18") || abort("\n== yarn failed to set version to 1.22.18 in #{engine.path} ==") if RUBY_PLATFORM.include?("s390x")
         system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
       end
     end


### PR DESCRIPTION
This reverts commit 939968feb7c5f55306d654e81bdbf6c94b2bcf83, reversing changes made to 7b3ca342c28abebe9f2dfb83faa8cf7abfbcd768.

On petrosian, s390x rpm build fails with:
```
 ---> yarn set version 1.22.18[0m[0m
➤ YN0000: Retrieving https://github.com/yarnpkg/yarn/releases/download/v1.22.18/yarn-1.22.18.js
➤ YN0000: Saving the new release in .yarn/releases/yarn-1.22.18.cjs
➤ YN0000: Done in 1s 201ms
[1m[33m
 ---> yarn install[0m[0m
yarn install v1.22.18
info If you think this is a bug, please open a bug report with the information provided in "/root/BUILD/manageiq-ui-service/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error An unexpected error occurred: "Unknown token: { line: 3, col: 2, type: 'INVALID', value: undefined } 3:2 in /root/BUILD/manageiq-ui-service/yarn.lock".
Build step 'Execute shell' marked build as failure
```