### PR TITLE
Enhance the MiqStructuredList for summary pages

### DIFF
--- a/app/javascript/components/miq-structured-list/index.jsx
+++ b/app/javascript/components/miq-structured-list/index.jsx
@@ -25,10 +25,6 @@ const MiqStructuredList = ({
 }) => {
   const clickEvents = hasClickEvents(mode);
 
-  const borderedList = ['simple_table', 'multilink_table', 'table_list_view'];
-
-  const hasBorder = borderedList.includes(mode);
-
   /** Function to render an icon in the cell. */
   const renderIcon = (row) => (
     <div className={classNames('cell icon', row.background ? 'backgrounded-icon' : '')} title={row.title}>
@@ -243,29 +239,28 @@ const MiqStructuredList = ({
   const renderNotification = () => {
     const noticeMessage = message || sprintf(__('No entries found for %s'), title.toLowerCase());
     return (
-      <NotificationMessage type="info" message={noticeMessage} />
+      <div className="miq-structured-list-notification">
+        <NotificationMessage type="info" message={noticeMessage} />
+      </div>
     );
   };
 
   /** Function to render the structured list. */
-  const renderList = (mode, headers, list) => {
-    const border = hasBorder ? 'bordered-list' : '';
-    return (
-      <StructuredListWrapper
-        ariaLabel="Structured list"
-        className={classNames('miq-structured-list', border, mode)}
-      >
+  const renderList = (mode, headers, list) => (
+    <StructuredListWrapper
+      ariaLabel="Structured list"
+      className={classNames('miq-structured-list', mode)}
+    >
+      {
+        headers && headers.length > 0 && <MiqStructuredListHeader headers={headers} />
+      }
+      <StructuredListBody>
         {
-          headers && headers.length > 0 && <MiqStructuredListHeader headers={headers} />
+          list && list.length > 0 && list.map((row, index) => renderRow(row, index))
         }
-        <StructuredListBody>
-          {
-            list && list.length > 0 && list.map((row, index) => renderRow(row, index))
-          }
-        </StructuredListBody>
-      </StructuredListWrapper>
-    );
-  };
+      </StructuredListBody>
+    </StructuredListWrapper>
+  );
 
   const simpleList = () => (list && list.length > 0
     ? renderList(mode, headers, list)

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -169,7 +169,7 @@ exports[`Structured list component should render a multilink_list table 1`] = `
   >
     <FeatureToggle(StructuredListWrapper)
       ariaLabel="Structured list"
-      className="miq-structured-list bordered-list multilink_table"
+      className="miq-structured-list multilink_table"
     >
       <FeatureToggle(StructuredListBody)>
         <FeatureToggle(StructuredListRow)
@@ -1712,10 +1712,14 @@ exports[`Structured list component should render a simple_table 1`] = `
     open={true}
     title="Firewall Rules"
   >
-    <NotificationMessage
-      message="No entries found for firewall rules"
-      type="info"
-    />
+    <div
+      className="miq-structured-list-notification"
+    >
+      <NotificationMessage
+        message="No entries found for firewall rules"
+        type="info"
+      />
+    </div>
   </AccordionItem>
 </Accordion>
 `;
@@ -1731,7 +1735,7 @@ exports[`Structured list component should render a simple_table with generic dat
   >
     <FeatureToggle(StructuredListWrapper)
       ariaLabel="Structured list"
-      className="miq-structured-list bordered-list simple_table"
+      className="miq-structured-list simple_table"
     >
       <FeatureToggle(StructuredListBody)>
         <FeatureToggle(StructuredListRow)
@@ -1805,7 +1809,7 @@ exports[`Structured list component should render a simple_table with sortable an
   >
     <FeatureToggle(StructuredListWrapper)
       ariaLabel="Structured list"
-      className="miq-structured-list bordered-list simple_table"
+      className="miq-structured-list simple_table"
     >
       <MiqStructuredListHeader
         headers={
@@ -1967,10 +1971,14 @@ exports[`Structured list component should render a table_list_view table 1`] = `
     open={true}
     title="Tables with the Most Rows"
   >
-    <NotificationMessage
-      message="No entries found for tables with the most rows"
-      type="info"
-    />
+    <div
+      className="miq-structured-list-notification"
+    >
+      <NotificationMessage
+        message="No entries found for tables with the most rows"
+        type="info"
+      />
+    </div>
   </AccordionItem>
 </Accordion>
 `;
@@ -2478,7 +2486,7 @@ exports[`Structured list component should render miq_ae_class_list_view with esc
   >
     <FeatureToggle(StructuredListWrapper)
       ariaLabel="Structured list"
-      className="miq-structured-list bordered-list table_list_view"
+      className="miq-structured-list table_list_view"
     >
       <FeatureToggle(StructuredListBody)>
         <FeatureToggle(StructuredListRow)

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
@@ -620,18 +620,18 @@ exports[`MultilinkTable renders just fine 1`] = `
             >
               <FeatureToggle(StructuredListWrapper)
                 ariaLabel="Structured list"
-                className="miq-structured-list bordered-list multilink_table"
+                className="miq-structured-list multilink_table"
               >
                 <StructuredListWrapper
                   ariaLabel="Structured list"
-                  className="miq-structured-list bordered-list multilink_table"
+                  className="miq-structured-list multilink_table"
                   isCondensed={false}
                   isFlush={false}
                   selection={false}
                 >
                   <div
                     aria-label="Structured list"
-                    className="bx--structured-list miq-structured-list bordered-list multilink_table"
+                    className="bx--structured-list miq-structured-list multilink_table"
                     role="table"
                   >
                     <FeatureToggle(StructuredListBody)>

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/simple_table.test.js.snap
@@ -175,18 +175,18 @@ exports[`Simple Table renders just fine... 1`] = `
             >
               <FeatureToggle(StructuredListWrapper)
                 ariaLabel="Structured list"
-                className="miq-structured-list bordered-list simple_table"
+                className="miq-structured-list simple_table"
               >
                 <StructuredListWrapper
                   ariaLabel="Structured list"
-                  className="miq-structured-list bordered-list simple_table"
+                  className="miq-structured-list simple_table"
                   isCondensed={false}
                   isFlush={false}
                   selection={false}
                 >
                   <div
                     aria-label="Structured list"
-                    className="bx--structured-list miq-structured-list bordered-list simple_table"
+                    className="bx--structured-list miq-structured-list simple_table"
                     role="table"
                   >
                     <MiqStructuredListHeader

--- a/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
+++ b/app/javascript/spec/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
@@ -144,18 +144,18 @@ exports[`TableListView renders just fine... 1`] = `
             >
               <FeatureToggle(StructuredListWrapper)
                 ariaLabel="Structured list"
-                className="miq-structured-list bordered-list table_list_view"
+                className="miq-structured-list table_list_view"
               >
                 <StructuredListWrapper
                   ariaLabel="Structured list"
-                  className="miq-structured-list bordered-list table_list_view"
+                  className="miq-structured-list table_list_view"
                   isCondensed={false}
                   isFlush={false}
                   selection={false}
                 >
                   <div
                     aria-label="Structured list"
-                    className="bx--structured-list miq-structured-list bordered-list table_list_view"
+                    className="bx--structured-list miq-structured-list table_list_view"
                     role="table"
                   >
                     <MiqStructuredListHeader

--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -4,7 +4,7 @@
 
   @include carbon--theme();
 
-  margin-bottom: 2rem;
+  margin-bottom: 0;
 
   .display_flex {
     display: flex;
@@ -35,17 +35,13 @@
     }
   }
 
-  .bx--structured-list-row {
-    border: 0;
-  }
-
   .bx--structured-list-td {
     padding: 0.3rem;
   }
 
   .label_header {
     font-weight: 600;
-    min-width: 20%;
+    max-width: 20%;
     width: 250px;
     padding-left: 0;
     overflow-wrap: anywhere;
@@ -73,6 +69,7 @@
     .content {
       display: flex;
       flex-direction: row;
+      align-items: flex-start;
 
       &.color_black {
         color: $text-primary;
@@ -125,16 +122,19 @@
       img {
         min-width: 20px;
         width: 20px;
-        height: 20px;
+        height: 15px;
       }
 
       i {
+        min-width: 20px;
+        min-height: 20px;
         width: 20px;
         height: 20px;
         font-size: 15px;
         display: flex;
         justify-content: center;
         flex-direction: row;
+        align-items: center;
         padding: 5px;
       }
       .settings-icn {
@@ -170,9 +170,25 @@
 }
 
 .miq-structured-list-accordion {
-  li .bx--accordion__content {
-    padding: 0.5rem 0 0 0 !important;
-    margin: 0 !important;
+  border: 1px solid $selected-ui;
+  margin-bottom: 15px;
+
+  li {
+    button.bx--accordion__heading{
+      background: $selected-ui;
+    }
+
+    .bx--accordion__content {
+      padding: 0 0 0 0 !important;
+      margin: 0 !important;
+
+      .miq-structured-list .bx--structured-list-tbody .bx--structured-list-row {
+
+        &:last-child {
+          border-bottom: 0;
+        }
+      }
+    }
   }
 
   li:last-child {
@@ -185,6 +201,17 @@
   &.simple_table {
     .bx--accordion__content {
       padding-right: 0;
+    }
+  }
+
+  .miq-structured-list-notification {
+    display: flex;
+    width: 100%;
+    padding: 10px;
+
+    .alert {
+      width: 100%;
+      margin-top: 20px;
     }
   }
 }


### PR DESCRIPTION
Before
<img width="1539" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/5cff2c7b-ed25-4afb-8ea3-e6a37ee76a2b">
<img width="1535" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/9ede0811-306a-4feb-a4ce-0d6ee035ca3c">

After
<img width="1532" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/eb90ed8a-6057-40e7-b0de-fc466025ce35">
<img width="1538" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/86289f6c-6cfd-4ef6-9c06-51756e052c98">
<img width="1536" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/fbc68dbf-ce07-4990-acf4-16a3f7c9b75c">
<img width="1790" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ae968693-434a-465c-887a-c24bc9f086fd">


