### PR TITLE
Added Button Helper For Embedded Workflows

### DIFF
--- a/app/helpers/application_helper/button/embedded_workflow.rb
+++ b/app/helpers/application_helper/button/embedded_workflow.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::EmbeddedWorkflow < ApplicationHelper::Button::Basic
+  def disabled?
+    if Rbac.filtered(ManageIQ::Providers::Workflows::AutomationManager.all).empty?
+      @error_message = _("User isn't allowed to use the Embedded Workflows provider.")
+    end
+  end
+end


### PR DESCRIPTION
Adds a button helper similar to `app/helpers/application_helper/button/embedded_ansible.rb` for use in the embedded workflow credential and repository show/show_list pages