### PR TITLE
Filter effect text and clear option missing in sub listing pages

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -787,6 +787,7 @@ module VmCommon
   end
 
   def list_child_vms(model, node_id, title, show_list)
+    @edit = session[:edit]
     options = {
       :model       => model,
       :named_scope => scopes_for_role,


### PR DESCRIPTION
Before
-----------
<img width="1671" alt="Screenshot 2023-07-07 at 2 19 30 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/16753936/be87a8fc-191b-4df4-830b-dc6249d557e1">


After
------------
<img width="1678" alt="Screenshot 2023-07-07 at 5 12 20 PM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/16753936/f2096a1c-0e55-40e1-aa06-33b49e8fc6e5">



Steps for Testing/QA 
-------------------------------

Click Compute -> Clouds -> Instances page. Select Instances from Explorer and apply a filter. Go to the Instances by the provider. The data table shows the filtered instances but the filter title and clear option are missing.
