### PR TITLE
Fix data-tables cell text alignment

### DIFF
--- a/app/stylesheet/miq-data-table.scss
+++ b/app/stylesheet/miq-data-table.scss
@@ -154,7 +154,6 @@
 
       &.white_space_normal {
         white-space: normal !important;
-        text-align: justify;
         margin-bottom: 10px;
       }
 


### PR DESCRIPTION
Removed the justify alignment style for cells with multiple lines

**Before**
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/7050bc94-8940-4093-8aa9-68d56b11f5bf)

**After**
Notable changes on the column `Description` and` Last Message`
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/c5efc183-400e-4227-b1f7-cba2f3c01d56)
