### PR TITLE
Fixed physical providers empty page

### DIFF
--- a/app/javascript/components/pf_aggregate_status_card.jsx
+++ b/app/javascript/components/pf_aggregate_status_card.jsx
@@ -31,7 +31,7 @@ const PfAggregateStatusCard = ({
       </h2>
       <div className="card-pf-body">
         <div className="card-pf-aggregate-status-notifications">
-          { (data.notifications && data.notifications[0].dataAvailable === false) ? (
+          { (data.notifications && data.notifications[0] && data.notifications[0].dataAvailable === false) ? (
             <div className="empty-chart-contents">
               <span className="pficon pficon-info" />
               {' '}
@@ -56,7 +56,7 @@ const PfAggregateStatusCard = ({
               </span>
             ))) }
 
-          { (data.notifications && data.notifications[0].iconClass) && (
+          { (data.notifications && data.notifications[0] && data.notifications[0].iconClass) && (
             <>
               <span className={data.notifications[0].iconClass} />
 


### PR DESCRIPTION
Fixed a bug with the physical providers overview page occurring when the page is loaded with no providers.

Before:
![Screenshot 2023-06-15 at 10 20 25 AM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/0d8e7a7d-012c-4782-ba23-c52ae8d852b7)

After:
![Screenshot 2023-06-15 at 10 22 45 AM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/b5e63596-2389-4bb5-ac31-3e157421193c)

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @jeffibm
@miq-bot add-label bug
