### PR TITLE
Integrating the CodeMirror into MiqStructuredList component.

### DIFF
--- a/app/helpers/miq_ae_class_helper.rb
+++ b/app/helpers/miq_ae_class_helper.rb
@@ -341,6 +341,17 @@ module MiqAeClassHelper
                         })
   end
 
+  def method_built_in_data(ae_method)
+    rows = [
+      row_data('', {:input => 'code_mirror', :props => {:mode => 'ruby', :payload => ae_method.data}})
+    ]
+    miq_structured_list({
+                          :title => _('Data'),
+                          :mode  => "method_built_in_data",
+                          :rows  => rows
+                        })
+  end
+
   private
 
   def row_data(label, value)

--- a/app/javascript/components/miq-structured-list/helpers.js
+++ b/app/javascript/components/miq-structured-list/helpers.js
@@ -8,6 +8,7 @@ export const InputTypes = {
   CHECKBOX: 'checkbox',
   COMPONENT: 'component',
   DROPDOWN: 'dropdown',
+  CODEMIRROR: 'code_mirror',
 };
 
 export const DynamicReactComponents = {

--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-inputs.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-tags/miq-structured-list-inputs.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox, TextArea, Dropdown } from 'carbon-components-react';
+import { Controlled as CodeMirror } from 'react-codemirror2';
 import { DynamicReactComponents, InputTypes } from '../../helpers';
 
 /** Component to render textarea / checkbox / react components */
@@ -34,6 +35,21 @@ const MiqStructuredListInputs = ({ value, action }) => {
     />
   );
 
+  /** Function to render the code mirror component. */
+  const renderCodeMirrorComponent = ({ props: { mode, payload } }) => (
+    <CodeMirror
+      className="miq-codemirror miq-structured-list-code-mirror"
+      options={{
+        mode,
+        lineNumbers: true,
+        matchBrackets: true,
+        theme: 'eclipse',
+        readOnly: 'nocursor',
+        viewportMargin: Infinity,
+      }}
+      value={payload}
+    />
+  );
   switch (value.input) {
     case InputTypes.TEXTAREA:
       return renderTextArea(value);
@@ -43,6 +59,8 @@ const MiqStructuredListInputs = ({ value, action }) => {
       return renderDynamicComponent(value);
     case InputTypes.DROPDOWN:
       return renderDropDownComponent(value);
+    case InputTypes.CODEMIRROR:
+      return renderCodeMirrorComponent(value);
     default:
       return null;
   }

--- a/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-object.jsx
+++ b/app/javascript/components/miq-structured-list/miq-structured-list-body/value-types/miq-structured-list-object.jsx
@@ -6,20 +6,24 @@ import MiqStructuredListConditionalTag from '../value-tags/miq-structured-list-c
 
 /** Usage eg: Automation / Embeded Automate / Generic Objects / item
   * Properties has no links & Relationships have links */
-const MiqStructuredListObject = ({ row, clickEvents, onClick }) => (
-  <StructuredListCell
-    className={classNames(row.label ? 'content_value' : 'label_header', 'object_item')}
-    title={row && row.title !== undefined ? row.title : ''}
-  >
-    <MiqStructuredListConditionalTag row={row} onClick={onClick} clickEvents={clickEvents} />
-  </StructuredListCell>
-);
+const MiqStructuredListObject = ({ row, clickEvents, onClick }) => {
+  const isContent = row.label || (row.value && row.value.input);
+  return ((
+    <StructuredListCell
+      className={classNames(isContent ? 'content_value' : 'label_header', 'object_item')}
+      title={row && row.title !== undefined ? row.title : ''}
+    >
+      <MiqStructuredListConditionalTag row={row} onClick={onClick} clickEvents={clickEvents} />
+    </StructuredListCell>
+  ));
+};
 
 export default MiqStructuredListObject;
 
 MiqStructuredListObject.propTypes = {
   row: PropTypes.shape({
     label: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.any]),
     title: PropTypes.string,
   }),
   clickEvents: PropTypes.bool.isRequired,

--- a/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
+++ b/app/javascript/spec/miq-structured-list/__snapshots__/miq-structured-list.spec.js.snap
@@ -696,6 +696,51 @@ exports[`Structured list component should render catalog_data with escaped strin
 </Accordion>
 `;
 
+exports[`Structured list component should render code mirror component 1`] = `
+<Accordion
+  align="start"
+  className="miq-structured-list-accordion miq_summary code_mirror"
+>
+  <AccordionItem
+    open={true}
+    title="Automation Method Data"
+  >
+    <FeatureToggle(StructuredListWrapper)
+      ariaLabel="Structured list"
+      className="miq-structured-list miq_summary code_mirror"
+    >
+      <MiqStructuredListBody
+        clickEvents={true}
+        mode="miq_summary code_mirror"
+        onClick={[MockFunction]}
+        rows={
+          Array [
+            Object {
+              "label": "Label",
+              "value": "Value",
+            },
+            Object {
+              "label": "",
+              "title": "code mirror",
+              "value": Object {
+                "input": "code_mirror",
+                "props": Object {
+                  "mode": "ruby",
+                  "payload": "
+  def notify(level, message, subject)
+    $evm.create_notification(:audience => 'user', :level => level, :message => message)
+  end",
+                },
+              },
+            },
+          ]
+        }
+      />
+    </FeatureToggle(StructuredListWrapper)>
+  </AccordionItem>
+</Accordion>
+`;
+
 exports[`Structured list component should render miq policy data without double escaping strings 1`] = `
 <FeatureToggle(StructuredListWrapper)
   ariaLabel="Structured list"

--- a/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
+++ b/app/javascript/spec/miq-structured-list/miq-structured-list.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';
 import MiqStructuredList from '../../components/miq-structured-list';
+import { codeMirrorData } from '../textual_summary/data/code_mirror_data';
 import { genericGroupData } from '../textual_summary/data/generic_group';
 import { multilinkTableData } from '../textual_summary/data/multilink_table';
 import { operationRangesData } from '../textual_summary/data/operation_ranges';
@@ -196,6 +197,17 @@ describe('Structured list component', () => {
       rows={reportScheduleListData.items}
       title={reportScheduleListData.title}
       mode={reportScheduleListData.mode}
+      onClick={onClick}
+    />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render code mirror component', () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(<MiqStructuredList
+      rows={codeMirrorData.items}
+      title={codeMirrorData.title}
+      mode={codeMirrorData.mode}
       onClick={onClick}
     />);
     expect(toJson(wrapper)).toMatchSnapshot();

--- a/app/javascript/spec/textual_summary/data/code_mirror_data.js
+++ b/app/javascript/spec/textual_summary/data/code_mirror_data.js
@@ -1,0 +1,20 @@
+const payloadData = `
+  def notify(level, message, subject)
+    $evm.create_notification(:audience => 'user', :level => level, :message => message)
+  end`;
+
+export const codeMirrorData = {
+  mode: 'miq_summary code_mirror',
+  items: [
+    {
+      label: __('Label'),
+      value: __('Value'),
+    },
+    {
+      label: '',
+      value: { input: 'code_mirror', props: { mode: 'ruby', payload: payloadData } },
+      title: 'code mirror',
+    },
+  ],
+  title: __('Automation Method Data'),
+};

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -11,20 +11,23 @@
     - if @ae_method.location == 'inline'
       = render :partial => "embedded_methods"
     = render :partial => "domain_overrides", :locals => {:node_prefix => "aem", :model => "Method"}
-    %h3= (@ae_method.location == 'builtin') ? _('Builtin name') : _('Data')
     - if @ae_method.location == "inline"
-      = text_area("method1",
-        "data",
-        :value    => @ae_method.data,
-        :size     => "90x20",
-        :disabled => true,
-        :style    => "display:none;")
-      -# Create a MyCodeMirror editor for the text area
-      = render :partial => "/layouts/my_code_mirror",
-        :locals  => {:text_area_id => "method1_data",
-          :mode                    => "ruby",
-          :line_numbers            => true,
-          :read_only               => true}
+      - if @in_a_form
+        %h3= @ae_method.location == 'builtin' ? _('Builtin name') : _('Data')
+        = text_area("method1",
+          "data",
+          :value    => @ae_method.data,
+          :size     => "90x20",
+          :disabled => true,
+          :style    => "display:none;")
+        -# Create a MyCodeMirror editor for the text area
+        = render :partial => "/layouts/my_code_mirror",
+          :locals  => {:text_area_id => "method1_data",
+            :mode                    => "ruby",
+            :line_numbers            => true,
+            :read_only               => true}
+      - else
+        = method_built_in_data(@ae_method)
     - elsif @ae_method.location == 'expression'
       = @expression
     - elsif playbook_style_location?(@ae_method.location)


### PR DESCRIPTION
Integrate the `CodeMirror` component in the `MiqStructuredList` component.

Note: Edit page will remain the same.

Before
<img width="1556" alt="Screenshot 2023-11-21 at 10 34 24 AM" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/c25f72fa-dd42-4101-a500-a3d2bc189608">

After
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/0e52f9c4-89b2-4474-95d3-c441ff189d0e)
