### PR TITLE
Container and container node timelines require ems

### DIFF
--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -39,7 +39,7 @@ describe ContainerController do
       container_group = ContainerGroup.create(:ext_management_system => ems,
                                               :container_project     => container_project,
                                               :name                  => "Test Group")
-      @container = FactoryBot.create(:container, :container_group => container_group, :name => "Test Container")
+      @container = FactoryBot.create(:container, :container_group => container_group, :ext_management_system => ems, :name => "Test Container")
     end
 
     context "render listnav partial" do

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -28,7 +28,7 @@ describe ContainerNodeController do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
       login_as FactoryBot.create(:user)
-      @node = FactoryBot.create(:container_node)
+      @node = FactoryBot.create(:container_node, :ext_management_system => FactoryBot.create(:ems_kubernetes))
     end
 
     context "render listnav partial" do


### PR DESCRIPTION
After [1] below, the event_where_clause logic has been implemented in the ems_event_filter and miq_event_filter and expectations around proper associations are enforced.

[1] https://github.com/ManageIQ/manageiq/pull/22388