### PR TITLE
Customizable chart top values (dropdown choices)

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -9,12 +9,15 @@ module ReportController::Reports::Editor
   DEFAULT_PDF_PAGE_SIZE = "US-Letter".freeze
 
   MAX_REPORT_COLUMNS = 100 # Default maximum number of columns in a report
-  GRAPH_MAX_COUNT = 10
 
   CHAREGEBACK_ALLOCATED_METHODS = {
     :max => N_('Maximum'),
     :avg => N_('Average')
   }.freeze
+
+  def self.chart_top_values
+    ::Settings.reporting.chart_top_values
+  end
 
   def chargeback_allocated_methods
     CHAREGEBACK_ALLOCATED_METHODS.map { |k, v| [k, _(v)] }.to_h
@@ -632,7 +635,7 @@ module ReportController::Reports::Editor
       else
         @edit[:new][:graph_other]  = true if @edit[:new][:graph_type].nil? # Reset other setting if choosing first chart
         @edit[:new][:graph_type]   = params[:chosen_graph] # Save graph type
-        @edit[:new][:graph_count] ||= GRAPH_MAX_COUNT # Reset graph count, if not set
+        @edit[:new][:graph_count] ||= ReportController::Reports::Editor.chart_top_values # Reset graph count, if not set
         @edit[:new][:chart_mode] ||= 'counts'
         @edit[:new][:chart_column] ||= ''
       end
@@ -653,7 +656,7 @@ module ReportController::Reports::Editor
     end
 
     if params[:chosen_count] && params[:chosen_count] != @edit[:new][:graph_count]
-      @edit[:new][:graph_count] = params[:chosen_count]
+      @edit[:new][:graph_count] = params[:chosen_count].to_i
       @refresh_div              = "chart_sample_div"
       @refresh_partial          = "form_chart_sample"
     end
@@ -1202,7 +1205,7 @@ module ReportController::Reports::Editor
       @edit[:new][:graph_other]  = @rpt.graph[:other] ? @rpt.graph[:other] : false
     else
       @edit[:new][:graph_type]   = @rpt.graph
-      @edit[:new][:graph_count]  = GRAPH_MAX_COUNT
+      @edit[:new][:graph_count]  = ReportController::Reports::Editor.chart_top_values
       @edit[:new][:chart_mode]   = 'counts'
       @edit[:new][:chart_column] = ''
       @edit[:new][:graph_other]  = true

--- a/app/views/report/_form_chart.html.haml
+++ b/app/views/report/_form_chart.html.haml
@@ -47,7 +47,7 @@
           = _('Top values to show')
         .col-md-8
           = select_tag('chosen_count',
-            options_for_select(3..ReportController::Reports::Editor::GRAPH_MAX_COUNT, @edit[:new][:graph_count].to_i),
+            options_for_select(3..ReportController::Reports::Editor.chart_top_values, @edit[:new][:graph_count].to_i),
             :multiple              => false,
             :class                 => "selectpicker")
           :javascript

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -418,7 +418,7 @@ describe ReportController do
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:graph_type]).to eq(chosen_graph)
           expect(edit_new[:graph_other]).to be_truthy
-          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor::GRAPH_MAX_COUNT)
+          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor.chart_top_values)
           expect(assigns(:refresh_div)).to eq("chart_div")
           expect(assigns(:refresh_partial)).to eq("form_chart")
         end
@@ -427,19 +427,19 @@ describe ReportController do
           chosen_graph = "<No chart>"
           controller.params = {:chosen_graph => chosen_graph}
           edit = assigns(:edit)
-          edit[:current] = {:graph_count => ReportController::Reports::Editor::GRAPH_MAX_COUNT, :graph_other => true}
+          edit[:current] = {:graph_count => ReportController::Reports::Editor.chart_top_values, :graph_other => true}
           controller.instance_variable_set(:@edit, edit)
           controller.send(:gfv_charts)
           edit_new = assigns(:edit)[:new]
           expect(edit_new[:graph_type]).to be_nil
           expect(edit_new[:graph_other]).to be_truthy
-          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor::GRAPH_MAX_COUNT)
+          expect(edit_new[:graph_count]).to eq(ReportController::Reports::Editor.chart_top_values)
           expect(assigns(:refresh_div)).to eq("chart_div")
           expect(assigns(:refresh_partial)).to eq("form_chart")
         end
 
         it "sets top values to show" do
-          top_val = "3"
+          top_val = 3
           controller.params = {:chosen_count => top_val}
           controller.send(:gfv_charts)
           expect(assigns(:edit)[:new][:graph_count]).to eq(top_val)


### PR DESCRIPTION
Depends on
- [x] https://github.com/ManageIQ/manageiq/pull/22632

Proposing to make the "chart top values" (currently hardcoded to 10) externalized to `settings.yaml` and thus customizable. It'd read the below setting, if present, and use it. If this is good, I'm happy to create a PR for the Core with the default value (10).
```
:reporting
  :chart_top_values: 20
```

This controls how long/big this dropdown goes;
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/1767126/3c4bca6e-79db-4ee7-8183-eb0c5ba93fe1)

