### PR TITLE
Fix utilization chart

### DIFF
--- a/app/javascript/components/performance-charts/groupChart.js
+++ b/app/javascript/components/performance-charts/groupChart.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { GroupedBarChart } from '@carbon/charts-react';
+import { getYAxisValue } from './helpers';
+
+const GroupBarChart = ({
+  data, format, size, title,
+}) => {
+  const options = {
+    title,
+    axes: {
+      left: {
+        mapsTo: 'value',
+        ticks: {
+          formatter(n) { return getYAxisValue(format, n); },
+        },
+      },
+      bottom: {
+        scaleType: 'labels',
+        mapsTo: 'key',
+      },
+    },
+    height: size,
+    tooltip: {
+      truncation: {
+        type: 'none',
+      },
+    },
+  };
+
+  return (
+    <GroupedBarChart data={data} options={options} />
+  );
+};
+
+GroupBarChart.propTypes = {
+  data: PropTypes.instanceOf(Array),
+  format: PropTypes.instanceOf(Object),
+  size: PropTypes.string,
+  title: PropTypes.string,
+};
+
+GroupBarChart.defaultProps = {
+  data: null,
+  format: null,
+  size: '400px',
+  title: '',
+};
+
+export default GroupBarChart;

--- a/app/javascript/components/performance-charts/index.jsx
+++ b/app/javascript/components/performance-charts/index.jsx
@@ -2,16 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LineChartGraph from './lineChart';
 import AreaChartGraph from './areaChart';
-import { getLineConvertedData } from '../carbon-charts/helpers';
+import GroupBarChart from './groupChart';
+import { getConvertedData, getLineConvertedData } from '../carbon-charts/helpers';
+import EmptyChart from '../dashboard-widgets/dashboard-charts/emptyChart';
 
 const PerformanceChartWidget = ({
   // eslint-disable-next-line no-unused-vars
   data, id, size, title,
 }) => {
-  const convertedData = getLineConvertedData(data);
-
+  let convertedData = getLineConvertedData(data);
+  if (data.miq && data.miq.empty) {
+    return (<EmptyChart />);
+  }
   if (data.miqChart === 'Area') {
     return (<AreaChartGraph data={convertedData} format={data.miq.format} size={size} title={title} />);
+  }
+  if ((data.miqChart === 'StackedColumn' || data.miqChart === 'Column') && !data.data.groups) {
+    convertedData = getConvertedData(data);
+    return (<GroupBarChart data={convertedData} format={data.miq.format} size={size} title={title} />);
   }
   return (<LineChartGraph data={convertedData} format={data.miq.format} size={size} title={title} />);
 };


### PR DESCRIPTION
Fixed utilization `Selected Day Percent Utilization` chart.

Before:
<img width="1526" alt="Screenshot 2023-07-25 at 10 50 02 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/feced217-c61c-4417-be1a-1e02d589059a">

After:
<img width="1528" alt="Screenshot 2023-07-25 at 10 45 21 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/32444791/c87cdd04-6d18-4626-822e-b55bd7798a6f">
