### PR TITLE
Added supports?(:update) check to Host Edit Form

### DIFF
--- a/app/helpers/application_helper/button/host_edit.rb
+++ b/app/helpers/application_helper/button/host_edit.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::HostEdit < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    !@record.supports?(:update)
+  end
+end

--- a/app/helpers/application_helper/toolbar/host_center.rb
+++ b/app/helpers/application_helper/toolbar/host_center.rb
@@ -47,7 +47,8 @@ class ApplicationHelper::Toolbar::HostCenter < ApplicationHelper::Toolbar::Basic
           'pficon pficon-edit fa-lg',
           t = N_('Edit this item'),
           t,
-          :url => "/edit"),
+          :klass => ApplicationHelper::Button::HostEdit,
+          :url   => "/edit"),
         button(
           :host_toggle_maintenance,
           'pficon pficon-edit fa-lg',

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -52,6 +52,8 @@ describe HostController do
     it 'edit renders GTL grid with selected Host records' do
       session[:host_items] = [h1.id, h2.id]
       session[:settings] = {:views   => {:host => 'grid'}}
+      stub_supports(h1, :update)
+      stub_supports(h2, :update)
 
       expect_any_instance_of(GtlHelper).to receive(:render_gtl).with match_gtl_options(
         :model_name       => 'Host',
@@ -493,6 +495,8 @@ describe HostController do
     before do
       allow(controller).to receive(:assert_privileges)
       allow(controller).to receive(:session).and_return(:host_items => [h1.id, h2.id])
+      stub_supports(h1, :update)
+      stub_supports(h2, :update)
       controller.instance_variable_set(:@breadcrumbs, [])
     end
 


### PR DESCRIPTION
Adds a check to the Host controller that ensures that a host is able to be edited/updated before proceeding to the Host Edit Form. Also disables the Edit button in the `show` page when the above condition is met.

**Before:**
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/ce7e9451-aa21-4bf9-8437-7683eb182b8e)

**After:**
Single Host Edit
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/f70d2a5e-55d0-4554-9253-94a9d77b5e91)

Multi-Host Edit
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/a3033f28-e79b-4e4d-a00b-0432611861f2)

`show` page
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/44185705-d007-48b8-bcc7-4391fba6a4ed)
