### PR TITLE
Ensure yarn.lock is not updated by yarn install

### DIFF
--- a/lib/tasks/manageiq/ui_tasks.rake
+++ b/lib/tasks/manageiq/ui_tasks.rake
@@ -9,7 +9,7 @@ namespace :update do
         puts "== #{engine.name} =="
         system("which yarn >/dev/null") || abort("\n== You have to install yarn ==")
         system("yarn set version 1.22.18") || abort("\n== yarn failed to set version to 1.22.18 in #{engine.path} ==") if RUBY_PLATFORM.include?("s390x")
-        system("yarn") || abort("\n== yarn failed in #{engine.path} ==")
+        system("yarn --frozen-lockfile") || abort("\n== yarn failed in #{engine.path} ==") # Switch --frozen-lockfile to --immutable once s390x is off of yarn 1.
       end
     end
   end


### PR DESCRIPTION
Without this it allows packages to be updated.  Not only is that not what we want for production builds, but upgrading from es-abstract 1.21 to 1.22 breaks us right now.

```
ERROR in ./node_modules/es-abstract/2015/Canonicalize.js Module not found: Error: Can't resolve '../helpers/caseFolding' in '/root/BUILD/infrastructure-management-gemset-16.0.0/bundler/gems/bluecf-ui-classic-2ea695ae0f41/node_modules/es-abstract/2015'
 @ ./node_modules/es-abstract/2015/Canonicalize.js 15:18-51
 @ ./node_modules/es-abstract/es2015.js
 @ ./node_modules/es-abstract/es6.js
 @ ./node_modules/array-includes/index.js
 @ multi es6-shim array-includes whatwg-fetch core-js/stable regenerator-runtime/runtime
webpack: done 2023-07-29T02:42:38.451Z
```
