### PR TITLE
Add Missing Routes to Configuration Profiles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2614,7 +2614,10 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         launch_configuration_profile_console
-      ]
+      ] +
+        adv_search_post +
+        exp_post +
+        save_post
     },
 
     :configured_system  => {

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -268,6 +268,16 @@ ConfigurationProfileController:
 - index
 - quick_search
 - reload
+- adv_search_button
+- adv_search_clear
+- adv_search_load_choice
+- adv_search_name_typed
+- adv_search_toggle
+- search_clear
+- exp_button
+- exp_changed
+- exp_token_pressed
+- save_default_search
 ConfigurationScriptController:
 - index
 - reload


### PR DESCRIPTION
Adds the missing advanced search routes to the Configuration Profiles page.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/38317336-6e8a-4c3b-94ea-53e37748ef02)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/c6a5a6bf-233c-4777-8236-acc5db6e6e4d)
