### PR TITLE
Mark workflow controllers as prototype

### DIFF
--- a/app/controllers/workflow_controller.rb
+++ b/app/controllers/workflow_controller.rb
@@ -1,4 +1,5 @@
 class WorkflowController < ApplicationController
+  before_action :check_prototype
   before_action :check_privileges
   before_action :get_session_data
 
@@ -56,6 +57,13 @@ class WorkflowController < ApplicationController
   end
 
   private
+
+  def check_prototype
+    return if Settings.prototype.ems_workflows.enabled
+
+    log_privileges(false, "Workflows are not enabled. The user is not authorized for this task or item.")
+    raise MiqException::RbacPrivilegeException, _('The user is not authorized for this task or item.')
+  end
 
   def textual_group_list
     [%i[properties relationships smart_management]]

--- a/app/controllers/workflow_repository_controller.rb
+++ b/app/controllers/workflow_repository_controller.rb
@@ -1,4 +1,6 @@
 class WorkflowRepositoryController < ApplicationController
+  before_action :check_prototype
+
   before_action :check_privileges
   before_action :get_session_data
 
@@ -31,6 +33,13 @@ class WorkflowRepositoryController < ApplicationController
   end
 
   private
+
+  def check_prototype
+    return if Settings.prototype.ems_workflows.enabled
+
+    log_privileges(false, "Workflows are not enabled. The user is not authorized for this task or item.")
+    raise MiqException::RbacPrivilegeException, _('The user is not authorized for this task or item.')
+  end
 
   def textual_group_list
     [%i[properties relationships options smart_management]]


### PR DESCRIPTION
This PR wrap prototype checks around the workflows and workflow_repositories controllers.  Note that setting the prototype flag still requires restarting the worker - I haven't found a way to do that yet because it requires reloading the menu and we don't seem to have a hook for that just yet, so I wanted to just get this base functionality in first.

Part of #8715 

@DavidResende0 Please review.