### PR TITLE
Fix for displaying ansible credential info

### DIFF
--- a/app/javascript/components/ansible-credentials-form/index.jsx
+++ b/app/javascript/components/ansible-credentials-form/index.jsx
@@ -39,6 +39,7 @@ const AnsibleCredentialsForm = ({ recordId }) => {
       return API.get(`/api/authentications/${recordId}`).then((initialValues) => promise.then(loadSchema(initialValues.type, {
         initialValues: {
           ...initialValues,
+          ...initialValues.options,
         },
         isLoading: false,
       })));


### PR DESCRIPTION
**Credential type: Azure**
Before - Subscription ID, Tenant Id, Client Id is missing
<img width="593" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/ec136822-8c2f-4479-8b17-c0c7e05550d7">
After
<img width="699" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/c59ef1e5-829d-4a5e-9d95-7d826c8dedf5">

**Credential type: Google Compute Engine**
Before - Project is missing
<img width="741" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/096da719-eb91-4383-9192-8ffe5a5e3a6f">
After
<img width="727" alt="image" src="https://github.com/ManageIQ/manageiq-ui-classic/assets/87487049/250bcef7-ec55-489e-89ad-929a582684a7">

