### PR TITLE
Change redirects to be portable

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -63,7 +63,7 @@ Jasmine.configure do |config|
   end
 
   # use google-chrome-beta if available, otherwise use the default
-  if system('which google-chrome-beta &>/dev/null')
+  if system('which google-chrome-beta >/dev/null 2>&1')
     config.chrome_binary = 'google-chrome-beta'
   end
 


### PR DESCRIPTION
Since the underlying shell used by system can be different, prefer a portable version of redirection as &> is shell specific.

@agrare Please review.