### PR TITLE
Added Filtering When Selecting An Ansible Credential Type

### DIFF
--- a/app/javascript/components/ansible-credentials-form/ansible-credentials-form.schema.js
+++ b/app/javascript/components/ansible-credentials-form/ansible-credentials-form.schema.js
@@ -48,7 +48,8 @@ const createSchema = (fields, promise, edit, loadSchema) => ({
               credential_types: { embedded_ansible_credential_types },
             },
           }) =>
-            Object.keys(embedded_ansible_credential_types).map((key) => ({
+            Object.keys(embedded_ansible_credential_types).filter((key) =>
+              key.includes('ManageIQ::Providers::EmbeddedAnsible::AutomationManager')).map((key) => ({
               value: key,
               label: __(embedded_ansible_credential_types[key].label),
             })),

--- a/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
+++ b/app/javascript/spec/ansible-credentials-form/__snapshots__/ansible-credentials-form.spec.js.snap
@@ -997,11 +997,7 @@ exports[`Ansible Credential Form Component should render adding a new credential
                                           },
                                           Object {
                                             "label": "Amazon",
-                                            "value": "foo",
-                                          },
-                                          Object {
-                                            "label": undefined,
-                                            "value": "bar",
+                                            "value": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
                                           },
                                         ]
                                       }
@@ -1082,34 +1078,20 @@ exports[`Ansible Credential Form Component should render adding a new credential
                                                 <SelectItem
                                                   disabled={false}
                                                   hidden={false}
-                                                  key="foo"
+                                                  key="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                   label="Amazon"
                                                   text="Amazon"
-                                                  value="foo"
+                                                  value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                 >
                                                   <option
                                                     className="bx--select-option"
                                                     disabled={false}
                                                     hidden={false}
                                                     label="Amazon"
-                                                    value="foo"
+                                                    value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                   >
                                                     Amazon
                                                   </option>
-                                                </SelectItem>
-                                                <SelectItem
-                                                  disabled={false}
-                                                  hidden={false}
-                                                  key="bar"
-                                                  text=""
-                                                  value="bar"
-                                                >
-                                                  <option
-                                                    className="bx--select-option"
-                                                    disabled={false}
-                                                    hidden={false}
-                                                    value="bar"
-                                                  />
                                                 </SelectItem>
                                               </select>
                                               <ForwardRef(ChevronDown16)
@@ -1509,7 +1491,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
       canReset={true}
       initialValues={
         Object {
-          "type": "foo",
+          "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
           "userid": "test",
         }
       }
@@ -1613,7 +1595,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
         dispatch={[Function]}
         initialValues={
           Object {
-            "type": "foo",
+            "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
             "userid": "test",
           }
         }
@@ -1708,7 +1690,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
           dispatch={[Function]}
           initialValues={
             Object {
-              "type": "foo",
+              "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
               "userid": "test",
             }
           }
@@ -1781,7 +1763,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
             dispatch={[Function]}
             initialValues={
               Object {
-                "type": "foo",
+                "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
                 "userid": "test",
               }
             }
@@ -2516,7 +2498,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                     placeholder="<Choose>"
                                     pluckSingleValue={true}
                                     simpleValue={false}
-                                    value="foo"
+                                    value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                   >
                                     <ClearedSelect
                                       className=""
@@ -2547,16 +2529,12 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                           },
                                           Object {
                                             "label": "Amazon",
-                                            "value": "foo",
-                                          },
-                                          Object {
-                                            "label": undefined,
-                                            "value": "bar",
+                                            "value": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
                                           },
                                         ]
                                       }
                                       placeholder="<Choose>"
-                                      value="foo"
+                                      value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                     >
                                       <Select
                                         className=""
@@ -2576,7 +2554,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                         onBlur={[Function]}
                                         onChange={[Function]}
                                         onFocus={[Function]}
-                                        value="foo"
+                                        value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                       >
                                         <div
                                           className="bx--form-item"
@@ -2610,7 +2588,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                                 onBlur={[Function]}
                                                 onChange={[Function]}
                                                 onFocus={[Function]}
-                                                value="foo"
+                                                value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                               >
                                                 <SelectItem
                                                   disabled={false}
@@ -2633,34 +2611,20 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                                 <SelectItem
                                                   disabled={false}
                                                   hidden={false}
-                                                  key="foo"
+                                                  key="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                   label="Amazon"
                                                   text="Amazon"
-                                                  value="foo"
+                                                  value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                 >
                                                   <option
                                                     className="bx--select-option"
                                                     disabled={false}
                                                     hidden={false}
                                                     label="Amazon"
-                                                    value="foo"
+                                                    value="ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo"
                                                   >
                                                     Amazon
                                                   </option>
-                                                </SelectItem>
-                                                <SelectItem
-                                                  disabled={false}
-                                                  hidden={false}
-                                                  key="bar"
-                                                  text=""
-                                                  value="bar"
-                                                >
-                                                  <option
-                                                    className="bx--select-option"
-                                                    disabled={false}
-                                                    hidden={false}
-                                                    value="bar"
-                                                  />
                                                 </SelectItem>
                                               </select>
                                               <ForwardRef(ChevronDown16)
@@ -2964,7 +2928,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                 "hasSubmitErrors": false,
                                 "hasValidationErrors": true,
                                 "initialValues": Object {
-                                  "type": "foo",
+                                  "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
                                   "userid": "test",
                                 },
                                 "invalid": true,
@@ -2990,7 +2954,7 @@ exports[`Ansible Credential Form Component should render editing a credential 1`
                                 "valid": false,
                                 "validating": false,
                                 "values": Object {
-                                  "type": "foo",
+                                  "type": "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo",
                                   "userid": "test",
                                 },
                                 "visited": Object {

--- a/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
+++ b/app/javascript/spec/ansible-credentials-form/ansible-credentials-form.spec.js
@@ -12,7 +12,7 @@ describe('Ansible Credential Form Component', () => {
     data: {
       credential_types: {
         embedded_ansible_credential_types: {
-          foo: {
+          'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo': {
             attributes: [
               {
                 component: 'text-field',
@@ -35,12 +35,12 @@ describe('Ansible Credential Form Component', () => {
   };
 
   beforeEach(() => {
-    fetchMock.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager', { 
-        "resources": [
-            {
-              "href": "http://localhost:3000/api/providers/1"
-            }
-        ],
+    fetchMock.get('/api/providers?collection_class=ManageIQ::Providers::EmbeddedAnsible::AutomationManager', {
+      resources: [
+        {
+          href: 'http://localhost:3000/api/providers/1',
+        },
+      ],
     });
   });
 
@@ -64,7 +64,7 @@ describe('Ansible Credential Form Component', () => {
 
   it('should render editing a credential', async(done) => {
     fetchMock.once('/api/authentications', api);
-    fetchMock.get('/api/authentications/1', { userid: 'test', type: 'foo' });
+    fetchMock.get('/api/authentications/1', { userid: 'test', type: 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::foo' });
     let wrapper;
 
     await act(async() => {


### PR DESCRIPTION
Filters the incoming credential types in the dropdown to ensure that only `EmbeddedAnsible` types appear as an option when creating a new Ansible Credential. This is needed now that Workflow credentials will exist.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/4c8c2334-8ecb-41d6-a622-7d1038109c5e)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/fa188ed1-baf4-4ce2-8a9f-edb9cdad3a7d)
