### PR TITLE
Add icons and provider name to a few screens

### DIFF
--- a/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
+++ b/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
@@ -5,11 +5,15 @@ module AuthKeyPairCloudHelper::TextualSummary
   # Groups
   #
   def textual_group_relationships
-    TextualGroup.new(_("Relationships"), %i[vms])
+    TextualGroup.new(_("Relationships"), %i[provider vms])
   end
 
   def textual_group_properties
     TextualGroup.new(_("Properties"), %i[name fingerprint])
+  end
+
+  def textual_provider
+    textual_link(@record.ext_management_system)
   end
 
   #

--- a/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/app/helpers/resource_pool_helper/textual_summary.rb
@@ -3,6 +3,10 @@ module ResourcePoolHelper::TextualSummary
   # Groups
   #
 
+  def textual_ext_management_system
+    textual_link(@record.ext_management_system)
+  end
+
   def textual_group_properties
     TextualGroup.new(
       _("Properties"),
@@ -16,7 +20,7 @@ module ResourcePoolHelper::TextualSummary
   def textual_group_relationships
     TextualGroup.new(
       _("Relationships"),
-      %i[parent_datacenter parent_cluster parent_host direct_vms allvms_size resource_pools]
+      %i[ext_management_system parent_datacenter parent_cluster parent_host direct_vms allvms_size resource_pools]
     )
   end
 

--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -30,6 +30,9 @@ include:
   container_image:
     columns:
     - name
+  ext_management_system:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -37,6 +40,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
+- ext_management_system.name
 - container_group.name
 - container_image.name
 - state
@@ -44,6 +48,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Provider
 - Pod Name
 - Image
 - State

--- a/product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
@@ -21,9 +21,13 @@ db: ManageIQ::Providers::CloudManager::AuthKeyPair
 cols:
 - name
 - fingerprint
+- type
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  ext_management_system:
+    columns:
+    - name
 
 # Included tables and columns for query performance
 include_for_find:
@@ -32,11 +36,13 @@ include_for_find:
 col_order:
 - name
 - fingerprint
+- ext_management_system.name
 
 # Column titles, in order
 headers:
 - Name
 - Fingerprint
+- Provider
 
 # Condition(s) string for the SQL query
 conditions:

--- a/product/views/PlacementGroup.yaml
+++ b/product/views/PlacementGroup.yaml
@@ -39,12 +39,14 @@ include_for_find:
 col_order:
 - name
 - id
+- ext_management_system.name
 - total_vms
 
 # Column titles, in order
 headers:
 - Name
 - ID
+- Provider
 - Total VMs
 
 # Condition(s) string for the SQL query

--- a/product/views/ResourcePool.yaml
+++ b/product/views/ResourcePool.yaml
@@ -30,10 +30,14 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  ext_management_system:
+    columns:
+    - name
 
 # Order of columns (from all tables)
 col_order:
 - name
+- ext_management_system.name
 - v_direct_vms
 - v_total_vms
 - v_total_miq_templates
@@ -45,6 +49,7 @@ col_order:
 # Column titles, in order
 headers:
 - Name
+- Provider
 - Direct VMs
 - Total VMs
 - Total Templates

--- a/product/views/Switch.yaml
+++ b/product/views/Switch.yaml
@@ -23,15 +23,23 @@ cols:
 - ports
 - switch_uuid
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
 # Order of columns (from all tables)
 col_order:
 - name
+- ext_management_system.name
 - ports
 - switch_uuid
 
 # Column titles, in order
 headers:
 - Name
+- Provider
 - Ports
 - UUID
 

--- a/spec/helpers/auth_key_pair_cloud_helper/textual_summary_spec.rb
+++ b/spec/helpers/auth_key_pair_cloud_helper/textual_summary_spec.rb
@@ -1,4 +1,4 @@
 describe AuthKeyPairCloudHelper::TextualSummary do
-  include_examples "textual_group", "Relationships", %i(vms)
-  include_examples "textual_group", "Properties", %i(name fingerprint)
+  include_examples "textual_group", "Relationships", %i[provider vms]
+  include_examples "textual_group", "Properties", %i[name fingerprint]
 end

--- a/spec/helpers/resource_pool_helper/textual_summary_spec.rb
+++ b/spec/helpers/resource_pool_helper/textual_summary_spec.rb
@@ -10,6 +10,7 @@ describe ResourcePoolHelper::TextualSummary do
   )
 
   include_examples "textual_group", "Relationships", %i(
+    ext_management_system
     parent_datacenter
     parent_cluster
     parent_host


### PR DESCRIPTION
alt for https://github.com/ManageIQ/manageiq-ui-classic/pull/8798

requires:
- [x] https://github.com/ManageIQ/manageiq/pull/22645
- [x] https://github.com/ManageIQ/manageiq/pull/22735

changes:

- fixed gtl so it properly passed ems to function displaying ems icons
- [x] Cloud - Key Pairs summary
- [x] Cloud - Key Pairs list
- Cloud - Placement Groups summary - already had ems_cloud
- [x] Cloud - Placement Groups list 
- [x] Infrastructure - Resource Pools summary page - tested
- [x] Infrastructure - Resource Pools list page - tested
- Infrastructure - Networking - `Switch` summary - already had provider
- [x] Infrastructure - Networking - `Switch` list
- Containers - Container summary - already had provider
- [x] Containers - Containers list

resource pools
==============

![8847-resource_pools-summary-after](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/c5bdcd0e-2b3e-436b-91a7-950347ef9742)

![8847-resource_pools-summary-before](https://github.com/ManageIQ/manageiq-ui-classic/assets/1930/fa20304b-b9df-4b81-a104-bf2bb9d0e47e)


After
**Container/ containers**
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/a5d5f775-3896-49ce-badf-45f62d37f463)
