### PR TITLE
Add Menu::Manager.reload method

### DIFF
--- a/app/presenters/menu/manager.rb
+++ b/app/presenters/menu/manager.rb
@@ -6,8 +6,13 @@ module Menu
     class << self
       extend Forwardable
 
-      delegate %i[menu item_in_section? item items section section_id_string_to_symbol
+      delegate %i[menu item_in_section? item items reload section section_id_string_to_symbol
                   section_for_item_id each map detect select] => :instance
+    end
+
+    def reload
+      @menu = @id_to_section = @valid_sections = nil
+      initialize
     end
 
     def each

--- a/spec/presenters/menu/menu_manager_spec.rb
+++ b/spec/presenters/menu/menu_manager_spec.rb
@@ -5,7 +5,7 @@ describe Menu::Manager do
     Singleton.__init__(Menu::Manager)
   end
 
-  context "initialize" do
+  describe "#initialize" do
     it "loads default menu items" do
       section = Menu::Manager.section(:vi)
       expect(section).to be_truthy
@@ -18,7 +18,7 @@ describe Menu::Manager do
     end
   end
 
-  context "menu" do
+  describe ".menu" do
     it "knows about custom section with items" do
       temp_file  = section_file
       temp_file2 = item_file
@@ -35,6 +35,26 @@ describe Menu::Manager do
         temp_file.unlink
         temp_file2.unlink
       end
+    end
+  end
+
+  describe ".reload" do
+    before do
+      stub_settings_merge(:product => {:consumption => nil})
+    end
+
+    it "reloads the menu" do
+      expect(described_class.item(:cons)).to be_nil
+
+      Settings.product.consumption = true
+      described_class.reload
+
+      expect(described_class.item(:cons)).to be_a(Menu::Section)
+
+      Settings.product.consumption = nil
+      described_class.reload
+
+      expect(described_class.item(:cons)).to be_nil
     end
   end
 end


### PR DESCRIPTION
This method will allow for reloading the menu as Settings change.

@agrare Please review.

This is technically part of the Workflows work in #8715, since I want the prototype settings change to call this (but it will be a core change for that).