### PR TITLE
Added Specs for When a Host Doesn't Support Editing

### DIFF
--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -140,7 +140,7 @@ class HostController < ApplicationController
       unless @host.supports?(:update) # if host doesn't support editing
         add_flash(_("This Host does not support editing"), :error)
         flash_to_session
-        redirect_to(:action => @lastaction, :id => params[:id])
+        return redirect_to(:action => @lastaction, :id => params[:id])
       end
 
       @in_a_form = true
@@ -164,7 +164,7 @@ class HostController < ApplicationController
         unless h.supports?(:update) # if host doesn't support editing
           add_flash(_("One of the Hosts does not support editing"), :error)
           flash_to_session
-          redirect_to(:action => @lastaction, :id => params[:id])
+          return redirect_to(:action => @lastaction, :id => params[:id])
         end
 
         @selected_hosts[h.id] = h.name

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -64,6 +64,14 @@ describe HostController do
       expect(response.status).to eq(200)
     end
 
+    it 'returns an error when trying to edit a host that does not support editing' do
+      session[:host_items] = [h1.id, h2.id]
+
+      get :edit
+      expect(controller.send(:flash_errors?)).to be_truthy
+      expect(response.status).to eq(302)
+    end
+
     it "when VM Right Size Recommendations is pressed" do
       expect(controller).to receive(:vm_right_size)
       post :button, :params => {:pressed => 'vm_right_size', :format => :js}


### PR DESCRIPTION
Follow up to: https://github.com/ManageIQ/manageiq-ui-classic/pull/8878

Adds a spec test that ensures the user is redirected from the edit page when the host they're trying to edit does not support editing. Also corrects an issue I encountered while working on the spec test.