### PR TITLE
failure in resource compliance check in storage service update shouldn't block form submission 

### DIFF
--- a/app/javascript/components/storage-service-form/get-compliant-resources.jsx
+++ b/app/javascript/components/storage-service-form/get-compliant-resources.jsx
@@ -36,7 +36,7 @@ const GetCompliantResources = ({ ...props }) => {
       })
       .then((result) => (result.task_results.compliant_resources.length
         ? resolve(getResourceNames(result.task_results.compliant_resources))
-        : reject(noCompliantMsg)))
+        : resolve(noCompliantMsg)))
       .catch(({ message }) => reject([__('compliance check failed:'), message].join(' ')));
   });
 


### PR DESCRIPTION
changed `reject` to another `resolve` since otherwise the form can't be submitted. 
A negative answer in the compliance check shouldn't block submission, only serve as a warning.

**before:**
changing capability `compression` to `True` produces a rejection on the compliance check, and form submission is blocked even when a resource which supports that capability is selected. 
<img width="912" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/aabc10f6-f23a-4d39-8ef4-e0fc2c1ba74d">


**after:**
the failed check returns a warning and not an error/rejection, so when a supporting resource is selected, the form can be submitted.
<img width="889" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/106743023/9e7adc1a-0fd8-4245-805d-fe9c69f885a8">
