### PR TITLE
Fix dropdown options that overlaps with header

### DIFF
--- a/app/stylesheet/legacy/dialog_fields.scss
+++ b/app/stylesheet/legacy/dialog_fields.scss
@@ -1,3 +1,7 @@
 .dynamic-radio-label {
   padding: 0 3px;
 }
+
+.bootstrap-select.btn-group.bs-container .dropdown-menu {
+  z-index: 8001;
+}


### PR DESCRIPTION
Order Service page

**Before**
The Dropdown option list goes under the header and the search box is not visible.
<img width="1213" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ce8d09d0-be43-4e40-a773-78cb172aa90a">

**After**
The Dropdown option stays over the header and the search box is visible.
<img width="1192" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/68e366d9-6a31-4cc3-b384-a4d5e2bc3cb6">

Note: connect `bluecf-customization` to see the header.
