### PR TITLE
Delete the cypress videos for passing tests on CI

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,8 +1,24 @@
 const { defineConfig } = require('cypress');
+const fs = require('fs')
 
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     numTestsKeptInMemory: 0,
+    videoCompression: false,
+    setupNodeEvents(on, config) {
+      on('after:spec', (spec, results) => {
+        // Delete the video on CI if the spec passed and no tests retried
+        if (process.env.CI && results && results.video && fs.existsSync(results.video)) {
+          // Do we have failures for any retry attempts?
+          const failures = results.tests.some((test) =>
+            test.attempts.some((attempt) => attempt.state === 'failed')
+          )
+          if (!failures) {
+            fs.unlinkSync(results.video)
+          }
+        }
+      })
+    },
   },
 });


### PR DESCRIPTION
This is for CI purposes, where these extra videos take up space, and
aren't needed when trying to debug failures. Additionally, this commit
removes the video compression since it takes time, and we are going to
delete 90%+ of the videos anyway.

@GilbertCherrie Please review.

~~WIP because I just added in the CI env var check and want to verify that works first.~~ It works: https://github.com/Fryguy/manageiq-cypress-tests/actions/runs/5614492505
