### PR TITLE
Refactor NotificationMessage component

### DIFF
--- a/app/javascript/components/notification-message.jsx
+++ b/app/javascript/components/notification-message.jsx
@@ -1,23 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { NotificationTypes } from '../helpers/notification-types';
 
-export const NotificationTypes = {
-  info: 'info',
-  danger: 'danger',
-  success: 'success',
-  warning: 'warning',
-};
-
-const NotificationMessage = ({
-  type, message,
-}) => {
-  const valid = Object.values(NotificationTypes).includes(type);
-
-  if (valid && message) {
+/** Component to render a notification message. */
+const NotificationMessage = ({ type, message }) => {
+  const validType = type && Object.keys(NotificationTypes).includes(type);
+  const notification = validType ? NotificationTypes[type] : NotificationTypes.unknown;
+  if (message) {
     return (
-      <div className={classNames('alert', `alert-${type}`)}>
-        <span className={classNames('pficon', `pficon-${type}`)} />
+      <div className={classNames('miq-notification-message-container', 'alert', notification.alert)}>
+        <span className={classNames('pficon', notification.icon)} />
         <strong>{message}</strong>
       </div>
     );
@@ -28,6 +21,11 @@ const NotificationMessage = ({
 export default NotificationMessage;
 
 NotificationMessage.propTypes = {
-  type: PropTypes.string.isRequired,
-  message: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  message: PropTypes.string,
+};
+
+NotificationMessage.defaultProps = {
+  type: undefined,
+  message: undefined,
 };

--- a/app/javascript/helpers/notification-types.js
+++ b/app/javascript/helpers/notification-types.js
@@ -1,0 +1,10 @@
+/** Types of notification messages
+ *  Used in NotificationMessage and ToastItem components.
+ */
+export const NotificationTypes = {
+  error: { alert: 'alert-danger', icon: 'pficon-error-circle-o' },
+  info: { alert: 'alert-info', icon: 'pficon-info' },
+  success: { alert: 'alert-success', icon: 'pficon-ok' },
+  warning: { alert: 'alert-warning', icon: 'pficon-warning-triangle-o' },
+  unknown: { alert: 'alert-info', icon: 'fa fa-regular fa-question-circle' },
+};

--- a/app/javascript/spec/notification-message/__snapshots__/notification-message.spec.js.snap
+++ b/app/javascript/spec/notification-message/__snapshots__/notification-message.spec.js.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationMessage component blank message should not render message 1`] = `
+<NotificationMessage
+  message=""
+  type="error"
+/>
+`;
+
+exports[`NotificationMessage component invalid type should not render message 1`] = `
+<NotificationMessage
+  message={"No message will be displayed"}
+  type="unknown"
+>
+  <div
+    className="miq-notification-message-container alert alert-info"
+  >
+    <span
+      className="pficon fa fa-regular fa-question-circle"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component should render error message 1`] = `
+<NotificationMessage
+  message={"Error message goes here"}
+  type="error"
+>
+  <div
+    className="miq-notification-message-container alert alert-danger"
+  >
+    <span
+      className="pficon pficon-error-circle-o"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component should render information message 1`] = `
+<NotificationMessage
+  message={"Information message goes here"}
+  type="info"
+>
+  <div
+    className="miq-notification-message-container alert alert-info"
+  >
+    <span
+      className="pficon pficon-info"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component should render success message 1`] = `
+<NotificationMessage
+  message={"Success message goes here"}
+  type="success"
+>
+  <div
+    className="miq-notification-message-container alert alert-success"
+  >
+    <span
+      className="pficon pficon-ok"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component should render warning message 1`] = `
+<NotificationMessage
+  message={"Warning message goes here"}
+  type="warning"
+>
+  <div
+    className="miq-notification-message-container alert alert-warning"
+  >
+    <span
+      className="pficon pficon-warning-triangle-o"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component unknown error type message should be rendered with blank type 1`] = `
+<NotificationMessage
+  message={"Message goes here"}
+  type=""
+>
+  <div
+    className="miq-notification-message-container alert alert-info"
+  >
+    <span
+      className="pficon fa fa-regular fa-question-circle"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;
+
+exports[`NotificationMessage component unknown error type message should be rendered with no type 1`] = `
+<NotificationMessage
+  message={"Message goes here"}
+>
+  <div
+    className="miq-notification-message-container alert alert-info"
+  >
+    <span
+      className="pficon fa fa-regular fa-question-circle"
+    />
+    <strong>
+      <Component />
+    </strong>
+  </div>
+</NotificationMessage>
+`;

--- a/app/javascript/spec/notification-message/notification-message.spec.js
+++ b/app/javascript/spec/notification-message/notification-message.spec.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { mount } from 'enzyme';
+import NotificationMessage from '../../components/notification-message';
+
+describe('NotificationMessage component', () => {
+  it('should render error message', () => {
+    const wrapper = mount(<NotificationMessage type="error" message={_('Error message goes here')} />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper.find('.alert-danger')).toHaveLength(1);
+    expect(wrapper.find('.pficon-error-circle-o')).toHaveLength(1);
+  });
+
+  it('should render information message', () => {
+    const wrapper = mount(<NotificationMessage type="info" message={_('Information message goes here')} />);
+    expect(wrapper.find('.alert-info')).toHaveLength(1);
+    expect(wrapper.find('.pficon-info')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render success message', () => {
+    const wrapper = mount(<NotificationMessage type="success" message={_('Success message goes here')} />);
+    expect(wrapper.find('.alert-success')).toHaveLength(1);
+    expect(wrapper.find('.pficon-ok')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render warning message', () => {
+    const wrapper = mount(<NotificationMessage type="warning" message={_('Warning message goes here')} />);
+    expect(wrapper.find('.alert-warning')).toHaveLength(1);
+    expect(wrapper.find('.pficon-warning-triangle-o')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('invalid type should not render message', () => {
+    const wrapper = mount(<NotificationMessage type="unknown" message={_('No message will be displayed')} />);
+    expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
+    expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('blank message should not render message', () => {
+    const wrapper = mount(<NotificationMessage type="error" message="" />);
+    expect(wrapper.find('.miq-notification-message-container')).toHaveLength(0);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('unknown error type message should be rendered with blank type', () => {
+    const wrapper = mount(<NotificationMessage type="" message={_('Message goes here')} />);
+    expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
+    expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('unknown error type message should be rendered with no type', () => {
+    const wrapper = mount(<NotificationMessage message={_('Message goes here')} />);
+    expect(wrapper.find('.miq-notification-message-container')).toHaveLength(1);
+    expect(wrapper.find('.fa-question-circle')).toHaveLength(1);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
+++ b/app/javascript/spec/settings-label-tag-mapping/__snapshots__/settings-label-tag-mapping.spec.js.snap
@@ -166,10 +166,10 @@ exports[`SettingsLabelTagMapping component should render a SettingsLabelTagMappi
       type="warning"
     >
       <div
-        className="alert alert-warning"
+        className="miq-notification-message-container alert alert-warning"
       >
         <span
-          className="pficon pficon-warning"
+          className="pficon pficon-warning-triangle-o"
         />
         <strong>
           Caution: Mappings with Resource Entity 'All-Entities' could cause overwriting existing tags on resources with mapped provider labels.


### PR DESCRIPTION
Before

- A few icons were not being rendered in the **`NotificationMessage`** component
- Also, the error notification was not available.

<img width="1511" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/a0d45683-fc63-4d53-a25f-af19e42f7056">

After
<img width="1499" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/68475cf9-d5d3-47f4-916e-cb9a0a3e0df1">

