### PR TITLE
Fixed ansible repository refresh buttons

### DIFF
--- a/app/helpers/application_helper/toolbar/ansible_repository_center.rb
+++ b/app/helpers/application_helper/toolbar/ansible_repository_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::AnsibleRepositoryCenter < ApplicationHelper::T
           :url     => "repository_refresh",
           :confirm => N_("Refresh this Repository?"),
           :enabled => true,
-          :onwhen  => "1"),
+        ),
         separator,
         button(
           :embedded_configuration_script_source_edit,


### PR DESCRIPTION
Ansible repository refresh button was disabled on the summary page. This pr fixes the issue and enables the button.

Before:
<img width="1180" alt="Screenshot 2023-06-30 at 1 49 15 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/91dc0e46-7c87-48a4-95f5-feb66166565f">

After:
<img width="1186" alt="Screenshot 2023-06-30 at 1 51 53 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/54e64ee9-5807-4ab3-8058-b3a1c083735f">

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @agrare 
@miq-bot assign @jeffibm 
@miq-bot add-label bug
