### PR TITLE
[WIP] Allow more specific restriction types for roles

### DIFF
--- a/app/helpers/ops_helper/role_rbac_details_helper.rb
+++ b/app/helpers/ops_helper/role_rbac_details_helper.rb
@@ -12,8 +12,11 @@ module OpsHelper::RoleRbacDetailsHelper
     rows = [
       row_data(_('ID'), role.id),
       row_data(_('Name'), role.name),
-      row_data(_("Access Restriction for Orchestration Stacks, Key Pairs, Services, VMs, and Templates"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :vms) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :vms)]) : _("None")),
       row_data(_("Access Restriction for Catalog Items"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :service_templates) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :service_templates)]) : _("None")),
+      row_data(_("Access Restriction for Key Pairs"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :auth_key_pairs) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :auth_key_pairs)]) : _("None")),
+      row_data(_("Access Restriction for Orchestration Stacks"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :orchestration_stacks) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :orchestration_stacks)]) : _("None")),
+      row_data(_("Access Restriction for Services"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :services) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :services)]) : _("None")),
+      row_data(_("Access Restriction for VMs and Templates"), role.settings.kind_of?(Hash) && role.settings.fetch_path(:restrictions, :vms) ? _(MiqUserRole::RESTRICTIONS[role.settings.fetch_path(:restrictions, :vms)]) : _("None")),
       row_data(_("Product Features (Read Only)"), {:input => 'component', :component => 'TREE_VIEW_REDUX', :props => rbac_menu_tree.locals_for_render, :name => rbac_menu_tree.name})
     ]
     miq_structured_list({

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -19,18 +19,6 @@
             = javascript_tag(javascript_focus('name'))
         .form-group
           %label.col-md-4.control-label
-            = _('Access Restriction for Orchestration Stacks, Key Pairs, Services, VMs, and Templates')
-          .col-md-8
-            - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
-            = select_tag('vm_restriction',
-                          options_for_select([[_("None"), "none"]] + restrictions,
-                          @edit[:new][:vm_restriction].to_sym),
-                          :class => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('vm_restriction', "#{url}")
-        .form-group
-          %label.col-md-4.control-label
             = _('Access Restriction for Catalog Items')
           .col-md-8
             - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
@@ -41,6 +29,54 @@
           :javascript
             miqInitSelectPicker();
             miqSelectPickerEvent('service_template_restriction', "#{url}")
+        .form-group
+          %label.col-md-4.control-label
+            = _('Access Restriction for Key Pairs')
+          .col-md-8
+            - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
+            = select_tag('auth_key_pair_restriction',
+                          options_for_select([[_("None"), "none"]] + restrictions,
+                          @edit[:new][:auth_key_pair_restriction].to_sym),
+                          :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('auth_key_pair_restriction', "#{url}")
+        .form-group
+          %label.col-md-4.control-label
+            = _('Access Restriction for Orchestration Stacks')
+          .col-md-8
+            - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
+            = select_tag('orchestration_stack_restriction',
+                          options_for_select([[_("None"), "none"]] + restrictions,
+                          @edit[:new][:orchestration_stack_restriction].to_sym),
+                          :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('orchestration_stack_restriction', "#{url}")
+        .form-group
+          %label.col-md-4.control-label
+            = _('Access Restriction for Services')
+          .col-md-8
+            - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
+            = select_tag('service_restriction',
+                          options_for_select([[_("None"), "none"]] + restrictions,
+                          @edit[:new][:service_restriction].to_sym),
+                          :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('service_restriction', "#{url}")
+        .form-group
+          %label.col-md-4.control-label
+            = _('Access Restriction for VMs and Templates')
+          .col-md-8
+            - restrictions = MiqUserRole::RESTRICTIONS.map { |k, v| [_(v), k] }.sort_by { |name, _value| name.downcase }
+            = select_tag('vm_restriction',
+                          options_for_select([[_("None"), "none"]] + restrictions,
+                          @edit[:new][:vm_restriction].to_sym),
+                          :class => "selectpicker")
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent('vm_restriction', "#{url}")
     .col-md-12.col-lg-6
       %hr
         = _("Product Features (Editing)")


### PR DESCRIPTION
Related to:
- ManageIQ/manageiq#22650
- ManageIQ/manageiq-schema#700

Follow up to #8833, which introduced separate restrictions for Catalog Items.

This changes further splits the role restriction settings to include the following types:
- Catalog Items
- Key Pairs
- Orchestration Stacks
- Services
- VMs and Templates