### PR TITLE
Fix for  multiselect dropdown to stay open for multiselection in edit…

### DIFF
--- a/app/javascript/tagging/components/InnerComponents/ValueSelector.js
+++ b/app/javascript/tagging/components/InnerComponents/ValueSelector.js
@@ -98,6 +98,7 @@ class ValueSelector extends React.Component {
         <MultiSelect
           className="tag-select"
           id="tag-select"
+          open
           label={label}
           initialSelectedItems={selectedOptions}
           // eslint-disable-next-line react/destructuring-assignment


### PR DESCRIPTION
Before
The Multiselect options disappear upon selecting an item.

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/c6c48fbd-006d-49b6-9367-6368b8980f79


After
The Multiselect options will be displayed till we click somewhere outside.

https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/b0913b09-b202-4d67-bd8e-3d0200dab34d


