### PR TITLE
Fix for no items in datastore list by showing no-records message

### DIFF
--- a/app/javascript/components/data-tables/datastore/index.jsx
+++ b/app/javascript/components/data-tables/datastore/index.jsx
@@ -5,6 +5,7 @@ import {
   tableData, addSelected, removeSelected,
 } from './helper';
 import MiqDataTable from '../../miq-data-table';
+import NoRecordsFound from '../../no-records-found';
 import { CellAction } from '../../miq-data-table/helper';
 
 const Datastore = ({
@@ -93,14 +94,22 @@ const Datastore = ({
   };
 
   return (
-    <MiqDataTable
-      rows={miqRows.rowItems}
-      headers={miqHeaders}
-      onCellClick={(selectedRow, cellType, event) => onCellClick(selectedRow, cellType, event)}
-      rowCheckBox={hasCheckbox}
-      mode={`datastore-list ${type}`}
-      gridChecks={selectionIds}
-    />
+    <>
+      {
+        (miqRows.rowItems.length === 0)
+          ? <NoRecordsFound />
+          : (
+            <MiqDataTable
+              rows={miqRows.rowItems}
+              headers={miqHeaders}
+              onCellClick={(selectedRow, cellType, event) => onCellClick(selectedRow, cellType, event)}
+              rowCheckBox={hasCheckbox}
+              mode={`datastore-list ${type}`}
+              gridChecks={selectionIds}
+            />
+          )
+      }
+    </>
   );
 };
 


### PR DESCRIPTION
Before
<img width="1532" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/e2d6fe77-1efd-49ef-b877-fca589af45a8">


After
<img width="1528" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/511341a0-bc44-4880-8c35-d048d7897531">
