### PR TITLE
Fix Configuration>Access Control>Tenants list view

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -9,7 +9,7 @@ module OpsController::OpsRbac
   }.freeze
 
   def role_allows?(**options)
-    if MiqProductFeature.my_root_tenant_identifier?(options[:feature]) && params.key?(:id)
+    if MiqProductFeature.my_root_tenant_identifier?(options[:feature]) && params.key?(:id) && params[:id] != 'xx-tn'
       if params[:id].to_s.include?('tn')
         _, id, _ = TreeBuilder.extract_node_model_and_id(params[:id].to_s)
       else


### PR DESCRIPTION
The params[:id] is used to identify a particular tenant and allow
different access controls for different tenants. The view to list the
tenants uses params[:id] = 'xx-tn', which breaks the role_allows? method
with a '[RuntimeError] role_allows? no feature was found with
identifier: ["rbac_tenant_manage_quotas_tenant_tn"].' message.

The base "rbac_tenant_manage_quotas_tenant" feature is sufficient, so
adding an extra conditional to skip the whole id parsing allows viewing
the list of tenants.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/1637291/7da6e585-ad59-4497-9a0e-18759d41335a)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/1637291/fbbd9f46-a40d-40dc-aaae-a22e6f880a60)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/8895