### PR TITLE
Fix cypress config file

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,11 +1,15 @@
+/* eslint-disable no-undef */
 const { defineConfig } = require('cypress');
-const fs = require('fs')
+const fs = require('fs');
 
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
+    viewportHeight: 800,
+    viewportWidth: 1800,
     numTestsKeptInMemory: 0,
     videoCompression: false,
+    // eslint-disable-next-line no-unused-vars
     setupNodeEvents(on, config) {
       on('after:spec', (spec, results) => {
         // Delete the video on CI if the spec passed and no tests retried
@@ -13,12 +17,12 @@ module.exports = defineConfig({
           // Do we have failures for any retry attempts?
           const failures = results.tests.some((test) =>
             test.attempts.some((attempt) => attempt.state === 'failed')
-          )
+          );
           if (!failures) {
-            fs.unlinkSync(results.video)
+            fs.unlinkSync(results.video);
           }
         }
-      })
+      });
     },
   },
 });

--- a/cypress/e2e/ui/searchbox.cy.js
+++ b/cypress/e2e/ui/searchbox.cy.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 describe('Search box', () => {
   beforeEach(() => {
-    cy.viewport(1280, 800);
     cy.login();
   });
 


### PR DESCRIPTION
Fixed lint errors in the cypress config file and added a default view port for all tests as well as removed the viewport line from the searchbox test file.