### PR TITLE
Fix page title on auth_error screen

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -622,11 +622,19 @@ class DashboardController < ApplicationController
   end
 
   def breadcrumbs_options
-    {
-      :breadcrumbs => [
-        {:title => _("Overview")},
-        {:title => (action_name == "show" ? _("Dashboard") : _("Timelines"))},
-      ],
-    }
+    if action_name == "auth_error"
+      {
+        :breadcrumbs => [
+          {:title => _("Authorization Error")}
+        ]
+      }
+    else
+      {
+        :breadcrumbs => [
+          {:title => _("Overview")},
+          {:title => (action_name == "show" ? _("Dashboard") : _("Timelines"))},
+        ]
+      }
+    end
   end
 end


### PR DESCRIPTION
The auth_error incorrectly said "Overview / Timelines" before this fix.

Before:
![ManageIQ__Logins](https://github.com/ManageIQ/manageiq-ui-classic/assets/52120/da1acca8-857e-4c25-9319-defdd3b9cb63)

After:
![ManageIQ__Logins](https://github.com/ManageIQ/manageiq-ui-classic/assets/52120/c03e3f60-12cf-47a1-a6c7-4d5909c03bd5)

@jeffibm or @DavidResende0 Please review.
