### PR TITLE
Adding embedded workflows to service catalog item

### DIFF
--- a/app/controllers/mixins/automation_mixin.rb
+++ b/app/controllers/mixins/automation_mixin.rb
@@ -1,7 +1,14 @@
 module Mixins
   module AutomationMixin
-    # Returns an object to be reused for passing down to service catalogs(rails) and dialog(angular) form.
-    # used in catalogs_helper, miq_ae_customization_helper, catalog_controller, editor.html.haml
+    # Returns an object to identify the entry_point types
+    ENTRY_POINT_TYPES = {
+      :fqname             => {:type => :provision,   :name => 'Provision'},
+      :reconfigure_fqname => {:type => :reconfigure, :name => 'Reconfigure'},
+      :retire_fqname      => {:type => :retire,      :name => 'Retirement'}
+    }.freeze
+
+    # Returns an object to be resued for passing down to rails form and angular form.
+    # Used in catalogs_helper, miq_ae_customization_helper, catalog_controller, editor.html.haml
     AUTOMATION_TYPES = {
       :automate => {
         :key    => 'embedded_automate',
@@ -16,27 +23,78 @@ module Mixins
     }.freeze
 
     # Returns an array of entry point options.
-    # used in provision_entry_points, retirement_entry_points, reconfigure_entry_points html files
+    # used in provision_entry_poins, retirement_entry_points, reconfigure_entry_points html files
     def automation_type_options
-      options = [["<#{_('No Entry Point')}>", nil]]
-      options + AUTOMATION_TYPES.values.map do |item|
+      AUTOMATION_TYPES.values.map do |item|
         [item[:label], item[:key]]
       end
     end
 
+    def embedded_automate_key
+      AUTOMATION_TYPES[:automate][:key]
+    end
+
+    def embedded_workflow_key
+      AUTOMATION_TYPES[:workflow][:key]
+    end
+
     # Returns true if the field holds value 'embedded_automate'
     def embedded_automate(field)
-      field == AUTOMATION_TYPES[:automate][:key]
+      field == embedded_automate_key
     end
 
     # Returns true if the field holds value 'embedded_workflow'
     def embedded_workflow(field)
-      field == AUTOMATION_TYPES[:workflow][:key]
+      field == embedded_workflow_key
     end
 
     # Returns the default automation type 'embedded_automate'
-    def default_automation_type
-      AUTOMATION_TYPES[:automate][:key]
+    def default_entry_point_type
+      embedded_automate_key
+    end
+
+    # Method to return the field identifier for type and configuration_script_id
+    def entry_point_fields(field)
+      key_prefix = ENTRY_POINT_TYPES[field][:type]
+      {
+        :type                    => "#{key_prefix}_entry_point_type".to_sym,
+        :configuration_script_id => "#{key_prefix}_configuration_script_id".to_sym,
+        :previous                => "#{field}_previous".to_sym,
+      }
+    end
+
+    # Method to return the data needed for entry_point selector in service-catalog form.
+    # Used in _provision_entry_points, _retirement_entry_points, _reconfigure_entry_points view files.
+    def entry_point_data(edit, key)
+      edit_new = edit[:new]
+      fields = entry_point_fields(key)
+      type = edit_new[fields[:type]] # 'embedded_automate' || 'embedded_workflow'
+      configuration_script_id = fields[:configuration_script_id]
+      return edit, edit_new, type, configuration_script_id
+    end
+
+    # Method to return the url for entry_point onchange event.
+    def form_field_change_url(edit)
+      action = edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed"
+      url_for(:id => (edit[:rec_id] || "new").to_s, :action => action, :form_field_changed => true)
+    end
+
+    # Method to return the modal-box open and close event actions.
+    # automation_type => 'embedded_automate' || 'embedded_workflow'
+    # field           => :fqname || :retire_fqname || :reconfigure_fqname
+    # type            => 'provision' || 'retire' || 'configure'
+    def entry_point_modal_events(automation_type, field)
+      type = ENTRY_POINT_TYPES[field][:type]
+      on_open = "miqShowAE_Tree('#{type}'); miqButtons('hide', 'automate');" # default
+      if embedded_workflow(automation_type)
+        configuration_script_id_key = entry_point_fields(field)[:configuration_script_id]
+        on_open = "miqShowEmbededdedWorkflowsModal('#{field}', '#{configuration_script_id_key}', '#{type}'); miqButtons('hide', 'automate');"
+      end
+
+      {
+        :open  => on_open,
+        :close => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => type)}');"
+      }
     end
   end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,6 +1,7 @@
 module CatalogHelper
   include_concern 'TextualSummary'
   include RequestInfoHelper
+  include Mixins::AutomationMixin
 
   def miq_catalog_resource(resources)
     headers = ["", _("Name"), _("Description"), _("Action Order"), _("Provision Order"), _("Action Start"), _("Action Stop"), _("Delay (mins) Start"), _("Delay (mins) Stop")]
@@ -297,5 +298,11 @@ module CatalogHelper
 
   def tab_label(item)
     {:name => item, :text => catalog_tabs_types[item]}
+  end
+
+  # Method which return true if workflows are behing prototype flag.
+  # Hides the Embedded Workflow option.
+  def workflows_enabled
+    Settings.prototype.ems_workflows.enabled
   end
 end

--- a/app/javascript/components/workflows/helper.js
+++ b/app/javascript/components/workflows/helper.js
@@ -1,0 +1,26 @@
+import { rowData } from '../miq-data-table/helper';
+
+/** Function to return the header information for the service catalog item's entry points. */
+const entryPointsHeaderInfo = () => [
+  { header: __('Name'), key: 'name' },
+];
+
+/** Function to return the cell data for a row item. */
+const celInfo = (workflow) => [
+  { text: workflow.name },
+];
+
+/** Function to return the row information for the list */
+const rowInfo = (headers, response) => {
+  const headerKeys = headers.map((item) => item.key);
+  const rows = response.resources.filter((item) => item.payload).map((workflow) => ({
+    id: workflow.id.toString(), cells: celInfo(workflow), clickable: true,
+  }));
+  const miqRows = rowData(headerKeys, rows, false);
+  return miqRows.rowItems;
+};
+
+export const workflowsEntryPoints = (response) => {
+  const headers = entryPointsHeaderInfo();
+  return { headers, rows: rowInfo(headers, response) };
+};

--- a/app/javascript/components/workflows/workflow-entry-points.jsx
+++ b/app/javascript/components/workflows/workflow-entry-points.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Loading, Modal, ModalBody } from 'carbon-components-react';
+import MiqDataTable from '../miq-data-table';
+import { workflowsEntryPoints } from './helper';
+import { http } from '../../http_api';
+
+const WorkflowEntryPoints = ({ field, selected, type }) => {
+  const [data, setData] = useState({
+    isLoading: true, list: {}, selectedItemId: selected,
+  });
+
+  const workflowTypes = {
+    provision: __('Provision'),
+    reconfigure: __('Reconfigure'),
+    retire: __('Retirement'),
+  };
+
+  useEffect(() => {
+    http.post(`/catalog/ae_tree_select_toggle?typ=${type}`, {}, { headers: {}, skipJsonParsing: true })
+      .then((_data) => {
+        API.get('/api/configuration_script_payloads?expand=resources')
+          .then((response) => {
+            setData({
+              ...data,
+              isLoading: false,
+              list: workflowsEntryPoints(response),
+            });
+          });
+      });
+  }, []);
+
+  /** Function to handle a row's click event. */
+  const onSelect = (selectedItemId) => {
+    setData({
+      ...data,
+      selectedItemId: (data.selectedItemId === selectedItemId) ? undefined : selectedItemId,
+    });
+    const params = `cfp-${encodeURIComponent(selectedItemId)}&tree=automate_catalog_tree&field=${field}`;
+    window.miqJqueryRequest(`/catalog/ae_tree_select/?id=${params}&typ=${type}`);
+  };
+  if (data.isLoading) {
+    return (<Loading active small withOverlay={false} className="loading" />);
+  }
+  /** Function to handle the modal box close button click event. */
+  const onCloseModal = () => {
+    document.getElementById(`${type}-workflows`).innerHTML = '';
+    http.post('/catalog/ae_tree_select_toggle?button=cancel', {}, { headers: {}, skipJsonParsing: true });
+  };
+  /** Function to handle the modal box apply button click event. */
+  const onApply = () => {
+    const seletedItem = data.list.rows.find((item) => item.id === data.selectedItemId);
+    const name = seletedItem.name.text;
+    if (seletedItem) {
+      const nameField = document.getElementById(field);
+      const selectedField = document.getElementById(`${type}_configuration_script_id`);
+
+      if (nameField && selectedField) {
+        nameField.value = name;
+        selectedField.value = data.selectedItemId;
+        http.post('/catalog/ae_tree_select_toggle?button=submit&automation_type=workflow', {}, { headers: {}, skipJsonParsing: true })
+          .then((_data) => {
+            document.getElementById(`${type}-workflows`).innerHTML = '';
+          });
+      }
+    }
+  };
+  return (
+    <Modal
+      open
+      modalHeading={sprintf(__('Select Embedded Workflow - %s Entry Point'), workflowTypes[type])}
+      primaryButtonText={__('Apply')}
+      secondaryButtonText={__('Cancel')}
+      onRequestSubmit={onApply}
+      onRequestClose={onCloseModal}
+      className="workflows-entry-point-modal"
+    >
+      <ModalBody className="workflows-entry-point-modal-body">
+        <MiqDataTable
+          headers={data.list.headers}
+          rows={data.list.rows}
+          onCellClick={(selectedRow) => onSelect(selectedRow.id)}
+          showPagination={false}
+          truncateText={false}
+          mode="automated-workflow-entry-points"
+          gridChecks={[data.selectedItemId]}
+          size="md"
+        />
+      </ModalBody>
+    </Modal>
+
+  );
+};
+WorkflowEntryPoints.propTypes = {
+  field: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  selected: PropTypes.string,
+};
+
+WorkflowEntryPoints.defaultProps = {
+  selected: '',
+};
+
+export default WorkflowEntryPoints;

--- a/app/javascript/oldjs/miq_application.js
+++ b/app/javascript/oldjs/miq_application.js
@@ -954,6 +954,19 @@ window.miqShowAE_Tree = function(typ) {
   return true;
 };
 
+/** Function to open the Workflows dialog box.
+ * Params are set from automation_mixin.rb
+ * fields = :fqname || :retire_fqname || :reconfigure_fqname
+ * key    = 'provision_configuration_script_id' || 'retire_configuration_script_id' || 'configure_configuration_script_id'
+ * type   = 'provision' || 'retire' || 'configure'
+ */
+window.miqShowEmbededdedWorkflowsModal = function(field, key, type) {
+  const url = `/${ManageIQ.controller}/embededded_workflows_modal`;
+  const selected = document.getElementById(key).value;
+  miqJqueryRequest(miqPassFields(url, { field, selected, type }));
+  return true;
+};
+
 // Toggle the user options div in the page header (:onclick from layouts/user_options)
 window.miqChangeGroup = function(id) {
   miqSparkleOn();

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -148,6 +148,7 @@ import WorkersForm from '../components/workers-form/workers-form';
 import WorkflowCredentialsForm from '../components/workflow-credentials-form';
 import WorkflowPayload from '../components/workflows/workflow_payload';
 import WorkflowRepositoryForm from '../components/workflow-repository-form';
+import WorkflowEntryPoints from '../components/workflows/workflow-entry-points';
 import PhysicalStorageForm from '../components/physical-storage-form';
 import SearchBar from '../components/search-bar';
 import SettingsCompanyCategories from '../components/settings-company-categories';
@@ -159,7 +160,7 @@ import HostInitiatorGroupForm from '../components/host-initiator-group-form';
 import StorageServiceForm from '../components/storage-service-form';
 import VolumeMappingForm from '../components/volume-mapping-form';
 import ZoneForm from '../components/zone-form';
-import AnsiblePlayBookEditCatalogForm from '../components/ansible-playbook-edit-catalog-form'
+import AnsiblePlayBookEditCatalogForm from '../components/ansible-playbook-edit-catalog-form';
 
 /**
 * Add component definitions to this file.
@@ -318,6 +319,7 @@ ManageIQ.component.addReact('WorkersForm', WorkersForm);
 ManageIQ.component.addReact('WorkflowCredentialsForm', WorkflowCredentialsForm);
 ManageIQ.component.addReact('WorkflowPayload', WorkflowPayload);
 ManageIQ.component.addReact('WorkflowRepositoryForm', WorkflowRepositoryForm);
+ManageIQ.component.addReact('WorkflowEntryPoints', WorkflowEntryPoints);
 ManageIQ.component.addReact('ProvGrid', ProvGrid);
 ManageIQ.component.addReact('PhysicalStorageForm', PhysicalStorageForm);
 ManageIQ.component.addReact('VisualSettingsForm', VisualSettingsForm);

--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -315,3 +315,41 @@ table.miq_preview {
     min-width: 50px !important;
   }
 }
+.catalogs_form {
+
+  input[type="text"] {
+    width: 220px;
+  }
+
+  .no-padding{
+    padding: 0;
+  }
+
+  .long_text {
+    width: 100% !important;
+  }
+
+  .entry_point_selector {
+    padding: 3px;
+
+    .entry_point_text, .entry_point_button {
+      border-right: 0;
+    }
+
+    span.input-group-addon{
+      visibility: hidden;
+    }
+  }
+  .workflow_modal_wrapper {
+    min-height: 26px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .workflows-entry-point-modal-body {
+    .miq-data-table {
+      margin-top: 0px;
+    }
+  }
+}
+

--- a/app/views/catalog/_embedded_workflows_modal.html.haml
+++ b/app/views/catalog/_embedded_workflows_modal.html.haml
@@ -1,0 +1,1 @@
+= react('WorkflowEntryPoints', {:field => field, :selected => selected, :type => type})

--- a/app/views/catalog/_entry_point_selector.html.haml
+++ b/app/views/catalog/_entry_point_selector.html.haml
@@ -1,0 +1,12 @@
+- entry_point_type = @edit[:new][type] || default_entry_point_type
+
+- if workflows_enabled
+  .col-md-3{:title => @edit[:new][type]}
+    %p.form-control-static
+      - options = options_for_select(automation_type_options, entry_point_type)
+      = select_tag(type, options, "data-miq_sparkle_on" => true, :class => "selectpicker")
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('#{type}', '#{url}')
+- else
+  = hidden_field_tag(type, entry_point_type)

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -1,36 +1,39 @@
-- url = url_for(:id => "#{@edit[:rec_id] || "new"}",
-  :action => @edit[:new][:service_type] == "composite" ? "st_form_field_changed" : "atomic_form_field_changed")
-%h3= _('Basic Information')
-#basic_info_div
+- url = form_field_change_url(@edit)
 
+%h3= _('Basic Information')
+.catalogs_form#basic_info_div
   = hidden_div_if(@edit && @edit[:ae_tree_select] != true, :id => "ae_tree_select_div") do
     = render(:partial => 'layouts/ae_tree_select')
   .form-horizontal
     .form-group
       %label.col-md-2.control-label
         = _('Name / Description')
-      .col-md-8{:style => "padding: 0px;"}
-        .col-md-4
+      .col-md-10.no-padding
+        .col-md-3
           = text_field_tag("name",
                            @edit[:new][:name].to_s,
                            :maxlength         => 40,
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        .col-md-4
-          = text_field_tag("description",
-                           @edit[:new][:description],
-                           :maxlength         => 60,
-                           :class             => "form-control",
-                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-        .col-md-3
-          = check_box_tag("display", "1", @edit[:new][:display],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-          = _('Display in Catalog')
+        .col-md-9
+          .col-md-10.no-padding
+            = text_field_tag("description",
+                            @edit[:new][:description],
+                            :maxlength         => 60,
+                            :class             => "form-control long_text",
+                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
     = javascript_tag(javascript_focus('name'))
     .form-group
       %label.col-md-2.control-label
+        = _('Display in Catalog')
+      .col-md-10.no-padding
+        .col-md-3
+          = check_box_tag("display", "1", @edit[:new][:display],
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
+    .form-group
+      %label.col-md-2.control-label
         = _('Catalog')
-      .col-md-4
+      .col-md-10
         - catalog_id = @edit[:new][:catalog_id]
         = select_tag('catalog_id',
                      options_for_select(([["<#{_('Unassigned')}>", nil]]) + @available_catalogs, catalog_id),
@@ -42,7 +45,7 @@
     .form-group
       %label.col-md-2.control-label
         = _('Dialog')
-      .col-md-4
+      .col-md-10
         %p.form-control-static
           - available_dialogs = @edit[:new][:available_dialogs].invert.to_a.sort_by { |a| a.first.downcase }
           - options = [["<#{_('No Dialog')}>", nil]] + available_dialogs
@@ -56,7 +59,7 @@
       .form-group
         %label.col-md-2.control-label
           = _('Zone')
-        .col-md-4
+        .col-md-10
           %p.form-control-static
             = select_tag('zone_id',
                           options_for_select([[_("<Choose>"), nil]] + @zones, @edit[:new][:zone_id]),
@@ -68,7 +71,7 @@
     .form-group
       %label.col-md-2.control-label
         = _('Select currency')
-      .col-md-4
+      .col-md-10
         %p.form-control-static
           - currency = Array(Currency.currencies_for_select)
           = select_tag("currency",
@@ -83,8 +86,8 @@
       %label.col-md-2.control-label
         %span#price_span
           = @edit[:new][:code_currency]
-      .col-md-8{:style => "padding: 0px;"}
-        .col-md-4
+      .col-md-8.no-padding
+        .col-md-10
           = text_field_tag("price",
                            @edit[:new][:price].to_s,
                            :maxlength         => 40,
@@ -95,7 +98,7 @@
       .form-group
         %label.col-md-2.control-label
           = _('Subtype')
-        .col-md-4
+        .col-md-10
           %p.form-control-static
             - if @record.try(:id)
               = h(_(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@edit[:new][:generic_subtype]]))
@@ -112,7 +115,7 @@
       .form-group
         %label.col-md-2.control-label
           = _('Orchestration Template')
-        .col-md-8
+        .col-md-10
           = select_tag('template_id',
                         options_for_select(opts, @edit[:new][:template_id]),
                         "data-miq_sparkle_on" => true,
@@ -124,7 +127,7 @@
         .form-group
           %label.col-md-2.control-label
             = _('Provider')
-          .col-md-8
+          .col-md-10
             = select_tag('manager_id',
                          options_for_select(opts, @edit[:new][:manager_id]),
                          "data-miq_sparkle_on" => true,
@@ -136,7 +139,7 @@
       .form-group
         %label.col-md-2.control-label
           = _('Provider')
-        .col-md-8
+        .col-md-10
           = select_tag('manager_id',
                        options_for_select(opts, @edit[:new][:manager_id]),
                        "data-miq_sparkle_on" => true,
@@ -147,7 +150,7 @@
         .form-group
           %label.col-md-2.control-label
             = @edit[:new][:st_prov_type] == "generic_ansible_tower" || @edit[:new][:st_prov_type] == "generic_awx" ? _('Ansible Template') : _('Container Template')
-          .col-md-8
+          .col-md-10
             - if @edit[:new][:st_prov_type] == "generic_ansible_tower" || @edit[:new][:st_prov_type] == "generic_awx"
               = select_tag('template_id',
                             grouped_options_for_select(@edit[:new][:available_templates], @edit[:new][:template_id]),
@@ -160,74 +163,35 @@
                        :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
+
     .form-group
       %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
         = _('Provisioning Entry Point')
-      .col-md-8{:title => @edit[:new][:fqname]}
-        .input-group
-          = text_field_tag("fqname",
-                           @edit[:new][:fqname],
-                           :class             => "form-control",
-                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          %span.input-group-btn
-            #fqname_div
-              %button.btn.btn-default{"onclick" => "miqShowAE_Tree('provision'); miqButtons('hide', 'automate');",
-                                      "title"   => _('Click to select Provisioning Entry Point')}
-                %i.ff.ff-load-balancer
-              %button.btn.btn-default{"id"           => "fqname_remove",
-                                      "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'provision')}');",
-                                      "title"        => _('Remove this Provisioning Entry Point'),
-                                      "data-confirm" => _("Are you sure you want to remove this Provisioning Entry Point?"),
-                                      "disabled"     => @edit[:new][:fqname].nil?}
-                %i.pficon.pficon-close
-          %span.input-group-addon{:style => "visibility:hidden"}
+      .col-md-10.no-padding
+        = render(:partial => "entry_point_selector", :locals => {:type => :provision_entry_point_type, :url => url})
+        .col-md-9#provision_entry_point
+          = render(:partial => "provision_entry_point")      
+
     - unless %w[generic_container_template generic_ovf_template].include?(@edit[:new][:st_prov_type])
       .form-group
         %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
           = _('Reconfigure Entry Point')
-        .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
-          .input-group
-            = text_field_tag("reconfigure_fqname",
-                             @edit[:new][:reconfigure_fqname],
-                             :class             => "form-control",
-                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %span.input-group-btn
-              #reconfigure_fqname_div
-                %button.btn.btn-default{"onclick" => "miqShowAE_Tree('reconfigure'); miqButtons('hide', 'automate');",
-                                        "title"   => _('Click to select Reconfigure Entry Point')}
-                  %i.ff.ff-load-balancer
-                %button.btn.btn-default{"id"           => "reconfigure_fqname_remove",
-                                        "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'reconfigure')}');",
-                                        "title"        => _('Remove this Reconfigure Entry Point'),
-                                        "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
-                                        "disabled"     => @edit[:new][:reconfigure_fqname].nil?}
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+        .col-md-10.no-padding
+          = render(:partial => "entry_point_selector", :locals => {:type => :reconfigure_entry_point_type, :url => url})
+          .col-md-9#reconfigure_entry_point
+            = render(:partial => "reconfigure_entry_point")
+
       .form-group
         %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
           = _('Retirement Entry Point')
-        .col-md-8{:title => @edit[:new][:retire_fqname]}
-          .input-group
-            = text_field_tag("retire_fqname",
-                             @edit[:new][:retire_fqname],
-                             :class             => "form-control",
-                             "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-            %span.input-group-btn
-              #retire_fqname_div
-                %button.btn.btn-default{"onclick" => "miqShowAE_Tree('retire'); miqButtons('hide', 'automate');",
-                                        "title"   => _('Click to select Retirement Entry Point')}
-                  %i.ff.ff-load-balancer
-                %button.btn.btn-default{"id"           => "retire_fqname_remove",
-                                        "onclick"      => "miqAjax('#{url_for_only_path(:action => 'ae_tree_select_discard', :typ => 'retire')}');",
-                                        "title"        => _('Remove this Retirement Entry Point'),
-                                        "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),
-                                        "disabled"     => @edit[:new][:retire_fqname].nil?}
-                  %i.pficon.pficon-close
-            %span.input-group-addon{:style => "visibility:hidden"}
+        .col-md-10.no-padding
+          = render(:partial => "entry_point_selector", :locals => {:type => :retire_entry_point_type, :url => url})
+          .col-md-9#retire_entry_point
+            = render(:partial => "retire_entry_point")
+
     - if role_allows?(:feature => 'rbac_tenant_view')
       = render(:partial => "tenants_tree_show")
   - if @edit[:new][:st_prov_type] == "generic_ovf_template"
     = render(:partial => "form_ovf_template_options")
   - if @edit[:new][:st_prov_type] == "cisco_intersight"
     = render(:partial => "form_server_profile_template_options")
-

--- a/app/views/catalog/_provision_entry_point.html.haml
+++ b/app/views/catalog/_provision_entry_point.html.haml
@@ -1,0 +1,28 @@
+- edit, edit_new, type, configuration_script_id = entry_point_data(@edit, :fqname)
+- show_selector = workflows_enabled ? true : type.present?
+- if show_selector
+  - url = form_field_change_url(edit)
+  - modal = entry_point_modal_events(type, :fqname)
+  
+  .col-md-10.entry_point_selector{:title => edit_new[:fqname]}
+    .input-group
+      = hidden_field_tag(configuration_script_id, edit_new[configuration_script_id] || nil)
+      = text_field_tag("fqname",
+                        edit_new[:fqname],
+                        :class             => "form-control long_text entry_point_text",
+                        :placeholder       => type&.gsub('_',' ').camelize,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      %span.input-group-btn
+        #fqname_div
+          %button.btn.btn-default.entry_point_button{:onclick => modal[:open],
+                                                     :title   => _('Click to select Provisioning Entry Point')}
+            %i.ff.ff-load-balancer
+          %button.btn.btn-default{:id            => "fqname_remove",
+                                  :onclick       => modal[:close],
+                                  :title         => _('Remove this Provisioning Entry Point'),
+                                  "data-confirm" => _("Are you sure you want to remove this Provisioning Entry Point?"),
+                                  :disabled      => edit_new[:fqname].nil?}
+            %i.pficon.pficon-close
+      %span.input-group-addon
+  .col-md-2.entry_point_selector
+    .workflow_modal_wrapper#provision-workflows

--- a/app/views/catalog/_reconfigure_entry_point.html.haml
+++ b/app/views/catalog/_reconfigure_entry_point.html.haml
@@ -1,0 +1,28 @@
+- edit, edit_new, type, configuration_script_id = entry_point_data(@edit, :reconfigure_fqname)
+- show_selector = workflows_enabled ? true : type.present?
+- if show_selector
+  - url = form_field_change_url(edit)
+  - modal = entry_point_modal_events(type, :reconfigure_fqname)
+
+  .col-md-10.entry_point_selector{:title => edit_new[:reconfigure_fqname]}
+    .input-group
+      = hidden_field_tag(configuration_script_id, edit_new[configuration_script_id] || nil)
+      = text_field_tag("reconfigure_fqname",
+                        edit_new[:reconfigure_fqname],
+                        :class             => "form-control long_text entry_point_text",
+                        :placeholder       => type&.gsub('_',' ').camelize,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      %span.input-group-btn
+        #reconfigure_fqname_div
+          %button.btn.btn-default.entry_point_button{:onclick => modal[:open],
+                                                     :title   => _('Click to select Reconfigure Entry Point')}
+            %i.ff.ff-load-balancer
+          %button.btn.btn-default{:id           => "reconfigure_fqname_remove",
+                                  :onclick      => modal[:close],
+                                  :title        => _('Remove this Reconfigure Entry Point'),
+                                  "data-confirm" => _("Are you sure you want to remove this Reconfigure Entry Point?"),
+                                  :disabled      => edit_new[:reconfigure_fqname].nil?}
+            %i.pficon.pficon-close
+      %span.input-group-addon
+  .col-md-2.entry_point_selector
+    .workflow_modal_wrapper#reconfigure-workflows

--- a/app/views/catalog/_retire_entry_point.html.haml
+++ b/app/views/catalog/_retire_entry_point.html.haml
@@ -1,0 +1,28 @@
+- edit, edit_new, type, configuration_script_id = entry_point_data(@edit, :retire_fqname)
+- show_selector = workflows_enabled ? true : type.present?
+- if show_selector
+  - url = form_field_change_url(edit)
+  - modal = entry_point_modal_events(type, :retire_fqname)
+  
+  .col-md-10.entry_point_selector{:title => edit_new[:retire_fqname]}
+    .input-group
+      = hidden_field_tag(configuration_script_id, edit_new[configuration_script_id] || nil)
+      = text_field_tag("retire_fqname",
+                        edit_new[:retire_fqname],
+                        :class             => "form-control long_text entry_point_text",
+                        :placeholder       => type&.gsub('_',' ').camelize,
+                        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+      %span.input-group-btn
+        #retire_fqname_div
+          %button.btn.btn-default.entry_point_button{:onclick => modal[:open],
+                                                     :title   => _('Click to select Retirement Entry Point')}
+            %i.ff.ff-load-balancer
+          %button.btn.btn-default{:id                => "retire_fqname_remove",
+                                  :onclick           => modal[:close],
+                                  :title             => _('Remove this Reconfigure Entry Point'),
+                                  "data-confirm" => _("Are you sure you want to remove this Retirement Entry Point?"),
+                                  :disabled          => edit_new[:retire_fqname].nil?}
+            %i.pficon.pficon-close
+      %span.input-group-addon
+  .col-md-2.entry_point_selector
+    .workflow_modal_wrapper#retire-workflows

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -314,6 +314,7 @@ Rails.application.routes.draw do
         atomic_st_edit
         automate_button_field_changed
         playbook_options_field_changed
+        embededded_workflows_modal
         explorer
         group_create
         group_reorder_field_changed

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -80,6 +80,7 @@ CatalogController:
 - dynamic_date_refresh
 - dynamic_radio_button_refresh
 - dynamic_text_box_refresh
+- embededded_workflows_modal
 - explorer
 - index
 - open_url_after_dialog

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -149,12 +149,15 @@ describe CatalogController do
         recon_fqname     = 'ns2/cls2/inst2'
         edit = {
           :new          => {
-            :name               => "New Name",
-            :description        => "New Description",
-            :reconfigure_fqname => recon_fqname,
-            :retire_fqname      => retire_fqname,
-            :fqname             => provision_fqname,
-            :tenant_ids         => []
+            :name                         => "New Name",
+            :description                  => "New Description",
+            :reconfigure_fqname           => recon_fqname,
+            :retire_fqname                => retire_fqname,
+            :fqname                       => provision_fqname,
+            :tenant_ids                   => [],
+            :provision_entry_point_type   => "embedded_automate",
+            :reconfigure_entry_point_type => "embedded_automate",
+            :retire_entry_point_type      => "embedded_automate",
           },
           :key          => "prov_edit__new",
           :rec_id       => st.id,
@@ -179,11 +182,15 @@ describe CatalogController do
         recon_fqname     = 'ns2/cls2/inst2'
         edit = {
           :new          => {
-            :name               => 'New Name',
-            :description        => 'New Description',
-            :reconfigure_fqname => recon_fqname,
-            :retire_fqname      => retire_fqname,
-            :fqname             => provision_fqname
+            :name                         => 'New Name',
+            :description                  => 'New Description',
+            :reconfigure_fqname           => recon_fqname,
+            :retire_fqname                => retire_fqname,
+            :fqname                       => provision_fqname,
+            :provision_entry_point_type   => "embedded_automate",
+            :reconfigure_entry_point_type => "embedded_automate",
+            :retire_entry_point_type      => "embedded_automate",
+
           },
           :key          => 'prov_edit__new',
           :rec_id       => st.id,
@@ -520,12 +527,15 @@ describe CatalogController do
         recon_fqname     = 'ns2/cls2/inst2'
         edit = {
           :new => {
-            :name               => "New Name",
-            :description        => "New Description",
-            :dialog_id          => dialog.id,
-            :reconfigure_fqname => recon_fqname,
-            :retire_fqname      => retire_fqname,
-            :fqname             => provision_fqname
+            :name                         => "New Name",
+            :description                  => "New Description",
+            :dialog_id                    => dialog.id,
+            :reconfigure_fqname           => recon_fqname,
+            :retire_fqname                => retire_fqname,
+            :fqname                       => provision_fqname,
+            :provision_entry_point_type   => "embedded_automate",
+            :reconfigure_entry_point_type => "embedded_automate",
+            :retire_entry_point_type      => "embedded_automate",
           },
         }
         controller.instance_variable_set(:@edit, edit)


### PR DESCRIPTION
Before
![Screenshot 2023-06-26 at 2 44 33 PM](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/b7d749c4-ad1a-4d37-9e88-e4c9f5b8f503)
* `Provisioning Entry Point `is mandatory, has a default value
* `Reconfigure Entry Point` is optional, and does not have a default value
* `Retirement Entry Point `is optional, has a default value

After

**Service Catalog item**
1. Go to Add a new Service Catalog item Form

2. `Provision Entry Point, Reconfigure Entry Point, Retirement Entry Point's `input changed to Drop down list
<img width="1529" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/3daf0153-5ca6-4ab5-9d53-6b2d4ef74c25">

3. Drop-down options are `Embedded Automate & Embedded Workflows`
<img width="475" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/3a3d7dfa-75ae-427b-bc17-69dbb81c22ca">

4. When one item is selected, the corresponding input field appears
<img width="1030" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/fc2cee2f-23c4-4cd4-881b-52376e224b39">

5. When you click on the input field, a new modal box appears for embedded workflows. The old modal will appear for embedded automated
<img width="1459" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/6c48459a-7f40-479b-a6d0-8d9cd66b001f">

6. When we select one of the items in the list, the name appears on the input field of
<img width="960" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/eb7feee1-2e8d-45d8-8774-df6ffb1be731">


