### PR TITLE
Fix for the subrow items in summary pages

### DIFF
--- a/app/stylesheet/miq-structured-list.scss
+++ b/app/stylesheet/miq-structured-list.scss
@@ -95,10 +95,14 @@
       .sub_row_item {
         width: 100%;
         display: flex;
-        padding: 5px 0 5px 0;
+        margin-bottom: 5px;
+
+        .cell {
+          align-items: flex-start;
+        }
 
         .sub_label {
-          width: 50%;
+          width: 45%;
           font-weight: 600;
           display: inline-block;
           text-overflow: ellipsis;
@@ -109,6 +113,7 @@
         .sub_value {
           display: flex;
           flex-grow: 1;
+          width: 45%;
         }
       }
     }


### PR DESCRIPTION
Notable changes in `Smart Management` box

Before
<img width="892" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/cb13731b-7f09-4c27-b457-b515ffe6a2a2">

After
<img width="1528" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/32fc2b77-1ed6-4abc-b486-412323a4cb73">
