### PR TITLE
[QUINTEROS] Lock the release branch to test with ruby 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,6 @@ jobs:
         - spec:jest
         - spec:routes
         - spec:security
-        include:
-        - ruby-version: '2.7'
-          node-version: 18
-          test-suite: spec
     services:
       postgres:
         image: manageiq/postgresql:13


### PR DESCRIPTION
[QUINTEROS] Lock the release branch to test with ruby 3.0