### PR TITLE
Mark Switch Labels for Translation in Settings-Category Form

### DIFF
--- a/app/javascript/components/settings-category-form/schema.js
+++ b/app/javascript/components/settings-category-form/schema.js
@@ -43,6 +43,8 @@ const createSchema = (newRecord) => ({
           name: 'show',
           label: __('Show in console'),
           maxLength: 50,
+          onText: __('Yes'),
+          offText: __('No'),
         },
         {
           component: componentTypes.SWITCH,
@@ -52,6 +54,8 @@ const createSchema = (newRecord) => ({
           maxLength: 50,
           isDisabled: !newRecord,
           className: 'settings_category_single_value',
+          onText: __('Yes'),
+          offText: __('No'),
         },
         {
           component: componentTypes.SWITCH,
@@ -59,6 +63,8 @@ const createSchema = (newRecord) => ({
           name: 'perf_by_tag',
           label: __('Capture C & U Data by Tag'),
           maxLength: 50,
+          onText: __('Yes'),
+          offText: __('No'),
         },
         {
           component: 'plain-text',

--- a/app/javascript/spec/settings-category-form/__snapshots__/settings-category-form.spec.js.snap
+++ b/app/javascript/spec/settings-category-form/__snapshots__/settings-category-form.spec.js.snap
@@ -82,6 +82,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                   "label": "Show in console",
                   "maxLength": 50,
                   "name": "show",
+                  "offText": "No",
+                  "onText": "Yes",
                 },
                 Object {
                   "className": "settings_category_single_value",
@@ -91,6 +93,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                   "label": "Single value",
                   "maxLength": 50,
                   "name": "single_value",
+                  "offText": "No",
+                  "onText": "Yes",
                 },
                 Object {
                   "component": "switch",
@@ -98,6 +102,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                   "label": "Capture C & U Data by Tag",
                   "maxLength": 50,
                   "name": "perf_by_tag",
+                  "offText": "No",
+                  "onText": "Yes",
                 },
                 Object {
                   "component": "plain-text",
@@ -212,6 +218,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                     "label": "Show in console",
                     "maxLength": 50,
                     "name": "show",
+                    "offText": "No",
+                    "onText": "Yes",
                   },
                   Object {
                     "className": "settings_category_single_value",
@@ -221,6 +229,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                     "label": "Single value",
                     "maxLength": 50,
                     "name": "single_value",
+                    "offText": "No",
+                    "onText": "Yes",
                   },
                   Object {
                     "component": "switch",
@@ -228,6 +238,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                     "label": "Capture C & U Data by Tag",
                     "maxLength": 50,
                     "name": "perf_by_tag",
+                    "offText": "No",
+                    "onText": "Yes",
                   },
                   Object {
                     "component": "plain-text",
@@ -335,6 +347,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                       "label": "Show in console",
                       "maxLength": 50,
                       "name": "show",
+                      "offText": "No",
+                      "onText": "Yes",
                     },
                     Object {
                       "className": "settings_category_single_value",
@@ -344,6 +358,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                       "label": "Single value",
                       "maxLength": 50,
                       "name": "single_value",
+                      "offText": "No",
+                      "onText": "Yes",
                     },
                     Object {
                       "component": "switch",
@@ -351,6 +367,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                       "label": "Capture C & U Data by Tag",
                       "maxLength": 50,
                       "name": "perf_by_tag",
+                      "offText": "No",
+                      "onText": "Yes",
                     },
                     Object {
                       "component": "plain-text",
@@ -458,6 +476,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Show in console",
                           "maxLength": 50,
                           "name": "show",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "className": "settings_category_single_value",
@@ -467,6 +487,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Single value",
                           "maxLength": 50,
                           "name": "single_value",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "component": "switch",
@@ -474,6 +496,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Capture C & U Data by Tag",
                           "maxLength": 50,
                           "name": "perf_by_tag",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "component": "plain-text",
@@ -545,6 +569,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Show in console",
                           "maxLength": 50,
                           "name": "show",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "className": "settings_category_single_value",
@@ -554,6 +580,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Single value",
                           "maxLength": 50,
                           "name": "single_value",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "component": "switch",
@@ -561,6 +589,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                           "label": "Capture C & U Data by Tag",
                           "maxLength": 50,
                           "name": "perf_by_tag",
+                          "offText": "No",
+                          "onText": "Yes",
                         },
                         Object {
                           "component": "plain-text",
@@ -643,6 +673,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Show in console",
                             "maxLength": 50,
                             "name": "show",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "className": "settings_category_single_value",
@@ -652,6 +684,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Single value",
                             "maxLength": 50,
                             "name": "single_value",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "component": "switch",
@@ -659,6 +693,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Capture C & U Data by Tag",
                             "maxLength": 50,
                             "name": "perf_by_tag",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "component": "plain-text",
@@ -736,6 +772,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Show in console",
                             "maxLength": 50,
                             "name": "show",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "className": "settings_category_single_value",
@@ -745,6 +783,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Single value",
                             "maxLength": 50,
                             "name": "single_value",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "component": "switch",
@@ -752,6 +792,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                             "label": "Capture C & U Data by Tag",
                             "maxLength": 50,
                             "name": "perf_by_tag",
+                            "offText": "No",
+                            "onText": "Yes",
                           },
                           Object {
                             "component": "plain-text",
@@ -849,6 +891,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Show in console",
                               "maxLength": 50,
                               "name": "show",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "className": "settings_category_single_value",
@@ -858,6 +902,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Single value",
                               "maxLength": 50,
                               "name": "single_value",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "component": "switch",
@@ -865,6 +911,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Capture C & U Data by Tag",
                               "maxLength": 50,
                               "name": "perf_by_tag",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "component": "plain-text",
@@ -942,6 +990,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Show in console",
                               "maxLength": 50,
                               "name": "show",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "className": "settings_category_single_value",
@@ -951,6 +1001,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Single value",
                               "maxLength": 50,
                               "name": "single_value",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "component": "switch",
@@ -958,6 +1010,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                               "label": "Capture C & U Data by Tag",
                               "maxLength": 50,
                               "name": "perf_by_tag",
+                              "offText": "No",
+                              "onText": "Yes",
                             },
                             Object {
                               "component": "plain-text",
@@ -1046,6 +1100,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                 "label": "Show in console",
                                 "maxLength": 50,
                                 "name": "show",
+                                "offText": "No",
+                                "onText": "Yes",
                               },
                               Object {
                                 "className": "settings_category_single_value",
@@ -1055,6 +1111,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                 "label": "Single value",
                                 "maxLength": 50,
                                 "name": "single_value",
+                                "offText": "No",
+                                "onText": "Yes",
                               },
                               Object {
                                 "component": "switch",
@@ -1062,6 +1120,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                 "label": "Capture C & U Data by Tag",
                                 "maxLength": 50,
                                 "name": "perf_by_tag",
+                                "offText": "No",
+                                "onText": "Yes",
                               },
                               Object {
                                 "component": "plain-text",
@@ -1127,6 +1187,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     "label": "Show in console",
                                     "maxLength": 50,
                                     "name": "show",
+                                    "offText": "No",
+                                    "onText": "Yes",
                                   },
                                   Object {
                                     "className": "settings_category_single_value",
@@ -1136,6 +1198,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     "label": "Single value",
                                     "maxLength": 50,
                                     "name": "single_value",
+                                    "offText": "No",
+                                    "onText": "Yes",
                                   },
                                   Object {
                                     "component": "switch",
@@ -1143,6 +1207,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     "label": "Capture C & U Data by Tag",
                                     "maxLength": 50,
                                     "name": "perf_by_tag",
+                                    "offText": "No",
+                                    "onText": "Yes",
                                   },
                                   Object {
                                     "component": "plain-text",
@@ -1212,6 +1278,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                       "label": "Show in console",
                                       "maxLength": 50,
                                       "name": "show",
+                                      "offText": "No",
+                                      "onText": "Yes",
                                     },
                                     Object {
                                       "className": "settings_category_single_value",
@@ -1221,6 +1289,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                       "label": "Single value",
                                       "maxLength": 50,
                                       "name": "single_value",
+                                      "offText": "No",
+                                      "onText": "Yes",
                                     },
                                     Object {
                                       "component": "switch",
@@ -1228,6 +1298,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                       "label": "Capture C & U Data by Tag",
                                       "maxLength": 50,
                                       "name": "perf_by_tag",
+                                      "offText": "No",
+                                      "onText": "Yes",
                                     },
                                     Object {
                                       "component": "plain-text",
@@ -1610,6 +1682,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     label="Show in console"
                                     maxLength={50}
                                     name="show"
+                                    offText="No"
+                                    onText="Yes"
                                   >
                                     <FormConditionWrapper
                                       field={
@@ -1619,6 +1693,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           "label": "Show in console",
                                           "maxLength": 50,
                                           "name": "show",
+                                          "offText": "No",
+                                          "onText": "Yes",
                                         }
                                       }
                                     >
@@ -1631,11 +1707,15 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           label="Show in console"
                                           maxLength={50}
                                           name="show"
+                                          offText="No"
+                                          onText="Yes"
                                         >
                                           <div>
                                             <FeatureToggle(Toggle)
                                               id="show"
                                               key="show"
+                                              labelA="No"
+                                              labelB="Yes"
                                               labelText="Show in console"
                                               maxLength={50}
                                               name="show"
@@ -1649,8 +1729,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                 aria-label="Toggle"
                                                 defaultToggled={false}
                                                 id="show"
-                                                labelA="Off"
-                                                labelB="On"
+                                                labelA="No"
+                                                labelB="Yes"
                                                 labelText="Show in console"
                                                 maxLength={50}
                                                 name="show"
@@ -1690,13 +1770,13 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--off"
                                                       >
-                                                        Off
+                                                        No
                                                       </span>
                                                       <span
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--on"
                                                       >
-                                                        On
+                                                        Yes
                                                       </span>
                                                     </span>
                                                   </label>
@@ -1718,6 +1798,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     label="Single value"
                                     maxLength={50}
                                     name="single_value"
+                                    offText="No"
+                                    onText="Yes"
                                   >
                                     <FormConditionWrapper
                                       field={
@@ -1729,6 +1811,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           "label": "Single value",
                                           "maxLength": 50,
                                           "name": "single_value",
+                                          "offText": "No",
+                                          "onText": "Yes",
                                         }
                                       }
                                     >
@@ -1743,6 +1827,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           label="Single value"
                                           maxLength={50}
                                           name="single_value"
+                                          offText="No"
+                                          onText="Yes"
                                         >
                                           <div>
                                             <FeatureToggle(Toggle)
@@ -1750,6 +1836,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                               disabled={false}
                                               id="single_value"
                                               key="single_value"
+                                              labelA="No"
+                                              labelB="Yes"
                                               labelText="Single value"
                                               maxLength={50}
                                               name="single_value"
@@ -1765,8 +1853,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                 defaultToggled={false}
                                                 disabled={false}
                                                 id="single_value"
-                                                labelA="Off"
-                                                labelB="On"
+                                                labelA="No"
+                                                labelB="Yes"
                                                 labelText="Single value"
                                                 maxLength={50}
                                                 name="single_value"
@@ -1807,13 +1895,13 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--off"
                                                       >
-                                                        Off
+                                                        No
                                                       </span>
                                                       <span
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--on"
                                                       >
-                                                        On
+                                                        Yes
                                                       </span>
                                                     </span>
                                                   </label>
@@ -1833,6 +1921,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                     label="Capture C & U Data by Tag"
                                     maxLength={50}
                                     name="perf_by_tag"
+                                    offText="No"
+                                    onText="Yes"
                                   >
                                     <FormConditionWrapper
                                       field={
@@ -1842,6 +1932,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           "label": "Capture C & U Data by Tag",
                                           "maxLength": 50,
                                           "name": "perf_by_tag",
+                                          "offText": "No",
+                                          "onText": "Yes",
                                         }
                                       }
                                     >
@@ -1854,11 +1946,15 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                           label="Capture C & U Data by Tag"
                                           maxLength={50}
                                           name="perf_by_tag"
+                                          offText="No"
+                                          onText="Yes"
                                         >
                                           <div>
                                             <FeatureToggle(Toggle)
                                               id="perf_by_tag"
                                               key="perf_by_tag"
+                                              labelA="No"
+                                              labelB="Yes"
                                               labelText="Capture C & U Data by Tag"
                                               maxLength={50}
                                               name="perf_by_tag"
@@ -1872,8 +1968,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                 aria-label="Toggle"
                                                 defaultToggled={false}
                                                 id="perf_by_tag"
-                                                labelA="Off"
-                                                labelB="On"
+                                                labelA="No"
+                                                labelB="Yes"
                                                 labelText="Capture C & U Data by Tag"
                                                 maxLength={50}
                                                 name="perf_by_tag"
@@ -1913,13 +2009,13 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--off"
                                                       >
-                                                        Off
+                                                        No
                                                       </span>
                                                       <span
                                                         aria-hidden="true"
                                                         className="bx--toggle__text--on"
                                                       >
-                                                        On
+                                                        Yes
                                                       </span>
                                                     </span>
                                                   </label>
@@ -2075,6 +2171,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Show in console",
                                         "maxLength": 50,
                                         "name": "show",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "className": "settings_category_single_value",
@@ -2084,6 +2182,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Single value",
                                         "maxLength": 50,
                                         "name": "single_value",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "component": "switch",
@@ -2091,6 +2191,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Capture C & U Data by Tag",
                                         "maxLength": 50,
                                         "name": "perf_by_tag",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "component": "plain-text",
@@ -2252,6 +2354,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Show in console",
                                         "maxLength": 50,
                                         "name": "show",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "className": "settings_category_single_value",
@@ -2261,6 +2365,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Single value",
                                         "maxLength": 50,
                                         "name": "single_value",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "component": "switch",
@@ -2268,6 +2374,8 @@ exports[`SettingsCategoryForm Component should render a new SettingsCategoryForm
                                         "label": "Capture C & U Data by Tag",
                                         "maxLength": 50,
                                         "name": "perf_by_tag",
+                                        "offText": "No",
+                                        "onText": "Yes",
                                       },
                                       Object {
                                         "component": "plain-text",


### PR DESCRIPTION
Found in: Application Settings -> Settings -> Region -> Tags -> Add Category

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/79073874-e321-4c4d-876b-abebc6e8e88c)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/25c47618-ef84-4ea5-814c-d660caa4b06a)
