### PR TITLE
Fixed cypress logout test

### DIFF
--- a/cypress/e2e/ui/login.cy.js
+++ b/cypress/e2e/ui/login.cy.js
@@ -18,13 +18,13 @@ describe('Login / Logout', () => {
 
   it('Logout button', () => {
     cy.login();
-    cy.intercept('GET', '/api/auth?requester_type=ws').as('get');
+    cy.intercept('GET', '/dashboard/logout').as('get');
     cy.get('#menu_item_logout').click();
 
     cy.get('@get').then((getCall) => {
       expect(getCall.state).to.equal('Complete');
       expect(getCall.response).to.include({
-        statusCode: 401,
+        statusCode: 302,
       });
     });
 


### PR DESCRIPTION
Fixed cypress logout test. The API call that was being intercepted was incorrect. Changed to intercept the right call and also changed the expected status code. This allows the test cases to pass on all of Chrome, Edge, and Firefox.