### PR TITLE
Fixed workflow repository specs

### DIFF
--- a/spec/controllers/workflow_repository_controller_spec.rb
+++ b/spec/controllers/workflow_repository_controller_spec.rb
@@ -1,8 +1,9 @@
 describe WorkflowRepositoryController do
   context 'with existing :embedded_workflow_configuration_script_source' do
     render_views
-
+    let(:workflows_enabled) { true }
     before do
+      stub_settings_merge(:prototype => {:ems_workflows => {:enabled => workflows_enabled}})
       EvmSpecHelper.assign_embedded_ansible_role
       login_as FactoryBot.create(:user_admin)
       # creating repository takes time, so we do it only once


### PR DESCRIPTION
Fixed workflow repository specs that were failing due to auth/permission errors.

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @agrare 
@miq-bot assign @agrare 
@miq-bot add-label bug