### PR TITLE
Fix the request refresh button

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -321,7 +321,7 @@ class MiqRequestController < ApplicationController
       show
       render :update do |page|
         page << javascript_prologue
-        page.replace("request_div", :partial => "miq_request/request")
+        page.replace("main_div", :template => "miq_request/show")
         page << javascript_reload_toolbars
       end
     elsif @display == "miq_provisions"


### PR DESCRIPTION
Fixed an issue where the request refresh button does not actually refresh the content on the page.

Create a request:
![Screenshot 2023-06-27 at 4 32 26 PM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/92b8d65d-a5f4-4c27-a7eb-98a6b18b982c)

After clicking the refresh button (no change):
![Screenshot 2023-06-27 at 4 32 55 PM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/bce7a66f-76e4-4a15-8ab8-812e60f0be1d)

After clicking the refresh button with this fix:
![Screenshot 2023-06-27 at 4 35 39 PM](https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/d81ab581-a637-4758-a679-b0b8cbfd14b6)

@miq-bot add_reviewer @DavidResende0
@miq-bot assign @DavidResende0 
@miq-bot add-label bug