### PR TITLE
Added New Feature That Controls Who Can See Request Logs

### DIFF
--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -112,7 +112,7 @@
             = button_tag(t, :class => "btn btn-primary disabled")
 - else
   = request_details_summary(@miq_request, @user)
-- if @miq_request.request_logs.any?
+- if role_allows?(:feature => 'miq_request_show_logs') && @miq_request.request_logs.any?
   %h3
     = _("Request Logs")
     = react('RequestsTable', {:initialData => @miq_request.request_logs})


### PR DESCRIPTION
Addresses: https://github.com/ManageIQ/manageiq-ui-classic/issues/8772
Related Core Pr: https://github.com/ManageIQ/manageiq/pull/22701

Preview:
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/c5f2b68b-e27e-4791-a8bf-cae26d426ae1)
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/ae8a6f76-585d-4ffd-9ada-24e628f7b1f4)
![image](https://github.com/ManageIQ/manageiq-ui-classic/assets/64800041/e3ce1eb3-98f1-4111-b807-f0958bbb8ddd)
