### PR TITLE
[MORPHY] Add Missing Routes to Configuration Profiles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2648,7 +2648,10 @@ Rails.application.routes.draw do
         show_list
         tagging_edit
         launch_configuration_profile_console
-      ]
+      ] +
+        adv_search_post +
+        exp_post +
+        save_post
     },
 
     :configured_system  => {

--- a/spec/config/routes.pending.yml
+++ b/spec/config/routes.pending.yml
@@ -283,6 +283,16 @@ ConfigurationProfileController:
 - index
 - quick_search
 - reload
+- adv_search_button
+- adv_search_clear
+- adv_search_load_choice
+- adv_search_name_typed
+- adv_search_toggle
+- search_clear
+- exp_button
+- exp_changed
+- exp_token_pressed
+- save_default_search
 ConfiguredSystemController:
 - dialog_field_changed
 - dialog_form_button_pressed


### PR DESCRIPTION
Same PR as https://github.com/ManageIQ/manageiq-ui-classic/pull/8862 but for Morphy. Solves the backport conflict.