### PR TITLE
Fixed Missing Styling for Remote Consoles

### DIFF
--- a/app/views/layouts/remote_console.html.haml
+++ b/app/views/layouts/remote_console.html.haml
@@ -8,6 +8,7 @@
     -# Load the required JS based on the console type
     = javascript_essential_dependencies
     = javascript_pack_tag("manageiq-ui-classic/remote_consoles_#{@console[:type]}.js")
+    = javascript_pack_tag("manageiq-ui-classic/application-common.js")
   %body
     #remote-console{'data-url' => @console[:url], 'data-secret' => @console[:secret], 'data-is-vcloud' => @console[:is_vcloud], 'data-vmx' => @console[:vmx]}
     %footer.remote-console


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8419

The changes made in https://github.com/ManageIQ/manageiq-ui-classic/pull/7838 made it so that the html5 web consoles no longer had their css stylings applied in the ui making them borderline unusable. This should reapply the css to the remote console ui.

Before:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/a66dd142-f13b-49c2-8ffd-7fc6319a911e)

After:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/6cffeaa6-2b39-4a34-af9b-697806fac3a9)